### PR TITLE
resource/alicloud_slb_listener: Change alicloud_slb_listener's bandwidth&scheduler

### DIFF
--- a/alicloud/resource_alicloud_slb_listener.go
+++ b/alicloud/resource_alicloud_slb_listener.go
@@ -83,7 +83,7 @@ func resourceAliyunSlbListener() *schema.Resource {
 			},
 			"scheduler": {
 				Type:         schema.TypeString,
-				ValidateFunc: validation.StringInSlice([]string{"wrr", "wlc", "rr", "sch"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"wrr", "wlc", "rr", "sch", "tch", "qch"}, false),
 				Optional:     true,
 				Default:      WRRScheduler,
 			},

--- a/alicloud/resource_alicloud_slb_listener.go
+++ b/alicloud/resource_alicloud_slb_listener.go
@@ -80,6 +80,7 @@ func resourceAliyunSlbListener() *schema.Resource {
 					validation.IntBetween(1, 1000),
 					validation.IntInSlice([]int{-1})),
 				Optional: true,
+				Default:  -1,
 			},
 			"scheduler": {
 				Type:         schema.TypeString,

--- a/website/docs/r/slb_listener.html.markdown
+++ b/website/docs/r/slb_listener.html.markdown
@@ -89,9 +89,9 @@ The following arguments are supported:
 * `frontend_port` - (Required, ForceNew) Port used by the Server Load Balancer instance frontend. Valid value range: [1-65535].
 * `backend_port` - (Optional, ForceNew) Port used by the Server Load Balancer instance backend. Valid value range: [1-65535].
 * `protocol` - (Required, ForceNew) The protocol to listen on. Valid values are [`http`, `https`, `tcp`, `udp`].
-* `bandwidth` - (Optional) Bandwidth peak of Listener. For the public network instance charged per traffic consumed, the Bandwidth on Listener can be set to -1, indicating the bandwidth peak is unlimited. Valid values are [-1, 1-1000] in Mbps.
+* `bandwidth` - (Optional) Bandwidth peak of Listener. For the public network instance charged per traffic consumed, the Bandwidth on Listener can be set to -1, indicating the bandwidth peak is unlimited. Valid values are [-1, 1-1000] in Mbps. Default to -1.
 * `description` - (Optional, Available in 1.69.0+) The description of slb listener. This description can have a string of 1 to 80 characters. Default value: null.
-* `scheduler` - (Optional) Scheduling algorithm,  Valid values: `wrr`, `rr`, `wlc`, `sch`. Default to `wrr`. Only when `protocol` is `tcp` or `udp`, `scheduler` can be set to `sch`.
+* `scheduler` - (Optional) Scheduling algorithm,  Valid values: `wrr`, `rr`, `wlc`, `sch`, `tcp`, `qch`. Default to `wrr`. Only when `protocol` is `tcp` or `udp`, `scheduler` can be set to `sch`. Only when instance is guaranteed-performance instance and `protocol` is `tcp` or `udp`, `scheduler` can be set to `tch`. Only when instance is guaranteed-performance instance and `protocol` is `udp`, `scheduler` can be set to `qch`.
 * `sticky_session` - (Optional) Whether to enable session persistence, Valid values are `on` and `off`. Default to `off`.
 * `sticky_session_type` - (Optional) Mode for handling the cookie. If `sticky_session` is "on", it is mandatory. Otherwise, it will be ignored. Valid values are `insert` and `server`. `insert` means it is inserted from Server Load Balancer; `server` means the Server Load Balancer learns from the backend server.
 * `cookie_timeout` - (Optional) Cookie timeout. It is mandatory when `sticky_session` is "on" and `sticky_session_type` is "insert". Otherwise, it will be ignored. Valid value range: [1-86400] in seconds.
@@ -149,7 +149,7 @@ backend_port | http & https & tcp & udp | 1-65535 |
 frontend_port | http & https & tcp & udp | 1-65535 |
 protocol | http & https & tcp & udp |
 bandwidth | http & https & tcp & udp | -1 / 1-1000 |
-scheduler | http & https & tcp & udp | wrr rr or wlc |
+scheduler | http & https & tcp & udp | wrr, rr, wlc, tch, qch |
 sticky_session | http & https | on or off |
 sticky_session_type | http & https | insert or server | 
 cookie_timeout | http & https | 1-86400  | 


### PR DESCRIPTION
## Bandwidth
After I import an "alicloud_slb_listener", I try to apply some changes. It seems the value of bandwidth in request will be 0 and will make request failed.
```
│ Error: [ERROR] terraform-provider-alicloud/alicloud/resource_alicloud_slb_listener.go:755: Resource lb-**:tcp:5672 SetLoadBalancerTCPListenerAttribute Failed!!! [SDK alibaba-cloud-sdk-go ERROR]:
│ SDK.ServerError
│ ErrorCode: InvalidParameter
│ Recommend: https://error-center.aliyun.com/status/search?Keyword=InvalidParameter&source=PopGw
│ RequestId: **
│ Message: The specified Bandwidth is invalid.
│ 
│   with alicloud_slb_listener.**,
│   on clb_hz.tf line 40, in resource "alicloud_slb_listener" "**":
│   40: resource "alicloud_slb_listener" "**" {
```
So I think bandwidth's default value should set to -1.

## Scheduler
According to [CreateLoadBalancerTCPListener](https://help.aliyun.com/document_detail/27594.html#h2-url-2) and [CreateLoadBalancerUDPListener](https://help.aliyun.com/document_detail/27595.html#h2-url-2), the "Scheduler" parameter have added "tch"&"qch" values.
For "wrr" value, I only found it in [CreateServerGroup](https://help.aliyun.com/document_detail/213624.html#h2-url-2). Is this a legacy value?