### PR TITLE
resource/{alicloud_ess_scaling,ecs}: Adds SecurityOptions.ConfidentialComputingMode support

### DIFF
--- a/alicloud/resource_alicloud_ess_scaling_configuration.go
+++ b/alicloud/resource_alicloud_ess_scaling_configuration.go
@@ -214,6 +214,20 @@ func resourceAlicloudEssScalingConfiguration() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: StringInSlice([]string{"Active", "Deactive"}, false),
 			},
+			"security_options": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"confidential_computing_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 			"system_disk_size": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -579,6 +593,16 @@ func resourceAliyunEssScalingConfigurationCreate(d *schema.ResourceData, meta in
 	}
 	if v, ok := d.GetOk("security_enhancement_strategy"); ok && v.(string) != "" {
 		request["SecurityEnhancementStrategy"] = v
+	}
+
+	if v, ok := d.GetOk("security_options"); ok {
+		securityOptions := v.(*schema.Set).List()
+		for _, securityOption := range securityOptions {
+			securityOptionMap := securityOption.(map[string]interface{})
+			if v, ok := securityOptionMap["confidential_computing_mode"]; ok {
+				request["SecurityOptions.ConfidentialComputingMode"] = v
+			}
+		}
 	}
 
 	if v := d.Get("internet_max_bandwidth_in").(int); v != 0 {
@@ -1320,6 +1344,7 @@ func resourceAliyunEssScalingConfigurationRead(d *schema.ResourceData, meta inte
 	}
 	d.Set("system_disk_category", response["SystemDiskCategory"])
 	d.Set("security_enhancement_strategy", response["SecurityEnhancementStrategy"])
+	d.Set("security_options", response["SecurityOptions"])
 	if response["InternetMaxBandwidthIn"] != nil {
 		d.Set("internet_max_bandwidth_in", response["InternetMaxBandwidthIn"])
 	}

--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -489,6 +489,20 @@ func resourceAliCloudInstance() *schema.Resource {
 					string(DeactiveSecurityEnhancementStrategy),
 				}, false),
 			},
+			"security_options": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"confidential_computing_mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 			"tags":        tagsSchemaWithIgnore(),
 			"volume_tags": tagsSchemaComputed(),
 			"auto_release_time": {
@@ -882,6 +896,16 @@ func resourceAliCloudInstanceCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("security_enhancement_strategy"); ok {
 		request["SecurityEnhancementStrategy"] = v
+	}
+
+	if v, ok := d.GetOk("security_options"); ok {
+		securityOptions := v.(*schema.Set).List()
+		for _, securityOption := range securityOptions {
+			securityOptionMap := securityOption.(map[string]interface{})
+			if v, ok := securityOptionMap["confidential_computing_mode"]; ok {
+				request["SecurityOptions.ConfidentialComputingMode"] = v
+			}
+		}
 	}
 
 	if v, ok := d.GetOk("auto_release_time"); ok && v.(string) != "" {


### PR DESCRIPTION
Allow `resource/{alicloud_ess_scaling,ecs}` to set `SecurityOptions.ConfidentialComputingMode` options.

[1] [RunInstances with ConfidentialComputingMode](https://api.aliyun.com/api/Ecs/2014-05-26/RunInstances?params={%22RegionId%22:%22cn-beijing%22}#:~:text=vTPM-,SecurityOptions.ConfidentialComputingMode,-string)
[2] [CreateScalingConfiguration with ConfidentialComputingMode](https://api.aliyun.com/api/Ess/2022-02-22/CreateScalingConfiguration#:~:text=%E5%AE%89%E5%85%A8%E9%80%89%E9%A1%B9%E3%80%82-,ConfidentialComputingMode,-string)