### PR TITLE
resource/alicloud_kvstore_instance: Supports to set readone, readthree, readfive node types

### DIFF
--- a/alicloud/resource_alicloud_kvstore_instance.go
+++ b/alicloud/resource_alicloud_kvstore_instance.go
@@ -186,7 +186,7 @@ func resourceAlicloudKvstoreInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"MASTER_SLAVE", "STAND_ALONE", "double", "single"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"MASTER_SLAVE", "STAND_ALONE", "double", "single", "readone", "readthree", "readfive"}, false),
 				Default:      "double",
 			},
 			"order_type": {

--- a/website/docs/r/kvstore_instance.html.markdown
+++ b/website/docs/r/kvstore_instance.html.markdown
@@ -127,7 +127,7 @@ or referring to help-docs [Instance type table](https://www.alibabacloud.com/hel
 * `connection_string_prefix` - (Optional, Available in v1.94.0+) It has been deprecated from provider version 1.101.0 and resource `alicloud_kvstore_connection` instead.
 * `port` - (Optional, Available in v1.94.0+) It has been deprecated from provider version 1.101.0 and resource `alicloud_kvstore_connection` instead.
 * `order_type`- (Optional, Available in 1.101.0+) Specifies a change type when you change the configuration of a subscription instance. Valid values: `UPGRADE`, `DOWNGRADE`. Default to `UPGRADE`. `UPGRADE` means upgrades the configuration of a subscription instance. `DOWNGRADE` means downgrades the configuration of a subscription instance.
-* `node_type`- (Optional, Available in 1.101.0+) Valid values: `MASTER_SLAVE`, `STAND_ALONE`, `double` and `single`. Default to `double`.
+* `node_type`- (Optional, Available in 1.101.0+) Valid values: `MASTER_SLAVE`, `STAND_ALONE`, `double`, `single`, `readone`, `readthree` and `readfive`. Default to `double`.
 * `ssl_enable`- (Optional, Available in 1.101.0+) Modifies the SSL status. Valid values: `Disable`, `Enable` and `Update`.
 * `force_upgrade`- (Optional, Available in 1.101.0+) Specifies whether to forcibly change the type. Default to: `true`.
 * `effective_time`- (Optional, Available in 1.101.0+) Specifies when this operation is changed. Valid values: `0`, `1`. Default to: `0`. `0` means immediately changes the type. `1` means changes the type within the maintenance window.


### PR DESCRIPTION
Some kvstore classes has node types `readone`, `readtree`, and `readfive`.

https://github.com/aliyun/terraform-provider-alicloud/blob/17ad012ff5db33eb01ef5faa3c9faab33a01f338/alicloud/data_source_alicloud_kvstore_instance_classes.go#L82-L87

```
$ aliyun r-kvstore DescribeAvailableResource  | jq -r '.AvailableZones.AvailableZone[] | .SupportedEngines.SupportedEngine[] | .SupportedEditionTypes.SupportedEditionType[] | .SupportedSeriesTypes.SupportedSeriesType[] | .SupportedEngineVersions.SupportedEngineVersion[] | .SupportedArchitectureTypes.SupportedArchitectureType[] | .SupportedShardNumbers.SupportedShardNumber[] | .SupportedNodeTypes.SupportedNodeType[] | .SupportedNodeType' | sort | uniq -c
    371 double
     35 readfive
     35 readone
     35 readthree
    200 single
```