### PR TITLE
Remove Japan site

### DIFF
--- a/website/docs/guides/getting-account.html.md
+++ b/website/docs/guides/getting-account.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # Getting an Alibaba Cloud Account
 
-The Alibaba Cloud has three accounts: International-Site Account, China-Site Account and JP-Site Account.
+The Alibaba Cloud has two accounts: International-Site Account and China-Site Account.
 In most cases the account type makes no difference when creating Alibaba Cloud resources.
 However, based on some internal reason, when using Terraform to manage cloud resources
 a few products and resources have different limitations when using different account types.
@@ -27,15 +27,9 @@ The China-Site website has a diferent URL. To sign up for a China-Site account, 
 [Alibaba Cloud China-Site Website](https://www.aliyun.com/).
 For more account registration details, see [Sign up with Alibaba Cloud](https://help.aliyun.com/knowledge_detail/37195.html)
 
-## Sign Up for an Alibaba Cloud JP-Site Account
-
-JP-Site (Japan-Site) also has a separate/standalone website. To sign up for a JP-Site account, visit
-[Alibaba Cloud JP-Site Website](https://jp.alibabacloud.com/).
-For more account registration details, see [Sign up with Alibaba Cloud](https://www.alibabacloud.com/help/doc-detail/50482.html)
-
 ## How to Distinguish Account Types
 
-There is a simple method to check whether an Alibaba Cloud account is an International-Site, China-Site, or JP-Site account:
-An account can only access its corresponding site. That is, an International-Site account can only login to the [International-Site Website](https://www.alibabacloud.com/),
-a China-Site account to the [China-Site Website](https://www.aliyun.com/), and a JP-Site to the [JP-Site Website](https://jp.alibabacloud.com/).
+There is a simple method to check whether an Alibaba Cloud account is an International-Site or China-Site account:
+An account can only access its corresponding site. That is, an International-Site account can only login to the [International-Site Website](https://www.alibabacloud.com/) and
+a China-Site account to the [China-Site Website](https://www.aliyun.com/).
 


### PR DESCRIPTION
The Japan site of Alibaba Cloud is deprecated. This PR removes information on creating a new account on the site.

I will provide you with a summary of relevant news releases:

> The Alibaba Cloud Japan (JP) site stopped registration on 2020-06-25. Customers residing in Japan are now accepted in the international site.

https://jp.alibabacloud.com/notice/account-stop-20200619?spm=a21mg.8121077.6051337650.2.36e53e13hoLn5V

> It's going to stop service on 2021-03-31, and existing customers of the JP site must apply for account migration to the international site by 2021-02-26. If the user doesn't migrate the account, all of the data on the JP site will become unavailable.

https://jp.alibabacloud.com/notice/account-migration-20200924?spm=a21mg.8121077.6051337650.1.36e53e13hoLn5V