### PR TITLE
resource/alicloud_polardb_database: Support for new parameters `account_name`, `collate` and `ctype`. Add support for output parameters `status`.

### DIFF
--- a/alicloud/data_source_alicloud_polardb_databases.go
+++ b/alicloud/data_source_alicloud_polardb_databases.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/polardb"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -51,6 +52,10 @@ func dataSourceAlicloudPolarDBDatabases() *schema.Resource {
 							Computed: true,
 						},
 						"engine": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -124,12 +129,13 @@ func dataSourceAlicloudPolarDBDatabasesRead(d *schema.ResourceData, meta interfa
 				nodes = append(nodes, nodeMap)
 			}
 			mapping := map[string]interface{}{
-				"character_set_name": item.CharacterSetName,
+				"character_set_name": strings.ToLower(item.CharacterSetName),
 				"db_description":     item.DBDescription,
 				"db_name":            item.DBName,
 				"db_status":          item.DBStatus,
 				"engine":             item.Engine,
 				"accounts":           nodes,
+				"status":             item.DBStatus,
 			}
 			ids = append(ids, item.DBName)
 			databases = append(databases, mapping)

--- a/alicloud/data_source_alicloud_polardb_databases_test.go
+++ b/alicloud/data_source_alicloud_polardb_databases_test.go
@@ -40,6 +40,7 @@ func TestAccAlicloudPolarDBClusterDatabasesDataSource(t *testing.T) {
 			"databases.0.db_status":          CHECKSET,
 			"databases.0.engine":             CHECKSET,
 			"databases.0.accounts.#":         CHECKSET,
+			"databases.0.status":             "Running",
 		}
 	}
 

--- a/alicloud/resource_alicloud_polardb_database_test.go
+++ b/alicloud/resource_alicloud_polardb_database_test.go
@@ -41,7 +41,9 @@ func TestAccAlicloudPolarDBDatabase_update(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"db_cluster_id": CHECKSET,
+						"db_cluster_id":  CHECKSET,
+						"db_name":        "tftestdatabase",
+						"db_description": "test",
 					}),
 				),
 			},
@@ -57,6 +59,57 @@ func TestAccAlicloudPolarDBDatabase_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{"db_description": "from terraform"}),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAlicloudPolarDBDatabase_PostgreSQL(t *testing.T) {
+	var database *polardb.Database
+	resourceId := "alicloud_polardb_database.default"
+
+	ra := resourceAttrInit(resourceId, nil)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &database, func() interface{} {
+		return &PolarDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribePolarDBDatabase")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := "tf-testAccDBdatabase_basic"
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourcePolarDBDatabaseConfigDependencePostgreSQL)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: resourceId,
+
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"db_cluster_id":  "${alicloud_polardb_cluster.instance.id}",
+					"db_name":        "tftestdatabase",
+					"db_description": "test",
+					"account_name":   "${alicloud_polardb_account.default.account_name}",
+					"collate":        "C",
+					"ctype":          "C",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"db_cluster_id":  CHECKSET,
+						"db_name":        "tftestdatabase",
+						"db_description": "test",
+						"account_name":   CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"collate", "ctype"},
 			},
 		},
 	})
@@ -82,4 +135,38 @@ func resourcePolarDBDatabaseConfigDependence(name string) string {
 		vswitch_id = local.vswitch_id
 		description = "${var.name}"
 	}`, PolarDBCommonTestCase, name)
+}
+
+func resourcePolarDBDatabaseConfigDependencePostgreSQL(name string) string {
+	return fmt.Sprintf(`
+	variable "name" {
+		default = "%s"
+	}
+	data "alicloud_polardb_node_classes" "this" {
+	  db_type    = "PostgreSQL"
+	  db_version = "11"
+	  pay_type   = "PostPaid"
+	}
+	data "alicloud_vpcs" "this" {
+		name_regex = "default-NODELETING"
+	}
+	data "alicloud_vswitches" "this" {
+		vpc_id  = data.alicloud_vpcs.this.ids.0
+		zone_id = data.alicloud_polardb_node_classes.this.classes.0.zone_id
+	}
+	resource "alicloud_polardb_cluster" "instance" {
+	  db_type       = "PostgreSQL"
+	  db_version    = "11"
+	  pay_type      = "PostPaid"
+	  db_node_class = data.alicloud_polardb_node_classes.this.classes.0.supported_engines.0.available_resources.0.db_node_class
+	  vswitch_id    = data.alicloud_vswitches.this.ids[0]
+	  description   = var.name
+	}
+	resource "alicloud_polardb_account" "default" {
+	  db_cluster_id        = alicloud_polardb_cluster.instance.id
+	  account_name         = "tftestnormal"
+	  account_password     = "YouPassword123"
+      account_description  = var.name
+      account_type         = "Normal"
+	}`, name)
 }

--- a/alicloud/service_alicloud_polardb.go
+++ b/alicloud/service_alicloud_polardb.go
@@ -622,6 +622,26 @@ func (s *PolarDBService) DescribePolarDBDatabase(id string) (ds *polardb.Databas
 	return ds, nil
 }
 
+func (s *PolarDBService) PolarDBDatabaseStateRefreshFunc(id string, failStates []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := s.DescribePolarDBDatabase(id)
+		if err != nil {
+			if NotFoundError(err) {
+				// Set this to nil as if we didn't find anything.
+				return nil, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+
+		for _, failState := range failStates {
+			if object.DBStatus == failState {
+				return object, object.DBStatus, WrapError(Error(FailedToReachTargetStatus, object.DBStatus))
+			}
+		}
+		return object, object.DBStatus, nil
+	}
+}
+
 func (s *PolarDBService) WaitForPolarDBDatabase(id string, status Status, timeout int) error {
 	parts, err := ParseResourceId(id, 2)
 	if err != nil {

--- a/website/docs/d/polardb_databases.html.markdown
+++ b/website/docs/d/polardb_databases.html.markdown
@@ -49,6 +49,7 @@ The following attributes are exported in addition to the arguments listed above:
   * `db_name` - Database name.
   * `db_status` - The status of database.
   * `engine` - The engine of database.
+  * `status` - The status of the polarDB database.
   * `accounts` - A list of accounts of database. Each element contains the following attributes.
       * `account_name` - Account name.
       * `account_status` - Account status.

--- a/website/docs/r/polardb_database.html.markdown
+++ b/website/docs/r/polardb_database.html.markdown
@@ -63,12 +63,25 @@ The following arguments are supported:
 * `db_name` - (Required, ForceNew) Name of the database requiring a uniqueness check. It may consist of lower case letters, numbers, and underlines, and must start with a letterand have no more than 64 characters.
 * `character_set_name` - (Optional,ForceNew) Character set. The value range is limited to the following: [ utf8, gbk, latin1, utf8mb4, Chinese_PRC_CI_AS, Chinese_PRC_CS_AS, SQL_Latin1_General_CP1_CI_AS, SQL_Latin1_General_CP1_CS_AS, Chinese_PRC_BIN ], default is "utf8" \(`utf8mb4` only supports versions 5.5 and 5.6\).
 * `db_description` - (Optional) Database description. It must start with a Chinese character or English letter, cannot start with "http://" or "https://". It can include Chinese and English characters, underlines (_), hyphens (-), and numbers. The length must be 2-256 characters.
+* `account_name` - (Optional, ForceNew, Available in v1.165.0+) The name of the account that is authorized to access the database. **NOTE:** This parameter is required when the cluster is a PolarDB O engine or a PolarDB PostgreSQL engine;
+* `collate` - (Optional, Available in v1.165.0+) The locale setting that specifies the collation of the new database. **NOTE:** This parameter is required when the cluster is a PolarDB O engine or a PolarDB PostgreSQL engine;
+* `ctype` - (Optional, Available in v1.165.0+) The locale setting is used to specify the character classification of the database. **NOTE:** This parameter is required when the cluster is a PolarDB O engine or a PolarDB PostgreSQL engine;
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The current database resource ID. Composed of cluster ID and database name with format `<cluster_id>:<name>`.
+* `status` - The status of the polarDB database.
+
+### Timeouts
+
+-> **NOTE:** Available in 1.165.0+.
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration-0-11/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 5 mins) Used when creating the polarDB database (until it reaches the initial `Running` status).
+* `delete` - (Defaults to 1 mins) Used when deleting the polarDB database.
 
 ## Import
 


### PR DESCRIPTION
resource/alicloud_polardb_database: Support for new parameters `account_name`, `collate` and `ctype`. Add support for output parameters `status`.