### PR TITLE
resource/alicloud_cen_transit_router_vpc_attachment: Removes the field `zone_mappings` forceNew and supports modifying it online.

### DIFF
--- a/alicloud/resource_alicloud_cen_transit_router_vpc_attachment_test.go
+++ b/alicloud/resource_alicloud_cen_transit_router_vpc_attachment_test.go
@@ -68,10 +68,7 @@ func TestAccAlicloudCenTransitRouterVpcAttachment_basic(t *testing.T) {
 						"transit_router_attachment_name":        name,
 						"transit_router_attachment_description": "tf-test",
 						"vpc_id":                                CHECKSET,
-						"zone_mappings.0.vswitch_id":            CHECKSET,
-						"zone_mappings.0.zone_id":               CHECKSET,
-						"zone_mappings.1.vswitch_id":            CHECKSET,
-						"zone_mappings.1.zone_id":               CHECKSET,
+						"zone_mappings.#":                       "2",
 					}),
 				),
 			},
@@ -80,6 +77,36 @@ func TestAccAlicloudCenTransitRouterVpcAttachment_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"dry_run", "route_table_association_enabled", "route_table_propagation_enabled", "transit_router_id"},
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_mappings": []map[string]interface{}{
+						{
+							"vswitch_id": "${data.alicloud_vswitches.default_master.vswitches.0.id}",
+							"zone_id":    "${data.alicloud_vswitches.default_master.vswitches.0.zone_id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_mappings.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_mappings": []map[string]interface{}{
+						{
+							"vswitch_id": "${data.alicloud_vswitches.default.vswitches.0.id}",
+							"zone_id":    "${data.alicloud_vswitches.default.vswitches.0.zone_id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_mappings.#": "1",
+					}),
+				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -178,10 +205,7 @@ func TestAccAlicloudCenTransitRouterVpcAttachment_basic1(t *testing.T) {
 						"transit_router_attachment_name":        name,
 						"transit_router_attachment_description": "tf-test",
 						"vpc_id":                                CHECKSET,
-						"zone_mappings.0.vswitch_id":            CHECKSET,
-						"zone_mappings.0.zone_id":               CHECKSET,
-						"zone_mappings.1.vswitch_id":            CHECKSET,
-						"zone_mappings.1.zone_id":               CHECKSET,
+						"zone_mappings.#":                       "2",
 						"dry_run":                               "false",
 						"resource_type":                         "VPC",
 						"route_table_association_enabled":       "false",

--- a/website/docs/r/cen_transit_router_vpc_attachment.html.markdown
+++ b/website/docs/r/cen_transit_router_vpc_attachment.html.markdown
@@ -89,7 +89,7 @@ The following arguments are supported:
 * `route_table_propagation_enabled` - (Optional) Whether to enabled route table propagation. The system default value is `true`.
 * `vpc_owner_id` - (Optional,ForceNew) The owner id of vpc.
 * `payment_type` - (Optional, ForceNew, Available in 1.168.0+) The payment type of the resource. Valid values: `PayAsYouGo`.
-* `zone_mappings` - (Required, ForceNew) The list of zone mapping of the VPC.
+* `zone_mappings` - (Required) The list of zone mapping of the VPC. **NOTE:** From version 1.184.0, `zone_mappings` can be modified.
 
 -> **NOTE:** The Zone of CEN has MasterZone and SlaveZone, first zone_id of zone_mapping need be MasterZone. We have a API to describeZones[API](https://help.aliyun.com/document_detail/261356.html)
 


### PR DESCRIPTION
resource/alicloud_cen_transit_router_vpc_attachment: Removes the field `zone_mappings` forceNew and supports modifying it online.