### PR TITLE
resource/alicloud_reserved_instance: Support new attribute `auto_renew`, `auto_renew_period`, `tags`, `reserved_instance_name`. Supports new output `allocation_status`, `create_time`, `expired_time`, `operation_locks`, `start_time`, `status`.

### DIFF
--- a/alicloud/resource_alicloud_cen_transit_router_cidr.go
+++ b/alicloud/resource_alicloud_cen_transit_router_cidr.go
@@ -2,13 +2,14 @@ package alicloud
 
 import (
 	"fmt"
+	"regexp"
+	"time"
+
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"regexp"
-	"time"
 )
 
 func resourceAlicloudCenTransitRouterCidr() *schema.Resource {

--- a/alicloud/resource_alicloud_das_switch_das_pro.go
+++ b/alicloud/resource_alicloud_das_switch_das_pro.go
@@ -2,12 +2,13 @@ package alicloud
 
 import (
 	"fmt"
+	"time"
+
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"time"
 )
 
 func resourceAlicloudDasSwitchDasPro() *schema.Resource {

--- a/alicloud/resource_alicloud_reserved_instance.go
+++ b/alicloud/resource_alicloud_reserved_instance.go
@@ -1,11 +1,16 @@
 package alicloud
 
 import (
+	"fmt"
 	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -20,7 +25,68 @@ func resourceAliCloudReservedInstance() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(1 * time.Minute),
+			Update: schema.DefaultTimeout(1 * time.Minute),
+		},
 		Schema: map[string]*schema.Schema{
+			"allocation_status": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"renewal_status": {
+				Optional:     true,
+				Computed:     true,
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{string(RenewAutoRenewal), string(RenewNormal)}, false),
+			},
+			"auto_renew_period": {
+				Computed:     true,
+				Optional:     true,
+				Type:         schema.TypeInt,
+				ValidateFunc: validation.IntInSlice([]int{1, 12, 36, 60}),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("renewal_status").(string) == string(RenewAutoRenewal) {
+						return false
+					}
+					return true
+				},
+			},
+			"create_time": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"expired_time": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"operation_locks": {
+				Computed: true,
+				Type:     schema.TypeSet,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"lock_reason": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+					},
+				},
+			},
+			"reserved_instance_name": {
+				Optional:      true,
+				Computed:      true,
+				Type:          schema.TypeString,
+				ConflictsWith: []string{"name"},
+			},
+			"start_time": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"status": {
+				Computed: true,
+				Type:     schema.TypeString,
+			},
+			"tags": tagsSchema(),
 			"instance_type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -71,8 +137,11 @@ func resourceAliCloudReservedInstance() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"No Upfront", "Partial Upfront", "All Upfront"}, false),
 			},
 			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				Deprecated:    "Field 'name' has been deprecated from provider version 1.194.0. New field 'reserved_instance_name' instead.",
+				ConflictsWith: []string{"reserved_instance_name"},
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -90,76 +159,143 @@ func resourceAliCloudReservedInstance() *schema.Resource {
 func resourceAliCloudReservedInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	ecsService := EcsService{client}
-	request := ecs.CreatePurchaseReservedInstancesOfferingRequest()
-	if v, ok := d.GetOk("instance_type"); ok {
-		request.InstanceType = v.(string)
+	request := map[string]interface{}{
+		"RegionId": client.RegionId,
 	}
-	request.RegionId = client.RegionId
+	conn, err := client.NewEcsClient()
+	if err != nil {
+		return WrapError(err)
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		request["Description"] = v
+	}
+	if v, ok := d.GetOk("instance_amount"); ok {
+		request["InstanceAmount"] = v
+	}
+	if v, ok := d.GetOk("instance_type"); ok {
+		request["InstanceType"] = v
+	}
+	if v, ok := d.GetOk("offering_type"); ok {
+		request["OfferingType"] = v
+	}
+	if v, ok := d.GetOk("period"); ok {
+		request["Period"] = v
+	}
+	if v, ok := d.GetOk("period_unit"); ok {
+		request["PeriodUnit"] = v
+	}
+	if v, ok := d.GetOk("platform"); ok {
+		request["Platform"] = v
+	}
+	if v, ok := d.GetOk("reserved_instance_name"); ok {
+		request["ReservedInstanceName"] = v
+	} else if v, ok := d.GetOk("name"); ok {
+		request["ReservedInstanceName"] = v
+	}
+
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
+	}
 	if scope, ok := d.GetOk("scope"); ok {
-		request.Scope = scope.(string)
+		request["Scope"] = scope
 		if v, ok := d.GetOk("zone_id"); ok {
 			if scope == "Zone" && v == "" {
 				return WrapError(Error("Required when Scope is Zone."))
 			}
-			request.ZoneId = v.(string)
+			request["ZoneId"] = v
 		}
 	}
-	if v, ok := d.GetOk("instance_amount"); ok {
-		request.InstanceAmount = requests.NewInteger(v.(int))
+	if v, ok := d.GetOk("tags"); ok {
+		count := 1
+		for key, value := range v.(map[string]interface{}) {
+			request[fmt.Sprintf("Tag.%d.Key", count)] = key
+			request[fmt.Sprintf("Tag.%d.Value", count)] = value
+			count++
+		}
 	}
-	if v, ok := d.GetOk("platform"); ok {
-		request.Platform = v.(string)
+
+	if v, ok := d.GetOk("renewal_status"); ok {
+		request["AutoRenew"] = v.(string) == string(RenewAutoRenewal)
 	}
-	if v, ok := d.GetOk("period_unit"); ok {
-		request.PeriodUnit = v.(string)
+	if v, ok := d.GetOkExists("auto_renew_period"); ok {
+		request["AutoRenewPeriod"] = v
 	}
-	if v, ok := d.GetOk("period"); ok {
-		request.Period = requests.NewInteger(v.(int))
-	}
-	if v, ok := d.GetOk("offering_type"); ok {
-		request.OfferingType = v.(string)
-	}
-	if v, ok := d.GetOk("name"); ok {
-		request.ReservedInstanceName = v.(string)
-	}
-	if v, ok := d.GetOk("description"); ok {
-		request.Description = v.(string)
-	}
-	if v, ok := d.GetOk("resource_group_id"); ok {
-		request.ResourceGroupId = v.(string)
-	}
-	raw, err := client.WithEcsClient(func(ecsClient *ecs.Client) (interface{}, error) {
-		return ecsClient.PurchaseReservedInstancesOffering(request)
+
+	request["ClientToken"] = buildClientToken("PurchaseReservedInstancesOffering")
+	var response map[string]interface{}
+	action := "PurchaseReservedInstancesOffering"
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
+		resp, err := conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2014-05-26"), StringPointer("AK"), nil, request, &runtime)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		response = resp
+
+		return nil
 	})
+	addDebug(action, response, request)
 	if err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, "alicloud_reserved_instance", request.GetActionName(), AlibabaCloudSdkGoERROR)
-	}
-	addDebug(request.GetActionName(), raw, request.RpcRequest, request)
-	response := raw.(*ecs.PurchaseReservedInstancesOfferingResponse)
-	if len(response.ReservedInstanceIdSets.ReservedInstanceId) != 1 {
-		return WrapError(Error("API returned wrong number of collections"))
-	}
-	d.SetId(response.ReservedInstanceIdSets.ReservedInstanceId[0])
-
-	if err := ecsService.WaitForReservedInstance(d.Id(), Active, DefaultTimeout); err != nil {
-		return WrapError(err)
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ecs_reserved_instance", action, AlibabaCloudSdkGoERROR)
 	}
 
+	if v, err := jsonpath.Get("$.ReservedInstanceIdSets.ReservedInstanceId[0]", response); err != nil || v == nil {
+		return WrapErrorf(err, IdMsg, "alicloud_ecs_reserved_instance")
+	} else {
+		d.SetId(fmt.Sprint(v))
+	}
+	stateConf := BuildStateConf([]string{}, []string{"Active"}, client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), 5*time.Second, ecsService.EcsReservedInstanceStateRefreshFunc(d, []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
 	return resourceAliCloudReservedInstanceRead(d, meta)
 }
 func resourceAliCloudReservedInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
-	request := ecs.CreateModifyReservedInstanceAttributeRequest()
+	conn, err := client.NewEcsClient()
+	if err != nil {
+		return WrapError(err)
+	}
+	ecsService := EcsService{client}
+	d.Partial(true)
+	if d.HasChange("tags") {
+		if err := ecsService.SetResourceTags(d, "reservedinstance"); err != nil {
+			return WrapError(err)
+		}
+		d.SetPartial("tags")
+	}
 
+	update := false
+	request := ecs.CreateModifyReservedInstanceAttributeRequest()
 	request.ReservedInstanceId = d.Id()
 	request.RegionId = client.RegionId
-	if d.HasChange("name") || d.HasChange("description") {
+	if d.HasChange("name") {
+		update = true
 		if v, ok := d.GetOk("name"); ok {
 			request.ReservedInstanceName = v.(string)
 		}
+	}
+	if d.HasChange("description") {
+		update = true
 		if v, ok := d.GetOk("description"); ok {
 			request.Description = v.(string)
 		}
+	}
+	if d.HasChange("reserved_instance_name") {
+		update = true
+		if v, ok := d.GetOk("reserved_instance_name"); ok {
+			request.ReservedInstanceName = v.(string)
+		}
+	}
+
+	if update {
 		raw, err := client.WithEcsClient(func(ecsClient *ecs.Client) (interface{}, error) {
 			return ecsClient.ModifyReservedInstanceAttribute(request)
 		})
@@ -167,6 +303,54 @@ func resourceAliCloudReservedInstanceUpdate(d *schema.ResourceData, meta interfa
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 		addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+
+		d.SetPartial("name")
+		d.SetPartial("reserved_instance_name")
+		d.SetPartial("description")
+	}
+
+	if d.HasChanges("auto_renew_period", "renewal_status") {
+		request := map[string]interface{}{
+			"ReservedInstanceId": []string{d.Id()},
+			"RegionId":           client.RegionId,
+		}
+		if v, ok := d.GetOk("auto_renew_period"); ok {
+			if formatInt(v) == 1 {
+				request["Period"] = v
+				request["PeriodUnit"] = "Month"
+			} else {
+				request["Period"] = formatInt(v) / 12
+				request["PeriodUnit"] = "Year"
+			}
+		}
+		if v, ok := d.GetOk("renewal_status"); ok {
+			request["RenewalStatus"] = v
+		}
+
+		action := "ModifyReservedInstanceAutoRenewAttribute"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
+			resp, err := conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2014-05-26"), StringPointer("AK"), nil, request, &util.RuntimeOptions{})
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, resp, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		d.SetPartial("auto_renew_period")
+		d.SetPartial("renewal_status")
+	}
+
+	stateConf := BuildStateConf([]string{}, []string{"Active"}, client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), 5*time.Second, ecsService.EcsReservedInstanceStateRefreshFunc(d, []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
 	}
 
 	return resourceAliCloudReservedInstanceRead(d, meta)
@@ -179,18 +363,50 @@ func resourceAliCloudReservedInstanceRead(d *schema.ResourceData, meta interface
 		return WrapError(err)
 	}
 	d.Set("instance_type", reservedInstances.InstanceType)
+	d.Set("allocation_status", reservedInstances.AllocationStatus)
 	d.Set("scope", reservedInstances.Scope)
 	d.Set("zone_id", reservedInstances.ZoneId)
 	d.Set("instance_amount", reservedInstances.InstanceAmount)
 	d.Set("platform", strings.Title(reservedInstances.Platform))
 	d.Set("offering_type", reservedInstances.OfferingType)
 	d.Set("name", reservedInstances.ReservedInstanceName)
+	d.Set("reserved_instance_name", reservedInstances.ReservedInstanceName)
 	d.Set("description", reservedInstances.Description)
 	d.Set("resource_group_id", reservedInstances.ReservedInstanceId)
+	d.Set("status", reservedInstances.Status)
+	d.Set("create_time", reservedInstances.CreationTime)
+	d.Set("expired_time", reservedInstances.ExpiredTime)
+	d.Set("start_time", reservedInstances.StartTime)
 
-	return WrapError(err)
+	operationLocks := make([]map[string]interface{}, 0)
+	for _, lock := range reservedInstances.OperationLocks.OperationLock {
+		operationLocks = append(operationLocks, map[string]interface{}{
+			"lock_reason": lock.LockReason,
+		})
+	}
+	d.Set("operation_locks", operationLocks)
+	tags := make(map[string]string)
+	for _, t := range reservedInstances.Tags.Tag {
+		tags[t.TagKey] = t.TagValue
+	}
+	d.Set("tags", tags)
+
+	object, err := ecsService.DescribeReservedInstanceAutoRenewAttribute(d.Id())
+	if err != nil {
+		return WrapError(err)
+	}
+	d.Set("renewal_status", object["RenewalStatus"])
+
+	if v, ok := object["Duration"]; ok && formatInt(v) != 0 {
+		renewPeriod := formatInt(v)
+		if object["PeriodUnit"] == string(Year) {
+			renewPeriod = renewPeriod * 12
+		}
+		d.Set("auto_renew_period", renewPeriod)
+	}
+
+	return nil
 }
-
 func resourceAliCloudReservedInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	// PurchaseReservedInstancesOffering can not be release.
 	return nil

--- a/alicloud/resource_alicloud_reserved_instance_test.go
+++ b/alicloud/resource_alicloud_reserved_instance_test.go
@@ -37,26 +37,34 @@ func TestAccAliCloudReservedInstanceBasic(t *testing.T) {
 			{
 
 				Config: testAccConfig(map[string]interface{}{
-					"instance_type":   "ecs.g6.large",
-					"instance_amount": "1",
-					"period_unit":     "Year",
-					"offering_type":   "All Upfront",
-					"name":            name,
-					"description":     "ReservedInstance",
-					"zone_id":         "${data.alicloud_instance_types.default.instance_types.0.availability_zones.0}",
-					"scope":           "Zone",
-					"period":          "1",
+					"instance_type":     "ecs.g6.large",
+					"instance_amount":   "1",
+					"period_unit":       "Month",
+					"offering_type":     "All Upfront",
+					"name":              name,
+					"description":       "ReservedInstance",
+					"zone_id":           "${data.alicloud_instance_types.default.instance_types.0.availability_zones.0}",
+					"scope":             "Zone",
+					"period":            "1",
+					"renewal_status":    "AutoRenewal",
+					"auto_renew_period": "36",
+					"tags":              map[string]interface{}{"Created": "TF", "Foo": "Bar"},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"instance_type":   "ecs.g6.large",
-						"instance_amount": "1",
-						"period_unit":     "Year",
-						"offering_type":   "All Upfront",
-						"name":            name,
-						"description":     "ReservedInstance",
-						"zone_id":         CHECKSET,
-						"scope":           "Zone",
+						"instance_type":     "ecs.g6.large",
+						"instance_amount":   "1",
+						"period_unit":       "Month",
+						"offering_type":     "All Upfront",
+						"name":              name,
+						"description":       "ReservedInstance",
+						"zone_id":           CHECKSET,
+						"scope":             "Zone",
+						"renewal_status":    "AutoRenewal",
+						"auto_renew_period": "36",
+						"tags.%":            "2",
+						"tags.Created":      "TF",
+						"tags.Foo":          "Bar",
 					}),
 				),
 			},
@@ -98,6 +106,66 @@ func TestAccAliCloudReservedInstanceBasic(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]interface{}{"Created": "TF1", "Foo": "Bar1"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF1",
+						"tags.Foo":     "Bar1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto_renew_period": "12",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"auto_renew_period": "12",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"renewal_status": "Normal",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"renewal_status": "Normal",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto_renew_period": "36",
+					"renewal_status":    "AutoRenewal",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"auto_renew_period": "36",
+						"renewal_status":    "AutoRenewal",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"renewal_status": "Normal",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"renewal_status": "Normal",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"period", "period_unit", "auto_renew_period"},
+			},
 		},
 	})
 }
@@ -129,27 +197,37 @@ func TestAccAliCloudReservedInstanceBasic1(t *testing.T) {
 			{
 
 				Config: testAccConfig(map[string]interface{}{
-					"instance_type":   "${data.alicloud_instance_types.default.instance_types.0.id}",
-					"instance_amount": "1",
-					"period":          "1",
-					"period_unit":     "Month",
-					"offering_type":   "All Upfront",
-					"name":            name,
-					"description":     "ReservedInstance",
-					"zone_id":         "${data.alicloud_instance_types.default.instance_types.0.availability_zones.0}",
-					"scope":           "Zone",
+					"instance_type":          "${data.alicloud_instance_types.default.instance_types.0.id}",
+					"instance_amount":        "1",
+					"period":                 "1",
+					"period_unit":            "Month",
+					"offering_type":          "All Upfront",
+					"reserved_instance_name": name,
+					"description":            "ReservedInstance",
+					"zone_id":                "${data.alicloud_instance_types.default.instance_types.0.availability_zones.0}",
+					"scope":                  "Zone",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"instance_type":   CHECKSET,
-						"instance_amount": "1",
-						"period":          "1",
-						"period_unit":     "Month",
-						"offering_type":   "All Upfront",
-						"name":            name,
-						"description":     "ReservedInstance",
-						"zone_id":         CHECKSET,
-						"scope":           "Zone",
+						"instance_type":          CHECKSET,
+						"instance_amount":        "1",
+						"period":                 "1",
+						"period_unit":            "Month",
+						"offering_type":          "All Upfront",
+						"reserved_instance_name": name,
+						"description":            "ReservedInstance",
+						"zone_id":                CHECKSET,
+						"scope":                  "Zone",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"reserved_instance_name": name + "change",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"reserved_instance_name": name + "change",
 					}),
 				),
 			},
@@ -163,7 +241,14 @@ func TestAccAliCloudReservedInstanceBasic1(t *testing.T) {
 	})
 }
 
-var testAccReservedInstanceCheckMap = map[string]string{}
+var testAccReservedInstanceCheckMap = map[string]string{
+	"allocation_status": "",
+	"create_time":       CHECKSET,
+	"expired_time":      CHECKSET,
+	"start_time":        CHECKSET,
+	"status":            CHECKSET,
+	"operation_locks.#": "0",
+}
 
 func resourceReservedInstanceBasicConfigDependence(name string) string {
 	return fmt.Sprintf(`

--- a/alicloud/service_alicloud_das.go
+++ b/alicloud/service_alicloud_das.go
@@ -2,11 +2,12 @@ package alicloud
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/PaesslerAG/jsonpath"
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"time"
 )
 
 type DasService struct {

--- a/website/docs/r/reserved_instance.html.markdown
+++ b/website/docs/r/reserved_instance.html.markdown
@@ -46,9 +46,13 @@ The following arguments are supported:
   - When `period_unit` is `Month`, Valid values: `1`.
 * `period_unit` - (Optional, ForceNew) The unit of the validity period of the reserved instance. Valid value: `Month`, `Year`. Default value: `Year`. **NOTE:** From version 1.183.0, `period_unit` can be set to `Month`.
 * `resource_group_id` - (Optional, ForceNew) Resource group ID.
-* `description` - (Optional) Description of the RI. 2 to 256 English or Chinese characters. It cannot start with http:// or https://.
-* `name` - (Optional) Name of the RI. The name must be a string of 2 to 128 characters in length and can contain letters, numbers, colons (:), underscores (_), and hyphens. It must start with a letter. It cannot start with http:// or https://.
+* `description` - (Optional) Description of the RI. 2 to 256 English or Chinese characters. It cannot start with `http://` or `https://`.
+* `name` - (Optional, Computed, Deprecated in v1.194.0+) Field `name` has been deprecated from provider version 1.194.0. New field `reserved_instance_name` instead.
 * `platform` - (Optional, ForceNew) The operating system type of the image used by the instance. Optional values: `Windows`, `Linux`. Default is `Linux`.
+* `reserved_instance_name` - (Optional, Computed, Available in v1.194.0+)  Name of the RI. The name must be a string of 2 to 128 characters in length and can contain letters, numbers, colons (:), underscores (_), and hyphens. It must start with a letter. It cannot start with http:// or https://.
+* `renewal_status` - (Optional, Computed, Available in v1.194.0+) Automatic renewal status. Valid values: `AutoRenewal`,`Normal`.
+* `auto_renew_period` - (Optional, Computed, Available in v1.194.0+) The auto-renewal term of the reserved instance. This parameter takes effect only when AutoRenew is set to true. Valid values: 1, 12, 36, and 60. Default value when `period_unit` is set to Month: 1 Default value when `period_unit` is set to Year: 12
+* `tags` - (Optional, Available in v1.194.0+) A mapping of tags to assign to the resource.
 
 ### Removing alicloud_reserved_instance from your configuration
  
@@ -59,7 +63,23 @@ The alicloud_reserved_instance resource allows you to manage your ReservedInstan
 
 The following attributes are exported:
 
-* `id` -  ID of the ReservedInstance.
+* `id` - ID of the ReservedInstance.
+* `allocation_status` - Indicates the sharing status of the reserved instance when the AllocationType parameter is set to Shared. Valid values: `allocated`: The reserved instance is allocated to another account. `beAllocated`: The reserved instance is allocated by another account.
+* `create_time` -  The time when the reserved instance was created.
+* `expired_time` -  The time when the reserved instance expires.
+* `operation_locks` -  Details about the lock status of the reserved instance.
+  * `lock_reason` - The reason why the reserved instance was locked.
+* `start_time` -  The time when the reserved instance took effect.
+* `status` -  The status of the reserved instance.
+
+#### Timeouts
+
+-> **NOTE:** Available in 1.194.0+.
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration-0-11/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 1 mins) Used when create the resource.
+* `update` - (Defaults to 1 mins) Used when update the resource.
 
 ## Import
 


### PR DESCRIPTION
resource/alicloud_reserved_instance: Support new attribute `auto_renew`, `auto_renew_period`, `tags`, `reserved_instance_name`. Supports new output `allocation_status`, `create_time`, `expired_time`, `operation_locks`, `start_time`, `status`.