### PR TITLE
added ForceNew to autoscaling group name param

### DIFF
--- a/alicloud/resource_alicloud_ess_scaling_group.go
+++ b/alicloud/resource_alicloud_ess_scaling_group.go
@@ -47,6 +47,7 @@ func resourceAlicloudEssScalingGroup() *schema.Resource {
 			"scaling_group_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 			"default_cooldown": {
 				Type:         schema.TypeInt,


### PR DESCRIPTION
As with the other major cloud providers, changing the scaling group name should force Terraform to replace the instance rather than just changing the name in-place. This allows for total replacements to be triggered allowing instances to be replaced and made ready rather than forcing us to use the not-always-reliable rolling update, or manually triggering a scaling out and in via null resource.