### PR TITLE
datasource/alicloud_ecd_network_packages: Supports new output `eip_addresses`.

### DIFF
--- a/alicloud/data_source_alicloud_ecd_network_packages.go
+++ b/alicloud/data_source_alicloud_ecd_network_packages.go
@@ -74,6 +74,11 @@ func dataSourceAlicloudEcdNetworkPackages() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"eip_addresses": {
+							Type:     schema.TypeList,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -160,6 +165,7 @@ func dataSourceAlicloudEcdNetworkPackagesRead(d *schema.ResourceData, meta inter
 			"office_site_id":       object["OfficeSiteId"],
 			"office_site_name":     object["OfficeSiteName"],
 			"status":               object["NetworkPackageStatus"],
+			"eip_addresses":        object["EipAddresses"],
 		}
 		ids = append(ids, fmt.Sprint(mapping["id"]))
 		s = append(s, mapping)

--- a/alicloud/data_source_alicloud_ecd_network_packages_test.go
+++ b/alicloud/data_source_alicloud_ecd_network_packages_test.go
@@ -45,6 +45,8 @@ func TestAccAlicloudECDNetworkPackagesDataSource(t *testing.T) {
 			"packages.0.expired_time":         CHECKSET,
 			"packages.0.create_time":          CHECKSET,
 			"packages.0.network_package_id":   CHECKSET,
+			"packages.0.eip_addresses.#":      "1",
+			"packages.0.eip_addresses.0":      CHECKSET,
 		}
 	}
 	var fakeAlicloudEventBridgeEventBusesDataSourceNameMapFunc = func(rand int) map[string]string {

--- a/website/docs/d/ecd_network_packages.html.markdown
+++ b/website/docs/d/ecd_network_packages.html.markdown
@@ -61,3 +61,4 @@ The following attributes are exported in addition to the arguments listed above:
 	* `office_site_id` - The ID of office site.
 	* `office_site_name` - The name of office site.
 	* `status` - The status of network package. Valid values: `Creating`, `InUse`, `Releasing`,`Released`.
+	* `eip_addresses` - The public IP address list of the network packet.


### PR DESCRIPTION
datasource/alicloud_ecd_network_packages: Supports new output `eip_addresses`.