### PR TITLE
resource/alicloud_cdn_domain_new: change the validation of sources/port to an integer between 1 and 65535

### DIFF
--- a/alicloud/resource_alicloud_cdn_domain_new.go
+++ b/alicloud/resource_alicloud_cdn_domain_new.go
@@ -141,7 +141,7 @@ func resourceAliCloudCdnDomain() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							Default:      80,
-							ValidateFunc: IntInSlice([]int{80, 443}),
+							ValidateFunc: IntBetween(1, 65535),
 						},
 						"weight": {
 							Type:         schema.TypeInt,


### PR DESCRIPTION
<img width="658" alt="截屏2024-01-21 15 15 34" src="https://github.com/aliyun/terraform-provider-alicloud/assets/302526/3a75a240-c4c0-48d6-9a84-3b36a852cda9">

The port of the CDN origin server can be any number from 1 to 65535, but not only 80 and 443.