### PR TITLE
docs/alicloud_vswitch: Replaces deprecated availability_zone with zone _id in the all of docs examples

### DIFF
--- a/website/docs/d/slb_master_slave_server_groups.html.markdown
+++ b/website/docs/d/slb_master_slave_server_groups.html.markdown
@@ -47,7 +47,7 @@ resource "alicloud_vpc" "main" {
 
 resource "alicloud_vswitch" "main" {
   vpc_id            = alicloud_vpc.main.id
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
   cidr_block = "172.16.0.0/16"
 }

--- a/website/docs/d/slb_master_slave_server_groups.html.markdown
+++ b/website/docs/d/slb_master_slave_server_groups.html.markdown
@@ -22,7 +22,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   eni_amount        = 2
 }
 

--- a/website/docs/d/slb_master_slave_server_groups.html.markdown
+++ b/website/docs/d/slb_master_slave_server_groups.html.markdown
@@ -22,7 +22,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   eni_amount        = 2
 }
 
@@ -47,7 +47,7 @@ resource "alicloud_vpc" "main" {
 
 resource "alicloud_vswitch" "main" {
   vpc_id            = alicloud_vpc.main.id
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
   cidr_block = "172.16.0.0/16"
 }

--- a/website/docs/d/slb_rules.html.markdown
+++ b/website/docs/d/slb_rules.html.markdown
@@ -31,7 +31,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  zone_id = data.alicloud_zones.default.zones.0.id
+  zone_id           = data.alicloud_zones.default.zones.0.id
   vswitch_name      = var.name
 }
 

--- a/website/docs/d/slb_rules.html.markdown
+++ b/website/docs/d/slb_rules.html.markdown
@@ -31,7 +31,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  availability_zone = data.alicloud_zones.default.zones.0.id
+  zone_id = data.alicloud_zones.default.zones.0.id
   vswitch_name      = var.name
 }
 

--- a/website/docs/d/slb_server_groups.html.markdown
+++ b/website/docs/d/slb_server_groups.html.markdown
@@ -31,7 +31,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/d/slb_server_groups.html.markdown
+++ b/website/docs/d/slb_server_groups.html.markdown
@@ -31,7 +31,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/adb_account.html.markdown
+++ b/website/docs/r/adb_account.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/adb_account.html.markdown
+++ b/website/docs/r/adb_account.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/adb_backup_policy.html.markdown
+++ b/website/docs/r/adb_backup_policy.html.markdown
@@ -37,7 +37,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/adb_backup_policy.html.markdown
+++ b/website/docs/r/adb_backup_policy.html.markdown
@@ -37,7 +37,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/adb_cluster.html.markdown
+++ b/website/docs/r/adb_cluster.html.markdown
@@ -42,7 +42,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/adb_cluster.html.markdown
+++ b/website/docs/r/adb_cluster.html.markdown
@@ -42,7 +42,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/adb_connection.html.markdown
+++ b/website/docs/r/adb_connection.html.markdown
@@ -39,7 +39,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/adb_connection.html.markdown
+++ b/website/docs/r/adb_connection.html.markdown
@@ -39,7 +39,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/adb_db_cluster.html.markdown
+++ b/website/docs/r/adb_db_cluster.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/adb_db_cluster.html.markdown
+++ b/website/docs/r/adb_db_cluster.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/alikafka_consumer_group.html.markdown
+++ b/website/docs/r/alikafka_consumer_group.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_alikafka_instance" "default" {

--- a/website/docs/r/alikafka_consumer_group.html.markdown
+++ b/website/docs/r/alikafka_consumer_group.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_alikafka_instance" "default" {

--- a/website/docs/r/alikafka_instance.html.markdown
+++ b/website/docs/r/alikafka_instance.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_alikafka_instance" "default" {

--- a/website/docs/r/alikafka_instance.html.markdown
+++ b/website/docs/r/alikafka_instance.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_alikafka_instance" "default" {

--- a/website/docs/r/alikafka_sasl_acl.html.markdown
+++ b/website/docs/r/alikafka_sasl_acl.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_alikafka_instance" "default" {

--- a/website/docs/r/alikafka_sasl_acl.html.markdown
+++ b/website/docs/r/alikafka_sasl_acl.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_alikafka_instance" "default" {

--- a/website/docs/r/alikafka_sasl_user.html.markdown
+++ b/website/docs/r/alikafka_sasl_user.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_alikafka_instance" "default" {

--- a/website/docs/r/alikafka_sasl_user.html.markdown
+++ b/website/docs/r/alikafka_sasl_user.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_alikafka_instance" "default" {

--- a/website/docs/r/alikafka_topic.html.markdown
+++ b/website/docs/r/alikafka_topic.html.markdown
@@ -32,7 +32,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_alikafka_instance" "default" {

--- a/website/docs/r/alikafka_topic.html.markdown
+++ b/website/docs/r/alikafka_topic.html.markdown
@@ -32,7 +32,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_alikafka_instance" "default" {

--- a/website/docs/r/auto_provisioning_group.html.markdown
+++ b/website/docs/r/auto_provisioning_group.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/auto_provisioning_group.html.markdown
+++ b/website/docs/r/auto_provisioning_group.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/cen_route_entry.html.markdown
+++ b/website/docs/r/cen_route_entry.html.markdown
@@ -36,7 +36,7 @@ data "alicloud_zones" "default" {
 
 data "alicloud_instance_types" "default" {
   provider          = alicloud.hz
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }

--- a/website/docs/r/cen_route_entry.html.markdown
+++ b/website/docs/r/cen_route_entry.html.markdown
@@ -58,7 +58,7 @@ resource "alicloud_vswitch" "default" {
   provider          = alicloud.hz
   vpc_id            = alicloud_vpc.vpc.id
   cidr_block        = "172.16.0.0/21"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/cen_route_entry.html.markdown
+++ b/website/docs/r/cen_route_entry.html.markdown
@@ -36,7 +36,7 @@ data "alicloud_zones" "default" {
 
 data "alicloud_instance_types" "default" {
   provider          = alicloud.hz
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }
@@ -58,7 +58,7 @@ resource "alicloud_vswitch" "default" {
   provider          = alicloud.hz
   vpc_id            = alicloud_vpc.vpc.id
   cidr_block        = "172.16.0.0/21"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/cs_serverless_kubernetes.html.markdown
+++ b/website/docs/r/cs_serverless_kubernetes.html.markdown
@@ -50,7 +50,7 @@ resource "alicloud_vswitch" "default" {
   vswitch_name      = var.name
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "10.1.1.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_cs_serverless_kubernetes" "serverless" {

--- a/website/docs/r/cs_serverless_kubernetes.html.markdown
+++ b/website/docs/r/cs_serverless_kubernetes.html.markdown
@@ -50,7 +50,7 @@ resource "alicloud_vswitch" "default" {
   vswitch_name      = var.name
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "10.1.1.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_cs_serverless_kubernetes" "serverless" {

--- a/website/docs/r/db_account.html.markdown
+++ b/website/docs/r/db_account.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_account.html.markdown
+++ b/website/docs/r/db_account.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_account_privilege.html.markdown
+++ b/website/docs/r/db_account_privilege.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_account_privilege.html.markdown
+++ b/website/docs/r/db_account_privilege.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_backup_policy.html.markdown
+++ b/website/docs/r/db_backup_policy.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_backup_policy.html.markdown
+++ b/website/docs/r/db_backup_policy.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_connection.html.markdown
+++ b/website/docs/r/db_connection.html.markdown
@@ -37,7 +37,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_connection.html.markdown
+++ b/website/docs/r/db_connection.html.markdown
@@ -37,7 +37,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_database.html.markdown
+++ b/website/docs/r/db_database.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_database.html.markdown
+++ b/website/docs/r/db_database.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -38,7 +38,7 @@ resource "alicloud_vpc" "example" {
 resource "alicloud_vswitch" "example" {
   vpc_id            = alicloud_vpc.example.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.example.zones[0].id
+  zone_id = data.alicloud_zones.example.zones[0].id
   name              = var.name
 }
 
@@ -65,7 +65,7 @@ resource "alicloud_vpc" "example" {
 resource "alicloud_vswitch" "example" {
   vpc_id            = alicloud_vpc.example.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.example.zones.0.id
+  zone_id = data.alicloud_zones.example.zones.0.id
   name              = "vpc-123456"
 }
 
@@ -112,7 +112,7 @@ resource "alicloud_vswitch" "example" {
   count             = 2
   vpc_id            = alicloud_vpc.example.id
   cidr_block        = format("172.16.%d.0/24", count.index+1)
-  availability_zone = data.alicloud_zones.example.zones[count.index].id
+  zone_id = data.alicloud_zones.example.zones[count.index].id
   name              = format("vswich_%d", var.name, count.index)
 }
 
@@ -152,7 +152,7 @@ resource "alicloud_vswitch" "example" {
   count             = length(data.alicloud_zones.example.zones.0.multi_zone_ids)
   vpc_id            = alicloud_vpc.example.id
   cidr_block        = format("172.16.%d.0/24", count.index+1)
-  availability_zone = data.alicloud_zones.example.zones.0.multi_zone_ids[count.index]
+  zone_id = data.alicloud_zones.example.zones.0.multi_zone_ids[count.index]
   name              = format("vswitch_%d", count.index)
 }
 
@@ -188,7 +188,7 @@ resource "alicloud_vswitch" "example" {
   count             = 3
   vpc_id            = alicloud_vpc.example.id
   cidr_block        = format("172.16.%d.0/24", count.index+1)
-  availability_zone = data.alicloud_zones.example.zones[count.index].id
+  zone_id = data.alicloud_zones.example.zones[count.index].id
   name              = format("vswich_%d", var.name, count.index)
 }
 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -38,7 +38,7 @@ resource "alicloud_vpc" "example" {
 resource "alicloud_vswitch" "example" {
   vpc_id            = alicloud_vpc.example.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.example.zones[0].id
+  zone_id           = data.alicloud_zones.example.zones[0].id
   name              = var.name
 }
 
@@ -65,7 +65,7 @@ resource "alicloud_vpc" "example" {
 resource "alicloud_vswitch" "example" {
   vpc_id            = alicloud_vpc.example.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.example.zones.0.id
+  zone_id           = data.alicloud_zones.example.zones.0.id
   name              = "vpc-123456"
 }
 
@@ -112,7 +112,7 @@ resource "alicloud_vswitch" "example" {
   count             = 2
   vpc_id            = alicloud_vpc.example.id
   cidr_block        = format("172.16.%d.0/24", count.index+1)
-  zone_id = data.alicloud_zones.example.zones[count.index].id
+  zone_id           = data.alicloud_zones.example.zones[count.index].id
   name              = format("vswich_%d", var.name, count.index)
 }
 
@@ -152,7 +152,7 @@ resource "alicloud_vswitch" "example" {
   count             = length(data.alicloud_zones.example.zones.0.multi_zone_ids)
   vpc_id            = alicloud_vpc.example.id
   cidr_block        = format("172.16.%d.0/24", count.index+1)
-  zone_id = data.alicloud_zones.example.zones.0.multi_zone_ids[count.index]
+  zone_id           = data.alicloud_zones.example.zones.0.multi_zone_ids[count.index]
   name              = format("vswitch_%d", count.index)
 }
 
@@ -188,7 +188,7 @@ resource "alicloud_vswitch" "example" {
   count             = 3
   vpc_id            = alicloud_vpc.example.id
   cidr_block        = format("172.16.%d.0/24", count.index+1)
-  zone_id = data.alicloud_zones.example.zones[count.index].id
+  zone_id           = data.alicloud_zones.example.zones[count.index].id
   name              = format("vswich_%d", var.name, count.index)
 }
 

--- a/website/docs/r/db_read_write_splitting_connection.html.markdown
+++ b/website/docs/r/db_read_write_splitting_connection.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_read_write_splitting_connection.html.markdown
+++ b/website/docs/r/db_read_write_splitting_connection.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_readonly_instance.html.markdown
+++ b/website/docs/r/db_readonly_instance.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/db_readonly_instance.html.markdown
+++ b/website/docs/r/db_readonly_instance.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -32,13 +32,13 @@ resource "alicloud_vpc" "vpc" {
 resource "alicloud_vswitch" "vsw" {
   vpc_id            = alicloud_vpc.vpc.id
   cidr_block        = "10.1.1.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 
   depends_on = [alicloud_vpc.vpc]
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 data "alicloud_images" "default" {
@@ -50,7 +50,7 @@ data "alicloud_images" "default" {
 resource "alicloud_instance" "ecs_instance" {
   image_id          = data.alicloud_images.default.images[0].id
   instance_type     = data.alicloud_instance_types.default.instance_types[0].id
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   security_groups   = [alicloud_security_group.group.id]
   vswitch_id        = alicloud_vswitch.vsw.id
   instance_name     = "hello"

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -38,7 +38,7 @@ resource "alicloud_vswitch" "vsw" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
 }
 
 data "alicloud_images" "default" {
@@ -50,7 +50,7 @@ data "alicloud_images" "default" {
 resource "alicloud_instance" "ecs_instance" {
   image_id          = data.alicloud_images.default.images[0].id
   instance_type     = data.alicloud_instance_types.default.instance_types[0].id
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   security_groups   = [alicloud_security_group.group.id]
   vswitch_id        = alicloud_vswitch.vsw.id
   instance_name     = "hello"

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -32,7 +32,7 @@ resource "alicloud_vpc" "vpc" {
 resource "alicloud_vswitch" "vsw" {
   vpc_id            = alicloud_vpc.vpc.id
   cidr_block        = "10.1.1.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 
   depends_on = [alicloud_vpc.vpc]
 }

--- a/website/docs/r/ess_alarm.html.markdown
+++ b/website/docs/r/ess_alarm.html.markdown
@@ -24,7 +24,7 @@ data "alicloud_images" "ecs_image" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }
@@ -38,14 +38,14 @@ resource "alicloud_vswitch" "foo" {
   vswitch_name      = "tf-testAccEssAlarm_basic_foo"
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_vswitch" "bar" {
   vswitch_name      = "tf-testAccEssAlarm_basic_bar"
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.1.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_ess_scaling_group" "foo" {

--- a/website/docs/r/ess_alarm.html.markdown
+++ b/website/docs/r/ess_alarm.html.markdown
@@ -38,14 +38,14 @@ resource "alicloud_vswitch" "foo" {
   vswitch_name      = "tf-testAccEssAlarm_basic_foo"
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_vswitch" "bar" {
   vswitch_name      = "tf-testAccEssAlarm_basic_bar"
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.1.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_ess_scaling_group" "foo" {

--- a/website/docs/r/ess_alarm.html.markdown
+++ b/website/docs/r/ess_alarm.html.markdown
@@ -24,7 +24,7 @@ data "alicloud_images" "ecs_image" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }

--- a/website/docs/r/ess_attachment.html.markdown
+++ b/website/docs/r/ess_attachment.html.markdown
@@ -28,7 +28,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }
@@ -47,7 +47,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/ess_attachment.html.markdown
+++ b/website/docs/r/ess_attachment.html.markdown
@@ -47,7 +47,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/ess_attachment.html.markdown
+++ b/website/docs/r/ess_attachment.html.markdown
@@ -28,7 +28,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }

--- a/website/docs/r/ess_notification.html.markdown
+++ b/website/docs/r/ess_notification.html.markdown
@@ -39,7 +39,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/ess_notification.html.markdown
+++ b/website/docs/r/ess_notification.html.markdown
@@ -39,7 +39,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -26,7 +26,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }
@@ -45,7 +45,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -45,7 +45,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -26,7 +26,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availabilty_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -28,7 +28,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }
@@ -47,7 +47,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 
@@ -70,7 +70,7 @@ resource "alicloud_security_group_rule" "default" {
 resource "alicloud_vswitch" "default2" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.1.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = "${var.name}-bar"
 }
 

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -47,7 +47,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 
@@ -70,7 +70,7 @@ resource "alicloud_security_group_rule" "default" {
 resource "alicloud_vswitch" "default2" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.1.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = "${var.name}-bar"
 }
 

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -28,7 +28,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }

--- a/website/docs/r/ess_scaling_lifecycle_hook.html.markdown
+++ b/website/docs/r/ess_scaling_lifecycle_hook.html.markdown
@@ -26,13 +26,13 @@ resource "alicloud_vpc" "foo" {
 resource "alicloud_vswitch" "foo" {
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_vswitch" "bar" {
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.1.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_ess_scaling_group" "foo" {

--- a/website/docs/r/ess_scaling_lifecycle_hook.html.markdown
+++ b/website/docs/r/ess_scaling_lifecycle_hook.html.markdown
@@ -26,13 +26,13 @@ resource "alicloud_vpc" "foo" {
 resource "alicloud_vswitch" "foo" {
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_vswitch" "bar" {
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.1.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_ess_scaling_group" "foo" {

--- a/website/docs/r/ess_scaling_rule.html.markdown
+++ b/website/docs/r/ess_scaling_rule.html.markdown
@@ -24,7 +24,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availabilty_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }

--- a/website/docs/r/ess_scaling_rule.html.markdown
+++ b/website/docs/r/ess_scaling_rule.html.markdown
@@ -43,7 +43,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/ess_scaling_rule.html.markdown
+++ b/website/docs/r/ess_scaling_rule.html.markdown
@@ -24,7 +24,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }
@@ -43,7 +43,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/ess_scalinggroup_vserver_groups.markdown
+++ b/website/docs/r/ess_scalinggroup_vserver_groups.markdown
@@ -49,7 +49,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/ess_scalinggroup_vserver_groups.markdown
+++ b/website/docs/r/ess_scalinggroup_vserver_groups.markdown
@@ -49,7 +49,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/ess_scheduled_task.html.markdown
+++ b/website/docs/r/ess_scheduled_task.html.markdown
@@ -43,7 +43,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/ess_scheduled_task.html.markdown
+++ b/website/docs/r/ess_scheduled_task.html.markdown
@@ -24,7 +24,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }
@@ -43,7 +43,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/ess_scheduled_task.html.markdown
+++ b/website/docs/r/ess_scheduled_task.html.markdown
@@ -24,7 +24,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }

--- a/website/docs/r/gpdb_connection.html.markdown
+++ b/website/docs/r/gpdb_connection.html.markdown
@@ -39,7 +39,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/gpdb_connection.html.markdown
+++ b/website/docs/r/gpdb_connection.html.markdown
@@ -39,7 +39,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/gpdb_instance.html.markdown
+++ b/website/docs/r/gpdb_instance.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vpc" "default" {
 }
 
 resource "alicloud_vswitch" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
   vswitch_name      = "vpc-123456"

--- a/website/docs/r/gpdb_instance.html.markdown
+++ b/website/docs/r/gpdb_instance.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vpc" "default" {
 }
 
 resource "alicloud_vswitch" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
   vswitch_name      = "vpc-123456"

--- a/website/docs/r/havip_attachment.html.markdown
+++ b/website/docs/r/havip_attachment.html.markdown
@@ -23,7 +23,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }
@@ -46,7 +46,7 @@ resource "alicloud_vpc" "foo" {
 resource "alicloud_vswitch" "foo" {
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.0.0/21"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 
@@ -67,7 +67,7 @@ resource "alicloud_security_group" "tf_test_foo" {
 }
 
 resource "alicloud_instance" "foo" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_id        = alicloud_vswitch.foo.id
   image_id          = data.alicloud_images.default.images[0].id
 

--- a/website/docs/r/havip_attachment.html.markdown
+++ b/website/docs/r/havip_attachment.html.markdown
@@ -46,7 +46,7 @@ resource "alicloud_vpc" "foo" {
 resource "alicloud_vswitch" "foo" {
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.0.0/21"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/havip_attachment.html.markdown
+++ b/website/docs/r/havip_attachment.html.markdown
@@ -23,7 +23,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }
@@ -67,7 +67,7 @@ resource "alicloud_security_group" "tf_test_foo" {
 }
 
 resource "alicloud_instance" "foo" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   vswitch_id        = alicloud_vswitch.foo.id
   image_id          = data.alicloud_images.default.images[0].id
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -58,7 +58,7 @@ resource "alicloud_vpc" "vpc" {
 resource "alicloud_vswitch" "vswitch" {
   vpc_id            = alicloud_vpc.vpc.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -58,7 +58,7 @@ resource "alicloud_vpc" "vpc" {
 resource "alicloud_vswitch" "vswitch" {
   vpc_id            = alicloud_vpc.vpc.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/key_pair_attachment.html.markdown
+++ b/website/docs/r/key_pair_attachment.html.markdown
@@ -26,7 +26,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "type" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  avaiability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }

--- a/website/docs/r/key_pair_attachment.html.markdown
+++ b/website/docs/r/key_pair_attachment.html.markdown
@@ -49,7 +49,7 @@ resource "alicloud_vpc" "vpc" {
 resource "alicloud_vswitch" "vswitch" {
   vpc_id            = alicloud_vpc.vpc.id
   cidr_block        = "10.1.1.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/key_pair_attachment.html.markdown
+++ b/website/docs/r/key_pair_attachment.html.markdown
@@ -26,7 +26,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "type" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }
@@ -49,7 +49,7 @@ resource "alicloud_vpc" "vpc" {
 resource "alicloud_vswitch" "vswitch" {
   vpc_id            = alicloud_vpc.vpc.id
   cidr_block        = "10.1.1.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/kvstore_account.html.markdown
+++ b/website/docs/r/kvstore_account.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/kvstore_account.html.markdown
+++ b/website/docs/r/kvstore_account.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/kvstore_backup_policy.html.markdown
+++ b/website/docs/r/kvstore_backup_policy.html.markdown
@@ -42,7 +42,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/kvstore_backup_policy.html.markdown
+++ b/website/docs/r/kvstore_backup_policy.html.markdown
@@ -42,7 +42,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/mongodb_instance.html.markdown
+++ b/website/docs/r/mongodb_instance.html.markdown
@@ -37,7 +37,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = "vpc-123456"
 }
 

--- a/website/docs/r/mongodb_instance.html.markdown
+++ b/website/docs/r/mongodb_instance.html.markdown
@@ -37,7 +37,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = "vpc-123456"
 }
 

--- a/website/docs/r/mongodb_sharding_instance.html.markdown
+++ b/website/docs/r/mongodb_sharding_instance.html.markdown
@@ -54,7 +54,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/mongodb_sharding_instance.html.markdown
+++ b/website/docs/r/mongodb_sharding_instance.html.markdown
@@ -54,7 +54,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -40,7 +40,7 @@ data "alicloud_enhanced_nat_available_zones" "enhanced"{
 
 resource "alicloud_vswitch" "enhanced" {
   vswitch_name      = var.name
-  zone_id = data.alicloud_enhanced_nat_available_zones.enhanced.zones.0.zone_id
+  zone_id           = data.alicloud_enhanced_nat_available_zones.enhanced.zones.0.zone_id
   cidr_block        = "10.10.0.0/20"
   vpc_id            = alicloud_vpc.enhanced.id
 }

--- a/website/docs/r/network_acl_attachment.html.markdown
+++ b/website/docs/r/network_acl_attachment.html.markdown
@@ -39,7 +39,7 @@ resource "alicloud_network_acl" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/21"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/network_acl_attachment.html.markdown
+++ b/website/docs/r/network_acl_attachment.html.markdown
@@ -39,7 +39,7 @@ resource "alicloud_network_acl" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/21"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/network_acl_entries.html.markdown
+++ b/website/docs/r/network_acl_entries.html.markdown
@@ -43,7 +43,7 @@ resource "alicloud_network_acl" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/21"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/network_acl_entries.html.markdown
+++ b/website/docs/r/network_acl_entries.html.markdown
@@ -43,7 +43,7 @@ resource "alicloud_network_acl" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/21"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -34,7 +34,7 @@ data "alicloud_zones" "default" {
 resource "alicloud_vswitch" "vswitch" {
   name              = var.name
   cidr_block        = "192.168.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vpc_id            = alicloud_vpc.vpc.id
 }
 

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -34,7 +34,7 @@ data "alicloud_zones" "default" {
 resource "alicloud_vswitch" "vswitch" {
   name              = var.name
   cidr_block        = "192.168.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vpc_id            = alicloud_vpc.vpc.id
 }
 

--- a/website/docs/r/network_interface_attachment.html.markdown
+++ b/website/docs/r/network_interface_attachment.html.markdown
@@ -48,7 +48,7 @@ resource "alicloud_security_group" "group" {
 }
 
 data "alicloud_instance_types" "instance_type" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   eni_amount        = 2
 }
 
@@ -60,7 +60,7 @@ data "alicloud_images" "default" {
 
 resource "alicloud_instance" "instance" {
   count             = var.number
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   security_groups   = [alicloud_security_group.group.id]
 
   instance_type              = data.alicloud_instance_types.instance_type.instance_types[0].id

--- a/website/docs/r/network_interface_attachment.html.markdown
+++ b/website/docs/r/network_interface_attachment.html.markdown
@@ -38,7 +38,7 @@ data "alicloud_zones" "default" {
 resource "alicloud_vswitch" "vswitch" {
   vswitch_name      = var.name
   cidr_block        = "192.168.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vpc_id            = alicloud_vpc.vpc.id
 }
 

--- a/website/docs/r/network_interface_attachment.html.markdown
+++ b/website/docs/r/network_interface_attachment.html.markdown
@@ -38,7 +38,7 @@ data "alicloud_zones" "default" {
 resource "alicloud_vswitch" "vswitch" {
   vswitch_name      = var.name
   cidr_block        = "192.168.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vpc_id            = alicloud_vpc.vpc.id
 }
 
@@ -48,7 +48,7 @@ resource "alicloud_security_group" "group" {
 }
 
 data "alicloud_instance_types" "instance_type" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   eni_amount        = 2
 }
 
@@ -60,7 +60,7 @@ data "alicloud_images" "default" {
 
 resource "alicloud_instance" "instance" {
   count             = var.number
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   security_groups   = [alicloud_security_group.group.id]
 
   instance_type              = data.alicloud_instance_types.instance_type.instance_types[0].id

--- a/website/docs/r/ots_instance_attachment.html.markdown
+++ b/website/docs/r/ots_instance_attachment.html.markdown
@@ -38,7 +38,7 @@ resource "alicloud_vswitch" "foo" {
   vpc_id            = alicloud_vpc.foo.id
   vswitch_name      = "for-ots-instance"
   cidr_block        = "172.16.1.0/24"
-  availability_zone = data.alicloud_zones.foo.zones[0].id
+  zone_id = data.alicloud_zones.foo.zones[0].id
 }
 
 resource "alicloud_ots_instance_attachment" "foo" {

--- a/website/docs/r/ots_instance_attachment.html.markdown
+++ b/website/docs/r/ots_instance_attachment.html.markdown
@@ -38,7 +38,7 @@ resource "alicloud_vswitch" "foo" {
   vpc_id            = alicloud_vpc.foo.id
   vswitch_name      = "for-ots-instance"
   cidr_block        = "172.16.1.0/24"
-  zone_id = data.alicloud_zones.foo.zones[0].id
+  zone_id           = data.alicloud_zones.foo.zones[0].id
 }
 
 resource "alicloud_ots_instance_attachment" "foo" {

--- a/website/docs/r/polardb_account.html.markdown
+++ b/website/docs/r/polardb_account.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones.0.id
+  zone_id = data.alicloud_zones.default.zones.0.id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/polardb_account.html.markdown
+++ b/website/docs/r/polardb_account.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones.0.id
+  zone_id           = data.alicloud_zones.default.zones.0.id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/polardb_account_privilege.html.markdown
+++ b/website/docs/r/polardb_account_privilege.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones.0.id
+  zone_id = data.alicloud_zones.default.zones.0.id
   name              = var.name
 }
 

--- a/website/docs/r/polardb_account_privilege.html.markdown
+++ b/website/docs/r/polardb_account_privilege.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones.0.id
+  zone_id           = data.alicloud_zones.default.zones.0.id
   name              = var.name
 }
 

--- a/website/docs/r/polardb_backup_policy.html.markdown
+++ b/website/docs/r/polardb_backup_policy.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/polardb_backup_policy.html.markdown
+++ b/website/docs/r/polardb_backup_policy.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/polardb_cluster.html.markdown
+++ b/website/docs/r/polardb_cluster.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/polardb_cluster.html.markdown
+++ b/website/docs/r/polardb_cluster.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/polardb_database.html.markdown
+++ b/website/docs/r/polardb_database.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones.0.id
+  zone_id = data.alicloud_zones.default.zones.0.id
   name              = var.name
 }
 

--- a/website/docs/r/polardb_database.html.markdown
+++ b/website/docs/r/polardb_database.html.markdown
@@ -36,7 +36,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones.0.id
+  zone_id           = data.alicloud_zones.default.zones.0.id
   name              = var.name
 }
 

--- a/website/docs/r/polardb_endpoint.html.markdown
+++ b/website/docs/r/polardb_endpoint.html.markdown
@@ -38,7 +38,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/polardb_endpoint.html.markdown
+++ b/website/docs/r/polardb_endpoint.html.markdown
@@ -38,7 +38,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/polardb_endpoint_address.html.markdown
+++ b/website/docs/r/polardb_endpoint_address.html.markdown
@@ -37,7 +37,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/polardb_endpoint_address.html.markdown
+++ b/website/docs/r/polardb_endpoint_address.html.markdown
@@ -37,7 +37,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/ram_role_attachment.html.markdown
+++ b/website/docs/r/ram_role_attachment.html.markdown
@@ -20,7 +20,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }
@@ -39,7 +39,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/ram_role_attachment.html.markdown
+++ b/website/docs/r/ram_role_attachment.html.markdown
@@ -39,7 +39,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/ram_role_attachment.html.markdown
+++ b/website/docs/r/ram_role_attachment.html.markdown
@@ -20,7 +20,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 2
   memory_size       = 4
 }

--- a/website/docs/r/rds_account.html.markdown
+++ b/website/docs/r/rds_account.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/rds_account.html.markdown
+++ b/website/docs/r/rds_account.html.markdown
@@ -40,7 +40,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/route_entry.html.markdown
+++ b/website/docs/r/route_entry.html.markdown
@@ -21,7 +21,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }

--- a/website/docs/r/route_entry.html.markdown
+++ b/website/docs/r/route_entry.html.markdown
@@ -44,7 +44,7 @@ resource "alicloud_vpc" "foo" {
 resource "alicloud_vswitch" "foo" {
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "10.1.1.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/route_entry.html.markdown
+++ b/website/docs/r/route_entry.html.markdown
@@ -21,7 +21,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }
@@ -44,7 +44,7 @@ resource "alicloud_vpc" "foo" {
 resource "alicloud_vswitch" "foo" {
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "10.1.1.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/route_table_attachment.html.markdown
+++ b/website/docs/r/route_table_attachment.html.markdown
@@ -36,7 +36,7 @@ data "alicloud_zones" "default" {
 resource "alicloud_vswitch" "foo" {
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.0.0/21"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/route_table_attachment.html.markdown
+++ b/website/docs/r/route_table_attachment.html.markdown
@@ -36,7 +36,7 @@ data "alicloud_zones" "default" {
 resource "alicloud_vswitch" "foo" {
   vpc_id            = alicloud_vpc.foo.id
   cidr_block        = "172.16.0.0/21"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/slb.html.markdown
+++ b/website/docs/r/slb.html.markdown
@@ -35,7 +35,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/21"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/slb.html.markdown
+++ b/website/docs/r/slb.html.markdown
@@ -35,7 +35,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/21"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/slb_attachment.html.markdown
+++ b/website/docs/r/slb_attachment.html.markdown
@@ -26,7 +26,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }
@@ -45,7 +45,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/slb_attachment.html.markdown
+++ b/website/docs/r/slb_attachment.html.markdown
@@ -45,7 +45,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/slb_attachment.html.markdown
+++ b/website/docs/r/slb_attachment.html.markdown
@@ -26,7 +26,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }

--- a/website/docs/r/slb_backend_server.html.markdown
+++ b/website/docs/r/slb_backend_server.html.markdown
@@ -26,7 +26,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }
@@ -45,7 +45,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/slb_backend_server.html.markdown
+++ b/website/docs/r/slb_backend_server.html.markdown
@@ -45,7 +45,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/slb_backend_server.html.markdown
+++ b/website/docs/r/slb_backend_server.html.markdown
@@ -26,7 +26,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }

--- a/website/docs/r/slb_master_slave_server_group.html.markdown
+++ b/website/docs/r/slb_master_slave_server_group.html.markdown
@@ -34,7 +34,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   eni_amount        = 2
 }
 
@@ -60,7 +60,7 @@ resource "alicloud_vpc" "main" {
 resource "alicloud_vswitch" "main" {
   vpc_id            = alicloud_vpc.main.id
   cidr_block        = "172.16.0.0/16"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/slb_master_slave_server_group.html.markdown
+++ b/website/docs/r/slb_master_slave_server_group.html.markdown
@@ -60,7 +60,7 @@ resource "alicloud_vpc" "main" {
 resource "alicloud_vswitch" "main" {
   vpc_id            = alicloud_vpc.main.id
   cidr_block        = "172.16.0.0/16"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   vswitch_name      = var.name
 }
 

--- a/website/docs/r/slb_master_slave_server_group.html.markdown
+++ b/website/docs/r/slb_master_slave_server_group.html.markdown
@@ -34,7 +34,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   eni_amount        = 2
 }
 

--- a/website/docs/r/slb_rule.html.markdown
+++ b/website/docs/r/slb_rule.html.markdown
@@ -35,7 +35,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }

--- a/website/docs/r/slb_rule.html.markdown
+++ b/website/docs/r/slb_rule.html.markdown
@@ -35,7 +35,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }
@@ -54,7 +54,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/slb_rule.html.markdown
+++ b/website/docs/r/slb_rule.html.markdown
@@ -54,7 +54,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/slb_server_group.html.markdown
+++ b/website/docs/r/slb_server_group.html.markdown
@@ -35,7 +35,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  zone_id = data.alicloud_zones.default.zones[0].id
+  availability_zone = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }

--- a/website/docs/r/slb_server_group.html.markdown
+++ b/website/docs/r/slb_server_group.html.markdown
@@ -35,7 +35,7 @@ data "alicloud_zones" "default" {
 }
 
 data "alicloud_instance_types" "default" {
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   cpu_core_count    = 1
   memory_size       = 2
 }
@@ -54,7 +54,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/slb_server_group.html.markdown
+++ b/website/docs/r/slb_server_group.html.markdown
@@ -54,7 +54,7 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "172.16.0.0/16"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
   name              = var.name
 }
 

--- a/website/docs/r/vpn_route_entry.html.markdown
+++ b/website/docs/r/vpn_route_entry.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vswitch" "default" {
   name              = "tf_test"
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "10.1.0.0/24"
-  zone_id = data.alicloud_zones.default.zones[0].id
+  zone_id           = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_vpn_gateway" "default" {

--- a/website/docs/r/vpn_route_entry.html.markdown
+++ b/website/docs/r/vpn_route_entry.html.markdown
@@ -34,7 +34,7 @@ resource "alicloud_vswitch" "default" {
   name              = "tf_test"
   vpc_id            = alicloud_vpc.default.id
   cidr_block        = "10.1.0.0/24"
-  availability_zone = data.alicloud_zones.default.zones[0].id
+  zone_id = data.alicloud_zones.default.zones[0].id
 }
 
 resource "alicloud_vpn_gateway" "default" {

--- a/website/docs/r/vswitch.html.markdown
+++ b/website/docs/r/vswitch.html.markdown
@@ -24,7 +24,7 @@ resource "alicloud_vpc" "vpc" {
 resource "alicloud_vswitch" "vsw" {
   vpc_id            = alicloud_vpc.vpc.id
   cidr_block        = "172.16.0.0/21"
-  zone_id = "cn-beijing-b"
+  zone_id           = "cn-beijing-b"
 }
 ```
 

--- a/website/docs/r/vswitch.html.markdown
+++ b/website/docs/r/vswitch.html.markdown
@@ -24,7 +24,7 @@ resource "alicloud_vpc" "vpc" {
 resource "alicloud_vswitch" "vsw" {
   vpc_id            = alicloud_vpc.vpc.id
   cidr_block        = "172.16.0.0/21"
-  availability_zone = "cn-beijing-b"
+  zone_id = "cn-beijing-b"
 }
 ```
 


### PR DESCRIPTION
As the usage of availability_zone is deprecated this PR replaces `availability_zone` with `zone_id` in respective website files

