### PR TITLE
resource/alicloud_route_entry: Adds retry for `IncorrectStatus.VpcPeer` error when creating.  doc/vswitch: Add an example of creating a cidr switch.

### DIFF
--- a/alicloud/resource_alicloud_route_entry.go
+++ b/alicloud/resource_alicloud_route_entry.go
@@ -93,7 +93,7 @@ func resourceAliyunRouteEntryCreate(d *schema.ResourceData, meta interface{}) er
 			// Route Entry does not support concurrence when creating or deleting it;
 			// Route Entry does not support creating or deleting within 5 seconds frequently
 			// It must ensure all the route entries, vpc, vswitches' status must be available before creating or deleting route entry.
-			if IsExpectedErrors(err, []string{"TaskConflict", "IncorrectRouteEntryStatus", Throttling, "IncorrectVpcStatus"}) {
+			if IsExpectedErrors(err, []string{"TaskConflict", "IncorrectRouteEntryStatus", Throttling, "IncorrectVpcStatus", "IncorrectStatus.VpcPeer"}) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/website/docs/r/vswitch.html.markdown
+++ b/website/docs/r/vswitch.html.markdown
@@ -28,6 +28,26 @@ resource "alicloud_vswitch" "vsw" {
 }
 ```
 
+Create a switch associated with the additional network segment
+
+```terraform
+resource "alicloud_vpc" "vpc" {
+  vpc_name   = "tf_test_foo"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vpc_ipv4_cidr_block" "example" {
+  vpc_id               = alicloud_vpc.default.id
+  secondary_cidr_block = "192.163.0.0/16"
+}
+
+resource "alicloud_vswitch" "vsw" {
+  vpc_id     = alicloud_vpc_ipv4_cidr_block.example.vpc_id
+  cidr_block = "192.163.0.0/24"
+  zone_id    = "cn-beijing-b"
+}
+```
+
 ## Module Support
 
 You can use to the existing [vpc module](https://registry.terraform.io/modules/alibaba/vpc/alicloud) 


### PR DESCRIPTION
resource/alicloud_route_entry: Adds retry for `IncorrectStatus.VpcPeer` error when creating.

doc/vswitch: Add an example of creating a cidr switch.