### PR TITLE
resource/alicloud_vpn_gateway_vpn_attachment: Fix error ModifyVpnAttachmentAttribute Api missing RegionId parameters.

### DIFF
--- a/alicloud/resource_alicloud_vpn_gateway_vpn_attachment.go
+++ b/alicloud/resource_alicloud_vpn_gateway_vpn_attachment.go
@@ -435,6 +435,7 @@ func resourceAlicloudVpnGatewayVpnAttachmentUpdate(d *schema.ResourceData, meta 
 	update := false
 	request := map[string]interface{}{
 		"VpnConnectionId": d.Id(),
+		"RegionId":        client.RegionId,
 	}
 	if d.HasChange("effect_immediately") {
 		update = true


### PR DESCRIPTION
resource/alicloud_vpn_gateway_vpn_attachment: Fix error ModifyVpnAttachmentAttribute Api missing RegionId parameters.