### PR TITLE
update the namespace & repo name length of alicloud_cr_ee

### DIFF
--- a/alicloud/resource_alicloud_cr_ee_namespace.go
+++ b/alicloud/resource_alicloud_cr_ee_namespace.go
@@ -30,7 +30,7 @@ func resourceAlicloudCrEENamespace() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(2, 30),
+				ValidateFunc: validation.StringLenBetween(2, 120),
 			},
 			"auto_create": {
 				Type:     schema.TypeBool,

--- a/alicloud/resource_alicloud_cr_ee_repo.go
+++ b/alicloud/resource_alicloud_cr_ee_repo.go
@@ -29,13 +29,13 @@ func resourceAlicloudCrEERepo() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(2, 30),
+				ValidateFunc: validation.StringLenBetween(2, 120),
 			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(2, 64),
+				ValidateFunc: validation.StringLenBetween(2, 120),
 			},
 			"summary": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_cr_ee_sync_rule.go
+++ b/alicloud/resource_alicloud_cr_ee_sync_rule.go
@@ -33,13 +33,13 @@ func resourceAlicloudCrEESyncRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(2, 30),
+				ValidateFunc: validation.StringLenBetween(2, 120),
 			},
 			"repo_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(2, 64),
+				ValidateFunc: validation.StringLenBetween(2, 120),
 			},
 			"target_region_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
The namespace and repo name now support 120 characters on aliyun console while the terraform code is still limit on 30.