### PR TITLE
resource/alicloud_gpdb_elastic_instance: Add support for output parameters `db_instance_category`, `encryption_type`, `encryption_key`, `tags`.

### DIFF
--- a/alicloud/connectivity/regions.go
+++ b/alicloud/connectivity/regions.go
@@ -179,3 +179,4 @@ var BrainIndustrialSupportRegions = []Region{Hangzhou}
 var TestSalveRegions = []Region{Hangzhou}
 var ECPSupportRegions = []Region{Beijing, Hangzhou}
 var DCDNSupportRegions = []Region{Hangzhou, APSouthEast1, APNorthEast1}
+var GpdbElasticInstanceSupportRegions = []Region{Beijing, Hangzhou, Shanghai, Shenzhen, APSouthEast1, APSouthEast5, Hongkong}

--- a/alicloud/data_source_alicloud_ecp_instance_types_test.go
+++ b/alicloud/data_source_alicloud_ecp_instance_types_test.go
@@ -2,9 +2,10 @@ package alicloud
 
 import (
 	"fmt"
-	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"strings"
 	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )

--- a/alicloud/data_source_alicloud_ecp_instances_test.go
+++ b/alicloud/data_source_alicloud_ecp_instances_test.go
@@ -2,10 +2,11 @@ package alicloud
 
 import (
 	"fmt"
-	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"strings"
 	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
 func TestAccAlicloudEcpInstancesDataSource(t *testing.T) {

--- a/alicloud/data_source_alicloud_ecp_zones_test.go
+++ b/alicloud/data_source_alicloud_ecp_zones_test.go
@@ -2,9 +2,10 @@ package alicloud
 
 import (
 	"fmt"
-	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"strings"
 	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )

--- a/alicloud/resource_alicloud_ecp_instance.go
+++ b/alicloud/resource_alicloud_ecp_instance.go
@@ -2,14 +2,15 @@ package alicloud
 
 import (
 	"fmt"
+	"log"
+	"regexp"
+	"time"
+
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"log"
-	"regexp"
-	"time"
 )
 
 func resourceAlicloudEcpInstance() *schema.Resource {

--- a/alicloud/resource_alicloud_ecp_instance_test.go
+++ b/alicloud/resource_alicloud_ecp_instance_test.go
@@ -2,10 +2,11 @@ package alicloud
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"testing"
 )
 
 func TestAccAlicloudECPInstance_basic0(t *testing.T) {

--- a/alicloud/resource_alicloud_gpdb_elastic_instance.go
+++ b/alicloud/resource_alicloud_gpdb_elastic_instance.go
@@ -74,11 +74,18 @@ func resourceAlicloudGpdbElasticInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"2C16G", "4C32G", "16C128G"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"2C16G", "4C32G", "16C128G", "2C8G", "4C16G", "8C32G", "16C64G"}, false),
 			},
 			"db_instance_description": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"db_instance_category": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Basic", "HighAvailability"}, false),
 			},
 			"instance_network_type": {
 				Type:         schema.TypeString,
@@ -106,6 +113,17 @@ func resourceAlicloudGpdbElasticInstance() *schema.Resource {
 				ValidateFunc:     validation.IntBetween(1, 12),
 				DiffSuppressFunc: PostPaidDiffSuppressFunc,
 			},
+			"encryption_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"encryption_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"tags": tagsSchema(),
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -161,6 +179,15 @@ func resourceAlicloudGpdbElasticInstanceCreate(d *schema.ResourceData, meta inte
 	request["RegionId"] = client.RegionId
 	if v, ok := d.GetOk("zone_id"); ok {
 		request["ZoneId"] = v
+	}
+	if v, ok := d.GetOk("db_instance_category"); ok {
+		request["DBInstanceCategory"] = v
+	}
+	if v, ok := d.GetOk("encryption_key"); ok {
+		request["EncryptionKey"] = v
+	}
+	if v, ok := d.GetOk("encryption_type"); ok {
+		request["EncryptionType"] = v
 	}
 
 	vswitchId := Trim(d.Get("vswitch_id").(string))
@@ -228,10 +255,12 @@ func resourceAlicloudGpdbElasticInstanceRead(d *schema.ResourceData, meta interf
 	d.Set("vswitch_id", instance["VSwitchId"])
 	d.Set("zone_id", instance["ZoneId"])
 	d.Set("connection_string", instance["ConnectionString"])
+	d.Set("db_instance_category", instance["DBInstanceCategory"])
+	d.Set("encryption_key", instance["EncryptionKey"])
+	d.Set("encryption_type", instance["EncryptionType"])
+	d.Set("tags", tagsToMap(instance["Tags"]))
+	d.Set("instance_spec", fmt.Sprintf("%dC%dG", formatInt(instance["CpuCores"]), formatInt(instance["MemorySize"])))
 
-	if v, exist := instance["DBInstanceClass"]; exist {
-		d.Set("instance_spec", convertDBInstanceClassToInstanceSpec(v.(string)))
-	}
 	if v, exist := instance["PayType"]; exist {
 		d.Set("payment_type", convertGpdbInstancePaymentTypeResponse(v.(string)))
 	}
@@ -251,6 +280,12 @@ func resourceAlicloudGpdbElasticInstanceUpdate(d *schema.ResourceData, meta inte
 	conn, err := client.NewGpdbClient()
 	if err != nil {
 		return WrapError(err)
+	}
+	if d.HasChange("tags") {
+		if err := gpdbService.SetResourceTags(d, "ALIYUN::GPDB::INSTANCE"); err != nil {
+			return WrapError(err)
+		}
+		d.SetPartial("tags")
 	}
 	if d.HasChange("db_instance_description") {
 		action := "ModifyDBInstanceDescription"

--- a/website/docs/r/gpdb_elastic_instance.html.markdown
+++ b/website/docs/r/gpdb_elastic_instance.html.markdown
@@ -61,7 +61,10 @@ The following arguments are supported:
 * `seg_storage_type` - (Required, ForceNew) The disk type of segment nodes. Valid values: `cloud_essd`, `cloud_efficiency`.
 * `seg_node_num` - (Required, ForceNew) The number of segment nodes. Minimum is `4`, max is `256`, step is `4`.
 * `storage_size` - (Required, ForceNew) The storage capacity of per segment node. Unit: GB. Minimum is `50`, max is `4000`, step is `50`. 
-* `instance_spec` - (Required, ForceNew) The specification of segment nodes. Valid values: `2C16G`, `4C32G`, `16C128G`.
+* `instance_spec` - (Required, ForceNew) The specification of segment nodes. 
+   * When `db_instance_category` is `HighAvailability`, Valid values: `2C16G`, `4C32G`, `16C128G`.
+   * When `db_instance_category` is `Basic`, Valid values: `2C8G`, `4C16G`, `8C32G`, `16C64G`.
+* `db_instance_category` - (Optional, ForceNew, Available in v1.158.0+) The edition of the instance. Valid values: `Basic`, `HighAvailability`. Default value: `HighAvailability`.
 * `db_instance_description` - (Optional) The description of ADB PG instance. It is a string of 2 to 256 characters.
 * `instance_network_type` - (Optional, ForceNew) The network type of ADB PG instance. Only `VPC` supported now.
 * `payment_type` - (Optional, ForceNew) Valid values are `PayAsYouGo`, `Subscription`. Default to `PayAsYouGo`.
@@ -72,6 +75,9 @@ The following arguments are supported:
 * `zone_id` - (Optional, ForceNew) The Zone to launch the ADB PG instance. If specified, must be consistent with the zone where the vswitch is located.
 * `vswitch_id` - (Required, ForceNew) The virtual switch ID to launch ADB PG instances in one VPC.
 * `security_ip_list` - (Optional) List of IP addresses allowed to access all databases of an instance. The list contains up to 1,000 IP addresses, separated by commas. Supported formats include 0.0.0.0/0, 10.23.12.24 (IP), and 10.23.12.24/24 (Classless Inter-Domain Routing (CIDR) mode. /24 represents the length of the prefix in an IP address. The range of the prefix length is [1,32]).
+* `tags` - (Optional, Available in v1.158.0+) A mapping of tags to assign to the resource.
+* `encryption_key` - (Optional, ForceNew, Available in v1.158.0+) The ID of the encryption key. **Note:** If the `encryption_type` parameter is set to `CloudDisk`, you must specify this parameter to the encryption key that is in the same region as the disk that is specified by the EncryptionType parameter. Otherwise, leave this parameter empty.
+* `encryption_type` - (Optional, ForceNew, Available in v1.158.0+)  The type of the encryption. Valid values: `CloudDisk`. **Note:** Disk encryption cannot be disabled after it is enabled.
 
 
 ### Timeouts


### PR DESCRIPTION
…eters `db_instance_category`, `encryption_type`, `encryption_key`, `tags`.