### PR TITLE
Fix CDN domain name verify regexp for wildcard

### DIFF
--- a/alicloud/resource_alicloud_cdn_domain_new.go
+++ b/alicloud/resource_alicloud_cdn_domain_new.go
@@ -102,7 +102,8 @@ func resourceAliCloudCdnDomain() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: StringMatch(regexp.MustCompile("^([a-z0-9]([a-z0-9\\-]{0,61}[a-z0-9])?\\.)+[a-z][a-z0-9\\-]{0,62}$"), "Name of the accelerated domain. This name without suffix can have a string of 1 to 63 characters, must contain only alphanumeric characters or \"-\", and must not begin or end with \"-\", and \"-\" must not in the 3th and 4th character positions at the same time. Suffix .sh and .tel are not supported."),
+				ValidateFunc: StringMatch(regexp.MustCompile("^([a-z0-9]([a-z0-9\\-]{0,61}[a-z0-9])?\\.)?[a-z][a-z0-9\\-]{0,62}$
+				"), "Name of the accelerated domain. This name without suffix can have a string of 1 to 63 characters, must contain only alphanumeric characters or \"-\", and must not begin or end with \"-\", and \"-\" must not in the 3th and 4th character positions at the same time. Suffix .sh and .tel are not supported."),
 			},
 			"resource_group_id": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
修復 DomainNew 中的 DomainName 檢查
`.a.com` 的 wildcard domain name 會報錯的問題