### PR TITLE
resource/oss_bucket_replication: Update doc for importing the resource

### DIFF
--- a/website/docs/r/oss_bucket_replication.html.markdown
+++ b/website/docs/r/oss_bucket_replication.html.markdown
@@ -158,10 +158,10 @@ The following attributes are exported:
 
 ## Import
 
-Oss Bucket Replication can be imported using the id, e.g.
+Oss Bucket Replication can be imported using the bucket name and rule_id, e.g.
 
 ```
-$ terraform import alicloud_oss_bucket_replication.example
+$ terraform import alicloud_oss_bucket_replication.example <bucket>:<rule_id>
 ```
 
 ### Timeouts


### PR DESCRIPTION
Passing only the id as specified in the doc returns an error because the code expects both the bucket and the rule id

See https://github.com/aliyun/terraform-provider-alicloud/blob/master/alicloud/resource_alicloud_oss_bucket_replication.go#L534