### PR TITLE
docs: Fix cen_transit_router_route_table_association link

### DIFF
--- a/website/docs/r/cen_transit_router_route_table_association.html.markdown
+++ b/website/docs/r/cen_transit_router_route_table_association.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 # alicloud_cen_transit_router_route_table_association
 
-Provides a CEN transit router route table association resource.[What is Cen Transit Router Route Table Association](https://www.alibabacloud.com/help/en/cloud-enterprise-network/latest/api-doc-cbn-2017-09-12-api-doc-createtransitroutetableaggregation)
+Provides a CEN transit router route table association resource.[What is Cen Transit Router Route Table Association](https://www.alibabacloud.com/help/en/cloud-enterprise-network/latest/set-association-forwarding)
 
 -> **NOTE:** Available since v1.126.0.
 


### PR DESCRIPTION
The docs link for cen_transit_router_route_table_association should point to [Associated forwarding
](https://www.alibabacloud.com/help/en/cloud-enterprise-network/latest/set-association-forwarding) page.