### PR TITLE
resource/alicloud_nlb_server_group_server_attachment: fix test case TestAccAlicloudNLBServerGroupServerAttachment_basic0. Add retry error code `Conflict.Lock` when creating.

### DIFF
--- a/alicloud/resource_alicloud_nlb_server_group_server_attachment.go
+++ b/alicloud/resource_alicloud_nlb_server_group_server_attachment.go
@@ -111,7 +111,7 @@ func resourceAlicloudNlbServerGroupServerAttachmentCreate(d *schema.ResourceData
 	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
 		resp, err := conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2022-04-30"), StringPointer("AK"), nil, request, &runtime)
 		if err != nil {
-			if NeedRetry(err) {
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"Conflict.Lock"}) {
 				wait()
 				return resource.RetryableError(err)
 			}

--- a/alicloud/resource_alicloud_nlb_server_group_server_attachment_test.go
+++ b/alicloud/resource_alicloud_nlb_server_group_server_attachment_test.go
@@ -250,8 +250,7 @@ data "alicloud_zones" "default" {
 
 data "alicloud_instance_types" "default" {
   availability_zone = data.alicloud_zones.default.zones[0].id
-  cpu_core_count    = 1
-  memory_size       = 2
+  instance_type_family = "ecs.sn1ne"
 }
 
 data "alicloud_images" "default" {


### PR DESCRIPTION
resource/alicloud_nlb_server_group_server_attachment: fix test case TestAccAlicloudNLBServerGroupServerAttachment_basic0. Add retry error code `Conflict.Lock` when creating.