### PR TITLE
**New Resource:** `alicloud_ess_eci_scaling_configuration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.164.0 (Unreleased)
+
+- **New Resource:** `alicloud_ess_eci_scaling_configuration`
+- resource/alicloud_ess_scaling_group: Add support for new parameter `group_type`
+
 ## 1.163.0 (April 10, 2022)
 
 - **New Resource:** `alicloud_alb_listener_acl_attachment` ([#4816](https://github.com/aliyun/terraform-provider-alicloud/issues/4816))

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -720,6 +720,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_db_readonly_instance":               resourceAlicloudDBReadonlyInstance(),
 			"alicloud_auto_provisioning_group":            resourceAlicloudAutoProvisioningGroup(),
 			"alicloud_ess_scaling_group":                  resourceAlicloudEssScalingGroup(),
+			"alicloud_ess_eci_scaling_configuration":      resourceAlicloudEssEciScalingConfiguration(),
 			"alicloud_ess_scaling_configuration":          resourceAlicloudEssScalingConfiguration(),
 			"alicloud_ess_scaling_rule":                   resourceAlicloudEssScalingRule(),
 			"alicloud_ess_schedule":                       resourceAlicloudEssScheduledTask(),

--- a/alicloud/resource_alicloud_ess_eci_scaling_configuration.go
+++ b/alicloud/resource_alicloud_ess_eci_scaling_configuration.go
@@ -1,0 +1,1201 @@
+package alicloud
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"regexp"
+	"strconv"
+	"time"
+
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ess"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAlicloudEssEciScalingConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliyunEssEciScalingConfigurationCreate,
+		Read:   resourceAliyunEssEciScalingConfigurationRead,
+		Update: resourceAliyunEssEciScalingConfigurationUpdate,
+		Delete: resourceAliyunEssEciScalingConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"active": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"force_delete": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"scaling_group_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"scaling_configuration_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[\\u4e00-\\u9fa5a-zA-Z0-9][\\u4e00-\\u9fa5a-zA-Z0-9\-_.]{1,63}$`), "It must be 2 to 64 characters in length and can contain letters, digits, underscores (_), hyphens (-), and periods (.). It must start with a letter or a digit."),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"security_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"container_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"restart_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cpu": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+			"memory": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"dns_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_sls": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"ram_role_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"spot_strategy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"spot_price_limit": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+			"auto_create_eip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"eip_bandwidth": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ingress_bandwidth": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"egress_bandwidth": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"tags": tagsSchema(),
+			"image_registry_credentials": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"password": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"server": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"username": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"containers": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ports": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"protocol": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"port": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"environment_vars": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"working_dir": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"args": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"cpu": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"gpu": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"memory": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"image": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"image_pull_policy": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"volume_mounts": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"mount_path": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"read_only": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"commands": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"init_containers": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ports": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"protocol": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"port": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"environment_vars": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"working_dir": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"args": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"cpu": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"gpu": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"memory": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"image": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"image_pull_policy": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"volume_mounts": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"mount_path": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"read_only": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"commands": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"volumes": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"config_file_volume_config_file_to_paths": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"content": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"path": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"disk_volume_disk_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"disk_volume_fs_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"disk_volume_disk_size": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"flex_volume_driver": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"flex_volume_fs_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"flex_volume_options": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"nfs_volume_path": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"nfs_volume_read_only": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"nfs_volume_server": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"host_aliases": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hostnames": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"ip": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAliyunEssEciScalingConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
+	// Ensure instance_type is generation three
+	client := meta.(*connectivity.AliyunClient)
+	var response map[string]interface{}
+	action := "CreateEciScalingConfiguration"
+	request := make(map[string]interface{})
+	conn, err := client.NewEssClient()
+	if err != nil {
+		return WrapError(err)
+	}
+	request["ScalingGroupId"] = d.Get("scaling_group_id")
+	request["ScalingConfigurationName"] = d.Get("scaling_configuration_name")
+	request["Description"] = d.Get("description")
+	request["SecurityGroupId"] = d.Get("security_group_id")
+	request["ContainerGroupName"] = d.Get("container_group_name")
+	request["RestartPolicy"] = d.Get("restart_policy")
+	request["Cpu"] = d.Get("cpu")
+	request["Memory"] = d.Get("memory")
+	request["ResourceGroupId"] = d.Get("resource_group_id")
+	request["DnsPolicy"] = d.Get("dns_policy")
+	request["EnableSls"] = d.Get("enable_sls")
+	request["RamRoleName"] = d.Get("ram_role_name")
+	request["AutoCreateEip"] = d.Get("auto_create_eip")
+	request["EipBandwidth"] = d.Get("eip_bandwidth")
+	request["HostName"] = d.Get("host_name")
+	request["IngressBandwidth"] = d.Get("ingress_bandwidth")
+	request["EgressBandwidth"] = d.Get("egress_bandwidth")
+	request["SpotStrategy"] = d.Get("spot_strategy")
+
+	if v, ok := d.GetOk("spot_price_limit"); ok {
+		request["SpotPriceLimit"] = strconv.FormatFloat(v.(float64), 'f', 2, 64)
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		count := 1
+		for key, value := range v.(map[string]interface{}) {
+			request[fmt.Sprintf("Tag.%d.Key", count)] = key
+			request[fmt.Sprintf("Tag.%d.Value", count)] = value
+			count++
+		}
+	}
+
+	if v, ok := d.GetOk("image_registry_credentials"); ok {
+		imageRegisryCredentialMaps := make([]map[string]interface{}, 0)
+		for _, raw := range v.(*schema.Set).List() {
+			obj := raw.(map[string]interface{})
+			imageRegisryCredentialMaps = append(imageRegisryCredentialMaps, map[string]interface{}{
+				"Password": obj["password"],
+				"Server":   obj["server"],
+				"UserName": obj["username"],
+			})
+		}
+		request["ImageRegistryCredential"] = imageRegisryCredentialMaps
+	}
+
+	Containers := make([]map[string]interface{}, len(d.Get("containers").(*schema.Set).List()))
+	for i, v := range d.Get("containers").(*schema.Set).List() {
+		ContainersMap := v.(map[string]interface{})
+		Containers[i] = make(map[string]interface{})
+		Ports := make([]map[string]interface{}, len(ContainersMap["ports"].(*schema.Set).List()))
+		for i, PortsValue := range ContainersMap["ports"].(*schema.Set).List() {
+			PortsMap := PortsValue.(map[string]interface{})
+			Ports[i] = make(map[string]interface{})
+			Ports[i]["Port"] = PortsMap["port"]
+			Ports[i]["Protocol"] = PortsMap["protocol"]
+		}
+		Containers[i]["Port"] = Ports
+		EnvironmentVars := make([]map[string]interface{}, len(ContainersMap["environment_vars"].(*schema.Set).List()))
+		for i, EnvironmentVarsValue := range ContainersMap["environment_vars"].(*schema.Set).List() {
+			EnvironmentVarsMap := EnvironmentVarsValue.(map[string]interface{})
+			EnvironmentVars[i] = make(map[string]interface{})
+			EnvironmentVars[i]["Key"] = EnvironmentVarsMap["key"]
+			EnvironmentVars[i]["Value"] = EnvironmentVarsMap["value"]
+		}
+		Containers[i]["EnvironmentVar"] = EnvironmentVars
+		Containers[i]["WorkingDir"] = ContainersMap["working_dir"]
+		Containers[i]["Arg"] = ContainersMap["args"]
+		Containers[i]["Cpu"] = ContainersMap["cpu"]
+		Containers[i]["Gpu"] = ContainersMap["gpu"]
+		Containers[i]["Memory"] = ContainersMap["memory"]
+		Containers[i]["Name"] = ContainersMap["name"]
+		Containers[i]["Image"] = ContainersMap["image"]
+		Containers[i]["ImagePullPolicy"] = ContainersMap["image_pull_policy"]
+		VolumeMounts := make([]map[string]interface{}, len(ContainersMap["volume_mounts"].(*schema.Set).List()))
+		for i, VolumeMountsValue := range ContainersMap["volume_mounts"].(*schema.Set).List() {
+			VolumeMountsMap := VolumeMountsValue.(map[string]interface{})
+			VolumeMounts[i] = make(map[string]interface{})
+			VolumeMounts[i]["MountPath"] = VolumeMountsMap["mount_path"]
+			VolumeMounts[i]["Name"] = VolumeMountsMap["name"]
+			VolumeMounts[i]["ReadOnly"] = VolumeMountsMap["read_only"]
+		}
+		Containers[i]["VolumeMount"] = VolumeMounts
+		Containers[i]["Command"] = ContainersMap["commands"]
+	}
+	request["Container"] = Containers
+
+	if v, ok := d.GetOk("init_containers"); ok {
+		InitContainers := make([]map[string]interface{}, len(v.(*schema.Set).List()))
+		for i, v := range v.(*schema.Set).List() {
+			InitContainersMap := v.(map[string]interface{})
+			InitContainers[i] = make(map[string]interface{})
+			Ports := make([]map[string]interface{}, len(InitContainersMap["ports"].(*schema.Set).List()))
+			for i, PortsValue := range InitContainersMap["ports"].(*schema.Set).List() {
+				PortsMap := PortsValue.(map[string]interface{})
+				Ports[i] = make(map[string]interface{})
+				Ports[i]["Port"] = PortsMap["port"]
+				Ports[i]["Protocol"] = PortsMap["protocol"]
+			}
+			InitContainers[i]["InitContainerPort"] = Ports
+			EnvironmentVars := make([]map[string]interface{}, len(InitContainersMap["environment_vars"].(*schema.Set).List()))
+			for i, EnvironmentVarsValue := range InitContainersMap["environment_vars"].(*schema.Set).List() {
+				EnvironmentVarsMap := EnvironmentVarsValue.(map[string]interface{})
+				EnvironmentVars[i] = make(map[string]interface{})
+				EnvironmentVars[i]["Key"] = EnvironmentVarsMap["key"]
+				EnvironmentVars[i]["Value"] = EnvironmentVarsMap["value"]
+			}
+			InitContainers[i]["InitContainerEnvironmentVar"] = EnvironmentVars
+			InitContainers[i]["WorkingDir"] = InitContainersMap["working_dir"]
+			InitContainers[i]["Arg"] = InitContainersMap["args"]
+			InitContainers[i]["Cpu"] = InitContainersMap["cpu"]
+			InitContainers[i]["Gpu"] = InitContainersMap["gpu"]
+			InitContainers[i]["Memory"] = InitContainersMap["memory"]
+			InitContainers[i]["Name"] = InitContainersMap["name"]
+			InitContainers[i]["Image"] = InitContainersMap["image"]
+			InitContainers[i]["ImagePullPolicy"] = InitContainersMap["image_pull_policy"]
+			VolumeMounts := make([]map[string]interface{}, len(InitContainersMap["volume_mounts"].(*schema.Set).List()))
+			for i, VolumeMountsValue := range InitContainersMap["volume_mounts"].(*schema.Set).List() {
+				VolumeMountsMap := VolumeMountsValue.(map[string]interface{})
+				VolumeMounts[i] = make(map[string]interface{})
+				VolumeMounts[i]["MountPath"] = VolumeMountsMap["mount_path"]
+				VolumeMounts[i]["Name"] = VolumeMountsMap["name"]
+				VolumeMounts[i]["ReadOnly"] = VolumeMountsMap["read_only"]
+			}
+			InitContainers[i]["InitContainerVolumeMount"] = VolumeMounts
+			InitContainers[i]["Command"] = InitContainersMap["commands"]
+		}
+		request["InitContainer"] = InitContainers
+	}
+
+	if v, ok := d.GetOk("volumes"); ok {
+		Volumes := make([]map[string]interface{}, len(v.(*schema.Set).List()))
+		for i, v := range v.(*schema.Set).List() {
+			VolumesMap := v.(map[string]interface{})
+			Volumes[i] = make(map[string]interface{})
+			ConfigFileVolumeConfigFileToPaths := make([]map[string]interface{}, len(VolumesMap["config_file_volume_config_file_to_paths"].(*schema.Set).List()))
+			for i, ConfigFileVolumeConfigFileToPathsValue := range VolumesMap["config_file_volume_config_file_to_paths"].(*schema.Set).List() {
+				ConfigFileVolumeConfigFileToPathsMap := ConfigFileVolumeConfigFileToPathsValue.(map[string]interface{})
+				ConfigFileVolumeConfigFileToPaths[i] = make(map[string]interface{})
+				ConfigFileVolumeConfigFileToPaths[i]["Content"] = ConfigFileVolumeConfigFileToPathsMap["content"]
+				ConfigFileVolumeConfigFileToPaths[i]["Path"] = ConfigFileVolumeConfigFileToPathsMap["path"]
+			}
+			Volumes[i]["ConfigFileVolumeConfigFileToPath"] = ConfigFileVolumeConfigFileToPaths
+			Volumes[i]["DiskVolume.DiskId"] = VolumesMap["disk_volume_disk_id"]
+			Volumes[i]["DiskVolume.FsType"] = VolumesMap["disk_volume_fs_type"]
+			Volumes[i]["DiskVolume.DiskSize"] = VolumesMap["disk_volume_disk_size"]
+			Volumes[i]["FlexVolume.Driver"] = VolumesMap["flex_volume_driver"]
+			Volumes[i]["FlexVolume.FsType"] = VolumesMap["flex_volume_fs_type"]
+			Volumes[i]["FlexVolume.Options"] = VolumesMap["flex_volume_options"]
+			Volumes[i]["NFSVolume.Path"] = VolumesMap["nfs_volume_path"]
+			Volumes[i]["NFSVolume.Server"] = VolumesMap["nfs_volume_server"]
+			Volumes[i]["NFSVolume.ReadOnly"] = VolumesMap["nfs_volume_read_only"]
+			Volumes[i]["Name"] = VolumesMap["name"]
+			Volumes[i]["Type"] = VolumesMap["type"]
+		}
+		request["Volume"] = Volumes
+	}
+
+	if v, ok := d.GetOk("host_aliases"); ok {
+		HostAliases := make([]map[string]interface{}, len(v.(*schema.Set).List()))
+		for i, HostAliasesValue := range v.(*schema.Set).List() {
+			HostAliasesMap := HostAliasesValue.(map[string]interface{})
+			HostAliases[i] = make(map[string]interface{})
+			HostAliases[i]["Hostname"] = HostAliasesMap["hostnames"]
+			HostAliases[i]["Ip"] = HostAliasesMap["ip"]
+		}
+		request["HostAliase"] = HostAliases
+	}
+
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2014-08-28"), StringPointer("AK"), nil, request, &runtime)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ess_eci_scaling_configuration", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["ScalingConfigurationId"]))
+
+	return resourceAliyunEssEciScalingConfigurationUpdate(d, meta)
+}
+
+func resourceAliyunEssEciScalingConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	essService := EssService{client}
+	o, err := essService.DescribeEssEciScalingConfiguration(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+	d.Set("active", d.Get("active"))
+	d.Set("force_delete", d.Get("force_delete"))
+	d.Set("scaling_group_id", o["ScalingGroupId"])
+	d.Set("scaling_configuration_name", o["ScalingConfigurationName"])
+	d.Set("description", o["Description"])
+	d.Set("security_group_id", o["SecurityGroupId"])
+	d.Set("container_group_name", o["ContainerGroupName"])
+	d.Set("restart_policy", o["RestartPolicy"])
+	d.Set("cpu", o["Cpu"])
+	d.Set("memory", o["Memory"])
+	d.Set("resource_group_id", o["ResourceGroupId"])
+	d.Set("dns_policy", o["DnsPolicy"])
+	d.Set("enable_sls", o["SlsEnable"])
+	d.Set("ram_role_name", o["RamRoleName"])
+	d.Set("auto_create_eip", o["AutoCreateEip"])
+	d.Set("eip_bandwidth", o["EipBandwidth"])
+	d.Set("host_name", o["HostName"])
+	d.Set("ingress_bandwidth", o["IngressBandwidth"])
+	d.Set("egress_bandwidth", o["EgressBandwidth"])
+	d.Set("tags", o["Tags"])
+	d.Set("spot_strategy", o["SpotStrategy"])
+	if o["spot_price_limit"] != nil {
+		d.Set("spot_price_limit", strconv.FormatFloat(o["SpotPriceLimit"].(float64), 'f', 2, 64))
+	}
+
+	credentials := make([]map[string]interface{}, 0)
+	if credentialList, ok := o["ImageRegistryCredentials"].([]interface{}); ok {
+		for _, v := range credentialList {
+			if m1, ok := v.(map[string]interface{}); ok {
+				temp1 := map[string]interface{}{
+					"password": m1["Password"],
+					"server":   m1["Server"],
+					"username": m1["UserName"],
+				}
+				credentials = append(credentials, temp1)
+			}
+		}
+	}
+	d.Set("image_registry_credentials", credentials)
+
+	containers := make([]map[string]interface{}, 0)
+	if containersList, ok := o["Containers"].([]interface{}); ok {
+		for _, v := range containersList {
+			if m1, ok := v.(map[string]interface{}); ok {
+				temp1 := map[string]interface{}{
+					"working_dir":       m1["WorkingDir"],
+					"args":              m1["Args"],
+					"cpu":               m1["Cpu"],
+					"gpu":               m1["Gpu"],
+					"memory":            m1["Memory"],
+					"name":              m1["Name"],
+					"image":             m1["Image"],
+					"image_pull_policy": m1["ImagePullPolicy"],
+					"commands":          m1["Commands"],
+				}
+				if m1["EnvironmentVars"] != nil {
+					environmentVarsMaps := make([]map[string]interface{}, 0)
+					for _, environmentVarsValue := range m1["EnvironmentVars"].([]interface{}) {
+						environmentVars := environmentVarsValue.(map[string]interface{})
+						environmentVarsMap := map[string]interface{}{
+							"key":   environmentVars["Key"],
+							"value": environmentVars["Value"],
+						}
+						environmentVarsMaps = append(environmentVarsMaps, environmentVarsMap)
+					}
+					temp1["environment_vars"] = environmentVarsMaps
+				}
+				if m1["Ports"] != nil {
+					portsMaps := make([]map[string]interface{}, 0)
+					for _, portsValue := range m1["Ports"].([]interface{}) {
+						ports := portsValue.(map[string]interface{})
+						portsMap := map[string]interface{}{
+							"port":     ports["Port"],
+							"protocol": ports["Protocol"],
+						}
+						portsMaps = append(portsMaps, portsMap)
+					}
+					temp1["ports"] = portsMaps
+				}
+				if m1["VolumeMounts"] != nil {
+					volumeMountsMaps := make([]map[string]interface{}, 0)
+					for _, volumeMountsValue := range m1["VolumeMounts"].([]interface{}) {
+						volumeMounts := volumeMountsValue.(map[string]interface{})
+						volumeMountsMap := map[string]interface{}{
+							"mount_path": volumeMounts["MountPath"],
+							"name":       volumeMounts["Name"],
+							"read_only":  volumeMounts["ReadOnly"],
+						}
+						volumeMountsMaps = append(volumeMountsMaps, volumeMountsMap)
+					}
+					temp1["volume_mounts"] = volumeMountsMaps
+				}
+				containers = append(containers, temp1)
+			}
+		}
+	}
+
+	if err := d.Set("containers", containers); err != nil {
+		return WrapError(err)
+	}
+
+	initContainers := make([]map[string]interface{}, 0)
+	if initContainersList, ok := o["InitContainers"].([]interface{}); ok {
+		for _, v := range initContainersList {
+			if m1, ok := v.(map[string]interface{}); ok {
+				temp1 := map[string]interface{}{
+					"working_dir":       m1["WorkingDir"],
+					"args":              m1["InitContainerArgs"],
+					"cpu":               m1["Cpu"],
+					"gpu":               m1["Gpu"],
+					"memory":            m1["Memory"],
+					"image":             m1["Image"],
+					"image_pull_policy": m1["ImagePullPolicy"],
+					"name":              m1["Name"],
+					"commands":          m1["InitContainerCommands"],
+				}
+				if m1["InitContainerEnvironmentVars"] != nil {
+					environmentVarsMaps := make([]map[string]interface{}, 0)
+					for _, environmentVarsValue := range m1["InitContainerEnvironmentVars"].([]interface{}) {
+						environmentVars := environmentVarsValue.(map[string]interface{})
+						environmentVarsMap := map[string]interface{}{
+							"key":   environmentVars["Key"],
+							"value": environmentVars["Value"],
+						}
+						environmentVarsMaps = append(environmentVarsMaps, environmentVarsMap)
+					}
+					temp1["environment_vars"] = environmentVarsMaps
+				}
+				if m1["InitContainerPorts"] != nil {
+					portsMaps := make([]map[string]interface{}, 0)
+					for _, portsValue := range m1["InitContainerPorts"].([]interface{}) {
+						ports := portsValue.(map[string]interface{})
+						portsMap := map[string]interface{}{
+							"port":     ports["Port"],
+							"protocol": ports["Protocol"],
+						}
+						portsMaps = append(portsMaps, portsMap)
+					}
+					temp1["ports"] = portsMaps
+				}
+				if m1["InitContainerVolumeMounts"] != nil {
+					volumeMountsMaps := make([]map[string]interface{}, 0)
+					for _, volumeMountsValue := range m1["InitContainerVolumeMounts"].([]interface{}) {
+						volumeMounts := volumeMountsValue.(map[string]interface{})
+						volumeMountsMap := map[string]interface{}{
+							"mount_path": volumeMounts["MountPath"],
+							"name":       volumeMounts["Name"],
+							"read_only":  volumeMounts["ReadOnly"],
+						}
+						volumeMountsMaps = append(volumeMountsMaps, volumeMountsMap)
+					}
+					temp1["volume_mounts"] = volumeMountsMaps
+				}
+				initContainers = append(initContainers, temp1)
+
+			}
+		}
+	}
+	if err := d.Set("init_containers", initContainers); err != nil {
+		return WrapError(err)
+	}
+
+	volumes := make([]map[string]interface{}, 0)
+	if volumesList, ok := o["Volumes"].([]interface{}); ok {
+		for _, v := range volumesList {
+			if m1, ok := v.(map[string]interface{}); ok {
+				temp1 := map[string]interface{}{
+					"disk_volume_disk_id":   m1["DiskVolumeDiskId"],
+					"disk_volume_fs_type":   m1["DiskVolumeFsType"],
+					"disk_volume_disk_size": m1["DiskVolumeDiskSize"],
+					"flex_volume_driver":    m1["FlexVolumeDriver"],
+					"flex_volume_fs_type":   m1["FlexVolumeFsType"],
+					"flex_volume_options":   m1["FlexVolumeOptions"],
+					"nfs_volume_path":       m1["NFSVolumePath"],
+					"nfs_volume_read_only":  m1["NFSVolumeReadOnly"],
+					"nfs_volume_server":     m1["NFSVolumeServer"],
+					"name":                  m1["Name"],
+					"type":                  m1["Type"],
+				}
+				if m1["ConfigFileVolumeConfigFileToPaths"] != nil {
+					configFileVolumeConfigFileToPathsMaps := make([]map[string]interface{}, 0)
+					for _, configFileVolumeConfigFileToPathsValue := range m1["ConfigFileVolumeConfigFileToPaths"].([]interface{}) {
+						configFileVolumeConfigFileToPaths := configFileVolumeConfigFileToPathsValue.(map[string]interface{})
+						configFileVolumeConfigFileToPathsMap := map[string]interface{}{
+							"content": configFileVolumeConfigFileToPaths["Content"],
+							"path":    configFileVolumeConfigFileToPaths["Path"],
+						}
+						configFileVolumeConfigFileToPathsMaps = append(configFileVolumeConfigFileToPathsMaps, configFileVolumeConfigFileToPathsMap)
+					}
+					temp1["config_file_volume_config_file_to_paths"] = configFileVolumeConfigFileToPathsMaps
+				}
+				volumes = append(volumes, temp1)
+
+			}
+		}
+	}
+	if err := d.Set("volumes", volumes); err != nil {
+		return WrapError(err)
+	}
+
+	hostAliases := make([]map[string]interface{}, 0)
+	if hostAliasesList, ok := o["HostAliases"].([]interface{}); ok {
+		for _, v := range hostAliasesList {
+			if m1, ok := v.(map[string]interface{}); ok {
+				temp1 := map[string]interface{}{
+					"hostnames": m1["Hostnames"],
+					"ip":        m1["Ip"],
+				}
+				hostAliases = append(hostAliases, temp1)
+
+			}
+		}
+	}
+	if err := d.Set("host_aliases", hostAliases); err != nil {
+		return WrapError(err)
+	}
+
+	return nil
+}
+
+func resourceAliyunEssEciScalingConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	essService := EssService{client}
+	d.Partial(true)
+
+	sgId := d.Get("scaling_group_id").(string)
+	group, err := essService.DescribeEssScalingGroup(sgId)
+	if err != nil {
+		return WrapError(err)
+	}
+
+	if d.HasChange("active") {
+		c, err := essService.DescribeEssEciScalingConfiguration(d.Id())
+		if err != nil {
+			if NotFoundError(err) {
+				d.SetId("")
+				return nil
+			}
+			return WrapError(err)
+		}
+		if d.Get("active").(bool) {
+			if c["LifecycleState"] == string(Inactive) {
+				modifyGroupRequest := ess.CreateModifyScalingGroupRequest()
+				modifyGroupRequest.ScalingGroupId = sgId
+				modifyGroupRequest.ActiveScalingConfigurationId = d.Id()
+				_, err := client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+					return essClient.ModifyScalingGroup(modifyGroupRequest)
+				})
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), modifyGroupRequest.GetActionName(), AlibabaCloudSdkGoERROR)
+				}
+			}
+			if group.LifecycleState == string(Inactive) {
+				enableGroupRequest := ess.CreateEnableScalingGroupRequest()
+				enableGroupRequest.RegionId = client.RegionId
+				enableGroupRequest.ScalingGroupId = sgId
+				_, err := client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+					return essClient.EnableScalingGroup(enableGroupRequest)
+				})
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), enableGroupRequest.GetActionName(), AlibabaCloudSdkGoERROR)
+				}
+			}
+		}
+		d.SetPartial("active")
+	}
+
+	request := map[string]interface{}{
+		"ScalingConfigurationId": d.Id(),
+		"RegionId":               client.RegionId,
+	}
+	update := false
+
+	if d.HasChange("scaling_configuration_name") {
+		update = true
+		request["ScalingConfigurationName"] = d.Get("scaling_configuration_name")
+	}
+	if d.HasChange("description") {
+		update = true
+		request["Description"] = d.Get("description")
+	}
+	if d.HasChange("security_group_id") {
+		update = true
+		request["SecurityGroupId"] = d.Get("security_group_id")
+	}
+	if d.HasChange("container_group_name") {
+		update = true
+		request["ContainerGroupName"] = d.Get("container_group_name")
+	}
+	if d.HasChange("restart_policy") {
+		update = true
+		request["RestartPolicy"] = d.Get("restart_policy")
+	}
+	if d.HasChange("cpu") {
+		update = true
+		request["Cpu"] = d.Get("cpu")
+	}
+	if d.HasChange("memory") {
+		update = true
+		request["Memory"] = d.Get("memory")
+	}
+	if d.HasChange("resource_group_id") {
+		update = true
+		request["ResourceGroupId"] = d.Get("resource_group_id")
+	}
+	if d.HasChange("dns_policy") {
+		update = true
+		request["DnsPolicy"] = d.Get("dns_policy")
+	}
+	if d.HasChange("enable_sls") {
+		update = true
+		request["EnableSls"] = d.Get("enable_sls")
+	}
+	if d.HasChange("ram_role_name") {
+		update = true
+		request["RamRoleName"] = d.Get("ram_role_name")
+	}
+	if d.HasChange("spot_strategy") {
+		update = true
+		request["SpotStrategy"] = d.Get("spot_strategy")
+	}
+	if d.HasChange("spot_price_limit") {
+		update = true
+		request["SpotPriceLimit"] = strconv.FormatFloat(d.Get("spot_price_limit").(float64), 'f', 2, 64)
+	}
+	if d.HasChange("auto_create_eip") {
+		update = true
+		request["AutoCreateEip"] = d.Get("auto_create_eip")
+	}
+	if d.HasChange("eip_bandwidth") {
+		update = true
+		request["EipBandwidth"] = d.Get("eip_bandwidth")
+	}
+	if d.HasChange("host_name") {
+		update = true
+		request["HostName"] = d.Get("host_name")
+	}
+	if d.HasChange("ingress_bandwidth") {
+		update = true
+		request["IngressBandwidth"] = d.Get("ingress_bandwidth")
+	}
+	if d.HasChange("egress_bandwidth") {
+		update = true
+		request["EgressBandwidth"] = d.Get("egress_bandwidth")
+	}
+	if d.HasChange("tags") {
+		update = true
+		count := 1
+		for key, value := range d.Get("tags").(map[string]interface{}) {
+			request[fmt.Sprintf("Tag.%d.Key", count)] = key
+			request[fmt.Sprintf("Tag.%d.Value", count)] = value
+			count++
+		}
+	}
+
+	if d.HasChange("image_registry_credentials") {
+		update = true
+		if v, ok := d.GetOk("image_registry_credentials"); ok {
+			imageRegisryCredentialMaps := make([]map[string]interface{}, 0)
+			for _, raw := range v.(*schema.Set).List() {
+				obj := raw.(map[string]interface{})
+				imageRegisryCredentialMaps = append(imageRegisryCredentialMaps, map[string]interface{}{
+					"Password": obj["password"],
+					"Server":   obj["server"],
+					"UserName": obj["username"],
+				})
+			}
+			request["ImageRegistryCredential"] = imageRegisryCredentialMaps
+		}
+	}
+
+	if d.HasChange("containers") {
+		update = true
+		Containers := make([]map[string]interface{}, len(d.Get("containers").(*schema.Set).List()))
+		for i, ContainersValue := range d.Get("containers").(*schema.Set).List() {
+			ContainersMap := ContainersValue.(map[string]interface{})
+			Containers[i] = make(map[string]interface{})
+			Containers[i]["WorkingDir"] = ContainersMap["working_dir"]
+			Containers[i]["Arg"] = ContainersMap["args"]
+			Containers[i]["Cpu"] = ContainersMap["cpu"]
+			Containers[i]["Gpu"] = ContainersMap["gpu"]
+			Containers[i]["Memory"] = ContainersMap["memory"]
+			Containers[i]["Name"] = ContainersMap["name"]
+			Containers[i]["Image"] = ContainersMap["image"]
+			Containers[i]["ImagePullPolicy"] = ContainersMap["image_pull_policy"]
+			Containers[i]["Command"] = ContainersMap["commands"]
+
+			EnvironmentVars := make([]map[string]interface{}, len(ContainersMap["environment_vars"].(*schema.Set).List()))
+			for i, EnvironmentVarsValue := range ContainersMap["environment_vars"].(*schema.Set).List() {
+				EnvironmentVarsMap := EnvironmentVarsValue.(map[string]interface{})
+				EnvironmentVars[i] = make(map[string]interface{})
+				EnvironmentVars[i]["Key"] = EnvironmentVarsMap["key"]
+				EnvironmentVars[i]["Value"] = EnvironmentVarsMap["value"]
+			}
+			Containers[i]["EnvironmentVar"] = EnvironmentVars
+
+			Ports := make([]map[string]interface{}, len(ContainersMap["ports"].(*schema.Set).List()))
+			for i, PortsValue := range ContainersMap["ports"].(*schema.Set).List() {
+				PortsMap := PortsValue.(map[string]interface{})
+				Ports[i] = make(map[string]interface{})
+				Ports[i]["Port"] = PortsMap["port"]
+				Ports[i]["Protocol"] = PortsMap["protocol"]
+			}
+			Containers[i]["Port"] = Ports
+
+			VolumeMounts := make([]map[string]interface{}, len(ContainersMap["volume_mounts"].(*schema.Set).List()))
+			for i, VolumeMountsValue := range ContainersMap["volume_mounts"].(*schema.Set).List() {
+				VolumeMountsMap := VolumeMountsValue.(map[string]interface{})
+				VolumeMounts[i] = make(map[string]interface{})
+				VolumeMounts[i]["MountPath"] = VolumeMountsMap["mount_path"]
+				VolumeMounts[i]["Name"] = VolumeMountsMap["name"]
+				VolumeMounts[i]["ReadOnly"] = VolumeMountsMap["read_only"]
+			}
+			Containers[i]["VolumeMount"] = VolumeMounts
+		}
+		request["Container"] = Containers
+	}
+
+	if d.HasChange("init_containers") {
+		update = true
+		InitContainers := make([]map[string]interface{}, len(d.Get("init_containers").(*schema.Set).List()))
+		for i, InitContainersValue := range d.Get("init_containers").(*schema.Set).List() {
+			InitContainersMap := InitContainersValue.(map[string]interface{})
+			InitContainers[i] = make(map[string]interface{})
+			InitContainers[i]["WorkingDir"] = InitContainersMap["working_dir"]
+			InitContainers[i]["Arg"] = InitContainersMap["args"]
+			InitContainers[i]["Cpu"] = InitContainersMap["cpu"]
+			InitContainers[i]["Gpu"] = InitContainersMap["gpu"]
+			InitContainers[i]["Memory"] = InitContainersMap["memory"]
+			InitContainers[i]["Name"] = InitContainersMap["name"]
+			InitContainers[i]["Image"] = InitContainersMap["image"]
+			InitContainers[i]["ImagePullPolicy"] = InitContainersMap["image_pull_policy"]
+			InitContainers[i]["Command"] = InitContainersMap["commands"]
+
+			EnvironmentVars := make([]map[string]interface{}, len(InitContainersMap["environment_vars"].(*schema.Set).List()))
+			for i, EnvironmentVarsValue := range InitContainersMap["environment_vars"].(*schema.Set).List() {
+				EnvironmentVarsMap := EnvironmentVarsValue.(map[string]interface{})
+				EnvironmentVars[i] = make(map[string]interface{})
+				EnvironmentVars[i]["Key"] = EnvironmentVarsMap["key"]
+				EnvironmentVars[i]["Value"] = EnvironmentVarsMap["value"]
+			}
+			InitContainers[i]["InitContainerEnvironmentVar"] = EnvironmentVars
+
+			Ports := make([]map[string]interface{}, len(InitContainersMap["ports"].(*schema.Set).List()))
+			for i, PortsValue := range InitContainersMap["ports"].(*schema.Set).List() {
+				PortsMap := PortsValue.(map[string]interface{})
+				Ports[i] = make(map[string]interface{})
+				Ports[i]["Port"] = PortsMap["port"]
+				Ports[i]["Protocol"] = PortsMap["protocol"]
+			}
+			InitContainers[i]["InitContainerPort"] = Ports
+
+			VolumeMounts := make([]map[string]interface{}, len(InitContainersMap["volume_mounts"].(*schema.Set).List()))
+			for i, VolumeMountsValue := range InitContainersMap["volume_mounts"].(*schema.Set).List() {
+				VolumeMountsMap := VolumeMountsValue.(map[string]interface{})
+				VolumeMounts[i] = make(map[string]interface{})
+				VolumeMounts[i]["MountPath"] = VolumeMountsMap["mount_path"]
+				VolumeMounts[i]["Name"] = VolumeMountsMap["name"]
+				VolumeMounts[i]["ReadOnly"] = VolumeMountsMap["read_only"]
+			}
+			InitContainers[i]["InitContainerVolumeMount"] = VolumeMounts
+		}
+		request["InitContainer"] = InitContainers
+	}
+
+	if d.HasChange("volumes") {
+		update = true
+		Volumes := make([]map[string]interface{}, len(d.Get("volumes").(*schema.Set).List()))
+		for i, VolumesValue := range d.Get("volumes").(*schema.Set).List() {
+			VolumesMap := VolumesValue.(map[string]interface{})
+			Volumes[i] = make(map[string]interface{})
+			ConfigFileVolumeConfigFileToPaths := make([]map[string]interface{}, len(VolumesMap["config_file_volume_config_file_to_paths"].(*schema.Set).List()))
+			for i, ConfigFileVolumeConfigFileToPathsValue := range VolumesMap["config_file_volume_config_file_to_paths"].(*schema.Set).List() {
+				ConfigFileVolumeConfigFileToPathsMap := ConfigFileVolumeConfigFileToPathsValue.(map[string]interface{})
+				ConfigFileVolumeConfigFileToPaths[i] = make(map[string]interface{})
+				ConfigFileVolumeConfigFileToPaths[i]["Content"] = ConfigFileVolumeConfigFileToPathsMap["content"]
+				ConfigFileVolumeConfigFileToPaths[i]["Path"] = ConfigFileVolumeConfigFileToPathsMap["path"]
+			}
+			Volumes[i]["ConfigFileVolumeConfigFileToPath"] = ConfigFileVolumeConfigFileToPaths
+			Volumes[i]["DiskVolume.DiskId"] = VolumesMap["disk_volume_disk_id"]
+			Volumes[i]["DiskVolume.FsType"] = VolumesMap["disk_volume_fs_type"]
+			Volumes[i]["DiskVolume.DiskSize"] = VolumesMap["disk_volume_disk_size"]
+			Volumes[i]["FlexVolume.Driver"] = VolumesMap["flex_volume_driver"]
+			Volumes[i]["FlexVolume.FsType"] = VolumesMap["flex_volume_fs_type"]
+			Volumes[i]["FlexVolume.Options"] = VolumesMap["flex_volume_options"]
+			Volumes[i]["NFSVolume.Path"] = VolumesMap["nfs_volume_path"]
+			Volumes[i]["NFSVolume.Server"] = VolumesMap["nfs_volume_server"]
+			Volumes[i]["NFSVolume.ReadOnly"] = VolumesMap["nfs_volume_read_only"]
+			Volumes[i]["Name"] = VolumesMap["name"]
+			Volumes[i]["Type"] = VolumesMap["type"]
+		}
+		request["Volume"] = Volumes
+	}
+
+	if d.HasChange("host_aliases") {
+		update = true
+		aliases := make([]map[string]interface{}, len(d.Get("host_aliases").(*schema.Set).List()))
+		for i, value := range d.Get("host_aliases").(*schema.Set).List() {
+			aliasMap := value.(map[string]interface{})
+			aliases[i] = make(map[string]interface{})
+			aliases[i]["Hostname"] = aliasMap["hostnames"]
+			aliases[i]["Ip"] = aliasMap["ip"]
+		}
+		request["HostAliase"] = aliases
+	}
+
+	if update {
+		conn, err := client.NewEssClient()
+		if err != nil {
+			return WrapError(err)
+		}
+		_, err = conn.DoRequest(StringPointer("ModifyEciScalingConfiguration"), nil, StringPointer("POST"), StringPointer("2014-08-28"), StringPointer("AK"), nil, request, &util.RuntimeOptions{})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, "alicloud_ess_eci_scaling_configuration", "ModifyEciScalingConfiguration", AlibabaCloudSdkGoERROR)
+		}
+	}
+	d.Partial(false)
+
+	return resourceAliyunEssEciScalingConfigurationRead(d, meta)
+}
+
+func resourceAliyunEssEciScalingConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	essService := EssService{client}
+	conn, err := client.NewEssClient()
+	if err != nil {
+		return WrapError(err)
+	}
+
+	o, err := essService.DescribeEssEciScalingConfiguration(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	if d.Get("force_delete").(bool) {
+		request := ess.CreateDeleteScalingGroupRequest()
+		request.ScalingGroupId = o["ScalingGroupId"].(string)
+		request.ForceDelete = requests.NewBoolean(true)
+		request.RegionId = client.RegionId
+		raw, err := client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+			return essClient.DeleteScalingGroup(request)
+		})
+
+		if err != nil {
+			if IsExpectedErrors(err, []string{"InvalidScalingGroupId.NotFound"}) {
+				return nil
+			}
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+		}
+		addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+		return WrapError(essService.WaitForEssScalingGroup(d.Id(), Deleted, DefaultTimeout))
+	} else {
+		request := map[string]interface{}{
+			"ScalingConfigurationId": d.Id(),
+			"RegionId":               client.RegionId,
+		}
+		_, err = conn.DoRequest(StringPointer("DeleteEciScalingConfiguration"), nil, StringPointer("POST"), StringPointer("2014-08-28"), StringPointer("AK"), nil, request, &util.RuntimeOptions{})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "DeleteEciScalingConfiguration", AlibabaCloudSdkGoERROR)
+		}
+		return nil
+	}
+
+}

--- a/alicloud/resource_alicloud_ess_eci_scaling_configuration_test.go
+++ b/alicloud/resource_alicloud_ess_eci_scaling_configuration_test.go
@@ -1,0 +1,447 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers(
+		"alicloud_ess_eci_scaling_configuration",
+		&resource.Sweeper{
+			Name: "alicloud_ess_eci_scaling_configuration",
+			F:    testSweepEciScalingConfiguration,
+		})
+}
+
+func testSweepEciScalingConfiguration(region string) error {
+	rawClient, err := sharedClientForRegion(region)
+	if err != nil {
+		return WrapErrorf(err, "error getting Alicloud client.")
+	}
+	client := rawClient.(*connectivity.AliyunClient)
+
+	prefixes := []string{
+		"tf-testAcc",
+		"tf_testAcc`",
+	}
+	var response map[string]interface{}
+	conn, err := client.NewEssClient()
+	if err != nil {
+		return WrapError(err)
+	}
+	action := "DescribeEciScalingConfigurations"
+	request := map[string]interface{}{
+		"RegionId": client.RegionId,
+	}
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2014-08-28"), StringPointer("AK"), nil, request, &runtime)
+	if err != nil {
+		return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_ess_eci_scaling_configuration", action, AlibabaCloudSdkGoERROR)
+	}
+	addDebug(action, response, request)
+	resp, err := jsonpath.Get("$.ScalingConfigurations", response)
+	if err != nil {
+		return WrapErrorf(err, FailedGetAttributeMsg, action, "$.ScalingConfigurations", response)
+	}
+	result, _ := resp.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		name := item["ScalingConfigurationName"].(string)
+		skip := true
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(strings.ToLower(name), strings.ToLower(prefix)) {
+				skip = false
+				break
+			}
+		}
+		if skip {
+			log.Printf("[INFO] Skipping Eci configuration: %s ", name)
+			continue
+		}
+		log.Printf("[INFO] Delete Eci configuration: %s ", name)
+		action := "DeleteEciScalingConfiguration"
+		request := map[string]interface{}{
+			"ScalingConfigurationId": item["ScalingConfigurationId"],
+		}
+		request["RegionId"] = client.RegionId
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(time.Minute*10, func() *resource.RetryError {
+			response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2014-08-28"), StringPointer("AK"), nil, request, &util.RuntimeOptions{})
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			log.Printf("[ERROR] Failed to delete Eci Scaling Configuration (%s): %s", name, err)
+		}
+	}
+
+	return nil
+}
+
+func TestAccAlicloudEssEciScalingConfigurationBasic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ess_eci_scaling_configuration.default"
+	ra := resourceAttrInit(resourceId, AlicloudEssEciScalingConfigurationMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EssService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEssEciScalingConfiguration")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAcc%sAlicloudEciContainerGroup%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceEssEciScalingConfiguration)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"scaling_group_id":           "${alicloud_ess_scaling_group.default.id}",
+					"scaling_configuration_name": name,
+					"description":                "desc",
+					"security_group_id":          "sg-bp1hi5tpb5c3e51a15pf",
+					"container_group_name":       "containerGroupName",
+					"restart_policy":             "restartPolicy",
+					"cpu":                        "2",
+					"memory":                     "4",
+					"resource_group_id":          "resourceGroupId",
+					"dns_policy":                 "dnsPolicy",
+					"enable_sls":                 "true",
+					"ram_role_name":              "ramRoleName",
+					"spot_strategy":              "SpotWithPriceLimit",
+					"spot_price_limit":           "1.1",
+					"auto_create_eip":            "true",
+					"eip_bandwidth":              "1",
+					"host_name":                  "hostname",
+					"ingress_bandwidth":          "1",
+					"egress_bandwidth":           "1",
+					"tags": map[string]string{
+						"name": "tf-test",
+					},
+					"image_registry_credentials": []map[string]interface{}{
+						{
+							"password": "password",
+							"server":   "server",
+							"username": "username",
+						},
+					},
+					"containers": []map[string]interface{}{
+						{
+							"ports": []map[string]interface{}{
+								{
+									"protocol": "protocol",
+									"port":     "1",
+								},
+							},
+							"environment_vars": []map[string]interface{}{
+								{
+									"key":   "key",
+									"value": "value",
+								},
+							},
+							"working_dir":       "workingDir",
+							"args":              []string{"arg"},
+							"cpu":               "1",
+							"gpu":               "1",
+							"memory":            "1",
+							"name":              "name",
+							"image":             "registry-vpc.aliyuncs.com/eci_open/alpine:3.5",
+							"image_pull_policy": "policy",
+							"volume_mounts": []map[string]interface{}{
+								{
+									"mount_path": "path",
+									"name":       "name",
+									"read_only":  "true",
+								},
+							},
+							"commands": []string{"cmd"},
+						},
+					},
+					"init_containers": []map[string]interface{}{
+						{
+							"ports": []map[string]interface{}{
+								{
+									"protocol": "protocol",
+									"port":     "1",
+								},
+							},
+							"environment_vars": []map[string]interface{}{
+								{
+									"key":   "key",
+									"value": "value",
+								},
+							},
+							"working_dir":       "workingDir",
+							"args":              []string{"arg"},
+							"cpu":               "1",
+							"gpu":               "1",
+							"memory":            "1",
+							"name":              "name",
+							"image":             "registry-vpc.aliyuncs.com/eci_open/alpine:3.5",
+							"image_pull_policy": "policy",
+							"volume_mounts": []map[string]interface{}{
+								{
+									"mount_path": "path",
+									"name":       "name",
+									"read_only":  "true",
+								},
+							},
+							"commands": []string{"cmd"},
+						},
+					},
+					"volumes": []map[string]interface{}{
+						{
+							"config_file_volume_config_file_to_paths": []map[string]interface{}{
+								{
+									"content": "content",
+									"path":    "path",
+								},
+							},
+							"disk_volume_disk_id":   "disk_volume_disk_id",
+							"disk_volume_fs_type":   "disk_volume_fs_type",
+							"disk_volume_disk_size": "1",
+							"flex_volume_driver":    "flex_volume_driver",
+							"flex_volume_fs_type":   "flex_volume_fs_type",
+							"flex_volume_options":   "flex_volume_options",
+							"nfs_volume_path":       "nfs_volume_path",
+							"nfs_volume_read_only":  "true",
+							"nfs_volume_server":     "nfs_volume_server",
+							"name":                  "name",
+							"type":                  "type",
+						},
+					},
+					"host_aliases": []map[string]interface{}{
+						{
+							"hostnames": []string{"hostnames"},
+							"ip":        "ip",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"scaling_group_id":             CHECKSET,
+						"scaling_configuration_name":   name,
+						"description":                  "desc",
+						"security_group_id":            "sg-bp1hi5tpb5c3e51a15pf",
+						"container_group_name":         "containerGroupName",
+						"restart_policy":               "restartPolicy",
+						"cpu":                          "2",
+						"memory":                       "4",
+						"resource_group_id":            "resourceGroupId",
+						"dns_policy":                   "dnsPolicy",
+						"enable_sls":                   "true",
+						"ram_role_name":                "ramRoleName",
+						"spot_strategy":                "SpotWithPriceLimit",
+						"spot_price_limit":             "1.1",
+						"auto_create_eip":              "true",
+						"host_name":                    "hostname",
+						"ingress_bandwidth":            "1",
+						"egress_bandwidth":             "1",
+						"tags.name":                    "tf-test",
+						"image_registry_credentials.#": "1",
+						"containers.#":                 "1",
+						"init_containers.#":            "1",
+						"volumes.#":                    "1",
+						"host_aliases.#":               "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"scaling_configuration_name": "newName",
+					"description":                "newDesc",
+					"container_group_name":       "newName",
+					"restart_policy":             "newPolicy",
+					"cpu":                        "2",
+					"memory":                     "2",
+					"resource_group_id":          "newGroupId",
+					"dns_policy":                 "newDnsPolicy",
+					"enable_sls":                 "false",
+					"ram_role_name":              "newRoleName",
+					"spot_strategy":              "SpotAsPriceGo",
+					"spot_price_limit":           "1.2",
+					"auto_create_eip":            "false",
+					"eip_bandwidth":              "3",
+					"host_name":                  "newHostName",
+					"ingress_bandwidth":          "2",
+					"egress_bandwidth":           "2",
+					"tags": map[string]string{
+						"name": "tf-test2",
+					},
+					"image_registry_credentials": []map[string]interface{}{
+						{
+							"password": "newPassword",
+							"server":   "newServer",
+							"username": "newUserName",
+						},
+					},
+					"containers": []map[string]interface{}{
+						{
+							"ports": []map[string]interface{}{
+								{
+									"protocol": "newProtocol",
+									"port":     "2",
+								},
+							},
+							"environment_vars": []map[string]interface{}{
+								{
+									"key":   "newKey",
+									"value": "newValue",
+								},
+							},
+							"working_dir":       "newWorkingDir",
+							"args":              []string{"arg2"},
+							"cpu":               "2",
+							"gpu":               "2",
+							"memory":            "2",
+							"name":              "newName",
+							"image":             "registry-vpc.aliyuncs.com/eci_open/alpine:3.5",
+							"image_pull_policy": "newPolicy",
+							"volume_mounts": []map[string]interface{}{
+								{
+									"mount_path": "newPath",
+									"name":       "newName",
+									"read_only":  "false",
+								},
+							},
+							"commands": []string{"cmd2"},
+						},
+					},
+					"init_containers": []map[string]interface{}{
+						{
+							"ports": []map[string]interface{}{
+								{
+									"protocol": "newProtocol",
+									"port":     "2",
+								},
+							},
+							"environment_vars": []map[string]interface{}{
+								{
+									"key":   "newKey",
+									"value": "newValue",
+								},
+							},
+							"working_dir":       "newWorkingDir",
+							"args":              []string{"arg2"},
+							"cpu":               "2",
+							"gpu":               "2",
+							"memory":            "2",
+							"name":              "newName",
+							"image":             "registry-vpc.aliyuncs.com/eci_open/alpine:3.5",
+							"image_pull_policy": "newPolicy",
+							"volume_mounts": []map[string]interface{}{
+								{
+									"mount_path": "newPath",
+									"name":       "newName",
+									"read_only":  "false",
+								},
+							},
+							"commands": []string{"cmd2"},
+						},
+					},
+					"volumes": []map[string]interface{}{
+						{
+							"config_file_volume_config_file_to_paths": []map[string]interface{}{
+								{
+									"content": "content2",
+									"path":    "path2",
+								},
+							},
+							"disk_volume_disk_id":   "disk_volume_disk_id2",
+							"disk_volume_fs_type":   "disk_volume_fs_type2",
+							"disk_volume_disk_size": "2",
+							"flex_volume_driver":    "flex_volume_driver2",
+							"flex_volume_fs_type":   "flex_volume_fs_type2",
+							"flex_volume_options":   "flex_volume_options2",
+							"nfs_volume_path":       "nfs_volume_path2",
+							"nfs_volume_read_only":  "false",
+							"nfs_volume_server":     "nfs_volume_server2",
+							"name":                  "name2",
+							"type":                  "type2",
+						},
+					},
+					"host_aliases": []map[string]interface{}{
+						{
+							"hostnames": []string{"hostnames2"},
+							"ip":        "ip2",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"scaling_configuration_name":   "newName",
+						"description":                  "newDesc",
+						"container_group_name":         "newName",
+						"restart_policy":               "newPolicy",
+						"cpu":                          "2",
+						"memory":                       "2",
+						"resource_group_id":            "newGroupId",
+						"dns_policy":                   "newDnsPolicy",
+						"enable_sls":                   "false",
+						"ram_role_name":                "newRoleName",
+						"spot_strategy":                "SpotAsPriceGo",
+						"spot_price_limit":             "1.2",
+						"auto_create_eip":              "false",
+						"eip_bandwidth":                "3",
+						"host_name":                    "newHostName",
+						"ingress_bandwidth":            "2",
+						"egress_bandwidth":             "2",
+						"tags.name":                    "tf-test2",
+						"image_registry_credentials.#": "1",
+						"containers.#":                 "1",
+						"init_containers.#":            "1",
+						"volumes.#":                    "1",
+						"host_aliases.#":               "1",
+					}),
+				),
+			},
+		},
+	})
+}
+
+var AlicloudEssEciScalingConfigurationMap = map[string]string{}
+
+func resourceEssEciScalingConfiguration(name string) string {
+	return fmt.Sprintf(`
+	%s
+
+	variable "name" {
+		default = "%s"
+	}
+
+	resource "alicloud_security_group" "default1" {
+	  name   = "${var.name}"
+	  vpc_id = "${alicloud_vpc.default.id}"
+	}
+
+	resource "alicloud_ess_scaling_group" "default" {
+		min_size = 0
+		max_size = 1
+		scaling_group_name = "${var.name}"
+		removal_policies = ["OldestInstance", "NewestInstance"]
+		vswitch_ids = ["${alicloud_vswitch.default.id}"]
+		group_type = "ECI"
+	}`, EcsInstanceCommonTestCase, name)
+}

--- a/website/docs/r/ess_eci_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_eci_scaling_configuration.html.markdown
@@ -1,0 +1,258 @@
+---
+subcategory: "Auto Scaling(ESS)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ess_eci_scaling_configuration"
+sidebar_current: "docs-alicloud-resource-ess-eci-scaling-configuration"
+description: |- Provides a ESS eci scaling configuration resource.
+---
+
+# alicloud\_ess\_eci\_scaling\_configuration
+
+Provides a ESS eci scaling configuration resource.
+
+-> **NOTE:** Resource `alicloud_ess_alb_server_group_attachment` is available in 1.164.0+.
+
+## Example Usage
+
+Basic Usage
+
+```
+variable "name" {
+  default = "essscalingconfiguration"
+}
+
+resource "alicloud_vpc" "default" {
+  name       = var.name
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = alicloud_vpc.default.id
+  cidr_block        = "172.16.0.0/24"
+  zone_id           = data.alicloud_zones.default.zones[0].id
+  vswitch_name      = var.name
+}
+
+resource "alicloud_security_group" "default" {
+  name   = var.name
+  vpc_id = alicloud_vpc.default.id
+}
+
+resource "alicloud_ess_scaling_group" "default" {
+  min_size           = 0
+  max_size           = 1
+  scaling_group_name = var.name
+  removal_policies   = ["OldestInstance", "NewestInstance"]
+  vswitch_ids        = [alicloud_vswitch.default.id]
+  group_type          = "ECI"
+}
+
+resource "alicloud_ess_eci_scaling_configuration" "default" {
+  scaling_group_id  = alicloud_ess_scaling_group.default.id
+  cpu               = 2
+  memory            = 4
+  security_group_id = alicloud_security_group.default.id
+  force_delete      = true
+  active            = true
+  container_group_name = "container-group-1649839595174"
+  containers {
+    name = "container-1"
+    image = "registry-vpc.cn-hangzhou.aliyuncs.com/eci_open/alpine:3.5"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `active` - (Optional) Whether active current eci scaling configuration in the specified scaling group. Note that only
+  one configuration can be active. Default to `false`.
+* `force_delete` - (Optional) The eci scaling configuration will be deleted forcibly with deleting its scaling group.
+  Default to false.
+* `scaling_group_id` - (Required, ForceNew) ID of the scaling group of a eci scaling configuration.
+* `scaling_configuration_name` - (Optional) Name shown for the scheduled task. which must contain 2-64 characters (
+  English or Chinese), starting with numbers, English letters or Chinese characters, and can contain number,
+  underscores `_`, hypens `-`, and decimal point `.`. If this parameter value is not specified, the default value is
+  EciScalingConfigurationId.
+* `description` - (Optional) The description of data disk N. Valid values of N: 1 to 16. The description must be 2 to
+  256 characters in length and cannot start with http:// or https://.
+* `security_group_id` - (Optional) ID of the security group used to create new instance. It is conflict
+  with `security_group_ids`.
+* `container_group_name` - (Optional) The name of the container group.
+* `restart_policy` - (Optional) The restart policy of the container group. Default to `Always`.
+* `cpu` - (Optional) The amount of CPU resources allocated to the container group.
+* `memory` - (Optional) The amount of memory resources allocated to the container group.
+* `resource_group_id` - (Optional) ID of resource group.
+* `dns_policy` - (Optional) dns policy of contain group.
+* `enable_sls` - (Optional) Enable sls log service.
+* `ram_role_name` - (Optional) The RAM role that the container group assumes. ECI and ECS share the same RAM role.
+* `spot_strategy` - (Optional) The spot strategy for a Pay-As-You-Go instance. Valid values: `NoSpot`, `SpotAsPriceGo`
+  , `SpotWithPriceLimit`.
+* `spot_price_limit` - (Optional) The maximum price hourly for spot instance.
+* `auto_create_eip` - (Optional) Whether create eip automatically.
+* `eip_bandwidth` - (Optional) Eip bandwidth.
+* `ingress_bandwidth` - (Optional) Ingress bandwidth.
+* `egress_bandwidth` - (Optional) egress bandwidth.
+* `host_name` - (Optional) Hostname of an ECI instance.
+* `tags` - (Optional) A mapping of tags to assign to the resource. It will be applied for ECI instances finally.
+    - Key: It can be up to 64 characters in length. It cannot begin with "aliyun", "http://", or "https://". It cannot
+      be a null string.
+    - Value: It can be up to 128 characters in length. It cannot begin with "aliyun", "http://", or "https://" It can be
+      a null string.
+* `image_registry_credentials` - (Optional)  The image registry credential. The details see
+  Block `image_registry_credential`.See [Block image_registry_credential](#block-image_registry_credential) below for
+  details.
+* `containers` - (Optional) The list of containers.See [Block container](#block-container) below for details.
+* `init_containers` - (Optional) The list of initContainers.See [Block init_container](#block-init_container) below for
+  details.
+* `volumes` - (Optional) The list of volumes.See [Block volume](#block-volume) below for details.
+* `host_aliases` - (Optional) HostAliases.See [Block host_alias](#block-host_alias) below for details.
+
+#### Block volume
+
+The volume supports the following:
+
+* `name` - (Optional) The name of the volume.
+* `type` - (Optional) The type of the volume.
+* `config_file_volume_config_file_to_paths` - (Optional) ConfigFileVolumeConfigFileToPaths.
+  See [Block_config_file_volume_config_file_to_path](#block-config_file_volume_config_file_to_path) below for details.
+* `disk_volume_disk_id` - (Optional) The ID of DiskVolume.
+* `disk_volume_fs_type` - (Optional) The system type of DiskVolume.
+* `flex_volume_driver` - (Optional) The name of the FlexVolume driver.
+* `flex_volume_fs_type` - (Optional) The type of the mounted file system. The default value is determined by the script
+  of FlexVolume.
+* `flex_volume_options` - (Optional) The list of FlexVolume objects. Each object is a key-value pair contained in a JSON
+  string.
+* `nfs_volume_path` - (Optional) The path to the NFS volume.
+* `nfs_volume_read_only` - (Optional) The nfs volume read only. Default to `false`.
+* `nfs_volume_server` - (Optional) The address of the NFS server.
+
+-> **NOTE:** Every volume mounted must have a name and type attributes.
+
+#### Block config_file_volume_config_file_to_path
+
+The config_file_volume_config_file_to_path supports the following:
+
+* `content` - (Optional) The content of the configuration file. Maximum size: 32 KB.
+* `path` - (Optional) The relative file path.
+
+#### Block init_container
+
+The init_container supports the following:
+
+* `args` - (Optional) The arguments passed to the commands.
+* `commands` - (Optional) The commands run by the init container.
+* `cpu` - (Optional) The amount of CPU resources allocated to the container.
+* `environment_vars` - (Optional) The structure of environmentVars.
+  See [Block_environment_var_in_init_container](#block-environment_var_in_init_containers) below for details.
+* `gpu` - (Optional) The number GPUs.
+* `image` - (Optional) The image of the container.
+* `image_pull_policy` - (Optional) The restart policy of the image.
+* `memory` - (Optional) The amount of memory resources allocated to the container.
+* `name` - (Optional) The name of the init container.
+* `ports` - (Optional) The structure of port. See [Block_port_in_init_container](#block-port_in_init_container) below
+  for details.
+* `volume_mounts` - (Optional) The structure of volumeMounts.
+  See [Block_volume_mount_in_init_container](#block-volume_mount_in_init_container) below for details.
+* `working_dir` - (Optional) The working directory of the container.
+
+#### Block environment_var_in_init_container
+
+The environment_var supports the following:
+
+* `key` - (Optional) The name of the variable. The name can be 1 to 128 characters in length and can contain letters,
+  digits, and underscores (_). It cannot start with a digit.
+* `value` - (Optional) The value of the variable. The value can be 0 to 256 characters in length.
+
+#### Block port_in_init_container
+
+The port supports the following:
+
+* `port` - (Optional, ForceNew) The port number. Valid values: 1 to 65535.
+* `protocol` - (Optional, ForceNew) Valid values: TCP and UDP.
+
+#### Block volume_mount_in_init_container
+
+The volume_mount supports the following:
+
+* `mount_path` - (Optional) The directory of the mounted volume. Data under this directory will be overwritten by the
+  data in the volume.
+* `name` - (Optional) The name of the mounted volume.
+* `read_only` - (Optional) Default to `false`.
+
+#### Block host_alias
+
+The host_alias supports the following:
+
+* `hostnames` - (Optional) Adds a host name.
+* `ip` - (Optional) Adds an IP address.
+
+#### Block image_registry_credential
+
+The image_registry_credential supports the following:
+
+* `password` - (Optional) The password used to log on to the image repository. It is required
+  when `image_registry_credential` is configured.
+* `server` - (Optional) The address of the image repository. It is required when `image_registry_credential` is
+  configured.
+* `user_name` - (Optional) The username used to log on to the image repository. It is required
+  when `image_registry_credential` is configured.
+
+#### Block container
+
+The container supports the following:
+
+* `args` - (Optional) The arguments passed to the commands.
+* `commands` - (Optional) The commands run by the init container.
+* `cpu` - (Optional) The amount of CPU resources allocated to the container.
+* `environment_vars` - (Optional) The structure of environmentVars.
+  See [Block_environment_var_in_container](#block-environment_var_in_container) below for details.
+* `gpu` - (Optional) The number GPUs.
+* `image` - (Optional) The image of the container.
+* `image_pull_policy` - (Optional) The restart policy of the image.
+* `memory` - (Optional) The amount of memory resources allocated to the container.
+* `name` - (Optional) The name of the init container.
+* `ports` - (Optional) The structure of port. See [Block_port_in_container](#block-port_in_container) below for details.
+* `volume_mounts` - (Optional) The structure of volumeMounts.
+  See [Block_volume_mount_in_container](#block-volume_mount_in_container) below for details.
+* `working_dir` - (Optional) The working directory of the container.
+
+#### Block environment_var_in_container
+
+The environment_var supports the following:
+
+* `key` - (Optional) The name of the variable. The name can be 1 to 128 characters in length and can contain letters,
+  digits, and underscores (_). It cannot start with a digit.
+* `value` - (Optional) The value of the variable. The value can be 0 to 256 characters in length.
+
+#### Block port_in_container
+
+The port supports the following:
+
+* `port` - (Optional, ForceNew) The port number. Valid values: 1 to 65535.
+* `protocol` - (Optional, ForceNew) Valid values: TCP and UDP.
+
+#### Block volume_mount_in_container
+
+The volume_mount supports the following:
+
+* `mount_path` - (Optional) The directory of the mounted volume. Data under this directory will be overwritten by the
+  data in the volume.
+* `name` - (Optional) The name of the mounted volume.
+* `read_only` - (Optional) Default to `false`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The eci scaling configuration ID.
+
+## Import
+
+ESS eci scaling configuration can be imported using the id, e.g.
+
+```
+$ terraform import alicloud_ess_eci_scaling_configuration.example asc-abc123456
+```
+

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -122,6 +122,7 @@ The following arguments are supported:
 * `group_deletion_protection` - (Optional, Available in v1.102.0+) Specifies whether the scaling group deletion protection is enabled. `true` or `false`, Default value: `false`.            
 * `launch_template_id` - (Optional, Available in v1.141.0+) Instance launch template ID, scaling group obtains launch configuration from instance launch template, see [Launch Template](https://www.alibabacloud.com/help/doc-detail/73916.html). Creating scaling group from launch template enable group automatically.
 * `launch_template_version` - (Optional, Available in v1.159.0+) The version number of the launch template. Valid values are the version number, `Latest`, or `Default`, Default value: `Default`.
+* `group_type` - (Optional, Available in v1.164.0+) Resource type within scaling group. Optional values: ECS, ECI. Default to ECS.
 * `tags` - (Optional, Available in v1.160.0+) A mapping of tags to assign to the resource.
   - Key: It can be up to 64 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It cannot be a null string.
   - Value: It can be up to 128 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It can be a null string.


### PR DESCRIPTION
=== RUN   TestAccAlicloudEssAlarmsDataSource
--- PASS: TestAccAlicloudEssAlarmsDataSource (144.03s)
=== RUN   TestAccAlicloudEssLifecycleHooksDataSource
--- PASS: TestAccAlicloudEssLifecycleHooksDataSource (76.78s)
=== RUN   TestAccAlicloudEssNotificationsDataSource
--- PASS: TestAccAlicloudEssNotificationsDataSource (58.46s)
=== RUN   TestAccAlicloudEssScalingconfigurationsDataSource
--- PASS: TestAccAlicloudEssScalingconfigurationsDataSource (100.20s)
=== RUN   TestAccAlicloudEssScalingGroupsDataSource
--- PASS: TestAccAlicloudEssScalingGroupsDataSource (85.78s)
=== RUN   TestAccAlicloudEssScheduledtasksDataSource
--- PASS: TestAccAlicloudEssScheduledtasksDataSource (108.77s)
=== RUN   TestAccAlicloudEssAlarmBasic
--- PASS: TestAccAlicloudEssAlarmBasic (178.03s)
=== RUN   TestAccAlicloudEssAlarmMulti
--- PASS: TestAccAlicloudEssAlarmMulti (63.98s)
=== RUN   TestAccAlicloudEssAlbServerGroupAttachment_basic
--- PASS: TestAccAlicloudEssAlbServerGroupAttachment_basic (167.13s)
=== RUN   TestAccAlicloudEssEciScalingConfigurationBasic
--- PASS: TestAccAlicloudEssEciScalingConfigurationBasic (51.70s)
=== RUN   TestAccAlicloudEssLifecycleHookBasic
--- PASS: TestAccAlicloudEssLifecycleHookBasic (98.70s)
=== RUN   TestAccAlicloudEssNotification_basic
--- PASS: TestAccAlicloudEssNotification_basic (74.92s)
=== RUN   TestAccAlicloudEssScalingConfigurationUpdate
    provider_test.go:155: Skipping unsupported region cn-hangzhou. Supported regions: [cn-beijing].
--- SKIP: TestAccAlicloudEssScalingConfigurationUpdate (0.00s)
=== RUN   TestAccAlicloudEssScalingConfigurationPerformanceLevel
--- PASS: TestAccAlicloudEssScalingConfigurationPerformanceLevel (108.03s)
=== RUN   TestAccAlicloudEssScalingConfigurationMulti
--- PASS: TestAccAlicloudEssScalingConfigurationMulti (48.20s)
=== RUN   TestAccAlicloudEssScalingGroup_basic
--- PASS: TestAccAlicloudEssScalingGroup_basic (121.59s)
=== RUN   TestAccAlicloudEssScalingGroup_withLaunchTemplateId
--- PASS: TestAccAlicloudEssScalingGroup_withLaunchTemplateId (61.79s)
=== RUN   TestAccAlicloudEssScalingGroup_costoptimized
--- PASS: TestAccAlicloudEssScalingGroup_costoptimized (94.37s)
=== RUN   TestAccAlicloudEssScalingGroup_vpc
--- PASS: TestAccAlicloudEssScalingGroup_vpc (110.04s)
=== RUN   TestAccAlicloudEssScalingGroup_slb
--- PASS: TestAccAlicloudEssScalingGroup_slb (141.41s)
=== RUN   TestAccAlicloudEssScalingGroup_tags
--- PASS: TestAccAlicloudEssScalingGroup_tags (68.38s)
=== RUN   TestAccAlicloudEssVserverGroups_basic
--- PASS: TestAccAlicloudEssVserverGroups_basic (76.90s)
=== RUN   TestAccAlicloudEssScalingRule_basic
--- PASS: TestAccAlicloudEssScalingRule_basic (89.57s)
=== RUN   TestAccAlicloudEssScalingRule_target_tracking_rule_basic
--- PASS: TestAccAlicloudEssScalingRule_target_tracking_rule_basic (97.38s)
=== RUN   TestAccAlicloudEssScalingRule_step_rule_basic
--- PASS: TestAccAlicloudEssScalingRule_step_rule_basic (58.47s)
=== RUN   TestAccAlicloudEssScalingRuleMulti
--- PASS: TestAccAlicloudEssScalingRuleMulti (55.18s)
=== RUN   TestAccAlicloudEssScheduledTask_basic
--- PASS: TestAccAlicloudEssScheduledTask_basic (106.82s)
=== RUN   TestAccAlicloudEssScheduledTask_basic_2
--- PASS: TestAccAlicloudEssScheduledTask_basic_2 (77.67s)
=== RUN   TestAccAlicloudEssScheduledTask_multi
--- PASS: TestAccAlicloudEssScheduledTask_multi (48.64s)