### PR TITLE
[Fix] Add environment sub type ManagedKubernetes

### DIFF
--- a/alicloud/resource_alicloud_arms_environment.go
+++ b/alicloud/resource_alicloud_arms_environment.go
@@ -3,9 +3,10 @@ package alicloud
 
 import (
 	"fmt"
-	"github.com/PaesslerAG/jsonpath"
 	"log"
 	"time"
+
+	"github.com/PaesslerAG/jsonpath"
 
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -53,7 +54,7 @@ func resourceAliCloudArmsEnvironment() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: StringInSlice([]string{"ECS", "ACK", "Cloud"}, true),
+				ValidateFunc: StringInSlice([]string{"ECS", "ACK", "Cloud", "ManagedKubernetes"}, true),
 			},
 			"environment_type": {
 				Type:         schema.TypeString,

--- a/website/docs/r/arms_environment.html.markdown
+++ b/website/docs/r/arms_environment.html.markdown
@@ -107,9 +107,10 @@ The following arguments are supported:
 * `drop_metrics` - (Optional) List of abandoned indicators.
 * `environment_name` - (Optional) The name of the resource.
 * `environment_sub_type` - (Required, ForceNew) Subtype of environment:
-  - Type of CS: ACK is currently supported.
+  - Type of ACK: ACK is currently supported.
   - Type of ECS: currently supports ECS.
   - Type of Cloud: currently supports Cloud.
+  - Type of ManagedKubernetes: currently supports ManagedKubernetes.
 * `environment_type` - (Required, ForceNew) Type of environment.
 * `managed_type` - (Optional, ForceNew) Hosting type:
   - none: unmanaged. The default value of the ACK cluster.


### PR DESCRIPTION
Hello @ChenHanZhang !

I have a resource I am importing that has the `environment_sub_type` of `ManagedKubernetes`.
However, this value will fail the validation.

![image](https://github.com/aliyun/terraform-provider-alicloud/assets/167060511/50c87737-f544-4867-94fc-e1118e422d63)
<img width="775" alt="image" src="https://github.com/aliyun/terraform-provider-alicloud/assets/167060511/9f93217d-a794-43f4-a437-8aa9409eba73">


I have added the `ManagedKubernetes` value and updated the docs.
Do I need to implement tests? If so, could you give me some pointers? It is not clear to me what the testing methodology is.
