### PR TITLE
resource/alicloud_governance_account: Supports a new argument default_domain_name.

### DIFF
--- a/alicloud/resource_alicloud_governance_account_test.go
+++ b/alicloud/resource_alicloud_governance_account_test.go
@@ -20,6 +20,7 @@ func TestAccAliCloudGovernanceAccount_basic0(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tf-testacc%sgovernanceaccount%d", defaultRegionToTest, rand)
+	defaultDomainName := fmt.Sprintf("%s.onaliyun.com", name)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudGovernanceAccountBasicDependence7372)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -37,6 +38,7 @@ func TestAccAliCloudGovernanceAccount_basic0(t *testing.T) {
 					"display_name":        name,
 					"account_name_prefix": name,
 					"folder_id":           "${data.alicloud_resource_manager_folders.default.ids.0}",
+					"default_domain_name": defaultDomainName,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -45,6 +47,7 @@ func TestAccAliCloudGovernanceAccount_basic0(t *testing.T) {
 						"display_name":        CHECKSET,
 						"account_name_prefix": CHECKSET,
 						"folder_id":           CHECKSET,
+						"default_domain_name": CHECKSET,
 					}),
 				),
 			},
@@ -52,7 +55,7 @@ func TestAccAliCloudGovernanceAccount_basic0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"account_name_prefix", "display_name", "folder_id", "payer_account_id", "baseline_id"},
+				ImportStateVerifyIgnore: []string{"account_name_prefix", "display_name", "folder_id", "payer_account_id", "baseline_id", "default_domain_name"},
 			},
 		},
 	})
@@ -69,6 +72,7 @@ func TestAccAliCloudGovernanceAccount_basic7372(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tf-testacc%sgovernanceaccount%d", defaultRegionToTest, rand)
+	defaultDomainName := fmt.Sprintf("%s.onaliyun.com", name)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudGovernanceAccountBasicDependence7372)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -85,6 +89,7 @@ func TestAccAliCloudGovernanceAccount_basic7372(t *testing.T) {
 					"display_name":        name,
 					"account_name_prefix": name,
 					"folder_id":           "${data.alicloud_resource_manager_folders.default.ids.0}",
+					"default_domain_name": defaultDomainName,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -93,6 +98,7 @@ func TestAccAliCloudGovernanceAccount_basic7372(t *testing.T) {
 						"display_name":        CHECKSET,
 						"account_name_prefix": CHECKSET,
 						"folder_id":           CHECKSET,
+						"default_domain_name": CHECKSET,
 					}),
 				),
 			},
@@ -110,7 +116,7 @@ func TestAccAliCloudGovernanceAccount_basic7372(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"account_name_prefix", "display_name", "folder_id", "payer_account_id", "baseline_id"},
+				ImportStateVerifyIgnore: []string{"account_name_prefix", "display_name", "folder_id", "payer_account_id", "baseline_id", "default_domain_name"},
 			},
 		},
 	})

--- a/examples/governance/main.tf
+++ b/examples/governance/main.tf
@@ -1,0 +1,7 @@
+resource "alicloud_governance_account" "default" {
+  account_name_prefix = var.account_name_prefix
+  folder_id           = var.folder_id
+  baseline_id         = var.baseline_id
+  display_name        = var.display_name
+  default_domain_name = var.default_domain_name
+}

--- a/examples/governance/outputs.tf
+++ b/examples/governance/outputs.tf
@@ -1,0 +1,8 @@
+output "account_id" {
+  value = alicloud_governance_account.default.id
+}
+
+output "status" {
+  value = alicloud_governance_account.default.status
+}
+

--- a/examples/governance/variables.tf
+++ b/examples/governance/variables.tf
@@ -1,0 +1,19 @@
+variable "account_name_prefix" {
+  default = "terraform-example-12"
+}
+
+variable "display_name" {
+  default = "terraform-example-7"
+}
+
+variable "folder_id" {
+  default = "fd-blYPI4NZdI"
+}
+
+variable "baseline_id" {
+  default = "afb-bp14xex9ccnlbe8yzmvd"
+}
+
+variable "default_domain_name" {
+  default = "af-tf-domain-test-11.onaliyun.com"
+}

--- a/examples/governance/versions.tf
+++ b/examples/governance/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/website/docs/r/governance_account.html.markdown
+++ b/website/docs/r/governance_account.html.markdown
@@ -84,6 +84,9 @@ The following arguments are supported:
 
   If the registration application is applied to an existing account, this parameter does not need to be filled in.
 * `payer_account_id` - (Optional) The ID of the billing account. If you leave this parameter empty, the current account is used as the billing account.
+* `default_domain_name` - (Optional, Available since v1.231.0) The domain name is used to qualify the login name of RAM users and RAM roles.
+
+  Format: \<AccountAlias>.onaliyun.com where \<AccountAlias> is the account alias, and the default value is the Aliyun account ID. The default domain name must end with the .onaliyun.com suffix. The maximum length of the default domain name (including suffix) is 64 characters. It can contain English letters, numbers, English periods (.) , dashes (-) and underscores (_).
 
 ## Attributes Reference
 


### PR DESCRIPTION
resource/alicloud_governance_account: Supports a new argument default_domain_name.