### PR TITLE
Change references to xxx.com

### DIFF
--- a/alicloud/resource_alicloud_imp_app_template_test.go
+++ b/alicloud/resource_alicloud_imp_app_template_test.go
@@ -96,19 +96,19 @@ func TestAccAlicloudIMPAppTemplate_basic0(t *testing.T) {
 					"config_list": []map[string]interface{}{
 						{
 							"key":   "config.appCallbackAuthKey",
-							"value": "tf-testAcc-jdD4qhGOxxxxxxxx",
+							"value": "tf-testAcc-jdD4qhGOexample",
 						},
 						{
 							"key":   "config.appCallbackUrl",
-							"value": "http://aliyun.com/tf-testAcc-jdD4qhGOxxxxxxxx",
+							"value": "http://aliyun.com/tf-testAcc-jdD4qhGOexample",
 						},
 						{
 							"key":   "config.livePullDomain",
-							"value": "tf-testAcc-jdD4qhGOxxxxxxxx.com",
+							"value": "tf-testAcc-jdD4qhGOexample.com",
 						},
 						{
 							"key":   "config.livePushDomain",
-							"value": "tf-testAcc-jdD4qhGOxxxxxxxx.com",
+							"value": "tf-testAcc-jdD4qhGOexample.com",
 						},
 						{
 							"key":   "config.regionId",
@@ -116,7 +116,7 @@ func TestAccAlicloudIMPAppTemplate_basic0(t *testing.T) {
 						},
 						{
 							"key":   "config.streamChangeCallbackUrl",
-							"value": "https://aliyun.com/tf-testAcc-jdD4qhGOxxxxxxxx",
+							"value": "https://aliyun.com/tf-testAcc-jdD4qhGOexample",
 						},
 					},
 				}),
@@ -143,7 +143,7 @@ var AlicloudIMPAppTemplateMap0 = map[string]string{
 }
 
 func AlicloudIMPAppTemplateBasicDependence0(name string) string {
-	return fmt.Sprintf(` 
+	return fmt.Sprintf(`
 variable "name" {
   default = "%s"
 }

--- a/examples/cdn/variables.tf
+++ b/examples/cdn/variables.tf
@@ -1,5 +1,5 @@
 variable "domain_name" {
-  default = "www.xxxxxx.com"
+  default = "www.example.com"
 }
 
 variable "cdn_type" {
@@ -10,9 +10,9 @@ variable "sources" {
   type = list(string)
 
   default = [
-    "xxx.com",
-    "xxxx.net",
-    "xxxxx.cn",
+    "example.com",
+    "example.net",
+    "example.cn",
   ]
 }
 
@@ -58,8 +58,7 @@ variable "refer_list" {
   type = list(string)
 
   default = [
-    "www.xxxx.com",
-    "www.xxxx.net",
+    "www.example.com",
+    "www.example.net",
   ]
 }
-

--- a/examples/mns-topic/variables.tf
+++ b/examples/mns-topic/variables.tf
@@ -19,8 +19,8 @@ variable "subscription_name" {
 }
 
 variable "endpoint" {
-  description = "Describe the terminal address of the message received in this subscription. email format: mail:directmail:XXX@YYY.com ,   queue format: http(s)://AccountId.mns.regionId.aliyuncs.com/, http format: http(s)://www.xxx.com/xxx"
-  default     = "http://www.xxx.com/xxx"
+  description = "Describe the terminal address of the message received in this subscription. email format: mail:directmail:XXX@YYY.com ,   queue format: http(s)://AccountId.mns.regionId.aliyuncs.com/, http format: http(s)://www.example.com/example"
+  default     = "http://www.example.com/example"
 }
 
 variable "notify_strategy" {
@@ -37,4 +37,3 @@ variable "filter_tag" {
   description = "Message Filter Label"
   default     = "tf-queue"
 }
-

--- a/website/docs/r/cdn_domain.html.markdown
+++ b/website/docs/r/cdn_domain.html.markdown
@@ -43,7 +43,7 @@ resource "alicloud_cdn_domain" "domain" {
   }
   refer_config {
     refer_type  = "block"
-    refer_list  = ["www.xxxx.com", "www.xxxx.cn"]
+    refer_list  = ["www.example.com", "www.example.cn"]
     allow_empty = "off"
   }
   auth_config {
@@ -99,7 +99,7 @@ The config supports the following:
 ### Block parameter_filter_config
 
 `parameter_filter_config` - (Optional, Type: set) Parameter filter config of the accelerated domain. It's a set and consists of at most one item.
-* `enable` - (Optional) This parameter indicates whether or not the `parameter_filter_config` is enable. Valid values are `on` and `off`. Default value is `off`.  
+* `enable` - (Optional) This parameter indicates whether or not the `parameter_filter_config` is enable. Valid values are `on` and `off`. Default value is `off`.
 * `hash_key_args` - (Optional, Type: list) Reserved parameters of `parameter_filter_config`. It's a list of string and consists of at most 10 items.
 
 ### Block page_404_config

--- a/website/docs/r/cdn_domain_new.html.markdown
+++ b/website/docs/r/cdn_domain_new.html.markdown
@@ -53,7 +53,7 @@ The `sources` block supports the following:
 * `type` - (Required) The type of the source. Valid values are `ipaddr`, `domain` and `oss`.
 * `port` - (Optional, Type: int) The port of source. Valid values are `443` and `80`. Default value is `80`.
 * `priority` - (Optional, Type: int) Priority of the source. Valid values are `0` and `100`. Default value is `20`.
-* `weight` - (Optional, Type: int) Weight of the source. Valid values are from `0` to `100`. Default value is `10`, but if type is `ipaddr`, the value can only be `10`. 
+* `weight` - (Optional, Type: int) Weight of the source. Valid values are from `0` to `100`. Default value is `10`, but if type is `ipaddr`, the value can only be `10`.
 
 ### Block certificate_config
 
@@ -79,5 +79,5 @@ The following attributes are exported:
 CDN domain can be imported using the id, e.g.
 
 ```
-terraform import alicloud_cdn_domain_new.example xxxx.com
+terraform import alicloud_cdn_domain_new.example example.com
 ```

--- a/website/docs/r/mns_topic_subscription.html.markdown
+++ b/website/docs/r/mns_topic_subscription.html.markdown
@@ -28,7 +28,7 @@ resource "alicloud_mns_topic_subscription" "subscription" {
   topic_name            = "tf-example-mnstopic"
   name                  = "tf-example-mnstopic-sub"
   filter_tag            = "test"
-  endpoint              = "http://www.xxx.com/xxx"
+  endpoint              = "http://www.example.com/example"
   notify_strategy       = "BACKOFF_RETRY"
   notify_content_format = "XML"
 }
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `notify_strategy` - (Optional) The NotifyStrategy attribute of Subscription. This attribute specifies the retry strategy when message sending fails. The Valid values: `EXPONENTIAL_DECAY_RETRY` and `BACKOFF_RETRY`. Default value to `BACKOFF_RETRY` .
 * `notify_content_format` - (Optional, ForceNew) The NotifyContentFormat attribute of Subscription. This attribute specifies the content format of the messages pushed to users. The valid values: `SIMPLIFIED`, `XML` and `JSON`. Default to `SIMPLIFIED`.
 * `endpoint` - (Required, ForceNew) The endpoint has three format. Available values format:
- - `HTTP Format`: http://xxx.com/xxx
+ - `HTTP Format`: http://example.com/example
  - `Queue Format`: acs:mns:{REGION}:{AccountID}:queues/{QueueName}
  - `Email Format`: mail:directmail:{MailAddress}
 


### PR DESCRIPTION
Some of these references to `xxx` point to websites with offensive content. This change uses the word `example` instead.