### PR TITLE
resource/alicloud_cloud_firewall_vpc_firewall_cen: Field `vpc_region` add `ForceNew` setting and add constraints to the test.

### DIFF
--- a/alicloud/data_source_alicloud_cloud_firewall_vpc_firewall_cens_test.go
+++ b/alicloud/data_source_alicloud_cloud_firewall_vpc_firewall_cens_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"os"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 func TestAccAlicloudCloudFirewallVpcFirewallCenDataSource(t *testing.T) {
 	rand := acctest.RandIntRange(1000000, 9999999)
+	checkoutSupportedRegions(t, true, connectivity.CloudFirewallVpcFirewallCenSupportRegions)
 
 	idsConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudCloudFirewallVpcFirewallCenSourceConfig(rand, map[string]string{

--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_cen.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_cen.go
@@ -176,6 +176,7 @@ func resourceAlicloudCloudFirewallVpcFirewallCen() *schema.Resource {
 			},
 			"vpc_region": {
 				Required: true,
+				ForceNew: true,
 				Type:     schema.TypeString,
 			},
 		},

--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_cen_test.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_cen_test.go
@@ -19,6 +19,7 @@ func TestAccAlicloudCloudFirewallVpcFirewallCen_basic(t *testing.T) {
 	rac := resourceAttrCheckInit(rc, ra)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
+	checkoutSupportedRegions(t, true, connectivity.CloudFirewallVpcFirewallCenSupportRegions)
 	name := fmt.Sprintf("tf-testacc%scfwCen%d", defaultRegionToTest, rand)
 	nameUpdate := fmt.Sprintf("tf-testacc%scfwCenup%d", defaultRegionToTest, rand)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudFirewallVpcFirewallCenBasicDependence)


### PR DESCRIPTION
resource/alicloud_cloud_firewall_vpc_firewall_cen: Field `vpc_region` add `ForceNew` setting and add constraints to the test.