### PR TITLE
docs/alicloud_cms_alarm: Adds missing values for cms_alarm statistics

### DIFF
--- a/website/docs/r/cms_alarm.html.markdown
+++ b/website/docs/r/cms_alarm.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 * `threshold` - It has been deprecated from provider version 1.94.0 and 'escalations_critical.threshold' instead.
 * `triggered_count` - It has been deprecated from provider version 1.94.0 and 'escalations_critical.times' instead.
 * `contact_groups` - (Required) List contact groups of the alarm rule, which must have been created on the console.
-* `effective_interval` - (Available in 1.50.0+) The interval of effecting alarm rule. It foramt as "hh:mm-hh:mm", like "0:00-4:00". Default to "00:00-23:59".
+* `effective_interval` - (Available in 1.50.0+) The interval of effecting alarm rule. It format as "hh:mm-hh:mm", like "0:00-4:00". Default to "00:00-23:59".
 * `start_time` - It has been deprecated from provider version 1.50.0 and 'effective_interval' instead.
 * `end_time` - It has been deprecated from provider version 1.50.0 and 'effective_interval' instead.
 * `silence_time` - Notification silence period in the alarm state, in seconds. Valid value range: [300, 86400]. Default to 86400
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 The escalations_critical supports the following:
 
-* `statistics` - Critical level alarm statistics method.. It must be consistent with that defined for metrics. Valid values: ["Average", "Minimum", "Maximum"]. Default to "Average".
+* `statistics` - Critical level alarm statistics method. It must be consistent with that defined for metrics. Valid values: ["Average", "Minimum", "Maximum", "Value", "ErrorCodeMaximum", "Sum", "Count"]. Default to "Average".
 * `comparison_operator` - Critical level alarm comparison operator. Valid values: ["<=", "<", ">", ">=", "==", "!="]. Default to "==".
 * `threshold` - Critical level alarm threshold value, which must be a numeric value currently.
 * `times` - Critical level alarm retry times. Default to 3.
@@ -78,7 +78,7 @@ The escalations_critical supports the following:
 
 The escalations_warn supports the following:
 
-* `statistics` - Critical level alarm statistics method.. It must be consistent with that defined for metrics. Valid values: ["Average", "Minimum", "Maximum"]. Default to "Average".
+* `statistics` - Critical level alarm statistics method. It must be consistent with that defined for metrics. Valid values: ["Average", "Minimum", "Maximum", "Value", "ErrorCodeMaximum", "Sum", "Count"]. Default to "Average".
 * `comparison_operator` - Critical level alarm comparison operator. Valid values: ["<=", "<", ">", ">=", "==", "!="]. Default to "==".
 * `threshold` - Critical level alarm threshold value, which must be a numeric value currently.
 * `times` - Critical level alarm retry times. Default to 3.
@@ -87,7 +87,7 @@ The escalations_warn supports the following:
 
 The escalations_info supports the following:
 
-* `statistics` - Critical level alarm statistics method.. It must be consistent with that defined for metrics. Valid values: ["Average", "Minimum", "Maximum"]. Default to "Average".
+* `statistics` - Critical level alarm statistics method. It must be consistent with that defined for metrics. Valid values: ["Average", "Minimum", "Maximum", "Value", "ErrorCodeMaximum", "Sum", "Count"]. Default to "Average".
 * `comparison_operator` - Critical level alarm comparison operator. Valid values: ["<=", "<", ">", ">=", "==", "!="]. Default to "==".
 * `threshold` - Critical level alarm threshold value, which must be a numeric value currently.
 * `times` - Critical level alarm retry times. Default to 3.


### PR DESCRIPTION
Current [cms_alarm documentation](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cms_alarm) is not up to date with the code. In this PR I would like to add missing values for `statistics` parameter according to schema defined in `resource_alicloud_cms_alarm.go`