### PR TITLE
data_source/alicloud_instance_types: Support new attribute `minimum_eni_ipv6_address_quantity`. data_source/alicloud_vswitches: Supports new output `ipv6_cidr_block`.  resource/alicloud_instance: Support new attribute `ipv6_address_count` and `ipv6_addresses`.

### DIFF
--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -1038,6 +1038,39 @@ func formatInt(src interface{}) int {
 	}
 }
 
+func formatFloat64(src interface{}) float64 {
+	if src == nil {
+		return 0
+	}
+	attrType := reflect.TypeOf(src)
+	switch attrType.String() {
+	case "float64":
+		return src.(float64)
+	case "float32":
+		return float64(src.(float32))
+	case "int64":
+		return float64(src.(int64))
+	case "int32":
+		return float64(src.(int32))
+	case "int":
+		return float64(src.(int))
+	case "string":
+		v, err := strconv.ParseFloat(src.(string), 64)
+		if err != nil {
+			panic(err)
+		}
+		return v
+	case "json.Number":
+		v, err := src.(json.Number).Float64()
+		if err != nil {
+			panic(err)
+		}
+		return v
+	default:
+		panic(fmt.Sprintf("Not support type %s", attrType.String()))
+	}
+}
+
 func convertArrayObjectToJsonString(src interface{}) (string, error) {
 	res, err := json.Marshal(&src)
 	if err != nil {

--- a/alicloud/data_source_alicloud_bp_studio_applications.go
+++ b/alicloud/data_source_alicloud_bp_studio_applications.go
@@ -2,14 +2,15 @@ package alicloud
 
 import (
 	"fmt"
+	"regexp"
+	"time"
+
 	"github.com/PaesslerAG/jsonpath"
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"regexp"
-	"time"
 )
 
 func dataSourceAlicloudBpStudioApplications() *schema.Resource {

--- a/alicloud/data_source_alicloud_bp_studio_applications_test.go
+++ b/alicloud/data_source_alicloud_bp_studio_applications_test.go
@@ -2,9 +2,10 @@ package alicloud
 
 import (
 	"fmt"
-	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"strings"
 	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )

--- a/alicloud/data_source_alicloud_instance_types.go
+++ b/alicloud/data_source_alicloud_instance_types.go
@@ -1,11 +1,17 @@
 package alicloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/bssopenapi"
 
@@ -17,7 +23,7 @@ import (
 )
 
 type instanceTypeWithOriginalPrice struct {
-	InstanceType  ecs.InstanceType
+	InstanceType  map[string]interface{}
 	OriginalPrice float64
 }
 
@@ -123,6 +129,11 @@ func dataSourceAlicloudInstanceTypes() *schema.Resource {
 			},
 			"image_id": {
 				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"minimum_eni_ipv6_address_quantity": {
+				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
 			},
@@ -255,100 +266,142 @@ func dataSourceAlicloudInstanceTypesRead(d *schema.ResourceData, meta interface{
 
 	cpu := d.Get("cpu_core_count").(int)
 	mem := d.Get("memory_size").(float64)
-	family := strings.TrimSpace(d.Get("instance_type_family").(string))
 	gpuAmount := d.Get("gpu_amount").(int)
-	gpuSpec := d.Get("gpu_spec").(string)
 
-	req := ecs.CreateDescribeInstanceTypesRequest()
-	req.InstanceTypeFamily = family
+	request := make(map[string]interface{})
 
-	raw, err := client.WithEcsClient(func(ecsClient *ecs.Client) (interface{}, error) {
-		return ecsClient.DescribeInstanceTypes(req)
-	})
+	if v, ok := d.GetOkExists("minimum_eni_ipv6_address_quantity"); ok {
+		request["MinimumEniIpv6AddressQuantity"] = v
+	}
+
+	if v, ok := d.GetOk("instance_type_family"); ok {
+		request["InstanceTypeFamily"] = v
+	}
+
+	if v, ok := d.GetOk("gpu_spec"); ok {
+		request["GPUSpec"] = v
+	}
+
+	conn, err := client.NewEcsClient()
 	if err != nil {
-		return err
+		return WrapError(err)
+	}
+	var objects []interface{}
+	var response map[string]interface{}
+
+	for {
+		action := "DescribeInstanceTypes"
+		runtime := util.RuntimeOptions{}
+		runtime.SetAutoretry(true)
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			resp, err := conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2014-05-26"), StringPointer("AK"), nil, request, &runtime)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			response = resp
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_instance_types", action, AlibabaCloudSdkGoERROR)
+		}
+		resp, err := jsonpath.Get("$.InstanceTypes.InstanceType", response)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.InstanceTypes.InstanceType", response)
+		}
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			objects = append(objects, item)
+		}
+		if nextToken, ok := response["NextToken"].(string); ok && nextToken != "" {
+			request["NextToken"] = nextToken
+		} else {
+			break
+		}
 	}
 	var instanceTypes []instanceTypeWithOriginalPrice
-	resp, _ := raw.(*ecs.DescribeInstanceTypesResponse)
-	if resp != nil {
-		imageSupportInstanceTypesMap := make(map[string]struct{}, 0)
-		imageId := strings.TrimSpace(d.Get("image_id").(string))
-		if imageId != "" {
-			reqImageId := ecs.CreateDescribeImageSupportInstanceTypesRequest()
-			reqImageId.ImageId = imageId
+	imageSupportInstanceTypesMap := make(map[string]struct{}, 0)
+	imageId := strings.TrimSpace(d.Get("image_id").(string))
+	if imageId != "" {
+		reqImageId := ecs.CreateDescribeImageSupportInstanceTypesRequest()
+		reqImageId.ImageId = imageId
 
-			raw1, err := client.WithEcsClient(func(ecsClient *ecs.Client) (interface{}, error) {
-				return ecsClient.DescribeImageSupportInstanceTypes(reqImageId)
-			})
-			if err != nil {
-				return err
-			}
-			imageSupportInstanceTypes, _ := raw1.(*ecs.DescribeImageSupportInstanceTypesResponse)
+		raw1, err := client.WithEcsClient(func(ecsClient *ecs.Client) (interface{}, error) {
+			return ecsClient.DescribeImageSupportInstanceTypes(reqImageId)
+		})
+		if err != nil {
+			return err
+		}
+		imageSupportInstanceTypes, _ := raw1.(*ecs.DescribeImageSupportInstanceTypesResponse)
 
-			for _, types := range imageSupportInstanceTypes.InstanceTypes.InstanceType {
-				imageSupportInstanceTypesMap[types.InstanceTypeId] = struct{}{}
+		for _, types := range imageSupportInstanceTypes.InstanceTypes.InstanceType {
+			imageSupportInstanceTypesMap[types.InstanceTypeId] = struct{}{}
+		}
+	}
+
+	eniAmount := d.Get("eni_amount").(int)
+	k8sNode := strings.TrimSpace(d.Get("kubernetes_node_role").(string))
+
+	for _, v := range objects {
+		object := v.(map[string]interface{})
+		if _, ok := mapInstanceTypes[object["InstanceTypeId"].(string)]; !ok {
+			continue
+		}
+
+		if len(imageSupportInstanceTypesMap) > 0 {
+			if _, ok := imageSupportInstanceTypesMap[object["InstanceTypeId"].(string)]; !ok {
+				continue
 			}
 		}
 
-		eniAmount := d.Get("eni_amount").(int)
-		k8sNode := strings.TrimSpace(d.Get("kubernetes_node_role").(string))
-		for _, types := range resp.InstanceTypes.InstanceType {
-			if _, ok := mapInstanceTypes[types.InstanceTypeId]; !ok {
-				continue
-			}
-
-			if len(imageSupportInstanceTypesMap) > 0 {
-				if _, ok := imageSupportInstanceTypesMap[types.InstanceTypeId]; !ok {
-					continue
-				}
-			}
-
-			if cpu > 0 && types.CpuCoreCount != cpu {
-				continue
-			}
-
-			if mem > 0 && types.MemorySize != mem {
-				continue
-			}
-			if eniAmount > types.EniQuantity {
-				continue
-			}
-			if gpuAmount > 0 && types.GPUAmount != gpuAmount {
-				continue
-			}
-			if gpuSpec != "" && !strings.Contains(types.GPUSpec, gpuSpec) {
-				continue
-			}
-			// Kubernetes node does not support instance types which family is "ecs.t5" and spec less that c2g4
-			// Kubernetes master node does not support gpu instance types which family prefixes with "ecs.gn"
-			if k8sNode != "" {
-				if types.InstanceTypeFamily == "ecs.t5" {
-					continue
-				}
-				if types.CpuCoreCount < 2 || types.MemorySize < 4 {
-					continue
-				}
-				if k8sNode == string(KubernetesNodeMaster) && strings.HasPrefix(types.InstanceTypeFamily, "ecs.gn") {
-					continue
-				}
-			}
-
-			instanceTypes = append(instanceTypes, instanceTypeWithOriginalPrice{
-				InstanceType: types,
-			})
+		if cpu > 0 && formatInt(object["CpuCoreCount"]) != cpu {
+			continue
 		}
-		sortedBy := d.Get("sorted_by").(string)
 
-		if sortedBy == "Price" && len(instanceTypes) > 0 {
-			bssopenapiService := BssopenapiService{client}
+		if mem > 0 && formatFloat64(object["MemorySize"]) != mem {
+			continue
+		}
+		if eniAmount > formatInt(object["EniQuantity"]) {
+			continue
+		}
+		if gpuAmount > 0 && formatInt(object["GPUAmount"]) != gpuAmount {
+			continue
+		}
+		// Kubernetes node does not support instance types which family is "ecs.t5" and spec less that c2g4
+		// Kubernetes master node does not support gpu instance types which family prefixes with "ecs.gn"
+		if k8sNode != "" {
+			if object["InstanceTypeFamily"].(string) == "ecs.t5" {
+				continue
+			}
+			if formatInt(object["CpuCoreCount"]) < 2 || formatFloat64(object["MemorySize"]) < 4 {
+				continue
+			}
+			if k8sNode == string(KubernetesNodeMaster) && strings.HasPrefix(object["InstanceTypeFamily"].(string), "ecs.gn") {
+				continue
+			}
+		}
 
-			priceList, err := getEcsInstanceTypePrice(bssopenapiService, d.Get("instance_charge_type").(string), instanceTypes)
-			if err != nil {
-				return WrapError(err)
-			}
-			for i := 0; i < len(instanceTypes); i++ {
-				instanceTypes[i].OriginalPrice = priceList[i]
-			}
+		instanceTypes = append(instanceTypes, instanceTypeWithOriginalPrice{
+			InstanceType: object,
+		})
+	}
+	sortedBy := d.Get("sorted_by").(string)
+
+	if sortedBy == "Price" && len(instanceTypes) > 0 {
+		bssopenapiService := BssopenapiService{client}
+
+		priceList, err := getEcsInstanceTypePrice(bssopenapiService, d.Get("instance_charge_type").(string), instanceTypes)
+		if err != nil {
+			return WrapError(err)
+		}
+		for i := 0; i < len(instanceTypes); i++ {
+			instanceTypes[i].OriginalPrice = priceList[i]
 		}
 	}
 
@@ -363,9 +416,9 @@ func instanceTypesDescriptionAttributes(d *schema.ResourceData, types []instance
 			case "Price":
 				return types[i].OriginalPrice < types[j].OriginalPrice
 			case "CPU":
-				return types[i].InstanceType.CpuCoreCount < types[j].InstanceType.CpuCoreCount
+				return formatInt(types[i].InstanceType["CpuCoreCount"]) < formatInt(types[j].InstanceType["CpuCoreCount"])
 			case "Memory":
-				return types[i].InstanceType.MemorySize < types[j].InstanceType.MemorySize
+				return formatFloat64(types[i].InstanceType["MemorySize"]) < formatFloat64(types[j].InstanceType["MemorySize"])
 			}
 			return false
 		})
@@ -375,37 +428,41 @@ func instanceTypesDescriptionAttributes(d *schema.ResourceData, types []instance
 	var s []map[string]interface{}
 	for _, t := range types {
 		mapping := map[string]interface{}{
-			"id":             t.InstanceType.InstanceTypeId,
-			"cpu_core_count": t.InstanceType.CpuCoreCount,
-			"memory_size":    t.InstanceType.MemorySize,
-			"family":         t.InstanceType.InstanceTypeFamily,
-			"eni_amount":     t.InstanceType.EniQuantity,
-			"nvme_support":   t.InstanceType.NvmeSupport,
+			"id":             t.InstanceType["InstanceTypeId"],
+			"cpu_core_count": formatInt(t.InstanceType["CpuCoreCount"]),
+			"memory_size":    formatFloat64(t.InstanceType["MemorySize"]),
+			"family":         t.InstanceType["InstanceTypeFamily"],
+			"eni_amount":     t.InstanceType["EniQuantity"],
+			"nvme_support":   t.InstanceType["NvmeSupport"],
 		}
 		if sortedBy == "Price" {
 			mapping["price"] = fmt.Sprintf("%.4f", t.OriginalPrice)
 		}
-		zoneIds := mapTypes[t.InstanceType.InstanceTypeId]
+		zoneIds := mapTypes[t.InstanceType["InstanceTypeId"].(string)]
 		sort.Strings(zoneIds)
 		mapping["availability_zones"] = zoneIds
 		gpu := map[string]interface{}{
-			"amount":   strconv.Itoa(t.InstanceType.GPUAmount),
-			"category": t.InstanceType.GPUSpec,
+			"amount":   strconv.Itoa(formatInt(t.InstanceType["GPUAmount"])),
+			"category": t.InstanceType["GPUSpec"],
 		}
 		mapping["gpu"] = gpu
 		brust := map[string]interface{}{
-			"initial_credit":  strconv.Itoa(t.InstanceType.InitialCredit),
-			"baseline_credit": strconv.Itoa(t.InstanceType.BaselineCredit),
+			"initial_credit":  strconv.Itoa(formatInt(t.InstanceType["InitialCredit"])),
+			"baseline_credit": strconv.Itoa(formatInt(t.InstanceType["BaselineCredit"])),
 		}
 		mapping["burstable_instance"] = brust
 		local := map[string]interface{}{
-			"capacity": strconv.FormatInt(t.InstanceType.LocalStorageCapacity, 10),
-			"amount":   strconv.Itoa(t.InstanceType.LocalStorageAmount),
-			"category": t.InstanceType.LocalStorageCategory,
+			"amount":   strconv.Itoa(formatInt(t.InstanceType["LocalStorageAmount"])),
+			"category": t.InstanceType["LocalStorageCategory"],
+		}
+		if v, ok := t.InstanceType["LocalStorageCapacity"]; ok {
+			local["capacity"] = v.(json.Number).String()
+		} else {
+			local["capacity"] = "0"
 		}
 		mapping["local_storage"] = local
 
-		ids = append(ids, t.InstanceType.InstanceTypeId)
+		ids = append(ids, fmt.Sprint(t.InstanceType["InstanceTypeId"]))
 		s = append(s, mapping)
 	}
 
@@ -432,7 +489,7 @@ func getEcsInstanceTypePrice(bssopenapiService BssopenapiService, instanceCharge
 	var subsciption []bssopenapi.GetSubscriptionPriceModuleList
 	for _, types := range instanceTypes {
 		config := fmt.Sprintf("InstanceType:%s,IoOptimized:IoOptimized,ImageOs:linux,Region:%s",
-			types.InstanceType.InstanceTypeId, client.RegionId)
+			fmt.Sprint(types.InstanceType["InstanceTypeId"]), client.RegionId)
 		if instanceChargeType == string(PostPaid) {
 			payAsYouGo = append(payAsYouGo, bssopenapi.GetPayAsYouGoPriceModuleList{
 				ModuleCode: moduleCode,

--- a/alicloud/data_source_alicloud_vswitches.go
+++ b/alicloud/data_source_alicloud_vswitches.go
@@ -154,6 +154,10 @@ func dataSourceAlicloudVswitches() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"ipv6_cidr_block": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -286,6 +290,7 @@ func dataSourceAlicloudVswitchesRead(d *schema.ResourceData, meta interface{}) e
 			"name":                       object["VSwitchName"],
 			"vpc_id":                     object["VpcId"],
 			"zone_id":                    object["ZoneId"],
+			"ipv6_cidr_block":            object["Ipv6CidrBlock"],
 		}
 
 		tags := make(map[string]interface{})

--- a/alicloud/resource_alicloud_bp_studio_application.go
+++ b/alicloud/resource_alicloud_bp_studio_application.go
@@ -2,11 +2,12 @@ package alicloud
 
 import (
 	"fmt"
+	"time"
+
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"time"
 )
 
 func resourceAlicloudBpStudioApplication() *schema.Resource {

--- a/alicloud/service_alicloud_bp_studio.go
+++ b/alicloud/service_alicloud_bp_studio.go
@@ -2,11 +2,12 @@ package alicloud
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/PaesslerAG/jsonpath"
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"time"
 )
 
 type BpStudioService struct {

--- a/alicloud/service_alicloud_ecs.go
+++ b/alicloud/service_alicloud_ecs.go
@@ -123,7 +123,7 @@ func (s *EcsService) DescribeInstance(id string) (instance ecs.Instance, err err
 	request := ecs.CreateDescribeInstancesRequest()
 	request.RegionId = s.client.RegionId
 	request.InstanceIds = convertListToJsonString([]interface{}{id})
-	request.AdditionalAttributes = &[]string{"META_OPTIONS"}
+	request.AdditionalAttributes = &[]string{"META_OPTIONS", "NETWORK_PRIMARY_ENI_IP"}
 
 	var response *ecs.DescribeInstancesResponse
 	wait := incrementalWait(1*time.Second, 1*time.Second)

--- a/website/docs/d/instance_types.html.markdown
+++ b/website/docs/d/instance_types.html.markdown
@@ -55,6 +55,7 @@ The following arguments are supported:
 * `system_disk_category` - (Optional, Available in 1.120.0+) Filter the results by system disk category. Valid values: `cloud`, `ephemeral_ssd`, `cloud_essd`, `cloud_efficiency`, `cloud_ssd`. 
   **NOTE**: Its default value `cloud_efficiency` has been removed from the version v1.150.0.
 * `image_id` - (Optional, Available in 1.163.0+) The ID of the image.
+* `minimum_eni_ipv6_address_quantity` (Optional, ForceNew, Available in 1.193.0+) The minimum number of IPv6 addresses per ENI. **Note:** If an instance type supports fewer IPv6 addresses per ENI than the specified value, information about the instance type is not queried.
 
 ## Attributes Reference
 

--- a/website/docs/d/vswitches.html.markdown
+++ b/website/docs/d/vswitches.html.markdown
@@ -78,3 +78,4 @@ The following attributes are exported in addition to the arguments listed above:
   * `tags` - The Tags of the VSwitch.
   * `vswitch_id` - ID of the VSwitch.
   * `vswitch_name` - Name of the VSwitch.
+  * `ipv6_cidr_block` - The IPv6 CIDR block of the switch.

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -236,6 +236,8 @@ Set it to null can cancel automatic release attribute and the ECS instance will 
   - required: forcefully uses the security-enhanced mode (IMDSv2). After you set this parameter to required, you cannot access instance metadata in normal mode.
 * `http_endpoint` - (Optional, Computed, Available in 1.192.0+) Specifies whether to enable the access channel for instance metadata. Valid values: `enabled`, `disabled`. Default value: `enabled`.
 * `http_put_response_hop_limit` - (Optional, Computed, ForceNew, Available in 1.192.0+) The HTTP PUT response hop limit for accessing instance metadata. Valid values: 1 to 64. Default value: 1.
+* `ipv6_address_count` - (Optional, ForceNew, Computed, Available in 1.193.0+) The number of IPv6 addresses to randomly generate for the primary ENI. Valid values: 1 to 10. **NOTE:** You cannot specify both the `ipv6_addresses` and `ipv6_address_count` parameters.
+* `ipv6_addresses` - (Optional, ForceNew, Computed, Available in 1.193.0+) A list of IPv6 address to be assigned to the primary ENI. Support up to 10.
 
 -> **NOTE:** System disk category `cloud` has been outdated and it only can be used none I/O Optimized ECS instances. Recommend `cloud_efficiency` and `cloud_ssd` disk.
 


### PR DESCRIPTION
data_source/alicloud_instance_types: Support new attribute `minimum_eni_ipv6_address_quantity`.
data_source/alicloud_vswitches: Supports new output `ipv6_cidr_block`. 
resource/alicloud_instance: Support new attribute `ipv6_address_count` and `ipv6_addresses`.