### PR TITLE
Don't use %#v to format error

### DIFF
--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -617,7 +617,7 @@ func ConvertIntegerToInt(value requests.Integer) (v int, err error) {
 	}
 	v, err = strconv.Atoi(string(value))
 	if err != nil {
-		return v, fmt.Errorf("Converting integer %s to int got an error: %#v.", value, err)
+		return v, fmt.Errorf("Converting integer %s to int got an error: %w", value, err)
 	}
 	return
 }
@@ -625,7 +625,7 @@ func ConvertIntegerToInt(value requests.Integer) (v int, err error) {
 func GetUserHomeDir() (string, error) {
 	usr, err := user.Current()
 	if err != nil {
-		return "", fmt.Errorf("Get current user got an error: %#v.", err)
+		return "", fmt.Errorf("Get current user got an error: %w", err)
 	}
 	return usr.HomeDir, nil
 }
@@ -641,7 +641,7 @@ func writeToFile(filePath string, data interface{}) error {
 	default:
 		bs, err := json.MarshalIndent(data, "", "\t")
 		if err != nil {
-			return fmt.Errorf("MarshalIndent data %#v got an error: %#v", data, err)
+			return fmt.Errorf("MarshalIndent data %#v got an error: %w", data, err)
 		}
 		out = string(bs)
 	}
@@ -703,7 +703,7 @@ func (a *Invoker) Run(f func() error) error {
 			catcher.RetryCount--
 
 			if catcher.RetryCount <= 0 {
-				return fmt.Errorf("Retry timeout and got an error: %#v.", err)
+				return fmt.Errorf("Retry timeout and got an error: %w", err)
 			} else {
 				time.Sleep(time.Duration(catcher.RetryWaitSeconds) * time.Second)
 				return a.Run(f)

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -1026,7 +1026,7 @@ func computePeriodByUnit(createTime, endTime interface{}, currentPeriod int, per
 	UnStandardRFC3339 := "2006-01-02T15:04Z07:00"
 	create, err := time.Parse(time.RFC3339, createTimeStr)
 	if err != nil {
-		log.Printf("Parase the CreateTime %#v failed and error is: %#v.", createTime, err)
+		log.Printf("Parase the CreateTime %#v failed and error is: %v", createTime, err)
 		create, err = time.Parse(UnStandardRFC3339, createTimeStr)
 		if err != nil {
 			return 0, WrapError(err)
@@ -1034,7 +1034,7 @@ func computePeriodByUnit(createTime, endTime interface{}, currentPeriod int, per
 	}
 	end, err := time.Parse(time.RFC3339, endTimeStr)
 	if err != nil {
-		log.Printf("Parase the EndTime %#v failed and error is: %#v.", endTime, err)
+		log.Printf("Parase the EndTime %#v failed and error is: %v", endTime, err)
 		end, err = time.Parse(UnStandardRFC3339, endTimeStr)
 		if err != nil {
 			return 0, WrapError(err)

--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -652,7 +652,7 @@ func (client *AliyunClient) WithOssClient(do func(*oss.Client) (interface{}, err
 		if endpoint == "" {
 			endpointItem, err := client.describeEndpointForService(strings.ToLower(string(OSSCode)))
 			if err != nil {
-				log.Printf("describeEndpointForService got an error: %#v.", err)
+				log.Printf("describeEndpointForService got an error: %v", err)
 			}
 			endpoint = endpointItem
 			if endpoint == "" {

--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -284,7 +284,7 @@ func (client *AliyunClient) WithEcsClient(do func(*ecs.Client) (interface{}, err
 		}
 		ecsconn, err := ecs.NewClientWithOptions(client.config.RegionId, client.getSdkConfig().WithTimeout(time.Duration(60)*time.Second), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the ECS client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the ECS client: %w", err)
 		}
 		ecs.SetClientProperty(ecsconn, "EndpointMap", map[string]string{
 			client.RegionId: endpoint,
@@ -320,7 +320,7 @@ func (client *AliyunClient) WithOfficalCSClient(do func(*officalCS.Client) (inte
 		}
 		csconn, err := officalCS.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the CS client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the CS client: %w", err)
 		}
 
 		csconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -350,7 +350,7 @@ func (client *AliyunClient) WithPolarDBClient(do func(*polardb.Client) (interfac
 
 		polarDBconn, err := polardb.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the PolarDB client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the PolarDB client: %w", err)
 
 		}
 
@@ -380,7 +380,7 @@ func (client *AliyunClient) WithSlbClient(do func(*slb.Client) (interface{}, err
 		}
 		slbconn, err := slb.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the SLB client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the SLB client: %w", err)
 		}
 
 		slbconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -409,7 +409,7 @@ func (client *AliyunClient) WithVpcClient(do func(*vpc.Client) (interface{}, err
 		}
 		vpcconn, err := vpc.NewClientWithOptions(client.config.RegionId, client.getSdkConfig().WithTimeout(time.Duration(60)*time.Second), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the VPC client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the VPC client: %w", err)
 		}
 
 		vpcconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -449,7 +449,7 @@ func (client *AliyunClient) NewEcsClient() (*rpc.Client, error) {
 
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 
 	return conn, nil
@@ -475,7 +475,7 @@ func (client *AliyunClient) NewVpcClient() (*rpc.Client, error) {
 
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 
 	return conn, nil
@@ -502,7 +502,7 @@ func (client *AliyunClient) NewRdsClient() (*rpc.Client, error) {
 
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 
 	return conn, nil
@@ -528,7 +528,7 @@ func (client *AliyunClient) NewPolarDBClient() (*rpc.Client, error) {
 
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 
 	return conn, nil
@@ -546,7 +546,7 @@ func (client *AliyunClient) WithCenClient(do func(*cbn.Client) (interface{}, err
 		}
 		cenconn, err := cbn.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the CEN client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the CEN client: %w", err)
 		}
 
 		cenconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -575,7 +575,7 @@ func (client *AliyunClient) WithEssClient(do func(*ess.Client) (interface{}, err
 		}
 		essconn, err := ess.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the ESS client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the ESS client: %w", err)
 		}
 
 		essconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -696,7 +696,7 @@ func (client *AliyunClient) WithOssClient(do func(*oss.Client) (interface{}, err
 
 		ossconn, err := oss.New(endpoint, "", "", clientOptions...)
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the OSS client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the OSS client: %w", err)
 		}
 
 		client.ossconn = ossconn
@@ -709,7 +709,7 @@ func (client *AliyunClient) WithOssBucketByName(bucketName string, do func(*oss.
 	return client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
 		bucket, err := client.ossconn.Bucket(bucketName)
 		if err != nil {
-			return nil, fmt.Errorf("unable to get the bucket %s: %#v", bucketName, err)
+			return nil, fmt.Errorf("unable to get the bucket %s: %w", bucketName, err)
 		}
 		return do(bucket)
 	})
@@ -728,7 +728,7 @@ func (client *AliyunClient) WithDnsClient(do func(*alidns.Client) (interface{}, 
 
 		dnsconn, err := alidns.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the DNS client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the DNS client: %w", err)
 		}
 		dnsconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		dnsconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -760,7 +760,7 @@ func (client *AliyunClient) WithRamClient(do func(*ram.Client) (interface{}, err
 
 		ramconn, err := ram.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the RAM client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the RAM client: %w", err)
 		}
 		ramconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		ramconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -846,7 +846,7 @@ func (client *AliyunClient) WithCrClient(do func(*cr.Client) (interface{}, error
 		}
 		crconn, err := cr.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the CR client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the CR client: %w", err)
 		}
 		crconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		crconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -877,7 +877,7 @@ func (client *AliyunClient) WithCrEEClient(do func(*cr_ee.Client) (interface{}, 
 		}
 		creeconn, err := cr_ee.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the CR EE client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the CR EE client: %w", err)
 		}
 		creeconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		creeconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -927,7 +927,7 @@ func (client *AliyunClient) WithCdnClient_new(do func(*cdn_new.Client) (interfac
 		}
 		cdnconn, err := cdn_new.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the CDN client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the CDN client: %w", err)
 		}
 		cdnconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		cdnconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -956,7 +956,7 @@ func (client *AliyunClient) WithOtsClient(do func(*ots.Client) (interface{}, err
 		}
 		otsconn, err := ots.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the OTS client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the OTS client: %w", err)
 		}
 
 		otsconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -996,7 +996,7 @@ func (client *AliyunClient) NewOtsRoaClient(productCode string) (*roa.Client, er
 
 	conn, err := roa.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 
 	return conn, nil
@@ -1024,7 +1024,7 @@ func (client *AliyunClient) WithCmsClient(do func(*cms.Client) (interface{}, err
 		}
 		cmsconn, err := cms.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the CMS client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the CMS client: %w", err)
 		}
 
 		cmsconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -1053,7 +1053,7 @@ func (client *AliyunClient) WithStsClient(do func(*sts.Client) (interface{}, err
 		}
 		stsconn, err := sts.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the STS client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the STS client: %w", err)
 		}
 
 		stsconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -1075,7 +1075,7 @@ func (client *AliyunClient) WithLogPopClient(do func(*slsPop.Client) (interface{
 	if client.logpopconn == nil {
 		logpopconn, err := slsPop.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the sls client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the sls client: %w", err)
 		}
 		logpopconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		logpopconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1142,7 +1142,7 @@ func (client *AliyunClient) WithDrdsClient(do func(*drds.Client) (interface{}, e
 
 		drdsconn, err := drds.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the DRDS client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the DRDS client: %w", err)
 
 		}
 		drdsconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -1171,7 +1171,7 @@ func (client *AliyunClient) WithDdsClient(do func(*dds.Client) (interface{}, err
 		}
 		ddsconn, err := dds.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the DDS client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the DDS client: %w", err)
 		}
 
 		ddsconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -1200,7 +1200,7 @@ func (client *AliyunClient) WithGpdbClient(do func(*gpdb.Client) (interface{}, e
 		}
 		gpdbconn, err := gpdb.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the GPDB client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the GPDB client: %w", err)
 		}
 		gpdbconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		gpdbconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1236,7 +1236,7 @@ func (client *AliyunClient) NewGpdbClient() (*rpc.Client, error) {
 
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 
 	return conn, nil
@@ -1272,7 +1272,7 @@ func (client *AliyunClient) WithFcClient(do func(*fc.Client) (interface{}, error
 
 		fcconn, err := fc.NewClient(fmt.Sprintf("https://%s.%s", accountId, endpoint), string(ApiVersion20160815), client.config.AccessKey, client.config.SecretKey, clientOptions...)
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the FC client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the FC client: %w", err)
 		}
 
 		fcconn.Config.UserAgent = client.getUserAgent()
@@ -1295,7 +1295,7 @@ func (client *AliyunClient) WithCloudApiClient(do func(*cloudapi.Client) (interf
 		}
 		cloudapiconn, err := cloudapi.NewClientWithOptions(client.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the CloudAPI client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the CloudAPI client: %w", err)
 		}
 		cloudapiconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		cloudapiconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1317,7 +1317,7 @@ func (client *AliyunClient) NewTeaCommonClient(endpoint string) (*rpc.Client, er
 
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the tea client: %#v", err)
+		return nil, fmt.Errorf("unable to initialize the tea client: %w", err)
 	}
 
 	return conn, nil
@@ -1328,7 +1328,7 @@ func (client *AliyunClient) NewTeaRoaCommonClient(endpoint string) (*roa.Client,
 
 	conn, err := roa.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the tea roa client: %#v", err)
+		return nil, fmt.Errorf("unable to initialize the tea roa client: %w", err)
 	}
 
 	return conn, nil
@@ -1418,7 +1418,7 @@ func (client *AliyunClient) WithElasticsearchClient(do func(*elasticsearch.Clien
 		}
 		elasticsearchconn, err := elasticsearch.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the Elasticsearch client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the Elasticsearch client: %w", err)
 		}
 		elasticsearchconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		elasticsearchconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1454,7 +1454,7 @@ func (client *AliyunClient) NewElasticsearchClient() (*roa.Client, error) {
 
 	conn, err := roa.NewClient(&roaSdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, err
 }
@@ -1541,7 +1541,7 @@ func (client *AliyunClient) WithCsProjectClient(clusterId, endpoint string, clus
 		var err error
 		csProjectClient, err = cs.NewProjectClient(clusterId, endpoint, clusterCerts)
 		if err != nil {
-			return nil, fmt.Errorf("Getting Application Client failed by cluster id %s: %#v.", clusterCerts, err)
+			return nil, fmt.Errorf("Getting Application Client failed by cluster id %s: %w", clusterCerts, err)
 		}
 		csProjectClient.SetDebug(false)
 		csProjectClient.SetUserAgent(client.getUserAgent())
@@ -1679,7 +1679,7 @@ func (client *AliyunClient) GetCallerIdentity() (*sts.GetCallerIdentityResponse,
 	}
 	stsClient, err := sts.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the STS client: %#v", err)
+		return nil, fmt.Errorf("unable to initialize the STS client: %w", err)
 	}
 
 	stsClient.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -1714,7 +1714,7 @@ func (client *AliyunClient) WithDdoscooClient(do func(*ddoscoo.Client) (interfac
 
 		ddoscooconn, err := ddoscoo.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the DDOSCOO client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the DDOSCOO client: %w", err)
 		}
 		ddoscooconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		ddoscooconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1744,7 +1744,7 @@ func (client *AliyunClient) WithDdosbgpClient(do func(*ddosbgp.Client) (interfac
 
 		ddosbgpconn, err := ddosbgp.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the DDOSBGP client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the DDOSBGP client: %w", err)
 		}
 		ddosbgpconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		ddosbgpconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1775,7 +1775,7 @@ func (client *AliyunClient) WithBssopenapiClient(do func(*bssopenapi.Client) (in
 		// Domestic account is business.aliyuncs.com (region is cn-hangzhou) and International account is business.ap-southeast-1.aliyuncs.com (region is ap-southeast-1)
 		bssopenapiconn, err := bssopenapi.NewClientWithOptions(string(Hangzhou), client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the BSSOPENAPI client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the BSSOPENAPI client: %w", err)
 		}
 		bssopenapiconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		bssopenapiconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1811,7 +1811,7 @@ func (client *AliyunClient) WithAlikafkaClient(do func(*alikafka.Client) (interf
 		}
 		alikafkaconn, err := alikafka.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the ALIKAFKA client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the ALIKAFKA client: %w", err)
 		}
 		alikafkaconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		alikafkaconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1838,7 +1838,7 @@ func (client *AliyunClient) WithEmrClient(do func(*emr.Client) (interface{}, err
 		}
 		emrConn, err := emr.NewClientWithOptions(client.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the E-MapReduce client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the E-MapReduce client: %w", err)
 		}
 		emrConn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		emrConn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1866,7 +1866,7 @@ func (client *AliyunClient) WithSagClient(do func(*smartag.Client) (interface{},
 		}
 		sagconn, err := smartag.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the SAG client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the SAG client: %w", err)
 		}
 		sagconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		sagconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1887,7 +1887,7 @@ func (client *AliyunClient) WithDbauditClient(do func(*yundun_dbaudit.Client) (i
 	if client.dbauditconn == nil {
 		dbauditconn, err := yundun_dbaudit.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the DBAUDIT client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the DBAUDIT client: %w", err)
 		}
 		dbauditconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		dbauditconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1907,7 +1907,7 @@ func (client *AliyunClient) WithBastionhostClient(do func(*yundun_bastionhost.Cl
 	if client.bastionhostconn == nil {
 		bastionhostconn, err := yundun_bastionhost.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the BASTIONHOST client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the BASTIONHOST client: %w", err)
 		}
 		bastionhostconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		bastionhostconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1935,7 +1935,7 @@ func (client *AliyunClient) WithMarketClient(do func(*market.Client) (interface{
 		}
 		marketconn, err := market.NewClientWithOptions(client.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the Market client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the Market client: %w", err)
 		}
 		marketconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		marketconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -1963,7 +1963,7 @@ func (client *AliyunClient) WithHbaseClient(do func(*hbase.Client) (interface{},
 		}
 		hbaseconn, err := hbase.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the hbase client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the hbase client: %w", err)
 		}
 		hbaseconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		hbaseconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -2002,7 +2002,7 @@ func (client *AliyunClient) NewAdbClient() (*rpc.Client, error) {
 
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 
 	return conn, nil
@@ -2021,7 +2021,7 @@ func (client *AliyunClient) WithAdbClient(do func(*adb.Client) (interface{}, err
 
 		adbconn, err := adb.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the adb client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the adb client: %w", err)
 
 		}
 		adbconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
@@ -2056,7 +2056,7 @@ func (client *AliyunClient) NewCbnClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2080,7 +2080,7 @@ func (client *AliyunClient) WithCbnClient(do func(*cbn.Client) (interface{}, err
 
 		cbnConn, err := cbn.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the Cbnclient: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the Cbnclient: %w", err)
 		}
 		cbnConn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		cbnConn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -2107,7 +2107,7 @@ func (client *AliyunClient) WithEdasClient(do func(*edas.Client) (interface{}, e
 		}
 		edasconn, err := edas.NewClientWithOptions(client.config.RegionId, client.getSdkConfig().WithTimeout(time.Duration(60)*time.Second), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the ALIKAFKA client: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the ALIKAFKA client: %w", err)
 		}
 		edasconn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		edasconn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -2138,7 +2138,7 @@ func (client *AliyunClient) WithAlidnsClient(do func(*alidns.Client) (interface{
 
 		alidnsConn, err := alidns.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the Alidnsclient: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the Alidnsclient: %w", err)
 		}
 		alidnsConn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		alidnsConn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -2162,7 +2162,7 @@ func (client *AliyunClient) WithCassandraClient(do func(*cassandra.Client) (inte
 		}
 		cassandraConn, err := cassandra.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the Cassandraclient: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the Cassandraclient: %w", err)
 		}
 		cassandraConn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		cassandraConn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -2192,7 +2192,7 @@ func (client *AliyunClient) WithEciClient(do func(*eci.Client) (interface{}, err
 
 		eciConn, err := eci.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the Eciclient: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the Eciclient: %w", err)
 		}
 		eciConn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		eciConn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -2222,7 +2222,7 @@ func (client *AliyunClient) WithDcdnClient(do func(*dcdn.Client) (interface{}, e
 
 		dcdnConn, err := dcdn.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the Dcdnclient: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the Dcdnclient: %w", err)
 		}
 		dcdnConn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		dcdnConn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -2265,7 +2265,7 @@ func (client *AliyunClient) WithRKvstoreClient(do func(*r_kvstore.Client) (inter
 
 		r_kvstoreConn, err := r_kvstore.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize the RKvstoreclient: %#v", err)
+			return nil, fmt.Errorf("unable to initialize the RKvstoreclient: %w", err)
 		}
 		r_kvstoreConn.SetReadTimeout(time.Duration(client.config.ClientReadTimeout) * time.Millisecond)
 		r_kvstoreConn.SetConnectTimeout(time.Duration(client.config.ClientConnectTimeout) * time.Millisecond)
@@ -2298,7 +2298,7 @@ func (client *AliyunClient) NewOnsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2321,7 +2321,7 @@ func (client *AliyunClient) NewCmsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2346,7 +2346,7 @@ func (client *AliyunClient) NewConfigClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2369,7 +2369,7 @@ func (client *AliyunClient) NewWafClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2382,7 +2382,7 @@ func (client *AliyunClient) NewBssopenapiClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2405,7 +2405,7 @@ func (client *AliyunClient) NewFnfClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2428,7 +2428,7 @@ func (client *AliyunClient) NewRosClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2453,7 +2453,7 @@ func (client *AliyunClient) NewPvtzClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2476,7 +2476,7 @@ func (client *AliyunClient) NewPrivatelinkClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2501,7 +2501,7 @@ func (client *AliyunClient) NewDcdnClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2524,7 +2524,7 @@ func (client *AliyunClient) NewOdpsClient() (*roa.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := roa.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2547,7 +2547,7 @@ func (client *AliyunClient) NewRessharingClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2572,7 +2572,7 @@ func (client *AliyunClient) NewGaplusClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2595,7 +2595,7 @@ func (client *AliyunClient) NewEciClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2618,7 +2618,7 @@ func (client *AliyunClient) NewActiontrailClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2641,7 +2641,7 @@ func (client *AliyunClient) NewMseClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2664,7 +2664,7 @@ func (client *AliyunClient) NewHitsdbClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2689,7 +2689,7 @@ func (client *AliyunClient) NewAistudioClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2714,7 +2714,7 @@ func (client *AliyunClient) NewEipanycastClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2737,7 +2737,7 @@ func (client *AliyunClient) NewOosClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2762,7 +2762,7 @@ func (client *AliyunClient) NewImsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2788,7 +2788,7 @@ func (client *AliyunClient) NewRamClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2814,7 +2814,7 @@ func (client *AliyunClient) NewResourcemanagerClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2839,7 +2839,7 @@ func (client *AliyunClient) NewQuotasClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2864,7 +2864,7 @@ func (client *AliyunClient) NewQuotasClientV2() (*openapi.Client, error) {
 	openapiConfig.Endpoint = tea.String(endpoint)
 	result, err := openapi.NewClient(&openapiConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return result, nil
 }
@@ -2887,7 +2887,7 @@ func (client *AliyunClient) NewNasClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2912,7 +2912,7 @@ func (client *AliyunClient) NewDmsenterpriseClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2935,7 +2935,7 @@ func (client *AliyunClient) NewHcsSgwClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2958,7 +2958,7 @@ func (client *AliyunClient) NewAdsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -2981,7 +2981,7 @@ func (client *AliyunClient) NewDdoscooClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3004,7 +3004,7 @@ func (client *AliyunClient) NewSlbClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3029,7 +3029,7 @@ func (client *AliyunClient) NewKmsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3054,7 +3054,7 @@ func (client *AliyunClient) NewAlidnsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3077,7 +3077,7 @@ func (client *AliyunClient) NewHbaseClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3100,7 +3100,7 @@ func (client *AliyunClient) NewDmClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3123,7 +3123,7 @@ func (client *AliyunClient) NewEventbridgeClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3146,7 +3146,7 @@ func (client *AliyunClient) NewOnsproxyClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3171,7 +3171,7 @@ func (client *AliyunClient) NewCdsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3196,7 +3196,7 @@ func (client *AliyunClient) NewHbrClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3224,7 +3224,7 @@ func (client *AliyunClient) NewCasClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3249,7 +3249,7 @@ func (client *AliyunClient) NewArmsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3274,7 +3274,7 @@ func (client *AliyunClient) NewCloudfwClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3299,7 +3299,7 @@ func (client *AliyunClient) NewServerlessClient() (*roa.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := roa.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3322,7 +3322,7 @@ func (client *AliyunClient) NewAlbClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3347,7 +3347,7 @@ func (client *AliyunClient) NewRedisaClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3372,7 +3372,7 @@ func (client *AliyunClient) NewGwsecdClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3397,7 +3397,7 @@ func (client *AliyunClient) NewCloudphoneClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3422,7 +3422,7 @@ func (client *AliyunClient) NewScdnClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3447,7 +3447,7 @@ func (client *AliyunClient) NewDataworkspublicClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3473,7 +3473,7 @@ func (client *AliyunClient) NewCdnClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3498,7 +3498,7 @@ func (client *AliyunClient) NewCddcClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3523,7 +3523,7 @@ func (client *AliyunClient) NewMscopensubscriptionClient() (*rpc.Client, error) 
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3547,7 +3547,7 @@ func (client *AliyunClient) NewSddpClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3572,7 +3572,7 @@ func (client *AliyunClient) NewBastionhostClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3597,7 +3597,7 @@ func (client *AliyunClient) NewSasClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3622,7 +3622,7 @@ func (client *AliyunClient) NewAlidfsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3647,7 +3647,7 @@ func (client *AliyunClient) NewEhpcClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3672,7 +3672,7 @@ func (client *AliyunClient) NewEnsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3697,7 +3697,7 @@ func (client *AliyunClient) NewIotClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3722,7 +3722,7 @@ func (client *AliyunClient) NewImmClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3747,7 +3747,7 @@ func (client *AliyunClient) NewClickhouseClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3772,7 +3772,7 @@ func (client *AliyunClient) NewDtsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3797,7 +3797,7 @@ func (client *AliyunClient) NewDgClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3822,7 +3822,7 @@ func (client *AliyunClient) NewCloudssoClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3847,7 +3847,7 @@ func (client *AliyunClient) NewSwasClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3872,7 +3872,7 @@ func (client *AliyunClient) NewVsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3897,7 +3897,7 @@ func (client *AliyunClient) NewQuickbiClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3922,7 +3922,7 @@ func (client *AliyunClient) NewDevopsrdcClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3947,7 +3947,7 @@ func (client *AliyunClient) NewVodClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3972,7 +3972,7 @@ func (client *AliyunClient) NewOpensearchClient() (*roa.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := roa.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -3997,7 +3997,7 @@ func (client *AliyunClient) NewGdsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4022,7 +4022,7 @@ func (client *AliyunClient) NewDbfsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4047,7 +4047,7 @@ func (client *AliyunClient) NewEaisClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4072,7 +4072,7 @@ func (client *AliyunClient) NewCloudauthClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4097,7 +4097,7 @@ func (client *AliyunClient) NewImpClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4120,7 +4120,7 @@ func (client *AliyunClient) NewMhubClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4144,7 +4144,7 @@ func (client *AliyunClient) NewServicemeshClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4169,7 +4169,7 @@ func (client *AliyunClient) NewAcrClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4194,7 +4194,7 @@ func (client *AliyunClient) NewEdsuserClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4219,7 +4219,7 @@ func (client *AliyunClient) NewEmrClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4244,7 +4244,7 @@ func (client *AliyunClient) NewDdsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4269,7 +4269,7 @@ func (client *AliyunClient) NewAlikafkaClient() (*rpc.Client, error) {
 
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 
 	return conn, nil
@@ -4295,7 +4295,7 @@ func (client *AliyunClient) NewEssClient() (*rpc.Client, error) {
 
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 
 	return conn, nil
@@ -4322,7 +4322,7 @@ func (client *AliyunClient) NewDdosbasicClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4347,7 +4347,7 @@ func (client *AliyunClient) NewSmartagClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4372,7 +4372,7 @@ func (client *AliyunClient) NewTagClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4397,7 +4397,7 @@ func (client *AliyunClient) NewEdasClient() (*roa.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := roa.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4423,7 +4423,7 @@ func (client *AliyunClient) NewEdasschedulerxClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4448,7 +4448,7 @@ func (client *AliyunClient) NewEhsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4473,7 +4473,7 @@ func (client *AliyunClient) NewDysmsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4504,7 +4504,7 @@ func (client *AliyunClient) NewFcClient() (*roa.Client, error) {
 	sdkConfig.SetEndpoint(fmt.Sprintf("%s.%s", accountId, endpoint))
 	conn, err := roa.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4529,7 +4529,7 @@ func (client *AliyunClient) NewDdosbgpClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4555,7 +4555,7 @@ func (client *AliyunClient) NewApigatewayClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4580,7 +4580,7 @@ func (client *AliyunClient) NewVpcpeerClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4605,7 +4605,7 @@ func (client *AliyunClient) NewCbsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4630,7 +4630,7 @@ func (client *AliyunClient) NewNlbClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4655,7 +4655,7 @@ func (client *AliyunClient) NewEbsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4680,7 +4680,7 @@ func (client *AliyunClient) NewMnsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4705,7 +4705,7 @@ func (client *AliyunClient) NewBpstudioClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4732,7 +4732,7 @@ func (client *AliyunClient) NewDasClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4758,7 +4758,7 @@ func (client *AliyunClient) NewCloudfirewallClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4784,7 +4784,7 @@ func (client *AliyunClient) NewThreatdetectionClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4810,7 +4810,7 @@ func (client *AliyunClient) NewSrvcatalogClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4836,7 +4836,7 @@ func (client *AliyunClient) NewVpcPeerClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4862,7 +4862,7 @@ func (client *AliyunClient) NewEfloClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4887,7 +4887,7 @@ func (client *AliyunClient) NewOceanbaseClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4913,7 +4913,7 @@ func (client *AliyunClient) NewBeebotClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4941,7 +4941,7 @@ func (client *AliyunClient) NewComputenestClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 
 	return conn, nil
@@ -4966,7 +4966,7 @@ func (client *AliyunClient) NewRedisClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -4990,7 +4990,7 @@ func (client *AliyunClient) NewEipClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5014,7 +5014,7 @@ func (client *AliyunClient) NewCbwpClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5045,7 +5045,7 @@ func (client *AliyunClient) NewFcv2Client() (*roa.Client, error) {
 	sdkConfig.SetEndpoint(fmt.Sprintf("%s.%s", accountId, endpoint))
 	conn, err := roa.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5069,7 +5069,7 @@ func (client *AliyunClient) NewDrdsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5093,7 +5093,7 @@ func (client *AliyunClient) NewAckoneClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5147,7 +5147,7 @@ func (client *AliyunClient) NewRocketmqClient() (*roa.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := roa.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5171,7 +5171,7 @@ func (client *AliyunClient) NewResourceCenterClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5195,7 +5195,7 @@ func (client *AliyunClient) NewHologramClient() (*roa.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := roa.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5219,7 +5219,7 @@ func (client *AliyunClient) NewRealtimecomputeClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5243,7 +5243,7 @@ func (client *AliyunClient) NewVpngatewayClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5268,7 +5268,7 @@ func (client *AliyunClient) NewAckClient() (*roa.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := roa.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5328,7 +5328,7 @@ func (client *AliyunClient) NewExpressconnectClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5350,7 +5350,7 @@ func (client *AliyunClient) NewCloudmonitorserviceClient() (*rpc.Client, error) 
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5374,7 +5374,7 @@ func (client *AliyunClient) NewWafv3Client() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5398,7 +5398,7 @@ func (client *AliyunClient) NewDfsClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }
@@ -5422,7 +5422,7 @@ func (client *AliyunClient) NewAmqpClient() (*rpc.Client, error) {
 	sdkConfig.SetEndpoint(endpoint)
 	conn, err := rpc.NewClient(&sdkConfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to initialize the %s client: %#v", productCode, err)
+		return nil, fmt.Errorf("unable to initialize the %s client: %w", productCode, err)
 	}
 	return conn, nil
 }

--- a/alicloud/connectivity/endpoint.go
+++ b/alicloud/connectivity/endpoint.go
@@ -244,7 +244,7 @@ func (client *AliyunClient) describeEndpointForService(serviceCode string) (stri
 
 	locationClient, err := location.NewClientWithOptions(client.config.RegionId, client.getSdkConfig(), client.config.getAuthCredential(true))
 	if err != nil {
-		return "", fmt.Errorf("Unable to initialize the location client: %#v", err)
+		return "", fmt.Errorf("Unable to initialize the location client: %w", err)
 
 	}
 	defer locationClient.Shutdown()
@@ -276,7 +276,7 @@ func (client *AliyunClient) describeEndpointForService(serviceCode string) (stri
 		return nil
 	})
 	if err != nil {
-		return "", fmt.Errorf("Describe %s endpoint using region: %#v got an error: %#v.", serviceCode, client.RegionId, err)
+		return "", fmt.Errorf("Describe %s endpoint using region: %#v got an error: %w", serviceCode, client.RegionId, err)
 	}
 	if endpointResult == "" {
 		return "", fmt.Errorf("There is no any available endpoint for %s in region %s.", serviceCode, client.RegionId)

--- a/alicloud/data_source_alicloud_zones.go
+++ b/alicloud/data_source_alicloud_zones.go
@@ -371,7 +371,7 @@ func dataSourceAlicloudZonesRead(d *schema.ResourceData, meta interface{}) error
 			return fcClient.GetAccountSettings(fc.NewGetAccountSettingsInput())
 		})
 		if err != nil {
-			return fmt.Errorf("[API ERROR] FC GetAccountSettings: %#v", err)
+			return fmt.Errorf("[API ERROR] FC GetAccountSettings: %w", err)
 		}
 		addDebug("GetAccountSettings", raw, clientInfo)
 		out, _ := raw.(*fc.GetAccountSettingsOutput)
@@ -426,7 +426,7 @@ func dataSourceAlicloudZonesRead(d *schema.ResourceData, meta interface{}) error
 		return ecsClient.DescribeZones(req)
 	})
 	if err != nil {
-		return fmt.Errorf("DescribeZones got an error: %#v", err)
+		return fmt.Errorf("DescribeZones got an error: %w", err)
 	}
 	addDebug(req.GetActionName(), raw, req.RpcRequest, req)
 	resp, _ := raw.(*ecs.DescribeZonesResponse)

--- a/alicloud/data_source_alicloud_zones_test.go
+++ b/alicloud/data_source_alicloud_zones_test.go
@@ -193,7 +193,7 @@ func testCheckZoneLength(name string) resource.TestCheckFunc {
 		i, err := strconv.Atoi(is.Attributes["zones.#"])
 
 		if err != nil {
-			return fmt.Errorf("convert zone length err: %#v", err)
+			return fmt.Errorf("convert zone length err: %w", err)
 		}
 
 		if i <= 0 {

--- a/alicloud/resource_alicloud_actiontrail_history_delivery_job_test.go
+++ b/alicloud/resource_alicloud_actiontrail_history_delivery_job_test.go
@@ -51,7 +51,7 @@ func testSweepActionTrailHistoryDeliveryJob(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewActiontrailClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -70,7 +70,7 @@ func testSweepActionTrailHistoryDeliveryJob(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_adb_db_cluster_test.go
+++ b/alicloud/resource_alicloud_adb_db_cluster_test.go
@@ -96,7 +96,7 @@ func testSweepAdbDbInstances(region string) error {
 					}
 					return resource.NonRetryableError(err)
 				}
-				log.Printf("[ERROR] Deleting ADB cluster failed with error: %#v", err)
+				log.Printf("[ERROR] Deleting ADB cluster failed with error: %v", err)
 				return nil
 			})
 		}

--- a/alicloud/resource_alicloud_alb_acl_test.go
+++ b/alicloud/resource_alicloud_alb_acl_test.go
@@ -42,7 +42,7 @@ func testSweepAlbAcl(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewAlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -61,7 +61,7 @@ func testSweepAlbAcl(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_alb_health_check_template_test.go
+++ b/alicloud/resource_alicloud_alb_health_check_template_test.go
@@ -51,7 +51,7 @@ func testSweepAlbHealthCheckTemplate(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewAlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 
 	for {
@@ -71,7 +71,7 @@ func testSweepAlbHealthCheckTemplate(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_alb_listener_test.go
+++ b/alicloud/resource_alicloud_alb_listener_test.go
@@ -41,7 +41,7 @@ func testSweepAlbListener(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewAlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -60,7 +60,7 @@ func testSweepAlbListener(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_alb_load_balancer_test.go
+++ b/alicloud/resource_alicloud_alb_load_balancer_test.go
@@ -41,7 +41,7 @@ func testSweepAlbLoadBalancer(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewAlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	runtime := util.RuntimeOptions{}
 	runtime.SetAutoretry(true)
@@ -59,7 +59,7 @@ func testSweepAlbLoadBalancer(region string) error {
 	})
 	addDebug(action, response, request)
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 

--- a/alicloud/resource_alicloud_alb_rule_test.go
+++ b/alicloud/resource_alicloud_alb_rule_test.go
@@ -41,7 +41,7 @@ func testSweepAlbRule(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewAlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 
@@ -62,7 +62,7 @@ func testSweepAlbRule(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_alb_security_policy_test.go
+++ b/alicloud/resource_alicloud_alb_security_policy_test.go
@@ -52,7 +52,7 @@ func testSweepAlbSecurityPolicy(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewAlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -71,7 +71,7 @@ func testSweepAlbSecurityPolicy(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_alb_server_group_test.go
+++ b/alicloud/resource_alicloud_alb_server_group_test.go
@@ -42,7 +42,7 @@ func testSweepAlbServerGroup(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewAlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -61,7 +61,7 @@ func testSweepAlbServerGroup(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_alidns_domain_group_test.go
+++ b/alicloud/resource_alicloud_alidns_domain_group_test.go
@@ -40,7 +40,7 @@ func testSweepAlidnsDomainGroup(region string) error {
 			return dnsClient.DescribeDomainGroups(request)
 		})
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", request.GetActionName(), err)
+			log.Printf("[ERROR] %s get an error: %v", request.GetActionName(), err)
 		}
 		addDebug(request.GetActionName(), raw)
 		response, _ := raw.(*alidns.DescribeDomainGroupsResponse)
@@ -70,7 +70,7 @@ func testSweepAlidnsDomainGroup(region string) error {
 			return dnsClient.DeleteDomainGroup(removeRequest)
 		})
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", request.GetActionName(), err)
+			log.Printf("[ERROR] %s get an error: %v", request.GetActionName(), err)
 		}
 		addDebug(request.GetActionName(), raw)
 	}

--- a/alicloud/resource_alicloud_alidns_domain_test.go
+++ b/alicloud/resource_alicloud_alidns_domain_test.go
@@ -41,7 +41,7 @@ func testSweepAlidnsDomain(region string) error {
 			return dnsClient.DescribeDomains(queryRequest)
 		})
 		if err != nil {
-			log.Printf("[ERROR] %s get an error %#v", queryRequest.GetActionName(), err)
+			log.Printf("[ERROR] %s get an error %v", queryRequest.GetActionName(), err)
 		}
 		addDebug(queryRequest.GetActionName(), raw)
 		response, _ := raw.(*alidns.DescribeDomainsResponse)

--- a/alicloud/resource_alicloud_api_gateway_api_test.go
+++ b/alicloud/resource_alicloud_api_gateway_api_test.go
@@ -42,7 +42,7 @@ func testSweepApiGatewayApi(region string) error {
 		return cloudApiClient.DescribeApis(req)
 	})
 	if err != nil {
-		log.Printf("[ERROR] %s got an error %#v", req.GetActionName(), err)
+		log.Printf("[ERROR] %s got an error %v", req.GetActionName(), err)
 		return nil
 	}
 	apis := raw.(*cloudapi.DescribeApisResponse)

--- a/alicloud/resource_alicloud_api_gateway_plugin_test.go
+++ b/alicloud/resource_alicloud_api_gateway_plugin_test.go
@@ -55,7 +55,7 @@ func testSweepApiGatewayPlugin(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewApigatewayClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -75,7 +75,7 @@ func testSweepApiGatewayPlugin(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_bastionhost_instance_test.go
+++ b/alicloud/resource_alicloud_bastionhost_instance_test.go
@@ -91,7 +91,7 @@ func testSweepBastionhostInstances(region string) error {
 			return bastionhostClient.RefundInstance(releaseReq)
 		})
 		if err != nil {
-			log.Printf("[ERROR] Deleting Instance %s got an error: %#v.", v.InstanceId, err)
+			log.Printf("[ERROR] Deleting Instance %s got an error: %v", v.InstanceId, err)
 		}
 	}
 

--- a/alicloud/resource_alicloud_cdn_domain.go
+++ b/alicloud/resource_alicloud_cdn_domain.go
@@ -335,14 +335,14 @@ func resourceAlicloudCdnDomainCreate(d *schema.ResourceData, meta interface{}) e
 		return cdnClient.AddCdnDomain(args)
 	})
 	if err != nil {
-		return fmt.Errorf("AddCdnDomain got an error: %#v", err)
+		return fmt.Errorf("AddCdnDomain got an error: %w", err)
 	}
 
 	d.SetId(args.DomainName)
 
 	err = WaitForDomainStatus(d.Id(), Configuring, 60, meta)
 	if err != nil {
-		return fmt.Errorf("Timeout when Cdn Domain Available. Error: %#v", err)
+		return fmt.Errorf("Timeout when Cdn Domain Available. Error: %w", err)
 	}
 
 	return resourceAlicloudCdnDomainUpdate(d, meta)
@@ -380,7 +380,7 @@ func resourceAlicloudCdnDomainUpdate(d *schema.ResourceData, meta interface{}) e
 				return cdnClient.ModifyCdnDomain(args)
 			})
 			if err != nil {
-				return fmt.Errorf("ModifyCdnDomain got an error: %#v", err)
+				return fmt.Errorf("ModifyCdnDomain got an error: %w", err)
 			}
 		}
 	}
@@ -442,7 +442,7 @@ func resourceAlicloudCdnDomainUpdate(d *schema.ResourceData, meta interface{}) e
 		if d.IsNewResource() {
 			err := WaitForDomainStatus(d.Id(), Online, 360, meta)
 			if err != nil {
-				return fmt.Errorf("Timeout when Cdn Domain Online. Error: %#v", err)
+				return fmt.Errorf("Timeout when Cdn Domain Online. Error: %w", err)
 			}
 		}
 		if err := certificateConfigUpdate(client, d); err != nil {
@@ -459,7 +459,7 @@ func resourceAlicloudCdnDomainRead(d *schema.ResourceData, meta interface{}) err
 
 	domain, err := DescribeDomainDetail(d.Id(), meta)
 	if err != nil {
-		return fmt.Errorf("DescribeDomainDetail got an error: %#v", err)
+		return fmt.Errorf("DescribeDomainDetail got an error: %w", err)
 	}
 	d.Set("domain_name", domain.DomainName)
 	d.Set("sources", domain.Sources.Source)
@@ -475,7 +475,7 @@ func resourceAlicloudCdnDomainRead(d *schema.ResourceData, meta interface{}) err
 		return cdnClient.DescribeDomainConfigs(describeConfigArgs)
 	})
 	if err != nil {
-		return fmt.Errorf("DescribeDomainConfigs got an error: %#v", err)
+		return fmt.Errorf("DescribeDomainConfigs got an error: %w", err)
 	}
 	resp, _ := raw.(cdn.DomainConfigResponse)
 	configs := resp.DomainConfigs
@@ -850,7 +850,7 @@ func certificateConfigUpdate(client *connectivity.AliyunClient, d *schema.Resour
 	if okServerCertificate && args.ServerCertificateStatus != "off" {
 		err := WaitForServerCertificate(client, d.Id(), args.ServerCertificate, 360)
 		if err != nil {
-			return fmt.Errorf("Timeout waiting for Cdn server certificate. Error: %#v", err)
+			return fmt.Errorf("Timeout waiting for Cdn server certificate. Error: %w", err)
 		}
 	}
 	return nil
@@ -889,7 +889,7 @@ func httpHeaderConfigUpdate(client *connectivity.AliyunClient, d *schema.Resourc
 			return cdnClient.SetHttpHeaderConfig(args)
 		})
 		if err != nil {
-			return fmt.Errorf("SetHttpHeaderConfig got an error: %#v", err)
+			return fmt.Errorf("SetHttpHeaderConfig got an error: %w", err)
 		}
 	}
 
@@ -913,7 +913,7 @@ func cacheConfigUpdate(client *connectivity.AliyunClient, d *schema.ResourceData
 			return cdnClient.DeleteCacheExpiredConfig(args)
 		})
 		if err != nil {
-			return fmt.Errorf("DeleteCacheExpiredConfig got an error: %#v", err)
+			return fmt.Errorf("DeleteCacheExpiredConfig got an error: %w", err)
 		}
 	}
 

--- a/alicloud/resource_alicloud_cen_bandwidth_limit_test.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_limit_test.go
@@ -69,7 +69,7 @@ func testSweepCenBandwidthLimit(region string) error {
 	for _, v := range insts {
 		cen, err := cbnService.DescribeCenInstance(v.CenId)
 		if err != nil {
-			log.Printf("[ERROR] Failed to describe cen instance, error: %#v", err)
+			log.Printf("[ERROR] Failed to describe cen instance, error: %v", err)
 			continue
 		}
 		name := fmt.Sprint(cen["Name"])

--- a/alicloud/resource_alicloud_cloud_sso_directory_test.go
+++ b/alicloud/resource_alicloud_cloud_sso_directory_test.go
@@ -40,7 +40,7 @@ func testSweepCloudSsoDirectory(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewCloudssoClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 
 	runtime := util.RuntimeOptions{}
@@ -59,7 +59,7 @@ func testSweepCloudSsoDirectory(region string) error {
 	})
 	addDebug(action, response, request)
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 

--- a/alicloud/resource_alicloud_cloud_storage_gateway_express_sync_test.go
+++ b/alicloud/resource_alicloud_cloud_storage_gateway_express_sync_test.go
@@ -48,7 +48,7 @@ func testSweepCloudStorageGatewayExpressSync(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewHcsSgwClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 
 	runtime := util.RuntimeOptions{}
@@ -67,7 +67,7 @@ func testSweepCloudStorageGatewayExpressSync(region string) error {
 	})
 	addDebug(action, response, request)
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	if fmt.Sprint(response["Success"]) == "false" {

--- a/alicloud/resource_alicloud_cms_alarm.go
+++ b/alicloud/resource_alicloud_cms_alarm.go
@@ -378,7 +378,7 @@ func resourceAliCloudCmsAlarmRead(d *schema.ResourceData, meta interface{}) erro
 	dims := make([]map[string]interface{}, 0)
 	if fmt.Sprint(object["Resources"]) != "" {
 		if err := json.Unmarshal([]byte(object["Resources"].(string)), &dims); err != nil {
-			return fmt.Errorf("Unmarshaling Dimensions got an error: %#v.", err)
+			return fmt.Errorf("Unmarshaling Dimensions got an error: %w", err)
 		}
 	}
 
@@ -509,7 +509,7 @@ func resourceAliCloudCmsAlarmUpdate(d *schema.ResourceData, meta interface{}) er
 
 		if len(dimList) > 0 {
 			if bytes, err := json.Marshal(dimList); err != nil {
-				return fmt.Errorf("Marshaling dimensions to json string got an error: %#v.", err)
+				return fmt.Errorf("Marshaling dimensions to json string got an error: %w", err)
 			} else {
 				request["Resources"] = string(bytes[:])
 			}

--- a/alicloud/resource_alicloud_cms_dynamic_tag_group_test.go
+++ b/alicloud/resource_alicloud_cms_dynamic_tag_group_test.go
@@ -50,7 +50,7 @@ func testSweepCmsDynamicTagGroup(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewCmsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 
 	for {
@@ -70,7 +70,7 @@ func testSweepCmsDynamicTagGroup(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.TagGroupList.TagGroup", response)

--- a/alicloud/resource_alicloud_cms_hybrid_monitor_sls_task_test.go
+++ b/alicloud/resource_alicloud_cms_hybrid_monitor_sls_task_test.go
@@ -54,7 +54,7 @@ func testSweepCmsHybridMonitorSlsTask(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewCmsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -74,7 +74,7 @@ func testSweepCmsHybridMonitorSlsTask(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_cms_metric_rule_template_test.go
+++ b/alicloud/resource_alicloud_cms_metric_rule_template_test.go
@@ -49,7 +49,7 @@ func testSweepCmsMetricRuleTemplate(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewCmsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -68,7 +68,7 @@ func testSweepCmsMetricRuleTemplate(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_cms_namespace_test.go
+++ b/alicloud/resource_alicloud_cms_namespace_test.go
@@ -51,7 +51,7 @@ func testSweepCmsNamespace(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewCmsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -71,7 +71,7 @@ func testSweepCmsNamespace(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_cms_sls_group_test.go
+++ b/alicloud/resource_alicloud_cms_sls_group_test.go
@@ -52,7 +52,7 @@ func testSweepCmsSlsGroup(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewCmsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -72,7 +72,7 @@ func testSweepCmsSlsGroup(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_cs_application.go
+++ b/alicloud/resource_alicloud_cs_application.go
@@ -159,13 +159,13 @@ func resourceAlicloudCSApplicationCreate(d *schema.ResourceData, meta interface{
 		}
 		return err
 	}); err != nil {
-		return fmt.Errorf("Creating container application got an error: %#v", err)
+		return fmt.Errorf("Creating container application got an error: %w", err)
 	}
 
 	d.SetId(fmt.Sprintf("%s%s%s", clusterName, COLON_SEPARATED, args.Name))
 
 	if err := csService.WaitForContainerApplication(clusterName, args.Name, Running, DefaultTimeoutMedium); err != nil {
-		return fmt.Errorf("Waitting for container application %#v got an error: %#v", cs.Running, err)
+		return fmt.Errorf("Waitting for container application %#v got an error: %w", cs.Running, err)
 	}
 
 	return resourceAlicloudCSApplicationRead(d, meta)
@@ -298,7 +298,7 @@ func resourceAlicloudCSApplicationUpdate(d *schema.ResourceData, meta interface{
 				return nil, csProjectClient.RollBackBlueGreenProject(parts[1], true)
 			})
 		}
-		return fmt.Errorf("Rollbacking container application blue-green got an error: %#v", err)
+		return fmt.Errorf("Rollbacking container application blue-green got an error: %w", err)
 	}
 	if update {
 		for {
@@ -323,15 +323,15 @@ func resourceAlicloudCSApplicationUpdate(d *schema.ResourceData, meta interface{
 						return err
 					})
 					if err != nil {
-						return fmt.Errorf("Rollbacking container application blue-green got an error: %#v", err)
+						return fmt.Errorf("Rollbacking container application blue-green got an error: %w", err)
 					}
 					err = csService.WaitForContainerApplication(parts[0], parts[1], Running, DefaultTimeoutMedium)
 					if err != nil {
-						return fmt.Errorf("After rolling back blue-green project, waitting for container application %#v got an error: %#v", Running, err)
+						return fmt.Errorf("After rolling back blue-green project, waitting for container application %#v got an error: %w", Running, err)
 					}
 					continue
 				}
-				return fmt.Errorf("Updating container application got an error: %#v", err)
+				return fmt.Errorf("Updating container application got an error: %w", err)
 			}
 			break
 		}
@@ -348,12 +348,12 @@ func resourceAlicloudCSApplicationUpdate(d *schema.ResourceData, meta interface{
 			return err
 		})
 		if err != nil {
-			return fmt.Errorf("Confirmming container application blue-green got an error: %#v", err)
+			return fmt.Errorf("Confirmming container application blue-green got an error: %w", err)
 		}
 	}
 
 	if err := csService.WaitForContainerApplication(parts[0], parts[1], Running, DefaultTimeoutMedium); err != nil {
-		return fmt.Errorf("After updating, waitting for container application %#v got an error: %#v", Running, err)
+		return fmt.Errorf("After updating, waitting for container application %#v got an error: %w", Running, err)
 	}
 
 	d.Partial(false)

--- a/alicloud/resource_alicloud_cs_swarm.go
+++ b/alicloud/resource_alicloud_cs_swarm.go
@@ -203,7 +203,7 @@ func resourceAlicloudCSSwarmCreate(d *schema.ResourceData, meta interface{}) err
 
 	vsw, err := vpcService.DescribeVSwitch(args.VSwitchID)
 	if err != nil {
-		return fmt.Errorf("Error DescribeVSwitches: %#v", err)
+		return fmt.Errorf("Error DescribeVSwitches: %w", err)
 	}
 
 	if vsw.CidrBlock == args.SubnetCIDR {
@@ -225,7 +225,7 @@ func resourceAlicloudCSSwarmCreate(d *schema.ResourceData, meta interface{}) err
 	})
 
 	if err != nil {
-		return fmt.Errorf("Creating container Cluster got an error: %#v", err)
+		return fmt.Errorf("Creating container Cluster got an error: %w", err)
 	}
 	cluster, _ := raw.(cs.ClusterCommonResponse)
 	d.SetId(cluster.ClusterID)
@@ -239,7 +239,7 @@ func resourceAlicloudCSSwarmCreate(d *schema.ResourceData, meta interface{}) err
 	})
 
 	if err != nil {
-		return fmt.Errorf("Waitting for container Cluster %#v got an error: %#v", cs.Running, err)
+		return fmt.Errorf("Waitting for container Cluster %#v got an error: %w", cs.Running, err)
 	}
 
 	return resourceAlicloudCSSwarmUpdate(d, meta)
@@ -268,7 +268,7 @@ func resourceAlicloudCSSwarmUpdate(d *schema.ResourceData, meta interface{}) err
 			})
 		})
 		if err != nil {
-			return fmt.Errorf("Resize Cluster got an error: %#v", err)
+			return fmt.Errorf("Resize Cluster got an error: %w", err)
 		}
 
 		_, err = client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
@@ -280,7 +280,7 @@ func resourceAlicloudCSSwarmUpdate(d *schema.ResourceData, meta interface{}) err
 		})
 
 		if err != nil {
-			return fmt.Errorf("Waitting for container Cluster %#v got an error: %#v", cs.Running, err)
+			return fmt.Errorf("Waitting for container Cluster %#v got an error: %w", cs.Running, err)
 		}
 	}
 
@@ -295,7 +295,7 @@ func resourceAlicloudCSSwarmUpdate(d *schema.ResourceData, meta interface{}) err
 			return nil, csClient.ModifyClusterName(d.Id(), clusterName)
 		})
 		if err != nil && !IsExpectedErrors(err, []string{"ErrorClusterNameAlreadyExist"}) {
-			return fmt.Errorf("Modify Cluster Name got an error: %#v", err)
+			return fmt.Errorf("Modify Cluster Name got an error: %w", err)
 		}
 		d.SetPartial("name")
 		d.SetPartial("name_prefix")
@@ -355,7 +355,7 @@ func resourceAlicloudCSSwarmRead(d *schema.ResourceData, meta interface{}) error
 			}
 			inst, err := ecsService.DescribeInstance(node.InstanceId)
 			if err != nil {
-				return fmt.Errorf("[ERROR] QueryInstancesById %s: %#v.", node.InstanceId, err)
+				return fmt.Errorf("[ERROR] QueryInstancesById %s: %w", node.InstanceId, err)
 			}
 			mapping["eip"] = inst.EipAddress.IpAddress
 			oneNode = inst
@@ -367,7 +367,7 @@ func resourceAlicloudCSSwarmRead(d *schema.ResourceData, meta interface{}) error
 		d.Set("instance_type", oneNode.InstanceType)
 		disks, err := ecsService.DescribeDisksByType(oneNode.InstanceId, DiskTypeData)
 		if err != nil {
-			return fmt.Errorf("[ERROR] DescribeDisks By Id %s: %#v.", resp[0].InstanceId, err)
+			return fmt.Errorf("[ERROR] DescribeDisks By Id %s: %w", resp[0].InstanceId, err)
 		}
 		for _, disk := range disks {
 			d.Set("disk_size", disk.Size)

--- a/alicloud/resource_alicloud_database_gateway_gateway_test.go
+++ b/alicloud/resource_alicloud_database_gateway_gateway_test.go
@@ -54,7 +54,7 @@ func testSweepDatabaseGatewayGateway(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewDgClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -73,7 +73,7 @@ func testSweepDatabaseGatewayGateway(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -137,7 +137,7 @@ func testSweepDBInstances(region string) error {
 				addDebug(action, response, request)
 				return nil
 			}); err != nil {
-				log.Printf("[ERROR] ReleaseReadWriteSplittingConnection error: %#v", err)
+				log.Printf("[ERROR] ReleaseReadWriteSplittingConnection error: %v", err)
 			}
 		}
 

--- a/alicloud/resource_alicloud_dbfs_instance_test.go
+++ b/alicloud/resource_alicloud_dbfs_instance_test.go
@@ -44,7 +44,7 @@ func testSweepDBFSInstance(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewDbfsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 
 	for {
@@ -64,7 +64,7 @@ func testSweepDBFSInstance(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_dbfs_snapshot_test.go
+++ b/alicloud/resource_alicloud_dbfs_snapshot_test.go
@@ -57,7 +57,7 @@ func testSweepDbfsSnapshot(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewDbfsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -76,7 +76,7 @@ func testSweepDbfsSnapshot(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_dbs_backup_plan_test.go
+++ b/alicloud/resource_alicloud_dbs_backup_plan_test.go
@@ -52,7 +52,7 @@ func testSweepDbsBackupPlan(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewCbsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -72,7 +72,7 @@ func testSweepDbsBackupPlan(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_dcdn_domain_test.go
+++ b/alicloud/resource_alicloud_dcdn_domain_test.go
@@ -38,7 +38,7 @@ func testSweepDcdnDomain(region string) error {
 			return dcdnClient.DescribeDcdnUserDomains(queryRequest)
 		})
 		if err != nil {
-			log.Printf("[ERROR] %s get an error %#v", queryRequest.GetActionName(), err)
+			log.Printf("[ERROR] %s get an error %v", queryRequest.GetActionName(), err)
 		}
 		addDebug(queryRequest.GetActionName(), raw)
 		response, _ := raw.(*dcdn.DescribeDcdnUserDomainsResponse)

--- a/alicloud/resource_alicloud_dcdn_ipa_domain_test.go
+++ b/alicloud/resource_alicloud_dcdn_ipa_domain_test.go
@@ -56,7 +56,7 @@ func testSweepDcdnIpaDomain(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewDcdnClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -76,7 +76,7 @@ func testSweepDcdnIpaDomain(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_dcdn_waf_policy_test.go
+++ b/alicloud/resource_alicloud_dcdn_waf_policy_test.go
@@ -56,7 +56,7 @@ func testSweepDcdnWafPolicy(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewDcdnClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -76,7 +76,7 @@ func testSweepDcdnWafPolicy(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ddoscoo_instance_test.go
+++ b/alicloud/resource_alicloud_ddoscoo_instance_test.go
@@ -70,7 +70,7 @@ func testSweepDdoscooInstances(region string) error {
 		})
 
 		if err != nil {
-			log.Printf("[ERROR] %s get an error %#v", action, err)
+			log.Printf("[ERROR] %s get an error %v", action, err)
 		}
 		resp, err := jsonpath.Get("$.Instances", response)
 		if resp == nil || len(resp.([]interface{})) < 1 || err != nil {
@@ -228,7 +228,7 @@ func testSweepDdoscooInstances(region string) error {
 		}
 		_, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2020-01-01"), StringPointer("AK"), nil, request, &util.RuntimeOptions{})
 		if err != nil {
-			log.Printf("[ERROR] Deleting Instance %s got an error: %#v.", fmt.Sprint(v["InstanceId"]), err)
+			log.Printf("[ERROR] Deleting Instance %s got an error: %v", fmt.Sprint(v["InstanceId"]), err)
 		}
 	}
 	return nil

--- a/alicloud/resource_alicloud_dfs_access_group_test.go
+++ b/alicloud/resource_alicloud_dfs_access_group_test.go
@@ -48,7 +48,7 @@ func testSweepDFSAccessGroup(region string) error {
 	action := "ListAccessGroups"
 	conn, err := client.NewAlidfsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	var response map[string]interface{}
 	runtime := util.RuntimeOptions{}
@@ -67,7 +67,7 @@ func testSweepDFSAccessGroup(region string) error {
 	})
 
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 

--- a/alicloud/resource_alicloud_dfs_file_system_test.go
+++ b/alicloud/resource_alicloud_dfs_file_system_test.go
@@ -50,7 +50,7 @@ func testSweepDFSFileSystem(region string) error {
 	action := "ListFileSystems"
 	conn, err := client.NewAlidfsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	var response map[string]interface{}
 	runtime := util.RuntimeOptions{}
@@ -69,7 +69,7 @@ func testSweepDFSFileSystem(region string) error {
 	})
 
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 

--- a/alicloud/resource_alicloud_direct_mail_domain_test.go
+++ b/alicloud/resource_alicloud_direct_mail_domain_test.go
@@ -53,7 +53,7 @@ func testSweepDirectMailDomain(region string) error {
 
 	conn, err := client.NewDmClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 
@@ -76,7 +76,7 @@ func testSweepDirectMailDomain(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.data.domain", response)
@@ -95,7 +95,7 @@ func testSweepDirectMailDomain(region string) error {
 		}
 
 		if page, err := getNextpageNumber(request["PageNo"].(requests.Integer)); err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", "getNextpageNumber", err)
+			log.Printf("[ERROR] %s get an error: %v", "getNextpageNumber", err)
 			break
 		} else {
 			request["PageNo"] = page

--- a/alicloud/resource_alicloud_direct_mail_tag_test.go
+++ b/alicloud/resource_alicloud_direct_mail_tag_test.go
@@ -75,7 +75,7 @@ func testSweepDirectMailTag(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_dns_group_test.go
+++ b/alicloud/resource_alicloud_dns_group_test.go
@@ -40,7 +40,7 @@ func testSweepDnsGroup(region string) error {
 			return dnsClient.DescribeDomainGroups(request)
 		})
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", request.GetActionName(), err)
+			log.Printf("[ERROR] %s get an error: %v", request.GetActionName(), err)
 		}
 		addDebug(request.GetActionName(), raw)
 		response, _ := raw.(*alidns.DescribeDomainGroupsResponse)
@@ -70,7 +70,7 @@ func testSweepDnsGroup(region string) error {
 			return dnsClient.DeleteDomainGroup(removeRequest)
 		})
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", request.GetActionName(), err)
+			log.Printf("[ERROR] %s get an error: %v", request.GetActionName(), err)
 		}
 		addDebug(request.GetActionName(), raw)
 	}

--- a/alicloud/resource_alicloud_dns_test.go
+++ b/alicloud/resource_alicloud_dns_test.go
@@ -39,7 +39,7 @@ func testSweepDns(region string) error {
 			return dnsClient.DescribeDomains(queryRequest)
 		})
 		if err != nil {
-			log.Printf("[ERROR] %s get an error %#v", queryRequest.GetActionName(), err)
+			log.Printf("[ERROR] %s get an error %v", queryRequest.GetActionName(), err)
 		}
 		addDebug(queryRequest.GetActionName(), raw)
 		response, _ := raw.(*alidns.DescribeDomainsResponse)

--- a/alicloud/resource_alicloud_dts_migration_job_test.go
+++ b/alicloud/resource_alicloud_dts_migration_job_test.go
@@ -52,7 +52,7 @@ func testSweepDTSMigrationJob(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewDtsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -71,7 +71,7 @@ func testSweepDTSMigrationJob(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_eais_instance_test.go
+++ b/alicloud/resource_alicloud_eais_instance_test.go
@@ -53,7 +53,7 @@ func testSweepEaisInstance(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewEaisClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 
 	for {
@@ -73,7 +73,7 @@ func testSweepEaisInstance(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		v, err := jsonpath.Get("$.Instances.Instance", response)

--- a/alicloud/resource_alicloud_ebs_disk_replica_group_test.go
+++ b/alicloud/resource_alicloud_ebs_disk_replica_group_test.go
@@ -40,7 +40,7 @@ func testSweepEbsDiskReplicaGroup(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewEbsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -59,7 +59,7 @@ func testSweepEbsDiskReplicaGroup(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ecd_ad_connector_directory_test.go
+++ b/alicloud/resource_alicloud_ecd_ad_connector_directory_test.go
@@ -54,7 +54,7 @@ func testSweepEcdAdConnectorDirectory(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewGwsecdClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -74,7 +74,7 @@ func testSweepEcdAdConnectorDirectory(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ecd_ad_connector_office_site_test.go
+++ b/alicloud/resource_alicloud_ecd_ad_connector_office_site_test.go
@@ -54,7 +54,7 @@ func testSweepEcdAdConnectorOfficeSite(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewGwsecdClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -74,7 +74,7 @@ func testSweepEcdAdConnectorOfficeSite(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ecd_bundle_test.go
+++ b/alicloud/resource_alicloud_ecd_bundle_test.go
@@ -56,7 +56,7 @@ func testSweepEcdBundle(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewGwsecdClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -76,7 +76,7 @@ func testSweepEcdBundle(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ecd_custom_property_test.go
+++ b/alicloud/resource_alicloud_ecd_custom_property_test.go
@@ -52,7 +52,7 @@ func testSweepEcdCustomProperty(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewEdsuserClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	runtime := util.RuntimeOptions{}
@@ -71,7 +71,7 @@ func testSweepEcdCustomProperty(region string) error {
 	})
 	addDebug(action, response, request)
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 

--- a/alicloud/resource_alicloud_ecd_desktop_test.go
+++ b/alicloud/resource_alicloud_ecd_desktop_test.go
@@ -42,7 +42,7 @@ func testSweepEcdDesktop(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewGwsecdClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -61,7 +61,7 @@ func testSweepEcdDesktop(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.Desktops", response)

--- a/alicloud/resource_alicloud_ecd_nas_file_system_test.go
+++ b/alicloud/resource_alicloud_ecd_nas_file_system_test.go
@@ -54,7 +54,7 @@ func testSweepEcdNasFileSystem(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewGwsecdClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -73,7 +73,7 @@ func testSweepEcdNasFileSystem(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.FileSystems", response)

--- a/alicloud/resource_alicloud_ecd_ram_directory_test.go
+++ b/alicloud/resource_alicloud_ecd_ram_directory_test.go
@@ -55,7 +55,7 @@ func testSweepEcdRamDirectory(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewGwsecdClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -75,7 +75,7 @@ func testSweepEcdRamDirectory(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ecd_user_test.go
+++ b/alicloud/resource_alicloud_ecd_user_test.go
@@ -53,7 +53,7 @@ func testSweepEcdUser(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewEdsuserClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 
@@ -74,7 +74,7 @@ func testSweepEcdUser(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.Users", response)

--- a/alicloud/resource_alicloud_eci_image_cache_test.go
+++ b/alicloud/resource_alicloud_eci_image_cache_test.go
@@ -34,7 +34,7 @@ func testSweepEciImageCache(region string) error {
 		return eciClient.DescribeImageCaches(queryRequest)
 	})
 	if err != nil {
-		log.Printf("[ERROR] %s get an error %#v", queryRequest.GetActionName(), err)
+		log.Printf("[ERROR] %s get an error %v", queryRequest.GetActionName(), err)
 	}
 	addDebug(queryRequest.GetActionName(), raw)
 	response, _ := raw.(*eci.DescribeImageCachesResponse)

--- a/alicloud/resource_alicloud_eci_virtual_node_test.go
+++ b/alicloud/resource_alicloud_eci_virtual_node_test.go
@@ -49,7 +49,7 @@ func testSweepECIVirtualNode(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewEciClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 
 	for {
@@ -69,7 +69,7 @@ func testSweepECIVirtualNode(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ecs_activation_test.go
+++ b/alicloud/resource_alicloud_ecs_activation_test.go
@@ -56,7 +56,7 @@ func testSweepEcsActivations(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewEcsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -76,7 +76,7 @@ func testSweepEcsActivations(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ecs_dedicated_host_cluster_test.go
+++ b/alicloud/resource_alicloud_ecs_dedicated_host_cluster_test.go
@@ -55,7 +55,7 @@ func testSweepEcsDedicatedHostCluster(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewEcsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -74,7 +74,7 @@ func testSweepEcsDedicatedHostCluster(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ecs_deployment_set_test.go
+++ b/alicloud/resource_alicloud_ecs_deployment_set_test.go
@@ -74,7 +74,7 @@ func testSweepEcsDeploymentSet(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.DeploymentSets.DeploymentSet", response)

--- a/alicloud/resource_alicloud_ecs_image_component_test.go
+++ b/alicloud/resource_alicloud_ecs_image_component_test.go
@@ -51,7 +51,7 @@ func testSweepEcsImageComponent(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewEcsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -71,7 +71,7 @@ func testSweepEcsImageComponent(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ecs_image_pipeline_test.go
+++ b/alicloud/resource_alicloud_ecs_image_pipeline_test.go
@@ -50,7 +50,7 @@ func testSweepEcsImagePipeline(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewEcsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -70,7 +70,7 @@ func testSweepEcsImagePipeline(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ecs_network_interface_test.go
+++ b/alicloud/resource_alicloud_ecs_network_interface_test.go
@@ -56,7 +56,7 @@ func testAliCloudEcsNetworkInterface(region string) error {
 
 		resp, err := jsonpath.Get("$.NetworkInterfaceSets.NetworkInterfaceSet", response)
 		if err != nil {
-			log.Printf("[ERROR] jsonpath Get NetworkInterface failed, %#v", err)
+			log.Printf("[ERROR] jsonpath Get NetworkInterface failed, %v", err)
 			continue
 		}
 
@@ -99,12 +99,12 @@ func testAliCloudEcsNetworkInterface(region string) error {
 				runtime.SetAutoretry(true)
 				response, err = conn.DoRequest(StringPointer(actionDetach), nil, StringPointer("POST"), StringPointer("2014-05-26"), StringPointer("AK"), nil, requestDetach, &runtime)
 				if err != nil {
-					log.Printf("[ERROR] Detach NetworkInterface failed, %#v", err)
+					log.Printf("[ERROR] Detach NetworkInterface failed, %v", err)
 					continue
 				}
 				stateConf := BuildStateConf([]string{}, []string{"Available"}, DefaultTimeout, 5*time.Second, ecsService.EcsNetworkInterfaceStateRefreshFunc(item["NetworkInterfaceId"].(string), []string{}))
 				if _, err := stateConf.WaitForState(); err != nil {
-					log.Printf("[ERROR] Detach NetworkInterface failed, %#v", err)
+					log.Printf("[ERROR] Detach NetworkInterface failed, %v", err)
 					continue
 				}
 			}

--- a/alicloud/resource_alicloud_ecs_prefix_list_test.go
+++ b/alicloud/resource_alicloud_ecs_prefix_list_test.go
@@ -55,7 +55,7 @@ func testAlicloudEcsPrefixList(region string) error {
 	runtime.SetAutoretry(true)
 	response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2014-05-26"), StringPointer("AK"), nil, request, &runtime)
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 

--- a/alicloud/resource_alicloud_ecs_snapshot_group_test.go
+++ b/alicloud/resource_alicloud_ecs_snapshot_group_test.go
@@ -53,7 +53,7 @@ func testSweepEcsSnapshotGroup(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewEcsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -73,7 +73,7 @@ func testSweepEcsSnapshotGroup(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_edas_namespace_test.go
+++ b/alicloud/resource_alicloud_edas_namespace_test.go
@@ -54,7 +54,7 @@ func testSweepEdasNamespace(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewEdasClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 
@@ -74,7 +74,7 @@ func testSweepEdasNamespace(region string) error {
 	})
 	addDebug(action, response, request)
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	if respBody, isExist := response["body"]; isExist {

--- a/alicloud/resource_alicloud_ga_acl_test.go
+++ b/alicloud/resource_alicloud_ga_acl_test.go
@@ -41,7 +41,7 @@ func testSweepGaAcl(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewGaplusClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -60,7 +60,7 @@ func testSweepGaAcl(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_gpdb_instance_test.go
+++ b/alicloud/resource_alicloud_gpdb_instance_test.go
@@ -51,7 +51,7 @@ func testSweepGPDBDBInstance(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewGpdbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -71,7 +71,7 @@ func testSweepGPDBDBInstance(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_graph_database_db_instance_test.go
+++ b/alicloud/resource_alicloud_graph_database_db_instance_test.go
@@ -51,7 +51,7 @@ func testSweepGraphDatabaseDbInstance(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewGdsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -71,7 +71,7 @@ func testSweepGraphDatabaseDbInstance(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_havip_attachment_test.go
+++ b/alicloud/resource_alicloud_havip_attachment_test.go
@@ -42,7 +42,7 @@ func testSweepHavipAttachment(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewVpcClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -61,7 +61,7 @@ func testSweepHavipAttachment(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_hbr_ots_backup_plan_test.go
+++ b/alicloud/resource_alicloud_hbr_ots_backup_plan_test.go
@@ -51,7 +51,7 @@ func testSweepHBROtsBackupPlan(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewHbrClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", "NewHbrClient", err)
+		log.Printf("[ERROR] %s get an error: %v", "NewHbrClient", err)
 		return nil
 	}
 	for {
@@ -71,7 +71,7 @@ func testSweepHBROtsBackupPlan(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.BackupPlans.BackupPlan", response)

--- a/alicloud/resource_alicloud_hbr_replication_vault_test.go
+++ b/alicloud/resource_alicloud_hbr_replication_vault_test.go
@@ -52,7 +52,7 @@ func testSweepHbrReplicationVault(region string) error {
 
 	conn, err := client.NewHbrClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 
@@ -74,7 +74,7 @@ func testSweepHbrReplicationVault(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.Vaults.Vault", response)

--- a/alicloud/resource_alicloud_hbr_server_backup_plan_test.go
+++ b/alicloud/resource_alicloud_hbr_server_backup_plan_test.go
@@ -55,7 +55,7 @@ func testSweepHbrServerBackupPlan(region string) error {
 	conn, err := client.NewHbrClient()
 
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 
@@ -78,7 +78,7 @@ func testSweepHbrServerBackupPlan(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.BackupPlans.BackupPlan", response)
@@ -97,7 +97,7 @@ func testSweepHbrServerBackupPlan(region string) error {
 		}
 
 		if page, err := getNextpageNumber(request["PageNumber"].(requests.Integer)); err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", "getNextpageNumber", err)
+			log.Printf("[ERROR] %s get an error: %v", "getNextpageNumber", err)
 			break
 		} else {
 			request["PageNumber"] = page

--- a/alicloud/resource_alicloud_imm_project_test.go
+++ b/alicloud/resource_alicloud_imm_project_test.go
@@ -52,7 +52,7 @@ func testSweepIMMProject(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewImmClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -71,7 +71,7 @@ func testSweepIMMProject(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.Projects", response)
@@ -100,7 +100,7 @@ func testSweepIMMProject(region string) error {
 			var response map[string]interface{}
 			conn, err := client.NewImmClient()
 			if err != nil {
-				log.Printf("[ERROR] %s get an error: %#v", action, err)
+				log.Printf("[ERROR] %s get an error: %v", action, err)
 			}
 			request := map[string]interface{}{
 				"Project": item["Project"],
@@ -120,7 +120,7 @@ func testSweepIMMProject(region string) error {
 			})
 			addDebug(action, response, request)
 			if err != nil {
-				log.Printf("[ERROR] %s get an error: %#v", action, err)
+				log.Printf("[ERROR] %s get an error: %v", action, err)
 				return nil
 			}
 			if sweeped {

--- a/alicloud/resource_alicloud_iot_device_group_test.go
+++ b/alicloud/resource_alicloud_iot_device_group_test.go
@@ -55,7 +55,7 @@ func testSweepDeviceGroup(region string) error {
 		runtime.SetAutoretry(true)
 		response, err = conn.DoRequest(StringPointer(action), nil, StringPointer("POST"), StringPointer("2018-01-20"), StringPointer("AK"), nil, request, &runtime)
 		if err != nil {
-			log.Printf("[ERROR] %s got an error: %#v", action, err)
+			log.Printf("[ERROR] %s got an error: %v", action, err)
 			return nil
 		}
 		addDebug(action, response, request)

--- a/alicloud/resource_alicloud_kvstore_backup_policy_test.go
+++ b/alicloud/resource_alicloud_kvstore_backup_policy_test.go
@@ -156,7 +156,7 @@ func testAccCheckKVStoreBackupPolicyDestroy(s *terraform.State) error {
 			if NotFoundError(err) {
 				continue
 			}
-			return fmt.Errorf("Error Describe DB backup policy: %#v", err)
+			return fmt.Errorf("Error Describe DB backup policy: %w", err)
 		}
 		return fmt.Errorf("KVStore Instance %s Policy sitll exists.", rs.Primary.ID)
 	}

--- a/alicloud/resource_alicloud_log_project_test.go
+++ b/alicloud/resource_alicloud_log_project_test.go
@@ -74,7 +74,7 @@ func testSweepLogProjectsWithPrefixAndSuffix(region string, prefixes, suffixes [
 					if IsExpectedErrors(err, []string{"ErrorClusterNotFound"}) {
 						skip = false
 					} else {
-						log.Printf("[ERROR] DescribeCluster got an error: %#v", err)
+						log.Printf("[ERROR] DescribeCluster got an error: %v", err)
 					}
 				} else {
 					cluster, _ := raw.(cs.ClusterType)

--- a/alicloud/resource_alicloud_mhub_app_test.go
+++ b/alicloud/resource_alicloud_mhub_app_test.go
@@ -55,7 +55,7 @@ func testSweepMHUBApp(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewMhubClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", "NewMhubClient", err)
+		log.Printf("[ERROR] %s get an error: %v", "NewMhubClient", err)
 		return nil
 	}
 	for {
@@ -75,7 +75,7 @@ func testSweepMHUBApp(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.ProductInfos.ProductInfo", response)
@@ -97,7 +97,7 @@ func testSweepMHUBApp(region string) error {
 			var response map[string]interface{}
 			conn, err := client.NewMhubClient()
 			if err != nil {
-				log.Printf("[ERROR] %s get an error: %#v", action, err)
+				log.Printf("[ERROR] %s get an error: %v", action, err)
 			}
 			for {
 				runtime := util.RuntimeOptions{}
@@ -116,7 +116,7 @@ func testSweepMHUBApp(region string) error {
 				})
 				addDebug(action, response, request)
 				if err != nil {
-					log.Printf("[ERROR] %s get an error: %#v", action, err)
+					log.Printf("[ERROR] %s get an error: %v", action, err)
 					return nil
 				}
 				resp, err := jsonpath.Get("$.AppInfos.AppInfo", response)

--- a/alicloud/resource_alicloud_mhub_product_test.go
+++ b/alicloud/resource_alicloud_mhub_product_test.go
@@ -52,7 +52,7 @@ func testSweepMHUBProduct(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewMhubClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", "NewMhubClient", err)
+		log.Printf("[ERROR] %s get an error: %v", "NewMhubClient", err)
 		return nil
 	}
 	for {
@@ -72,7 +72,7 @@ func testSweepMHUBProduct(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		resp, err := jsonpath.Get("$.ProductInfos.ProductInfo", response)

--- a/alicloud/resource_alicloud_mns_queue_test.go
+++ b/alicloud/resource_alicloud_mns_queue_test.go
@@ -39,7 +39,7 @@ func testSweepMnsQueues(region string) error {
 				return queueManager.ListQueueDetail(nextMaker, 1000, namePrefix)
 			})
 			if err != nil {
-				return fmt.Errorf("get queueDetails  error: %#v", err)
+				return fmt.Errorf("get queueDetails  error: %w", err)
 			}
 			queueDetails, _ := raw.(ali_mns.QueueDetails)
 			for _, attr := range queueDetails.Attrs {

--- a/alicloud/resource_alicloud_mns_topic_test.go
+++ b/alicloud/resource_alicloud_mns_topic_test.go
@@ -39,7 +39,7 @@ func testSweepMnsTopics(region string) error {
 				return topicManager.ListTopicDetail(nextMaker, 1000, namePrefix)
 			})
 			if err != nil {
-				return fmt.Errorf("get topicDetails  error: %#v", err)
+				return fmt.Errorf("get topicDetails  error: %w", err)
 			}
 			topicDetails, _ := raw.(ali_mns.TopicDetails)
 			for _, attr := range topicDetails.Attrs {

--- a/alicloud/resource_alicloud_mongodb_instance_test.go
+++ b/alicloud/resource_alicloud_mongodb_instance_test.go
@@ -43,7 +43,7 @@ func testSweepMongoDBInstances(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewDdsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -63,7 +63,7 @@ func testSweepMongoDBInstances(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_mongodb_sharding_instance_test.go
+++ b/alicloud/resource_alicloud_mongodb_sharding_instance_test.go
@@ -44,7 +44,7 @@ func testSweepMongoDBShardingInstances(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewDdsClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -64,7 +64,7 @@ func testSweepMongoDBShardingInstances(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_msc_sub_webhook_test.go
+++ b/alicloud/resource_alicloud_msc_sub_webhook_test.go
@@ -48,7 +48,7 @@ func testSweepMscSubWebhook(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewMscopensubscriptionClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -67,7 +67,7 @@ func testSweepMscSubWebhook(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_mse_gateway_test.go
+++ b/alicloud/resource_alicloud_mse_gateway_test.go
@@ -57,7 +57,7 @@ func testSweepMseGateway(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewMseClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -76,7 +76,7 @@ func testSweepMseGateway(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_nas_auto_snapshot_policy_test.go
+++ b/alicloud/resource_alicloud_nas_auto_snapshot_policy_test.go
@@ -59,7 +59,7 @@ func testSweepNasAutoSnapshotPolicy(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewNasClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -78,7 +78,7 @@ func testSweepNasAutoSnapshotPolicy(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_network_acl_attachment_test.go
+++ b/alicloud/resource_alicloud_network_acl_attachment_test.go
@@ -45,7 +45,7 @@ func testSweepNetworkAclAttachment(region string) error {
 			return vpcClient.DescribeNetworkAcls(request)
 		})
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", request.GetActionName(), err)
+			log.Printf("[ERROR] %s get an error: %v", request.GetActionName(), err)
 		}
 		response, _ := raw.(*vpc.DescribeNetworkAclsResponse)
 		if len(response.NetworkAcls.NetworkAcl) < 1 {

--- a/alicloud/resource_alicloud_nlb_load_balancer_test.go
+++ b/alicloud/resource_alicloud_nlb_load_balancer_test.go
@@ -50,7 +50,7 @@ func testSweepNlbLoadBalancer(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewNlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -70,7 +70,7 @@ func testSweepNlbLoadBalancer(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_nlb_security_policy_test.go
+++ b/alicloud/resource_alicloud_nlb_security_policy_test.go
@@ -51,7 +51,7 @@ func testSweepNlbSecurityPolicy(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewNlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -71,7 +71,7 @@ func testSweepNlbSecurityPolicy(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_nlb_server_group_server_attachment_test.go
+++ b/alicloud/resource_alicloud_nlb_server_group_server_attachment_test.go
@@ -52,7 +52,7 @@ func testSweepNlbServerGroupServerAttachment(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewNlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -72,7 +72,7 @@ func testSweepNlbServerGroupServerAttachment(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_nlb_server_group_test.go
+++ b/alicloud/resource_alicloud_nlb_server_group_test.go
@@ -50,7 +50,7 @@ func testSweepNlbServerGroup(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewNlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -70,7 +70,7 @@ func testSweepNlbServerGroup(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_oos_application_test.go
+++ b/alicloud/resource_alicloud_oos_application_test.go
@@ -51,7 +51,7 @@ func testSweepOOSApplication(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewOosClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -70,7 +70,7 @@ func testSweepOOSApplication(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_oos_parameter_test.go
+++ b/alicloud/resource_alicloud_oos_parameter_test.go
@@ -57,7 +57,7 @@ func testSweepOosParameter(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewOosClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -76,7 +76,7 @@ func testSweepOosParameter(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_oos_patch_baseline_test.go
+++ b/alicloud/resource_alicloud_oos_patch_baseline_test.go
@@ -56,7 +56,7 @@ func testSweepOosPatchBaseline(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewOosClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -75,7 +75,7 @@ func testSweepOosPatchBaseline(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_oos_secret_parameter_test.go
+++ b/alicloud/resource_alicloud_oos_secret_parameter_test.go
@@ -58,7 +58,7 @@ func testSweepOosSecretParameter(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewOosClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -77,7 +77,7 @@ func testSweepOosSecretParameter(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_oos_state_configuration_test.go
+++ b/alicloud/resource_alicloud_oos_state_configuration_test.go
@@ -56,7 +56,7 @@ func testSweepOOSStateConfiguration(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewOosClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -75,7 +75,7 @@ func testSweepOOSStateConfiguration(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_oss_bucket_object_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_object_test.go
@@ -168,7 +168,7 @@ func testAccCheckOssBucketObjectExistsWithProviders(n string, bucket string, obj
 			})
 			buck, _ := raw.(*oss.Bucket)
 			if err != nil {
-				return fmt.Errorf("Error getting bucket: %#v", err)
+				return fmt.Errorf("Error getting bucket: %w", err)
 			}
 			object, err := buck.GetObjectMeta(rs.Primary.ID)
 			log.Printf("[WARN]get oss bucket object %#v", bucket)
@@ -202,7 +202,7 @@ func testAccCheckOssBucketObjectDestroyWithProvider(s *terraform.State, provider
 			return ossClient.Bucket(rs.Primary.ID)
 		})
 		if err != nil {
-			return fmt.Errorf("Error getting bucket: %#v", err)
+			return fmt.Errorf("Error getting bucket: %w", err)
 		}
 		bucket, _ = raw.(*oss.Bucket)
 	}
@@ -221,7 +221,7 @@ func testAccCheckOssBucketObjectDestroyWithProvider(s *terraform.State, provider
 			if IsExpectedErrors(err, []string{"NoSuchBucket"}) {
 				return nil
 			}
-			return fmt.Errorf("IsObjectExist got an error: %#v", err)
+			return fmt.Errorf("IsObjectExist got an error: %w", err)
 		}
 
 		if !exist {

--- a/alicloud/resource_alicloud_oss_bucket_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_test.go
@@ -69,7 +69,7 @@ func testSweepOSSBuckets(region string) error {
 			return ossClient.Bucket(name)
 		})
 		if err != nil {
-			return fmt.Errorf("Error getting bucket (%s): %#v", name, err)
+			return fmt.Errorf("Error getting bucket (%s): %w", name, err)
 		}
 		bucket, _ := raw.(*oss.Bucket)
 		if objects, err := bucket.ListObjects(options...); err != nil {

--- a/alicloud/resource_alicloud_ots_instance_test.go
+++ b/alicloud/resource_alicloud_ots_instance_test.go
@@ -90,7 +90,7 @@ func testSweepOtsInstances(region string) error {
 			return tableStoreClient.ListTable()
 		})
 		if err != nil {
-			log.Printf("[ERROR] List OTS Instance %s table stores got an error: %#v.", name, err)
+			log.Printf("[ERROR] List OTS Instance %s table stores got an error: %v", name, err)
 		}
 		tables, _ := raw.(*tablestore.ListTableResponse)
 		if tables != nil && len(tables.TableNames) > 0 {
@@ -101,7 +101,7 @@ func testSweepOtsInstances(region string) error {
 				if _, err := otsService.client.WithTableStoreClient(name, func(tableStoreClient *tablestore.TableStoreClient) (interface{}, error) {
 					return tableStoreClient.DeleteTable(req)
 				}); err != nil {
-					log.Printf("[ERROR] Delete OTS Instance %s table store %s got an error: %#v.", name, t, err)
+					log.Printf("[ERROR] Delete OTS Instance %s table store %s got an error: %v", name, t, err)
 				}
 			}
 			time.Sleep(30 * time.Second)
@@ -128,7 +128,7 @@ func sweepTunnelsInTable(client *connectivity.AliyunClient, instanceName string,
 		})
 	})
 	if err != nil {
-		log.Printf("[ERROR] List OTS Tunnel failed, instance: %s, table: %s, error: %#v", instanceName, tableName, err)
+		log.Printf("[ERROR] List OTS Tunnel failed, instance: %s, table: %s, error: %v", instanceName, tableName, err)
 		return
 	}
 
@@ -141,7 +141,7 @@ func sweepTunnelsInTable(client *connectivity.AliyunClient, instanceName string,
 					TunnelName: t.TunnelName,
 				})
 			}); err != nil {
-				log.Printf("[ERROR] Delete OTS Tunnel failed, instance: %s, table: %s, tunnel: %s, error: %#v", instanceName, tableName, t.TunnelName, err)
+				log.Printf("[ERROR] Delete OTS Tunnel failed, instance: %s, table: %s, tunnel: %s, error: %v", instanceName, tableName, t.TunnelName, err)
 			}
 		}
 	}

--- a/alicloud/resource_alicloud_ots_table_test.go
+++ b/alicloud/resource_alicloud_ots_table_test.go
@@ -427,7 +427,7 @@ func testAccCheckOtsTableExist(n string, table *tablestore.DescribeTableResponse
 		response, err := otsService.DescribeOtsTable(rs.Primary.ID)
 
 		if err != nil {
-			return fmt.Errorf("Error finding OTS table %s: %#v", rs.Primary.ID, err)
+			return fmt.Errorf("Error finding OTS table %s: %w", rs.Primary.ID, err)
 		}
 
 		table = response

--- a/alicloud/resource_alicloud_pvtz_endpoint_test.go
+++ b/alicloud/resource_alicloud_pvtz_endpoint_test.go
@@ -54,7 +54,7 @@ func testSweepPrivateZoneEndpoint(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewPvtzClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -73,7 +73,7 @@ func testSweepPrivateZoneEndpoint(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_quick_bi_user_test.go
+++ b/alicloud/resource_alicloud_quick_bi_user_test.go
@@ -50,7 +50,7 @@ func testSweepQuickBIUser(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewQuickbiClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -69,7 +69,7 @@ func testSweepQuickBIUser(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_ram_role_test.go
+++ b/alicloud/resource_alicloud_ram_role_test.go
@@ -87,7 +87,7 @@ func testSweepRamRoles(region string) error {
 					return ramClient.DetachPolicyFromRole(request)
 				})
 				if err != nil && !IsExpectedErrors(err, []string{"EntityNotExist"}) {
-					log.Printf("[ERROR] Failed detach Policy %s: %#v", v.PolicyName, err)
+					log.Printf("[ERROR] Failed detach Policy %s: %v", v.PolicyName, err)
 				}
 			}
 		}

--- a/alicloud/resource_alicloud_rds_ddr_instance_test.go
+++ b/alicloud/resource_alicloud_rds_ddr_instance_test.go
@@ -132,7 +132,7 @@ func testSweepDBDdrInstances(region string) error {
 				addDebug(action, response, request)
 				return nil
 			}); err != nil {
-				log.Printf("[ERROR] ReleaseReadWriteSplittingConnection error: %#v", err)
+				log.Printf("[ERROR] ReleaseReadWriteSplittingConnection error: %v", err)
 			}
 		}
 

--- a/alicloud/resource_alicloud_ros_template_scratch_test.go
+++ b/alicloud/resource_alicloud_ros_template_scratch_test.go
@@ -48,7 +48,7 @@ func testSweepRosTemplateScratch(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewRosClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -68,7 +68,7 @@ func testSweepRosTemplateScratch(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_route_table_attachment_test.go
+++ b/alicloud/resource_alicloud_route_table_attachment_test.go
@@ -117,7 +117,7 @@ func testAccCheckRouteTableAttachmentDestroy(s *terraform.State) error {
 			if NotFoundError(err) {
 				continue
 			}
-			return fmt.Errorf("Describe Route Table attachment error %#v", err)
+			return fmt.Errorf("Describe Route Table attachment error %w", err)
 		}
 	}
 	return nil

--- a/alicloud/resource_alicloud_router_interface_connection_test.go
+++ b/alicloud/resource_alicloud_router_interface_connection_test.go
@@ -27,7 +27,7 @@ func testAccCheckRouterInterfaceConnectionExists(n string) resource.TestCheckFun
 
 		response, err := vpcService.DescribeRouterInterfaceConnection(rs.Primary.ID, client.RegionId)
 		if err != nil {
-			return fmt.Errorf("Error finding interface %s: %#v", rs.Primary.ID, err)
+			return fmt.Errorf("Error finding interface %s: %w", rs.Primary.ID, err)
 		}
 		if response.Status != string(Active) {
 			return fmt.Errorf("Error connection router interface id %s is not Active.", response.RouterInterfaceId)

--- a/alicloud/resource_alicloud_router_interface_test.go
+++ b/alicloud/resource_alicloud_router_interface_test.go
@@ -112,7 +112,7 @@ func testAccCheckRouterInterfaceExists(n string, ri *vpc.RouterInterfaceType) re
 
 		response, err := vpcService.DescribeRouterInterface(rs.Primary.ID, client.RegionId)
 		if err != nil {
-			return fmt.Errorf("Error finding interface %s: %#v", rs.Primary.ID, err)
+			return fmt.Errorf("Error finding interface %s: %w", rs.Primary.ID, err)
 		}
 		ri = &response
 		return nil

--- a/alicloud/resource_alicloud_sae_ingress_test.go
+++ b/alicloud/resource_alicloud_sae_ingress_test.go
@@ -42,7 +42,7 @@ func testSweepSaeIngress(region string) error {
 	action := "/pop/v1/sam/namespace/describeNamespaceList"
 	conn, err := client.NewServerlessClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 
@@ -50,7 +50,7 @@ func testSweepSaeIngress(region string) error {
 	runtime.SetAutoretry(true)
 	response, err = conn.DoRequest(StringPointer("2019-05-06"), nil, StringPointer("GET"), StringPointer("AK"), StringPointer(action), request, nil, nil, &util.RuntimeOptions{})
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	if respBody, isExist := response["body"]; isExist {
@@ -71,14 +71,14 @@ func testSweepSaeIngress(region string) error {
 		action = "/pop/v1/sam/ingress/IngressList"
 		conn, err = client.NewServerlessClient()
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		request["RegionId"] = StringPointer(client.RegionId)
 		request["NamespaceId"] = StringPointer(item["NamespaceId"].(string))
 		response, err = conn.DoRequest(StringPointer("2019-05-06"), nil, StringPointer("GET"), StringPointer("AK"), StringPointer(action), request, nil, nil, &util.RuntimeOptions{})
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 		if respBody, isExist := response["body"]; isExist {

--- a/alicloud/resource_alicloud_service_mesh_service_mesh_test.go
+++ b/alicloud/resource_alicloud_service_mesh_service_mesh_test.go
@@ -39,7 +39,7 @@ func testSweepServiceMeshServiceMesh(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewServicemeshClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 
 	runtime := util.RuntimeOptions{}
@@ -58,7 +58,7 @@ func testSweepServiceMeshServiceMesh(region string) error {
 	})
 	addDebug(action, response, request)
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 

--- a/alicloud/resource_alicloud_slb_acl_test.go
+++ b/alicloud/resource_alicloud_slb_acl_test.go
@@ -50,7 +50,7 @@ func testSweepSlbAcl(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewSlbClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 
@@ -71,7 +71,7 @@ func testSweepSlbAcl(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_slb_listener_test.go
+++ b/alicloud/resource_alicloud_slb_listener_test.go
@@ -1593,14 +1593,14 @@ func testAccCheckSlbListenerDestroy(s *terraform.State) error {
 			port, err = strconv.Atoi(parts[1])
 		}
 		if err != nil {
-			return fmt.Errorf("Parsing SlbListener's id got an error: %#v", err)
+			return fmt.Errorf("Parsing SlbListener's id got an error: %w", err)
 		}
 		loadBalancer, err := slbService.DescribeSlb(parts[0])
 		if err != nil {
 			if NotFoundError(err) {
 				continue
 			}
-			return fmt.Errorf("DescribeLoadBalancerAttribute got an error: %#v", err)
+			return fmt.Errorf("DescribeLoadBalancerAttribute got an error: %w", err)
 		}
 		if len(parts) == 3 {
 			for _, portAndProtocol := range loadBalancer.ListenerPortsAndProtocol.ListenerPortAndProtocol {

--- a/alicloud/resource_alicloud_smartag_flow_log_test.go
+++ b/alicloud/resource_alicloud_smartag_flow_log_test.go
@@ -57,7 +57,7 @@ func testSweepSmartagFlowLog(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewSmartagClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -77,7 +77,7 @@ func testSweepSmartagFlowLog(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_vpc_bgp_group_test.go
+++ b/alicloud/resource_alicloud_vpc_bgp_group_test.go
@@ -59,7 +59,7 @@ func testSweepVpcBgpGroup(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewVpcClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -79,7 +79,7 @@ func testSweepVpcBgpGroup(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_vpc_dhcp_options_set_test.go
+++ b/alicloud/resource_alicloud_vpc_dhcp_options_set_test.go
@@ -41,7 +41,7 @@ func testSweepVpcDhcpOptionsSet(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewVpcClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -60,7 +60,7 @@ func testSweepVpcDhcpOptionsSet(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_vpc_ipv4_gateway_test.go
+++ b/alicloud/resource_alicloud_vpc_ipv4_gateway_test.go
@@ -50,7 +50,7 @@ func testSweepVpcIpv4Gateway(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewVpcClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -70,7 +70,7 @@ func testSweepVpcIpv4Gateway(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_vpc_ipv6_gateway_test.go
+++ b/alicloud/resource_alicloud_vpc_ipv6_gateway_test.go
@@ -59,7 +59,7 @@ func testSweepVpcIpv6Gateway(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewVpcClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -78,7 +78,7 @@ func testSweepVpcIpv6Gateway(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_vpc_peer_connection_test.go
+++ b/alicloud/resource_alicloud_vpc_peer_connection_test.go
@@ -51,7 +51,7 @@ func testSweepVpcPeerConnection(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewVpcpeerClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -71,7 +71,7 @@ func testSweepVpcPeerConnection(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_vpc_prefix_list_test.go
+++ b/alicloud/resource_alicloud_vpc_prefix_list_test.go
@@ -51,7 +51,7 @@ func testSweepVpcPrefixList(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewVpcClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -71,7 +71,7 @@ func testSweepVpcPrefixList(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_vpc_traffic_mirror_filter_test.go
+++ b/alicloud/resource_alicloud_vpc_traffic_mirror_filter_test.go
@@ -53,7 +53,7 @@ func testSweepVPCTrafficMirrorFilter(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewVpcClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -72,7 +72,7 @@ func testSweepVPCTrafficMirrorFilter(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_vpc_traffic_mirror_session_test.go
+++ b/alicloud/resource_alicloud_vpc_traffic_mirror_session_test.go
@@ -48,7 +48,7 @@ func testSweepVpcTrafficMirrorSession(region string) error {
 	var response map[string]interface{}
 	conn, err := client.NewVpcClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 	}
 	for {
 		runtime := util.RuntimeOptions{}
@@ -67,7 +67,7 @@ func testSweepVpcTrafficMirrorSession(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_vpn_gateway_vpn_attachment_test.go
+++ b/alicloud/resource_alicloud_vpn_gateway_vpn_attachment_test.go
@@ -55,7 +55,7 @@ func testSweepVpnGatewayVpnAttachment(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewVpcClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -75,7 +75,7 @@ func testSweepVpnGatewayVpnAttachment(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_vpn_ipsec_server_test.go
+++ b/alicloud/resource_alicloud_vpn_ipsec_server_test.go
@@ -51,7 +51,7 @@ func testSweepVpnIpsecServer(region string) error {
 	var response map[string]interface{}
 	conn, err := aliyunClient.NewVpcClient()
 	if err != nil {
-		log.Printf("[ERROR] %s get an error: %#v", action, err)
+		log.Printf("[ERROR] %s get an error: %v", action, err)
 		return nil
 	}
 	for {
@@ -71,7 +71,7 @@ func testSweepVpnIpsecServer(region string) error {
 		})
 		addDebug(action, response, request)
 		if err != nil {
-			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			log.Printf("[ERROR] %s get an error: %v", action, err)
 			return nil
 		}
 

--- a/alicloud/resource_alicloud_yundun_dbaudit_instance_test.go
+++ b/alicloud/resource_alicloud_yundun_dbaudit_instance_test.go
@@ -98,7 +98,7 @@ func testSweepDbauditInstances(region string) error {
 			return dbauditClient.RefundInstance(releaseReq)
 		})
 		if err != nil {
-			log.Printf("[ERROR] Deleting Instance %s got an error: %#v.", v.InstanceId, err)
+			log.Printf("[ERROR] Deleting Instance %s got an error: %v", v.InstanceId, err)
 		}
 		// 释放产生的 sls project
 		_, err = client.WithLogClient(func(slsClient *sls.Client) (interface{}, error) {

--- a/alicloud/service_alicloud_cs.go
+++ b/alicloud/service_alicloud_cs.go
@@ -87,7 +87,7 @@ func (s *CsService) GetContainerClusterByName(name string) (cluster cs.ClusterTy
 	})
 
 	if err != nil {
-		return cluster, fmt.Errorf("Describe cluster failed by name %s: %#v.", name, err)
+		return cluster, fmt.Errorf("Describe cluster failed by name %s: %w", name, err)
 	}
 
 	if len(clusters) < 1 {
@@ -141,7 +141,7 @@ func (s *CsService) DescribeContainerApplication(clusterName, appName string) (a
 		if IsExpectedErrors(err, []string{"Not Found"}) {
 			return app, GetNotFoundErrorFromString(GetNotFoundMessage("Container Application", appName))
 		}
-		return app, fmt.Errorf("Getting Application failed by name %s: %#v.", appName, err)
+		return app, fmt.Errorf("Getting Application failed by name %s: %w", appName, err)
 	}
 	if app.Name != appName {
 		return app, GetNotFoundErrorFromString(GetNotFoundMessage("Container Application", appName))

--- a/alicloud/service_alicloud_cs.go
+++ b/alicloud/service_alicloud_cs.go
@@ -1023,7 +1023,7 @@ func (s *CsService) UpgradeCluster(clusterId string, args *cs.UpgradeClusterArgs
 	}
 
 	if state, err := s.WaitForUpgradeCluster(clusterId, "CancelUpgrade"); err != nil || state != cs.Task_Status_Success {
-		log.Printf("[WARN] %s ACK Cluster cancel upgrade error: %#v", clusterId, err)
+		log.Printf("[WARN] %s ACK Cluster cancel upgrade error: %v", clusterId, err)
 	}
 
 	return WrapError(upgradeError)

--- a/alicloud/service_alicloud_ecs.go
+++ b/alicloud/service_alicloud_ecs.go
@@ -32,7 +32,7 @@ func (s *EcsService) JudgeRegionValidation(key, region string) error {
 		return ecsClient.DescribeRegions(request)
 	})
 	if err != nil {
-		return fmt.Errorf("DescribeRegions got an error: %#v", err)
+		return fmt.Errorf("DescribeRegions got an error: %w", err)
 	}
 	addDebug(request.GetActionName(), raw, request.RpcRequest, request)
 	resp, _ := raw.(*ecs.DescribeRegionsResponse)


### PR DESCRIPTION
%#v is not suitable for print error. It is unreadable, and missing important information.
For example, before (with %#v):
```
&url.Error{Op:"Post", URL:"https://...", Err:(*net.OpError)(0x14002fa4000)}
```

after (in this PR, with %w or %v):
```
Post "https://...": dial tcp: lookup example.com: no such host
```