### PR TITLE
Vswitch ipv6

### DIFF
--- a/alicloud/data_source_alicloud_vswitches.go
+++ b/alicloud/data_source_alicloud_vswitches.go
@@ -20,6 +20,11 @@ func dataSourceAlicloudVswitches() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"ipv6_cidr_block": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
 			"dry_run": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -104,6 +109,10 @@ func dataSourceAlicloudVswitches() *schema.Resource {
 						},
 						"cidr_block": {
 							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ipv6_cidr_block": {
+							Type: 	  schema.TypeInt,
 							Computed: true,
 						},
 						"description": {
@@ -275,6 +284,7 @@ func dataSourceAlicloudVswitchesRead(d *schema.ResourceData, meta interface{}) e
 			"creation_time":              object["CreationTime"],
 			"available_ip_address_count": object["AvailableIpAddressCount"],
 			"cidr_block":                 object["CidrBlock"],
+			"ipv6_cidr_block":            object["Ipv6CidrBlock"],
 			"description":                object["Description"],
 			"is_default":                 object["IsDefault"],
 			"resource_group_id":          object["ResourceGroupId"],

--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -97,7 +97,7 @@ func resourceAlicloudVswitchCreate(d *schema.ResourceData, meta interface{}) err
 	}
 	request["CidrBlock"] = d.Get("cidr_block")
 	if v, ok := d.GetOk("ipv6_cidr_block"); ok && v.(int) >= 0 {
-		request["Ipv6CidrBlock"] = v
+		request["Ipv6CidrBlock"] = v.(int)
 	}
 	if v, ok := d.GetOk("description"); ok {
 		request["Description"] = v

--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -29,6 +31,13 @@ func resourceAlicloudVswitch() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+			"ipv6_cidr_block": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 255),
+				Default:      0,
+				ForceNew:     true,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -87,6 +96,9 @@ func resourceAlicloudVswitchCreate(d *schema.ResourceData, meta interface{}) err
 		return WrapError(err)
 	}
 	request["CidrBlock"] = d.Get("cidr_block")
+	if v, ok := d.GetOk("ipv6_cidr_block"); ok && v.(int) >= 0 {
+		request["Ipv6CidrBlock"] = v
+	}
 	if v, ok := d.GetOk("description"); ok {
 		request["Description"] = v
 	}
@@ -148,6 +160,7 @@ func resourceAlicloudVswitchRead(d *schema.ResourceData, meta interface{}) error
 		return WrapError(err)
 	}
 	d.Set("cidr_block", object["CidrBlock"])
+	d.Set("ipv6_cidr_block", object["Ipv6CidrBlock"])
 	d.Set("description", object["Description"])
 	d.Set("status", object["Status"])
 	d.Set("vswitch_name", object["VSwitchName"])


### PR DESCRIPTION
I'm not sure how to write the go tests for this, but I have verified this works with the following HCL:
```
resource "alicloud_vpc" "vpc" {
  vpc_name   = "tf_test_foo"
  cidr_block = "172.16.0.0/12"
  enable_ipv6 = true
}

data "alicloud_zones" "zones"{

}

resource "alicloud_vswitch" "vsw" {
  vpc_id            = alicloud_vpc.vpc.id
  cidr_block        = "172.16.0.0/21"
  zone_id = data.alicloud_zones.zones.zones.0.id
  ipv6_cidr_block = 10
  provider = alibaba
}

resource "alicloud_vswitch" "vsw2" {
  vpc_id            = alicloud_vpc.vpc.id
  cidr_block        = "172.16.8.0/21"
  zone_id = data.alicloud_zones.zones.zones.0.id
  ipv6_cidr_block = 200
  provider = alibaba
}
```