### PR TITLE
data/alicloud_instance_types: substring match for gpu_spec

### DIFF
--- a/alicloud/data_source_alicloud_instance_types.go
+++ b/alicloud/data_source_alicloud_instance_types.go
@@ -316,7 +316,7 @@ func dataSourceAlicloudInstanceTypesRead(d *schema.ResourceData, meta interface{
 			if gpuAmount > 0 && types.GPUAmount != gpuAmount {
 				continue
 			}
-			if gpuSpec != "" && types.GPUSpec != gpuSpec {
+			if gpuSpec != "" && !strings.Contains(types.GPUSpec, gpuSpec) {
 				continue
 			}
 			// Kubernetes node does not support instance types which family is "ecs.t5" and spec less that c2g4


### PR DESCRIPTION
Ref: https://help.aliyun.com/document_detail/25620.html

> 说明 支持模糊匹配，如某规格的GPU类型为NVIDIA V100，输入NVIDIA也可查询到该规格信息。

Translate

> NOTE: fuzzy matching is supported, e.g. argument "NVIDIA" will match those ecs instance types with GPU "NVIDIA V100"