### PR TITLE
resource/alicloud_vswitch: "ipv6_cidr_block_mask/Ipv6CidrBlock" should accept zero value

### DIFF
--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -128,7 +128,7 @@ func resourceAliCloudVpcVswitchCreate(d *schema.ResourceData, meta interface{}) 
 	if v, ok := d.GetOk("zone_id"); ok {
 		request["ZoneId"] = v
 	}
-	if v, ok := d.GetOk("ipv6_cidr_block_mask"); ok {
+	if v, ok := d.GetOkExists("ipv6_cidr_block_mask"); ok {
 		request["Ipv6CidrBlock"] = v
 	}
 	wait := incrementalWait(3*time.Second, 5*time.Second)
@@ -235,7 +235,7 @@ func resourceAliCloudVpcVswitchUpdate(d *schema.ResourceData, meta interface{}) 
 		if err != nil {
 			return WrapError(err)
 		}
-		if v, ok := d.GetOk("ipv6_cidr_block_mask"); ok {
+		if v, ok := d.GetOkExists("ipv6_cidr_block_mask"); ok {
 			update = true
 			request["EnableIPv6"] = true
 			request["Ipv6CidrBlock"] = v

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -532,11 +532,11 @@ func TestAccAlicloudVPCVSwitch_basic5(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"ipv6_cidr_block_mask": "10",
+					"ipv6_cidr_block_mask": "0",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"ipv6_cidr_block_mask": "10",
+						"ipv6_cidr_block_mask": "0",
 					}),
 				),
 			},


### PR DESCRIPTION
when ipv6_cidr_block_mask is set to 0, I got this:

```
│ SDKError:
│    StatusCode: 400
│    Code: MissingParam.Ipv6CidrBlock
│    Message: code: 400, The parameter The parameter Ipv6CidrBlock is mandatory. is mandatory. request id: 34A0498F-9634-571C-929A-A0037F1D6E8B
```