### PR TITLE
resource/alicloud_adb_db_cluster: Fixes the IncorrectDBInstanceState error while deleting the cluster; Enlarges the default waiting timeout for updating the cluster attributes

### DIFF
--- a/alicloud/resource_alicloud_adb_db_cluster.go
+++ b/alicloud/resource_alicloud_adb_db_cluster.go
@@ -27,7 +27,7 @@ func resourceAlicloudAdbDbCluster() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(50 * time.Minute),
 			Delete: schema.DefaultTimeout(50 * time.Minute),
-			Update: schema.DefaultTimeout(72 * time.Minute),
+			Update: schema.DefaultTimeout(6 * time.Hour),
 		},
 		Schema: map[string]*schema.Schema{
 			"auto_renew_period": {
@@ -684,7 +684,7 @@ func resourceAlicloudAdbDbClusterDelete(d *schema.ResourceData, meta interface{}
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2019-03-15"), StringPointer("AK"), nil, request, &util.RuntimeOptions{})
 		if err != nil {
-			if NeedRetry(err) {
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"IncorrectDBInstanceState"}) {
 				wait()
 				return resource.RetryableError(err)
 			}

--- a/website/docs/r/adb_db_cluster.html.markdown
+++ b/website/docs/r/adb_db_cluster.html.markdown
@@ -46,7 +46,7 @@ resource "alicloud_vswitch" "default" {
 
 resource "alicloud_adb_db_cluster" "this" {
   db_cluster_category = "Cluster"
-  db_cluster_class    = "C8"
+  db_node_class       = "C8"
   db_node_count       = "4"
   db_node_storage     = "400"
   mode                = "reserver"
@@ -115,7 +115,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 50 mins) Used when create the DBCluster.
 * `delete` - (Defaults to 50 mins) Used when delete the DBCluster.
-* `update` - (Defaults to 72 mins) Used when update the DBCluster.
+* `update` - (Defaults to 6  hours) Used when update the DBCluster.
 
 ## Import
 


### PR DESCRIPTION
…