### PR TITLE
resource/alicloud_config_aggregate_compliance_pack : Modify the parameter `compliance_pack_template_id to `optional, Field `config_rules` has been deprecated from provider version 1.141.0. New field `config_rule_ids'` instead. resource/alicloud_config_aggregate_config_rule: Add the output parameter `config_rule_id`. resource/alicloud_config_compliance_pack : Modify the parameter `compliance_pack_template_id to `optional, Field `config_rules` has been deprecated from provider version 1.141.0. New field `config_rule_ids'` instead.

### DIFF
--- a/alicloud/resource_alicloud_config_aggregate_compliance_pack.go
+++ b/alicloud/resource_alicloud_config_aggregate_compliance_pack.go
@@ -38,12 +38,14 @@ func resourceAlicloudConfigAggregateCompliancePack() *schema.Resource {
 			},
 			"compliance_pack_template_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"config_rules": {
-				Type:     schema.TypeSet,
-				Required: true,
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Deprecated:    "Field 'config_rules' has been deprecated from provider version 1.141.0. New field 'config_rule_ids' instead.",
+				ConflictsWith: []string{"config_rule_ids"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"config_rule_parameters": {
@@ -65,6 +67,19 @@ func resourceAlicloudConfigAggregateCompliancePack() *schema.Resource {
 						"managed_rule_identifier": {
 							Type:     schema.TypeString,
 							Required: true,
+						},
+					},
+				},
+			},
+			"config_rule_ids": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				ConflictsWith: []string{"config_rules"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"config_rule_id": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},
@@ -98,25 +113,38 @@ func resourceAlicloudConfigAggregateCompliancePackCreate(d *schema.ResourceData,
 	}
 	request["CompliancePackName"] = d.Get("aggregate_compliance_pack_name")
 	request["AggregatorId"] = d.Get("aggregator_id")
-	request["CompliancePackTemplateId"] = d.Get("compliance_pack_template_id")
-	configRulesMaps := make([]map[string]interface{}, 0)
-	for _, configRules := range d.Get("config_rules").(*schema.Set).List() {
-		configRulesArg := configRules.(map[string]interface{})
-		configRulesMap := map[string]interface{}{
-			"ManagedRuleIdentifier": configRulesArg["managed_rule_identifier"],
-		}
-		configRuleParametersMaps := make([]map[string]interface{}, 0)
-		for _, configRuleParameters := range configRulesArg["config_rule_parameters"].(*schema.Set).List() {
-			configRuleParametersArg := configRuleParameters.(map[string]interface{})
-			configRuleParametersMap := map[string]interface{}{
-				"ParameterName":  configRuleParametersArg["parameter_name"],
-				"ParameterValue": configRuleParametersArg["parameter_value"],
-			}
-			configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
-		}
-		configRulesMap["ConfigRuleParameters"] = configRuleParametersMaps
-		configRulesMaps = append(configRulesMaps, configRulesMap)
+	if v, ok := d.GetOk("compliance_pack_template_id"); ok {
+		request["CompliancePackTemplateId"] = v
 	}
+	configRulesMaps := make([]map[string]interface{}, 0)
+	if _, ok := d.GetOk("config_rules"); ok {
+		for _, configRules := range d.Get("config_rules").(*schema.Set).List() {
+			configRulesArg := configRules.(map[string]interface{})
+			configRulesMap := map[string]interface{}{
+				"ManagedRuleIdentifier": configRulesArg["managed_rule_identifier"],
+			}
+			configRuleParametersMaps := make([]map[string]interface{}, 0)
+			for _, configRuleParameters := range configRulesArg["config_rule_parameters"].(*schema.Set).List() {
+				configRuleParametersArg := configRuleParameters.(map[string]interface{})
+				configRuleParametersMap := map[string]interface{}{
+					"ParameterName":  configRuleParametersArg["parameter_name"],
+					"ParameterValue": configRuleParametersArg["parameter_value"],
+				}
+				configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
+			}
+			configRulesMap["ConfigRuleParameters"] = configRuleParametersMaps
+			configRulesMaps = append(configRulesMaps, configRulesMap)
+		}
+	} else {
+		for _, configRuleIds := range d.Get("config_rule_ids").(*schema.Set).List() {
+			configRulesIdArg := configRuleIds.(map[string]interface{})
+			configRuleIdMap := map[string]interface{}{
+				"ConfigRuleId": configRulesIdArg["config_rule_id"],
+			}
+			configRulesMaps = append(configRulesMaps, configRuleIdMap)
+		}
+	}
+
 	if v, err := convertArrayObjectToJsonString(configRulesMaps); err == nil {
 		request["ConfigRules"] = v
 	} else {
@@ -172,33 +200,48 @@ func resourceAlicloudConfigAggregateCompliancePackRead(d *schema.ResourceData, m
 	d.Set("aggregate_compliance_pack_name", object["CompliancePackName"])
 	d.Set("compliance_pack_template_id", object["CompliancePackTemplateId"])
 
-	configRules := make([]map[string]interface{}, 0)
-	if configRulesList, ok := object["ConfigRules"].([]interface{}); ok {
-		for _, v := range configRulesList {
-			if m1, ok := v.(map[string]interface{}); ok {
-				temp1 := map[string]interface{}{
-					"managed_rule_identifier": m1["ManagedRuleIdentifier"],
-				}
-				if m1["ConfigRuleParameters"] != nil {
-					configRuleParametersMaps := make([]map[string]interface{}, 0)
-					for _, configRuleParametersValue := range m1["ConfigRuleParameters"].([]interface{}) {
-						configRuleParameters := configRuleParametersValue.(map[string]interface{})
-						configRuleParametersMap := map[string]interface{}{
-							"parameter_name":  configRuleParameters["ParameterName"],
-							"parameter_value": configRuleParameters["ParameterValue"],
-						}
-						configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
+	if _, ok := d.GetOk("config_rules"); ok {
+		configRules := make([]map[string]interface{}, 0)
+		if configRulesList, ok := object["ConfigRules"].([]interface{}); ok {
+			for _, v := range configRulesList {
+				if m1, ok := v.(map[string]interface{}); ok {
+					temp1 := map[string]interface{}{
+						"managed_rule_identifier": m1["ManagedRuleIdentifier"],
 					}
-					temp1["config_rule_parameters"] = configRuleParametersMaps
-				}
-				configRules = append(configRules, temp1)
+					if m1["ConfigRuleParameters"] != nil {
+						configRuleParametersMaps := make([]map[string]interface{}, 0)
+						for _, configRuleParametersValue := range m1["ConfigRuleParameters"].([]interface{}) {
+							configRuleParameters := configRuleParametersValue.(map[string]interface{})
+							configRuleParametersMap := map[string]interface{}{
+								"parameter_name":  configRuleParameters["ParameterName"],
+								"parameter_value": configRuleParameters["ParameterValue"],
+							}
+							configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
+						}
+						temp1["config_rule_parameters"] = configRuleParametersMaps
+					}
+					configRules = append(configRules, temp1)
 
+				}
 			}
 		}
+		d.Set("config_rules", configRules)
+	} else {
+
+		configRuleIds := make([]map[string]interface{}, 0)
+		if configRuleIdsList, ok := object["ConfigRules"].([]interface{}); ok {
+			for _, v := range configRuleIdsList {
+				if m1, ok := v.(map[string]interface{}); ok {
+					temp1 := map[string]interface{}{
+						"config_rule_id": m1["ConfigRuleId"],
+					}
+					configRuleIds = append(configRuleIds, temp1)
+				}
+			}
+		}
+		d.Set("config_rule_ids", configRuleIds)
 	}
-	if err := d.Set("config_rules", configRules); err != nil {
-		return WrapError(err)
-	}
+
 	d.Set("description", object["Description"])
 	d.Set("risk_level", formatInt(object["RiskLevel"]))
 	d.Set("status", object["Status"])
@@ -208,6 +251,7 @@ func resourceAlicloudConfigAggregateCompliancePackUpdate(d *schema.ResourceData,
 	client := meta.(*connectivity.AliyunClient)
 	configService := ConfigService{client}
 	var response map[string]interface{}
+	d.Partial(true)
 	parts, err := ParseResourceId(d.Id(), 2)
 	if err != nil {
 		return WrapError(err)
@@ -217,32 +261,38 @@ func resourceAlicloudConfigAggregateCompliancePackUpdate(d *schema.ResourceData,
 		"CompliancePackId": parts[1],
 		"AggregatorId":     parts[0],
 	}
-	if d.HasChange("config_rules") {
-		update = true
-	}
-	configRulesMaps := make([]map[string]interface{}, 0)
-	for _, configRules := range d.Get("config_rules").(*schema.Set).List() {
-		configRulesArg := configRules.(map[string]interface{})
-		configRulesMap := map[string]interface{}{
-			"ManagedRuleIdentifier": configRulesArg["managed_rule_identifier"],
-		}
-		configRuleParametersMaps := make([]map[string]interface{}, 0)
-		for _, configRuleParameters := range configRulesArg["config_rule_parameters"].(*schema.Set).List() {
-			configRuleParametersArg := configRuleParameters.(map[string]interface{})
-			configRuleParametersMap := map[string]interface{}{
-				"ParameterName":  configRuleParametersArg["parameter_name"],
-				"ParameterValue": configRuleParametersArg["parameter_value"],
+
+	if _, ok := d.GetOk("config_rules"); ok {
+		configRulesMaps := make([]map[string]interface{}, 0)
+		if d.HasChange("config_rules") {
+			update = true
+			for _, configRules := range d.Get("config_rules").(*schema.Set).List() {
+				configRulesArg := configRules.(map[string]interface{})
+				configRulesMap := map[string]interface{}{
+					"ConfigRuleName":        configRulesArg["config_rule_name"],
+					"ManagedRuleIdentifier": configRulesArg["managed_rule_identifier"],
+				}
+				configRuleParametersMaps := make([]map[string]interface{}, 0)
+				for _, configRuleParameters := range configRulesArg["config_rule_parameters"].(*schema.Set).List() {
+					configRuleParametersArg := configRuleParameters.(map[string]interface{})
+					configRuleParametersMap := map[string]interface{}{
+						"ParameterName":  configRuleParametersArg["parameter_name"],
+						"ParameterValue": configRuleParametersArg["parameter_value"],
+					}
+					configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
+				}
+				configRulesMap["ConfigRuleParameters"] = configRuleParametersMaps
+				configRulesMaps = append(configRulesMaps, configRulesMap)
 			}
-			configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
 		}
-		configRulesMap["ConfigRuleParameters"] = configRuleParametersMaps
-		configRulesMaps = append(configRulesMaps, configRulesMap)
+
+		if v, err := convertArrayObjectToJsonString(configRulesMaps); err == nil {
+			request["ConfigRules"] = v
+		} else {
+			return WrapError(err)
+		}
 	}
-	if v, err := convertArrayObjectToJsonString(configRulesMaps); err == nil {
-		request["ConfigRules"] = v
-	} else {
-		return WrapError(err)
-	}
+
 	if d.HasChange("description") {
 		update = true
 	}
@@ -280,7 +330,105 @@ func resourceAlicloudConfigAggregateCompliancePackUpdate(d *schema.ResourceData,
 		if _, err := stateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
+
+		d.SetPartial("risk_level")
+		d.SetPartial("description")
+		d.SetPartial("config_rules")
 	}
+
+	if _, ok := d.GetOk("config_rule_ids"); ok {
+		if d.HasChange("config_rule_ids") {
+
+			oraw, nraw := d.GetChange("config_rule_ids")
+			remove := oraw.(*schema.Set).Difference(nraw.(*schema.Set)).List()
+			create := nraw.(*schema.Set).Difference(oraw.(*schema.Set)).List()
+			parts, err := ParseResourceId(d.Id(), 2)
+			if err != nil {
+				return WrapError(err)
+			}
+
+			if len(remove) > 0 {
+				removeRulesReq := map[string]interface{}{
+					"AggregatorId":     parts[0],
+					"CompliancePackId": parts[1],
+				}
+
+				ruleMaps := make([]interface{}, 0)
+				for _, rule := range remove {
+					ruleArg := rule.(map[string]interface{})
+					ruleMaps = append(ruleMaps, ruleArg["config_rule_id"].(string))
+				}
+				removeRulesReq["ConfigRuleIds"] = convertListToCommaSeparate(ruleMaps)
+
+				action := "DetachAggregateConfigRuleToCompliancePack"
+				conn, err := client.NewConfigClient()
+				if err != nil {
+					return WrapError(err)
+				}
+				removeRulesReq["ClientToken"] = buildClientToken("DetachAggregateConfigRuleToCompliancePack")
+				runtime := util.RuntimeOptions{}
+				runtime.SetAutoretry(true)
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2020-09-07"), StringPointer("AK"), nil, removeRulesReq, &runtime)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, removeRulesReq)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+			}
+
+			if len(create) > 0 {
+				addRulesReq := map[string]interface{}{
+					"AggregatorId":     parts[0],
+					"CompliancePackId": parts[1],
+				}
+
+				ruleMaps := make([]interface{}, 0)
+				for _, rule := range create {
+					ruleArg := rule.(map[string]interface{})
+					ruleMaps = append(ruleMaps, ruleArg["config_rule_id"].(string))
+				}
+				addRulesReq["ConfigRuleIds"] = convertListToCommaSeparate(ruleMaps)
+
+				action := "AttachAggregateConfigRuleToCompliancePack"
+				conn, err := client.NewConfigClient()
+				if err != nil {
+					return WrapError(err)
+				}
+				addRulesReq["ClientToken"] = buildClientToken("AttachAggregateConfigRuleToCompliancePack")
+				runtime := util.RuntimeOptions{}
+				runtime.SetAutoretry(true)
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2020-09-07"), StringPointer("AK"), nil, addRulesReq, &runtime)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, addRulesReq)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+			}
+
+			d.SetPartial("config_rule_ids")
+		}
+	}
+	d.Partial(false)
 	return resourceAlicloudConfigAggregateCompliancePackRead(d, meta)
 }
 func resourceAlicloudConfigAggregateCompliancePackDelete(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_config_aggregate_compliance_pack_test.go
+++ b/alicloud/resource_alicloud_config_aggregate_compliance_pack_test.go
@@ -226,11 +226,6 @@ func TestAccAlicloudConfigAggregateCompliancePack_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceId,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
 				Config: testAccConfig(map[string]interface{}{
 					"config_rules": []map[string]interface{}{
 						{
@@ -353,11 +348,6 @@ func TestAccAlicloudConfigAggregateCompliancePack_basic0(t *testing.T) {
 					}),
 				),
 			},
-			{
-				ResourceName:      resourceId,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }
@@ -379,6 +369,132 @@ variable "name" {
 }
 
 data "alicloud_config_aggregators" "default" {}
+
+`, name)
+}
+
+func TestAccAlicloudConfigAggregateCompliancePack_basic1(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_config_aggregate_compliance_pack.default"
+	ra := resourceAttrInit(resourceId, AlicloudConfigAggregateCompliancePackMap1)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ConfigService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeConfigAggregateCompliancePack")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sconfigaggregatecompliancepack%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudConfigAggregateCompliancePackBasicDependence1)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckEnterpriseAccountEnabled(t)
+		},
+
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"aggregator_id":                  "${data.alicloud_config_aggregators.default.ids.0}",
+					"aggregate_compliance_pack_name": name,
+					"config_rule_ids": []map[string]interface{}{
+						{
+							"config_rule_id": "${alicloud_config_aggregate_config_rule.default.0.config_rule_id}",
+						},
+						{
+							"config_rule_id": "${alicloud_config_aggregate_config_rule.default.1.config_rule_id}",
+						},
+					},
+					"description": name,
+					"risk_level":  "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"aggregator_id":                  CHECKSET,
+						"aggregate_compliance_pack_name": name,
+						"config_rule_ids.#":              "2",
+						"description":                    name,
+						"risk_level":                     "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"config_rule_ids": []map[string]interface{}{
+						{
+							"config_rule_id": "${alicloud_config_aggregate_config_rule.default.0.config_rule_id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"config_rule_ids.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"config_rule_ids": []map[string]interface{}{
+						{
+							"config_rule_id": "${alicloud_config_aggregate_config_rule.default.0.config_rule_id}",
+						},
+						{
+							"config_rule_id": "${alicloud_config_aggregate_config_rule.default.1.config_rule_id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"config_rule_ids.#": "2",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudConfigAggregateCompliancePackMap1 = map[string]string{}
+
+func AlicloudConfigAggregateCompliancePackBasicDependence1(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {
+  status = "OK"
+}
+
+data "alicloud_instances" "default" {}
+
+data "alicloud_config_aggregators" "default" {}
+
+resource "alicloud_config_aggregate_config_rule" "default" {
+  count                      = 2
+  aggregator_id              = data.alicloud_config_aggregators.default.ids.0
+  aggregate_config_rule_name = var.name
+  source_owner               = "ALIYUN"
+  source_identifier    		= "ecs-cpu-min-count-limit"
+  config_rule_trigger_types = "ConfigurationItemChangeNotification"
+  resource_types_scope      = ["ACS::ECS::Instance"]
+  risk_level                = 1
+  description                = var.name
+  exclude_resource_ids_scope = data.alicloud_instances.default.ids.0
+  input_parameters = {
+    cpuCount = "4",
+  }
+  region_ids_scope         = "cn-hangzhou"
+  resource_group_ids_scope = data.alicloud_resource_manager_resource_groups.default.ids.0
+  tag_key_scope            = "tFTest"
+  tag_value_scope          = "forTF 123"
+}
 
 `, name)
 }

--- a/alicloud/resource_alicloud_config_aggregate_config_rule.go
+++ b/alicloud/resource_alicloud_config_aggregate_config_rule.go
@@ -36,6 +36,10 @@ func resourceAlicloudConfigAggregateConfigRule() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"config_rule_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"config_rule_trigger_types": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -200,6 +204,7 @@ func resourceAlicloudConfigAggregateConfigRuleRead(d *schema.ResourceData, meta 
 		return WrapError(err)
 	}
 	d.Set("aggregator_id", parts[0])
+	d.Set("config_rule_id", parts[1])
 	d.Set("aggregate_config_rule_name", object["ConfigRuleName"])
 	d.Set("config_rule_trigger_types", object["ConfigRuleTriggerTypes"])
 	d.Set("description", object["Description"])

--- a/alicloud/resource_alicloud_config_compliance_pack.go
+++ b/alicloud/resource_alicloud_config_compliance_pack.go
@@ -33,12 +33,14 @@ func resourceAlicloudConfigCompliancePack() *schema.Resource {
 			},
 			"compliance_pack_template_id": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"config_rules": {
-				Type:     schema.TypeSet,
-				Required: true,
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Deprecated:    "Field 'config_rules' has been deprecated from provider version 1.141.0. New field 'config_rule_ids' instead.",
+				ConflictsWith: []string{"config_rule_ids"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"config_rule_parameters": {
@@ -60,6 +62,20 @@ func resourceAlicloudConfigCompliancePack() *schema.Resource {
 						"managed_rule_identifier": {
 							Type:     schema.TypeString,
 							Required: true,
+						},
+					},
+				},
+			},
+			"config_rule_ids": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				ConflictsWith: []string{"config_rules"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"config_rule_id": {
+							Type: schema.TypeString,
+
+							Optional: true,
 						},
 					},
 				},
@@ -92,25 +108,39 @@ func resourceAlicloudConfigCompliancePackCreate(d *schema.ResourceData, meta int
 		return WrapError(err)
 	}
 	request["CompliancePackName"] = d.Get("compliance_pack_name")
-	request["CompliancePackTemplateId"] = d.Get("compliance_pack_template_id")
-	configRulesMaps := make([]map[string]interface{}, 0)
-	for _, configRules := range d.Get("config_rules").(*schema.Set).List() {
-		configRulesArg := configRules.(map[string]interface{})
-		configRulesMap := map[string]interface{}{
-			"ManagedRuleIdentifier": configRulesArg["managed_rule_identifier"],
-		}
-		configRuleParametersMaps := make([]map[string]interface{}, 0)
-		for _, configRuleParameters := range configRulesArg["config_rule_parameters"].(*schema.Set).List() {
-			configRuleParametersArg := configRuleParameters.(map[string]interface{})
-			configRuleParametersMap := map[string]interface{}{
-				"ParameterName":  configRuleParametersArg["parameter_name"],
-				"ParameterValue": configRuleParametersArg["parameter_value"],
-			}
-			configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
-		}
-		configRulesMap["ConfigRuleParameters"] = configRuleParametersMaps
-		configRulesMaps = append(configRulesMaps, configRulesMap)
+	if v, ok := d.GetOk("compliance_pack_template_id"); ok {
+		request["CompliancePackTemplateId"] = v
 	}
+
+	configRulesMaps := make([]map[string]interface{}, 0)
+	if _, ok := d.GetOk("config_rules"); ok {
+		for _, configRules := range d.Get("config_rules").(*schema.Set).List() {
+			configRulesArg := configRules.(map[string]interface{})
+			configRulesMap := map[string]interface{}{
+				"ManagedRuleIdentifier": configRulesArg["managed_rule_identifier"],
+			}
+			configRuleParametersMaps := make([]map[string]interface{}, 0)
+			for _, configRuleParameters := range configRulesArg["config_rule_parameters"].(*schema.Set).List() {
+				configRuleParametersArg := configRuleParameters.(map[string]interface{})
+				configRuleParametersMap := map[string]interface{}{
+					"ParameterName":  configRuleParametersArg["parameter_name"],
+					"ParameterValue": configRuleParametersArg["parameter_value"],
+				}
+				configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
+			}
+			configRulesMap["ConfigRuleParameters"] = configRuleParametersMaps
+			configRulesMaps = append(configRulesMaps, configRulesMap)
+		}
+	} else {
+		for _, configRuleIds := range d.Get("config_rule_ids").(*schema.Set).List() {
+			configRulesIdArg := configRuleIds.(map[string]interface{})
+			configRuleIdMap := map[string]interface{}{
+				"ConfigRuleId": configRulesIdArg["config_rule_id"],
+			}
+			configRulesMaps = append(configRulesMaps, configRuleIdMap)
+		}
+	}
+
 	if v, err := convertArrayObjectToJsonString(configRulesMaps); err == nil {
 		request["ConfigRules"] = v
 	} else {
@@ -125,7 +155,7 @@ func resourceAlicloudConfigCompliancePackCreate(d *schema.ResourceData, meta int
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2020-09-07"), StringPointer("AK"), nil, request, &runtime)
 		if err != nil {
-			if IsExpectedErrors(err, []string{"ServiceUnavailable"}) || NeedRetry(err) {
+			if NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}
@@ -161,33 +191,46 @@ func resourceAlicloudConfigCompliancePackRead(d *schema.ResourceData, meta inter
 	d.Set("compliance_pack_name", object["CompliancePackName"])
 	d.Set("compliance_pack_template_id", object["CompliancePackTemplateId"])
 
-	configRules := make([]map[string]interface{}, 0)
-	if configRulesList, ok := object["ConfigRules"].([]interface{}); ok {
-		for _, v := range configRulesList {
-			if m1, ok := v.(map[string]interface{}); ok {
-				temp1 := map[string]interface{}{
-					"managed_rule_identifier": m1["ManagedRuleIdentifier"],
-				}
-				if m1["ConfigRuleParameters"] != nil {
-					configRuleParametersMaps := make([]map[string]interface{}, 0)
-					for _, configRuleParametersValue := range m1["ConfigRuleParameters"].([]interface{}) {
-						configRuleParameters := configRuleParametersValue.(map[string]interface{})
-						configRuleParametersMap := map[string]interface{}{
-							"parameter_name":  configRuleParameters["ParameterName"],
-							"parameter_value": configRuleParameters["ParameterValue"],
-						}
-						configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
+	if _, ok := d.GetOk("config_rules"); ok {
+		configRules := make([]map[string]interface{}, 0)
+		if configRulesList, ok := object["ConfigRules"].([]interface{}); ok {
+			for _, v := range configRulesList {
+				if m1, ok := v.(map[string]interface{}); ok {
+					temp1 := map[string]interface{}{
+						"managed_rule_identifier": m1["ManagedRuleIdentifier"],
 					}
-					temp1["config_rule_parameters"] = configRuleParametersMaps
+					if m1["ConfigRuleParameters"] != nil {
+						configRuleParametersMaps := make([]map[string]interface{}, 0)
+						for _, configRuleParametersValue := range m1["ConfigRuleParameters"].([]interface{}) {
+							configRuleParameters := configRuleParametersValue.(map[string]interface{})
+							configRuleParametersMap := map[string]interface{}{
+								"parameter_name":  configRuleParameters["ParameterName"],
+								"parameter_value": configRuleParameters["ParameterValue"],
+							}
+							configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
+						}
+						temp1["config_rule_parameters"] = configRuleParametersMaps
+					}
+					configRules = append(configRules, temp1)
 				}
-				configRules = append(configRules, temp1)
-
 			}
 		}
+		d.Set("config_rules", configRules)
+	} else {
+		configRuleIds := make([]map[string]interface{}, 0)
+		if configRuleIdsList, ok := object["ConfigRules"].([]interface{}); ok {
+			for _, v := range configRuleIdsList {
+				if m1, ok := v.(map[string]interface{}); ok {
+					temp1 := map[string]interface{}{
+						"config_rule_id": m1["ConfigRuleId"],
+					}
+					configRuleIds = append(configRuleIds, temp1)
+				}
+			}
+		}
+		d.Set("config_rule_ids", configRuleIds)
 	}
-	if err := d.Set("config_rules", configRules); err != nil {
-		return WrapError(err)
-	}
+
 	d.Set("description", object["Description"])
 	d.Set("risk_level", formatInt(object["RiskLevel"]))
 	d.Set("status", object["Status"])
@@ -197,37 +240,44 @@ func resourceAlicloudConfigCompliancePackUpdate(d *schema.ResourceData, meta int
 	client := meta.(*connectivity.AliyunClient)
 	configService := ConfigService{client}
 	var response map[string]interface{}
+	d.Partial(true)
+
 	update := false
 	request := map[string]interface{}{
 		"CompliancePackId": d.Id(),
 	}
-	if d.HasChange("config_rules") {
-		update = true
-	}
-	configRulesMaps := make([]map[string]interface{}, 0)
-	for _, configRules := range d.Get("config_rules").(*schema.Set).List() {
-		configRulesArg := configRules.(map[string]interface{})
-		configRulesMap := map[string]interface{}{
-			"ConfigRuleName":        configRulesArg["config_rule_name"],
-			"ManagedRuleIdentifier": configRulesArg["managed_rule_identifier"],
-		}
-		configRuleParametersMaps := make([]map[string]interface{}, 0)
-		for _, configRuleParameters := range configRulesArg["config_rule_parameters"].(*schema.Set).List() {
-			configRuleParametersArg := configRuleParameters.(map[string]interface{})
-			configRuleParametersMap := map[string]interface{}{
-				"ParameterName":  configRuleParametersArg["parameter_name"],
-				"ParameterValue": configRuleParametersArg["parameter_value"],
+
+	if _, ok := d.GetOk("config_rules"); ok {
+		configRulesMaps := make([]map[string]interface{}, 0)
+		if d.HasChange("config_rules") {
+			update = true
+			for _, configRules := range d.Get("config_rules").(*schema.Set).List() {
+				configRulesArg := configRules.(map[string]interface{})
+				configRulesMap := map[string]interface{}{
+					"ConfigRuleName":        configRulesArg["config_rule_name"],
+					"ManagedRuleIdentifier": configRulesArg["managed_rule_identifier"],
+				}
+				configRuleParametersMaps := make([]map[string]interface{}, 0)
+				for _, configRuleParameters := range configRulesArg["config_rule_parameters"].(*schema.Set).List() {
+					configRuleParametersArg := configRuleParameters.(map[string]interface{})
+					configRuleParametersMap := map[string]interface{}{
+						"ParameterName":  configRuleParametersArg["parameter_name"],
+						"ParameterValue": configRuleParametersArg["parameter_value"],
+					}
+					configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
+				}
+				configRulesMap["ConfigRuleParameters"] = configRuleParametersMaps
+				configRulesMaps = append(configRulesMaps, configRulesMap)
 			}
-			configRuleParametersMaps = append(configRuleParametersMaps, configRuleParametersMap)
 		}
-		configRulesMap["ConfigRuleParameters"] = configRuleParametersMaps
-		configRulesMaps = append(configRulesMaps, configRulesMap)
+
+		if v, err := convertArrayObjectToJsonString(configRulesMaps); err == nil {
+			request["ConfigRules"] = v
+		} else {
+			return WrapError(err)
+		}
 	}
-	if v, err := convertArrayObjectToJsonString(configRulesMaps); err == nil {
-		request["ConfigRules"] = v
-	} else {
-		return WrapError(err)
-	}
+
 	if d.HasChange("description") {
 		update = true
 	}
@@ -265,7 +315,99 @@ func resourceAlicloudConfigCompliancePackUpdate(d *schema.ResourceData, meta int
 		if _, err := stateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
+
+		d.SetPartial("risk_level")
+		d.SetPartial("description")
+		d.SetPartial("config_rules")
 	}
+
+	if _, ok := d.GetOk("config_rule_ids"); ok {
+		if d.HasChange("config_rule_ids") {
+
+			oraw, nraw := d.GetChange("config_rule_ids")
+			remove := oraw.(*schema.Set).Difference(nraw.(*schema.Set)).List()
+			create := nraw.(*schema.Set).Difference(oraw.(*schema.Set)).List()
+
+			if len(remove) > 0 {
+				removeRulesReq := map[string]interface{}{
+					"CompliancePackId": d.Id(),
+				}
+
+				ruleMaps := make([]interface{}, 0)
+				for _, rule := range remove {
+					ruleArg := rule.(map[string]interface{})
+					ruleMaps = append(ruleMaps, ruleArg["config_rule_id"].(string))
+				}
+				removeRulesReq["ConfigRuleIds"] = convertListToCommaSeparate(ruleMaps)
+
+				action := "DetachConfigRuleToCompliancePack"
+				conn, err := client.NewConfigClient()
+				if err != nil {
+					return WrapError(err)
+				}
+				removeRulesReq["ClientToken"] = buildClientToken("DetachConfigRuleToCompliancePack")
+				runtime := util.RuntimeOptions{}
+				runtime.SetAutoretry(true)
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2020-09-07"), StringPointer("AK"), nil, removeRulesReq, &runtime)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, removeRulesReq)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+			}
+
+			if len(create) > 0 {
+				addRulesReq := map[string]interface{}{
+					"CompliancePackId": d.Id(),
+				}
+
+				ruleMaps := make([]interface{}, 0)
+				for _, rule := range create {
+					ruleArg := rule.(map[string]interface{})
+					ruleMaps = append(ruleMaps, ruleArg["config_rule_id"].(string))
+				}
+				addRulesReq["ConfigRuleIds"] = convertListToCommaSeparate(ruleMaps)
+
+				action := "AttachConfigRuleToCompliancePack"
+				conn, err := client.NewConfigClient()
+				if err != nil {
+					return WrapError(err)
+				}
+				addRulesReq["ClientToken"] = buildClientToken("AttachConfigRuleToCompliancePack")
+				runtime := util.RuntimeOptions{}
+				runtime.SetAutoretry(true)
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2020-09-07"), StringPointer("AK"), nil, addRulesReq, &runtime)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, addRulesReq)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+			}
+
+			d.SetPartial("config_rule_ids")
+		}
+	}
+	d.Partial(false)
 	return resourceAlicloudConfigCompliancePackRead(d, meta)
 }
 func resourceAlicloudConfigCompliancePackDelete(d *schema.ResourceData, meta interface{}) error {

--- a/website/docs/r/config_aggregate_compliance_pack.html.markdown
+++ b/website/docs/r/config_aggregate_compliance_pack.html.markdown
@@ -20,7 +20,17 @@ For information about Cloud Config Aggregate Compliance Pack and how to use it, 
 Basic Usage
 
 ```terraform
-resource "alicloud_config_aggregator" "example" {
+variable "name" {
+  default = "example_name"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {
+  status = "OK"
+}
+
+data "alicloud_instances" "default" {}
+
+resource "alicloud_config_aggregator" "default" {
   aggregator_accounts {
     account_id   = "140278452670****"
     account_name = "test-2"
@@ -30,25 +40,33 @@ resource "alicloud_config_aggregator" "example" {
   description     = "tf-testaccaggregator"
 }
 
-resource "alicloud_config_aggregate_compliance_pack" "example" {
+
+resource "alicloud_config_aggregate_config_rule" "default" {
+  aggregator_id              = alicloud_config_aggregator.default.id
+  aggregate_config_rule_name = var.name
+  source_owner               = "ALIYUN"
+  source_identifier          = "ecs-cpu-min-count-limit"
+  config_rule_trigger_types  = "ConfigurationItemChangeNotification"
+  resource_types_scope       = ["ACS::ECS::Instance"]
+  risk_level                 = 1
+  description                = var.name
+  exclude_resource_ids_scope = data.alicloud_instances.default.ids.0
+  input_parameters = {
+    cpuCount = "4",
+  }
+  region_ids_scope         = "cn-hangzhou"
+  resource_group_ids_scope = data.alicloud_resource_manager_resource_groups.default.ids.0
+  tag_key_scope            = "tFTest"
+  tag_value_scope          = "forTF 123"
+}
+
+resource "alicloud_config_aggregate_compliance_pack" "default" {
   aggregate_compliance_pack_name = "tf-testaccConfig1234"
-  aggregator_id                  = alicloud_config_aggregators.example.id
-  compliance_pack_template_id    = "ct-3d20ff4e06a30027f76e"
+  aggregator_id                  = alicloud_config_aggregator.default.id
   description                    = "tf-testaccConfig1234"
   risk_level                     = 1
-  config_rules {
-    managed_rule_identifier = "ecs-instance-expired-check"
-    config_rule_parameters {
-      parameter_name  = "days"
-      parameter_value = "60"
-    }
-  }
-  config_rules {
-    managed_rule_identifier = "ecs-snapshot-retention-days"
-    config_rule_parameters {
-      parameter_name  = "days"
-      parameter_value = "7"
-    }
+  config_rule_ids {
+    config_rule_id = alicloud_config_aggregate_config_rule.default.config_rule_id
   }
 }
 
@@ -60,8 +78,9 @@ The following arguments are supported:
 
 * `aggregate_compliance_pack_name` - (Required, ForceNew)The name of compliance package name.
 * `aggregator_id` - (Required, ForceNew)The ID of aggregator.
-* `compliance_pack_template_id` - (Required, ForceNew)The Template ID of compliance package.
-* `config_rules` - (Required) A list of  compliance package rules.
+* `compliance_pack_template_id` - (Optional form v1.141.0, ForceNew)The Template ID of compliance package.
+* `config_rules` - (Optional, Computed, Deprecated form v1.141.0) A list of Config Rules.
+* `config_rule_ids` - (Optional, Computed, Available in v1.141.0) A list of Config Rule IDs.
 * `description` - (Required) Teh description of compliance package.
 * `risk_level` - (Required) The Risk Level. Valid values: `1`, `2`, `3`.
 
@@ -71,6 +90,12 @@ The config_rules supports the following:
 
 * `config_rule_parameters` - (Optional) A list of parameter rules.
 * `managed_rule_identifier` - (Required) The Managed Rule Identifier.
+
+#### Block config_rule_ids
+
+The config_rule_ids supports the following:
+
+* `config_rule_id` - (Optional) The rule ID of Aggregate Config Rule.
 
 #### Block config_rule_parameters
 

--- a/website/docs/r/config_aggregate_config_rule.html.markdown
+++ b/website/docs/r/config_aggregate_config_rule.html.markdown
@@ -70,6 +70,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The resource ID of Aggregate Config Rule. The value is formatted `<aggregator_id>:<config_rule_id>`.
+* `config_rule_id` - (Available in 1.141.0+) The rule ID of Aggregate Config Rule.
 
 ### Timeouts
 


### PR DESCRIPTION
config
