### PR TITLE
bug fix: The managed k8s does not display connections information

### DIFF
--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -964,38 +964,38 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 	// Get slb information
 	connection := make(map[string]string)
 
+	request := slb.CreateDescribeLoadBalancersRequest()
 	if len(masterNodes) != 0 {
-		request := slb.CreateDescribeLoadBalancersRequest()
 		request.ServerId = masterNodes[0]["id"].(string)
-		raw, err := client.WithSlbClient(func(slbClient *slb.Client) (interface{}, error) {
-			return slbClient.DescribeLoadBalancers(request)
-		})
-		if err != nil {
-			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
-		}
-		addDebug(request.GetActionName(), raw, request.RpcRequest, request)
-		lbs, _ := raw.(*slb.DescribeLoadBalancersResponse)
-		for _, lb := range lbs.LoadBalancers.LoadBalancer {
-			if strings.ToLower(lb.AddressType) == strings.ToLower(string(Internet)) {
-				d.Set("slb_internet", lb.LoadBalancerId)
-				connection["api_server_internet"] = fmt.Sprintf("https://%s:6443", lb.Address)
-				connection["master_public_ip"] = lb.Address
-			} else {
-				d.Set("slb_intranet", lb.LoadBalancerId)
-				connection["api_server_intranet"] = fmt.Sprintf("https://%s:6443", lb.Address)
+	}
+	raw, err := client.WithSlbClient(func(slbClient *slb.Client) (interface{}, error) {
+		return slbClient.DescribeLoadBalancers(request)
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+	}
+	addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+	lbs, _ := raw.(*slb.DescribeLoadBalancersResponse)
+	for _, lb := range lbs.LoadBalancers.LoadBalancer {
+		if strings.ToLower(lb.AddressType) == strings.ToLower(string(Internet)) {
+			d.Set("slb_internet", lb.LoadBalancerId)
+			connection["api_server_internet"] = fmt.Sprintf("https://%s:6443", lb.Address)
+			connection["master_public_ip"] = lb.Address
+		} else {
+			d.Set("slb_intranet", lb.LoadBalancerId)
+			connection["api_server_intranet"] = fmt.Sprintf("https://%s:6443", lb.Address)
 
-				reqVpc := vpc.CreateDescribeEipAddressesRequest()
-				reqVpc.AssociatedInstanceId = lb.LoadBalancerId
-				reqVpc.AssociatedInstanceType = "SlbInstance"
-				raw, err = client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
-					return vpcClient.DescribeEipAddresses(reqVpc)
-				})
-				eip, _ := raw.(*vpc.DescribeEipAddressesResponse)
-				if eip != nil && len(eip.EipAddresses.EipAddress) > 0 {
-					eipAddr := eip.EipAddresses.EipAddress[0].IpAddress
-					connection["master_public_ip"] = eipAddr
-					connection["api_server_internet"] = fmt.Sprintf("https://%s:6443", eipAddr)
-				}
+			reqVpc := vpc.CreateDescribeEipAddressesRequest()
+			reqVpc.AssociatedInstanceId = lb.LoadBalancerId
+			reqVpc.AssociatedInstanceType = "SlbInstance"
+			raw, err = client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+				return vpcClient.DescribeEipAddresses(reqVpc)
+			})
+			eip, _ := raw.(*vpc.DescribeEipAddressesResponse)
+			if eip != nil && len(eip.EipAddresses.EipAddress) > 0 {
+				eipAddr := eip.EipAddresses.EipAddress[0].IpAddress
+				connection["master_public_ip"] = eipAddr
+				connection["api_server_internet"] = fmt.Sprintf("https://%s:6443", eipAddr)
 			}
 		}
 	}
@@ -1005,7 +1005,7 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("connections", connection)
 	natRequest := vpc.CreateDescribeNatGatewaysRequest()
 	natRequest.VpcId = object.VpcId
-	raw, err := client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
+	raw, err = client.WithVpcClient(func(vpcClient *vpc.Client) (interface{}, error) {
 		return vpcClient.DescribeNatGateways(natRequest)
 	})
 	if err != nil {

--- a/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
@@ -387,7 +387,7 @@ func resourceAlicloudCSNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 
 	if d.HasChange("enable_auto_scaling") {
 		update = true
-		args.AutoScaling.EnableAutoScaling = d.Get("enable_auto_scaling").(bool)
+		args.AutoScaling.Enable = d.Get("enable_auto_scaling").(bool)
 	}
 
 	if d.HasChange("max") {
@@ -467,7 +467,7 @@ func resourceAlicloudCSNodePoolRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("max", object.MaxInstance)
 	}
 	if _, ok := d.GetOk("enable_auto_scaling"); ok {
-		d.Set("enable_auto_scaling", object.EnableAutoScaling)
+		d.Set("enable_auto_scaling", object.Enable)
 	}
 	if sg, ok := d.GetOk("min"); ok && sg.(string) != "" {
 		d.Set("min", object.MinInstance)
@@ -592,10 +592,10 @@ func buildNodePoolArgs(d *schema.ResourceData, meta interface{}) (*cs.CreateNode
 	if v, ok := d.GetOk("enable_auto_scaling"); ok {
 		if enable, ok := v.(bool); ok && enable {
 			creationArgs.AutoScaling = cs.AutoScaling{
-				EnableAutoScaling: true,
-				MaxInstance:       int64(d.Get("max").(int)),
-				MinInstance:       int64(d.Get("min").(int)),
-				Type:              d.Get("type").(string),
+				Enable:      true,
+				MaxInstance: int64(d.Get("max").(int)),
+				MinInstance: int64(d.Get("min").(int)),
+				Type:        d.Get("type").(string),
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aliyun/credentials-go v1.1.2
 	github.com/aliyun/fc-go-sdk v0.0.0-20200925033337-c013428cbe21
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
-	github.com/denverdino/aliyungo v0.0.0-20201012074500-9311540c3f72
+	github.com/denverdino/aliyungo v0.0.0-20201022023337-dbe44e48e083
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/gogap/errors v0.0.0-20160523102334-149c546090d0 // indirect
 	github.com/gogap/stack v0.0.0-20150131034635-fef68dddd4f8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denverdino/aliyungo v0.0.0-20201012074500-9311540c3f72 h1:MMjMIwHW3XO7x82o/TIqf1CJUX5fcw9oQTHGKl79yH4=
 github.com/denverdino/aliyungo v0.0.0-20201012074500-9311540c3f72/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
+github.com/denverdino/aliyungo v0.0.0-20201022023337-dbe44e48e083 h1:fVr4tjtO8Z6zdb9SW5lpbz8m1vcBMbRS7A5OZ0wRatg=
+github.com/denverdino/aliyungo v0.0.0-20201022023337-dbe44e48e083/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/vendor/github.com/denverdino/aliyungo/cs/node_pool.go
+++ b/vendor/github.com/denverdino/aliyungo/cs/node_pool.go
@@ -35,10 +35,10 @@ type ScalingGroup struct {
 }
 
 type AutoScaling struct {
-	EnableAutoScaling bool   `json:"enable_auto_scaling"`
-	MaxInstance       int64  `json:"max_instance"`
-	MinInstance       int64  `json:"min_instance"`
-	Type              string `json:"type"`
+	Enable      bool   `json:"enable"`
+	MaxInstance int64  `json:"max_instance"`
+	MinInstance int64  `json:"min_instance"`
+	Type        string `json:"type"`
 }
 
 type KubernetesConfig struct {

--- a/vendor/github.com/denverdino/aliyungo/ecs/instance_types.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/instance_types.go
@@ -4,6 +4,7 @@ import "github.com/denverdino/aliyungo/common"
 
 type DescribeInstanceTypesArgs struct {
 	InstanceTypeFamily string
+	InstanceTypes      []string `query:"list"`
 }
 
 //

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -161,7 +161,7 @@ github.com/bgentry/speakeasy
 github.com/cenkalti/backoff
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
-# github.com/denverdino/aliyungo v0.0.0-20201012074500-9311540c3f72
+# github.com/denverdino/aliyungo v0.0.0-20201022023337-dbe44e48e083
 github.com/denverdino/aliyungo/cdn
 github.com/denverdino/aliyungo/common
 github.com/denverdino/aliyungo/cs

--- a/website/docs/d/cs_managed_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_managed_kubernetes_clusters.html.markdown
@@ -59,8 +59,9 @@ The following attributes are exported in addition to the arguments listed above:
     * `project` - Log Service project name. 
   * `resource_group_id` - (Optional, ForceNew, Available in 1.101.0+) The ID of the resource group,by default these cloud resources are automatically assigned to the default resource group.
   * `cluster_spec` - (Optional, ForceNew, Available in 1.101.0+) The cluster specifications of kubernetes cluster,which can be empty.Valid values:
-    - `ack.standard` - Standard managed clusters.
-    - `ack.pro.small` -  Professional managed clusters.
+    - ack.standard: Standard managed clusters.
+    - ack.pro.small: Professional managed clusters.
+
 ### Block Nodes
 
 * `id` - ID of the node.

--- a/website/docs/r/cs_kubernetes.html.markdown
+++ b/website/docs/r/cs_kubernetes.html.markdown
@@ -71,6 +71,7 @@ resource "alicloud_cs_kubernetes" "k8s" {
       content {
         name                    = lookup(addons.value, "name", var.cluster_addons)
         config                  = lookup(addons.value, "config", var.cluster_addons)
+        disabled                = lookup(addons.value, "disabled", var.cluster_addons)
       }
   }
 }

--- a/website/docs/r/cs_kubernetes.html.markdown
+++ b/website/docs/r/cs_kubernetes.html.markdown
@@ -122,6 +122,7 @@ It is a new field since 1.75.0. You can specific network plugin,log component,in
       content {
         name                    = lookup(addons.value, "name", var.cluster_addons)
         config                  = lookup(addons.value, "config", var.cluster_addons)
+        disabled                = lookup(addons.value, "disabled", var.cluster_addons)
       }
   }
 ```

--- a/website/docs/r/cs_kubernetes.html.markdown
+++ b/website/docs/r/cs_kubernetes.html.markdown
@@ -109,6 +109,7 @@ The following arguments are supported:
 * `service_account_issuer` - (Optional, ForceNew, Available in 1.92.0+) The issuer of the Service Account token for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm), corresponds to the `iss` field in the token payload. Set this to `"kubernetes.default.svc"` to enable the Token Volume Projection feature (requires specifying `api_audiences` as well).
 * `api_audiences` - (Optional, ForceNew, Available in 1.92.0+) A list of API audiences for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm). Set this to `["kubernetes.default.svc"]` if you want to enable the Token Volume Projection feature (requires specifying `service_account_issuer` as well.
 * `tags` - (Optional, Available in 1.97.0+) Default nil, A map of tags assigned to the kubernetes cluster .
+* `resource_group_id` - (Optional, ForceNew, Available in 1.101.0+) The ID of the resource group,by default these cloud resources are automatically assigned to the default resource group.
 
 #### Addons 
 It is a new field since 1.75.0. You can specific network plugin,log component,ingress component and so on.     

--- a/website/docs/r/cs_managed_kubernetes.html.markdown
+++ b/website/docs/r/cs_managed_kubernetes.html.markdown
@@ -112,6 +112,11 @@ The following arguments are supported:
 * `service_account_issuer` - (Optional, ForceNew, Available in 1.92.0+) The issuer of the Service Account token for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm), corresponds to the `iss` field in the token payload. Set this to `kubernetes.default.svc` to enable the Token Volume Projection feature.
 * `api_audiences` - (Optional, ForceNew, Available in 1.92.0+) A list of API audiences for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm). Set this to `["kubernetes.default.svc"]` if you want to enable the Token Volume Projection feature.
 * `tags` - (Optional, Available in 1.97.0+) Default nil, A map of tags assigned to the kubernetes cluster .
+* `resource_group_id` - (Optional, ForceNew, Available in 1.101.0+) The ID of the resource group,by default these cloud resources are automatically assigned to the default resource group.
+* `cluster_spec` - (Optional, ForceNew, Available in 1.101.0+) The cluster specifications of kubernetes cluster,which can be empty.Valid values:
+  - ack.standard: Standard managed clusters.
+  - ack.pro.small:  Professional managed clusters.
+
 
 #### Addons 
 It is a new field since 1.75.0. You can specific network plugin,log component,ingress component and so on.     

--- a/website/docs/r/cs_managed_kubernetes.html.markdown
+++ b/website/docs/r/cs_managed_kubernetes.html.markdown
@@ -131,6 +131,7 @@ It is a new field since 1.75.0. You can specific network plugin,log component,in
       content {
         name                    = lookup(addons.value, "name", var.cluster_addons)
         config                  = lookup(addons.value, "config", var.cluster_addons)
+        disabled                = lookup(addons.value, "disabled", var.cluster_addons)
       }
   }
 ```

--- a/website/docs/r/cs_serverless_kubernetes.html.markdown
+++ b/website/docs/r/cs_serverless_kubernetes.html.markdown
@@ -90,6 +90,7 @@ The following arguments are supported:
 * `client_key` - (Optional) The path of client key, like `~/.kube/client-key.pem`.
 * `cluster_ca_cert` - (Optional) The path of cluster ca certificate, like `~/.kube/cluster-ca-cert.pem`
 * `security_group_id` - (Optional, Available in 1.91.0+) The ID of the security group to which the ECS instances in the cluster belong. If it is not specified, a new Security group will be built.
+* `resource_group_id` - (Optional, ForceNew, Available in 1.101.0+) The ID of the resource group,by default these cloud resources are automatically assigned to the default resource group.
 
 
 #### Addons 

--- a/website/docs/r/cs_serverless_kubernetes.html.markdown
+++ b/website/docs/r/cs_serverless_kubernetes.html.markdown
@@ -104,6 +104,7 @@ It is a new field since 1.91.0. You can specific network plugin,log component,in
       content {
         name                    = lookup(addons.value, "name", var.cluster_addons)
         config                  = lookup(addons.value, "config", var.cluster_addons)
+        disabled                = lookup(addons.value, "disabled", var.cluster_addons)
       }
   }
 ```


### PR DESCRIPTION
// 托管版集群创建完成后，connections信息只输出了service_domain。terraform.tfstate
"connections": {
              "api_server_internet": "https://xx",
              "api_server_intranet": "https://xx",
              "master_public_ip": "xx",
              "service_domain": "xx"
}

EnableAutoScaling 这个字段的修改，是因为SDK 变了