### PR TITLE
resource/alicloud_graph_database_db_instance: The `db_instance_category` attribute supports the option of `SINGLE`.

### DIFF
--- a/alicloud/resource_alicloud_graph_database_db_instance.go
+++ b/alicloud/resource_alicloud_graph_database_db_instance.go
@@ -53,7 +53,7 @@ func resourceAlicloudGraphDatabaseDbInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"HA"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"HA", "SINGLE"}, false),
 			},
 			"db_instance_description": {
 				Type:     schema.TypeString,
@@ -74,7 +74,7 @@ func resourceAlicloudGraphDatabaseDbInstance() *schema.Resource {
 			"db_node_class": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"gdb.r.xlarge", "gdb.r.2xlarge", "gdb.r.4xlarge", "gdb.r.8xlarge", "gdb.r.16xlarge"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"gdb.r.xlarge", "gdb.r.2xlarge", "gdb.r.4xlarge", "gdb.r.8xlarge", "gdb.r.16xlarge", "gdb.r.xlarge_basic", "gdb.r.2xlarge_basic", "gdb.r.4xlarge_basic", "gdb.r.8xlarge_basic", "gdb.r.16xlarge_basic"}, false),
 			},
 			"db_node_storage": {
 				Type:         schema.TypeInt,

--- a/alicloud/resource_alicloud_graph_database_db_instance_test.go
+++ b/alicloud/resource_alicloud_graph_database_db_instance_test.go
@@ -302,6 +302,66 @@ func TestAccAlicloudGraphDatabaseDbInstance_basic1(t *testing.T) {
 	})
 }
 
+func TestAccAlicloudGraphDatabaseDbInstance_single(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_graph_database_db_instance.default"
+	checkoutSupportedRegions(t, true, connectivity.GraphDatabaseDbInstanceSupportRegions)
+	ra := resourceAttrInit(resourceId, AlicloudGraphDatabaseDbInstanceMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GdbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGraphDatabaseDbInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sgraphdatabasedbinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudGraphDatabaseDbInstanceBasicDependence1)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"db_node_class":            "gdb.r.xlarge_basic",
+					"db_instance_network_type": "vpc",
+					"db_version":               "1.0",
+					"db_instance_category":     "SINGLE",
+					"db_instance_storage_type": "cloud_essd",
+					"db_node_storage":          "50",
+					"payment_type":             "PayAsYouGo",
+					"db_instance_description":  "${var.name}",
+					"vswitch_id":               "${data.alicloud_vswitches.default.ids.0}",
+					"vpc_id":                   "${data.alicloud_vpcs.default.ids.0}",
+					"zone_id":                  "${local.zone_id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"db_node_class":            "gdb.r.xlarge_basic",
+						"db_instance_network_type": "vpc",
+						"db_version":               "1.0",
+						"db_instance_category":     "SINGLE",
+						"db_instance_storage_type": "cloud_essd",
+						"db_node_storage":          "50",
+						"payment_type":             "PayAsYouGo",
+						"db_instance_description":  name,
+						"vswitch_id":               CHECKSET,
+						"vpc_id":                   CHECKSET,
+						"zone_id":                  CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 var AlicloudGraphDatabaseDbInstanceMap0 = map[string]string{}
 
 func AlicloudGraphDatabaseDbInstanceBasicDependence0(name string) string {

--- a/website/docs/r/graph_database_db_instance.html.markdown
+++ b/website/docs/r/graph_database_db_instance.html.markdown
@@ -37,11 +37,11 @@ resource "alicloud_graph_database_db_instance" "example" {
 
 The following arguments are supported:
 
-* `db_instance_category` - (Required, ForceNew) The category of the db instance. Valid values: `HA`.
+* `db_instance_category` - (Required, ForceNew) The category of the db instance. Valid values: `HA`, `SINGLE`(Available in 1.173.0+).
 * `db_instance_description` - (Optional) According to the practical example or notes.
 * `db_instance_network_type` - (Required, ForceNew) The network type of the db instance. Valid values: `vpc`.
 * `db_instance_storage_type` - (Required) Disk storage type. Valid values: `cloud_essd`, `cloud_ssd`. Modification is not supported.
-* `db_node_class` - (Required) The class of the db node. Valid values: `gdb.r.xlarge`, `gdb.r.2xlarge`, `gdb.r.4xlarge`, `gdb.r.8xlarge`, `gdb.r.16xlarge`.
+* `db_node_class` - (Required) The class of the db node. Valid values: `gdb.r.xlarge`, `gdb.r.2xlarge`, `gdb.r.4xlarge`, `gdb.r.8xlarge`, `gdb.r.16xlarge`, `gdb.r.xlarge_basic`, `gdb.r.2xlarge_basic`, `gdb.r.4xlarge_basic`, `gdb.r.8xlarge_basic`, `gdb.r.16xlarge_basic`.
 * `db_node_storage` - (Required) Instance storage space, which is measured in GB.
 * `db_version` - (Required, ForceNew) Kernel Version. Valid values: `1.0` or `1.0-OpenCypher`. `1.0`: represented as gremlin, `1.0-OpenCypher`: said opencypher.
 * `payment_type` - (Required, ForceNew) The paymen type of the resource. Valid values: `PayAsYouGo`.


### PR DESCRIPTION
resource/alicloud_graph_database_db_instance: The `db_instance_category` attribute supports the option of `SINGLE`.