### PR TITLE
resource/alicloud_amqp_instance：supports enterprise edtion for rabbitmq

### DIFF
--- a/alicloud/resource_alicloud_amqp_instance.go
+++ b/alicloud/resource_alicloud_amqp_instance.go
@@ -34,7 +34,7 @@ func resourceAlicloudAmqpInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"professional", "vip"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"professional", "enterprise", "vip"}, false),
 			},
 			"logistics": {
 				Type:     schema.TypeString,
@@ -487,6 +487,8 @@ func convertAmqpInstanceInstanceTypeResponse(source interface{}) interface{} {
 	switch source {
 	case "PROFESSIONAL":
 		return "professional"
+	case "ENTERPRISE":
+		return "enterprise"
 	case "VIP":
 		return "vip"
 	}

--- a/alicloud/resource_alicloud_ehpc_cluster_test.go
+++ b/alicloud/resource_alicloud_ehpc_cluster_test.go
@@ -2,12 +2,13 @@ package alicloud
 
 import (
 	"fmt"
-	"github.com/agiledragon/gomonkey/v2"
-	util "github.com/alibabacloud-go/tea-utils/service"
 	"log"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	util "github.com/alibabacloud-go/tea-utils/service"
 
 	"github.com/alibabacloud-go/tea-rpc/client"
 	"github.com/alibabacloud-go/tea/tea"

--- a/website/docs/r/amqp_instance.html.markdown
+++ b/website/docs/r/amqp_instance.html.markdown
@@ -49,7 +49,7 @@ resource "alicloud_amqp_instance" "vip" {
 The following arguments are supported:
 
 * `instance_name` - (Optional, Available in v1.131.0+) The instance name.
-* `instance_type` - (Required, ForceNew) The Instance Type. Valid values: `professional`, `vip`.
+* `instance_type` - (Required, ForceNew) The Instance Type. Valid values: `professional`, `enterprise`, `vip`.
 * `max_eip_tps` - (Optional) The max eip tps. It is valid when `support_eip` is true. The valid value is [128, 45000] with the step size 128.
 * `max_tps` - (Required) The peak TPS traffic. The smallest valid value is 1000 and the largest value is 100,000.
 * `modify_type` - (Optional) The modify type. Valid values: `Downgrade`, `Upgrade`. It is required when updating other attributes.


### PR DESCRIPTION
This PR is to add enterprise edtion for rabbitmq, so that users could create enterprise edtion rabbitmq instance via terraform.

Fix issue: https://github.com/aliyun/terraform-provider-alicloud/issues/5213