### PR TITLE
doc/config_delivery_channels: Add `DEPRECATED` identity; docs_website: Remove the link address of the `alicloud_cdn_domain`.

### DIFF
--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -623,9 +623,6 @@
                           <a href="#">Resources</a>
                           <ul class="nav nav-auto-expand">
                             <li>
-                              <a href="/docs/providers/alicloud/r/cdn_domain.html">alicloud_cdn_domain</a>
-                            </li>
-                            <li>
                               <a href="/docs/providers/alicloud/r/cdn_domain_config.html">alicloud_cdn_domain_config</a>
                             </li>
                             <li>

--- a/website/docs/d/config_delivery_channels.html.markdown
+++ b/website/docs/d/config_delivery_channels.html.markdown
@@ -9,6 +9,9 @@ description: |-
 
 # alicloud\_config\_delivery\_channels
 
+-> **DEPRECATED:**  This resource is based on Config's old version OpenAPI, and it has been deprecated from version `1.173.0`.
+Please use new datasource [alicloud_config_deliveries](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/data-sources/config_deliveries) instead.
+
 This data source provides the Config Delivery Channels of the current Alibaba Cloud user.
 
 -> **NOTE:**  Available in 1.99.0+.

--- a/website/docs/r/config_delivery_channel.html.markdown
+++ b/website/docs/r/config_delivery_channel.html.markdown
@@ -10,7 +10,7 @@ description: |-
 # alicloud\_config\_delivery\_channel
 
 -> **DEPRECATED:**  This resource is based on Config's old version OpenAPI, and it has been deprecated from version `1.171.0`.
-Please use new resource [alicloud_config_deliveries](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/config_delivery) instead.
+Please use new resource [alicloud_config_delivery](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/config_delivery) instead.
 
 Provides an Alicloud Config Delivery Channel resource. You can receive configuration audit event changes by configuring OSS, MNS and SLS services provided by Alibaba Cloud.
 For information about Alicloud Config Delivery Channel and how to use it, see [What is Delivery Channel](https://www.alibabacloud.com/help/en/doc-detail/307022.html).


### PR DESCRIPTION
doc/config_delivery_channels: Add `DEPRECATED` identity;
docs_website: Remove the link address of the `alicloud_cdn_domain`.