### PR TITLE
resource/alicloud_lindorm_instance: Fixes the upgrading core_single_storage does not work bug; Enlarges the update default timeout to 180 mins

### DIFF
--- a/alicloud/resource_alicloud_lindorm_instance.go
+++ b/alicloud/resource_alicloud_lindorm_instance.go
@@ -23,7 +23,7 @@ func resourceAlicloudLindormInstance() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(90 * time.Minute),
-			Update: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(180 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
@@ -660,6 +660,11 @@ func resourceAlicloudLindormInstanceUpdate(d *schema.ResourceData, meta interfac
 		update = true
 		upgradeLindormLogReq["UpgradeType"] = "upgrade-lindorm-engine"
 		upgradeLindormLogReq["LogSpec"] = d.Get("log_spec")
+	}
+	if !d.IsNewResource() && d.HasChange("core_single_storage") {
+		update = true
+		upgradeLindormLogReq["UpgradeType"] = "upgrade-disk-size"
+		upgradeLindormLogReq["CoreSingleStorage"] = d.Get("core_single_storage")
 	}
 	if update {
 		err := UpgradeLindormInstance(d, meta, upgradeLindormLogReq)

--- a/alicloud/resource_alicloud_lindorm_instance_test.go
+++ b/alicloud/resource_alicloud_lindorm_instance_test.go
@@ -772,6 +772,26 @@ func TestAccAlicloudLindormInstance_basic6(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"core_single_storage": "440",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"core_single_storage": "440",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"log_single_storage": "440",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"log_single_storage": "440",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"table_engine_node_count": "48",
 					"log_num":                 "48",
 				}),
@@ -779,6 +799,16 @@ func TestAccAlicloudLindormInstance_basic6(t *testing.T) {
 					testAccCheck(map[string]string{
 						"table_engine_node_count": "48",
 						"log_num":                 "48",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"log_spec": "lindorm.sn1.2xlarge",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"log_spec": "lindorm.sn1.2xlarge",
 					}),
 				),
 			},

--- a/website/docs/r/lindorm_instance.html.markdown
+++ b/website/docs/r/lindorm_instance.html.markdown
@@ -125,7 +125,7 @@ The following attributes are exported:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration-0-11/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 90 mins) Used when create the Instance.
-* `update` - (Defaults to 60 mins) Used when update the Instance.
+* `update` - (Defaults to 180 mins) Used when update the Instance.
 * `delete` - (Defaults to 30 mins) Used when delete the Instance.
 
 ## Import


### PR DESCRIPTION
…