### PR TITLE
resource/alicloud_resource_manager_shared_resource: The `resource_type` attribute supports the option of `PrefixList` and `Image`.

### DIFF
--- a/alicloud/resource_alicloud_resource_manager_shared_resource.go
+++ b/alicloud/resource_alicloud_resource_manager_shared_resource.go
@@ -40,7 +40,7 @@ func resourceAlicloudResourceManagerSharedResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"VSwitch", "ROSTemplate", "ServiceCatalogPortfolio"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"VSwitch", "ROSTemplate", "ServiceCatalogPortfolio", "PrefixList", "Image"}, false),
 			},
 			"status": {
 				Type:     schema.TypeString,

--- a/website/docs/r/resource_manager_shared_resource.html.markdown
+++ b/website/docs/r/resource_manager_shared_resource.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `resource_id` - (Required, ForceNew) The resource ID need shared.
 * `resource_share_id` - (Required, ForceNew) The resource share ID of resource manager.
-* `resource_type` - (Required, ForceNew) The resource type of should shared, valid value `VSwitch`. The following types are added after v1.173.0: `ROSTemplate` and `ServiceCatalogPortfolio`.
+* `resource_type` - (Required, ForceNew) The resource type of should shared, valid value `VSwitch`. The following types are added after v1.173.0: `ROSTemplate` and `ServiceCatalogPortfolio`. The following types are added after v1.192.0: `PrefixList` and `Image`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
resource/alicloud_resource_manager_shared_resource: The `resource_type` attribute supports the option of `PrefixList` and `Image`.