### PR TITLE
Add support for the LOAD_BALANCER health check type in alicloud_ess_scaling_group

### DIFF
--- a/alicloud/resource_alicloud_ess_scaling_group.go
+++ b/alicloud/resource_alicloud_ess_scaling_group.go
@@ -53,7 +53,7 @@ func resourceAlicloudEssScalingGroup() *schema.Resource {
 			"health_check_type": {
 				Type:         schema.TypeString,
 				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"ECS", "NONE"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"ECS", "LOAD_BALANCER", "NONE"}, false),
 				Optional:     true,
 			},
 			"default_cooldown": {


### PR DESCRIPTION
Already supported by the [CreateScalingGroup](https://www.alibabacloud.com/help/en/auto-scaling/developer-reference/api-createscalinggroup?spm=a2c63.p38356.0.0.57ed7d87Gt29Kl) API.
