### PR TITLE
resource/alicloud_lindorm_instance: Field 'time_serires_engine_specification' deprecated and instead by 'time_series_engine_specification'.

### DIFF
--- a/alicloud/resource_alicloud_lindorm_instance_test.go
+++ b/alicloud/resource_alicloud_lindorm_instance_test.go
@@ -558,33 +558,120 @@ func TestAccAlicloudLindormInstance_basic4(t *testing.T) {
 	})
 }
 
+func TestAccAlicloudLindormInstance_basic5(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_lindorm_instance.default_5"
+	ra := resourceAttrInit(resourceId, AlicloudLindormInstanceMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &HitsdbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeLindormInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testaccLindorminstance%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudLindormInstanceBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"disk_category":             "cloud_efficiency",
+					"payment_type":              "PayAsYouGo",
+					"zone_id":                   "${data.alicloud_zones.default.zones.0.id}",
+					"vswitch_id":                "${data.alicloud_vswitches.default.ids[0]}",
+					"instance_name":             "${var.name}",
+					"file_engine_specification": "lindorm.c.xlarge",
+					"file_engine_node_count":    "2",
+					"instance_storage":          "1920",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"disk_category":             "cloud_efficiency",
+						"payment_type":              "PayAsYouGo",
+						"instance_name":             name,
+						"file_engine_specification": "lindorm.c.xlarge",
+						"file_engine_node_count":    "2",
+						"instance_storage":          "1920",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"time_series_engine_specification": "lindorm.g.2xlarge",
+					"time_series_engine_node_count":    "2",
+					"instance_storage":                 "4320",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"time_series_engine_specification": "lindorm.g.2xlarge",
+						"time_series_engine_node_count":    "2",
+						"instance_storage":                 "4320",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"time_series_engine_specification": "lindorm.g.4xlarge",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"time_series_engine_specification": "lindorm.g.4xlarge",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"time_series_engine_node_count": "3",
+					"instance_storage":              "5440",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"time_series_engine_node_count": "3",
+						"instance_storage":              "5440",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"upgrade_type", "core_num", "group_name", "core_spec", "pricing_cycle", "duration"},
+			},
+		},
+	})
+}
+
 var AlicloudLindormInstanceMap0 = map[string]string{
-	"cold_storage":                      CHECKSET,
-	"search_engine_specification":       CHECKSET,
-	"duration":                          NOSET,
-	"deletion_proection":                CHECKSET,
-	"file_engine_specification":         CHECKSET,
-	"status":                            CHECKSET,
-	"core_num":                          NOSET,
-	"phoenix_node_count":                CHECKSET,
-	"phoenix_node_specification":        CHECKSET,
-	"group_name":                        NOSET,
-	"lts_node_specification":            CHECKSET,
-	"time_series_engine_node_count":     CHECKSET,
-	"time_serires_engine_specification": CHECKSET,
-	"file_engine_node_count":            CHECKSET,
-	"lts_node_count":                    CHECKSET,
-	"search_engine_node_count":          CHECKSET,
-	"core_spec":                         NOSET,
-	"pricing_cycle":                     NOSET,
-	"table_engine_node_count":           CHECKSET,
-	"instance_storage":                  "480",
-	"zone_id":                           CHECKSET,
-	"disk_category":                     "cloud_efficiency",
-	"payment_type":                      "PayAsYouGo",
-	"vswitch_id":                        CHECKSET,
-	"instance_name":                     CHECKSET,
-	"table_engine_specification":        CHECKSET,
+	"cold_storage":                  CHECKSET,
+	"search_engine_specification":   CHECKSET,
+	"duration":                      NOSET,
+	"deletion_proection":            CHECKSET,
+	"file_engine_specification":     CHECKSET,
+	"status":                        CHECKSET,
+	"core_num":                      NOSET,
+	"phoenix_node_count":            CHECKSET,
+	"phoenix_node_specification":    CHECKSET,
+	"group_name":                    NOSET,
+	"lts_node_specification":        CHECKSET,
+	"time_series_engine_node_count": CHECKSET,
+	"file_engine_node_count":        CHECKSET,
+	"lts_node_count":                CHECKSET,
+	"search_engine_node_count":      CHECKSET,
+	"core_spec":                     NOSET,
+	"pricing_cycle":                 NOSET,
+	"table_engine_node_count":       CHECKSET,
+	"instance_storage":              "480",
+	"zone_id":                       CHECKSET,
+	"disk_category":                 "cloud_efficiency",
+	"payment_type":                  "PayAsYouGo",
+	"vswitch_id":                    CHECKSET,
+	"instance_name":                 CHECKSET,
+	"table_engine_specification":    CHECKSET,
 }
 
 func AlicloudLindormInstanceBasicDependence0(name string) string {

--- a/website/docs/r/lindorm_instance.html.markdown
+++ b/website/docs/r/lindorm_instance.html.markdown
@@ -79,7 +79,8 @@ The following arguments are supported:
 * `table_engine_node_count` - (Optional, Computed) The count of table engine.
 * `table_engine_specification` - (Optional, Computed) The specification of  table engine. Valid values: `lindorm.c.2xlarge`, `lindorm.c.4xlarge`, `lindorm.c.8xlarge`, `lindorm.c.xlarge`, `lindorm.g.2xlarge`, `lindorm.g.4xlarge`, `lindorm.g.8xlarge`, `lindorm.g.xlarge`.
 * `time_series_engine_node_count` - (Optional, Computed) The count of time series engine.
-* `time_serires_engine_specification` - (Optional, Computed) The specification of time series engine. Valid values: `lindorm.g.2xlarge`, `lindorm.g.4xlarge`, `lindorm.g.8xlarge`, `lindorm.g.xlarge`.
+* `time_serires_engine_specification` - (Optional, Computed, Deprecated in v1.182.0+) Field `time_serires_engine_specification` has been deprecated from provider version 1.182.0. New field `time_series_engine_specification` instead.
+* `time_series_engine_specification` - (Optional, Computed, Available in v1.182.0+) The specification of time series engine. Valid values: `lindorm.g.2xlarge`, `lindorm.g.4xlarge`, `lindorm.g.8xlarge`, `lindorm.g.xlarge`.
 * `upgrade_type` - (Optional) The upgrade type. **NOTE:** Field 'upgrade_type' has been deprecated from provider version 1.163.0 and it will be removed in the future version. Valid values:  `open-lindorm-engine`, `open-phoenix-engine`, `open-search-engine`, `open-tsdb-engine`,  `upgrade-cold-storage`, `upgrade-disk-size`,  `upgrade-lindorm-core-num`, `upgrade-lindorm-engine`,  `upgrade-search-core-num`, `upgrade-search-engine`, `upgrade-tsdb-core-num`, `upgrade-tsdb-engine`.
 * `vswitch_id` - (Required, ForceNew) The vswitch id.
 * `zone_id` - (Optional, Computed, ForceNew) The zone ID of the instance.


### PR DESCRIPTION
resource/alicloud_lindorm_instance: Field 'time_serires_engine_specification' deprecated and instead by 'time_series_engine_specification'.