### PR TITLE
resource/alicloud_route_table: Removes  the specified expectedError into Retry Process with Delete Method

### DIFF
--- a/alicloud/resource_alicloud_route_table.go
+++ b/alicloud/resource_alicloud_route_table.go
@@ -198,7 +198,7 @@ func resourceAlicloudRouteTableDelete(d *schema.ResourceData, meta interface{}) 
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2016-04-28"), StringPointer("AK"), nil, request, &util.RuntimeOptions{})
 		if err != nil {
-			if IsExpectedErrors(err, []string{"OperationConflict"}) || NeedRetry(err) {
+			if IsExpectedErrors(err, []string{"OperationConflict","DependencyViolation.RouteEntry", "IncorrectRouteTableStatus"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}
@@ -208,9 +208,6 @@ func resourceAlicloudRouteTableDelete(d *schema.ResourceData, meta interface{}) 
 		return nil
 	})
 	if err != nil {
-		if IsExpectedErrors(err, []string{"DependencyViolation.RouteEntry", "IncorrectRouteTableStatus", "InvalidParameter.Action", "InvalidRegionId.NotFound"}) {
-			return nil
-		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 	return nil


### PR DESCRIPTION
Updated File:
- resource_alicloud_route_table.go


remove

resource/alicloud_slb_listener: Fixes the default parameter when updating the specified parameter with SetLoadBalancerHTTPSListenerAttribute Method (#3735)