### PR TITLE
resource/alicloud_ess_scaling_group: Add support for new parameter `tags`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.160.0 (Unreleased)
+
+- resource/alicloud_ess_scaling_group: Add support for new parameter `tags`
+- datasource/alicloud_ess_scaling_group: Add support for new parameter `tags`
+
 ## 1.159.0 (March 06, 2022)
 
 - **New Resource:** `alicloud_sddp_data_limit` ([#4622](https://github.com/aliyun/terraform-provider-alicloud/issues/4622))

--- a/alicloud/data_source_alicloud_ess_scalinggroups_test.go
+++ b/alicloud/data_source_alicloud_ess_scalinggroups_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-func TestAccAlicloudEssScalinggroupsDataSource(t *testing.T) {
+func TestAccAlicloudEssScalingGroupsDataSource(t *testing.T) {
 	rand := acctest.RandInt()
 	nameRegexConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudEssScalinggroupsDataSourceConfig(rand, map[string]string{
@@ -69,6 +69,7 @@ func TestAccAlicloudEssScalinggroupsDataSource(t *testing.T) {
 			"groups.0.modification_time":         CHECKSET,
 			"groups.0.total_instance_count":      CHECKSET,
 			"groups.0.lifecycle_state":           CHECKSET,
+			"groups.0.tags.key":                  "value",
 		}
 	}
 
@@ -109,6 +110,7 @@ resource "alicloud_ess_scaling_group" "default" {
 	default_cooldown = 20
 	removal_policies = ["OldestInstance", "NewestInstance"]
 	vswitch_ids = ["${alicloud_vswitch.default.id}"]
+	tags = {"key": "value"}
 }
 
 data "alicloud_ess_scaling_groups" "default" {

--- a/website/docs/d/ess_scaling_groups.html.markdown
+++ b/website/docs/d/ess_scaling_groups.html.markdown
@@ -65,5 +65,6 @@ The following attributes are exported in addition to the arguments listed above:
   * `pending_capacity` - Number of pending instances in scaling group.
   * `removing_capacity` - Number of removing instances in scaling group.
   * `creation_time` - Creation time of scaling group.
+  * `tags` - A mapping of tags to assign to the resource.
   
   

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -122,6 +122,9 @@ The following arguments are supported:
 * `group_deletion_protection` - (Optional, Available in v1.102.0+) Specifies whether the scaling group deletion protection is enabled. `true` or `false`, Default value: `false`.            
 * `launch_template_id` - (Optional, Available in v1.141.0+) Instance launch template ID, scaling group obtains launch configuration from instance launch template, see [Launch Template](https://www.alibabacloud.com/help/doc-detail/73916.html). Creating scaling group from launch template enable group automatically.
 * `launch_template_version` - (Optional, Available in v1.159.0+) The version number of the launch template. Valid values are the version number, `Latest`, or `Default`, Default value: `Default`.
+* `tags` - (Optional, Available in v1.160.0+) A mapping of tags to assign to the resource.
+  - Key: It can be up to 64 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It cannot be a null string.
+  - Value: It can be up to 128 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It can be a null string.
 
 -> **NOTE:** When detach loadbalancers, instances in group will be remove from loadbalancer's `Default Server Group`; On the contrary, When attach loadbalancers, instances in group will be added to loadbalancer's `Default Server Group`.
 


### PR DESCRIPTION
 TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudEssScalingGroup -timeout=300m
=== RUN   TestAccAlicloudEssScalingGroupsDataSource
--- PASS: TestAccAlicloudEssScalingGroupsDataSource (79.53s)
=== RUN   TestAccAlicloudEssScalingGroup_basic
--- PASS: TestAccAlicloudEssScalingGroup_basic (114.51s)
=== RUN   TestAccAlicloudEssScalingGroup_launchTemplateIdAndTags
--- PASS: TestAccAlicloudEssScalingGroup_launchTemplateIdAndTags (58.19s)
=== RUN   TestAccAlicloudEssScalingGroup_costoptimized
--- PASS: TestAccAlicloudEssScalingGroup_costoptimized (92.29s)
=== RUN   TestAccAlicloudEssScalingGroup_vpc
--- PASS: TestAccAlicloudEssScalingGroup_vpc (91.56s)
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (127.41s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  566.043s
