### PR TITLE
resource/alicloud_ecs_instance_set: exclude instances due to instance creation failure.   datasource/alicloud_instances: supported for `disk_id`, `disk_name`.

### DIFF
--- a/alicloud/data_source_alicloud_instances.go
+++ b/alicloud/data_source_alicloud_instances.go
@@ -211,6 +211,14 @@ func dataSourceAlicloudInstances() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"disk_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"disk_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 								},
 							},
 						},
@@ -427,7 +435,7 @@ func instancessDescriptionAttributes(d *schema.ResourceData, instances []ecs.Ins
 		if len(inst.PublicIpAddress.IpAddress) > 0 {
 			mapping["public_ip"] = inst.PublicIpAddress.IpAddress[0]
 		} else {
-			mapping["public_ip"] = inst.VpcAttributes.NatIpAddress
+			mapping["public_ip"] = inst.EipAddress.IpAddress
 		}
 
 		ids = append(ids, inst.InstanceId)
@@ -490,10 +498,12 @@ func getInstanceDisksMappings(instanceMap map[string]string, meta interface{}) (
 			continue
 		}
 		mapping := map[string]interface{}{
-			"device":   disk.Device,
-			"size":     disk.Size,
-			"category": disk.Category,
-			"type":     disk.Type,
+			"device":    disk.Device,
+			"size":      disk.Size,
+			"category":  disk.Category,
+			"type":      disk.Type,
+			"disk_id":   disk.DiskId,
+			"disk_name": disk.DiskName,
 		}
 		instanceDisks[disk.InstanceId] = append(instanceDisks[disk.InstanceId], mapping)
 	}

--- a/alicloud/data_source_alicloud_polardb_global_database_networks.go
+++ b/alicloud/data_source_alicloud_polardb_global_database_networks.go
@@ -2,13 +2,14 @@ package alicloud
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/PaesslerAG/jsonpath"
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"time"
 )
 
 func dataSourceAlicloudPolarDBGlobalDatabaseNetworks() *schema.Resource {

--- a/alicloud/resource_alicloud_polardb_global_database_network.go
+++ b/alicloud/resource_alicloud_polardb_global_database_network.go
@@ -2,11 +2,12 @@ package alicloud
 
 import (
 	"fmt"
+	"time"
+
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"time"
 )
 
 func resourceAlicloudPolarDBGlobalDatabaseNetwork() *schema.Resource {

--- a/alicloud/resource_alicloud_polardb_global_database_network_test.go
+++ b/alicloud/resource_alicloud_polardb_global_database_network_test.go
@@ -2,13 +2,14 @@ package alicloud
 
 import (
 	"fmt"
-	"github.com/PaesslerAG/jsonpath"
 	"log"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/PaesslerAG/jsonpath"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/alibabacloud-go/tea/tea"

--- a/alicloud/service_alicloud_polardb.go
+++ b/alicloud/service_alicloud_polardb.go
@@ -3,11 +3,12 @@ package alicloud
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/PaesslerAG/jsonpath"
 	"log"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/PaesslerAG/jsonpath"
 
 	util "github.com/alibabacloud-go/tea-utils/service"
 

--- a/website/docs/d/instances.html.markdown
+++ b/website/docs/d/instances.html.markdown
@@ -84,6 +84,8 @@ The following attributes are exported in addition to the arguments listed above:
     * `size` - Size of the created disk.
     * `category` - Cloud disk category.
     * `type` - Cloud disk type: system disk or data disk.
+    * `disk_id` - The ID of the Disk.
+    * `disk_name` - The name of the Disk.
   * `tags` - A map of tags assigned to the ECS instance.
   * `resource_group_id` - The Id of resource group.
   * `ram_role_name` - The Ram role name.


### PR DESCRIPTION
…o instance creation failure