### PR TITLE
resource/alicloud_ess_scalingconfiguration: Adds new attribute resource_group_id to support set resource group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.135.0 (Unreleased)
+
+ENHANCEMENTS:
+
+- resource/alicloud_ess_scalingconfiguration: Support resource_group_id.
+
 ## 1.134.0 (September 5, 2021)
 
 - **New Resource:** `alicloud_dts_jobmonitor_rule` ([#3965](https://github.com/aliyun/terraform-provider-alicloud/issues/3965))

--- a/alicloud/resource_alicloud_ess_scalingconfiguration.go
+++ b/alicloud/resource_alicloud_ess_scalingconfiguration.go
@@ -283,6 +283,10 @@ func resourceAlicloudEssScalingConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -482,6 +486,11 @@ func modifyEssScalingConfiguration(d *schema.ResourceData, meta interface{}) err
 		d.SetPartial("system_disk_performance_level")
 	}
 
+	if d.HasChange("resource_group_id") {
+		request.ResourceGroupId = d.Get("resource_group_id").(string)
+		d.SetPartial("resource_group_id")
+	}
+
 	if d.HasChange("user_data") {
 		if v, ok := d.GetOk("user_data"); ok && v.(string) != "" {
 			_, base64DecodeError := base64.StdEncoding.DecodeString(v.(string))
@@ -669,6 +678,7 @@ func resourceAliyunEssScalingConfigurationRead(d *schema.ResourceData, meta inte
 	d.Set("instance_name", object.InstanceName)
 	d.Set("override", d.Get("override").(bool))
 	d.Set("password_inherit", object.PasswordInherit)
+	d.Set("resource_group_id", object.ResourceGroupId)
 
 	if sg, ok := d.GetOk("security_group_id"); ok && sg.(string) != "" {
 		d.Set("security_group_id", object.SecurityGroupId)
@@ -877,6 +887,10 @@ func buildAlicloudEssScalingConfigurationArgs(d *schema.ResourceData, meta inter
 
 	if v := d.Get("system_disk_performance_level").(string); v != "" {
 		request.SystemDiskPerformanceLevel = v
+	}
+
+	if v := d.Get("resource_group_id").(string); v != "" {
+		request.ResourceGroupId = v
 	}
 
 	dds, ok := d.GetOk("data_disk")

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -130,6 +130,7 @@ The following arguments are supported:
 * `password` - (Optional, ForceNew, Available in 1.60.0+) The password of the ECS instance. The password must be 8 to 30 characters in length. It must contains at least three of the following character types: uppercase letters, lowercase letters, digits, and special characters. Special characters include `() ~!@#$%^&*-_+=\|{}[]:;'<>,.?/`, The password of Windows-based instances cannot start with a forward slash (/).
 * `kms_encrypted_password` - (Optional, ForceNew, Available in 1.60.0+) An KMS encrypts password used to a db account. If the `password` is filled in, this field will be ignored.
 * `kms_encryption_context` - (Optional, MapString, Available in 1.60.0+) An KMS encryption context used to decrypt `kms_encrypted_password` before creating or updating a db account with `kms_encrypted_password`. See [Encryption Context](https://www.alibabacloud.com/help/doc-detail/42975.htm). It is valid when `kms_encrypted_password` is set.
+* `resource_group_id` - (Optional, Available in 1.135.0+) ID of resource group.
 
 -> **NOTE:** Before enabling the scaling group, it must have a active scaling configuration.
 


### PR DESCRIPTION
=== RUN   TestAccAlicloudEssAlarmsDataSource
--- PASS: TestAccAlicloudEssAlarmsDataSource (120.67s)
=== RUN   TestAccAlicloudEssLifecycleHooksDataSource
--- PASS: TestAccAlicloudEssLifecycleHooksDataSource (70.88s)
=== RUN   TestAccAlicloudEssNotificationsDataSource
--- PASS: TestAccAlicloudEssNotificationsDataSource (52.87s)
=== RUN   TestAccAlicloudEssScalingconfigurationsDataSource
--- PASS: TestAccAlicloudEssScalingconfigurationsDataSource (86.10s)
=== RUN   TestAccAlicloudEssScalinggroupsDataSource
--- PASS: TestAccAlicloudEssScalinggroupsDataSource (69.97s)
=== RUN   TestAccAlicloudEssScalingrulesDataSource
--- PASS: TestAccAlicloudEssScalingrulesDataSource (93.81s)
=== RUN   TestAccAlicloudEssScheduledtasksDataSource
--- PASS: TestAccAlicloudEssScheduledtasksDataSource (93.22s)
=== RUN   TestAccAlicloudEssAlarmBasic
--- PASS: TestAccAlicloudEssAlarmBasic (155.67s)
=== RUN   TestAccAlicloudEssAlarmMulti
--- PASS: TestAccAlicloudEssAlarmMulti (54.67s)
=== RUN   TestAccAlicloudEssAttachment_update
--- PASS: TestAccAlicloudEssAttachment_update (123.66s)
=== RUN   TestAccAlicloudEssLifecycleHookBasic
--- PASS: TestAccAlicloudEssLifecycleHookBasic (86.96s)
=== RUN   TestAccAlicloudEssNotification_basic
--- PASS: TestAccAlicloudEssNotification_basic (65.87s)
=== RUN   TestAccAlicloudEssScalingConfigurationPerformanceLevel
--- PASS: TestAccAlicloudEssScalingConfigurationPerformanceLevel (70.64s)
=== RUN   TestAccAlicloudEssScalingConfigurationMulti
--- PASS: TestAccAlicloudEssScalingConfigurationMulti (44.83s)
=== RUN   TestAccAlicloudEssScalingGroup_basic
--- PASS: TestAccAlicloudEssScalingGroup_basic (103.43s)
=== RUN   TestAccAlicloudEssScalingGroup_costoptimized
--- PASS: TestAccAlicloudEssScalingGroup_costoptimized (83.89s)
=== RUN   TestAccAlicloudEssScalingGroup_vpc
--- PASS: TestAccAlicloudEssScalingGroup_vpc (88.08s)
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (115.54s)
=== RUN   TestAccAlicloudEssVserverGroups_basic
--- PASS: TestAccAlicloudEssVserverGroups_basic (65.98s)
=== RUN   TestAccAlicloudEssScalingRule_basic
--- PASS: TestAccAlicloudEssScalingRule_basic (72.47s)
=== RUN   TestAccAlicloudEssScalingRule_target_tracking_rule_basic
--- PASS: TestAccAlicloudEssScalingRule_target_tracking_rule_basic (77.02s)
=== RUN   TestAccAlicloudEssScalingRule_step_rule_basic
--- PASS: TestAccAlicloudEssScalingRule_step_rule_basic (47.61s)
=== RUN   TestAccAlicloudEssScalingRuleMulti
--- PASS: TestAccAlicloudEssScalingRuleMulti (39.32s)
=== RUN   TestAccAlicloudEssScheduledTask_basic
--- PASS: TestAccAlicloudEssScheduledTask_basic (83.71s)
=== RUN   TestAccAlicloudEssScheduledTask_basic_2
--- PASS: TestAccAlicloudEssScheduledTask_basic_2 (63.13s)
=== RUN   TestAccAlicloudEssScheduledTask_multi
--- PASS: TestAccAlicloudEssScheduledTask_multi (37.95s)