### PR TITLE
resource/alicloud_cen_transit_router: Fixes the ParameterInstanceId error when deleting the resource; Improves other testcases

### DIFF
--- a/alicloud/data_source_alicloud_cen_transit_router_route_entries_test.go
+++ b/alicloud/data_source_alicloud_cen_transit_router_route_entries_test.go
@@ -104,7 +104,7 @@ resource "alicloud_express_connect_virtual_border_router" "default" {
   peering_subnet_mask        = "255.255.255.252"
   physical_connection_id     = data.alicloud_express_connect_physical_connections.nameRegex.connections.0.id
   virtual_border_router_name = var.name
-  vlan_id                    = 1
+  vlan_id                    = 12
   min_rx_interval            = 1000
   min_tx_interval            = 1000
   detect_multiplier          = 10
@@ -120,17 +120,17 @@ resource "alicloud_cen_transit_router_vbr_attachment" "default" {
 }
 
 resource "alicloud_cen_transit_router_route_table" "default" {
-transit_router_id = alicloud_cen_transit_router.default.transit_router_id
-transit_router_route_table_name = var.name
+	transit_router_id = alicloud_cen_transit_router_vbr_attachment.default.transit_router_id
+	transit_router_route_table_name = var.name
 }
 
 resource "alicloud_cen_transit_router_route_entry" "default" {
-transit_router_route_entry_description = "desc"
-transit_router_route_entry_destination_cidr_block = "192.168.1.0/24"
-transit_router_route_entry_name = var.name
-transit_router_route_entry_next_hop_id = alicloud_cen_transit_router_vbr_attachment.default.transit_router_attachment_id
-transit_router_route_entry_next_hop_type = "Attachment"
-transit_router_route_table_id = alicloud_cen_transit_router_route_table.default.transit_router_route_table_id
+	transit_router_route_entry_description = "desc"
+	transit_router_route_entry_destination_cidr_block = "192.168.1.0/24"
+	transit_router_route_entry_name = var.name
+	transit_router_route_entry_next_hop_id = alicloud_cen_transit_router_vbr_attachment.default.transit_router_attachment_id
+	transit_router_route_entry_next_hop_type = "Attachment"
+	transit_router_route_table_id = alicloud_cen_transit_router_route_table.default.transit_router_route_table_id
 }
 
 data "alicloud_cen_transit_router_route_entries" "default" {

--- a/alicloud/data_source_alicloud_cen_transit_router_route_table_associations_test.go
+++ b/alicloud/data_source_alicloud_cen_transit_router_route_table_associations_test.go
@@ -97,7 +97,7 @@ resource "alicloud_express_connect_virtual_border_router" "default" {
   peering_subnet_mask        = "255.255.255.252"
   physical_connection_id     = data.alicloud_express_connect_physical_connections.nameRegex.connections.0.id
   virtual_border_router_name = var.name
-  vlan_id                    = 1
+  vlan_id                    = 13
   min_rx_interval            = 1000
   min_tx_interval            = 1000
   detect_multiplier          = 10

--- a/alicloud/data_source_alicloud_cen_transit_router_route_table_propagations_test.go
+++ b/alicloud/data_source_alicloud_cen_transit_router_route_table_propagations_test.go
@@ -95,7 +95,7 @@ resource "alicloud_express_connect_virtual_border_router" "default" {
   peering_subnet_mask        = "255.255.255.252"
   physical_connection_id     = data.alicloud_express_connect_physical_connections.nameRegex.connections.0.id
   virtual_border_router_name = var.name
-  vlan_id                    = 1
+  vlan_id                    = 14
   min_rx_interval            = 1000
   min_tx_interval            = 1000
   detect_multiplier          = 10

--- a/alicloud/data_source_alicloud_cen_transit_router_vbr_attachments_test.go
+++ b/alicloud/data_source_alicloud_cen_transit_router_vbr_attachments_test.go
@@ -9,11 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-/**
-This resource has buried point data.
-VBR is buried point data.
-*/
-func SkipTestAccAlicloudCenTransitRouterVbrAttachmentsDataSource(t *testing.T) {
+func TestAccAlicloudCenTransitRouterVbrAttachmentsDataSource(t *testing.T) {
 	rand := acctest.RandInt()
 	idsConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudCenTransitRouterVbrAttachmentsDataSourceName(rand, map[string]string{
@@ -53,7 +49,7 @@ func SkipTestAccAlicloudCenTransitRouterVbrAttachmentsDataSource(t *testing.T) {
 			"attachments.0.transit_router_attachment_id":          CHECKSET,
 			"attachments.0.transit_router_attachment_description": `desp`,
 			"attachments.0.transit_router_attachment_name":        fmt.Sprintf("tf-testAccDataTransitRouterVbrAttachment-%d", rand),
-			"attachments.0.vbr_id":                                `vbr-j6cd9pm9y6d6e20atoi6w`,
+			"attachments.0.vbr_id":                                CHECKSET,
 			"attachments.0.resource_type":                         `VBR`,
 		}
 	}
@@ -104,22 +100,22 @@ resource "alicloud_express_connect_virtual_border_router" "default" {
   peering_subnet_mask        = "255.255.255.252"
   physical_connection_id     = data.alicloud_express_connect_physical_connections.nameRegex.connections.0.id
   virtual_border_router_name = var.name
-  vlan_id                    = 1
+  vlan_id                    = 11
   min_rx_interval            = 1000
   min_tx_interval            = 1000
   detect_multiplier          = 10
 }
 resource "alicloud_cen_transit_router_vbr_attachment" "default" {
-auto_publish_route_enabled = true
-cen_id = alicloud_cen_instance.default.id
-transit_router_id = alicloud_cen_transit_router.default.transit_router_id
-vbr_id = alicloud_express_connect_virtual_border_router.default.id
-transit_router_attachment_description = "desp"
-transit_router_attachment_name = var.name
+	auto_publish_route_enabled = true
+	cen_id = alicloud_cen_instance.default.id
+	transit_router_id = alicloud_cen_transit_router.default.transit_router_id
+	vbr_id = alicloud_express_connect_virtual_border_router.default.id
+	transit_router_attachment_description = "desp"
+	transit_router_attachment_name = var.name
 }
 
 data "alicloud_cen_transit_router_vbr_attachments" "default" {	
-cen_id = alicloud_cen_instance.default.id
+	cen_id = alicloud_cen_transit_router_vbr_attachment.default.cen_id
 	%s
 }
 `, rand, strings.Join(pairs, " \n "))

--- a/alicloud/data_source_alicloud_cen_vbr_health_checks_test.go
+++ b/alicloud/data_source_alicloud_cen_vbr_health_checks_test.go
@@ -117,7 +117,7 @@ resource "alicloud_express_connect_virtual_border_router" "default" {
   peering_subnet_mask        = "255.255.255.252"
   physical_connection_id     = data.alicloud_express_connect_physical_connections.nameRegex.connections.0.id
   virtual_border_router_name = var.name
-  vlan_id                    = 1
+  vlan_id                    = 10
   min_rx_interval            = 1000
   min_tx_interval            = 1000
   detect_multiplier          = 10
@@ -126,6 +126,7 @@ resource "alicloud_cen_instance_attachment" "vbr" {
   instance_id = "${alicloud_cen_instance.default.id}"
   child_instance_id = alicloud_express_connect_virtual_border_router.default.id
   child_instance_region_id = "%[2]s"
+  child_instance_type = "VBR"
 }
 
 resource "alicloud_cen_vbr_health_check" "default" {

--- a/alicloud/data_source_alicloud_express_connect_virtual_border_routers_test.go
+++ b/alicloud/data_source_alicloud_express_connect_virtual_border_routers_test.go
@@ -165,7 +165,7 @@ resource "alicloud_express_connect_virtual_border_router" "default" {
   peering_subnet_mask        = "255.255.255.252"
   physical_connection_id     = data.alicloud_express_connect_physical_connections.nameRegex.connections.0.id
   virtual_border_router_name = var.name
-  vlan_id                    = 1
+  vlan_id                    = 15
   min_rx_interval            = 1000
   min_tx_interval            = 1000
   detect_multiplier          = 10

--- a/alicloud/resource_alicloud_amqp_virtual_host_test.go
+++ b/alicloud/resource_alicloud_amqp_virtual_host_test.go
@@ -71,6 +71,9 @@ func testSweepAmqpVirtualHost(region string) error {
 		for _, v := range result {
 			item := v.(map[string]interface{})
 			instanceId := fmt.Sprint(item["InstanceId"])
+			if fmt.Sprint(item["Status"]) != "SERVING" {
+				continue
+			}
 			action := "ListVirtualHosts"
 			request := make(map[string]interface{})
 			request["InstanceId"] = instanceId

--- a/alicloud/resource_alicloud_cen_private_zone_test.go
+++ b/alicloud/resource_alicloud_cen_private_zone_test.go
@@ -34,10 +34,9 @@ func TestAccAlicloudCenPrivateZone_basic(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"access_region_id": defaultRegionToTest,
-					"cen_id":           "${alicloud_cen_instance.default.id}",
+					"cen_id":           "${alicloud_cen_instance_attachment.default.instance_id}",
 					"host_region_id":   defaultRegionToTest,
-					"host_vpc_id":      "${alicloud_vpc.default.id}",
-					"depends_on":       []string{"alicloud_cen_instance_attachment.default"},
+					"host_vpc_id":      "${alicloud_cen_instance_attachment.default.child_instance_id}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -78,9 +77,6 @@ resource "alicloud_cen_instance_attachment" "default" {
 	child_instance_id = "${alicloud_vpc.default.id}"
 	child_instance_type = "VPC"
 	child_instance_region_id = "%s"
-  	depends_on = [
-		"alicloud_cen_instance.default",
-		"alicloud_vpc.default"]
 }
 `, name, defaultRegionToTest)
 }

--- a/alicloud/resource_alicloud_cen_transit_router.go
+++ b/alicloud/resource_alicloud_cen_transit_router.go
@@ -226,6 +226,9 @@ func resourceAlicloudCenTransitRouterDelete(d *schema.ResourceData, meta interfa
 	})
 	addDebug(action, response, request)
 	if err != nil {
+		if IsExpectedErrors(err, []string{"ParameterInstanceId"}) {
+			return nil
+		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 	return nil

--- a/alicloud/resource_alicloud_cen_transit_router_route_entry_test.go
+++ b/alicloud/resource_alicloud_cen_transit_router_route_entry_test.go
@@ -134,7 +134,7 @@ resource "alicloud_express_connect_virtual_border_router" "default" {
   peering_subnet_mask        = "255.255.255.252"
   physical_connection_id     = data.alicloud_express_connect_physical_connections.nameRegex.connections.0.id
   virtual_border_router_name = var.name
-  vlan_id                    = 1
+  vlan_id                    = 16
   min_rx_interval            = 1000
   min_tx_interval            = 1000
   detect_multiplier          = 10

--- a/alicloud/resource_alicloud_cen_transit_router_route_table_association_test.go
+++ b/alicloud/resource_alicloud_cen_transit_router_route_table_association_test.go
@@ -85,7 +85,7 @@ resource "alicloud_express_connect_virtual_border_router" "default" {
   peering_subnet_mask        = "255.255.255.252"
   physical_connection_id     = data.alicloud_express_connect_physical_connections.nameRegex.connections.0.id
   virtual_border_router_name = var.name
-  vlan_id                    = 1
+  vlan_id                    = 17
   min_rx_interval            = 1000
   min_tx_interval            = 1000
   detect_multiplier          = 10

--- a/alicloud/resource_alicloud_cen_transit_router_route_table_propagation_test.go
+++ b/alicloud/resource_alicloud_cen_transit_router_route_table_propagation_test.go
@@ -86,7 +86,7 @@ resource "alicloud_express_connect_virtual_border_router" "default" {
   peering_subnet_mask        = "255.255.255.252"
   physical_connection_id     = data.alicloud_express_connect_physical_connections.nameRegex.connections.0.id
   virtual_border_router_name = var.name
-  vlan_id                    = 1
+  vlan_id                    = 18
   min_rx_interval            = 1000
   min_tx_interval            = 1000
   detect_multiplier          = 10

--- a/alicloud/resource_alicloud_cen_transit_router_vbr_attachment_test.go
+++ b/alicloud/resource_alicloud_cen_transit_router_vbr_attachment_test.go
@@ -149,7 +149,7 @@ resource "alicloud_express_connect_virtual_border_router" "default" {
   peering_subnet_mask        = "255.255.255.252"
   physical_connection_id     = data.alicloud_express_connect_physical_connections.nameRegex.connections.0.id
   virtual_border_router_name = var.name
-  vlan_id                    = 1
+  vlan_id                    = 19
   min_rx_interval            = 1000
   min_tx_interval            = 1000
   detect_multiplier          = 10

--- a/alicloud/resource_alicloud_cen_vbr_health_check_test.go
+++ b/alicloud/resource_alicloud_cen_vbr_health_check_test.go
@@ -139,7 +139,7 @@ resource "alicloud_express_connect_virtual_border_router" "default" {
   peering_subnet_mask        = "255.255.255.252"
   physical_connection_id     = data.alicloud_express_connect_physical_connections.nameRegex.connections.0.id
   virtual_border_router_name = var.name
-  vlan_id                    = 1
+  vlan_id                    = 100
   min_rx_interval            = 1000
   min_tx_interval            = 1000
   detect_multiplier          = 10


### PR DESCRIPTION
…