### PR TITLE
fix(alicloud_amqp_binding):  avoid collisions in the state when one Exchange is bound to many queues

### DIFF
--- a/alicloud/service_alicloud_amqp_open.go
+++ b/alicloud/service_alicloud_amqp_open.go
@@ -324,7 +324,7 @@ func (s *AmqpOpenService) DescribeAmqpBinding(id string) (object map[string]inte
 			return object, WrapErrorf(Error(GetNotFoundMessage("Amqp", id)), NotFoundWithResponse, response)
 		}
 		for _, v := range v.([]interface{}) {
-			if fmt.Sprint(v.(map[string]interface{})["SourceExchange"]) == parts[2] {
+			if fmt.Sprint(v.(map[string]interface{})["SourceExchange"]) == parts[2] && parts[3] == fmt.Sprint(v.(map[string]interface{})["DestinationName"]) {
 				idExist = true
 				return v.(map[string]interface{}), nil
 			}


### PR DESCRIPTION
When building an ID terraform provider uses InstanceID, VirtualHost, SourceExchange and DestinationName:
```
d.SetId(fmt.Sprint(request["InstanceId"], ":", request["VirtualHost"], ":", request["SourceExchange"], ":", request["DestinationName"]))
```

Later on, when provider reads bindings from the API, and it is looking for the right binding, `DestinationName` is missing.