### PR TITLE
resource/click_house_db_clusters: Fixed the difference error in the attribute `db_cluster_access_white_list`; Remove the `db_cluster_ip_array_attribute` attribute.

### DIFF
--- a/alicloud/data_source_alicloud_click_house_db_clusters.go
+++ b/alicloud/data_source_alicloud_click_house_db_clusters.go
@@ -75,6 +75,7 @@ func dataSourceAlicloudClickHouseDbClusters() *schema.Resource {
 									"db_cluster_ip_array_attribute": {
 										Type:     schema.TypeString,
 										Computed: true,
+										Removed:  "Field 'db_cluster_ip_array_attribute' has been removed from provider",
 									},
 									"db_cluster_ip_array_name": {
 										Type:     schema.TypeString,
@@ -357,7 +358,7 @@ func dataSourceAlicloudClickHouseDbClustersRead(d *schema.ResourceData, meta int
 		if iPArrayList, ok := getResp1["DBClusterAccessWhiteList"].(map[string]interface{})["IPArray"].([]interface{}); ok {
 			for _, v := range iPArrayList {
 				if m1, ok := v.(map[string]interface{}); ok {
-					if m1["DBClusterIPArrayName"].(string) == "default" {
+					if m1["DBClusterIPArrayName"].(string) == "default" || m1["DBClusterIPArrayName"].(string) == "dms" {
 						continue
 					}
 					temp1 := map[string]interface{}{

--- a/alicloud/data_source_alicloud_click_house_db_clusters_test.go
+++ b/alicloud/data_source_alicloud_click_house_db_clusters_test.go
@@ -66,9 +66,8 @@ func TestAccAlicloudClickHouseDbClusterDataSource(t *testing.T) {
 			"clusters.0.payment_type":                   "PayAsYouGo",
 			"clusters.0.category":                       "Basic",
 			"clusters.0.db_cluster_access_white_list.#": "1",
-			"clusters.0.db_cluster_access_white_list.0.db_cluster_ip_array_name":      "test",
-			"clusters.0.db_cluster_access_white_list.0.db_cluster_ip_array_attribute": "test",
-			"clusters.0.db_cluster_access_white_list.0.security_ip_list":              "192.168.0.1",
+			"clusters.0.db_cluster_access_white_list.0.db_cluster_ip_array_name": "test",
+			"clusters.0.db_cluster_access_white_list.0.security_ip_list":         "192.168.0.1",
 			"clusters.0.ali_uid":                  CHECKSET,
 			"clusters.0.bid":                      CHECKSET,
 			"clusters.0.commodity_code":           CHECKSET,
@@ -80,7 +79,7 @@ func TestAccAlicloudClickHouseDbClusterDataSource(t *testing.T) {
 			"clusters.0.db_cluster_type":          "Common",
 			"clusters.0.db_node_class":            "S8",
 			"clusters.0.db_node_count":            "1",
-			"clusters.0.db_node_storage":          "500",
+			"clusters.0.db_node_storage":          "100",
 			"clusters.0.encryption_key":           "",
 			"clusters.0.encryption_type":          "",
 			"clusters.0.engine":                   "clickhouse",
@@ -131,13 +130,17 @@ func testAccCheckAlicloudClickHouseDbClusterDataSourceName(rand int, attrMap map
 
 	config := fmt.Sprintf(`
 variable "name" {	
-	default = "tf-testAccClickhouseDbCluster-%d"
+  default = "tf-testAccClickhouseDbCluster-%d"
+}
+data "alicloud_click_house_regions" "default" {	
+  current = true
 }
 data "alicloud_vpcs" "default"	{
   name_regex = "default-NODELETING"
 }
 data "alicloud_vswitches" "default" {
   vpc_id = "${data.alicloud_vpcs.default.ids.0}"
+  zone_id = data.alicloud_click_house_regions.default.regions.0.zone_ids.0.zone_id
 }
 resource "alicloud_click_house_db_cluster" "default" {
   db_cluster_version      = "20.3.10.75"
@@ -148,11 +151,10 @@ resource "alicloud_click_house_db_cluster" "default" {
   db_cluster_description  = var.name
   db_node_group_count     = "1"
   payment_type            = "PayAsYouGo"
-  db_node_storage         = "500"
+  db_node_storage         = "100"
   storage_type            = "cloud_essd"
   vswitch_id              = data.alicloud_vswitches.default.vswitches.0.id
   db_cluster_access_white_list {
-    db_cluster_ip_array_attribute = "test"
     db_cluster_ip_array_name      = "test"
     security_ip_list              = "192.168.0.1"
   }

--- a/alicloud/resource_alicloud_click_house_db_cluster.go
+++ b/alicloud/resource_alicloud_click_house_db_cluster.go
@@ -40,6 +40,7 @@ func resourceAlicloudClickHouseDbCluster() *schema.Resource {
 						"db_cluster_ip_array_attribute": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Removed:  "Field 'db_cluster_ip_array_attribute' has been removed from provider",
 						},
 						"db_cluster_ip_array_name": {
 							Type:     schema.TypeString,
@@ -249,7 +250,7 @@ func resourceAlicloudClickHouseDbClusterRead(d *schema.ResourceData, meta interf
 			dBClusterAccessWhiteListMaps := make([]map[string]interface{}, 0)
 			for _, iPArrayListItem := range iPArrayList.([]interface{}) {
 				if v, ok := iPArrayListItem.(map[string]interface{}); ok {
-					if v["DBClusterIPArrayName"].(string) == "default" {
+					if v["DBClusterIPArrayName"].(string) == "default" || v["DBClusterIPArrayName"].(string) == "dms" {
 						continue
 					}
 					iPArrayListItemMap := make(map[string]interface{})

--- a/alicloud/resource_alicloud_click_house_db_cluster_test.go
+++ b/alicloud/resource_alicloud_click_house_db_cluster_test.go
@@ -319,9 +319,8 @@ func TestAccAlicloudClickHouseDBCluster_basic2(t *testing.T) {
 					"vswitch_id":              "${data.alicloud_vswitches.default.vswitches.0.id}",
 					"db_cluster_access_white_list": []map[string]interface{}{
 						{
-							"db_cluster_ip_array_attribute": "test1",
-							"db_cluster_ip_array_name":      "test1",
-							"security_ip_list":              "192.168.0.1",
+							"db_cluster_ip_array_name": "test1",
+							"security_ip_list":         "192.168.0.1",
 						},
 					},
 				}),
@@ -344,14 +343,12 @@ func TestAccAlicloudClickHouseDBCluster_basic2(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"db_cluster_access_white_list": []map[string]interface{}{
 						{
-							"db_cluster_ip_array_attribute": "test2",
-							"db_cluster_ip_array_name":      "test2",
-							"security_ip_list":              "192.168.0.3",
+							"db_cluster_ip_array_name": "test2",
+							"security_ip_list":         "192.168.0.3",
 						},
 						{
-							"db_cluster_ip_array_attribute": "test1",
-							"db_cluster_ip_array_name":      "test1",
-							"security_ip_list":              "192.168.0.2",
+							"db_cluster_ip_array_name": "test1",
+							"security_ip_list":         "192.168.0.2",
 						},
 					},
 				}),

--- a/website/docs/d/click_house_db_clusters.html.markdown
+++ b/website/docs/d/click_house_db_clusters.html.markdown
@@ -95,6 +95,6 @@ The following attributes are exported in addition to the arguments listed above:
     * `control_version` - The control version of the DBCluster.
     * `status` - The status of the DBCluster. Valid values: `Running`,`Creating`,`Deleting`,`Restarting`,`Preparing`.
     * `db_cluster_access_white_list` - The db cluster access white list.
-        * `db_cluster_ip_array_attribute` - Whitelist grouping attribute.
+        * `db_cluster_ip_array_attribute` - Field `db_cluster_ip_array_attribute` has been removed from provider.
         * `db_cluster_ip_array_name` - Whitelist group name.
         * `security_ip_list` - The IP address list under the whitelist group.

--- a/website/docs/r/click_house_db_cluster.html.markdown
+++ b/website/docs/r/click_house_db_cluster.html.markdown
@@ -20,6 +20,16 @@ For information about Click House DBCluster and how to use it, see [What is DBCl
 Basic Usage
 
 ```terraform
+data "alicloud_click_house_regions" "default" {
+  current = true
+}
+data "alicloud_vpcs" "default" {
+  name_regex = "default-NODELETING"
+}
+data "alicloud_vswitches" "default" {
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+  zone_id = data.alicloud_click_house_regions.default.regions.0.zone_ids.0.zone_id
+}
 resource "alicloud_click_house_db_cluster" "default" {
   db_cluster_version      = "20.3.10.75"
   category                = "Basic"
@@ -29,14 +39,13 @@ resource "alicloud_click_house_db_cluster" "default" {
   payment_type            = "PayAsYouGo"
   db_node_storage         = "500"
   storage_type            = "cloud_essd"
-  vswitch_id              = "your_vswitch_id"
+  vswitch_id              = data.alicloud_vswitches.default.ids.0
   db_cluster_access_white_list {
     db_cluster_ip_array_attribute = "test"
     db_cluster_ip_array_name      = "test"
     security_ip_list              = "192.168.0.1"
   }
 }
-
 ```
 
 ## Argument Reference
@@ -67,7 +76,7 @@ The following arguments are supported:
 
 The db_cluster_access_white_list supports the following:
 
-* `db_cluster_ip_array_attribute` - (Optional) Whitelist grouping attribute.
+* `db_cluster_ip_array_attribute` - (Optional, Removed) Field `db_cluster_ip_array_attribute` has been removed from provider.
 * `db_cluster_ip_array_name` - (Optional) Whitelist group name.
 * `security_ip_list` - (Optional) The IP address list under the whitelist group.
 


### PR DESCRIPTION
resource/click_house_db_clusters: Fixed the difference error in the attribute `db_cluster_access_white_list`; Remove the `db_cluster_ip_array_attribute` attribute.