### PR TITLE
datasource/alicloud_ecs_network_interfaces: support the field `associated_public_ip` && resource/alicloud_slb_backend_server: add the retry code during the delete

### DIFF
--- a/alicloud/data_source_alicloud_ecs_network_interfaces.go
+++ b/alicloud/data_source_alicloud_ecs_network_interfaces.go
@@ -217,6 +217,18 @@ func dataSourceAlicloudEcsNetworkInterfaces() *schema.Resource {
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
+						"associated_public_ip": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"public_ip_address": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -395,6 +407,16 @@ func dataSourceAlicloudEcsNetworkInterfacesRead(d *schema.ResourceData, meta int
 			}
 		}
 		mapping["tags"] = tags
+
+		associatedPublicIps := make([]map[string]interface{}, 0)
+		if v, ok := object["AssociatedPublicIp"].(map[string]interface{}); ok && len(v) != 0 {
+			associatedPublicIp := map[string]interface{}{
+				"public_ip_address": v["PublicIpAddress"],
+			}
+			associatedPublicIps = append(associatedPublicIps, associatedPublicIp)
+		}
+		mapping["associated_public_ip"] = associatedPublicIps
+
 		ids = append(ids, fmt.Sprint(object["NetworkInterfaceId"]))
 		names = append(names, object["NetworkInterfaceName"])
 		s = append(s, mapping)

--- a/alicloud/resource_alicloud_slb_backend_server.go
+++ b/alicloud/resource_alicloud_slb_backend_server.go
@@ -305,7 +305,7 @@ func resourceAliyunSlbBackendServersDelete(d *schema.ResourceData, meta interfac
 					return slbClient.RemoveBackendServers(request)
 				})
 				if err != nil {
-					if IsExpectedErrors(err, []string{"RspoolVipExist", "ObtainIpFail"}) {
+					if IsExpectedErrors(err, []string{"RspoolVipExist", "ObtainIpFail", "ServiceIsStopping"}) {
 						return resource.RetryableError(err)
 					}
 					return resource.NonRetryableError(err)

--- a/website/docs/d/ecs_network_interfaces.html.markdown
+++ b/website/docs/d/ecs_network_interfaces.html.markdown
@@ -63,7 +63,7 @@ The following attributes are exported in addition to the arguments listed above:
     * `name` - The network interface name.
     * `network_interface_id` - The network interface id.
     * `network_interface_name` - The network interface name.
-    *  `network_interface_traffic_mode` - The communication mode of the elastic network card.
+    * `network_interface_traffic_mode` - The communication mode of the elastic network card.
     * `owner_id` - The ID of the account to which the ENIC belongs.
     * `primary_ip_address` - The primary private IP address of the ENI. 
     * `private_ip` - The primary private IP address of the ENI.
@@ -83,3 +83,5 @@ The following attributes are exported in addition to the arguments listed above:
     * `vpc_id` - The Vpc Id.
     * `vswitch_id` - The vswitch id.
     * `zone_id` - The zone id.
+    * `associated_public_ip` - The EIP associated with the secondary private IP address of the ENI.  **NOTE:** Available in v1.163.0+.
+      * `public_ip_address` - The EIP of the ENI.

--- a/website/docs/r/slb_backend_server.html.markdown
+++ b/website/docs/r/slb_backend_server.html.markdown
@@ -93,7 +93,7 @@ resource "alicloud_slb_backend_server" "default" {
 The following arguments are supported:
 
 * `load_balancer_id` - (Required) ID of the load balancer.
-* `backend_servers` - (Required) A list of instances to added backend server in the SLB. It contains three sub-fields as `Block server` follows.
+* `backend_servers` - (Optional) A list of instances to added backend server in the SLB. It contains three sub-fields as `Block server` follows.
 * `delete_protection_validation` - (Optional, Available in 1.63.0+) Checking DeleteProtection of SLB instance before deleting. If true, this resource will not be deleted when its SLB instance enabled DeleteProtection. Default to false.
 
 ## Block servers


### PR DESCRIPTION
- datasource/alicloud_ecs_network_interfaces: support the field associated_public_ip
- resource/alicloud_slb_backend_server: add the retry code during the delete