### PR TITLE
resource/alicloud_polardb_global_database_network: Enlarges the default waiting timeout for deleting the PolarDB Global Database Network.

### DIFF
--- a/alicloud/resource_alicloud_polardb_global_database_network.go
+++ b/alicloud/resource_alicloud_polardb_global_database_network.go
@@ -22,7 +22,7 @@ func resourceAlicloudPolarDBGlobalDatabaseNetwork() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(3 * time.Minute),
-			Delete: schema.DefaultTimeout(3 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"db_cluster_id": {

--- a/website/docs/r/polardb_global_database_network.html.markdown
+++ b/website/docs/r/polardb_global_database_network.html.markdown
@@ -70,7 +70,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 10 mins) Used when create the PolarDB Global Database Network.
 * `update` - (Defaults to 3 mins) Used when update the PolarDB Global Database Network.
-* `delete` - (Defaults to 3 mins) Used when delete the PolarDB Global Database Network.
+* `delete` - (Defaults to 10 mins) Used when delete the PolarDB Global Database Network.
 
 ## Import
 


### PR DESCRIPTION
resource/alicloud_polardb_global_database_network: Enlarges the default waiting timeout for deleting the PolarDB Global Database Network.