### PR TITLE
alicloud_ess_scalingconfiguration: Adds new attributes spot_strategy and spot_price_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.151.0 (Unreleased)
+
+- resource/alicloud_ess_scalingconfiguration: Adds new attributes spot_strategy and spot_price_limit. ([#4180](https://github.com/aliyun/terraform-provider-alicloud/issues/4180))
+- datasource/alicloud_ess_scalingconfiguration: Adds new attributes spot_strategy and spot_price_limit. ([#4180](https://github.com/aliyun/terraform-provider-alicloud/issues/4180))
+
 ## 1.150.0 (January 02, 2022)
 
 - **New Resource:** `alicloud_ga_acl` ([#4416](https://github.com/aliyun/terraform-provider-alicloud/issues/4416))

--- a/alicloud/data_source_alicloud_ess_scalingconfigurations.go
+++ b/alicloud/data_source_alicloud_ess_scalingconfigurations.go
@@ -147,6 +147,26 @@ func dataSourceAlicloudEssScalingConfigurations() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"spot_strategy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"spot_price_limit": {
+							Type: schema.TypeList,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"instance_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"price_limit": {
+										Type:     schema.TypeFloat,
+										Optional: true,
+									},
+								},
+							},
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -255,6 +275,8 @@ func scalingConfigurationsDescriptionAttribute(d *schema.ResourceData, scalingCo
 			"creation_time":                 scalingConfiguration.CreationTime,
 			"instance_name":                 scalingConfiguration.InstanceName,
 			"host_name":                     scalingConfiguration.HostName,
+			"spot_strategy":                 scalingConfiguration.SpotStrategy,
+			"spot_price_limit":              essService.flattenSpotPriceLimitMappings(scalingConfiguration.SpotPriceLimit.SpotPriceModel),
 		}
 		ids = append(ids, scalingConfiguration.ScalingConfigurationId)
 		names = append(names, scalingConfiguration.ScalingConfigurationName)

--- a/alicloud/data_source_alicloud_ess_scalingconfigurations_test.go
+++ b/alicloud/data_source_alicloud_ess_scalingconfigurations_test.go
@@ -70,6 +70,8 @@ func TestAccAlicloudEssScalingconfigurationsDataSource(t *testing.T) {
 			"configurations.0.data_disks.#":                  "0",
 			"configurations.0.instance_name":                 "instance_name",
 			"configurations.0.host_name":                     "hostname",
+			"configurations.0.spot_strategy":                 "SpotWithPriceLimit",
+			"configurations.0.spot_price_limit.#":            "1",
 		}
 	}
 
@@ -123,6 +125,11 @@ resource "alicloud_ess_scaling_configuration" "default"{
 	force_delete = true
 	instance_name = "instance_name"
 	host_name = "hostname"
+	spot_strategy = "SpotWithPriceLimit"
+	spot_price_limit {
+		instance_type = "${data.alicloud_instance_types.default.instance_types.0.id}"
+		price_limit = 2.2
+	}
 }
 
 data "alicloud_ess_scaling_configurations" "default"{

--- a/alicloud/resource_alicloud_ess_scaling_configuration_test.go
+++ b/alicloud/resource_alicloud_ess_scaling_configuration_test.go
@@ -432,6 +432,33 @@ func TestAccAlicloudEssScalingConfigurationPerformanceLevel(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"spot_strategy": "NoSpot",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"spot_strategy":    "NoSpot",
+						"spot_price_limit": NOSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"spot_strategy": "SpotWithPriceLimit",
+					"spot_price_limit": []map[string]string{{
+						"instance_type": "${data.alicloud_instance_types.default.instance_types.0.id}",
+						"price_limit":   "2.1",
+					},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"spot_strategy":      "SpotWithPriceLimit",
+						"spot_price_limit.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"data_disk": []map[string]string{{
 						"size":                 "20",
 						"category":             "cloud_essd",

--- a/alicloud/service_alicloud_ess.go
+++ b/alicloud/service_alicloud_ess.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -250,6 +251,19 @@ func (s *EssService) flattenDataDiskMappings(list []ess.DataDisk) []map[string]i
 			"description":             i.Description,
 			"auto_snapshot_policy_id": i.AutoSnapshotPolicyId,
 			"performance_level":       i.PerformanceLevel,
+		}
+		result = append(result, l)
+	}
+	return result
+}
+
+func (s *EssService) flattenSpotPriceLimitMappings(list []ess.SpotPriceModel) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(list))
+	for _, i := range list {
+		p, _ := strconv.ParseFloat(strconv.FormatFloat(i.PriceLimit, 'f', 2, 64), 64)
+		l := map[string]interface{}{
+			"instance_type": i.InstanceType,
+			"price_limit":   p,
 		}
 		result = append(result, l)
 	}

--- a/website/docs/d/ess_scaling_configurations.html.markdown
+++ b/website/docs/d/ess_scaling_configurations.html.markdown
@@ -65,4 +65,7 @@ The following attributes are exported in addition to the arguments listed above:
   * `creation_time` - Creation time of the scaling configuration.
   * `instance_name` - (Optional,Available in 1.143.0+) InstanceName of an ECS instance.
   * `host_name` - (Optional,Available in 1.143.0+) Hostname of an ECS instance.
-  
+  * `spot_strategy` - (Optional, Available in 1.151.0+) The spot strategy for a Pay-As-You-Go instance.
+  * `spot_price_limit` - (Optional, Available in 1.151.0+) The maximum price hourly for instance types.
+    * `instance_type` - Resource type of an ECS instance.
+    * `price_limit` - Price limit hourly of instance type.

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -132,6 +132,8 @@ The following arguments are supported:
 * `kms_encryption_context` - (Optional, MapString, Available in 1.60.0+) An KMS encryption context used to decrypt `kms_encrypted_password` before creating or updating a db account with `kms_encrypted_password`. See [Encryption Context](https://www.alibabacloud.com/help/doc-detail/42975.htm). It is valid when `kms_encrypted_password` is set.
 * `resource_group_id` - (Optional, Available in 1.135.0+) ID of resource group.
 * `host_name` - (Optional, Available in 1.143.0+) Hostname of an ECS instance.
+* `spot_strategy` - (Optional, Available in 1.151.0+) The spot strategy for a Pay-As-You-Go instance. Valid values: `NoSpot`, `SpotAsPriceGo`, `SpotWithPriceLimit`.
+* `spot_price_limit` - (Optional, Available in 1.151.0+) Sets the maximum price hourly for instance types. See [Block spotPriceLimit](#block-spotPriceLimit) below for details.
 
 -> **NOTE:** Before enabling the scaling group, it must have a active scaling configuration.
 
@@ -164,6 +166,14 @@ The datadisk mapping supports the following:
 * `auto_snapshot_policy_id` - (Optional, Available in 1.92.0+) The id of auto snapshot policy for data disk.
 * `performance_level` - (Optional, Available in 1.124.3+) The performance level of the ESSD used as data disk.
 
+## Block spotPriceLimit
+
+The spotPriceLimit mapping supports the following:
+
+* `instance_type` - (Optional, Available in 1.151.0+) Resource type of an ECS instance.
+* `price_limit` - (Optional, Available in 1.151.0+) Price limit hourly of instance type, 2 decimals is allowed at most.
+
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -179,4 +189,3 @@ $ terraform import alicloud_ess_scaling_configuration.example asg-abc123456
 ```
 
 -> **NOTE:** Available in 1.46.0+
-


### PR DESCRIPTION
=== RUN   TestAccAlicloudEssScalingconfigurationsDataSource
--- PASS: TestAccAlicloudEssScalingconfigurationsDataSource (81.92s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  83.627s

=== RUN   TestAccAlicloudEssScalingconfigurationsDataSource
--- PASS: TestAccAlicloudEssScalingconfigurationsDataSource (83.38s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  85.091s
