### PR TITLE
Add support for setting Database Slave Zone ids (fix #2847)

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -107,6 +107,11 @@ func resourceAlicloudDBInstance() *schema.Resource {
 					return old == Trim(strings.Split(new, COMMA_SEPARATED)[0])
 				},
 			},
+			"vswitch_id_slave_1": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
 			"instance_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -791,6 +796,10 @@ func buildDBCreateRequest(d *schema.ResourceData, meta interface{}) (*rds.Create
 	}
 
 	vswitchId := Trim(d.Get("vswitch_id").(string))
+
+	if vswitchIdSlave1, ok := d.GetOk("vswitch_id_slave_1"); ok && Trim(vswitchIdSlave1.(string)) != "" {
+		vswitchId = strings.Join([]string{vswitchId, vswitchIdSlave1.(string)}, ",")
+	}
 
 	request.InstanceNetworkType = string(Classic)
 

--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -101,6 +101,11 @@ func resourceAlicloudDBInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Unfortunately RDS API doesn't retain the info about the additional vswitch
+					// so after creation, we can only compare the first vswitch to guess if there is a diff
+					return old == Trim(strings.Split(new, COMMA_SEPARATED)[0])
+				},
 			},
 			"instance_name": {
 				Type:         schema.TypeString,

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -130,7 +130,11 @@ If it is a multi-zone and `vswitch_id` is specified, the vswitch must in the one
 The multiple zone ID can be retrieved by setting `multi` to "true" in the data source `alicloud_zones`.
 * `vswitch_id` - (ForceNew) The virtual switch ID to launch DB instances in one VPC. If there are multiple vswitches, separate them with commas.
 
-  Note: For multiple vswitches, only the first vswitch will be saved eventually in the Terraform state eventually as [DescribeDBInstanceAttribute](https://www.alibabacloud.com/help/doc-detail/26231.htm) only returns the first vswitch.
+  Note: putting multiple vswitches separated with commas in this field has been deprecated. Use `vswitch_id_slave_1` if you need to define the vswitch of the secondary instance.
+
+* `vswitch_id_slave_1` - (ForceNew, Optional) The virtual switch ID to launch the secondary DB instances in one VPC in the case of a High-Availability DB instance.
+
+  Note: You need to use a multi-AZ zone (like `cn-beijing-MAZ5(a,c)`, `ap-southeast-1MAZ1(a,b)`... ) in `zone_id` for this argument to work.
 
 * `security_ips` - (Optional) List of IP addresses allowed to access all databases of an instance. The list contains up to 1,000 IP addresses, separated by commas. Supported formats include 0.0.0.0/0, 10.23.12.24 (IP), and 10.23.12.24/24 (Classless Inter-Domain Routing (CIDR) mode. /24 represents the length of the prefix in an IP address. The range of the prefix length is [1,32]).
 * `security_ip_mode` - (Optional, Available in 1.62.1+)  Valid values are `normal`, `safety`, Default to `normal`. support `safety` switch to high security access mode 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -129,6 +129,9 @@ The following arguments are supported:
 If it is a multi-zone and `vswitch_id` is specified, the vswitch must in the one of them.
 The multiple zone ID can be retrieved by setting `multi` to "true" in the data source `alicloud_zones`.
 * `vswitch_id` - (ForceNew) The virtual switch ID to launch DB instances in one VPC. If there are multiple vswitches, separate them with commas.
+
+  Note: For multiple vswitches, only the first vswitch will be saved eventually in the Terraform state eventually as [DescribeDBInstanceAttribute](https://www.alibabacloud.com/help/doc-detail/26231.htm) only returns the first vswitch.
+
 * `security_ips` - (Optional) List of IP addresses allowed to access all databases of an instance. The list contains up to 1,000 IP addresses, separated by commas. Supported formats include 0.0.0.0/0, 10.23.12.24 (IP), and 10.23.12.24/24 (Classless Inter-Domain Routing (CIDR) mode. /24 represents the length of the prefix in an IP address. The range of the prefix length is [1,32]).
 * `security_ip_mode` - (Optional, Available in 1.62.1+)  Valid values are `normal`, `safety`, Default to `normal`. support `safety` switch to high security access mode 
 * `parameters` - (Optional) Set of parameters needs to be set after DB instance was launched. Available parameters can refer to the latest docs [View database parameter templates](https://www.alibabacloud.com/help/doc-detail/26284.htm) .

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -130,9 +130,9 @@ If it is a multi-zone and `vswitch_id` is specified, the vswitch must in the one
 The multiple zone ID can be retrieved by setting `multi` to "true" in the data source `alicloud_zones`.
 * `vswitch_id` - (ForceNew) The virtual switch ID to launch DB instances in one VPC. If there are multiple vswitches, separate them with commas.
 
-  Note: putting multiple vswitches separated with commas in this field has been deprecated. Use `vswitch_id_slave_1` if you need to define the vswitch of the secondary instance.
+  Note: putting multiple vswitches separated with commas in this field has been deprecated. Use `vswitch_id_slaves` if you need to define additional vswitches for secondary instances.
 
-* `vswitch_id_slave_1` - (ForceNew, Optional) The virtual switch ID to launch the secondary DB instances in one VPC in the case of a High-Availability DB instance.
+* `vswitch_id_slaves` - (ForceNew, Optional) List of virtual switchs ID where to launch the secondary DB instances in one VPC in the case of a High-Availability DB instance.
 
   Note: You need to use a multi-AZ zone (like `cn-beijing-MAZ5(a,c)`, `ap-southeast-1MAZ1(a,b)`... ) in `zone_id` for this argument to work.
 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -128,6 +128,12 @@ The following arguments are supported:
 * `zone_id` - (ForceNew) The Zone to launch the DB instance. From version 1.8.1, it supports multiple zone.
 If it is a multi-zone and `vswitch_id` is specified, the vswitch must in the one of them.
 The multiple zone ID can be retrieved by setting `multi` to "true" in the data source `alicloud_zones`.
+
+* `zone_id_slaves` - (ForceNew) The Zones where to launch the secondary DB instances.
+If vswitches are specified in `vswitch_id_slaves`, they should belong to the corresponding zones defined here.
+
+  Note: for high-availability instances, you should either use a multi-AZ zone in `zone_id` (like `cn-beijing-MAZ5(a,c)`, `ap-southeast-1MAZ1(a,b)`... ), or set both `zone_id` and `zone_id_slaves`. Both modes are incompatibles.
+
 * `vswitch_id` - (ForceNew) The virtual switch ID to launch DB instances in one VPC. If there are multiple vswitches, separate them with commas.
 
   Note: putting multiple vswitches separated with commas in this field has been deprecated. Use `vswitch_id_slaves` if you need to define additional vswitches for secondary instances.


### PR DESCRIPTION
This PR add a new settings `zone_id_slaves` which allows to specify the zone id of the secondary instances, as supported by the API itself (with the arguments `ZoneIdSlave1` and `ZoneIdSlave2`).
It aims at fixing #2847 2847

This PR is based on the not-yet-merged #2846 , so #2846 should be merged before this PR is accepted.
