### PR TITLE
resource/alicloud_cs_kubernetes_nood_pool: Adds supports to create spot instance, set public IP and resource_group_id; resource/alicloud_cs_serverless_kubernetes: Support to set coredns as service discovery, time zone and sls log config; resource/alicloud_cs_managed_kubernetes: Fixes the bug that upgrades the cluster after creating it.

### DIFF
--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -206,6 +206,13 @@ func csNodepoolDiskPerformanceLevelDiffSuppressFunc(k, old, new string, d *schem
 	return false
 }
 
+func csNodepoolSpotInstanceSettingDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if v, ok := d.GetOk("spot_strategy"); !ok && v.(string) != "SpotWithPriceLimit" {
+		return true
+	}
+	return false
+}
+
 func csForceUpdate(k, old, new string, d *schema.ResourceData) bool {
 	if d.Id() == "" {
 		return false

--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -207,10 +207,10 @@ func csNodepoolDiskPerformanceLevelDiffSuppressFunc(k, old, new string, d *schem
 }
 
 func csNodepoolSpotInstanceSettingDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
-	if v, ok := d.GetOk("spot_strategy"); !ok && v.(string) != "SpotWithPriceLimit" {
-		return true
+	if v, ok := d.GetOk("spot_strategy"); ok && v.(string) == "SpotWithPriceLimit" {
+		return false
 	}
-	return false
+	return true
 }
 
 func csForceUpdate(k, old, new string, d *schema.ResourceData) bool {

--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -824,7 +824,7 @@ func resourceAlicloudCSKubernetesCreate(d *schema.ResourceData, meta interface{}
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
 
-	return resourceAlicloudCSKubernetesUpdate(d, meta)
+	return resourceAlicloudCSKubernetesRead(d, meta)
 }
 
 func resourceAlicloudCSKubernetesUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
@@ -609,7 +609,7 @@ func resourceAlicloudCSNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 	// spot
 	if d.HasChange("spot_strategy") {
 		update = true
-		args.ResourceGroupId = d.Get("spot_strategy").(string)
+		args.SpotStrategy = d.Get("spot_strategy").(string)
 	}
 	if d.HasChange("spot_price_limit") {
 		update = true

--- a/alicloud/resource_alicloud_cs_serverless_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_serverless_kubernetes.go
@@ -207,12 +207,6 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
-			"region_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
 		},
 	}
 }
@@ -300,7 +294,7 @@ func resourceAlicloudCSServerlessKubernetesCreate(d *schema.ResourceData, meta i
 		args.ServiceDiscoveryTypes = expandStringList(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("private_zone"); ok {
+	if v, ok := d.GetOkExists("private_zone"); ok {
 		if v.(bool) == true {
 			args.ServiceDiscoveryTypes = []string{"PrivateZone"}
 		} else {
@@ -376,7 +370,6 @@ func resourceAlicloudCSServerlessKubernetesRead(d *schema.ResourceData, meta int
 	d.Set("version", object.CurrentVersion)
 	d.Set("resource_group_id", object.ResourceGroupId)
 	d.Set("cluster_spec", object.ClusterSpec)
-	d.Set("region_id", object.RegionId)
 
 	if err := d.Set("tags", flattenTagsConfig(object.Tags)); err != nil {
 		return WrapError(err)

--- a/alicloud/resource_alicloud_cs_serverless_kubernetes_test.go
+++ b/alicloud/resource_alicloud_cs_serverless_kubernetes_test.go
@@ -2,6 +2,8 @@ package alicloud
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -13,8 +15,27 @@ import (
 )
 
 func TestAccAlicloudCSServerlessKubernetes_basic(t *testing.T) {
-	var v *cs.ServerlessClusterResponse
+	var timeZoneMap = map[string]string{
+		"eu-central-1": "Europe/London",
+		"cn-hangzhou":  "Asia/Shanghai",
+		"cn-shanghai":  "Asia/Shanghai",
+		"cn-beijing":   "Asia/Shanghai",
+	}
 
+	var regionId string
+	if v := os.Getenv("ALICLOUD_REGION"); v != "" {
+		regionId = v
+	} else {
+		log.Println("[INFO] Test: Using cn-beijing as test region")
+		regionId = "cn-beijing"
+	}
+
+	var timeZone string
+	if v, ok := timeZoneMap[regionId]; ok {
+		timeZone = v
+	}
+
+	var v *cs.ServerlessClusterResponse
 	resourceId := "alicloud_cs_serverless_kubernetes.default"
 	ra := resourceAttrInit(resourceId, csServerlessKubernetesBasicMap)
 
@@ -57,8 +78,7 @@ func TestAccAlicloudCSServerlessKubernetes_basic(t *testing.T) {
 					"service_cidr":            "172.21.0.0/20",
 					"service_discovery_types": []string{"PrivateZone"},
 					"logging_type":            "SLS",
-					"time_zone":               "Asia/Shanghai",
-					"region_id":               "cn-hangzhou",
+					"time_zone":               timeZone,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -70,7 +90,6 @@ func TestAccAlicloudCSServerlessKubernetes_basic(t *testing.T) {
 						"vswitch_ids.#":                  "1",
 						"tags.%":                         "1",
 						"tags.Platform":                  "TF",
-						"region_id":                      "cn-hangzhou",
 					}),
 				),
 			},

--- a/alicloud/resource_alicloud_slb_ca_certificate_test.go
+++ b/alicloud/resource_alicloud_slb_ca_certificate_test.go
@@ -2,13 +2,14 @@ package alicloud
 
 import (
 	"fmt"
-	"github.com/PaesslerAG/jsonpath"
-	util "github.com/alibabacloud-go/tea-utils/service"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"log"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/slb"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aliyun/fc-go-sdk v0.0.0-20200925033337-c013428cbe21
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect
 	github.com/deckarep/golang-set v1.7.1
-	github.com/denverdino/aliyungo v0.0.0-20210318042315-546d0768f5c7
+	github.com/denverdino/aliyungo v0.0.0-20210518071019-eb3bbb144d8a
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
 	github.com/gogap/errors v0.0.0-20160523102334-149c546090d0 // indirect
 	github.com/gogap/stack v0.0.0-20150131034635-fef68dddd4f8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9r
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/denverdino/aliyungo v0.0.0-20210318042315-546d0768f5c7 h1:olbRoASibs9s5oTbeNrZnWK1ARyi0xGT1EGZnMopPIU=
 github.com/denverdino/aliyungo v0.0.0-20210318042315-546d0768f5c7/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
+github.com/denverdino/aliyungo v0.0.0-20210518071019-eb3bbb144d8a h1:J9+NI0ywi1btTOYseLdmr/H3XxutbC4m2bU48kKpwVs=
+github.com/denverdino/aliyungo v0.0.0-20210518071019-eb3bbb144d8a/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/vendor/github.com/denverdino/aliyungo/cs/serverless.go
+++ b/vendor/github.com/denverdino/aliyungo/cs/serverless.go
@@ -10,23 +10,29 @@ import (
 )
 
 type ServerlessCreationArgs struct {
-	ClusterType          KubernetesClusterType `json:"cluster_type"`
-	Name                 string                `json:"name"`
-	RegionId             string                `json:"region_id"`
-	VpcId                string                `json:"vpc_id"`
-	VSwitchId            string                `json:"vswitch_id"`
-	VswitchIds           []string              `json:"vswitch_ids"`
-	EndpointPublicAccess bool                  `json:"public_slb"`
-	PrivateZone          bool                  `json:"private_zone"`
-	NatGateway           bool                  `json:"nat_gateway"`
-	KubernetesVersion    string                `json:"kubernetes_version"`
-	DeletionProtection   bool                  `json:"deletion_protection"`
-	SecurityGroupId      string                `json:"security_group_id"`
-	Tags                 []Tag                 `json:"tags"`
-	Addons               []Addon               `json:"addons"`
-	ResourceGroupId      string                `json:"resource_group_id"`
-	ClusterSpec          string                `json:"cluster_spec"`
-	LoadBalancerSpec     string                `json:"load_balancer_spec"` //api server slb实例规格
+	ClusterType           KubernetesClusterType `json:"cluster_type"`
+	Name                  string                `json:"name"`
+	RegionId              string                `json:"region_id"`
+	VpcId                 string                `json:"vpc_id"`
+	VSwitchId             string                `json:"vswitch_id"`
+	VswitchIds            []string              `json:"vswitch_ids"`
+	EndpointPublicAccess  bool                  `json:"public_slb"`
+	PrivateZone           bool                  `json:"private_zone"`
+	NatGateway            bool                  `json:"nat_gateway"`
+	KubernetesVersion     string                `json:"kubernetes_version"`
+	DeletionProtection    bool                  `json:"deletion_protection"`
+	SecurityGroupId       string                `json:"security_group_id"`
+	Tags                  []Tag                 `json:"tags"`
+	Addons                []Addon               `json:"addons"`
+	ResourceGroupId       string                `json:"resource_group_id"`
+	ClusterSpec           string                `json:"cluster_spec"`
+	LoadBalancerSpec      string                `json:"load_balancer_spec"` //api server slb实例规格
+	ServiceCIDR           string                `json:"service_cidr"`
+	TimeZone              string                `json:"timezone"`
+	ServiceDiscoveryTypes []string              `json:"service_discovery_types"`
+	ZoneID                string                `json:"zone_id"`
+	LoggingType           string                `json:"logging_type"`
+	SLSProjectName        string                `json:"sls_project_name"`
 }
 
 type ServerlessClusterResponse struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -167,7 +167,7 @@ github.com/cenkalti/backoff
 github.com/davecgh/go-spew/spew
 # github.com/deckarep/golang-set v1.7.1
 github.com/deckarep/golang-set
-# github.com/denverdino/aliyungo v0.0.0-20210318042315-546d0768f5c7
+# github.com/denverdino/aliyungo v0.0.0-20210518071019-eb3bbb144d8a
 github.com/denverdino/aliyungo/cdn
 github.com/denverdino/aliyungo/common
 github.com/denverdino/aliyungo/cs

--- a/website/docs/r/cs_kubernetes_permissions.html.markdown
+++ b/website/docs/r/cs_kubernetes_permissions.html.markdown
@@ -110,7 +110,7 @@ resource "alicloud_ram_user_policy_attachment" "attach" {
 Finally, complete the RBAC authorization.
 ```terraform
 # Grant users developer permissions for the cluster.
-resource "alicloud_cs_kubernetes_permissions_grant" "default" {
+resource "alicloud_cs_kubernetes_permissions" "default" {
   # uid
   uid = alicloud_ram_user.user.id
   # permissions
@@ -169,7 +169,7 @@ resource "alicloud_ram_user_policy_attachment" "attach" {
 }
 
 # RBAC authorization for the cluster
-resource "alicloud_cs_kubernetes_permissions_grant" "default" {
+resource "alicloud_cs_kubernetes_permissions" "default" {
   uid = data.alicloud_ram_users.users_ds.users.0.id
   permissions {
     cluster     = "target cluster id1"
@@ -193,7 +193,7 @@ resource "alicloud_cs_kubernetes_permissions_grant" "default" {
 Remove the current user's permissions on the cluster
 ```terraform
 # remove the permissions on the "cluster_id_01", "cluster_id_02".
-resource "alicloud_cs_kubernetes_permissions_grant" "default" {
+resource "alicloud_cs_kubernetes_permissions" "default" {
   uid = data.alicloud_ram_users.users_ds.users.0.id
 }
 ```

--- a/website/docs/r/cs_managed_kubernetes.html.markdown
+++ b/website/docs/r/cs_managed_kubernetes.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 This resource will help you to manage a ManagedKubernetes Cluster in Alibaba Cloud Kubernetes Service. 
 
+-> **NOTE:** It is recommended to create a cluster with zero worker nodes, and then use a node pool to manage the cluster nodes. 
+
 -> **NOTE:** Kubernetes cluster only supports VPC network and it can access internet while creating kubernetes cluster.
 A Nat Gateway and configuring a SNAT for it can ensure one VPC network access internet. If there is no nat gateway in the
 VPC, you can set `new_nat_gateway` to "true" to create one automatically.

--- a/website/docs/r/cs_serverless_kubernetes.html.markdown
+++ b/website/docs/r/cs_serverless_kubernetes.html.markdown
@@ -11,6 +11,7 @@ description: |-
 
 This resource will help you to manager a Serverless Kubernetes Cluster. The cluster is same as container service created by web console.
 
+-> **NOTE:** Available in 1.58.0+
 
 -> **NOTE:** Serverless Kubernetes cluster only supports VPC network and it can access internet while creating kubernetes cluster.
 A Nat Gateway and configuring a SNAT for it can ensure one VPC network access internet. If there is no nat gateway in the
@@ -26,7 +27,7 @@ after creating cluster successfully, and you can put them into the specified loc
 -> **NOTE:** You need to activate several other products and confirm Authorization Policy used by Container Service before using this resource.
 Please refer to the `Authorization management` and `Cluster management` sections in the [Document Center](https://www.alibabacloud.com/help/doc-detail/86488.htm).
 
--> **NOTE:** Available in 1.58.0+
+-> **NOTE:** 
 
 ## Example Usage
 
@@ -34,7 +35,7 @@ Basic Usage
 
 ```terraform
 variable "name" {
-  default = "my-first-k8s"
+  default = "ask-example"
 }
 
 data "alicloud_zones" "default" {
@@ -59,12 +60,35 @@ resource "alicloud_cs_serverless_kubernetes" "serverless" {
   vswitch_ids                    = [alicloud_vswitch.default.id]
   new_nat_gateway                = true
   endpoint_public_access_enabled = true
-  private_zone                   = false
   deletion_protection            = false
+
+  load_balancer_spec             = "slb.s2.small"
+  time_zone                      = "Asia/Shanghai" 
+  service_cidr                   = "172.21.0.0/20"
+  service_discovery_types        = ["PrivateZone"]
+  # Enable log service, A project named k8s-log-{ClusterID} will be automatically created
+  logging_type                   = "SLS"
+  # Select an existing sls project
+  # sls_project_name             = ""
+
+  # tags 
   tags = {
     "k-aa" = "v-aa"
     "k-bb" = "v-aa"
   }
+
+  # addons 
+  addons {
+    # SLB Ingress
+    name = "alb-ingress-controller"
+  }
+  addons {
+    name = "metrics-server"
+  }
+  addons {
+    name = "knative"
+  }
+
 }
 ```
 
@@ -77,9 +101,9 @@ The following arguments are supported:
 * `version` - (Optional, Available since 1.97.0) Desired Kubernetes version. If you do not specify a value, the latest available version at resource creation is used.
 * `vpc_id` - (Required, ForceNew) The vpc where new kubernetes cluster will be located. Specify one vpc's id, if it is not specified, a new VPC  will be built.
 * `vswitch_ids` - (Required, ForceNew) The vswitches where new kubernetes cluster will be located.
-* `new_nat_gateway` - (Optional) Whether to create a new nat gateway while creating kubernetes cluster. Default to true.
+* `new_nat_gateway` - (Optional) Whether to create a new nat gateway while creating kubernetes cluster. SNAT must be configured when a new VPC is automatically created. Default is `true`.
 * `endpoint_public_access_enabled` - (Optional, ForceNew) Whether to create internet  eip for API Server. Default to false.
-* `private_zone` - (Optional, ForceNew) Enable Privatezone if you need to use the service discovery feature within the serverless cluster. Default to false.
+* `service_discovery_types` - (ForceNew, Available in 1.124.0+) Service discovery type. If the value is empty, it means that service discovery is not enabled. Valid values are `CoreDNS` and `PrivateZone`. 
 * `deletion_protection` - (Optional, ForceNew) Whether enable the deletion protection or not.
     - true: Enable deletion protection.
     - false: Disable deletion protection.
@@ -92,47 +116,49 @@ The following arguments are supported:
 * `security_group_id` - (Optional, Available in 1.91.0+) The ID of the security group to which the ECS instances in the cluster belong. If it is not specified, a new Security group will be built.
 * `resource_group_id` - (Optional, ForceNew, Available in 1.101.0+) The ID of the resource group,by default these cloud resources are automatically assigned to the default resource group.
 * `load_balancer_spec` - (ForceNew, Available in 1.117.0+) The cluster api server load balance instance specification, default `slb.s1.small`. For more information on how to select a LB instance specification, see [SLB instance overview](https://help.aliyun.com/document_detail/85931.html).
+* `addons` - (Available in 1.91.0+)) You can specific network plugin,log component,ingress component and so on.Detailed below.
+* `time_zone` - (Optional, ForceNew, Available in 1.124.0+) The time zone of the cluster.
+* `zone_id` - (Optional, ForceNew, Available in 1.124.0+) When creating a cluster using automatic VPC creation, you need to specify the zone where the VPC is located. 
+* `region_id` - (Optional, ForceNew, Available in 1.124.0+) ID of the region where the cluster is located.
+* `service_cidr` - (Optional, ForceNew, Available in 1.124.0+) CIDR block of the service network. The specified CIDR block cannot overlap with that of the VPC or those of the ACK clusters that are deployed in the VPC. The CIDR block cannot be modified after the cluster is created.
+* `logging_type` - (ForceNew, Available in 1.124.0+) Enable log service, Valid value `SLS`. 
+* `sls_project_name` - (ForceNew, Available in 1.124.0+) If you use an existing SLS project, you must specify `sls_project_name`.
 
-#### Addons 
-It is a new field since 1.91.0. You can specific network plugin,log component,ingress component and so on.     
- 
-```$xslt
-  main.tf
-   
-  dynamic "addons" {
-      for_each = var.cluster_addons
-      content {
-        name                    = lookup(addons.value, "name", var.cluster_addons)
-        config                  = lookup(addons.value, "config", var.cluster_addons)
-        disabled                = lookup(addons.value, "disabled", var.cluster_addons)
-      }
-  }
+#### addons 
+It is a new field since 1.91.0. You can specific network plugin,log component,ingress component and so on. 
+The following arguments are optional:
+* `name` - Name of the ACK add-on. The name must match one of the names returned by [DescribeAddons](https://help.aliyun.com/document_detail/171524.html).
+* `config` - The ACK add-on configurations.
+* `disabled` -  Disables the automatic installation of a component. Default is `false`.
+
+The following example is the definition of addons block, The type of this field is list:
+
 ```
-```$xslt
-    varibales.tf 
-    
-    // Log
-    variable "cluster_addons" {
-        type = list(object({
-            name      = string
-            config    = string
-        }))
-    
-        default = [
-            {
-                "name"     = "logtail-ds",
-                "config"   = "{\"IngressDashboardEnabled\":\"true\",\"sls_project_name\":\"your-sls-project-name\"}",
-            }
-        ]
-    } 
-    
-  
+# install nginx ingress, conflict with SLB ingress
+addons {
+  name = "nginx-ingress-controller"
+  # use internet
+  config = "{\"IngressSlbNetworkType\":\"internet",\"IngressSlbSpec\":\"slb.s2.small\"}"
+  # if use intranet, detail below.
+  # config = "{\"IngressSlbNetworkType\":\"intranet",\"IngressSlbSpec\":\"slb.s2.small\"}"
+}
+# install SLB ingress, conflict with nginx ingress
+addons {
+  name = "alb-ingress-controller"
+}
+# install metric server
+addons {
+  name = "metrics-server"
+}
+# install knative
+addons {
+  name = "knative"
+}
 ```
-* `logtail-ds` - You can specific `IngressDashboardEnabled` and `sls_project_name` in config. If you switch on `IngressDashboardEnabled` and `sls_project_name`,then logtail-ds would use `sls_project_name` as default log store.
 
 #### Removed params (Never Supported)
-* `vswitch_id` - (Deprecated from version 1.91.0)(Required, ForceNew) The vswitch where new kubernetes cluster will be located. Specify one vswitch's id, if it is not specified, a new VPC and VSwicth will be built. It must be in the zone which `availability_zone` specified.
-
+* `vswitch_id` - (Deprecated from version 1.91.0) (Required, ForceNew) The vswitch where new kubernetes cluster will be located. Specify one vswitch's id, if it is not specified, a new VPC and VSwicth will be built. It must be in the zone which `availability_zone` specified.
+* `private_zone` - (Deprecated from version 1.124.0) (Optional, ForceNew) Has been deprecated from provider version 1.124.0. `PrivateZone` is used as the enumeration value of `service_discovery_types`.
 
 ### Timeouts
 
@@ -142,7 +168,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 60 mins) Used when creating the kubernetes cluster (until it reaches the initial `running` status). 
 * `delete` - (Defaults to 30 mins) Used when terminating the kubernetes cluster. 
-
 
 ## Attributes Reference
 
@@ -160,5 +185,5 @@ The following attributes are exported:
 Serverless Kubernetes cluster can be imported using the id, e.g.
 
 ```
-$ terraform import alicloud_cs_serverless_kubernetes.main ce4273f9156874b46bb
+$ terraform import alicloud_cs_serverless_kubernetes.main ${cluster_id}
 ```

--- a/website/docs/r/cs_serverless_kubernetes.html.markdown
+++ b/website/docs/r/cs_serverless_kubernetes.html.markdown
@@ -185,5 +185,5 @@ The following attributes are exported:
 Serverless Kubernetes cluster can be imported using the id, e.g.
 
 ```
-$ terraform import alicloud_cs_serverless_kubernetes.main ${cluster_id}
+$ terraform import alicloud_cs_serverless_kubernetes.main ce4273f9156874b46bb
 ```

--- a/website/docs/r/cs_serverless_kubernetes.html.markdown
+++ b/website/docs/r/cs_serverless_kubernetes.html.markdown
@@ -27,8 +27,6 @@ after creating cluster successfully, and you can put them into the specified loc
 -> **NOTE:** You need to activate several other products and confirm Authorization Policy used by Container Service before using this resource.
 Please refer to the `Authorization management` and `Cluster management` sections in the [Document Center](https://www.alibabacloud.com/help/doc-detail/86488.htm).
 
--> **NOTE:** 
-
 ## Example Usage
 
 Basic Usage
@@ -119,7 +117,6 @@ The following arguments are supported:
 * `addons` - (Available in 1.91.0+)) You can specific network plugin,log component,ingress component and so on.Detailed below.
 * `time_zone` - (Optional, ForceNew, Available in 1.124.0+) The time zone of the cluster.
 * `zone_id` - (Optional, ForceNew, Available in 1.124.0+) When creating a cluster using automatic VPC creation, you need to specify the zone where the VPC is located. 
-* `region_id` - (Optional, ForceNew, Available in 1.124.0+) ID of the region where the cluster is located.
 * `service_cidr` - (Optional, ForceNew, Available in 1.124.0+) CIDR block of the service network. The specified CIDR block cannot overlap with that of the VPC or those of the ACK clusters that are deployed in the VPC. The CIDR block cannot be modified after the cluster is created.
 * `logging_type` - (ForceNew, Available in 1.124.0+) Enable log service, Valid value `SLS`. 
 * `sls_project_name` - (ForceNew, Available in 1.124.0+) If you use an existing SLS project, you must specify `sls_project_name`.


### PR DESCRIPTION
1. Node pool supports spot instances and sets public IP for the instances 
2. Support for specifying resource groups when creating a node pool 
3. Serverless k8s support coredns as service discovery
4. Serverless k8s support setting region, time zone, log configuration 
5. bugfix: The managed cluster will be upgraded when it is created 