### PR TITLE
resource/alicloud_ecs_key_pair: Fixes the InvalidResourceGroup.NotFound error when resource_group_id is empty

### DIFF
--- a/alicloud/resource_alicloud_ecs_key_pair.go
+++ b/alicloud/resource_alicloud_ecs_key_pair.go
@@ -195,7 +195,7 @@ func resourceAlicloudEcsKeyPairUpdate(d *schema.ResourceData, meta interface{}) 
 		"ResourceId": d.Id(),
 	}
 	request["RegionId"] = client.RegionId
-	if d.HasChange("resource_group_id") {
+	if d.HasChange("resource_group_id") && d.Get("resource_group_id").(string) != "" {
 		update = true
 		request["ResourceGroupId"] = d.Get("resource_group_id")
 	}


### PR DESCRIPTION
…