### PR TITLE
resource/alicloud_resource_manager_shared_resource: The `resource_type` attribute supports the option of `ROSTemplate` and `ServiceCatalogPortfolio`.

### DIFF
--- a/alicloud/resource_alicloud_resource_manager_shared_resource.go
+++ b/alicloud/resource_alicloud_resource_manager_shared_resource.go
@@ -40,7 +40,7 @@ func resourceAlicloudResourceManagerSharedResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"VSwitch"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"VSwitch", "ROSTemplate", "ServiceCatalogPortfolio"}, false),
 			},
 			"status": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_resource_manager_shared_resource_test.go
+++ b/alicloud/resource_alicloud_resource_manager_shared_resource_test.go
@@ -45,7 +45,7 @@ func TestAccAlicloudResourceManagerSharedResource_basic(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"resource_share_id": "${alicloud_resource_manager_resource_share.default.id}",
-					"resource_id":       "${alicloud_vswitch.default.id}",
+					"resource_id":       "${data.alicloud_vswitches.default.ids.0}",
 					"resource_type":     "VSwitch",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -77,14 +77,12 @@ variable "name" {
 data "alicloud_zones" "default" {
   available_resource_creation = "VSwitch"
 }
-resource "alicloud_vpc" "default" {
-  name = var.name
-  cidr_block = "192.168.0.0/16"
+data "alicloud_vpcs" "default"{
+  name_regex = "default-NODELETING"
 }
-resource "alicloud_vswitch" "default" {
-  availability_zone = data.alicloud_zones.default.ids.0
-  cidr_block = "192.168.0.0/16"
-  vpc_id = alicloud_vpc.default.id
+data "alicloud_vswitches" "default" {
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+  zone_id = data.alicloud_zones.default.ids.0
 }
 resource "alicloud_resource_manager_resource_share" "default" {
 	resource_share_name = var.name

--- a/website/docs/r/resource_manager_shared_resource.html.markdown
+++ b/website/docs/r/resource_manager_shared_resource.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `resource_id` - (Required, ForceNew) The resource ID need shared.
 * `resource_share_id` - (Required, ForceNew) The resource share ID of resource manager.
-* `resource_type` - (Required, ForceNew) The resource type of should shared, valid value `VSwitch`.
+* `resource_type` - (Required, ForceNew) The resource type of should shared, valid value `VSwitch`. The following types are added after v1.173.0: `ROSTemplate` and `ServiceCatalogPortfolio`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
resource/alicloud_resource_manager_shared_resource: The `resource_type` attribute supports the option of `ROSTemplate` and `ServiceCatalogPortfolio`.