### PR TITLE
resource/alicloud_elasitcsearch_instance: Fixes the enable_kibana_private_network  is not effect error when the first creation.

### DIFF
--- a/alicloud/resource_alicloud_elasticsearch_instance.go
+++ b/alicloud/resource_alicloud_elasticsearch_instance.go
@@ -404,7 +404,7 @@ func resourceAlicloudElasticsearchUpdate(d *schema.ResourceData, meta interface{
 		d.SetPartial("public_whitelist")
 	}
 
-	if d.HasChange("enable_kibana_public_network") {
+	if d.HasChange("enable_kibana_public_network") || d.IsNewResource() {
 		content := make(map[string]interface{})
 		content["networkType"] = string(PUBLIC)
 		content["nodeType"] = string(KIBANA)

--- a/alicloud/service_alicloud_elasticsearch.go
+++ b/alicloud/service_alicloud_elasticsearch.go
@@ -121,6 +121,9 @@ func (s *ElasticsearchService) TriggerNetwork(d *schema.ResourceData, content ma
 
 	addDebug(action, response, content)
 	if err != nil {
+		if IsExpectedErrors(err, []string{"RepetitionOperationError"}) {
+			return nil
+		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 


### PR DESCRIPTION
Fix:Close kibana public network was not applied at creation