### PR TITLE
resource/alicloud_alikafka_topic: Supports setting self-define create timeout. 

### DIFF
--- a/alicloud/resource_alicloud_alikafka_sasl_acl.go
+++ b/alicloud/resource_alicloud_alikafka_sasl_acl.go
@@ -106,7 +106,7 @@ func resourceAlicloudAlikafkaSaslAclCreate(d *schema.ResourceData, meta interfac
 	}
 
 	// Server may have cache, sleep a while.
-	time.Sleep(2 * time.Second)
+	time.Sleep(60 * time.Second)
 	d.SetId(fmt.Sprintf("%s:%s:%s:%s:%s:%s", instanceId, username, aclResourceType, aclResourceName, aclResourcePatternType, aclOperationType))
 	return resourceAlicloudAlikafkaSaslAclRead(d, meta)
 }
@@ -185,5 +185,7 @@ func resourceAlicloudAlikafkaSaslAclDelete(d *schema.ResourceData, meta interfac
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
 
+	// Server may have cache, sleep a while.
+	time.Sleep(60 * time.Second)
 	return WrapError(alikafkaService.WaitForAlikafkaSaslAcl(d.Id(), Deleted, DefaultTimeoutMedium))
 }

--- a/alicloud/resource_alicloud_alikafka_topic.go
+++ b/alicloud/resource_alicloud_alikafka_topic.go
@@ -26,8 +26,6 @@ func resourceAlicloudAlikafkaTopic() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/alicloud/resource_alicloud_alikafka_topic.go
+++ b/alicloud/resource_alicloud_alikafka_topic.go
@@ -24,6 +24,12 @@ func resourceAlicloudAlikafkaTopic() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"instance_id": {
 				Type:     schema.TypeString,
@@ -111,7 +117,12 @@ func resourceAlicloudAlikafkaTopicCreate(d *schema.ResourceData, meta interface{
 
 	d.SetId(instanceId + ":" + topic)
 
-	alikafkaService.WaitForAlikafkaTopicStatus(d.Id(), DefaultTimeoutMedium)
+	// wait topic status change from Creating to running
+	stateConf := BuildStateConf([]string{"Creating"}, []string{"Running"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, alikafkaService.KafkaTopicStatusRefreshFunc(d.Id()))
+
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
 
 	return resourceAlicloudAlikafkaTopicUpdate(d, meta)
 }

--- a/alicloud/resource_alicloud_alikafka_topic.go
+++ b/alicloud/resource_alicloud_alikafka_topic.go
@@ -95,7 +95,7 @@ func resourceAlicloudAlikafkaTopicCreate(d *schema.ResourceData, meta interface{
 			return alikafkaClient.CreateTopic(request)
 		})
 		if err != nil {
-			if IsExpectedErrors(err, []string{ThrottlingUser}) {
+			if IsExpectedErrors(err, []string{ThrottlingUser, "ONS_SYSTEM_FLOW_CONTROL"}) {
 				time.Sleep(10 * time.Second)
 				return resource.RetryableError(err)
 			}
@@ -110,6 +110,9 @@ func resourceAlicloudAlikafkaTopicCreate(d *schema.ResourceData, meta interface{
 	}
 
 	d.SetId(instanceId + ":" + topic)
+
+	alikafkaService.WaitForAlikafkaTopicStatus(d.Id(), DefaultTimeoutMedium)
+
 	return resourceAlicloudAlikafkaTopicUpdate(d, meta)
 }
 
@@ -176,7 +179,7 @@ func resourceAlicloudAlikafkaTopicUpdate(d *schema.ResourceData, meta interface{
 					return alikafkaClient.ModifyPartitionNum(modifyPartitionReq)
 				})
 				if err != nil {
-					if IsExpectedErrors(err, []string{ThrottlingUser}) {
+					if IsExpectedErrors(err, []string{ThrottlingUser, "ONS_SYSTEM_FLOW_CONTROL"}) {
 						time.Sleep(10 * time.Second)
 						return resource.RetryableError(err)
 					}
@@ -249,7 +252,7 @@ func resourceAlicloudAlikafkaTopicDelete(d *schema.ResourceData, meta interface{
 			return alikafkaClient.DeleteTopic(request)
 		})
 		if err != nil {
-			if IsExpectedErrors(err, []string{ThrottlingUser}) {
+			if IsExpectedErrors(err, []string{ThrottlingUser, "ONS_SYSTEM_FLOW_CONTROL"}) {
 				time.Sleep(10 * time.Second)
 				return resource.RetryableError(err)
 			}

--- a/alicloud/service_alicloud_alikafka.go
+++ b/alicloud/service_alicloud_alikafka.go
@@ -224,7 +224,7 @@ func (alikafkaService *AlikafkaService) DescribeAlikafkaTopicStatus(id string) (
 		return &topicStatusResp.TopicStatus, nil
 	}
 
-	return alikafkaTopicStatus, WrapErrorf(Error(GetNotFoundMessage("AlikafkaTopicStatus " + ResourceNotfound, id)), ResourceNotfound)
+	return alikafkaTopicStatus, WrapErrorf(Error(GetNotFoundMessage("AlikafkaTopicStatus "+ResourceNotfound, id)), ResourceNotfound)
 }
 
 func (alikafkaService *AlikafkaService) DescribeAlikafkaTopic(id string) (*alikafka.TopicVO, error) {

--- a/alicloud/service_alicloud_alikafka.go
+++ b/alicloud/service_alicloud_alikafka.go
@@ -511,28 +511,6 @@ func (s *AlikafkaService) KafkaTopicStatusRefreshFunc(id string) resource.StateR
 	}
 }
 
-func (s *AlikafkaService) WaitForAlikafkaTopicStatus(id string, timeout int) error {
-
-	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
-	for {
-		object, err := s.DescribeAlikafkaTopicStatus(id)
-		if err != nil {
-			if !IsExpectedErrors(err, []string{ResourceNotfound}) {
-				return WrapError(err)
-			}
-		}
-
-		if object.OffsetTable.OffsetTableItem != nil && len(object.OffsetTable.OffsetTableItem) > 0 {
-			return nil
-		}
-
-		if time.Now().After(deadline) {
-			return WrapErrorf(err, WaitTimeoutMsg, id, GetFunc(1), timeout, object, id, ProviderERROR)
-		}
-		time.Sleep(DefaultIntervalShort * time.Second)
-	}
-}
-
 func (s *AlikafkaService) WaitForAlikafkaTopic(id string, status Status, timeout int) error {
 	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
 	for {

--- a/website/docs/r/alikafka_topic.html.markdown
+++ b/website/docs/r/alikafka_topic.html.markdown
@@ -84,3 +84,11 @@ ALIKAFKA TOPIC can be imported using the id, e.g.
 ```
 $ terraform import alicloud_alikafka_topic.topic alikafka_post-cn-123455abc:topicName
 ```
+
+### Timeouts
+
+-> **NOTE:** Available in v1.119.0+.
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration-0-11/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 10 mins) Used when creating the topic (until it reaches the initial `Running` status). 


### PR DESCRIPTION
1. Synchronize to create kafka topic
2. Retry to create or delete resource if encounters the flow control