### PR TITLE
add EphemeralStorage on eci

### DIFF
--- a/alicloud/resource_alicloud_eci_container_group.go
+++ b/alicloud/resource_alicloud_eci_container_group.go
@@ -109,6 +109,10 @@ func resourceAlicloudEciContainerGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"ephemeral_storage": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"tags": tagsSchema(),
 			"containers": {
 				Type:     schema.TypeList,
@@ -1060,6 +1064,9 @@ func resourceAlicloudEciContainerGroupCreate(d *schema.ResourceData, meta interf
 
 	if v, ok := d.GetOk("insecure_registry"); ok {
 		request["InsecureRegistry"] = v
+	}
+	if v, ok := d.GetOkExists("ephemeral_storage"); ok {
+		request["EphemeralStorage"] = v
 	}
 
 	request["ClientToken"] = buildClientToken("CreateContainerGroup")

--- a/alicloud/resource_alicloud_ess_eci_scaling_configuration.go
+++ b/alicloud/resource_alicloud_ess_eci_scaling_configuration.go
@@ -577,6 +577,7 @@ func resourceAliyunEssEciScalingConfigurationCreate(d *schema.ResourceData, meta
 	request["IngressBandwidth"] = d.Get("ingress_bandwidth")
 	request["EgressBandwidth"] = d.Get("egress_bandwidth")
 	request["SpotStrategy"] = d.Get("spot_strategy")
+	request["EphemeralStorage"] = d.Get("ephemeral_storage")
 
 	if v, ok := d.GetOk("spot_price_limit"); ok {
 		request["SpotPriceLimit"] = strconv.FormatFloat(v.(float64), 'f', 2, 64)


### PR DESCRIPTION
On create ECI with volumes its required to set EphemeralStorage.

https://www.alibabacloud.com/help/en/eci/developer-reference/api-eci-2018-08-08-createcontainergroup

on this pull request I have added the missing argument.