### PR TITLE
resource/alicloud_ots_instance: Upgrade openapi version

### DIFF
--- a/alicloud/connectivity/endpoint.go
+++ b/alicloud/connectivity/endpoint.go
@@ -158,6 +158,13 @@ func loadEndpoint(region string, serviceCode ServiceCode) string {
 	return ""
 }
 
+// irregularProductCode specially records those product codes that
+// cannot be parsed out by the location service.
+// The priority of this configuration is higher than location service, lower than user environment variable configuration
+var irregularProductCode = map[string]string{
+	"tablestore": "tablestore.%s.aliyuncs.com",
+}
+
 // NOTE: The productCode must be lower.
 func (client *AliyunClient) loadEndpoint(productCode string) error {
 	// Firstly, load endpoint from environment variables
@@ -168,11 +175,10 @@ func (client *AliyunClient) loadEndpoint(productCode string) error {
 	}
 
 	// Secondly, load endpoint from known rules
-	// Currently, this way is not pass.
-	// if _, ok := irregularProductCode[productCode]; !ok {
-	// 	client.config.Endpoints[productCode] = regularEndpoint
-	// 	return nil
-	// }
+	if endpointFmt, ok := irregularProductCode[productCode]; ok {
+		client.config.Endpoints.Store(productCode, fmt.Sprintf(endpointFmt, client.RegionId))
+		return nil
+	}
 
 	// Thirdly, load endpoint from location
 	serviceCode := serviceCodeMapping[productCode]

--- a/alicloud/resource_alicloud_ots_instance_test.go
+++ b/alicloud/resource_alicloud_ots_instance_test.go
@@ -147,7 +147,7 @@ func sweepTunnelsInTable(client *connectivity.AliyunClient, instanceName string,
 	}
 }
 
-func TestAccAlicloudOtsInstance_basic(t *testing.T) {
+func TestAccAliCloudOtsInstance_basic(t *testing.T) {
 	var v ots.InstanceInfo
 
 	resourceId := "alicloud_ots_instance.default"
@@ -255,7 +255,7 @@ func TestAccAlicloudOtsInstance_basic(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudOtsInstanceHighPerformance(t *testing.T) {
+func TestAccAliCloudOtsInstanceHighPerformance(t *testing.T) {
 	var v ots.InstanceInfo
 
 	resourceId := "alicloud_ots_instance.default"
@@ -363,7 +363,7 @@ func TestAccAlicloudOtsInstanceHighPerformance(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudOtsInstance_multi(t *testing.T) {
+func TestAccAliCloudOtsInstance_multi(t *testing.T) {
 	var v ots.InstanceInfo
 
 	resourceId := "alicloud_ots_instance.default.4"

--- a/website/docs/r/ots_instance.html.markdown
+++ b/website/docs/r/ots_instance.html.markdown
@@ -7,10 +7,12 @@ description: |-
   Provides an OTS (Open Table Service) instance resource.
 ---
 
-# alicloud\_ots\_instance
+# alicloud_ots_instance
 
 This resource will help you to manager a [Table Store](https://www.alibabacloud.com/help/doc-detail/27280.htm) Instance.
 It is foundation of creating data table.
+
+-> **NOTE:** Available since v1.10.0.
 
 ## Example Usage
 
@@ -32,15 +34,15 @@ resource "alicloud_ots_instance" "foo" {
 The following arguments are supported:
 
 * `name` - (Required, ForceNew) The name of the instance.
-* `accessed_by` - The network limitation of accessing instance. Valid values:
+* `accessed_by` - (Optional) The network limitation of accessing instance. Valid values:
     * `Any` - Allow all network to access the instance.
     * `Vpc` - Only can the attached VPC allow to access the instance.
     * `ConsoleOrVpc` - Allow web console or the attached VPC to access the instance.
 
     Default to "Any".
-* `instance_type` - (ForceNew) The type of instance. Valid values are "Capacity" and "HighPerformance". Default to "HighPerformance".
+* `instance_type` - (Optional, ForceNew) The type of instance. Valid values are "Capacity" and "HighPerformance". Default to "HighPerformance".
 * `description` - (Optional, ForceNew) The description of the instance. Currently, it does not support modifying.
-* `tags` - A mapping of tags to assign to the instance.
+* `tags` - (Optional) A mapping of tags to assign to the instance.
 
 ## Attributes Reference
 


### PR DESCRIPTION
OTS Upgrade api from 2017 to 2020(by roa tea-rpc client): `CreateInstance`, `UpdateInstance`, `DeleteInstance`.

Resource Acc
``` bash
(base) ~/GolandProjects/terraform-provider-alicloud ᐅ GODEBUG=asyncpreemptoff=1 TF_ACC=1 go test ./alicloud -v -run='TestAccAlicloudOtsInstance_basic' -timeout=100m 
=== RUN   TestAccAlicloudOtsInstance_basic
--- PASS: TestAccAlicloudOtsInstance_basic (518.50s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  530.663s

```

Data Acc
``` bash
~/GolandProjects/terraform-provider-alicloud ᐅ GODEBUG=asyncpreemptoff=1 TF_ACC=1 go test ./alicloud -v -run='TestAccAlicloudOtsInstancesDataSource' -timeout=100m
=== RUN   TestAccAlicloudOtsInstancesDataSource
--- PASS: TestAccAlicloudOtsInstancesDataSource (551.05s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  562.518s

```