### PR TITLE
datasource/alicloud_alb_rules: Adds output variable `rule_actions.traffic_limit_config`, `rule_actions.traffic_mirror_config` and `rule_conditions.source_ip_config`.  resource/alicloud_alb_rule: Support for new parameters `rule_actions.traffic_limit_config`, `rule_actions.traffic_mirror_config` and `rule_conditions.source_ip_config`.

### DIFF
--- a/alicloud/data_source_alicloud_alb_rules_test.go
+++ b/alicloud/data_source_alicloud_alb_rules_test.go
@@ -90,10 +90,20 @@ func TestAccAlicloudALBRulesDataSource(t *testing.T) {
 
 	var existDataAlicloudAlbRulesSourceNameMapFunc = func(rand int) map[string]string {
 		return map[string]string{
-			"ids.#":             "1",
-			"rules.#":           "1",
-			"rules.0.rule_name": fmt.Sprintf("tf-testAccAlbRule%d", rand),
-			"rules.0.status":    "Available",
+			"ids.#":                                        "1",
+			"rules.#":                                      "1",
+			"rules.0.rule_name":                            fmt.Sprintf("tf-testAccAlbRule%d", rand),
+			"rules.0.status":                               "Available",
+			"rules.0.listener_id":                          CHECKSET,
+			"rules.0.priority":                             "555",
+			"rules.0.rule_actions.#":                       "2",
+			"rules.0.rule_actions.0.order":                 CHECKSET,
+			"rules.0.rule_actions.0.type":                  CHECKSET,
+			"rules.0.rule_conditions.#":                    "1",
+			"rules.0.rule_conditions.0.type":               "SourceIp",
+			"rules.0.rule_conditions.0.source_ip_config.#": "1",
+			"rules.0.rule_conditions.0.source_ip_config.0.values.#": "1",
+			"rules.0.rule_conditions.0.source_ip_config.0.values.0": "192.168.0.0/24",
 		}
 	}
 	var fakeDataAlicloudAlbRulesSourceNameMapFunc = func(rand int) map[string]string {
@@ -173,6 +183,7 @@ resource "alicloud_alb_load_balancer" "default" {
 }
 
 resource "alicloud_alb_server_group" "default" {
+	count = 3
 	protocol = "HTTP"
 	vpc_id = data.alicloud_vpcs.default.vpcs.0.id
 	server_group_name = var.name
@@ -193,35 +204,48 @@ resource "alicloud_alb_listener" "default" {
 		type = "ForwardGroup"
 		forward_group_config{
 			server_group_tuples{
-				server_group_id = alicloud_alb_server_group.default.id
+				server_group_id = alicloud_alb_server_group.default.0.id
 			}
 		}
 	}
 }
 
 resource "alicloud_alb_rule" "default" {
-	rule_name = var.name
-	listener_id = alicloud_alb_listener.default.id
-	priority =   "555"
-	rule_conditions {
-		cookie_config {
-			values {
-				key = "created"
-				value= "tf"
-			}
-		}
-		type = "Cookie"
-   }
-	
-	rule_actions {
-		forward_group_config {
-			server_group_tuples{
-					server_group_id = alicloud_alb_server_group.default.id
-				}
-		}
-		order = "9"
-		type =  "ForwardGroup"
-	}
+  rule_name   = var.name
+  listener_id = alicloud_alb_listener.default.id
+  priority    = "555"
+  rule_conditions {
+    source_ip_config {
+      values = ["192.168.0.0/24"]
+    }
+    type = "SourceIp"
+  }
+  rule_actions {
+    traffic_mirror_config {
+      target_type = "ForwardGroupMirror"
+      mirror_group_config {
+        server_group_tuples {
+          server_group_id = alicloud_alb_server_group.default.2.id
+        }
+      }
+    }
+    order = 1
+    type  = "TrafficMirror"
+  }
+  rule_actions {
+    forward_group_config {
+      server_group_tuples {
+        server_group_id = alicloud_alb_server_group.default.0.id
+        weight          = 1
+      }
+      server_group_tuples {
+        server_group_id = alicloud_alb_server_group.default.1.id
+        weight          = 2
+      }
+    }
+    order = 2
+    type  = "ForwardGroup"
+  }
 }
 
 data "alicloud_alb_rules" "default" {	

--- a/website/docs/d/alb_rules.html.markdown
+++ b/website/docs/d/alb_rules.html.markdown
@@ -57,7 +57,7 @@ The following attributes are exported in addition to the arguments listed above:
     * `load_balancer_id` - The ID of the Application Load Balancer (ALB) instance to which the forwarding rule belongs.
     * `priority` - The priority of the rule. Valid values: 1 to 10000. A smaller value indicates a higher priority.  Note The priority of each rule within the same listener must be unique.
     * `rule_actions` - The actions of the forwarding rules.
-        * `type` - The action. Valid values: `ForwardGroup`, `Redirect`, `FixedResponse`, `Rewrite`, `InsertHeader`.
+        * `type` - The action type.
         * `fixed_response_config` - The configuration of the fixed response.
             * `content` - The fixed response. The response cannot exceed 1 KB in size and can contain only ASCII characters.
             * `content_type` - The format of the fixed response.  Valid values: text/plain, text/css, text/html, application/javascript, and application/json.
@@ -65,6 +65,7 @@ The following attributes are exported in addition to the arguments listed above:
         * `forward_group_config` - The configurations of the destination server groups.
             * `server_group_tuples` - The destination server group to which requests are forwarded.
                 * `server_group_id` - The ID of the destination server group to which requests are forwarded.
+                * `weight` - The Weight of server group.
         * `insert_header_config` - The configuration of the inserted header field.
             * `key` - The name of the inserted header field. The name must be 1 to 40 characters in length, and can contain letters, digits, underscores (_), and hyphens (-). You cannot use the same name in InsertHeader.  Note You cannot use Cookie or Host in the name.
             * `value` - The content of the inserted header field:  If the ValueType parameter is set to SystemDefined, the following values are used:  ClientSrcPort: the port of the client ClientSrcIp: the IP address of the client Protocol: the protocol used by client requests (HTTP or HTTPS) SLBId: the ID of the ALB instance SLBPort: the listener port of the ALB instance If the ValueType parameter is set to UserDefined: The header value must be 1 to 128 characters in length, and can contain lowercase letters, printable characters whose ASCII value is ch >= 32 && ch < 127, and wildcards such as asterisks (*) and question marks (?). The header value cannot start or end with a space.  If the ValueType parameter is set to ReferenceHeader: The header value must be 1 to 128 characters in length, and can contain lowercase letters, digits, underscores (_), and hyphens (-).
@@ -81,6 +82,13 @@ The following attributes are exported in addition to the arguments listed above:
             * `host` - The host name of the destination to which requests are redirected within ALB.  Valid values:  The host name must be 3 to 128 characters in length, and can contain letters, digits, hyphens (-), periods (.), asterisks (*), and question marks (?). The host name must contain at least one period (.), and cannot start or end with a period (.). The rightmost domain label can contain only letters, asterisks (*) and question marks (?) and cannot contain digits or hyphens (-). Other domain labels cannot start or end with a hyphen (-). You can include asterisks (*) and question marks (?) anywhere in a domain label. Default value: ${host}. You cannot use this value with other characters at the same time.
             * `path` - The path to which requests are to be redirected within ALB.  Valid values: The path must be 1 to 128 characters in length, and start with a forward slash (/). The path can contain letters, digits, asterisks (*), question marks (?)and the following special characters: $ - _ . + / & ~ @ :. It cannot contain the following special characters: " % # ; ! ( ) [ ] ^ , ”. The path is case-sensitive.  Default value: ${path}. This value can be used only once. You can use it with a valid string.
             * `query` - The query string of the request to be redirected within ALB.  The query string must be 1 to 128 characters in length, can contain letters and printable characters. It cannot contain the following special characters: # [ ] { } \ | < > &.  Default value: ${query}. This value can be used only once. You can use it with a valid string.
+        * `traffic_limit_config` - The Flow speed limit.
+            * `qps` - The Number of requests per second.
+        * `traffic_mirror_config` - The Traffic mirroring.
+            * `target_type` - The Mirror target type.
+            * `mirror_group_config` - The Traffic is mirrored to the server group.
+                * `server_group_tuples` - The destination server group to which requests are forwarded.
+                    * `server_group_id` - The ID of the destination server group to which requests are forwarded.
     * `rule_conditions` - The conditions of the forwarding rule.
         * `type` - The type of the forwarding rule.
         * `query_string_config` - The configuration of the query string.
@@ -98,6 +106,8 @@ The following attributes are exported in addition to the arguments listed above:
             * `values` - The request method. Valid values: `HEAD`, `GET`, `POST`, `OPTIONS`, `PUT`, `PATCH`, and `DELETE`.
         * `path_config` - The configuration of the path for the request to be forwarded.
             * `values` - The path of the request to be forwarded. The path must be 1 to 128 characters in length and must start with a forward slash (/). The path can contain letters, digits, and the following special characters: $ - _ . + / & ~ @ :. It cannot contain the following special characters: " % # ; ! ( ) [ ] ^ , ". The value is case-sensitive, and can contain asterisks (*) and question marks (?).
+        * `source_ip_config` - The Based on source IP traffic matching.
+            * `values` - Add one or more IP addresses or IP address segments.
     * `rule_id` - The first ID of the resource.
     * `rule_name` - The name of the forwarding rule. The name must be 2 to 128 characters in length, and can contain letters, digits, periods (.), underscores (_), and hyphens (-). The name must start with a letter.
     * `status` - The status of the resource.

--- a/website/docs/r/alb_rule.html.markdown
+++ b/website/docs/r/alb_rule.html.markdown
@@ -146,19 +146,21 @@ The following arguments are supported:
 
 The rule_conditions supports the following: 
 
-* `type` - (Required) The type of the forwarding rule. Valid values: `Header`, `Host`, `Path`,  `Cookie`, `QueryString`, and `Method`.
+* `type` - (Required) The type of the forwarding rule. Valid values: `Header`, `Host`, `Path`,  `Cookie`, `QueryString`, `Method` and `SourceIp`.
   * `Host`: Requests are forwarded based on the domain name. 
   * `Path`: Requests are forwarded based on the path. 
   * `Header`: Requests are forwarded based on the HTTP header field. 
   * `QueryString`: Requests are forwarded based on the query string. 
   * `Method`: Request are forwarded based on the request method. 
   * `Cookie`: Requests are forwarded based on the cookie.
+  * `SourceIp`: Requests are forwarded based on the source ip. **NOTE:** The `SourceIp` option is available in 1.162.0+.
 * `header_config` - (Optional) The configuration of the header field. See the following `Block header_config`.
 * `cookie_config` - (Optional) The configuration of the cookie. See the following `Block cookie_config`.
 * `host_config` - (Optional) The configuration of the host field. See the following `Block host_config`.
 * `method_config` - (Optional) The configuration of the request method. See the following `Block method_config`.
 * `path_config` - (Optional) The configuration of the path for the request to be forwarded. See the following `Block path_config`.
 * `query_string_config` - (Optional) The configuration of the query string. See the following `Block query_string_config`.
+* `source_ip_config` - (Optional, Available in 1.162.0+) The Based on source IP traffic matching. Required and valid when Type is SourceIP. See the following `Block source_ip_config`.
 
 #### Block header_config
 
@@ -191,6 +193,12 @@ The path_config supports the following:
 
 * `values` - (Optional, Array) The path of the request to be forwarded. The path must be 1 to 128 characters in length and must start with a forward slash (/). The path can contain letters, digits, and the following special characters: $ - _ . + / & ~ @ :. It cannot contain the following special characters: " % # ; ! ( ) [ ] ^ , ". The value is case-sensitive, and can contain asterisks (*) and question marks (?).
 
+#### Block source_ip_config
+
+The source_ip_config supports the following:
+
+* `values` - (Optional, Array) Add one or more IP addresses or IP address segments. You can add up to 5 forwarding rules in a SourceIp.
+
 #### Block query_string_config
 
 The query_string_config supports the following:
@@ -204,12 +212,14 @@ The query_string_config supports the following:
 The rule_actions supports the following: 
 
 * `order` - (Required) The order of the forwarding rule actions. Valid values: 1 to 50000. The actions are performed in ascending order. You cannot leave this parameter empty. Each value must be unique.
-* `type` - (Required) The action. Valid values: `ForwardGroup`, `Redirect`, `FixedResponse`, `Rewrite`, `InsertHeader`. **Note:**  The preceding actions can be classified into two types:  `FinalType`: A forwarding rule can contain only one `FinalType` action, which is executed last. This type of action can contain only one `ForwardGroup`, `Redirect` or `FixedResponse` action. `ExtType`: A forwarding rule can contain one or more `ExtType` actions, which are executed before `FinalType` actions and need to coexist with the `FinalType` actions. This type of action can contain multiple `InsertHeader` actions or one `Rewrite` action.
+* `type` - (Required) The action. Valid values: `ForwardGroup`, `Redirect`, `FixedResponse`, `Rewrite`, `InsertHeader`, `TrafficLimit` and `TrafficMirror`. **Note:**  The preceding actions can be classified into two types:  `FinalType`: A forwarding rule can contain only one `FinalType` action, which is executed last. This type of action can contain only one `ForwardGroup`, `Redirect` or `FixedResponse` action. `ExtType`: A forwarding rule can contain one or more `ExtType` actions, which are executed before `FinalType` actions and need to coexist with the `FinalType` actions. This type of action can contain multiple `InsertHeader` actions or one `Rewrite` action. **NOTE:** The `TrafficLimit` and `TrafficMirror` option is available in 1.162.0+.
 * `fixed_response_config` - (Optional) The configuration of the fixed response. See the following `Block fixed_response_config`.
 * `insert_header_config` - (Optional) The configuration of the inserted header field. See the following `Block insert_header_config`.
 * `redirect_config` - (Optional) The configuration of the external redirect action. See the following `Block redirect_config`.
 * `rewrite_config` - (Optional) The redirect action within ALB. See the following `Block rewrite_config`.
 * `forward_group_config` - (Optional) The forward response action within ALB. See the following `Block forward_group_config`.
+* `traffic_limit_config` - (Optional, Available in 1.162.0+) The Flow speed limit. See the following `Block traffic_limit_config`.
+* `traffic_mirror_config` - (Optional, Available in 1.162.0+) The Traffic mirroring. See the following `Block traffic_mirror_config`.
 
 #### Block rewrite_config
 
@@ -251,7 +261,28 @@ The fixed_response_config supports the following:
 The forward_group_config supports the following:
 
 * `server_group_tuples` - (Optional, Array) The destination server group to which requests are forwarded.
- * `server_group_id` - (Optional) The ID of the destination server group to which requests are forwarded.
+  * `server_group_id` - (Optional) The ID of the destination server group to which requests are forwarded.
+  * `weight` - (Optional, Computed, Available in 1.162.0+) The Weight of server group.
+
+#### Block traffic_limit_config
+
+The traffic_limit_config supports the following:
+
+* `qps` - (Optional) The Number of requests per second. Value range: 1~100000.
+
+#### Block traffic_mirror_config
+
+The traffic_mirror_config supports the following:
+
+* `target_type` - (Optional) The Mirror target type.
+* `mirror_group_config` - (Optional) The Traffic is mirrored to the server group. See the following `Block mirror_group_config`.
+
+#### Block mirror_group_config
+
+The mirror_group_config supports the following:
+
+* `server_group_tuples` - (Optional, Array) The destination server group to which requests are forwarded.
+  * `server_group_id` - (Optional) The ID of the destination server group to which requests are forwarded.
 
 ## Attributes Reference
 


### PR DESCRIPTION
datasource/alicloud_alb_rules: Adds output variable `rule_actions.traffic_limit_config`, `rule_actions.traffic_mirror_config` and `rule_conditions.source_ip_config`.  resource/alicloud_alb_rule: Support for new parameters `rule_actions.traffic_limit_config`, `rule_actions.traffic_mirror_config` and `rule_conditions.source_ip_config`.