### PR TITLE
resource/alicloud_nlb_server_group_server_attachment:  Add retry error code `IncorrectStatus.serverGroup`  when deleting.

### DIFF
--- a/alicloud/resource_alicloud_nlb_server_group_server_attachment.go
+++ b/alicloud/resource_alicloud_nlb_server_group_server_attachment.go
@@ -261,7 +261,7 @@ func resourceAlicloudNlbServerGroupServerAttachmentDelete(d *schema.ResourceData
 	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutDelete)), func() *resource.RetryError {
 		resp, err := conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2022-04-30"), StringPointer("AK"), nil, request, &runtime)
 		if err != nil {
-			if NeedRetry(err) {
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"IncorrectStatus.serverGroup"}) {
 				wait()
 				return resource.RetryableError(err)
 			}


### PR DESCRIPTION
resource/alicloud_nlb_server_group_server_attachment:  Add retry error code `IncorrectStatus.serverGroup`  when deleting.