### PR TITLE
resource/resource_alicloud_elasticsearch_instance: remove param;resource/resource_alicloud_elasticsearch_instance_test:remove param;docs: improve document for es instance creating

### DIFF
--- a/alicloud/resource_alicloud_elasticsearch_instance_test.go
+++ b/alicloud/resource_alicloud_elasticsearch_instance_test.go
@@ -155,7 +155,7 @@ func testSweepElasticsearch(region string) error {
 	return nil
 }
 
-func TestAccAlicloudElasticsearchInstance_basic(t *testing.T) {
+func TestAccAliCloudElasticsearchInstance_basic(t *testing.T) {
 	var instance *elasticsearch.DescribeInstanceResponse
 
 	resourceId := "alicloud_elasticsearch_instance.default"
@@ -199,6 +199,9 @@ func TestAccAlicloudElasticsearchInstance_basic(t *testing.T) {
 					"kibana_node_spec":                 KibanaSpec,
 					"instance_charge_type":             string(PostPaid),
 					"zone_count":                       "1",
+					"kms_encrypted_password":           "Yourpassword1234",
+					"kms_encryption_context":           "context01",
+					"resource_group_id":                "groupId01",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -260,6 +263,28 @@ func TestAccAlicloudElasticsearchInstance_basic(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"kms_encrypted_password": "Yourpassword1235",
+					"kms_encryption_context": "context02",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"kms_encrypted_password": "Yourpassword1235",
+						"kms_encryption_context": "context02",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_id": "groupId02",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id": "groupId02",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"description": name[:len(name)-1],
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -272,7 +297,7 @@ func TestAccAlicloudElasticsearchInstance_basic(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"data_node_spec":                   DataNodeSpecForUpdate,
 					"data_node_amount":                 DataNodeAmountForUpdate,
-					"data_node_disk_type":              DataNodeEssdDiskType,
+					"data_node_disk_type":              DataNodeSsdDiskType,
 					"data_node_disk_size":              DataNodeDiskForEssdUpdate,
 					"data_node_disk_performance_level": DataNodeDiskPerformanceLevel2,
 				}),
@@ -280,7 +305,7 @@ func TestAccAlicloudElasticsearchInstance_basic(t *testing.T) {
 					testAccCheck(map[string]string{
 						"data_node_spec":                   DataNodeSpecForUpdate,
 						"data_node_amount":                 DataNodeAmountForUpdate,
-						"data_node_disk_type":              DataNodeEssdDiskType,
+						"data_node_disk_type":              DataNodeSsdDiskType,
 						"data_node_disk_size":              DataNodeDiskForEssdUpdate,
 						"data_node_disk_performance_level": DataNodeDiskPerformanceLevel2,
 					}),
@@ -344,7 +369,7 @@ func TestAccAlicloudElasticsearchInstance_basic(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudElasticsearchInstance_version(t *testing.T) {
+func TestAccAliCloudElasticsearchInstance_version(t *testing.T) {
 	var instance *elasticsearch.DescribeInstanceResponse
 
 	resourceId := "alicloud_elasticsearch_instance.default"
@@ -410,7 +435,7 @@ func TestAccAlicloudElasticsearchInstance_version(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudElasticsearchInstance_multizone(t *testing.T) {
+func TestAccAliCloudElasticsearchInstance_multizone(t *testing.T) {
 	var instance *elasticsearch.DescribeInstanceResponse
 
 	resourceId := "alicloud_elasticsearch_instance.default"
@@ -476,7 +501,7 @@ func TestAccAlicloudElasticsearchInstance_multizone(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudElasticsearchInstance_encrypt_disk(t *testing.T) {
+func TestAccAliCloudElasticsearchInstance_encrypt_disk(t *testing.T) {
 	var instance *elasticsearch.DescribeInstanceResponse
 
 	resourceId := "alicloud_elasticsearch_instance.default"
@@ -531,7 +556,7 @@ func TestAccAlicloudElasticsearchInstance_encrypt_disk(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudElasticsearchInstance_prepaid_autorenew(t *testing.T) {
+func TestAccAliCloudElasticsearchInstance_prepaid_autorenew(t *testing.T) {
 	var instance *elasticsearch.DescribeInstanceResponse
 
 	resourceId := "alicloud_elasticsearch_instance.default"
@@ -646,11 +671,21 @@ func TestAccAlicloudElasticsearchInstance_prepaid_autorenew(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_charge_type": "PostPaid",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_charge_type": "PostPaid",
+					}),
+				),
+			},
 		},
 	})
 }
 
-func TestAccAlicloudElasticsearchInstance_network(t *testing.T) {
+func TestAccAliCloudElasticsearchInstance_network(t *testing.T) {
 	var instance *elasticsearch.DescribeInstanceResponse
 
 	resourceId := "alicloud_elasticsearch_instance.default"
@@ -693,7 +728,7 @@ func TestAccAlicloudElasticsearchInstance_network(t *testing.T) {
 					"instance_charge_type":             string(PostPaid),
 					"zone_count":                       "1",
 					"enable_public":                    "true",
-					"enable_kibana_private_network":    "true",
+					"enable_kibana_public_network":     "true",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -709,7 +744,7 @@ func TestAccAlicloudElasticsearchInstance_network(t *testing.T) {
 						"instance_charge_type":             string(PostPaid),
 						"zone_count":                       "1",
 						"enable_public":                    "true",
-						"enable_kibana_private_network":    "true",
+						"enable_kibana_public_network":     "true",
 					}),
 				),
 			},
@@ -726,16 +761,6 @@ func TestAccAlicloudElasticsearchInstance_network(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"kibana_whitelist.#": "2",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"kibana_private_whitelist": []string{"192.168.0.0/24", "127.0.0.1/32"},
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"kibana_private_whitelist.#": "2",
 					}),
 				),
 			},
@@ -777,6 +802,18 @@ func TestAccAlicloudElasticsearchInstance_network(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_public":                "false",
+					"enable_kibana_public_network": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable_public":                "false",
+						"enable_kibana_public_network": "false",
+					}),
+				),
+			},
 		},
 	})
 }
@@ -792,7 +829,6 @@ var elasticsearchMap = map[string]string{
 	"status":                           "active",
 	"enable_public":                    "false",
 	"enable_kibana_public_network":     "true",
-	"enable_kibana_private_network":    "false",
 	"id":                               CHECKSET,
 	"vswitch_id":                       CHECKSET,
 }

--- a/website/docs/r/elasticsearch_instance.html.markdown
+++ b/website/docs/r/elasticsearch_instance.html.markdown
@@ -13,6 +13,8 @@ Provides an Elasticsearch instance resource. It contains data nodes, dedicated m
 
 -> **NOTE:** Only one operation is supported in a request. So if `data_node_spec` and `data_node_disk_size` are both changed, system will respond error.
 
+-> **NOTE:** Kibana private network configuration is not supported at the time of instance creation. it is only supported after the instance has been created, by calling the relevant API operations.
+
 -> **NOTE:** At present, `version` can not be modified once instance has been created.
 
 -> **NOTE:** Available since v1.30.0.
@@ -87,8 +89,6 @@ The following arguments are supported:
 * `enable_public` - (Optional, Available since v1.87.0) Bool, default to false. When it set to true, the instance can enable public network access。
 * `kibana_whitelist` - (Optional) Set the Kibana's IP whitelist in internet network.
 * `enable_kibana_public_network` - (Optional, Available since v1.87.0) Bool, default to true. When it set to false, the instance can enable kibana public network access。
-* `kibana_private_whitelist` - (Optional, Available since v1.87.0) Set the Kibana's IP whitelist in private network.
-* `enable_kibana_private_network` - (Optional, Available since v1.87.0) Bool, default to false. When it set to true, the instance can close kibana private network access。
 * `master_node_spec` - (Optional) The dedicated master node spec. If specified, dedicated master node will be created.
 * `master_node_disk_type` - (Optional, Available since 1.208.1) The single master node storage space. Valid values are `PrePaid`, `PostPaid`.
 * `client_node_amount` - (Optional, Available since v1.101.0) The Elasticsearch cluster's client node quantity, between 2 and 25.


### PR DESCRIPTION
kibana私网配置仅支持在实例创建完成后，通过控制台或调用相关api 配置，不支持创建时指定