### PR TITLE
resource/alicloud_alb_rule: Fix errors when the `weight` attribute is not configured.

### DIFF
--- a/alicloud/resource_alicloud_alb_rule.go
+++ b/alicloud/resource_alicloud_alb_rule.go
@@ -77,7 +77,7 @@ func resourceAlicloudAlbRule() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"server_group_tuples": {
-										Type:     schema.TypeList,
+										Type:     schema.TypeSet,
 										Optional: true,
 										Computed: true,
 										Elem: &schema.Resource{
@@ -90,7 +90,7 @@ func resourceAlicloudAlbRule() *schema.Resource {
 												"weight": {
 													Type:         schema.TypeInt,
 													Optional:     true,
-													Computed:     true,
+													Default:      100,
 													ValidateFunc: validation.IntBetween(1, 100),
 												},
 											},
@@ -459,7 +459,7 @@ func resourceAlicloudAlbRuleCreate(d *schema.ResourceData, meta interface{}) err
 		for _, forwardGroupConfig := range ruleActionsArg["forward_group_config"].([]interface{}) {
 			forwardGroupConfigArg := forwardGroupConfig.(map[string]interface{})
 			serverGroupTuplesMaps := make([]map[string]interface{}, 0)
-			for _, serverGroupTuples := range forwardGroupConfigArg["server_group_tuples"].([]interface{}) {
+			for _, serverGroupTuples := range forwardGroupConfigArg["server_group_tuples"].(*schema.Set).List() {
 				serverGroupTuplesArg := serverGroupTuples.(map[string]interface{})
 				serverGroupTuplesMap := map[string]interface{}{}
 				serverGroupTuplesMap["ServerGroupId"] = serverGroupTuplesArg["server_group_id"]
@@ -979,7 +979,7 @@ func resourceAlicloudAlbRuleUpdate(d *schema.ResourceData, meta interface{}) err
 			for _, forwardGroupConfig := range ruleActionsArg["forward_group_config"].([]interface{}) {
 				forwardGroupConfigArg := forwardGroupConfig.(map[string]interface{})
 				serverGroupTuplesMaps := make([]map[string]interface{}, 0)
-				for _, serverGroupTuples := range forwardGroupConfigArg["server_group_tuples"].([]interface{}) {
+				for _, serverGroupTuples := range forwardGroupConfigArg["server_group_tuples"].(*schema.Set).List() {
 					serverGroupTuplesArg := serverGroupTuples.(map[string]interface{})
 					serverGroupTuplesMap := map[string]interface{}{}
 					serverGroupTuplesMap["ServerGroupId"] = serverGroupTuplesArg["server_group_id"]

--- a/website/docs/r/alb_rule.html.markdown
+++ b/website/docs/r/alb_rule.html.markdown
@@ -262,7 +262,7 @@ The forward_group_config supports the following:
 
 * `server_group_tuples` - (Optional, Array) The destination server group to which requests are forwarded.
   * `server_group_id` - (Optional) The ID of the destination server group to which requests are forwarded.
-  * `weight` - (Optional, Computed, Available in 1.162.0+) The Weight of server group. **NOTE:** This attribute is required when the number of `server_group_tuples` is greater than 2.
+  * `weight` - (Optional, Computed, Available in 1.162.0+) The Weight of server group. Default value: `100`. **NOTE:** This attribute is required when the number of `server_group_tuples` is greater than 2.
 * `server_group_sticky_session` - (Optional, Computed, Available in 1.179.0+) The configuration of session persistence for server groups.
   * `enabled` - (Optional, Computed, Available in 1.179.0+) Whether to enable session persistence.
   * `timeout` - (Optional, Computed, Available in 1.179.0+) The timeout period. Unit: seconds. Valid values: `1` to `86400`. Default value: `1000`.


### PR DESCRIPTION
resource/alicloud_alb_rule: Fix errors when the `weight` attribute is not configured.