### PR TITLE
bugfix: ignore Invalid.ConfigRuleId.Value error while detach rule in config compliance pack

### DIFF
--- a/alicloud/resource_alicloud_config_aggregate_compliance_pack.go
+++ b/alicloud/resource_alicloud_config_aggregate_compliance_pack.go
@@ -385,6 +385,9 @@ func resourceAlicloudConfigAggregateCompliancePackUpdate(d *schema.ResourceData,
 			})
 			addDebug(action, response, removeRulesReq)
 			if err != nil {
+				if IsExpectedErrors(err, []string{"Invalid.ConfigRuleId.Value"}) {
+					return nil
+				}
 				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 			}
 		}

--- a/alicloud/resource_alicloud_config_compliance_pack.go
+++ b/alicloud/resource_alicloud_config_compliance_pack.go
@@ -364,6 +364,9 @@ func resourceAlicloudConfigCompliancePackUpdate(d *schema.ResourceData, meta int
 			})
 			addDebug(action, response, removeRulesReq)
 			if err != nil {
+				if IsExpectedErrors(err, []string{"Invalid.ConfigRuleId.Value"}) {
+					return nil
+				}
 				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 			}
 		}
@@ -441,6 +444,9 @@ func resourceAlicloudConfigCompliancePackDelete(d *schema.ResourceData, meta int
 	})
 	addDebug(action, response, request)
 	if err != nil {
+		if IsExpectedErrors(err, []string{"Invalid.CompliancePackId.Value"}) {
+			return nil
+		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 	return nil


### PR DESCRIPTION
An error will be occured in the following case：

1. Create config rule
2. Attach config rule into a config compliance pack
3. Then delete config rule
4. "Invalid.ConfigRuleId.Value" error will throw when detach this rule。Because the rule are deleted first, and then the rules are detached

In this case, error named "Invalid.ConfigRuleId.Value" should be ignored.