### PR TITLE
resource/alicloud_slb_backend_server: Supports adding `eci` backend servers  resource/alicloud_eci_container_group: add the field `internet_ip` and `intranet_ip`

### DIFF
--- a/alicloud/resource_alicloud_eci_container_group.go
+++ b/alicloud/resource_alicloud_eci_container_group.go
@@ -510,6 +510,14 @@ func resourceAlicloudEciContainerGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"internet_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"intranet_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -801,6 +809,8 @@ func resourceAlicloudEciContainerGroupRead(d *schema.ResourceData, meta interfac
 		return WrapError(err)
 	}
 	d.Set("container_group_name", object["ContainerGroupName"])
+	d.Set("internet_ip", object["InternetIp"])
+	d.Set("intranet_ip", object["IntranetIp"])
 
 	containers := make([]map[string]interface{}, 0)
 	if containersList, ok := object["Containers"].([]interface{}); ok {

--- a/alicloud/resource_alicloud_slb_backend_server.go
+++ b/alicloud/resource_alicloud_slb_backend_server.go
@@ -47,7 +47,7 @@ func resourceAliyunSlbBackendServer() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      string(ECS),
-							ValidateFunc: validation.StringInSlice([]string{"eni", "ecs"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"eni", "ecs", "eci"}, false),
 						},
 						"server_ip": {
 							Type:     schema.TypeString,

--- a/website/docs/r/eci_container_group.html.markdown
+++ b/website/docs/r/eci_container_group.html.markdown
@@ -255,6 +255,8 @@ The following attributes are exported:
 
 * `id` - The resource ID in terraform of Container Group. Value as `container_group_id`.
 * `status` - The status of container group.
+* `internet_ip` - (Available in v1.170.0+) The Public IP of the container group.
+* `intranet_ip` - (Available in v1.170.0+) The Private IP of the container group.
 
 ### Timeouts
 

--- a/website/docs/r/slb_backend_server.html.markdown
+++ b/website/docs/r/slb_backend_server.html.markdown
@@ -102,7 +102,7 @@ The servers mapping supports the following:
 
 * `server_id` - (Required) A list backend server ID (ECS instance ID).
 * `weight` - (Optional) Weight of the backend server. Valid value range: [0-100]. 
-* `type` - (Optional) Type of the backend server. Valid value `ecs`, `eni`. Default to `ecs`.
+* `type` - (Optional) Type of the backend server. Valid value `ecs`, `eni`, `eci`. Default to `ecs`. **NOTE:** From 1.170.0+, The `eci` is valid. 
 * `server_ip` - (Optional, Computed, Available in 1.93.0+) ServerIp of the backend server. This parameter can be specified when the type is `eni`. `ecs` type currently does not support adding `server_ip` parameter.
 
 ## Attributes Reference
@@ -116,5 +116,5 @@ The following attributes are exported:
 Load balancer backend server can be imported using the load balancer id.
 
 ```
-$ terraform import alicloud_slb_backend_server.example lb-abc123456
+$ terraform import alicloud_slb_backend_server.example <load_balancer_id>
 ```


### PR DESCRIPTION
…ervers

resource/alicloud_eci_container_group: add the field `public_ip` and `private_ip`