### PR TITLE
resource/alicloud_cs_serverless_kubernetes: support modify cluster name and migrate cluster; add params custom_san, addon version and add param delete_options for delete operation; update vpc_id as Optional; deprecate load_balancer_spec, logging_type, sls_project_name; remove force_update, create_v2_cluster, vswitch_id. resource/alicloud_cs_managed_kubernetes: support update custom_san, refactor modifyCluster. resource/alicloud_cs_kubernetes: refactor modifyCluster. docs: improve code sample for alicloud_cs_kubernetes, alicloud_cs_serverless_kubernetes.

### DIFF
--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -62,14 +62,14 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ValidateFunc:  validation.StringLenBetween(1, 63),
+				ValidateFunc:  StringLenBetween(1, 63),
 				ConflictsWith: []string{"name_prefix"},
 			},
 			"name_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Default:       "Terraform-Creation",
-				ValidateFunc:  validation.StringLenBetween(0, 37),
+				ValidateFunc:  StringLenBetween(0, 37),
 				ConflictsWith: []string{"name"},
 				Deprecated:    "Field 'name_prefix' has been deprecated from provider version 1.75.0.",
 			},
@@ -80,7 +80,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				ForceNew: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
+					ValidateFunc: StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
 				},
 				MinItems: 3,
 				MaxItems: 5,
@@ -100,7 +100,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      40,
-				ValidateFunc: validation.IntBetween(40, 500),
+				ValidateFunc: IntBetween(40, 500),
 			},
 			"master_disk_category": {
 				Type:     schema.TypeString,
@@ -112,7 +112,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
-				ValidateFunc:     validation.StringInSlice([]string{"PL0", "PL1", "PL2", "PL3"}, false),
+				ValidateFunc:     StringInSlice([]string{"PL0", "PL1", "PL2", "PL3"}, false),
 				DiffSuppressFunc: masterDiskPerformanceLevelDiffSuppressFunc,
 			},
 			"master_disk_snapshot_policy_id": {
@@ -124,7 +124,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{string(common.PrePaid), string(common.PostPaid)}, false),
+				ValidateFunc: StringInSlice([]string{string(common.PrePaid), string(common.PostPaid)}, false),
 				Default:      PostPaid,
 			},
 			"master_period_unit": {
@@ -132,7 +132,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Optional:         true,
 				ForceNew:         true,
 				Default:          Month,
-				ValidateFunc:     validation.StringInSlice([]string{"Week", "Month"}, false),
+				ValidateFunc:     StringInSlice([]string{"Week", "Month"}, false),
 				DiffSuppressFunc: csKubernetesMasterPostPaidDiffSuppressFunc,
 			},
 			"master_period": {
@@ -142,8 +142,8 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Default:  1,
 				// must be a valid period, expected [1-9], 12, 24, 36, 48 or 60,
 				ValidateFunc: validation.Any(
-					validation.IntBetween(1, 9),
-					validation.IntInSlice([]int{12, 24, 36, 48, 60})),
+					IntBetween(1, 9),
+					IntInSlice([]int{12, 24, 36, 48, 60})),
 				DiffSuppressFunc: csKubernetesMasterPostPaidDiffSuppressFunc,
 			},
 			"master_auto_renew": {
@@ -158,7 +158,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Optional:         true,
 				ForceNew:         true,
 				Default:          1,
-				ValidateFunc:     validation.IntInSlice([]int{1, 2, 3, 6, 12}),
+				ValidateFunc:     IntInSlice([]int{1, 2, 3, 6, 12}),
 				DiffSuppressFunc: csKubernetesMasterPostPaidDiffSuppressFunc,
 			},
 			// worker configurations
@@ -167,7 +167,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
+					ValidateFunc: StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
 				},
 				Removed:  "Field 'worker_vswitch_ids' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster worker nodes, by using field 'vswitch_ids' to replace it",
 				MinItems: 1,
@@ -191,7 +191,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.IntBetween(20, 32768),
+				ValidateFunc: IntBetween(20, 32768),
 				Removed:      "Field 'worker_disk_size' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster worker nodes, by using field 'system_disk_size' to replace it",
 			},
 			"worker_disk_category": {
@@ -202,7 +202,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 			"worker_disk_performance_level": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ValidateFunc:     validation.StringInSlice([]string{"PL0", "PL1", "PL2", "PL3"}, false),
+				ValidateFunc:     StringInSlice([]string{"PL0", "PL1", "PL2", "PL3"}, false),
 				DiffSuppressFunc: workerDiskPerformanceLevelDiffSuppressFunc,
 				Removed:          "Field 'worker_disk_performance_level' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster worker nodes, by using field 'system_disk_performance_level' to replace it",
 			},
@@ -214,7 +214,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 			"worker_data_disk_size": {
 				Type:             schema.TypeInt,
 				Optional:         true,
-				ValidateFunc:     validation.IntBetween(20, 32768),
+				ValidateFunc:     IntBetween(20, 32768),
 				DiffSuppressFunc: workerDataDiskSizeSuppressFunc,
 				Removed:          "Field 'worker_data_disk_size' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster worker nodes, by using field 'data_disks.size' to replace it",
 			},
@@ -235,7 +235,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 						"category": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"all", "cloud", "ephemeral_ssd", "cloud_essd", "cloud_efficiency", "cloud_ssd", "local_disk"}, false),
+							ValidateFunc: StringInSlice([]string{"all", "cloud", "ephemeral_ssd", "cloud_essd", "cloud_efficiency", "cloud_ssd", "local_disk"}, false),
 						},
 						"snapshot_id": {
 							Type:     schema.TypeString,
@@ -279,7 +279,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
-				ValidateFunc:     validation.StringInSlice([]string{"Week", "Month"}, false),
+				ValidateFunc:     StringInSlice([]string{"Week", "Month"}, false),
 				DiffSuppressFunc: csKubernetesWorkerPostPaidDiffSuppressFunc,
 				Removed:          "Field 'worker_period_unit' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster worker nodes, by using field 'period_unit' to replace it",
 			},
@@ -288,8 +288,8 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateFunc: validation.Any(
-					validation.IntBetween(1, 9),
-					validation.IntInSlice([]int{12, 24, 36, 48, 60})),
+					IntBetween(1, 9),
+					IntInSlice([]int{12, 24, 36, 48, 60})),
 				DiffSuppressFunc: csKubernetesWorkerPostPaidDiffSuppressFunc,
 				Removed:          "Field 'worker_period' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster worker nodes, by using field 'period' to replace it",
 			},
@@ -303,7 +303,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Type:             schema.TypeInt,
 				Optional:         true,
 				Computed:         true,
-				ValidateFunc:     validation.IntInSlice([]int{1, 2, 3, 6, 12}),
+				ValidateFunc:     IntInSlice([]int{1, 2, 3, 6, 12}),
 				DiffSuppressFunc: csKubernetesWorkerPostPaidDiffSuppressFunc,
 				Removed:          "Field 'worker_auto_renew_period' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster worker nodes, by using field 'auto_renew_period' to replace it",
 			},
@@ -319,7 +319,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
+					ValidateFunc: StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
 				},
 			},
 			// Flannel network
@@ -338,7 +338,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      KubernetesClusterNodeCIDRMasksByDefault,
-				ValidateFunc: validation.IntBetween(24, 28),
+				ValidateFunc: IntBetween(24, 28),
 			},
 			"new_nat_gateway": {
 				Type:     schema.TypeBool,
@@ -383,7 +383,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"slb.s1.small", "slb.s2.small", "slb.s2.medium", "slb.s3.small", "slb.s3.medium", "slb.s3.large"}, false),
+				ValidateFunc: StringInSlice([]string{"slb.s1.small", "slb.s2.small", "slb.s2.medium", "slb.s3.small", "slb.s3.medium", "slb.s3.large"}, false),
 				Default:      "slb.s1.small",
 			},
 			"image_id": {
@@ -407,14 +407,14 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 			"cpu_policy": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"none", "static"}, false),
+				ValidateFunc: StringInSlice([]string{"none", "static"}, false),
 				Removed:      "Field 'cpu_policy' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster worker nodes, by using field 'cpu_policy' to replace it",
 			},
 			"proxy_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"iptables", "ipvs"}, false),
+				ValidateFunc: StringInSlice([]string{"iptables", "ipvs"}, false),
 			},
 			"addons": {
 				Type:     schema.TypeList,
@@ -465,7 +465,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Optional:     true,
 				Default:      "Linux",
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"Windows", "Linux"}, false),
+				ValidateFunc: StringInSlice([]string{"Windows", "Linux"}, false),
 			},
 			"platform": {
 				Type:     schema.TypeString,
@@ -521,7 +521,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 						"effect": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"NoSchedule", "NoExecute", "PreferNoSchedule"}, false),
+							ValidateFunc: StringInSlice([]string{"NoSchedule", "NoExecute", "PreferNoSchedule"}, false),
 						},
 					},
 				},
@@ -687,7 +687,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
+					ValidateFunc: StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
 				},
 				MinItems: 3,
 				MaxItems: 5,
@@ -745,7 +745,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Type:         schema.TypeString,
-							ValidateFunc: validation.StringInSlice([]string{KubernetesClusterLoggingTypeSLS}, false),
+							ValidateFunc: StringInSlice([]string{KubernetesClusterLoggingTypeSLS}, false),
 							Required:     true,
 						},
 						"project": {
@@ -759,7 +759,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 			"cluster_network_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{KubernetesClusterNetworkTypeFlannel, KubernetesClusterNetworkTypeTerway}, false),
+				ValidateFunc: StringInSlice([]string{KubernetesClusterNetworkTypeFlannel, KubernetesClusterNetworkTypeTerway}, false),
 				Removed:      "Field 'cluster_network_type' has been removed from provider version 1.75.0. New field 'addons' replaces it.",
 			},
 			"user_data": {
@@ -771,7 +771,7 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^customized,[a-z0-9]([-a-z0-9\.])*,([5-9]|[1][0-2]),([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`), "Each node name consists of a prefix, an IP substring, and a suffix. For example, if the node IP address is 192.168.0.55, the prefix is aliyun.com, IP substring length is 5, and the suffix is test, the node name will be aliyun.com00055test."),
+				ValidateFunc: StringMatch(regexp.MustCompile(`^customized,[a-z0-9]([-a-z0-9\.])*,([5-9]|[1][0-2]),([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`), "Each node name consists of a prefix, an IP substring, and a suffix. For example, if the node IP address is 192.168.0.55, the prefix is aliyun.com, IP substring length is 5, and the suffix is test, the node name will be aliyun.com00055test."),
 				ForceNew:     true,
 			},
 			"worker_ram_role_name": {
@@ -811,12 +811,12 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 						"resource_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"SLB", "ALB", "SLS_Data", "SLS_ControlPlane", "PrivateZone"}, false),
+							ValidateFunc: StringInSlice([]string{"SLB", "ALB", "SLS_Data", "SLS_ControlPlane", "PrivateZone"}, false),
 						},
 						"delete_mode": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"delete", "retain"}, false),
+							ValidateFunc: StringInSlice([]string{"delete", "retain"}, false),
 						},
 					},
 				},
@@ -874,55 +874,10 @@ func resourceAlicloudCSKubernetesCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceAlicloudCSKubernetesUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*connectivity.AliyunClient)
-	csService := CsService{client}
 	d.Partial(true)
 	invoker := NewInvoker()
-	if !d.IsNewResource() && d.HasChange("resource_group_id") {
-		var requestInfo cs.ModifyClusterArgs
-		requestInfo.ResourceGroupId = d.Get("resource_group_id").(string)
-
-		response, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
-			return nil, csClient.ModifyCluster(d.Id(), &requestInfo)
-		})
-		if err != nil {
-			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "ModifyCluster", DenverdinoAliyungo)
-		}
-		addDebug("ModifyCluster", response, requestInfo)
-		d.SetPartial("resource_group_id")
-	}
-
-	// modify cluster name
-	if !d.IsNewResource() && (d.HasChange("name") || d.HasChange("name_prefix")) {
-		var clusterName string
-		if v, ok := d.GetOk("name"); ok {
-			clusterName = v.(string)
-		} else {
-			clusterName = resource.PrefixedUniqueId(d.Get("name_prefix").(string))
-		}
-		var requestInfo *cs.Client
-		var response interface{}
-		if err := invoker.Run(func() error {
-			raw, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
-				requestInfo = csClient
-				return nil, csClient.ModifyClusterName(d.Id(), clusterName)
-			})
-			response = raw
-			return err
-		}); err != nil && !IsExpectedErrors(err, []string{"ErrorClusterNameAlreadyExist"}) {
-			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "ModifyClusterName", DenverdinoAliyungo)
-		}
-		if debugOn() {
-			requestMap := make(map[string]interface{})
-			requestMap["ClusterId"] = d.Id()
-			requestMap["ClusterName"] = clusterName
-			addDebug("ModifyClusterName", response, requestInfo, requestMap)
-		}
-		d.SetPartial("name")
-		d.SetPartial("name_prefix")
-	}
-
-	if !d.IsNewResource() && d.HasChanges("deletion_protection", "maintenance_window", "enable_rrsa") {
+	// modifyCluster
+	if !d.IsNewResource() && d.HasChanges("resource_group_id", "name", "name_prefix", "deletion_protection", "custom_san", "maintenance_window", "enable_rrsa") {
 		if err := modifyCluster(d, meta, &invoker); err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "ModifyCluster", AlibabaCloudSdkGoERROR)
 		}
@@ -943,37 +898,13 @@ func resourceAlicloudCSKubernetesUpdate(d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	// migrate cluster to pro form standard
+	// migrate cluster to pro from standard
 	if d.HasChange("cluster_spec") {
-		oldValue, newValue := d.GetChange("cluster_spec")
-		o, ok := oldValue.(string)
-		if ok != true {
-			return WrapErrorf(fmt.Errorf("cluster_spec old value can not be parsed"), "parseError %d", oldValue)
-		}
-		n, ok := newValue.(string)
-		if ok != true {
-			return WrapErrorf(fmt.Errorf("cluster_pec new value can not be parsed"), "parseError %d", newValue)
-		}
-
-		// The field `cluster_spec` of some ack.standard managed cluster is "" since some historical reasons.
-		// The logic here is to confirm whether the cluster is the above.
-		// The interface error should not block the main process and errors will be output to the log.
-		clusterInfo, err := csService.DescribeCsManagedKubernetes(d.Id())
-		if err != nil || clusterInfo == nil {
-			log.Printf("[DEBUG] Failed to DescribeCsManagedKubernetes cluster %s when migrate", d.Id())
-		} else {
-			o = clusterInfo.ClusterSpec
-		}
-
-		if (o == "ack.standard" || o == "") && strings.Contains(n, "pro") {
-			err := migrateAlicloudManagedKubernetesCluster(d, meta)
-			if err != nil {
-				return WrapErrorf(err, ResponseCodeMsg, d.Id(), "MigrateCluster", AlibabaCloudSdkGoERROR)
-			}
+		err := migrateCluster(d, meta)
+		if err != nil {
+			return WrapError(err)
 		}
 	}
-
-	d.SetPartial("tags")
 
 	err := UpgradeAlicloudKubernetesCluster(d, meta)
 	if err != nil {
@@ -984,21 +915,72 @@ func resourceAlicloudCSKubernetesUpdate(d *schema.ResourceData, meta interface{}
 	return resourceAlicloudCSKubernetesRead(d, meta)
 }
 
+func migrateCluster(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	csService := CsService{client}
+	oldValue, newValue := d.GetChange("cluster_spec")
+	o, ok := oldValue.(string)
+	if ok != true {
+		return WrapErrorf(fmt.Errorf("cluster_spec old value can not be parsed"), "parseError %d", oldValue)
+	}
+	n, ok := newValue.(string)
+	if ok != true {
+		return WrapErrorf(fmt.Errorf("cluster_pec new value can not be parsed"), "parseError %d", newValue)
+	}
+
+	// The field `cluster_spec` of some ack.standard managed cluster is "" since some historical reasons.
+	// The logic here is to confirm whether the cluster is the above.
+	// The interface error should not block the main process and errors will be output to the log.
+	clusterInfo, err := csService.DescribeCsManagedKubernetes(d.Id())
+	if err != nil || clusterInfo == nil {
+		log.Printf("[DEBUG] Failed to DescribeCsManagedKubernetes cluster %s when migrate", d.Id())
+	} else {
+		o = clusterInfo.ClusterSpec
+	}
+
+	if (o == "ack.standard" || o == "") && strings.Contains(n, "pro") {
+		err := migrateAlicloudManagedKubernetesCluster(d, meta)
+		if err != nil {
+			return WrapErrorf(err, ResponseCodeMsg, d.Id(), "MigrateCluster", AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return nil
+}
+
 func modifyCluster(d *schema.ResourceData, meta interface{}, invoker *Invoker) error {
+	updated := false
 	request := &roacs.ModifyClusterRequest{}
 	client := meta.(*connectivity.AliyunClient)
 	csClient, err := client.NewRoaCsClient()
 	csService := CsService{client}
+
+	if !d.IsNewResource() && d.HasChange("resource_group_id") {
+		request.SetResourceGroupId(d.Get("resource_group_id").(string))
+		updated = true
+	}
+
+	if !d.IsNewResource() && d.HasChange("name") {
+		var clusterName string
+		if v, ok := d.GetOk("name"); ok {
+			clusterName = v.(string)
+			request.SetClusterName(clusterName)
+			updated = true
+		}
+	}
+
 	// modify cluster deletion protection
 	if !d.IsNewResource() && d.HasChange("deletion_protection") {
 		v := d.Get("deletion_protection")
 		request.SetDeletionProtection(v.(bool))
+		updated = true
 	}
 
 	// modify cluster maintenance window
 	if !d.IsNewResource() && d.HasChange("maintenance_window") {
 		if v := d.Get("maintenance_window").([]interface{}); len(v) > 0 {
 			request.MaintenanceWindow = expandMaintenanceWindowConfigRoa(v)
+			updated = true
 		}
 		d.SetPartial("maintenance_window")
 	}
@@ -1021,7 +1003,23 @@ func modifyCluster(d *schema.ResourceData, meta interface{}, invoker *Invoker) e
 			return fmt.Errorf("RRSA is not supported in current version: %s", clusterVersion)
 		}
 		request.SetEnableRrsa(enableRRSA)
+		updated = true
 		d.SetPartial("enable_rrsa")
+	}
+
+	if d.HasChange("custom_san") {
+		custom_san := d.Get("custom_san").(string)
+		request.SetApiServerCustomCertSans(
+			&roacs.ModifyClusterRequestApiServerCustomCertSans{
+				SubjectAlternativeNames: tea.StringSlice(strings.Split(custom_san, ",")),
+				Action:                  tea.String("overwrite"),
+			},
+		)
+		updated = true
+	}
+
+	if updated == false {
+		return nil
 	}
 
 	if err := invoker.Run(func() error {
@@ -1257,7 +1255,7 @@ func resourceAlicloudCSKubernetesRead(d *schema.ResourceData, meta interface{}) 
 
 	// get cluster conn certs
 	// If the cluster is failed, there is no need to get cluster certs
-	if object.State == "failed" {
+	if object.State == "failed" || object.State == "deleted_failed" || object.State == "deleting" {
 		return nil
 	}
 	var requestInfo *cs.Client
@@ -2037,4 +2035,33 @@ func fetchWorkerNodes(d *schema.ResourceData, meta interface{}) []map[string]int
 	}
 
 	return workerNodes
+}
+
+func flattenTags(config []*roacs.Tag) map[string]string {
+	m := make(map[string]string, len(config))
+	if len(config) < 0 {
+		return m
+	}
+
+	for _, tag := range config {
+		key := tea.StringValue(tag.Key)
+		value := tea.StringValue(tag.Value)
+		if key != DefaultClusterTag && key != CsPlayerAccountIdTag {
+			m[key] = value
+		}
+	}
+
+	return m
+}
+
+func fetchClusterMetaDataMap(meta string) map[string]interface{} {
+	metadata := make(map[string]interface{}, 0)
+	if meta != "" {
+		err := json.Unmarshal([]byte(meta), &metadata)
+		if err != nil {
+			log.Printf("[DEBUG] Failed to unmarshal metadata due to %++v", err)
+		}
+	}
+
+	return metadata
 }

--- a/alicloud/resource_alicloud_cs_managed_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes.go
@@ -13,8 +13,6 @@ import (
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-
 	roacs "github.com/alibabacloud-go/cs-20151215/v5/client"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/denverdino/aliyungo/common"
@@ -43,14 +41,14 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ValidateFunc:  validation.StringLenBetween(1, 63),
+				ValidateFunc:  StringLenBetween(1, 63),
 				ConflictsWith: []string{"name_prefix"},
 			},
 			"name_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Default:       "Terraform-Creation",
-				ValidateFunc:  validation.StringLenBetween(0, 37),
+				ValidateFunc:  StringLenBetween(0, 37),
 				ConflictsWith: []string{"name"},
 			},
 			// worker configurations，TODO: name issue
@@ -60,7 +58,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				ForceNew: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
+					ValidateFunc: StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
 				},
 				MinItems: 1,
 			},
@@ -82,7 +80,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.IntBetween(20, 32768),
+				ValidateFunc: IntBetween(20, 32768),
 				Removed:      "Field 'worker_disk_size' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes, by using field 'system_disk_size' to replace it.",
 			},
 			"worker_disk_category": {
@@ -93,7 +91,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 			"worker_disk_performance_level": {
 				Type:             schema.TypeString,
 				Optional:         true,
-				ValidateFunc:     validation.StringInSlice([]string{"PL0", "PL1", "PL2", "PL3"}, false),
+				ValidateFunc:     StringInSlice([]string{"PL0", "PL1", "PL2", "PL3"}, false),
 				DiffSuppressFunc: workerDiskPerformanceLevelDiffSuppressFunc,
 				Removed:          "Field 'worker_disk_performance_level' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes, by using field 'system_disk_performance_level' to replace it",
 			},
@@ -105,7 +103,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 			"worker_data_disk_size": {
 				Type:             schema.TypeInt,
 				Optional:         true,
-				ValidateFunc:     validation.IntBetween(20, 32768),
+				ValidateFunc:     IntBetween(20, 32768),
 				DiffSuppressFunc: workerDataDiskSizeSuppressFunc,
 				Removed:          "Field 'worker_data_disk_size' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes, by using field 'data_disks.size' to replace it",
 			},
@@ -132,7 +130,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 						"category": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"all", "cloud", "ephemeral_ssd", "cloud_essd", "cloud_efficiency", "cloud_ssd", "local_disk"}, false),
+							ValidateFunc: StringInSlice([]string{"all", "cloud", "ephemeral_ssd", "cloud_essd", "cloud_efficiency", "cloud_ssd", "local_disk"}, false),
 						},
 						"snapshot_id": {
 							Type:     schema.TypeString,
@@ -170,17 +168,14 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
-				ValidateFunc:     validation.StringInSlice([]string{"Week", "Month"}, false),
+				ValidateFunc:     StringInSlice([]string{"Week", "Month"}, false),
 				DiffSuppressFunc: csKubernetesWorkerPostPaidDiffSuppressFunc,
 				Removed:          "Field 'worker_period_unit' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes, by using field 'period_unit' to replace it",
 			},
 			"worker_period": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.Any(
-					validation.IntBetween(1, 9),
-					validation.IntInSlice([]int{12, 24, 36, 48, 60})),
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Computed:         true,
 				DiffSuppressFunc: csKubernetesWorkerPostPaidDiffSuppressFunc,
 				Removed:          "Field 'worker_period' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes, by using field 'period' to replace it",
 			},
@@ -194,7 +189,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Type:             schema.TypeInt,
 				Optional:         true,
 				Computed:         true,
-				ValidateFunc:     validation.IntInSlice([]int{1, 2, 3, 6, 12}),
+				ValidateFunc:     IntInSlice([]int{1, 2, 3, 6, 12}),
 				DiffSuppressFunc: csKubernetesWorkerPostPaidDiffSuppressFunc,
 				Removed:          "Field 'worker_auto_renew_period' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes, by using field 'auto_renew_period' to replace it",
 			},
@@ -209,7 +204,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
+					ValidateFunc: StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
 				},
 			},
 			"pod_cidr": {
@@ -227,7 +222,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      KubernetesClusterNodeCIDRMasksByDefault,
-				ValidateFunc: validation.IntBetween(24, 28),
+				ValidateFunc: IntBetween(24, 28),
 			},
 			"enable_ssh": {
 				Type:     schema.TypeBool,
@@ -291,7 +286,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 			"cpu_policy": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"none", "static"}, false),
+				ValidateFunc: StringInSlice([]string{"none", "static"}, false),
 				Removed:      "Field 'cpu_policy' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes, by using field 'cpu_policy' to replace it",
 			},
 			"proxy_mode": {
@@ -299,7 +294,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      "ipvs",
-				ValidateFunc: validation.StringInSlice([]string{"iptables", "ipvs"}, false),
+				ValidateFunc: StringInSlice([]string{"iptables", "ipvs"}, false),
 			},
 			"addons": {
 				Type:     schema.TypeList,
@@ -335,7 +330,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"slb.s1.small", "slb.s2.small", "slb.s2.medium", "slb.s3.small", "slb.s3.medium", "slb.s3.large"}, false),
+				ValidateFunc: StringInSlice([]string{"slb.s1.small", "slb.s2.small", "slb.s2.medium", "slb.s3.small", "slb.s3.medium", "slb.s3.large"}, false),
 				Default:      "slb.s1.small",
 			},
 			"deletion_protection": {
@@ -357,7 +352,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Optional:     true,
 				Default:      "Linux",
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"Windows", "Linux"}, false),
+				ValidateFunc: StringInSlice([]string{"Windows", "Linux"}, false),
 				Removed:      "Field 'os_type' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes.",
 			},
 			"platform": {
@@ -414,7 +409,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 						"effect": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"NoSchedule", "NoExecute", "PreferNoSchedule"}, false),
+							ValidateFunc: StringInSlice([]string{"NoSchedule", "NoExecute", "PreferNoSchedule"}, false),
 						},
 					},
 				},
@@ -436,7 +431,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 			"node_name_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^customized,[a-z0-9]([-a-z0-9\.])*,([5-9]|[1][0-2]),([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`), "Each node name consists of a prefix, an IP substring, and a suffix. For example, if the node IP address is 192.168.0.55, the prefix is aliyun.com, IP substring length is 5, and the suffix is test, the node name will be aliyun.com00055test."),
+				ValidateFunc: StringMatch(regexp.MustCompile(`^customized,[a-z0-9]([-a-z0-9\.])*,([5-9]|[1][0-2]),([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`), "Each node name consists of a prefix, an IP substring, and a suffix. For example, if the node IP address is 192.168.0.55, the prefix is aliyun.com, IP substring length is 5, and the suffix is test, the node name will be aliyun.com00055test."),
 				Removed:      "Field 'node_name_mode' has been removed from provider version 1.212.0. Please use resource 'alicloud_cs_kubernetes_node_pool' to manage cluster nodes, by using field 'node_name_mode' to replace it.",
 			},
 			"worker_nodes": {
@@ -464,7 +459,6 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 			"custom_san": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 			"encryption_provider_key": {
 				Type:        schema.TypeString,
@@ -579,7 +573,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
+					ValidateFunc: StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
 				},
 				MinItems: 3,
 				MaxItems: 5,
@@ -606,7 +600,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 			"cluster_network_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{KubernetesClusterNetworkTypeFlannel, KubernetesClusterNetworkTypeTerway}, false),
+				ValidateFunc: StringInSlice([]string{KubernetesClusterNetworkTypeFlannel, KubernetesClusterNetworkTypeTerway}, false),
 				Removed:      "Field 'cluster_network_type' has been removed from provider version 1.75.0. New field 'addons' replaces it.",
 			},
 			// too hard to use this config
@@ -618,7 +612,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"type": {
 							Type:         schema.TypeString,
-							ValidateFunc: validation.StringInSlice([]string{KubernetesClusterLoggingTypeSLS}, false),
+							ValidateFunc: StringInSlice([]string{KubernetesClusterLoggingTypeSLS}, false),
 							Required:     true,
 						},
 						"project": {
@@ -665,7 +659,7 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"ack.standard", "ack.pro.small"}, false),
+				ValidateFunc: StringInSlice([]string{"ack.standard", "ack.pro.small"}, false),
 			},
 			"maintenance_window": {
 				Type:     schema.TypeList,
@@ -726,12 +720,12 @@ func resourceAlicloudCSManagedKubernetes() *schema.Resource {
 						"resource_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"SLB", "ALB", "SLS_Data", "SLS_ControlPlane", "PrivateZone"}, false),
+							ValidateFunc: StringInSlice([]string{"SLB", "ALB", "SLS_Data", "SLS_ControlPlane", "PrivateZone"}, false),
 						},
 						"delete_mode": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"delete", "retain"}, false),
+							ValidateFunc: StringInSlice([]string{"delete", "retain"}, false),
 						},
 					},
 				},

--- a/alicloud/resource_alicloud_cs_managed_kubernetes_test.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes_test.go
@@ -112,11 +112,13 @@ func TestAccAliCloudCSManagedKubernetes_basic(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"name":                name + "_update",
+					"custom_san":          "www.terraform.io,terraform.test",
 					"deletion_protection": "true",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"name":                name + "_update",
+						"custom_san":          "www.terraform.io,terraform.test",
 						"deletion_protection": "true",
 					}),
 				),

--- a/alicloud/resource_alicloud_cs_serverless_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_serverless_kubernetes.go
@@ -1,21 +1,16 @@
 package alicloud
 
 import (
-	"fmt"
+	"encoding/json"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	roacs "github.com/alibabacloud-go/cs-20151215/v5/client"
 	"github.com/alibabacloud-go/tea/tea"
 
-	util "github.com/alibabacloud-go/tea-utils/service"
-
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
-	"github.com/denverdino/aliyungo/common"
-	"github.com/denverdino/aliyungo/cs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -40,37 +35,39 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				ValidateFunc:  validation.StringLenBetween(1, 63),
+				ValidateFunc:  StringLenBetween(1, 63),
 				ConflictsWith: []string{"name_prefix"},
 			},
 			"name_prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ForceNew:      true,
-				ValidateFunc:  validation.StringLenBetween(0, 37),
+				ValidateFunc:  StringLenBetween(0, 37),
 				ConflictsWith: []string{"name"},
 			},
 			"vpc_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"zone_id"},
 			},
 			"vswitch_id": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				Deprecated: "Field 'vswitch_id' has been deprecated from provider version 1.91.0. New field 'vswitch_ids' replace it.",
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Removed:  "Field 'vswitch_id' has been removed from provider version 1.228.0. New field 'vswitch_ids' replace it.",
 			},
 			"vswitch_ids": {
 				Type:     schema.TypeList,
 				Optional: true,
+				ForceNew: true,
 				Computed: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
+					ValidateFunc: StringMatch(regexp.MustCompile(`^vsw-[a-z0-9]*$`), "should start with 'vsw-'."),
 				},
 				MinItems:      1,
-				ConflictsWith: []string{"vswitch_id"},
+				ConflictsWith: []string{"zone_id"},
 			},
 			"service_cidr": {
 				Type:     schema.TypeString,
@@ -80,7 +77,6 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 			"new_nat_gateway": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
 				Default:  true,
 			},
 			"deletion_protection": {
@@ -95,24 +91,22 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 			"private_zone": {
 				Type:          schema.TypeBool,
 				Optional:      true,
-				ForceNew:      true,
 				ConflictsWith: []string{"service_discovery_types"},
 				Deprecated:    "Field 'private_zone' has been deprecated from provider version 1.123.1. New field 'service_discovery_types' replace it.",
 			},
 			"service_discovery_types": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{"CoreDNS", "PrivateZone"}, false),
+					ValidateFunc: StringInSlice([]string{"CoreDNS", "PrivateZone"}, false),
 				},
 				ConflictsWith: []string{"private_zone"},
 			},
 			"zone_id": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"vpc_id", "vswitch_ids", "vswitch_id"},
 			},
 			"endpoint_public_access_enabled": {
 				Type:     schema.TypeBool,
@@ -122,23 +116,19 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 			},
 			"kube_config": {
 				Type:       schema.TypeString,
-				ForceNew:   true,
 				Optional:   true,
 				Deprecated: "Field 'kube_config' has been deprecated from provider version 1.187.0. New DataSource 'alicloud_cs_cluster_credential' manage your cluster's kube config.",
 			},
 			"client_cert": {
 				Type:     schema.TypeString,
-				ForceNew: true,
 				Optional: true,
 			},
 			"client_key": {
 				Type:     schema.TypeString,
-				ForceNew: true,
 				Optional: true,
 			},
 			"cluster_ca_cert": {
 				Type:     schema.TypeString,
-				ForceNew: true,
 				Optional: true,
 			},
 			"tags": {
@@ -148,18 +138,17 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 			"force_update": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				ForceNew: true,
-				Default:  false,
+				Removed:  "Field 'force_update' has been removed from provider version 1.228.0.",
 			},
 			"security_group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Computed: true,
 			},
 			"addons": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -167,6 +156,10 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 							Optional: true,
 						},
 						"config": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"version": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -187,31 +180,30 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"load_balancer_spec": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"slb.s1.small", "slb.s2.small", "slb.s2.medium", "slb.s3.small", "slb.s3.medium", "slb.s3.large"}, false),
+				ValidateFunc: StringInSlice([]string{"slb.s1.small", "slb.s2.small", "slb.s2.medium", "slb.s3.small", "slb.s3.medium", "slb.s3.large"}, false),
+				Deprecated:   "Field 'load_balancer_spec' has been deprecated from provider version 1.228.0. The load balancer has been changed to PayByCLCU so that no spec is need anymore.",
 			},
 			"logging_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  "SLS",
+				Type:       schema.TypeString,
+				Optional:   true,
+				Default:    "SLS",
+				Deprecated: "Field 'logging_type' has been deprecated from provider version 1.228.0. Please use addons `alibaba-log-controller` to enable logging.",
 			},
 			"sls_project_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "Field 'sls_project_name' has been deprecated from provider version 1.228.0. Please use the field `config` of addons `alibaba-log-controller` to specify log project name.",
 			},
 			"time_zone": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"retain_resources": {
 				Type:     schema.TypeList,
@@ -224,17 +216,16 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"ack.standard", "ack.pro.small"}, false),
+				ValidateFunc: StringInSlice([]string{"ack.standard", "ack.pro.small"}, false),
 			},
 			"create_v2_cluster": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
+				Removed:  "Field 'create_v2_cluster' has been removed from provider version 1.228.0.",
 			},
 			"rrsa_metadata": {
 				Type:     schema.TypeList,
-				Optional: true,
 				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -258,15 +249,36 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 					},
 				},
 			},
+			"custom_san": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"delete_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: StringInSlice([]string{"SLB", "ALB", "SLS_Data", "SLS_ControlPlane", "PrivateZone"}, false),
+						},
+						"delete_mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: StringInSlice([]string{"delete", "retain"}, false),
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
 func resourceAlicloudCSServerlessKubernetesCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
-	invoker := NewInvoker()
-
-	csService := CsService{client}
+	roa, _ := client.NewRoaCsClient()
+	csClient := CsClient{roa}
 
 	var clusterName string
 	if v, ok := d.GetOk("name"); ok {
@@ -275,166 +287,177 @@ func resourceAlicloudCSServerlessKubernetesCreate(d *schema.ResourceData, meta i
 		clusterName = resource.PrefixedUniqueId(d.Get("name_prefix").(string))
 	}
 
-	tags := make([]cs.Tag, 0)
+	tags := make([]*roacs.Tag, 0)
 	tagsMap, ok := d.Get("tags").(map[string]interface{})
 	if ok {
 		for key, value := range tagsMap {
 			if value != nil {
 				if v, ok := value.(string); ok {
-					tags = append(tags, cs.Tag{
-						Key:   key,
-						Value: v,
+					tags = append(tags, &roacs.Tag{
+						Key:   tea.String(key),
+						Value: tea.String(v),
 					})
 				}
 			}
 		}
 	}
 
-	addons := make([]cs.Addon, 0)
+	addons := make([]*roacs.Addon, 0)
 	if v, ok := d.GetOk("addons"); ok {
 		all, ok := v.([]interface{})
 		if ok {
 			for _, a := range all {
 				addon, ok := a.(map[string]interface{})
 				if ok {
-					addons = append(addons, cs.Addon{
-						Name:     addon["name"].(string),
-						Config:   addon["config"].(string),
-						Disabled: addon["disabled"].(bool),
+					addons = append(addons, &roacs.Addon{
+						Name:     tea.String(addon["name"].(string)),
+						Config:   tea.String(addon["config"].(string)),
+						Version:  tea.String(addon["version"].(string)),
+						Disabled: tea.Bool(addon["disabled"].(bool)),
 					})
 				}
 			}
 		}
 	}
-
-	var clusterType, profile string
-	if d.Get("create_v2_cluster").(bool) {
-		clusterType = cs.ClusterTypeServerlessKubernetes
-		profile = "ask.v2"
-	} else {
-		clusterType = cs.ClusterTypeManagedKubernetes
-		profile = cs.ProfileServerlessKubernetes
-	}
-
-	args := &cs.ServerlessCreationArgs{
-		Name:                 clusterName,
-		ClusterType:          cs.KubernetesClusterType(clusterType),
-		Profile:              cs.KubernetesClusterProfile(profile),
-		RegionId:             client.RegionId,
-		VpcId:                d.Get("vpc_id").(string),
-		EndpointPublicAccess: d.Get("endpoint_public_access_enabled").(bool),
-		NatGateway:           d.Get("new_nat_gateway").(bool),
-		SecurityGroupId:      d.Get("security_group_id").(string),
-		Addons:               addons,
-		KubernetesVersion:    d.Get("version").(string),
-		DeletionProtection:   d.Get("deletion_protection").(bool),
-		ResourceGroupId:      d.Get("resource_group_id").(string),
-	}
-
-	newGatway := d.Get("new_nat_gateway").(bool)
-	if d.Get("create_v2_cluster").(bool) {
-		args.NatGateway = newGatway
-	} else {
-		args.SnatEntry = newGatway
-	}
-
-	if v, ok := d.GetOk("time_zone"); ok {
-		args.TimeZone = v.(string)
-	}
-
-	if v, ok := d.GetOk("zone_id"); ok {
-		args.ZoneID = v.(string)
-	}
-
-	if v, ok := d.GetOk("service_cidr"); ok {
-		args.ServiceCIDR = v.(string)
-	}
-
-	if v, ok := d.GetOk("logging_type"); ok {
-		args.LoggingType = v.(string)
-	}
-
 	if v, ok := d.GetOk("sls_project_name"); ok {
-		args.SLSProjectName = v.(string)
-	}
+		exist := false
+		for _, addon := range addons {
+			if tea.StringValue(addon.Name) == "alibaba-log-controller" {
+				var config map[string]interface{}
+				err := json.Unmarshal([]byte(tea.StringValue(addon.Config)), &config)
+				if err == nil {
+					if project, ok := config["sls_project_name"].(string); !ok || project == "" {
+						config["sls_project_name"] = v.(string)
+					}
+					if configRaw, err := json.Marshal(config); err == nil {
+						addon.Config = tea.String(string(configRaw))
+					}
+				}
+				exist = true
+				break
+			}
+		}
+		if exist == false {
+			config := map[string]interface{}{
+				"sls_project_name": v.(string),
+			}
+			if configRaw, err := json.Marshal(config); err == nil {
+				addons = append(addons, &roacs.Addon{
+					Name:   tea.String("alibaba-log-controller"),
+					Config: tea.String(string(configRaw)),
+				})
+			}
 
-	if v, ok := d.GetOk("service_discovery_types"); ok {
-		args.ServiceDiscoveryTypes = expandStringList(v.([]interface{}))
-	}
-
-	if v, ok := d.GetOkExists("private_zone"); ok {
-		args.ServiceDiscoveryTypes = []string{}
-		if v.(bool) == true {
-			args.ServiceDiscoveryTypes = []string{"PrivateZone"}
 		}
 	}
 
-	if v := d.Get("vswitch_id").(string); v != "" {
-		args.VSwitchId = v
+	request := &roacs.CreateClusterRequest{
+		Name:                 tea.String(clusterName),
+		KubernetesVersion:    tea.String(d.Get("version").(string)),
+		ClusterType:          tea.String("ManagedKubernetes"),
+		Profile:              tea.String("Serverless"),
+		Tags:                 tags,
+		Addons:               addons,
+		DeletionProtection:   tea.Bool(d.Get("deletion_protection").(bool)),
+		RegionId:             tea.String(client.RegionId),
+		ResourceGroupId:      tea.String(d.Get("resource_group_id").(string)),
+		Vpcid:                tea.String(d.Get("vpc_id").(string)),
+		SnatEntry:            tea.Bool(d.Get("new_nat_gateway").(bool)),
+		NatGateway:           tea.Bool(d.Get("new_nat_gateway").(bool)),
+		EndpointPublicAccess: tea.Bool(d.Get("endpoint_public_access_enabled").(bool)),
+		SecurityGroupId:      tea.String(d.Get("security_group_id").(string)),
+		LoggingType:          tea.String(d.Get("logging_type").(string)),
+	}
+	if v, ok := d.GetOk("time_zone"); ok {
+		request.Timezone = tea.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("zone_id"); ok {
+		request.ZoneId = tea.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("service_cidr"); ok {
+		request.ServiceCidr = tea.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("service_discovery_types"); ok {
+		r := make([]*string, 0)
+		for _, vv := range v.([]interface{}) {
+			r = append(r, tea.String(vv.(string)))
+		}
+		request.ServiceDiscoveryTypes = r
+	}
+
+	if v, ok := d.GetOkExists("private_zone"); ok {
+		request.ServiceDiscoveryTypes = []*string{}
+		if v.(bool) == true {
+			request.ServiceDiscoveryTypes = []*string{tea.String("PrivateZone")}
+		}
 	}
 
 	if v, ok := d.GetOk("vswitch_ids"); ok {
-		args.VswitchIds = expandStringList(v.([]interface{}))
+		r := make([]*string, 0)
+		for _, vv := range v.([]interface{}) {
+			r = append(r, tea.String(vv.(string)))
+		}
+		request.VswitchIds = r
 	}
 
-	if lbSpec, ok := d.GetOk("load_balancer_spec"); ok {
-		args.LoadBalancerSpec = lbSpec.(string)
+	if v, ok := d.GetOk("load_balancer_spec"); ok {
+		request.LoadBalancerSpec = tea.String(v.(string))
 	}
 
-	if spec, ok := d.GetOk("cluster_spec"); ok {
-		args.ClusterSpec = spec.(string)
+	if v, ok := d.GetOk("cluster_spec"); ok {
+		request.ClusterSpec = tea.String(v.(string))
 	}
 
-	if enableRRSA, ok := d.GetOk("enable_rrsa"); ok {
-		args.EnableRRSA = enableRRSA.(bool)
+	if v, ok := d.GetOk("enable_rrsa"); ok {
+		request.EnableRrsa = tea.Bool(v.(bool))
+	}
+	if v, ok := d.GetOk("custom_san"); ok {
+		request.CustomSan = tea.String(v.(string))
 	}
 
 	//set tags
 	if len(tags) > 0 {
-		args.Tags = tags
+		request.Tags = tags
 	}
-
-	var requestInfo *cs.Client
-	var response interface{}
-	if err := invoker.Run(func() error {
-		raw, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
-			requestInfo = csClient
-			return csClient.CreateServerlessKubernetesCluster(args)
-		})
-		response = raw
-		return err
-	}); err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cs_serverless_kubernetes", "CreateServerlessKubernetesCluster", DenverdinoAliyungo)
+	var err error
+	var resp *roacs.CreateClusterResponse
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		resp, err = csClient.client.CreateCluster(request)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cs_serverless_kubernetes", "CreateServerlessKubernetesCluster", AlibabaCloudSdkGoERROR)
 	}
-	if debugOn() {
-		requestMap := make(map[string]interface{})
-		requestMap["RegionId"] = common.Region(client.RegionId)
-		requestMap["Args"] = args
-		addDebug("CreateServerlessKubernetesCluster", response, requestInfo, requestMap)
-	}
-	cluster, _ := response.(*cs.ClusterCommonResponse)
-	d.SetId(cluster.ClusterID)
-
+	d.SetId(tea.StringValue(resp.Body.ClusterId))
+	csService := CsService{client}
 	stateConf := BuildStateConf([]string{"initial"}, []string{"running"}, d.Timeout(schema.TimeoutCreate), 30*time.Second, csService.CsServerlessKubernetesInstanceStateRefreshFunc(d.Id(), []string{"deleting", "failed"}))
 
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
-
 	return resourceAlicloudCSServerlessKubernetesRead(d, meta)
 }
 
 func resourceAlicloudCSServerlessKubernetesRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
-	csService := CsService{client}
-	invoker := NewInvoker()
 	rosClient, err := client.NewRoaCsClient()
 	if err != nil {
 		return WrapErrorf(err, DefaultErrorMsg, ResourceName, "InitializeClient", err)
 	}
 	csClient := CsClient{rosClient}
 
-	object, err := csService.DescribeCsServerlessKubernetes(d.Id())
+	object, err := csClient.DescribeClusterDetail(d.Id())
 	if err != nil {
 		if NotFoundError(err) {
 			d.SetId("")
@@ -454,7 +477,6 @@ func resourceAlicloudCSServerlessKubernetesRead(d *schema.ResourceData, meta int
 
 	d.Set("name", object.Name)
 	d.Set("vpc_id", object.VpcId)
-	d.Set("vswitch_id", object.VSwitchId)
 	d.Set("vswitch_ids", vswitchIds)
 	d.Set("security_group_id", object.SecurityGroupId)
 	d.Set("deletion_protection", object.DeletionProtection)
@@ -462,7 +484,7 @@ func resourceAlicloudCSServerlessKubernetesRead(d *schema.ResourceData, meta int
 	d.Set("resource_group_id", object.ResourceGroupId)
 	d.Set("cluster_spec", object.ClusterSpec)
 
-	if err := d.Set("tags", flattenTagsConfig(object.Tags)); err != nil {
+	if err := d.Set("tags", flattenTags(object.Tags)); err != nil {
 		return WrapError(err)
 	}
 	if d.Get("load_balancer_spec") == "" {
@@ -472,192 +494,99 @@ func resourceAlicloudCSServerlessKubernetesRead(d *schema.ResourceData, meta int
 		d.Set("logging_type", "SLS")
 	}
 
+	if v, ok := object.Parameters["ServiceCIDR"]; ok {
+		d.Set("service_cidr", v)
+	}
+	capabilities := fetchClusterCapabilities(tea.StringValue(object.MetaData))
+	if v, ok := capabilities["PublicSLB"]; ok {
+		d.Set("endpoint_public_access_enabled", Interface2Bool(v))
+	}
+	metadata := fetchClusterMetaDataMap(tea.StringValue(object.MetaData))
+	if v, ok := metadata["ExtraCertSAN"]; ok && v != nil {
+		l := expandStringList(v.([]interface{}))
+		d.Set("custom_san", strings.Join(l, ","))
+	}
+	if v, ok := metadata["Timezone"]; ok {
+		d.Set("timezone", v)
+	}
 	// get cluster conn certs
 	// If the cluster is failed, there is no need to get cluster certs
-	if object.State == "failed" {
+	if tea.StringValue(object.State) == "failed" || tea.StringValue(object.State) == "deleted_failed" || tea.StringValue(object.State) == "deleting" {
 		return nil
 	}
 
-	var requestInfo *cs.Client
-	var response interface{}
-
-	if err := invoker.Run(func() error {
-		raw, err := client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
-			requestInfo = csClient
-			return csClient.GetClusterCerts(d.Id())
-		})
-		response = raw
-		return err
-	}); err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, d.Id(), "GetClusterCerts", DenverdinoAliyungo)
+	kubeConfig, err := csClient.DescribeClusterKubeConfigWithExpiration(d.Id(), 0)
+	if err != nil {
+		log.Printf("[ERROR] Failed to get kubeconfig due to %++v", err)
 	}
-	if debugOn() {
-		requestMap := make(map[string]interface{})
-		requestMap["ClusterId"] = d.Id()
-		addDebug("GetClusterCerts", response, requestInfo, requestMap)
-	}
-	cert, _ := response.(cs.ClusterCerts)
-	if ce, ok := d.GetOk("client_cert"); ok && ce.(string) != "" {
-		if err := writeToFile(ce.(string), cert.Cert); err != nil {
-			return WrapError(err)
+	m := flattenAlicloudCSCertificate(kubeConfig)
+	if len(m) >= 3 {
+		if ce, ok := d.GetOk("client_cert"); ok && ce.(string) != "" {
+			if err := writeToFile(ce.(string), m["client_cert"]); err != nil {
+				return WrapError(err)
+			}
+		}
+		if key, ok := d.GetOk("client_key"); ok && key.(string) != "" {
+			if err := writeToFile(key.(string), m["client_key"]); err != nil {
+				return WrapError(err)
+			}
+		}
+		if ca, ok := d.GetOk("cluster_ca_cert"); ok && ca.(string) != "" {
+			if err := writeToFile(ca.(string), m["cluster_cert"]); err != nil {
+				return WrapError(err)
+			}
 		}
 	}
-	if key, ok := d.GetOk("client_key"); ok && key.(string) != "" {
-		if err := writeToFile(key.(string), cert.Key); err != nil {
-			return WrapError(err)
-		}
-	}
-	if ca, ok := d.GetOk("cluster_ca_cert"); ok && ca.(string) != "" {
-		if err := writeToFile(ca.(string), cert.CA); err != nil {
-			return WrapError(err)
-		}
-	}
-
 	// kube_config
 	if file, ok := d.GetOk("kube_config"); ok && file.(string) != "" {
-		kubeConfig, err := csClient.DescribeClusterKubeConfigWithExpiration(d.Id(), 0)
-		if err != nil {
-			log.Printf("[ERROR] Failed to get kubeconfig due to %++v", err)
-		} else {
-			writeToFile(file.(string), tea.StringValue(kubeConfig.Config))
-		}
+		writeToFile(file.(string), tea.StringValue(kubeConfig.Config))
 	}
 
-	if data, err := flattenRRSAMetadata(object.MetaData); err != nil {
+	if data, err := flattenRRSAMetadata(tea.StringValue(object.MetaData)); err != nil {
 		return WrapError(err)
 	} else {
 		d.Set("rrsa_metadata", data)
+		if len(data) > 0 {
+			d.Set("enable_rrsa", data[0]["enabled"].(bool))
+		}
 	}
 
 	return nil
 }
 
 func resourceAlicloudCSServerlessKubernetesUpdate(d *schema.ResourceData, meta interface{}) error {
-	d.Partial(true)
+	invoker := NewInvoker()
+	// modifyCluster
+	if !d.IsNewResource() && d.HasChanges("resource_group_id", "name", "name_prefix", "deletion_protection", "custom_san", "maintenance_window", "enable_rrsa") {
+		if err := modifyCluster(d, meta, &invoker); err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "ModifyCluster", AlibabaCloudSdkGoERROR)
+		}
+	}
+
 	// modify cluster tag
 	if d.HasChange("tags") {
 		err := updateKubernetesClusterTag(d, meta)
 		if err != nil {
 			return WrapErrorf(err, ResponseCodeMsg, d.Id(), "ModifyClusterTags", AlibabaCloudSdkGoERROR)
 		}
-		d.SetPartial("tags")
+	}
+	// migrate cluster to pro form standard
+	if d.HasChange("cluster_spec") {
+		err := migrateCluster(d, meta)
+		if err != nil {
+			return WrapError(err)
+		}
 	}
 
-	// upgrade cluster version
+	// upgrade cluster
 	err := UpgradeAlicloudKubernetesCluster(d, meta)
 	if err != nil {
 		return WrapError(err)
 	}
 
-	if err := modifyKubernetesCluster(d, meta); err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, d.Id(), "ModifyCluster", DenverdinoAliyungo)
-	}
-
-	d.Partial(false)
 	return resourceAlicloudCSServerlessKubernetesRead(d, meta)
 }
 
 func resourceAlicloudCSServerlessKubernetesDelete(d *schema.ResourceData, meta interface{}) error {
-	csService := CsService{meta.(*connectivity.AliyunClient)}
-	client, err := meta.(*connectivity.AliyunClient).NewRoaCsClient()
-	if err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, ResourceName, "InitializeClient", err)
-	}
-
-	args := &roacs.DeleteClusterRequest{}
-	if v := d.Get("retain_resources"); len(v.([]interface{})) > 0 {
-		args.RetainResources = tea.StringSlice(expandStringList(v.([]interface{})))
-	}
-
-	wait := incrementalWait(3*time.Second, 3*time.Second)
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err = client.DeleteCluster(tea.String(d.Id()), args)
-		if err != nil {
-			if NeedRetry(err) {
-				wait()
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-
-	if err != nil {
-		if IsExpectedErrors(err, []string{"ErrorClusterNotFound"}) {
-			return nil
-		}
-		return WrapErrorf(err, DefaultErrorMsg, ResourceName, "DeleteCluster", AliyunTablestoreGoSdk)
-	}
-
-	stateConf := BuildStateConf([]string{"running", "deleting"}, []string{}, d.Timeout(schema.TimeoutDelete), 30*time.Second, csService.CsServerlessKubernetesInstanceStateRefreshFunc(d.Id(), []string{}))
-
-	if _, err := stateConf.WaitForState(); err != nil {
-		return WrapErrorf(err, IdMsg, d.Id())
-	}
-	return nil
-}
-
-func modifyKubernetesCluster(d *schema.ResourceData, meta interface{}) error {
-	update := false
-	action := "ModifyCluster"
-	client := meta.(*connectivity.AliyunClient)
-	csService := CsService{client}
-
-	var modifyClusterRequest cs.ModifyClusterArgs
-
-	if d.HasChange("deletion_protection") {
-		update = true
-		modifyClusterRequest.DeletionProtection = d.Get("deletion_protection").(bool)
-	}
-
-	if d.HasChange("enable_rrsa") {
-		enableRRSA := false
-		if v, ok := d.GetOk("enable_rrsa"); ok {
-			enableRRSA = v.(bool)
-		}
-		// it's not allowed to disable rrsa
-		if !enableRRSA {
-			return fmt.Errorf("It's not supported to disable RRSA! " +
-				"If your cluster has enabled this function, please manually modify your tf file and add the rrsa configuration to the file")
-		}
-		// version check
-		version := d.Get("version").(string)
-		if res, err := versionCompare(KubernetesClusterRRSASupportedVersion, version); res < 0 || err != nil {
-			return fmt.Errorf("RRSA is not supported in current version: %s", version)
-		}
-		update = true
-		modifyClusterRequest.EnableRRSA = enableRRSA
-	}
-
-	if update {
-		conn, err := meta.(*connectivity.AliyunClient).NewTeaRoaCommonClient(connectivity.OpenAckService)
-		if err != nil {
-			return WrapError(err)
-		}
-		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-			response, err := conn.DoRequestWithAction(StringPointer(action), StringPointer("2015-12-15"), nil, StringPointer("PUT"), StringPointer("AK"), String(fmt.Sprintf("/api/v2/clusters/%s", d.Id())), nil, nil, modifyClusterRequest, &util.RuntimeOptions{})
-			if err != nil {
-				if IsExpectedErrors(err, []string{"QPS Limit Exceeded"}) || NeedRetry(err) {
-					return resource.RetryableError(err)
-				}
-				addDebug(action, response, nil)
-				return resource.NonRetryableError(err)
-			}
-			addDebug(action, response, nil)
-			return nil
-		})
-
-		stateConf := BuildStateConf([]string{"updating"}, []string{"running"}, d.Timeout(schema.TimeoutUpdate), 10*time.Second, csService.CsKubernetesInstanceStateRefreshFunc(d.Id(), []string{"deleting", "failed"}))
-		if _, err := stateConf.WaitForState(); err != nil {
-			return err
-		}
-
-		if err != nil {
-			return err
-		}
-	}
-	d.SetPartial("deletion_protection")
-	d.SetPartial("enable_rrsa")
-
-	return nil
+	return resourceAlicloudCSKubernetesDelete(d, meta)
 }

--- a/alicloud/resource_alicloud_cs_serverless_kubernetes_test.go
+++ b/alicloud/resource_alicloud_cs_serverless_kubernetes_test.go
@@ -39,6 +39,14 @@ func TestAccAliCloudCSServerlessKubernetes_basic(t *testing.T) {
 
 	rac := resourceAttrCheckInit(rc, ra)
 
+	clusterCaCertFile, clientCertFile, clientKeyFile, err := CreateTempFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(clientCertFile.Name())
+	defer os.Remove(clientKeyFile.Name())
+	defer os.Remove(clusterCaCertFile.Name())
+
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(1000000, 9999999)
 	name := fmt.Sprintf("tf-testaccserverlesskubernetes-%d", rand)
@@ -56,33 +64,51 @@ func TestAccAliCloudCSServerlessKubernetes_basic(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"name":                           name,
+					"version":                        "${data.alicloud_cs_kubernetes_version.version-126.metadata.0.version}",
 					"vpc_id":                         "${alicloud_vpc.default.id}",
 					"vswitch_ids":                    []string{"${alicloud_vswitch.default.id}"},
+					"security_group_id":              "${alicloud_security_group.default.id}",
 					"new_nat_gateway":                "true",
 					"deletion_protection":            "false",
-					"enable_rrsa":                    "true",
+					"enable_rrsa":                    "false",
 					"endpoint_public_access_enabled": "true",
 					"load_balancer_spec":             "slb.s2.small",
 					"resource_group_id":              "${data.alicloud_resource_manager_resource_groups.default.groups.0.id}",
 					"tags": map[string]string{
 						"Platform": "TF",
 					},
-					"service_cidr":            "10.0.1.0/24",
-					"service_discovery_types": []string{"PrivateZone"},
-					"logging_type":            "SLS",
-					"time_zone":               getTimezone(os.Getenv("ALICLOUD_REGION")),
-					"cluster_spec":            "ack.pro.small",
+					"service_cidr":     "10.0.1.0/24",
+					"private_zone":     "true",
+					"logging_type":     "SLS",
+					"sls_project_name": name,
+					"time_zone":        getTimezone(os.Getenv("ALICLOUD_REGION")),
+					"cluster_spec":     "ack.standard",
+					"custom_san":       "www.terraform.io,1.1.1.1",
+					"addons": []map[string]string{
+						{
+							"name":     "managed-arms-prometheus",
+							"config":   "",
+							"version":  "",
+							"disabled": "false",
+						},
+					},
+					"cluster_ca_cert": clusterCaCertFile.Name(),
+					"client_key":      clientKeyFile.Name(),
+					"client_cert":     clientCertFile.Name(),
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"name":                           name,
+						"version":                        CHECKSET,
 						"deletion_protection":            "false",
-						"enable_rrsa":                    "true",
+						"enable_rrsa":                    "false",
 						"new_nat_gateway":                "true",
 						"endpoint_public_access_enabled": "true",
 						"resource_group_id":              CHECKSET,
+						"security_group_id":              CHECKSET,
 						"vswitch_ids.#":                  "1",
-						"cluster_spec":                   "ack.pro.small",
+						"cluster_spec":                   "ack.standard",
+						"custom_san":                     "www.terraform.io,1.1.1.1",
 					}),
 				),
 			},
@@ -90,8 +116,58 @@ func TestAccAliCloudCSServerlessKubernetes_basic(t *testing.T) {
 				ResourceName:      resourceId,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"load_balancer_spec", "endpoint_public_access_enabled", "force_update",
-					"new_nat_gateway", "private_zone", "zone_id", "vswitch_ids", "service_cidr", "service_discovery_types", "logging_type", "time_zone", "enable_rrsa"},
+				ImportStateVerifyIgnore: []string{"load_balancer_spec", "new_nat_gateway", "private_zone", "sls_project_name",
+					"service_discovery_types", "logging_type", "time_zone", "addons", "cluster_ca_cert", "client_key", "client_cert"},
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name": name + "_update",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name": name + "_update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"cluster_spec": "ack.pro.small",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cluster_spec": "ack.pro.small",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"version": "${data.alicloud_cs_kubernetes_version.version-128.metadata.0.version}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"version": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_rrsa": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable_rrsa": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"custom_san": "www.terraform.io,terraform.test",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"custom_san": "www.terraform.io,terraform.test",
+					}),
+				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -110,6 +186,170 @@ func TestAccAliCloudCSServerlessKubernetes_basic(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"delete_options": []map[string]interface{}{
+						{
+							"delete_mode":   "delete",
+							"resource_type": "SLB",
+						},
+						{
+							"delete_mode":   "delete",
+							"resource_type": "ALB",
+						},
+						{
+							"delete_mode":   "delete",
+							"resource_type": "PrivateZone",
+						},
+						{
+							"delete_mode":   "delete",
+							"resource_type": "SLS_Data",
+						},
+						{
+							"delete_mode":   "delete",
+							"resource_type": "SLS_ControlPlane",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{})),
+			},
+		},
+	})
+}
+
+func TestAccAliCloudCSServerlessKubernetesAuto(t *testing.T) {
+	var v *cs.ServerlessClusterResponse
+	resourceId := "alicloud_cs_serverless_kubernetes.auto"
+	ra := resourceAttrInit(resourceId, csServerlessKubernetesBasicMap)
+
+	serviceFunc := func() interface{} {
+		return &CsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+
+	rac := resourceAttrCheckInit(rc, ra)
+
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	namePrefix := "tf-testaccserverlesskubernetes"
+	name := fmt.Sprintf("%s-%d", namePrefix, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceCSServerlessKubernetesConfigDependenceAuto)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		// module name
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name_prefix":                    namePrefix,
+					"zone_id":                        "${data.alicloud_enhanced_nat_available_zones.enhanced.zones.0.zone_id}",
+					"cluster_spec":                   "ack.pro.small",
+					"new_nat_gateway":                "true",
+					"deletion_protection":            "false",
+					"enable_rrsa":                    "true",
+					"endpoint_public_access_enabled": "true",
+					"load_balancer_spec":             "slb.s1.small",
+					"service_discovery_types":        []string{"PrivateZone"},
+					"tags": map[string]string{
+						"Platform": "TF",
+					},
+					"service_cidr": "10.0.1.0/24",
+					"time_zone":    getTimezone(os.Getenv("ALICLOUD_REGION")),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":                           CHECKSET,
+						"name_prefix":                    namePrefix,
+						"cluster_spec":                   "ack.pro.small",
+						"vpc_id":                         CHECKSET,
+						"deletion_protection":            "false",
+						"enable_rrsa":                    "true",
+						"new_nat_gateway":                "true",
+						"endpoint_public_access_enabled": "true",
+						"service_discovery_types.#":      "1",
+						"resource_group_id":              CHECKSET,
+						"vswitch_ids.#":                  "1",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"load_balancer_spec", "new_nat_gateway", "private_zone", "sls_project_name",
+					"service_discovery_types", "logging_type", "time_zone", "addons", "zone_id", "name_prefix"},
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Platform": "TF",
+						"Env":      "Pre",
+					},
+					"deletion_protection": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":              "2",
+						"tags.Platform":       "TF",
+						"tags.Env":            "Pre",
+						"deletion_protection": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_id": "${alicloud_resource_manager_resource_group.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"deletion_protection": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"deletion_protection": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"delete_options": []map[string]interface{}{
+						{
+							"delete_mode":   "delete",
+							"resource_type": "SLB",
+						},
+						{
+							"delete_mode":   "delete",
+							"resource_type": "ALB",
+						},
+						{
+							"delete_mode":   "delete",
+							"resource_type": "PrivateZone",
+						},
+						{
+							"delete_mode":   "delete",
+							"resource_type": "SLS_Data",
+						},
+						{
+							"delete_mode":   "delete",
+							"resource_type": "SLS_ControlPlane",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{})),
+			},
 		},
 	})
 }
@@ -126,6 +366,18 @@ data "alicloud_zones" "default" {
 
 data "alicloud_resource_manager_resource_groups" "default" {}
 
+data "alicloud_cs_kubernetes_version" "version-126" {
+  cluster_type       = "Kubernetes"
+  kubernetes_version = "1.26"
+  profile            = "Serverless"
+}
+
+data "alicloud_cs_kubernetes_version" "version-128" {
+  cluster_type       = "Kubernetes"
+  kubernetes_version = "1.28"
+  profile            = "Serverless"
+}
+
 resource "alicloud_vpc" "default" {
 	vpc_name   = var.name
 	cidr_block = "172.16.0.0/12"
@@ -137,6 +389,27 @@ resource "alicloud_vswitch" "default" {
 	zone_id           = data.alicloud_zones.default.zones.0.id
 	vswitch_name      = var.name
 }
+
+resource "alicloud_security_group" "default" {
+  name   = var.name
+  vpc_id = alicloud_vpc.default.id
+}
+`, name)
+}
+
+func resourceCSServerlessKubernetesConfigDependenceAuto(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "%s"
+}
+
+data "alicloud_enhanced_nat_available_zones" "enhanced" {
+}
+
+resource "alicloud_resource_manager_resource_group" "default" {
+  resource_group_name = "tfTest"
+  display_name        = var.name
+}
 `, name)
 }
 
@@ -144,5 +417,4 @@ var csServerlessKubernetesBasicMap = map[string]string{
 	"new_nat_gateway":                "true",
 	"deletion_protection":            "false",
 	"endpoint_public_access_enabled": "true",
-	"force_update":                   "false",
 }

--- a/alicloud/service_alicloud_cs.go
+++ b/alicloud/service_alicloud_cs.go
@@ -50,6 +50,7 @@ const (
 	SCALING_CONFIGURATION_NAME = "kubernetes_autoscaler_autogen"
 	DefaultECSTag              = "k8s.aliyun.com"
 	DefaultClusterTag          = "ack.aliyun.com"
+	CsPlayerAccountIdTag       = "ack.playeraccount"
 	RECYCLE_MODE_LABEL         = "k8s.io/cluster-autoscaler/node-template/label/policy"
 	DefaultAutoscalerTag       = "k8s.io/cluster-autoscaler"
 	SCALING_GROUP_NAME         = "sg-%s-%s"
@@ -201,6 +202,23 @@ func (s *CsService) DescribeCsKubernetes(id string) (cluster *cs.KubernetesClust
 		return cluster, WrapErrorf(Error(GetNotFoundMessage("CsKubernetes", id)), NotFoundMsg, ProviderERROR)
 	}
 	return
+}
+
+func (s *CsClient) DescribeClusterDetail(id string) (*client.DescribeClusterDetailResponseBody, error) {
+	if id == "" {
+		return nil, WrapError(fmt.Errorf("cluster id is empty"))
+	}
+	response, err := s.client.DescribeClusterDetail(tea.String(id))
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	if debugOn() {
+		requestMap := make(map[string]interface{})
+		requestMap["ClusterId"] = id
+		addDebug("DescribeClusterDetail", response, id, requestMap)
+	}
+	return response.Body, nil
 }
 
 // DescribeClusterKubeConfig return cluster kube_config credential.

--- a/website/docs/r/cs_kubernetes.html.markdown
+++ b/website/docs/r/cs_kubernetes.html.markdown
@@ -47,55 +47,137 @@ Please use resource **`alicloud_cs_kubernetes_node_pool`** to manage your cluste
 
 ```terraform
 variable "name" {
-  default = "tf-example"
+  default = "tf-kubernetes-example"
 }
-data "alicloud_zones" "default" {
-  available_resource_creation = "VSwitch"
+
+# leave it to empty would create a new one
+variable "vpc_id" {
+  description = "Existing vpc id used to create several vswitches and other resources."
+  default     = ""
 }
+
+variable "vpc_cidr" {
+  description = "The cidr block used to launch a new vpc when 'vpc_id' is not specified."
+  default     = "10.0.0.0/8"
+}
+
+# leave it to empty then terraform will create several vswitches
+variable "vswitch_ids" {
+  description = "List of existing vswitch id."
+  type        = list(string)
+  default     = []
+}
+
+variable "vswitch_cidrs" {
+  description = "List of cidr blocks used to create several new vswitches when 'vswitch_ids' is not specified."
+  type        = list(string)
+  default     = ["10.1.0.0/16", "10.2.0.0/16", "10.3.0.0/16"]
+}
+
+variable "terway_vswitch_ids" {
+  description = "List of existing vswitch ids for terway."
+  type        = list(string)
+  default     = []
+}
+
+variable "terway_vswitch_cidrs" {
+  description = "List of cidr blocks used to create several new vswitches when 'terway_vswitch_cidrs' is not specified."
+  type        = list(string)
+  default     = ["10.4.0.0/16", "10.5.0.0/16", "10.6.0.0/16"]
+}
+
+variable "cluster_addons" {
+  type = list(object({
+    name   = string
+    config = string
+  }))
+
+  default = [
+    # If use terway network, must specify addons with `terway-eniip` and param `pod_vswitch_ids`
+    {
+      "name"   = "terway-eniip",
+      "config" = ""
+    },
+    {
+      "name"   = "csi-plugin",
+      "config" = "",
+    },
+    {
+      "name"   = "csi-provisioner",
+      "config" = "",
+    },
+    {
+      "name"   = "logtail-ds",
+      "config" = "\"IngressDashboardEnabled\":\"true\"",
+    },
+    {
+      "name"   = "nginx-ingress-controller",
+      "config" = "\"IngressSlbNetworkType\":\"internet\"",
+    },
+    {
+      "name"   = "arms-prometheus",
+      "config" = "",
+    },
+    {
+      "name"   = "ack-node-problem-detector",
+      "config" = "\"sls_project_name\":\"\"",
+    }
+  ]
+}
+
+data "alicloud_enhanced_nat_available_zones" "enhanced" {}
+
+# If there is not specifying vpc_id, the module will launch a new vpc
+resource "alicloud_vpc" "vpc" {
+  count      = var.vpc_id == "" ? 1 : 0
+  cidr_block = var.vpc_cidr
+}
+
+# According to the vswitch cidr blocks to launch several vswitches
+resource "alicloud_vswitch" "vswitches" {
+  count      = length(var.vswitch_ids) > 0 ? 0 : length(var.vswitch_cidrs)
+  vpc_id     = var.vpc_id == "" ? join("", alicloud_vpc.vpc.*.id) : var.vpc_id
+  cidr_block = element(var.vswitch_cidrs, count.index)
+  zone_id    = data.alicloud_enhanced_nat_available_zones.enhanced.zones[count.index < length(data.alicloud_enhanced_nat_available_zones.enhanced.zones) ? count.index : 0].zone_id
+}
+
+# According to the vswitch cidr blocks to launch several vswitches
+resource "alicloud_vswitch" "terway_vswitches" {
+  count      = length(var.terway_vswitch_ids) > 0 ? 0 : length(var.terway_vswitch_cidrs)
+  vpc_id     = var.vpc_id == "" ? join("", alicloud_vpc.vpc.*.id) : var.vpc_id
+  cidr_block = element(var.terway_vswitch_cidrs, count.index)
+  zone_id    = data.alicloud_enhanced_nat_available_zones.enhanced.zones[count.index < length(data.alicloud_enhanced_nat_available_zones.enhanced.zones) ? count.index : 0].zone_id
+}
+
 data "alicloud_resource_manager_resource_groups" "default" {
   status = "OK"
 }
 
-data "alicloud_instance_types" "default" {
-  count                = 3
-  availability_zone    = data.alicloud_zones.default.zones[count.index].id
-  cpu_core_count       = 4
-  memory_size          = 8
-  kubernetes_node_role = "Master"
-  system_disk_category = "cloud_essd"
-}
-
-resource "alicloud_vpc" "default" {
-  vpc_name   = var.name
-  cidr_block = "10.4.0.0/16"
-}
-resource "alicloud_vswitch" "default" {
-  count        = 3
-  vswitch_name = format("${var.name}_%d", count.index + 1)
-  cidr_block   = format("10.4.%d.0/24", count.index + 1)
-  zone_id      = data.alicloud_zones.default.zones[count.index].id
-  vpc_id       = alicloud_vpc.default.id
-}
-
 resource "alicloud_cs_kubernetes" "default" {
-  master_vswitch_ids    = alicloud_vswitch.default.*.id
-  master_instance_types = [data.alicloud_instance_types.default.0.instance_types.0.id, data.alicloud_instance_types.default.1.instance_types.0.id, data.alicloud_instance_types.default.2.instance_types.0.id]
+  master_vswitch_ids    = length(var.vswitch_ids) > 0 ? split(",", join(",", var.vswitch_ids)) : length(var.vswitch_cidrs) < 1 ? [] : split(",", join(",", alicloud_vswitch.vswitches.*.id))
+  pod_vswitch_ids       = length(var.terway_vswitch_ids) > 0 ? split(",", join(",", var.terway_vswitch_ids)) : length(var.terway_vswitch_cidrs) < 1 ? [] : split(",", join(",", alicloud_vswitch.terway_vswitches.*.id))
+  master_instance_types = ["ecs.c6.xlarge", "ecs.c6.xlarge", "ecs.c6.xlarge"]
   master_disk_category  = "cloud_essd"
-  version               = "1.24.6-aliyun.1"
   password              = "Yourpassword1234"
-  pod_cidr              = "10.72.0.0/16"
   service_cidr          = "172.18.0.0/16"
-  load_balancer_spec    = "slb.s2.small"
+  load_balancer_spec    = "slb.s1.small"
   install_cloud_monitor = "true"
   resource_group_id     = data.alicloud_resource_manager_resource_groups.default.groups.0.id
   deletion_protection   = "false"
   timezone              = "Asia/Shanghai"
   os_type               = "Linux"
-  platform              = "CentOS"
+  platform              = "AliyunLinux3"
   cluster_domain        = "cluster.local"
   proxy_mode            = "ipvs"
   custom_san            = "www.terraform.io"
   new_nat_gateway       = "true"
+  dynamic "addons" {
+    for_each = var.cluster_addons
+    content {
+      name   = lookup(addons.value, "name", var.cluster_addons)
+      config = lookup(addons.value, "config", var.cluster_addons)
+    }
+  }
 }
 ```
 
@@ -133,7 +215,7 @@ resource "alicloud_cs_kubernetes" "default" {
 * `os_type` - (Optional, ForceNew, Available since v1.103.2) The operating system of the nodes that run pods, its valid value is either `Linux` or `Windows`. Default to `Linux`.
 * `platform` - (Optional, ForceNew, Available since v1.103.2) The architecture of the nodes that run pods, its valid value is either `CentOS` or `AliyunLinux`. Default to `CentOS`.
 * `node_name_mode` - (Optional, ForceNew, Available since v1.88.0) Each node name consists of a prefix, an IP substring, and a suffix, the input format is `customized,<prefix>,IPSubStringLen,<suffix>`. For example "customized,aliyun.com-,5,-test", if the node IP address is 192.168.59.176, the prefix is aliyun.com-, IP substring length is 5, and the suffix is -test, the node name will be aliyun.com-59176-test.
-* `addons` - (Optional, Available since v1.88.0) The addon you want to install in cluster. See [`addons`](#addons) below.
+* `addons` - (Optional, Available since v1.88.0) The addon you want to install in cluster. See [`addons`](#addons) below. Only works for **Create** Operation, use [resource cs_kubernetes_addon](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cs_kubernetes_addon) to manage addons if cluster is created.
 
 *Network params*
 
@@ -273,7 +355,7 @@ The following arguments are supported in the `delete_options` configuration bloc
   - `delete`: delete resources created by the cluster.
   - `retain`: retain resources created by the cluster.
 * `resource_type` - (Optional) The type of resources that are created by cluster. Valid values:
-  - `SLB`: SLB resources created through the service, default behavior is to delete, option to retain is available. 
+  - `SLB`: SLB resources created by the Nginx Ingress Service, default behavior is to delete, option to retain is available. 
   - `ALB`: ALB resources created by the ALB Ingress Controller, default behavior is to retain, option to delete is available. 
   - `SLS_Data`: SLS Project used by the cluster logging feature, default behavior is to retain, option to delete is available. 
   - `SLS_ControlPlane`: SLS Project used for the managed cluster control plane logs, default behavior is to retain, option to delete is available.
@@ -281,7 +363,7 @@ The following arguments are supported in the `delete_options` configuration bloc
 ```
   ...
   // Specify delete_options as below when deleting cluster
-  // delete SLB resources created by the cluster
+  // delete SLB resources created by the Nginx Ingress Service
   delete_options {
     delete_mode = "delete"
     resource_type = "SLB"

--- a/website/docs/r/cs_managed_kubernetes.html.markdown
+++ b/website/docs/r/cs_managed_kubernetes.html.markdown
@@ -35,7 +35,7 @@ Please refer to the `Authorization management` and `Cluster management` sections
 
 -> **NOTE:** From version 1.120.0, Support for cluster migration from Standard cluster to professional.
 
--> **NOTE:** From version 1.177.0+, `runtime`,`enable_ssh`,`rds_instances`,`exclude_autoscaler_nodes`,`worker_number`,`worker_instance_types`,`password`,`key_name`,`kms_encrypted_password`,`kms_encryption_context`,`worker_instance_charge_type`,`worker_period`,`worker_period_unit`,`worker_auto_renew`,`worker_auto_renew_period`,`worker_disk_category`,`worker_disk_size`,`worker_data_disks`,`node_name_mode`,`node_port_range`,`os_type`,`platform`,`image_id`,`cpu_policy`,`user_data`,`taints`,`worker_disk_performance_level`,`worker_disk_snapshot_policy_id`,`install_cloud_monitor` are deprecated.
+-> **NOTE:** From version 1.177.0, `runtime`,`enable_ssh`,`rds_instances`,`exclude_autoscaler_nodes`,`worker_number`,`worker_instance_types`,`password`,`key_name`,`kms_encrypted_password`,`kms_encryption_context`,`worker_instance_charge_type`,`worker_period`,`worker_period_unit`,`worker_auto_renew`,`worker_auto_renew_period`,`worker_disk_category`,`worker_disk_size`,`worker_data_disks`,`node_name_mode`,`node_port_range`,`os_type`,`platform`,`image_id`,`cpu_policy`,`user_data`,`taints`,`worker_disk_performance_level`,`worker_disk_snapshot_policy_id`,`install_cloud_monitor` are deprecated.
 We Suggest you using resource **`alicloud_cs_kubernetes_node_pool`** to manage your cluster worker nodes.
 
 -> **NOTE:** From version 1.212.0, `runtime`,`enable_ssh`,`rds_instances`,`exclude_autoscaler_nodes`,`worker_number`,`worker_instance_types`,`password`,`key_name`,`kms_encrypted_password`,`kms_encryption_context`,`worker_instance_charge_type`,`worker_period`,`worker_period_unit`,`worker_auto_renew`,`worker_auto_renew_period`,`worker_disk_category`,`worker_disk_size`,`worker_data_disks`,`node_name_mode`,`node_port_range`,`os_type`,`platform`,`image_id`,`cpu_policy`,`user_data`,`taints`,`worker_disk_performance_level`,`worker_disk_snapshot_policy_id`,`install_cloud_monitor`,`kube_config`,`availability_zone` are removed.
@@ -182,32 +182,32 @@ The following arguments are supported:
 * `name` - (Optional) The kubernetes cluster's name. It is unique in one Alicloud account.
 * `worker_vswitch_ids` - (**Required**, ForceNew) The vswitches used by control plane.  See [`worker_vswitch_ids`](#worker_vswitch_ids) below.
 * `name_prefix` - (Optional) The kubernetes cluster name's prefix. It is conflict with `name`. If it is specified, terraform will using it to build the only cluster name. Default to "Terraform-Creation".
-* `timezone` - (Optional, ForceNew, Available in 1.103.2+) When you create a cluster, set the time zones for the Master and Worker nodes. You can only change the managed node time zone if you create a cluster. Once the cluster is created, you can only change the time zone of the Worker node.
-* `resource_group_id` - (Optional, ForceNew, Available in 1.101.0+) The ID of the resource group,by default these cloud resources are automatically assigned to the default resource group.
+* `timezone` - (Optional, ForceNew, Available since v1.103.2) When you create a cluster, set the time zones for the Master and Worker nodes. You can only change the managed node time zone if you create a cluster. Once the cluster is created, you can only change the time zone of the Worker node.
+* `resource_group_id` - (Optional, ForceNew, Available since v1.101.0) The ID of the resource group,by default these cloud resources are automatically assigned to the default resource group.
 * `version` - (Optional, Available since 1.70.1) Desired Kubernetes version. If you do not specify a value, the latest available version at resource creation is used and no upgrades will occur except you set a higher version number. The value must be configured and increased to upgrade the version when desired. Downgrades are not supported by ACK.
-* `security_group_id` - (Optional, ForceNew, Available in 1.91.0+) The ID of the security group to which the ECS instances in the cluster belong. If it is not specified, a new Security group will be built.
-* `is_enterprise_security_group` - (Optional, ForceNew, Available in 1.91.0+) Enable to create advanced security group. default: false. See [Advanced security group](https://www.alibabacloud.com/help/doc-detail/120621.htm).
+* `security_group_id` - (Optional, ForceNew, Available since v1.91.0) The ID of the security group to which the ECS instances in the cluster belong. If it is not specified, a new Security group will be built.
+* `is_enterprise_security_group` - (Optional, ForceNew, Available since v1.91.0) Enable to create advanced security group. default: false. See [Advanced security group](https://www.alibabacloud.com/help/doc-detail/120621.htm).
 * `proxy_mode` - (Optional, ForceNew) Proxy mode is option of kube-proxy. options: iptables|ipvs. default: ipvs.
-* `cluster_domain` - (Optional, ForceNew, Available in 1.103.2+) Cluster local domain name, Default to `cluster.local`. A domain name consists of one or more sections separated by a decimal point (.), each of which is up to 63 characters long, and can be lowercase, numerals, and underscores (-), and must be lowercase or numerals at the beginning and end.
-* `custom_san` - (Optional, ForceNew, Available in 1.103.2+) Customize the certificate SAN, multiple IP or domain names are separated by English commas (,).
+* `cluster_domain` - (Optional, ForceNew, Available since v1.103.2) Cluster local domain name, Default to `cluster.local`. A domain name consists of one or more sections separated by a decimal point (.), each of which is up to 63 characters long, and can be lowercase, numerals, and underscores (-), and must be lowercase or numerals at the beginning and end.
+* `custom_san` - (Optional, ForceNew, Available since v1.103.2) Customize the certificate SAN, multiple IP or domain names are separated by English commas (,).
 * `user_ca` - (Optional) The path of customized CA cert, you can use this CA to sign client certs to connect your cluster.
-* `deletion_protection` - (Optional, Available in 1.103.2+)  Whether to enable cluster deletion protection.
-* `enable_rrsa` - (Optional, Available in 1.171.0+) Whether to enable cluster to support RRSA for version 1.22.3+. Default to `false`. Once the RRSA function is turned on, it is not allowed to turn off. If your cluster has enabled this function, please manually modify your tf file and add the rrsa configuration to the file, learn more [RAM Roles for Service Accounts](https://www.alibabacloud.com/help/zh/container-service-for-kubernetes/latest/use-rrsa-to-enforce-access-control).
-* `service_account_issuer` - (Optional, ForceNew, Available in 1.92.0+) The issuer of the Service Account token for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm), corresponds to the `iss` field in the token payload. Set this to `"https://kubernetes.default.svc"` to enable the Token Volume Projection feature (requires specifying `api_audiences` as well). From cluster version 1.22+, Service Account Token Volume Projection will be enabled by default.
-* `api_audiences` - (Optional, ForceNew, Available in 1.92.0+) A list of API audiences for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm). Set this to `["https://kubernetes.default.svc"]` if you want to enable the Token Volume Projection feature (requires specifying `service_account_issuer` as well. From cluster version 1.22+, Service Account Token Volume Projection will be enabled by default.
-* `tags` - (Optional, Available in 1.97.0+) Default nil, A map of tags assigned to the kubernetes cluster and work nodes. See [`tags`](#tags) below.
-* `cluster_spec` - (Optional, Available in 1.101.0+) The cluster specifications of kubernetes cluster,which can be empty. Valid values:
+* `deletion_protection` - (Optional, Available since v1.103.2)  Whether to enable cluster deletion protection.
+* `enable_rrsa` - (Optional, Available since v1.171.0) Whether to enable cluster to support RRSA for kubernetes version 1.22.3+. Default to `false`. Once the RRSA function is turned on, it is not allowed to turn off. If your cluster has enabled this function, please manually modify your tf file and add the rrsa configuration to the file, learn more [RAM Roles for Service Accounts](https://www.alibabacloud.com/help/zh/container-service-for-kubernetes/latest/use-rrsa-to-enforce-access-control).
+* `service_account_issuer` - (Optional, ForceNew, Available since v1.92.0) The issuer of the Service Account token for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm), corresponds to the `iss` field in the token payload. Set this to `"https://kubernetes.default.svc"` to enable the Token Volume Projection feature (requires specifying `api_audiences` as well). From cluster version 1.22, Service Account Token Volume Projection will be enabled by default.
+* `api_audiences` - (Optional, ForceNew, Available since v1.92.0) A list of API audiences for [Service Account Token Volume Projection](https://www.alibabacloud.com/help/doc-detail/160384.htm). Set this to `["https://kubernetes.default.svc"]` if you want to enable the Token Volume Projection feature (requires specifying `service_account_issuer` as well. From cluster version 1.22, Service Account Token Volume Projection will be enabled by default.
+* `tags` - (Optional, Available since v1.97.0) Default nil, A map of tags assigned to the kubernetes cluster and work nodes. See [`tags`](#tags) below.
+* `cluster_spec` - (Optional, Available since v1.101.0) The cluster specifications of kubernetes cluster,which can be empty. Valid values:
   * ack.standard : Standard managed clusters.
   * ack.pro.small : Professional managed clusters.
-* `encryption_provider_key` - (Optional, ForceNew, Available in 1.103.2+) The disk encryption key.
-* `maintenance_window` - (Optional, Available in 1.109.1+) The cluster maintenance window，effective only in the professional managed cluster. Managed node pool will use it. See [`maintenance_window`](#maintenance_window) below.
-* `load_balancer_spec` - (Optional, ForceNew, Available in 1.117.0+) The cluster api server load balance instance specification, default `slb.s1.small`. For more information on how to select a LB instance specification, see [SLB instance overview](https://help.aliyun.com/document_detail/85931.html).
-* `control_plane_log_ttl` - (Optional, Available in 1.141.0+) Control plane log retention duration (unit: day). Default `30`. If control plane logs are to be collected, `control_plane_log_ttl` and `control_plane_log_components` must be specified.
-* `control_plane_log_components` - (Optional, Available in 1.141.0+) List of target components for which logs need to be collected. Supports `apiserver`, `kcm`, `scheduler`, `ccm` and `controlplane-events`.
-* `control_plane_log_project` - (Optional, Available in 1.141.0+) Control plane log project. If this field is not set, a log service project named k8s-log-{ClusterID} will be automatically created.
-* `retain_resources` - (Optional, Available in 1.141.0+) Resources that are automatically created during cluster creation, including NAT gateways, SNAT rules, SLB instances, and RAM Role, will be deleted. Resources that are manually created after you create the cluster, such as SLB instances for Services, will also be deleted. If you need to retain resources, please configure with `retain_resources`. There are several aspects to pay attention to when using `retain_resources` to retain resources. After configuring `retain_resources` into the terraform configuration manifest file, you first need to run `terraform apply`.Then execute `terraform destroy`.
+* `encryption_provider_key` - (Optional, ForceNew, Available since v1.103.2) The disk encryption key.
+* `maintenance_window` - (Optional, Available since v1.109.1) The cluster maintenance window，effective only in the professional managed cluster. Managed node pool will use it. See [`maintenance_window`](#maintenance_window) below.
+* `load_balancer_spec` - (Optional, ForceNew, Available since v1.117.0) The cluster api server load balance instance specification, default `slb.s1.small`. For more information on how to select a LB instance specification, see [SLB instance overview](https://help.aliyun.com/document_detail/85931.html).
+* `control_plane_log_ttl` - (Optional, Available since v1.141.0) Control plane log retention duration (unit: day). Default `30`. If control plane logs are to be collected, `control_plane_log_ttl` and `control_plane_log_components` must be specified.
+* `control_plane_log_components` - (Optional, Available since v1.141.0) List of target components for which logs need to be collected. Supports `apiserver`, `kcm`, `scheduler`, `ccm` and `controlplane-events`.
+* `control_plane_log_project` - (Optional, Available since v1.141.0) Control plane log project. If this field is not set, a log service project named k8s-log-{ClusterID} will be automatically created.
+* `retain_resources` - (Optional, Available since v1.141.0) Resources that are automatically created during cluster creation, including NAT gateways, SNAT rules, SLB instances, and RAM Role, will be deleted. Resources that are manually created after you create the cluster, such as SLB instances for Services, will also be deleted. If you need to retain resources, please configure with `retain_resources`. There are several aspects to pay attention to when using `retain_resources` to retain resources. After configuring `retain_resources` into the terraform configuration manifest file, you first need to run `terraform apply`.Then execute `terraform destroy`.
 * `delete_options` - (Optional) Delete options, only work for deleting resource. Make sure you have run `terraform apply` to make the configuration applied. See [`delete_options`](#delete_options) below.
-* `addons` - (Optional, Available in 1.88.0+) The addon you want to install in cluster. See [`addons`](#addons) below.
+* `addons` - (Optional, Available since v1.88.0) The addon you want to install in cluster. See [`addons`](#addons) below. Only works for **Create** Operation, use [resource cs_kubernetes_addon](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cs_kubernetes_addon) to manage addons if cluster is created.
 
 ### Network params
 
@@ -242,7 +242,7 @@ If you want to use `Flannel` as CNI network plugin, You need to specify the `pod
 * `rds_instances` - (Removed since v1.212.0) RDS instance list, You can choose which RDS instances whitelist to add instances to.
 * `install_cloud_monitor` - (Removed since v1.212.0) Install cloud monitor agent on ECS. Default is `true` in previous version. From provider version 1.208.0, the default value is `false`.
 * `exclude_autoscaler_nodes` - (Removed since v1.212.0) Exclude autoscaler nodes from `worker_nodes`. Default to `false`.
-* `kube_config` - (Removed since v1.212.0) The path of kube config, like `~/.kube/config`. You can set some file paths to save kube_config information, but this way is cumbersome. Since version 1.105.0, we've written it to tf state file. About its use，see export attribute certificate_authority. From version 1.187.0+, new DataSource `alicloud_cs_cluster_credential` is recommended to manage cluster's kube_config.
+* `kube_config` - (Removed since v1.212.0) The path of kube config, like `~/.kube/config`. You can set some file paths to save kube_config information, but this way is cumbersome. Since version 1.105.0, we've written it to tf state file. About its use，see export attribute certificate_authority. From version 1.187.0, new DataSource `alicloud_cs_cluster_credential` is recommended to manage cluster's kube_config.
 * `availability_zone` - (Removed since v1.212.0) The Zone where new kubernetes cluster will be located. If it is not be specified, the `vswitch_ids` should be set, its value will be vswitch's zone.
 * `worker_number` - (Removed since v1.212.0) The worker node number of the kubernetes cluster. Default to 3. It is limited up to 50 and if you want to enlarge it, please apply white list or contact with us. From version 1.109.1, It is not necessary in the professional managed cluster, but it is necessary in other types of clusters.
 * `worker_instance_types` - (Removed since v1.212.0) The instance type of worker node. Specify one type for single AZ Cluster, three types for MultiAZ Cluster. From version 1.109.1, It is not necessary in the professional managed cluster, but it is necessary in other types of clusters.
@@ -486,8 +486,8 @@ The following arguments are supported in the `worker_data_disks` configuration b
 * `category` - (Optional) The type of the data disks. Valid values: `cloud`, `cloud_efficiency`, `cloud_ssd` and `cloud_essd`. Default to `cloud_efficiency`.
 * `size` - (Optional) The size of a data disk, at least 40. Unit: GiB.
 * `encrypted` - (Optional) Specifies whether to encrypt data disks. Valid values: true and false. Default to `false`.
-* `performance_level` - (Optional, Available in 1.120.0+) Worker node data disk performance level, when `category` values `cloud_essd`, the optional values are `PL0`, `PL1`, `PL2` or `PL3`, but the specific performance level is related to the disk capacity. For more information, see [Enhanced SSDs](https://www.alibabacloud.com/help/doc-detail/122389.htm). Default is `PL1`.
-* `auto_snapshot_policy_id` - (Optional, Available in 1.120.0+) Worker node data disk auto snapshot policy.
+* `performance_level` - (Optional, Available since v1.120.0) Worker node data disk performance level, when `category` values `cloud_essd`, the optional values are `PL0`, `PL1`, `PL2` or `PL3`, but the specific performance level is related to the disk capacity. For more information, see [Enhanced SSDs](https://www.alibabacloud.com/help/doc-detail/122389.htm). Default is `PL1`.
+* `auto_snapshot_policy_id` - (Optional, Available since v1.120.0) Worker node data disk auto snapshot policy.
 * `kms_key_id` - (Optional) The ID of the Key Management Service (KMS) key to use for data disk N.
 * `device` - (Optional) The mount point of data disk N.
 * `name` - (Optional) The name of data disk N. The name must be 2 to 128 characters in length. It must start with a letter and cannot start with http:// or https://. It can contain letters, digits, colons (.), underscores (_), and hyphens (-).
@@ -573,7 +573,7 @@ The following arguments are supported in the `delete_options` configuration bloc
   - `delete`: delete resources created by the cluster.
   - `retain`: retain resources created by the cluster.
 * `resource_type` - (Optional) The type of resources that are created by cluster. Valid values:
-  - `SLB`: SLB resources created through the service, default behavior is to delete, option to retain is available. 
+  - `SLB`: SLB resources created by the Nginx Ingress Service, default behavior is to delete, option to retain is available.  
   - `ALB`: ALB resources created by the ALB Ingress Controller, default behavior is to retain, option to delete is available. 
   - `SLS_Data`: SLS Project used by the cluster logging feature, default behavior is to retain, option to delete is available. 
   - `SLS_ControlPlane`: SLS Project used for the managed cluster control plane logs, default behavior is to retain, option to delete is available.
@@ -581,7 +581,7 @@ The following arguments are supported in the `delete_options` configuration bloc
 ```
   ...
   // Specify delete_options as below when deleting cluster
-  // delete SLB resources created by the cluster
+  // delete SLB resources created by the Nginx Ingress Service
   delete_options {
     delete_mode = "delete"
     resource_type = "SLB"
@@ -622,11 +622,11 @@ The following attributes are exported:
   * `master_public_ip` - Master node SSH IP address.
   * `service_domain` - Service Access Domain.
 * `worker_ram_role_name` - The RamRole Name attached to worker node.
-* `certificate_authority` - (Available in 1.105.0+) Nested attribute containing certificate authority data for your cluster.
+* `certificate_authority` - (Available since v1.105.0) Nested attribute containing certificate authority data for your cluster.
   * `cluster_cert` - The base64 encoded cluster certificate data required to communicate with your cluster. Add this to the certificate-authority-data section of the kubeconfig file for your cluster.
   * `client_cert` - The base64 encoded client certificate data required to communicate with your cluster. Add this to the client-certificate-data section of the kubeconfig file for your cluster.
   * `client_key` - The base64 encoded client key data required to communicate with your cluster. Add this to the client-key-data section of the kubeconfig file for your cluster.
-* `rrsa_metadata` - (Optional, Available in v1.185.0+) Nested attribute containing RRSA related data for your cluster.
+* `rrsa_metadata` - (Optional, Available since v1.185.0) Nested attribute containing RRSA related data for your cluster.
   * `enabled` - Whether the RRSA feature has been enabled.
   * `rrsa_oidc_issuer_url` - The issuer URL of RRSA OIDC Token.
   * `ram_oidc_provider_name` - The name of OIDC Provider that was registered in RAM.
@@ -634,7 +634,7 @@ The following attributes are exported:
 
 ## Timeouts
 
--> **NOTE:** Available in 1.58.0+.
+-> **NOTE:** Available since v1.58.0.
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration-0-11/resources.html#timeouts) for certain actions:
 
 * `create` - (Defaults to 90 mins) Used when creating the kubernetes cluster (until it reaches the initial `running` status).

--- a/website/docs/r/cs_serverless_kubernetes.html.markdown
+++ b/website/docs/r/cs_serverless_kubernetes.html.markdown
@@ -29,13 +29,15 @@ Please refer to the `Authorization management` and `Cluster management` sections
 
 -> **NOTE:** From version 1.162.0, support for creating professional serverless cluster.
 
+-> **NOTE:** From version 1.228.0, support to migrate basic serverless cluster to professional serverless cluster.
+
 ## Example Usage
 
 Basic Usage
 
 ```terraform
 variable "name" {
-  default = "ask-example"
+  default = "ask-example-pro"
 }
 
 data "alicloud_zones" "default" {
@@ -44,13 +46,13 @@ data "alicloud_zones" "default" {
 
 resource "alicloud_vpc" "default" {
   vpc_name   = var.name
-  cidr_block = "10.1.0.0/21"
+  cidr_block = "10.2.0.0/21"
 }
 
 resource "alicloud_vswitch" "default" {
   vswitch_name = var.name
   vpc_id       = alicloud_vpc.default.id
-  cidr_block   = "10.1.1.0/24"
+  cidr_block   = "10.2.1.0/24"
   zone_id      = data.alicloud_zones.default.zones[0].id
 }
 
@@ -69,8 +71,6 @@ resource "alicloud_cs_serverless_kubernetes" "serverless" {
   service_discovery_types = ["PrivateZone"]
   # Enable log service, A project named k8s-log-{ClusterID} will be automatically created
   logging_type = "SLS"
-  # Select an existing sls project
-  # sls_project_name             = ""
 
   # tags
   tags = {
@@ -80,7 +80,7 @@ resource "alicloud_cs_serverless_kubernetes" "serverless" {
 
   # addons
   addons {
-    # SLB Ingress
+    # ALB Ingress
     name = "alb-ingress-controller"
   }
   addons {
@@ -89,7 +89,9 @@ resource "alicloud_cs_serverless_kubernetes" "serverless" {
   addons {
     name = "knative"
   }
-
+  addons {
+    name = "arms-prometheus"
+  }
 }
 ```
 
@@ -100,41 +102,42 @@ The following arguments are supported:
 * `name` - (Optional) The kubernetes cluster's name. It is the only in one Alicloud account.
 * `name_prefix` - (Optional, ForceNew) The kubernetes cluster name's prefix. It is conflict with `name`. If it is specified, terraform will using it to build the only cluster name. Default to "Terraform-Creation".
 * `version` - (Optional, Available since v1.97.0) Desired Kubernetes version. If you do not specify a value, the latest available version at resource creation is used.
-* `vpc_id` - (Required, ForceNew) The vpc where new kubernetes cluster will be located. Specify one vpc's id, if it is not specified, a new VPC  will be built.
-* `vswitch_ids` - (Optional) The vswitches where new kubernetes cluster will be located.
-* `new_nat_gateway` - (Optional, ForceNew) Whether to create a new nat gateway while creating kubernetes cluster. SNAT must be configured when a new VPC is automatically created. Default is `true`.
-* `endpoint_public_access_enabled` - (Optional, ForceNew) Whether to create internet  eip for API Server. Default to false.
-* `service_discovery_types` - (Optional, ForceNew, Available since v1.123.1) Service discovery type. If the value is empty, it means that service discovery is not enabled. Valid values are `CoreDNS` and `PrivateZone`. 
+* `vpc_id` - (Optional, ForceNew) The vpc where new kubernetes cluster will be located. Specify one vpc's id, if it is not specified, a new VPC will be built.
+* `vswitch_ids` - (Optional, ForceNew) The vswitches where new kubernetes cluster will be located.
+* `new_nat_gateway` - (Optional) Whether to create a new nat gateway while creating kubernetes cluster. SNAT must be configured when a new VPC is automatically created. Default is `true`.
+* `endpoint_public_access_enabled` - (Optional, ForceNew) Whether to create internet eip for API Server. Default to false.
+* `service_discovery_types` - (Optional, Available since v1.123.1) Service discovery type. Only works for **Create** Operation. If the value is empty, it means that service discovery is not enabled. Valid values are `CoreDNS` and `PrivateZone`.
 * `deletion_protection` - (Optional, ForceNew) Whether enable the deletion protection or not.
     - true: Enable deletion protection.
     - false: Disable deletion protection.
 * `enable_rrsa` - (Optional, Available since v1.171.0) Whether to enable cluster to support RRSA for version 1.22.3+. Default to `false`. Once the RRSA function is turned on, it is not allowed to turn off. If your cluster has enabled this function, please manually modify your tf file and add the rrsa configuration to the file, learn more [RAM Roles for Service Accounts](https://www.alibabacloud.com/help/zh/container-service-for-kubernetes/latest/use-rrsa-to-enforce-access-control).
-* `force_update` - (Optional, ForceNew) Default false, when you want to change `vpc_id` and `vswitch_id`, you have to set this field to true, then the cluster will be recreated.
 * `tags` - (Optional) Default nil, A map of tags assigned to the kubernetes cluster and work nodes.
 * `kube_config` - (Optional, Deprecated from v1.187.0) The path of kube config, like `~/.kube/config`.
-* `client_cert` - (Optional, ForceNew) The path of client certificate, like `~/.kube/client-cert.pem`.
-* `client_key` - (Optional, ForceNew) The path of client key, like `~/.kube/client-key.pem`.
-* `cluster_ca_cert` - (Optional, ForceNew) The path of cluster ca certificate, like `~/.kube/cluster-ca-cert.pem`
-* `security_group_id` - (Optional, Available since v1.91.0) The ID of the security group to which the ECS instances in the cluster belong. If it is not specified, a new Security group will be built.
-* `resource_group_id` - (Optional, ForceNew, Available since v1.101.0) The ID of the resource group,by default these cloud resources are automatically assigned to the default resource group.
-* `load_balancer_spec` - (Optional, Available since v1.117.0) The cluster api server load balance instance specification, default `slb.s2.small`. For more information on how to select a LB instance specification, see [SLB instance overview](https://help.aliyun.com/document_detail/85931.html).
-* `addons` - (Optional, Available since v1.91.0) You can specific network plugin,log component,ingress component and so on. See [`addons`](#addons) below.
-* `time_zone` - (Optional, ForceNew, Available since v1.123.1) The time zone of the cluster.
-* `zone_id` - (Optional, ForceNew, Available since v1.123.1) When creating a cluster using automatic VPC creation, you need to specify the zone where the VPC is located. 
+* `client_cert` - (Optional) The path of client certificate, like `~/.kube/client-cert.pem`.
+* `client_key` - (Optional) The path of client key, like `~/.kube/client-key.pem`.
+* `cluster_ca_cert` - (Optional) The path of cluster ca certificate, like `~/.kube/cluster-ca-cert.pem`
+* `security_group_id` - (Optional, ForceNew, Available since v1.91.0) The ID of the security group to which the ECS instances in the cluster belong. If it is not specified, a new Security group will be built.
+* `resource_group_id` - (Optional, Available since v1.101.0) The ID of the resource group,by default these cloud resources are automatically assigned to the default resource group.
+* `load_balancer_spec` - (Optional, Deprecated since v1.226.0) The cluster api server load balance instance specification, default `slb.s2.small`. For more information on how to select a LB instance specification, see [SLB instance overview](https://help.aliyun.com/document_detail/85931.html).
+* `addons` - (Optional, Available since v1.91.0) You can specific network plugin, log component, ingress component and so on. See [`addons`](#addons) below. Only works for **Create** Operation, use [resource cs_kubernetes_addon](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cs_kubernetes_addon) to manage addons if cluster is created.
+* `time_zone` - (Optional, Available since v1.123.1) The time zone of the cluster.
+* `zone_id` - (Optional, Available since v1.123.1) When creating a cluster using automatic VPC creation, you need to specify the zone where the VPC is located. 
 * `service_cidr` - (Optional, ForceNew, Available since v1.123.1) CIDR block of the service network. The specified CIDR block cannot overlap with that of the VPC or those of the ACK clusters that are deployed in the VPC. The CIDR block cannot be modified after the cluster is created.
-* `logging_type` - (Optional, ForceNew, Available since v1.123.1) Enable log service, Valid value `SLS`. 
-* `sls_project_name` - (Optional, ForceNew, Available since v1.123.1) If you use an existing SLS project, you must specify `sls_project_name`.
+* `logging_type` - (Optional, ForceNew, Deprecated since v1.226.0) Enable log service, Valid value `SLS`. 
+* `sls_project_name` - (Optional, ForceNew, Deprecated since v1.226.0) If you use an existing SLS project, you must specify `sls_project_name`.
 * `retain_resources` - (Optional, Available since v1.141.0) Resources that are automatically created during cluster creation, including NAT gateways, SNAT rules, SLB instances, and RAM Role, will be deleted. Resources that are manually created after you create the cluster, such as SLB instances for Services, will also be deleted. If you need to retain resources, please configure with `retain_resources`. There are several aspects to pay attention to when using `retain_resources` to retain resources. After configuring `retain_resources` into the terraform configuration manifest file, you first need to run `terraform apply`.Then execute `terraform destroy`.
+* `delete_options` - (Optional) Delete options, only work for deleting resource. Make sure you have run `terraform apply` to make the configuration applied. See [`delete_options`](#delete_options) below.
 * `cluster_spec` - (Optional, ForceNew, Available since v1.162.0) The cluster specifications of serverless kubernetes cluster, which can be empty. Valid values:
     - ack.standard: Standard serverless clusters.
     - ack.pro.small: Professional serverless clusters.
-* `rrsa_metadata` - (Optional, Available since v1.185.0) Nested attribute containing RRSA related data for your cluster. See [`rrsa_metadata`](#rrsa_metadata) below.
-* `create_v2_cluster` - (Optional) whether to create a v2 version cluster.
+* `custom_san` - (Optional) Customize the certificate SAN, multiple IP or domain names are separated by English commas (,).
 
 *Removed params*
 
-* `vswitch_id` - (Deprecated from version 1.91.0) The vswitch where new kubernetes cluster will be located. Specify one vswitch's id, if it is not specified, a new VPC and VSwicth will be built. It must be in the zone which `availability_zone` specified.
+* `vswitch_id` - (Removed since v1.226.0) The vswitch where new kubernetes cluster will be located. Specify one vswitch's id, if it is not specified, a new VPC and VSwicth will be built. It must be in the zone which `availability_zone` specified.
 * `private_zone` - (Deprecated from version 1.123.1) Has been deprecated from provider version 1.123.1. `PrivateZone` is used as the enumeration value of `service_discovery_types`.
+* `create_v2_cluster` - (Removed since v1.226.0) whether to create a v2 version cluster.
+* `force_update` - (Removed since v1.226.0) Default false, when you want to change `vpc_id` and `vswitch_id`, you have to set this field to true, then the cluster will be recreated.
 
 ### `addons`
 
@@ -142,12 +145,13 @@ The addons supports the following:
 
 * `name` - (Optional) Name of the ACK add-on. The name must match one of the names returned by [DescribeAddons](https://help.aliyun.com/document_detail/171524.html).
 * `config` - (Optional) The ACK add-on configurations. For more config information, see [cs_kubernetes_addon_metadata](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/data-sources/cs_kubernetes_addon_metadata).
+* `version` - (Optional) It specifies the version of the component.
 * `disabled` - (Optional) Disables the automatic installation of a component. Default is `false`.
 
 The following example is the definition of addons block, The type of this field is list:
 
 ```
-# install nginx ingress, conflict with SLB ingress
+# install nginx ingress, conflict with ALB ingress
 addons {
   name = "nginx-ingress-controller"
   # use internet
@@ -155,7 +159,7 @@ addons {
   # if use intranet, detail below.
   # config = "{\"IngressSlbNetworkType\":\"intranet",\"IngressSlbSpec\":\"slb.s2.small\"}"
 }
-# install SLB ingress, conflict with nginx ingress
+# install ALB ingress, conflict with nginx ingress
 addons {
   name = "alb-ingress-controller"
 }
@@ -170,19 +174,60 @@ addons {
 # install prometheus
 addons {
   name = "arms-prometheus"
-  # prometheus also provides managed version, specify with name `managed-arms-prometheus` for professional serverless clusters
-  # name = "managed-arms-prometheus"
 }
 ```
+### `delete_options`
 
-### `rrsa_metadata`
+The following arguments are supported in the `delete_options` configuration block:
+* `delete_mode` - (Optional) The deletion mode of the cluster. Different resources may have different default behavior, see `resource_type` for details. Valid values:
+  - `delete`: delete resources created by the cluster.
+  - `retain`: retain resources created by the cluster.
+* `resource_type` - (Optional) The type of resources that are created by cluster. Valid values:
+  - `SLB`: SLB resources created by the Nginx Ingress Service, default behavior is to delete, option to retain is available. 
+  - `ALB`: ALB resources created by the ALB Ingress Controller, default behavior is to retain, option to delete is available. 
+  - `SLS_Data`: SLS Project used by the cluster logging feature, default behavior is to retain, option to delete is available. 
+  - `SLS_ControlPlane`: SLS Project used for the managed cluster control plane logs, default behavior is to retain, option to delete is available.
+  - `PrivateZone`: PrivateZone resources created by the cluster, default behavior is to retain, option to delete is available.
+```
+  ...
+  // Specify delete_options as below when deleting cluster
+  // delete SLB resources created by the Nginx Ingress Service
+  delete_options {
+    delete_mode = "delete"
+    resource_type = "SLB"
+  }
+  // delete ALB resources created by the ALB Ingress Controller
+  delete_options {
+    delete_mode = "delete"
+    resource_type = "ALB"
+  }
+  // delete SLS Project used by the cluster logging feature
+  delete_options {
+    delete_mode = "delete"
+    resource_type = "SLS_Data"
+  }
+  // delete SLS Project used for the managed cluster control plane logs
+  delete_options {
+    delete_mode = "delete"
+    resource_type = "SLS_ControlPlane"
+  }
+  // delete PrivateZone resources created by the cluster
+  delete_options {
+    delete_mode = "delete"
+    resource_type = "PrivateZone"
+  }
+```
 
-The rrsa_metadata supports the following:
+## Attributes Reference
 
-* `enabled` - (Optional) Whether the RRSA feature has been enabled.
-* `rrsa_oidc_issuer_url` - (Optional) The issuer URL of RRSA OIDC Token.
-* `ram_oidc_provider_name` - (Optional) The name of OIDC Provider that was registered in RAM.
-* `ram_oidc_provider_arn` - (Optional) The arn of OIDC provider that was registered in RAM.
+The following attributes are exported:
+
+* `id` - The Cluster ID of the serverless cluster.
+* `rrsa_metadata` - Nested attribute containing RRSA related data for your cluster.
+  * `enabled` - Whether the RRSA feature has been enabled.
+  * `rrsa_oidc_issuer_url` - The issuer URL of RRSA OIDC Token.
+  * `ram_oidc_provider_name` - The name of OIDC Provider that was registered in RAM.
+  * `ram_oidc_provider_arn` -  The arn of OIDC provider that was registered in RAM.
 
 ## Timeouts
 
@@ -192,17 +237,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 * `create` - (Defaults to 60 mins) Used when creating the kubernetes cluster (until it reaches the initial `running` status). 
 * `delete` - (Defaults to 30 mins) Used when terminating the kubernetes cluster. 
-
-## Attributes Reference
-
-The following attributes are exported:
-
-* `id` - The ID of the container cluster.
-* `name` - The name of the container cluster.
-* `vpc_id` - The ID of VPC where the current cluster is located.
-* `vswitch_id` - The ID of VSwicth where the current cluster is located.
-* `security_group_id` - The ID of security group where the current cluster worker node is located.
-* `deletion_protection` - Whether enable the deletion protection or not.
 
 
 ## Import


### PR DESCRIPTION
resource/alicloud_cs_serverless_kubernetes: 
- support modify cluster name and migrate cluster.
- add params custom_san, addon version and add param delete_options for delete operation;
- update vpc_id as Optional; 
- deprecate load_balancer_spec, logging_type, sls_project_name; 
- remove force_update, create_v2_cluster, vswitch_id. 

resource/alicloud_cs_managed_kubernetes: 
- support update custom_san. 

docs: improve code sample for alicloud_cs_kubernetes, alicloud_cs_serverless_kubernetes.