### PR TITLE
testcase: fix issue for acc test of alb system security policies

### DIFF
--- a/alicloud/data_source_alicloud_alb_system_security_policies_test.go
+++ b/alicloud/data_source_alicloud_alb_system_security_policies_test.go
@@ -16,10 +16,10 @@ func TestAccAlicloudALBSystemSecurityPoliciesDataSource(t *testing.T) {
 
 	idsConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudAlbSystemSecurityPolicieDataSourceName(rand, map[string]string{
-			"ids": fmt.Sprintf("[%s]", systemPolicyIds),
+			"ids": fmt.Sprintf(`["%s"]`, systemPolicyIds),
 		}),
 		fakeConfig: testAccCheckAlicloudAlbSystemSecurityPolicieDataSourceName(rand, map[string]string{
-			"ids": fmt.Sprintf("[%s_fake]", systemPolicyIds),
+			"ids": fmt.Sprintf(`["%s_fake"]`, systemPolicyIds),
 		}),
 	}
 


### PR DESCRIPTION
This PR is to fix the following issue for acc test of alb system security policies.
`
testing.go:635: Step 0 error: config is invalid: Invalid reference: A reference to a resource type must be followed by at least one attribute access, specifying the resource name.
`