### PR TITLE
resource/alicloud_kvstore_instance: Converts auto_renew attribute to bool before saving

### DIFF
--- a/alicloud/resource_alicloud_kvstore_instance.go
+++ b/alicloud/resource_alicloud_kvstore_instance.go
@@ -604,7 +604,12 @@ func resourceAlicloudKvstoreInstanceRead(d *schema.ResourceData, meta interface{
 		if err != nil {
 			return WrapError(err)
 		}
-		d.Set("auto_renew", describeInstanceAutoRenewalAttributeObject.AutoRenew)
+		autoRenew, err := strconv.ParseBool(describeInstanceAutoRenewalAttributeObject.AutoRenew)
+		if err != nil {
+			// invalid request response
+			return WrapError(err)
+		}
+		d.Set("auto_renew", autoRenew)
 		d.Set("auto_renew_period", describeInstanceAutoRenewalAttributeObject.Duration)
 	}
 	//refresh parameters


### PR DESCRIPTION
The problem: can't refresh `auto_renew` field

The `AutoRenew` field in API response is type string:

```
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: *************** DescribeInstanceAutoRenewalAttribute Response *************** 
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: HTTP/1.1 200 OK
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: Access-Control-Max-Age: 172800
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: X-Acs-Request-Id: 53DBD88B-AD15-4096-93FF-5E957978B772
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: Content-Length: 224
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: Access-Control-Allow-Methods: POST, GET, OPTIONS
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: Connection: keep-alive
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: Access-Control-Allow-Origin: *
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: Access-Control-Allow-Headers: X-Requested-With, X-Sequence, _aop_secret, _aop_signature
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: Date: Wed, 25 Nov 2020 03:16:29 GMT
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: Content-Type: application/json;charset=utf-8
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: 
2020-11-25T11:16:29.042+0800 [DEBUG] plugin.terraform-provider-alicloud_v1.102.0+6.4421b545: {"TotalRecordCount":1,"PageRecordCount":1,"RequestId":"53DBD88B-AD15-4096-93FF-5E957978B772","PageNumber":1,"Items":{"Item":[{"DBInstanceId":"r-uf6jtn1bwg5ej0hbwm","AutoRenew":"true","Duration":1,"RegionId":"cn-shanghai"}]}}
```

So we need to convert it to bool type first.