### PR TITLE
Support ACR Enterprise Edition

### DIFF
--- a/alicloud/resource_alicloud_fcv2_function.go
+++ b/alicloud/resource_alicloud_fcv2_function.go
@@ -575,6 +575,7 @@ func resourceAliCloudFcv2FunctionRead(d *schema.ResourceData, meta interface{}) 
 		customContainerConfigMap["command"] = customContainerConfig1Raw["command"]
 		customContainerConfigMap["image"] = customContainerConfig1Raw["image"]
 		customContainerConfigMap["web_server_mode"] = customContainerConfig1Raw["webServerMode"]
+		customContainerConfigMap["instance_id"] = customContainerConfig1Raw["instanceID"]
 		customContainerConfigMaps = append(customContainerConfigMaps, customContainerConfigMap)
 	}
 	d.Set("custom_container_config", customContainerConfigMaps)

--- a/website/docs/r/fcv2_function.html.markdown
+++ b/website/docs/r/fcv2_function.html.markdown
@@ -347,6 +347,7 @@ The custom_container_config supports the following:
 * `args` - (Optional) Container startup parameters.
 * `command` - (Optional) Container start command, equivalent to Docker ENTRYPOINT.
 * `image` - (Optional) Container Image address. Example value: registry-vpc.cn-hangzhou.aliyuncs.com/fc-demo/helloworld:v1beta1.
+* `instance_id` - (Optional) The ID of the image repository for the Container Registry Enterprise Edition. You must specify this parameter when you use an image for Container Registry Enterprise Edition. Example value: cri-xxxxxxxxxx.
 * `web_server_mode` - (Optional) Whether the image is run in Web Server mode. The value of true needs to implement the Web Server in the container image to listen to the port and process the request. The value of false needs to actively exit the process after the container runs, and the ExitCode needs to be 0. Default true.
 
 ### `custom_dns`


### PR DESCRIPTION
ACR Enterprise Edition requires the instanceID parameter.
To make the parameter available in Enterprise Edition, we have added it.

<img width="750" alt="image" src="https://github.com/aliyun/terraform-provider-alicloud/assets/2449509/a5698a0c-6d05-4ee1-a34d-8bfd60ccb014">

ref
https://www.alibabacloud.com/help/en/fc/developer-reference/api-fc-open-2021-04-06-struct-customcontainerconfig