### PR TITLE
perf(db_connection):perf rds resource document description

### DIFF
--- a/alicloud/validators.go
+++ b/alicloud/validators.go
@@ -1316,8 +1316,8 @@ func validateInstanceSpotStrategy(v interface{}, k string) (ws []string, errors 
 
 func validateDBConnectionPrefix(v interface{}, k string) (ws []string, errors []error) {
 	if value := v.(string); value != "" {
-		if len(value) < 1 || len(value) > 31 {
-			errors = append(errors, fmt.Errorf("%q cannot be less than 1 and larger than 30.", k))
+		if len(value) < 8 || len(value) > 31 {
+			errors = append(errors, fmt.Errorf("%q cannot be less than 8 and larger than 30.", k))
 		}
 	}
 	return

--- a/website/docs/r/db_connection.html.markdown
+++ b/website/docs/r/db_connection.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 * `instance_id` - (Required, ForceNew) The Id of instance that can run database.
 * `connection_prefix` - (ForceNew) Prefix of an Internet connection string. It must be checked for uniqueness. It may consist of lowercase letters, numbers, and underlines, and must start with a letter and have no more than 30 characters. Default to <instance_id> + 'tf'.
-* `port` - (Optional) Internet connection port. Valid value: [3001-3999]. Default to 3306.
+* `port` - (Optional) Internet connection port. Valid value: [3001-3999]. You can set the required port number for different engines. Default to 3306.
 
 ## Attributes Reference
 


### PR DESCRIPTION
perf(db_connection):perf rds resource document description;
=== RUN   TestAccAlicloudDBConnectionConfigUpdate
--- PASS: TestAccAlicloudDBConnectionConfigUpdate (818.20s)
PASS