### PR TITLE
resource/alicloud_cs_kubernetes_node_pool unschedulable parameter bugfix

### DIFF
--- a/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
@@ -580,9 +580,8 @@ func resourceAlicloudCSNodePoolUpdate(d *schema.ResourceData, meta interface{}) 
 		args.CmsEnabled = d.Get("install_cloud_monitor").(bool)
 	}
 
-	if d.HasChange("unschedulable") {
-		update = true
-		args.Unschedulable = d.Get("unschedulable").(bool)
+	if v, ok := d.GetOk("unschedulable"); ok {
+		args.Unschedulable = v.(bool)
 	}
 
 	if d.HasChange("instance_types") {


### PR DESCRIPTION
Fix the bug that the scale out of the node pool will cause the unschedulable parameter to be overwritten.