### PR TITLE
resource/alicloud_vpc_peer_connection: Fixes the ResourceNotFound.InstanceId error when destroying it

### DIFF
--- a/alicloud/resource_alicloud_vpc_peer_connection.go
+++ b/alicloud/resource_alicloud_vpc_peer_connection.go
@@ -427,6 +427,9 @@ func resourceAliCloudVpcPeerConnectionDelete(d *schema.ResourceData, meta interf
 	})
 
 	if err != nil {
+		if IsExpectedErrors(err, []string{"ResourceNotFound.InstanceId"}) {
+			return nil
+		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 


### PR DESCRIPTION
…