### PR TITLE
resource/alicloud_slb_listener: Fixes the default parameter when updating the specified parameter with SetLoadBalancerHTTPSListenerAttribute Method

### DIFF
--- a/alicloud/resource_alicloud_slb_listener.go
+++ b/alicloud/resource_alicloud_slb_listener.go
@@ -663,11 +663,12 @@ func resourceAliyunSlbListenerUpdate(d *schema.ResourceData, meta interface{}) e
 
 	// http https tcp
 	if d.HasChange("health_check_domain") {
-		if domain, ok := d.GetOk("health_check_domain"); ok {
-			httpArgs.QueryParams["HealthCheckDomain"] = domain.(string)
-			tcpArgs.QueryParams["HealthCheckDomain"] = domain.(string)
-			update = true
-		}
+		update = true
+	}
+	// todo: depends on Api fixing the default value
+	if domain, ok := d.GetOk("health_check_domain"); ok {
+		httpArgs.QueryParams["HealthCheckDomain"] = domain.(string)
+		tcpArgs.QueryParams["HealthCheckDomain"] = domain.(string)
 	}
 	if d.HasChange("health_check_uri") {
 		tcpArgs.QueryParams["HealthCheckURI"] = d.Get("health_check_uri").(string)

--- a/alicloud/resource_alicloud_slb_listener_test.go
+++ b/alicloud/resource_alicloud_slb_listener_test.go
@@ -420,6 +420,7 @@ func TestAccAlicloudSlbListener_https_update(t *testing.T) {
 					"cookie":                    "testslblistenercookie",
 					"health_check":              "on",
 					"health_check_uri":          "/cons",
+					"health_check_domain": "internal-health-check",
 					"health_check_connect_port": "20",
 					"healthy_threshold":         "8",
 					"unhealthy_threshold":       "8",
@@ -456,6 +457,7 @@ func TestAccAlicloudSlbListener_https_update(t *testing.T) {
 						"cookie_timeout":            "86400",
 						"health_check":              "on",
 						"health_check_connect_port": "20",
+						"health_check_domain": "internal-health-check",
 						"healthy_threshold":         "8",
 						"unhealthy_threshold":       "8",
 						"health_check_timeout":      "8",
@@ -629,6 +631,17 @@ func TestAccAlicloudSlbListener_https_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"bandwidth": "15",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"acl_status": "off",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"acl_status": "off",
+						"health_check_domain": "internal-health-check",
 					}),
 				),
 			},


### PR DESCRIPTION
updated file:
- resource_alicloud_slb_listener.go
- resource_alicloud_slb_listener_test.go