### PR TITLE
elasticsearch instance support configuration 'client node' and 'protocol'

### DIFF
--- a/alicloud/resource_alicloud_elasticsearch_instance_test.go
+++ b/alicloud/resource_alicloud_elasticsearch_instance_test.go
@@ -30,6 +30,12 @@ const DefaultZoneAmount = "2"
 const MasterNodeSpec = "elasticsearch.sn2ne.large"
 const MasterNodeSpecForUpdate = "elasticsearch.sn2ne.xlarge"
 
+const ClientNodeSpec = "elasticsearch.sn2ne.large"
+const ClientNodeAmount = "2"
+
+const ClientNodeSpecForUpdate = "elasticsearch.sn2ne.xlarge"
+const ClientNodeAmountForUpdate = "3"
+
 func init() {
 	resource.AddTestSweepers("alicloud_elasticsearch_instance", &resource.Sweeper{
 		Name: "alicloud_elasticsearch_instance",
@@ -565,6 +571,74 @@ func TestAccAlicloudElasticsearchInstance_encrypt_disk(t *testing.T) {
 						"data_node_disk_encrypted": "true",
 						"master_node_spec":         MasterNodeSpec,
 						"zone_count":               DefaultZoneAmount,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudElasticsearchInstance_client_node(t *testing.T) {
+	var instance *elasticsearch.DescribeInstanceResponse
+
+	resourceId := "alicloud_elasticsearch_instance.default"
+	ra := resourceAttrInit(resourceId, elasticsearchMap)
+
+	serviceFunc := func() interface{} {
+		return &ElasticsearchService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &instance, serviceFunc)
+
+	rac := resourceAttrCheckInit(rc, ra)
+
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandInt()
+	name := fmt.Sprintf("tf-testAccES%s%d", defaultRegionToTest, rand)
+	if len(name) > 30 {
+		name = name[:30]
+	}
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceElasticsearchInstanceConfigDependence)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithNoDefaultVpc(t)
+		},
+		// module name
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":          name,
+					"vswitch_id":           "${data.alicloud_vswitches.default.ids[0]}",
+					"version":              "6.3_with_X-Pack",
+					"password":             "Yourpassword1234",
+					"data_node_spec":       DataNodeSpec,
+					"data_node_amount":     DataNodeAmount,
+					"data_node_disk_size":  DataNodeDisk,
+					"data_node_disk_type":  DataNodeDiskType,
+					"instance_charge_type": string(PostPaid),
+					"client_node_spec":     ClientNodeSpec,
+					"client_node_amount":   ClientNodeAmount,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"client_node_spec":   ClientNodeSpec,
+						"client_node_amount": ClientNodeAmount,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"client_node_spec":   ClientNodeSpecForUpdate,
+					"client_node_amount": ClientNodeAmountForUpdate,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"client_node_spec":   ClientNodeSpecForUpdate,
+						"client_node_amount": ClientNodeAmountForUpdate,
 					}),
 				),
 			},

--- a/examples/elasticsearch/main.tf
+++ b/examples/elasticsearch/main.tf
@@ -11,5 +11,7 @@ resource "alicloud_elasticsearch_instance" "instance" {
   description               = var.description
   zone_count                = var.zone_count
   master_node_spec          = var.master_node_spec
+  client_node_amount        = var.client_node_amount
+  client_node_spec          = var.client_node_spec
 }
 

--- a/examples/elasticsearch/main.tf
+++ b/examples/elasticsearch/main.tf
@@ -13,5 +13,6 @@ resource "alicloud_elasticsearch_instance" "instance" {
   master_node_spec          = var.master_node_spec
   client_node_amount        = var.client_node_amount
   client_node_spec          = var.client_node_spec
+  protocol                  = var.protocol
 }
 

--- a/examples/elasticsearch/variables.tf
+++ b/examples/elasticsearch/variables.tf
@@ -67,3 +67,7 @@ variable "client_node_amount" {
 variable "client_node_spec" {
   default = "elasticsearch.sn2ne.large"
 }
+
+variable "protocol" {
+  default = "HTTPS"
+}

--- a/examples/elasticsearch/variables.tf
+++ b/examples/elasticsearch/variables.tf
@@ -60,3 +60,10 @@ variable "zone_count" {
   default = "1"
 }
 
+variable "client_node_amount" {
+  default = "2"
+}
+
+variable "client_node_spec" {
+  default = "elasticsearch.sn2ne.large"
+}

--- a/website/docs/r/elasticsearch.html.markdown
+++ b/website/docs/r/elasticsearch.html.markdown
@@ -26,6 +26,8 @@ resource "alicloud_elasticsearch_instance" "instance" {
   data_node_spec       = "elasticsearch.sn2ne.large"
   data_node_disk_size  = "20"
   data_node_disk_type  = "cloud_ssd"
+  client_node_amount   = "2"
+  client_node_spec     = "elasticsearch.sn2ne.large"
   vswitch_id           = "some vswitch id"
   password             = "Your password"
   version              = "5.5.3_with_X-Pack"
@@ -64,6 +66,8 @@ The following arguments are supported:
 * `kibana_private_whitelist` - (Optional, Available in v1.87.0+) Set the Kibana's IP whitelist in private network.
 * `enable_kibana_private_network` - (Optional, Available in v1.87.0+) Bool, default to false. When it set to true, the instance can close kibana private network access。
 * `master_node_spec` - (Optional) The dedicated master node spec. If specified, dedicated master node will be created.
+* `client_node_amount` - (Optional, Available in v1.101.0+) The Elasticsearch cluster's client node quantity, between 2 and 25.
+* `client_node_spec` - (Optional, Available in v1.101.0+) The client node spec. If specified, client node will be created.
 * `zone_count` - (Optional, Available in 1.44.0+) The Multi-AZ supported for Elasticsearch, between 1 and 3. The `data_node_amount` value must be an integral multiple of the `zone_count` value.
 * `tags` - (Optional, Available in v1.73.0+) A mapping of tags to assign to the resource. 
   - key: It can be up to 128 characters in length. It cannot begin with "aliyun", "acs:". It cannot contain "http://" and "https://". It cannot be a null string.

--- a/website/docs/r/elasticsearch.html.markdown
+++ b/website/docs/r/elasticsearch.html.markdown
@@ -28,6 +28,7 @@ resource "alicloud_elasticsearch_instance" "instance" {
   data_node_disk_type  = "cloud_ssd"
   client_node_amount   = "2"
   client_node_spec     = "elasticsearch.sn2ne.large"
+  protocol             = "HTTPS"
   vswitch_id           = "some vswitch id"
   password             = "Your password"
   version              = "5.5.3_with_X-Pack"
@@ -68,6 +69,7 @@ The following arguments are supported:
 * `master_node_spec` - (Optional) The dedicated master node spec. If specified, dedicated master node will be created.
 * `client_node_amount` - (Optional, Available in v1.101.0+) The Elasticsearch cluster's client node quantity, between 2 and 25.
 * `client_node_spec` - (Optional, Available in v1.101.0+) The client node spec. If specified, client node will be created.
+* `protocol` - (Optional, Available in v1.101.0+) Elasticsearch protocol. Supported values: `HTTP`, `HTTPS`.default is `HTTP`.
 * `zone_count` - (Optional, Available in 1.44.0+) The Multi-AZ supported for Elasticsearch, between 1 and 3. The `data_node_amount` value must be an integral multiple of the `zone_count` value.
 * `tags` - (Optional, Available in v1.73.0+) A mapping of tags to assign to the resource. 
   - key: It can be up to 128 characters in length. It cannot begin with "aliyun", "acs:". It cannot contain "http://" and "https://". It cannot be a null string.


### PR DESCRIPTION
# Description
elasticsearch instance support configuration 'client node' and 'protocol'


# Acceptance Test
--- PASS: TestAccAlicloudElasticsearchInstance_basic (19685.08s)
PASS
--- PASS: TestAccAlicloudElasticsearchInstance_encrypt_disk (3666.08s)
PASS
--- PASS: TestAccAlicloudElasticsearchInstance_multi (3159.57s)
PASS
--- PASS: TestAccAlicloudElasticsearchInstance_multizone (3639.55s)
PASS
--- PASS: TestAccAlicloudElasticsearchInstance_version (6113.09s)
PASS
--- PASS: TestAccAlicloudElasticsearchInstance_client_node (8049.87s)
PASS
--- PASS: TestAccAlicloudElasticsearchInstance_https (10580.06s)
PASS