### PR TITLE
resource/alicloud_cms?alarm: Adds statistics more valid values: Value, Sum, Count

### DIFF
--- a/alicloud/extension_cms.go
+++ b/alicloud/extension_cms.go
@@ -5,6 +5,9 @@ const (
 	Minimum          = "Minimum"
 	Maximum          = "Maximum"
 	ErrorCodeMaximum = "ErrorCodeMaximum"
+	Value            = "Value"
+	Sum              = "Sum"
+	Count            = "Count"
 )
 
 const (

--- a/alicloud/resource_alicloud_cms_alarm.go
+++ b/alicloud/resource_alicloud_cms_alarm.go
@@ -62,7 +62,7 @@ func resourceAlicloudCmsAlarm() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      Average,
-							ValidateFunc: validation.StringInSlice([]string{Average, Minimum, Maximum, ErrorCodeMaximum}, false),
+							ValidateFunc: validation.StringInSlice([]string{Average, Minimum, Maximum, ErrorCodeMaximum, Value, Sum, Count}, false),
 						},
 						"comparison_operator": {
 							Type:     schema.TypeString,
@@ -95,7 +95,7 @@ func resourceAlicloudCmsAlarm() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      Average,
-							ValidateFunc: validation.StringInSlice([]string{Average, Minimum, Maximum, ErrorCodeMaximum}, false),
+							ValidateFunc: validation.StringInSlice([]string{Average, Minimum, Maximum, ErrorCodeMaximum, Value, Sum, Count}, false),
 						},
 						"comparison_operator": {
 							Type:     schema.TypeString,
@@ -128,7 +128,7 @@ func resourceAlicloudCmsAlarm() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      Average,
-							ValidateFunc: validation.StringInSlice([]string{Average, Minimum, Maximum, ErrorCodeMaximum}, false),
+							ValidateFunc: validation.StringInSlice([]string{Average, Minimum, Maximum, ErrorCodeMaximum, Value, Sum, Count}, false),
 						},
 						"comparison_operator": {
 							Type:     schema.TypeString,
@@ -156,7 +156,7 @@ func resourceAlicloudCmsAlarm() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{Average, Minimum, Maximum, ErrorCodeMaximum}, false),
+				ValidateFunc: validation.StringInSlice([]string{Average, Minimum, Maximum, ErrorCodeMaximum, Value, Sum, Count}, false),
 				Deprecated:   "Field 'statistics' has been deprecated from provider version 1.94.0. New field 'escalations_critical.statistics' instead.",
 			},
 			"operator": {


### PR DESCRIPTION
The statistics's value in resource "alicloud_cms_alarm" should be allowed to set as Value,Sum,Count.
In some product such as [API Gateway](https://www.alibabacloud.com/help/doc-detail/164689.htm),[Kafka](https://www.alibabacloud.com/help/doc-detail/165126.htm), the statistics of metrics should not be "Average", "Minimum", "Maximum" or "ErrorCodeMaximum".