### PR TITLE
Add parameter 'force_delete' to support deleting 'PrePaid' instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- Add parameter 'force_delete' to support deleting 'PrePaid' instance [GH-377]
 - Add wait time to fix random detaching disk error [GH-373]
 
 ## 1.17.0 (September 22, 2018)

--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -236,6 +236,14 @@ func resourceAliyunInstance() *schema.Resource {
 				DiffSuppressFunc: ecsSpotPriceLimitDiffSuppressFunc,
 			},
 
+			"force_delete": &schema.Schema{
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          false,
+				Description:      descriptions["A behavior mark used to delete 'PrePaid' ECS instance forcibly."],
+				DiffSuppressFunc: ecsPostPaidDiffSuppressFunc,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -457,22 +465,6 @@ func resourceAliyunInstanceUpdate(d *schema.ResourceData, meta interface{}) erro
 
 		d.SetPartial("security_groups")
 	}
-	if d.HasChange("renewal_status") || d.HasChange("auto_renew_period") {
-		status := d.Get("renewal_status").(string)
-		args := ecs.CreateModifyInstanceAutoRenewAttributeRequest()
-		args.InstanceId = d.Id()
-		args.RenewalStatus = status
-
-		if status == string(RenewAutoRenewal) {
-			args.Duration = requests.NewInteger(d.Get("auto_renew_period").(int))
-		}
-
-		if _, err := client.ecsconn.ModifyInstanceAutoRenewAttribute(args); err != nil {
-			return fmt.Errorf("ModifyInstanceAutoRenewAttribute got an error: %#v", err)
-		}
-		d.SetPartial("renewal_status")
-		d.SetPartial("auto_renew_period")
-	}
 
 	run := false
 	imageUpdate, err := modifyInstanceImage(d, meta, run)
@@ -545,8 +537,36 @@ func resourceAliyunInstanceUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if err := modifyInstanceChargeType(d, meta); err != nil {
+	updateRenewal := false
+	if d.HasChange("instance_charge_type") {
+		if _, n := d.GetChange("instance_charge_type"); n.(string) == string(PrePaid) {
+			updateRenewal = true
+		}
+	}
+	if err := modifyInstanceChargeType(d, meta, false); err != nil {
 		return err
+	}
+
+	// Only PrePaid instance can support modifying renewal attribute
+	if updateRenewal && (d.HasChange("renewal_status") || d.HasChange("auto_renew_period")) {
+		status := d.Get("renewal_status").(string)
+		args := ecs.CreateModifyInstanceAutoRenewAttributeRequest()
+		args.InstanceId = d.Id()
+		args.RenewalStatus = status
+
+		if status == string(RenewAutoRenewal) {
+			args.Duration = requests.NewInteger(d.Get("auto_renew_period").(int))
+		}
+
+		if _, err := client.ecsconn.ModifyInstanceAutoRenewAttribute(args); err != nil {
+			return fmt.Errorf("ModifyInstanceAutoRenewAttribute got an error: %#v", err)
+		}
+		d.SetPartial("renewal_status")
+		d.SetPartial("auto_renew_period")
+	}
+
+	if d.HasChange("force_delete") {
+		d.SetPartial("force_delete")
 	}
 
 	d.Partial(false)
@@ -557,7 +577,12 @@ func resourceAliyunInstanceDelete(d *schema.ResourceData, meta interface{}) erro
 	client := meta.(*AliyunClient)
 	conn := client.ecsconn
 	if d.Get("instance_charge_type").(string) == string(PrePaid) {
-		return fmt.Errorf("At present, 'PrePaid' instance cannot be deleted and must wait it to be expired and release it automatically.")
+		force := d.Get("force_delete").(bool)
+		if !force {
+			return fmt.Errorf("Please convert 'PrePaid' instance to 'PostPaid' or set 'force_delete' as true before deleting 'PrePaid' instance.")
+		} else if err := modifyInstanceChargeType(d, meta, force); err != nil {
+			return fmt.Errorf("Before deleteing ECS instance forcibly, converting instance charge type got an error: %#v.", err)
+		}
 	}
 	stop := ecs.CreateStopInstanceRequest()
 	stop.InstanceId = d.Id()
@@ -712,15 +737,17 @@ func buildAliyunInstanceArgs(d *schema.ResourceData, meta interface{}) (*ecs.Cre
 	return args, nil
 }
 
-func modifyInstanceChargeType(d *schema.ResourceData, meta interface{}) error {
+func modifyInstanceChargeType(d *schema.ResourceData, meta interface{}, forceDelete bool) error {
 	if d.IsNewResource() {
 		return nil
 	}
 
-	conn := meta.(*AliyunClient).ecsconn
-
-	if d.HasChange("instance_charge_type") {
-		chargeType := d.Get("instance_charge_type").(string)
+	client := meta.(*AliyunClient)
+	chargeType := d.Get("instance_charge_type").(string)
+	if d.HasChange("instance_charge_type") || forceDelete {
+		if forceDelete {
+			chargeType = string(PostPaid)
+		}
 		args := ecs.CreateModifyInstanceChargeTypeRequest()
 		args.InstanceIds = convertListToJsonString(append(make([]interface{}, 0, 1), d.Id()))
 		args.IncludeDataDisks = requests.NewBoolean(d.Get("include_data_disks").(bool))
@@ -733,7 +760,7 @@ func modifyInstanceChargeType(d *schema.ResourceData, meta interface{}) error {
 		}
 		args.InstanceChargeType = chargeType
 		if err := resource.Retry(6*time.Minute, func() *resource.RetryError {
-			if _, err := conn.ModifyInstanceChargeType(args); err != nil {
+			if _, err := client.ecsconn.ModifyInstanceChargeType(args); err != nil {
 				if IsExceptedErrors(err, []string{Throttling}) {
 					time.Sleep(10 * time.Second)
 					return resource.RetryableError(fmt.Errorf("Modifying instance %s chareType timeout and got an error:%#v.", d.Id(), err))
@@ -741,6 +768,17 @@ func modifyInstanceChargeType(d *schema.ResourceData, meta interface{}) error {
 				return resource.NonRetryableError(fmt.Errorf("Modifying instance %s chareType timeout and got an error: %#v.", d.Id(), err))
 			}
 			return nil
+		}); err != nil {
+			return err
+		}
+		// Wait for instance charge type has been changed
+		if err := resource.Retry(3*time.Minute, func() *resource.RetryError {
+			if instance, err := client.DescribeInstanceById(d.Id()); err != nil {
+				return resource.NonRetryableError(fmt.Errorf("Describing instance %s got an error: %#v.", d.Id(), err))
+			} else if instance.InstanceChargeType == chargeType {
+				return nil
+			}
+			return resource.RetryableError(fmt.Errorf("Waitting for instance %s to be %s timeout.", d.Id(), chargeType))
 		}); err != nil {
 			return err
 		}

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -1904,7 +1904,7 @@ resource "alicloud_instance" "private_ip" {
 }
 `
 
-const testAccCheckInstanceChargeType = `
+const testAccCheckInstanceChargeTypeUpdate = `
 data "alicloud_images" "ubuntu" {
 	most_recent = true
 	owners = "system"
@@ -1949,10 +1949,11 @@ resource "alicloud_instance" "charge_type" {
 	vswitch_id = "${alicloud_vswitch.foo.id}"
 	instance_charge_type = "PrePaid"
 	period_unit = "Week"
+	force_delete = "true"
 }
 `
 
-const testAccCheckInstanceChargeTypeUpdate = `
+const testAccCheckInstanceChargeType = `
 data "alicloud_images" "ubuntu" {
 	most_recent = true
 	owners = "system"

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -114,7 +114,8 @@ On other OSs such as Linux, the host name can contain a maximum of 30 characters
 
     Default to NoSpot.
 * `spot_price_limit` - (Optional, Float, Force New) The hourly price threshold of a instance, and it takes effect only when parameter 'spot_strategy' is 'SpotWithPriceLimit'. Three decimals is allowed at most.
-
+* `force_delete` - (Optional, Available 1.18.0+) If it is true, the "PrePaid" instance will be change to "PostPaid" and then deleted forcibly.
+However, because of changing instance charge type has CPU core count quota limitation, so strongly recommand that "Don't modify instance charge type frequentlly in one month".
 
 ~> **NOTE:** System disk category `cloud` has been outdated and it only can be used none I/O Optimized ECS instances. Recommend `cloud_efficiency` and `cloud_ssd` disk.
 


### PR DESCRIPTION
The result of running test case as follows:
```
TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudInstanceChargeType_update -timeout=240m
=== RUN   TestAccAlicloudInstanceChargeType_update
--- PASS: TestAccAlicloudInstanceChargeType_update (562.00s)
PASS
ok  	github.com/terraform-providers/terraform-provider-alicloud/alicloud	562.065s
```