### PR TITLE
resource/alicloud_ots_instance: Upgrade openapi version

### DIFF
--- a/alicloud/connectivity/endpoint.go
+++ b/alicloud/connectivity/endpoint.go
@@ -158,6 +158,13 @@ func loadEndpoint(region string, serviceCode ServiceCode) string {
 	return ""
 }
 
+// irregularProductCode specially records those product codes that
+// cannot be parsed out by the location service.
+// The priority of this configuration is higher than location service, lower than user environment variable configuration
+var irregularProductCode = map[string]string{
+	"tablestore": "tablestore.%s.aliyuncs.com",
+}
+
 // NOTE: The productCode must be lower.
 func (client *AliyunClient) loadEndpoint(productCode string) error {
 	// Firstly, load endpoint from environment variables
@@ -168,11 +175,10 @@ func (client *AliyunClient) loadEndpoint(productCode string) error {
 	}
 
 	// Secondly, load endpoint from known rules
-	// Currently, this way is not pass.
-	// if _, ok := irregularProductCode[productCode]; !ok {
-	// 	client.config.Endpoints[productCode] = regularEndpoint
-	// 	return nil
-	// }
+	if endpointFmt, ok := irregularProductCode[productCode]; ok {
+		client.config.Endpoints.Store(productCode, fmt.Sprintf(endpointFmt, client.RegionId))
+		return nil
+	}
 
 	// Thirdly, load endpoint from location
 	serviceCode := serviceCodeMapping[productCode]

--- a/alicloud/resource_alicloud_ots_instance_test.go
+++ b/alicloud/resource_alicloud_ots_instance_test.go
@@ -147,7 +147,7 @@ func sweepTunnelsInTable(client *connectivity.AliyunClient, instanceName string,
 	}
 }
 
-func TestAccAlicloudOtsInstance_basic(t *testing.T) {
+func TestAccAliCloudOtsInstance_basic(t *testing.T) {
 	var v ots.InstanceInfo
 
 	resourceId := "alicloud_ots_instance.default"
@@ -255,7 +255,7 @@ func TestAccAlicloudOtsInstance_basic(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudOtsInstanceHighPerformance(t *testing.T) {
+func TestAccAliCloudOtsInstanceHighPerformance(t *testing.T) {
 	var v ots.InstanceInfo
 
 	resourceId := "alicloud_ots_instance.default"
@@ -363,7 +363,7 @@ func TestAccAlicloudOtsInstanceHighPerformance(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudOtsInstance_multi(t *testing.T) {
+func TestAccAliCloudOtsInstance_multi(t *testing.T) {
 	var v ots.InstanceInfo
 
 	resourceId := "alicloud_ots_instance.default.4"

--- a/alicloud/service_alicloud_ots.go
+++ b/alicloud/service_alicloud_ots.go
@@ -1,6 +1,8 @@
 package alicloud
 
 import (
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"regexp"
 	"strings"
 
@@ -913,4 +915,50 @@ func (s *OtsService) DeleteSearchIndex(instanceName string, tableName string, in
 		return nil
 	})
 	return err
+}
+
+// OtsRestApiPostWithRetry send POST request by CommonSDK(roa/restful) with retry.
+// This method directly passes OpenAPI parameters such as product and version, without relying on SDK version upgrades.
+// Retry policy: 3, 3+5, 3+5+5.., retry timeout: d.Timeout(schema.TimeoutCreate)
+// product is openapi product code, version is openapi version, actionPath is restful openapi backend api path, requestBody is request body content
+func OtsRestApiPostWithRetry(d *schema.ResourceData, client *connectivity.AliyunClient, product string, version string, actionPath string, requestBody map[string]*string) (map[string]interface{}, error) {
+	return invokeOtsRestApiWithRetry(d, client, product, version, actionPath, "POST", nil, nil, requestBody)
+}
+
+// OtsRestApiGetWithRetry send GET request by CommonSDK(roa/restful) with retry.
+// This method directly passes OpenAPI parameters such as product and version, without relying on SDK version upgrades.
+// Retry policy: 3, 3+5, 3+5+5.., retry timeout: d.Timeout(schema.TimeoutCreate)
+// product is openapi product code, version is openapi version, actionPath is restful openapi backend api path, urlQuery is url param
+func OtsRestApiGetWithRetry(d *schema.ResourceData, client *connectivity.AliyunClient, product string, version string, actionPath string, urlQuery map[string]*string) (map[string]interface{}, error) {
+	return invokeOtsRestApiWithRetry(d, client, product, version, actionPath, "GET", urlQuery, nil, nil)
+}
+
+func invokeOtsRestApiWithRetry(d *schema.ResourceData, client *connectivity.AliyunClient, product string, version string, actionPath string, httpMethod string, urlQuery map[string]*string, headers map[string]*string, requestBody map[string]*string) (map[string]interface{}, error) {
+	var response map[string]interface{}
+	otsClient, err := client.NewOtsRoaClient(product)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = otsClient.DoRequest(StringPointer(version), nil, StringPointer(httpMethod), StringPointer("AK"), StringPointer(actionPath), urlQuery, headers, requestBody, &util.RuntimeOptions{})
+		if err != nil {
+			if IsExpectedErrors(err, OtsTableIsTemporarilyUnavailable) ||
+				IsExpectedErrors(err, OtsTunnelIsTemporarilyUnavailable) ||
+				IsExpectedErrors(err, OtsSecondaryIndexIsTemporarilyUnavailable) ||
+				IsExpectedErrors(err, OtsSearchIndexIsTemporarilyUnavailable) ||
+				NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(actionPath, response, requestBody)
+		return nil
+	})
+
+	if err != nil {
+		return nil, WrapErrorf(err, DefaultErrorMsg, product, actionPath, AlibabaCloudSdkGoERROR)
+	}
+	return response, nil
 }

--- a/website/docs/r/ots_instance.html.markdown
+++ b/website/docs/r/ots_instance.html.markdown
@@ -47,11 +47,6 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The resource ID. The value is same as the "name".
-* `name` - The instance name.
-* `description` - The instance description.
-* `accessed_by` - TThe network limitation of accessing instance.
-* `instance_type` - The instance type.
-* `tags` - The instance tags.
 
 ## Import
 


### PR DESCRIPTION
OTS Upgrade api from 2017 to 2020(by roa tea-rpc client): `CreateInstance`, `UpdateInstance`, `DeleteInstance`.

Resource Acc
``` bash
(base) ~/GolandProjects/terraform-provider-alicloud ᐅ GODEBUG=asyncpreemptoff=1 TF_ACC=1 go test ./alicloud -v -run='TestAccAlicloudOtsInstance_basic' -timeout=100m 
=== RUN   TestAccAlicloudOtsInstance_basic
--- PASS: TestAccAlicloudOtsInstance_basic (518.50s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  530.663s

```

Data Acc
``` bash
~/GolandProjects/terraform-provider-alicloud ᐅ GODEBUG=asyncpreemptoff=1 TF_ACC=1 go test ./alicloud -v -run='TestAccAlicloudOtsInstancesDataSource' -timeout=100m
=== RUN   TestAccAlicloudOtsInstancesDataSource
--- PASS: TestAccAlicloudOtsInstancesDataSource (551.05s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  562.518s

```