### PR TITLE
resource/alicloud_ess_scalingconfiguration: Adds new attributes `performance_level` and `system_disk_performance_level` to support performance level

### DIFF
--- a/alicloud/data_source_alicloud_ess_scalingconfigurations.go
+++ b/alicloud/data_source_alicloud_ess_scalingconfigurations.go
@@ -95,6 +95,10 @@ func dataSourceAlicloudEssScalingConfigurations() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"system_disk_performance_level": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"data_disks": {
 							Type: schema.TypeList,
 							Elem: &schema.Resource{
@@ -117,6 +121,10 @@ func dataSourceAlicloudEssScalingConfigurations() *schema.Resource {
 									},
 									"delete_with_instance": {
 										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"performance_level": {
+										Type:     schema.TypeString,
 										Optional: true,
 									},
 								},
@@ -221,21 +229,22 @@ func scalingConfigurationsDescriptionAttribute(d *schema.ResourceData, scalingCo
 	essService := EssService{client}
 	for _, scalingConfiguration := range scalingConfigurations {
 		mapping := map[string]interface{}{
-			"id":                         scalingConfiguration.ScalingConfigurationId,
-			"name":                       scalingConfiguration.ScalingConfigurationName,
-			"scaling_group_id":           scalingConfiguration.ScalingGroupId,
-			"image_id":                   scalingConfiguration.ImageId,
-			"instance_type":              scalingConfiguration.InstanceType,
-			"security_group_id":          scalingConfiguration.SecurityGroupId,
-			"internet_charge_type":       scalingConfiguration.InternetChargeType,
-			"internet_max_bandwidth_in":  scalingConfiguration.InternetMaxBandwidthIn,
-			"internet_max_bandwidth_out": scalingConfiguration.InternetMaxBandwidthOut,
-			"credit_specification":       scalingConfiguration.CreditSpecification,
-			"system_disk_category":       scalingConfiguration.SystemDiskCategory,
-			"system_disk_size":           scalingConfiguration.SystemDiskSize,
-			"data_disks":                 essService.flattenDataDiskMappings(scalingConfiguration.DataDisks.DataDisk),
-			"lifecycle_state":            scalingConfiguration.LifecycleState,
-			"creation_time":              scalingConfiguration.CreationTime,
+			"id":                            scalingConfiguration.ScalingConfigurationId,
+			"name":                          scalingConfiguration.ScalingConfigurationName,
+			"scaling_group_id":              scalingConfiguration.ScalingGroupId,
+			"image_id":                      scalingConfiguration.ImageId,
+			"instance_type":                 scalingConfiguration.InstanceType,
+			"security_group_id":             scalingConfiguration.SecurityGroupId,
+			"internet_charge_type":          scalingConfiguration.InternetChargeType,
+			"internet_max_bandwidth_in":     scalingConfiguration.InternetMaxBandwidthIn,
+			"internet_max_bandwidth_out":    scalingConfiguration.InternetMaxBandwidthOut,
+			"credit_specification":          scalingConfiguration.CreditSpecification,
+			"system_disk_category":          scalingConfiguration.SystemDiskCategory,
+			"system_disk_size":              scalingConfiguration.SystemDiskSize,
+			"system_disk_performance_level": scalingConfiguration.SystemDiskPerformanceLevel,
+			"data_disks":                    essService.flattenDataDiskMappings(scalingConfiguration.DataDisks.DataDisk),
+			"lifecycle_state":               scalingConfiguration.LifecycleState,
+			"creation_time":                 scalingConfiguration.CreationTime,
 		}
 		ids = append(ids, scalingConfiguration.ScalingConfigurationId)
 		names = append(names, scalingConfiguration.ScalingConfigurationName)

--- a/alicloud/data_source_alicloud_ess_scalingconfigurations_test.go
+++ b/alicloud/data_source_alicloud_ess_scalingconfigurations_test.go
@@ -52,21 +52,22 @@ func TestAccAlicloudEssScalingconfigurationsDataSource(t *testing.T) {
 
 	var existEssScalingconfigurationsMapFunc = func(rand int) map[string]string {
 		return map[string]string{
-			"ids.#":                                       "1",
-			"names.#":                                     "1",
-			"configurations.#":                            "1",
-			"configurations.0.name":                       fmt.Sprintf("tf-testAccDataSourceEssScalingRules-%d", rand),
-			"configurations.0.scaling_group_id":           CHECKSET,
-			"configurations.0.image_id":                   CHECKSET,
-			"configurations.0.instance_type":              CHECKSET,
-			"configurations.0.security_group_id":          CHECKSET,
-			"configurations.0.creation_time":              CHECKSET,
-			"configurations.0.system_disk_category":       CHECKSET,
-			"configurations.0.system_disk_size":           CHECKSET,
-			"configurations.0.internet_max_bandwidth_in":  CHECKSET,
-			"configurations.0.internet_max_bandwidth_out": CHECKSET,
-			"configurations.0.internet_charge_type":       CHECKSET,
-			"configurations.0.data_disks.#":               "0",
+			"ids.#":                                          "1",
+			"names.#":                                        "1",
+			"configurations.#":                               "1",
+			"configurations.0.name":                          fmt.Sprintf("tf-testAccDataSourceEssScalingRules-%d", rand),
+			"configurations.0.scaling_group_id":              CHECKSET,
+			"configurations.0.image_id":                      CHECKSET,
+			"configurations.0.instance_type":                 CHECKSET,
+			"configurations.0.security_group_id":             CHECKSET,
+			"configurations.0.creation_time":                 CHECKSET,
+			"configurations.0.system_disk_category":          CHECKSET,
+			"configurations.0.system_disk_size":              CHECKSET,
+			"configurations.0.system_disk_performance_level": "PL1",
+			"configurations.0.internet_max_bandwidth_in":     CHECKSET,
+			"configurations.0.internet_max_bandwidth_out":    CHECKSET,
+			"configurations.0.internet_charge_type":          CHECKSET,
+			"configurations.0.data_disks.#":                  "0",
 		}
 	}
 
@@ -115,6 +116,8 @@ resource "alicloud_ess_scaling_configuration" "default"{
 	image_id = "${data.alicloud_images.default.images.0.id}"
 	instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
 	security_group_id = "${alicloud_security_group.default.id}"
+	system_disk_category = "cloud_essd"
+	system_disk_performance_level = "PL1"
 	force_delete = true
 }
 

--- a/alicloud/resource_alicloud_ess_scalingconfiguration.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration.go
@@ -189,6 +189,10 @@ func resourceAlicloudEssScalingConfiguration() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"performance_level": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -274,6 +278,10 @@ func resourceAlicloudEssScalingConfiguration() *schema.Resource {
 					return d.Get("kms_encrypted_password").(string) == ""
 				},
 				Elem: schema.TypeString,
+			},
+			"system_disk_performance_level": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}
@@ -469,6 +477,11 @@ func modifyEssScalingConfiguration(d *schema.ResourceData, meta interface{}) err
 		d.SetPartial("system_disk_auto_snapshot_policy_id")
 	}
 
+	if d.HasChange("system_disk_performance_level") {
+		request.SystemDiskPerformanceLevel = d.Get("system_disk_performance_level").(string)
+		d.SetPartial("system_disk_performance_level")
+	}
+
 	if d.HasChange("user_data") {
 		if v, ok := d.GetOk("user_data"); ok && v.(string) != "" {
 			_, base64DecodeError := base64.StdEncoding.DecodeString(v.(string))
@@ -525,6 +538,7 @@ func modifyEssScalingConfiguration(d *schema.ResourceData, meta interface{}) err
 					DiskName:             pack["name"].(string),
 					Description:          pack["description"].(string),
 					AutoSnapshotPolicyId: pack["auto_snapshot_policy_id"].(string),
+					PerformanceLevel:     pack["performance_level"].(string),
 				}
 				createDataDisks = append(createDataDisks, dataDisk)
 			}
@@ -646,6 +660,7 @@ func resourceAliyunEssScalingConfigurationRead(d *schema.ResourceData, meta inte
 	d.Set("system_disk_name", object.SystemDiskName)
 	d.Set("system_disk_description", object.SystemDiskDescription)
 	d.Set("system_disk_auto_snapshot_policy_id", object.SystemDiskAutoSnapshotPolicyId)
+	d.Set("system_disk_performance_level", object.SystemDiskPerformanceLevel)
 	d.Set("data_disk", essService.flattenDataDiskMappings(object.DataDisks.DataDisk))
 	d.Set("role_name", object.RamRoleName)
 	d.Set("key_name", object.KeyPairName)
@@ -860,6 +875,10 @@ func buildAlicloudEssScalingConfigurationArgs(d *schema.ResourceData, meta inter
 		request.SystemDiskAutoSnapshotPolicyId = v
 	}
 
+	if v := d.Get("system_disk_performance_level").(string); v != "" {
+		request.SystemDiskPerformanceLevel = v
+	}
+
 	dds, ok := d.GetOk("data_disk")
 	if ok {
 		disks := dds.([]interface{})
@@ -877,6 +896,7 @@ func buildAlicloudEssScalingConfigurationArgs(d *schema.ResourceData, meta inter
 				DiskName:             pack["name"].(string),
 				Description:          pack["description"].(string),
 				AutoSnapshotPolicyId: pack["auto_snapshot_policy_id"].(string),
+				PerformanceLevel:     pack["performance_level"].(string),
 			}
 			createDataDisks = append(createDataDisks, dataDisk)
 		}

--- a/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration_test.go
@@ -338,6 +338,121 @@ func TestAccAlicloudEssScalingConfigurationUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAlicloudEssScalingConfigurationPerformanceLevel(t *testing.T) {
+	rand := acctest.RandIntRange(1000, 999999)
+	var v ess.ScalingConfiguration
+	resourceId := "alicloud_ess_scaling_configuration.pl"
+	basicMap := map[string]string{
+		"scaling_group_id":  CHECKSET,
+		"instance_type":     CHECKSET,
+		"security_group_id": CHECKSET,
+		"image_id":          REGEXMATCH + "^ubuntu",
+		"override":          "false",
+	}
+	ra := resourceAttrInit(resourceId, basicMap)
+	rc := resourceCheckInit(resourceId, &v, func() interface{} {
+		return &EssService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	})
+	rac := resourceAttrCheckInit(rc, ra)
+
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAccEssScalingConfiguration-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceEssScalingConfigurationConfigDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: resourceId,
+
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"scaling_group_id":  "${alicloud_ess_scaling_group.default.id}",
+					"image_id":          "${data.alicloud_images.default.images.0.id}",
+					"instance_type":     "${data.alicloud_instance_types.default.instance_types.0.id}",
+					"security_group_id": "${alicloud_security_group.default.id}",
+					"force_delete":      "true",
+					"password":          "123-abcABC",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"password_inherit": "false",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_delete", "instance_type", "security_group_id", "password", "kms_encrypted_password", "kms_encryption_context"},
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"active": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"active": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"system_disk_category": "cloud_essd",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"system_disk_category": "cloud_essd",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"system_disk_performance_level": "PL1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"system_disk_performance_level": "PL1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"data_disk": []map[string]string{{
+						"size":                 "20",
+						"category":             "cloud_essd",
+						"delete_with_instance": "false",
+						"encrypted":            "true",
+						"kms_key_id":           "${alicloud_kms_key.key.id}",
+						"name":                 "kms",
+						"description":          "kms",
+						"performance_level":    "PL1",
+					},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"data_disk.#":                      "1",
+						"data_disk.0.size":                 "20",
+						"data_disk.0.category":             "cloud_essd",
+						"data_disk.0.delete_with_instance": "false",
+						"data_disk.0.encrypted":            "true",
+						"data_disk.0.kms_key_id":           CHECKSET,
+						"data_disk.0.name":                 "kms",
+						"data_disk.0.description":          "kms",
+						"data_disk.0.performance_level":    "PL1",
+					}),
+				),
+			},
+
+		},
+	})
+}
+
 func TestAccAlicloudEssScalingConfigurationMulti(t *testing.T) {
 	rand := acctest.RandIntRange(1000, 999999)
 	var v ess.ScalingConfiguration

--- a/alicloud/service_alicloud_ess.go
+++ b/alicloud/service_alicloud_ess.go
@@ -250,6 +250,7 @@ func (s *EssService) flattenDataDiskMappings(list []ess.DataDisk) []map[string]i
 			"disk_name":               i.DiskName,
 			"description":             i.Description,
 			"auto_snapshot_policy_id": i.AutoSnapshotPolicyId,
+			"performance_level":       i.PerformanceLevel,
 		}
 		result = append(result, l)
 	}

--- a/website/docs/d/ess_scaling_configurations.html.markdown
+++ b/website/docs/d/ess_scaling_configurations.html.markdown
@@ -53,12 +53,14 @@ The following attributes are exported in addition to the arguments listed above:
   * `credit_specification` - Performance mode of the t5 burstable instance.
   * `system_disk_category` - System disk category of the scaling configuration.
   * `system_disk_size` - System disk size of the scaling configuration.
+  * `system_disk_performance_level` - The performance level of the ESSD used as the system disk.
   * `data_disks` - Data disks of the scaling configuration.
     * `size` - Size of data disk.
     * `category` - Category of data disk.
     * `snapshot_id` - Size of data disk.
     * `device` - Device attribute of data disk.
     * `delete_with_instance` - Delete_with_instance attribute of data disk.
+    * `performance_level` - The performance level of the ESSD used as data disk.
   * `lifecycle_state` - Lifecycle state of the scaling configuration.
   * `creation_time` - Creation time of the scaling configuration.
   

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -112,6 +112,7 @@ The following arguments are supported:
 * `system_disk_name` - (Optional, Available in 1.92.0+) The name of the system disk. It must be 2 to 128 characters in length. It must start with a letter and cannot start with http:// or https://. It can contain letters, digits, colons (:), underscores (_), and hyphens (-). Default value: null.
 * `system_disk_description` - (Optional, Available in 1.92.0+) The description of the system disk. The description must be 2 to 256 characters in length and cannot start with http:// or https://.
 * `system_disk_auto_snapshot_policy_id` - (Optional, Available in 1.92.0+) The id of auto snapshot policy for system disk.
+* `system_disk_performance_level` - (Optional, Available in 1.124.3+) The performance level of the ESSD used as the system disk.
 * `enable` - (Optional) Whether enable the specified scaling group(make it active) to which the current scaling configuration belongs.
 * `active` - (Optional) Whether active current scaling configuration in the specified scaling group. Default to `false`.
 * `substitute` - (Optional) The another scaling configuration which will be active automatically and replace current configuration when setting `active` to 'false'. It is invalid when `active` is 'true'.
@@ -159,6 +160,7 @@ The datadisk mapping supports the following:
 * `name` - (Optional, Available in 1.92.0+) The name of data disk N. Valid values of N: 1 to 16. It must be 2 to 128 characters in length. It must start with a letter and cannot start with http:// or https://. It can contain letters, digits, colons (:), underscores (_), and hyphens (-). Default value: null.
 * `description` - (Optional, Available in 1.92.0+) The description of data disk N. Valid values of N: 1 to 16. The description must be 2 to 256 characters in length and cannot start with http:// or https://.
 * `auto_snapshot_policy_id` - (Optional, Available in 1.92.0+) The id of auto snapshot policy for data disk.
+* `performance_level` - (Optional, Available in 1.124.3+) The performance level of the ESSD used as data disk.
 
 ## Attributes Reference
 


### PR DESCRIPTION
ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssScaling -timeout=300m
=== RUN   TestAccAlicloudEssScalingconfigurationsDataSource
--- PASS: TestAccAlicloudEssScalingconfigurationsDataSource (89.40s)
=== RUN   TestAccAlicloudEssScalinggroupsDataSource
--- PASS: TestAccAlicloudEssScalinggroupsDataSource (70.61s)
=== RUN   TestAccAlicloudEssScalingrulesDataSource
--- PASS: TestAccAlicloudEssScalingrulesDataSource (97.35s)
=== RUN   TestAccAlicloudEssScalingConfigurationUpdate
--- PASS: TestAccAlicloudEssScalingConfigurationUpdate (174.39s)
=== RUN   TestAccAlicloudEssScalingConfigurationMulti
--- PASS: TestAccAlicloudEssScalingConfigurationMulti (45.93s)
=== RUN   TestAccAlicloudEssScalingGroup_basic
--- PASS: TestAccAlicloudEssScalingGroup_basic (102.94s)
=== RUN   TestAccAlicloudEssScalingGroup_costoptimized
--- PASS: TestAccAlicloudEssScalingGroup_costoptimized (79.06s)
=== RUN   TestAccAlicloudEssScalingGroup_vpc
--- PASS: TestAccAlicloudEssScalingGroup_vpc (101.61s)
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (127.62s)
=== RUN   TestAccAlicloudEssScalingRule_basic
--- PASS: TestAccAlicloudEssScalingRule_basic (75.75s)
=== RUN   TestAccAlicloudEssScalingRule_target_tracking_rule_basic
--- PASS: TestAccAlicloudEssScalingRule_target_tracking_rule_basic (78.25s)
=== RUN   TestAccAlicloudEssScalingRule_step_rule_basic
--- PASS: TestAccAlicloudEssScalingRule_step_rule_basic (58.42s)
=== RUN   TestAccAlicloudEssScalingRuleMulti
--- PASS: TestAccAlicloudEssScalingRuleMulti (43.81s)
PASS
ok  	github.com/aliyun/terraform-provider-alicloud/alicloud	1147.747s