### PR TITLE
add retry logic for describe waf domain apis.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -76,14 +76,10 @@ github.com/alibabacloud-go/tea v1.1.11/go.mod h1:/tmnEaQMyb4Ky1/5D+SE1BAsa5zj/Ke
 github.com/alibabacloud-go/tea v1.1.15/go.mod h1:nXxjm6CIFkBhwW4FQkNrolwbfon8Svy6cujmKFUq98A=
 github.com/alibabacloud-go/tea v1.1.17 h1:05R5DnaJXe9sCNIe8KUgWHC/z6w/VZIwczgUwzRnul8=
 github.com/alibabacloud-go/tea v1.1.17/go.mod h1:nXxjm6CIFkBhwW4FQkNrolwbfon8Svy6cujmKFUq98A=
-github.com/alibabacloud-go/tea-roa v1.2.9 h1:RLOaT7qdxtMyRqdRv7yJyH1TI0WIZWCF3Ek40KQwpRY=
-github.com/alibabacloud-go/tea-roa v1.2.9/go.mod h1:Cdv5rQZqx9V8kYbAHSfvCgYR6KXRnbuM12piJOjssYY=
 github.com/alibabacloud-go/tea-roa v1.3.0 h1:834Mszn4zEibGPG9InAGvyYHoNH4QU/RuOEC2Tnt2ls=
 github.com/alibabacloud-go/tea-roa v1.3.0/go.mod h1:Cdv5rQZqx9V8kYbAHSfvCgYR6KXRnbuM12piJOjssYY=
 github.com/alibabacloud-go/tea-roa-utils v1.1.5 h1:BkZAywim4piCeTA9qmRTq9gkcOI3Gltu3VobZwegnUE=
 github.com/alibabacloud-go/tea-roa-utils v1.1.5/go.mod h1:7mkMI3FZEm4LGKIR1322y0N6N9EC0R1G/oXvzQjf1fQ=
-github.com/alibabacloud-go/tea-rpc v1.1.9 h1:vhatw+FHYEGCFcwmRnhyJkAFa9uzdkNMOUjurjEQn/0=
-github.com/alibabacloud-go/tea-rpc v1.1.9/go.mod h1:zwKwxuf92liNsPcLOxPdrkvR5Dq6jtX2du6qx8FT094=
 github.com/alibabacloud-go/tea-rpc v1.2.0 h1:m3ohmuAT+IdXigKp7enB+lXuksqsor0OFNB5+QB7Isk=
 github.com/alibabacloud-go/tea-rpc v1.2.0/go.mod h1:zwKwxuf92liNsPcLOxPdrkvR5Dq6jtX2du6qx8FT094=
 github.com/alibabacloud-go/tea-rpc-utils v1.1.2 h1:ZTfFREnP2q9D49T2J/1jYYOndepGdrUOgm/JR8/bIQ0=


### PR DESCRIPTION
To solve:

```
Error: [31m[ERROR][0m terraform-provider-alicloud/alicloud/resource_alicloud_waf_domain.go:270:
[31m[ERROR][0m terraform-provider-alicloud/alicloud/service_alicloud_waf_openapi.go:60: Resource xxxxxx DescribeDomain Failed!!! [SDK alibaba-cloud-sdk-go ERROR]:
SDKError:
   StatusCode: 400
   Code: Throttling.User
   Message: code: 400, Request was denied due to user flow control. request id: xxxxxx
   Data: {"Code":"Throttling.User","HostId":"wafopenapi.cn-hangzhou.aliyuncs.com","Message":"Request was denied due to user flow control.","Recommend":"https://error-center.aliyun.com/status/search?Keyword=Throttling.User\u0026source=PopGw","RequestId":"xxxxxx"}


  with alicloud_waf_domain.cn_domain["xxxxxx.com"],
  on waf_cn.tf line 1, in resource "alicloud_waf_domain" "cn_domain":
   1: resource "alicloud_waf_domain" "cn_domain" {
```