### PR TITLE
resource/alicloud_actiontrail_trail: Add missing params to export trail to maxcompute

### DIFF
--- a/alicloud/resource_alicloud_actiontrail_trail.go
+++ b/alicloud/resource_alicloud_actiontrail_trail.go
@@ -68,6 +68,14 @@ func resourceAlicloudActiontrailTrail() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
+			"max_compute_project_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"max_compute_write_role_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"status": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -133,6 +141,14 @@ func resourceAlicloudActiontrailTrailCreate(d *schema.ResourceData, meta interfa
 		request["SlsWriteRoleArn"] = v
 	}
 
+	if v, ok := d.GetOk("max_compute_project_arn"); ok {
+		request["MaxComputeProjectArn"] = v
+	}
+
+	if v, ok := d.GetOk("max_compute_write_role_arn"); ok {
+		request["MaxComputeWriteRoleArn"] = v
+	}
+
 	if v, ok := d.GetOk("trail_name"); ok {
 		request["Name"] = v
 	} else if v, ok := d.GetOk("name"); ok {
@@ -192,6 +208,8 @@ func resourceAlicloudActiontrailTrailRead(d *schema.ResourceData, meta interface
 	d.Set("oss_write_role_arn", object["OssWriteRoleArn"])
 	d.Set("sls_project_arn", object["SlsProjectArn"])
 	d.Set("sls_write_role_arn", object["SlsWriteRoleArn"])
+	d.Set("max_compute_project_arn", object["MaxComputeProjectArn"])
+	d.Set("max_compute_write_role_arn", object["MaxComputeWriteRoleArn"])
 	d.Set("status", object["Status"])
 	d.Set("trail_region", object["TrailRegion"])
 	return nil
@@ -231,6 +249,14 @@ func resourceAlicloudActiontrailTrailUpdate(d *schema.ResourceData, meta interfa
 	if !d.IsNewResource() && d.HasChange("sls_write_role_arn") {
 		update = true
 		request["SlsWriteRoleArn"] = d.Get("sls_write_role_arn")
+	}
+	if !d.IsNewResource() && d.HasChange("max_compute_project_arn") {
+		update = true
+		request["MaxComputeProjectArn"] = d.Get("max_compute_project_arn")
+	}
+	if !d.IsNewResource() && d.HasChange("max_compute_write_role_arn") {
+		update = true
+		request["MaxComputeWriteRoleArn"] = d.Get("max_compute_write_role_arn")
 	}
 	if !d.IsNewResource() && d.HasChange("trail_region") {
 		update = true
@@ -274,6 +300,8 @@ func resourceAlicloudActiontrailTrailUpdate(d *schema.ResourceData, meta interfa
 		d.SetPartial("oss_write_role_arn")
 		d.SetPartial("sls_project_arn")
 		d.SetPartial("sls_write_role_arn")
+		d.SetPartial("max_compute_project_arn")
+		d.SetPartial("max_compute_write_role_arn")
 		d.SetPartial("trail_region")
 	}
 	if d.HasChange("status") {

--- a/alicloud/resource_alicloud_actiontrail_trail_test.go
+++ b/alicloud/resource_alicloud_actiontrail_trail_test.go
@@ -242,7 +242,7 @@ func ActiontrailTrailBasicdependence(name string) string {
 	  description = "this is a test"
 	  force = true
 	}
-	
+
 	resource "alicloud_ram_policy" "default" {
 	  name = "${var.name}-trigger"
 	  document = <<EOF
@@ -356,7 +356,7 @@ func ActiontrailTrailBasicdependence(name string) string {
 	  description = "this is a test"
 	  force = true
 	}
-	
+
 	resource "alicloud_ram_role_policy_attachment" "default" {
 	  role_name = "${alicloud_ram_role.default.name}"
 	  policy_name = "${alicloud_ram_policy.default.name}"
@@ -375,16 +375,18 @@ func TestUnitAlicloudActiontrailTrail(t *testing.T) {
 	dCreate, _ := schema.InternalMap(p["alicloud_actiontrail_trail"].Schema).Data(nil, nil)
 	dCreate.MarkNewResource()
 	for key, value := range map[string]interface{}{
-		"trail_name":            "trail_name",
-		"oss_write_role_arn":    "oss_write_role_arn",
-		"oss_bucket_name":       "oss_bucket_name",
-		"status":                "Disable",
-		"event_rw":              "event_rw",
-		"is_organization_trail": true,
-		"oss_key_prefix":        "oss_key_prefix",
-		"sls_project_arn":       "sls_project_arn",
-		"sls_write_role_arn":    "sls_write_role_arn",
-		"trail_region":          "trail_region",
+		"trail_name":                 "trail_name",
+		"oss_write_role_arn":         "oss_write_role_arn",
+		"oss_bucket_name":            "oss_bucket_name",
+		"status":                     "Disable",
+		"event_rw":                   "event_rw",
+		"is_organization_trail":      true,
+		"oss_key_prefix":             "oss_key_prefix",
+		"sls_project_arn":            "sls_project_arn",
+		"sls_write_role_arn":         "sls_write_role_arn",
+		"max_compute_project_arn":    "max_compute_project_arn",
+		"max_compute_write_role_arn": "max_compute_write_role_arn",
+		"trail_region":               "trail_region",
 	} {
 		err := dCreate.Set(key, value)
 		assert.Nil(t, err)
@@ -401,16 +403,18 @@ func TestUnitAlicloudActiontrailTrail(t *testing.T) {
 	ReadMockResponse := map[string]interface{}{
 		"TrailList": []interface{}{
 			map[string]interface{}{
-				"EventRW":             "event_rw",
-				"IsOrganizationTrail": true,
-				"OssBucketName":       "MockName",
-				"OssKeyPrefix":        "oss_key_prefix",
-				"OssWriteRoleArn":     "oss_write_role_arn",
-				"SlsProjectArn":       "sls_project_arn",
-				"SlsWriteRoleArn":     "sls_write_role_arn",
-				"Status":              "Fresh",
-				"TrailRegion":         "trail_region",
-				"Name":                "MockName",
+				"EventRW":                "event_rw",
+				"IsOrganizationTrail":    true,
+				"OssBucketName":          "MockName",
+				"OssKeyPrefix":           "oss_key_prefix",
+				"OssWriteRoleArn":        "oss_write_role_arn",
+				"SlsProjectArn":          "sls_project_arn",
+				"SlsWriteRoleArn":        "sls_write_role_arn",
+				"MaxComputeProjectArn":   "max_compute_project_arn",
+				"MaxComputeWriteRoleArn": "max_compute_write_role_arn",
+				"Status":                 "Fresh",
+				"TrailRegion":            "trail_region",
+				"Name":                   "MockName",
 			},
 		},
 	}
@@ -456,16 +460,18 @@ func TestUnitAlicloudActiontrailTrail(t *testing.T) {
 			result := map[string]interface{}{
 				"TrailList": []interface{}{
 					map[string]interface{}{
-						"EventRW":             "event_rw",
-						"IsOrganizationTrail": true,
-						"OssBucketName":       "MockName",
-						"OssKeyPrefix":        "oss_key_prefix",
-						"OssWriteRoleArn":     "oss_write_role_arn",
-						"SlsProjectArn":       "sls_project_arn",
-						"SlsWriteRoleArn":     "sls_write_role_arn",
-						"Status":              "Disable",
-						"TrailRegion":         "trail_region",
-						"Name":                "MockName",
+						"EventRW":                "event_rw",
+						"IsOrganizationTrail":    true,
+						"OssBucketName":          "MockName",
+						"OssKeyPrefix":           "oss_key_prefix",
+						"OssWriteRoleArn":        "oss_write_role_arn",
+						"SlsProjectArn":          "sls_project_arn",
+						"SlsWriteRoleArn":        "sls_write_role_arn",
+						"MaxComputeProjectArn":   "max_compute_project_arn",
+						"MaxComputeWriteRoleArn": "max_compute_write_role_arn",
+						"Status":                 "Disable",
+						"TrailRegion":            "trail_region",
+						"Name":                   "MockName",
 					},
 				},
 				"Status": "Enable",
@@ -477,16 +483,18 @@ func TestUnitAlicloudActiontrailTrail(t *testing.T) {
 			result := map[string]interface{}{
 				"TrailList": []interface{}{
 					map[string]interface{}{
-						"EventRW":             "event_rw",
-						"IsOrganizationTrail": true,
-						"OssBucketName":       "MockName",
-						"OssKeyPrefix":        "oss_key_prefix",
-						"OssWriteRoleArn":     "oss_write_role_arn",
-						"SlsProjectArn":       "sls_project_arn",
-						"SlsWriteRoleArn":     "sls_write_role_arn",
-						"Status":              "Disable",
-						"TrailRegion":         "trail_region",
-						"Name":                "MockName",
+						"EventRW":                "event_rw",
+						"IsOrganizationTrail":    true,
+						"OssBucketName":          "MockName",
+						"OssKeyPrefix":           "oss_key_prefix",
+						"OssWriteRoleArn":        "oss_write_role_arn",
+						"SlsProjectArn":          "sls_project_arn",
+						"SlsWriteRoleArn":        "sls_write_role_arn",
+						"MaxComputeProjectArn":   "max_compute_project_arn",
+						"MaxComputeWriteRoleArn": "max_compute_write_role_arn",
+						"Status":                 "Disable",
+						"TrailRegion":            "trail_region",
+						"Name":                   "MockName",
 					},
 				},
 				"Status": "Disable",
@@ -498,16 +506,18 @@ func TestUnitAlicloudActiontrailTrail(t *testing.T) {
 			result := map[string]interface{}{
 				"TrailList": []interface{}{
 					map[string]interface{}{
-						"EventRW":             "event_rw",
-						"IsOrganizationTrail": true,
-						"OssBucketName":       "MockName",
-						"OssKeyPrefix":        "oss_key_prefix",
-						"OssWriteRoleArn":     "oss_write_role_arn",
-						"SlsProjectArn":       "sls_project_arn",
-						"SlsWriteRoleArn":     "sls_write_role_arn",
-						"Status":              "Enable",
-						"TrailRegion":         "trail_region",
-						"Name":                "MockName",
+						"EventRW":                "event_rw",
+						"IsOrganizationTrail":    true,
+						"OssBucketName":          "MockName",
+						"OssKeyPrefix":           "oss_key_prefix",
+						"OssWriteRoleArn":        "oss_write_role_arn",
+						"SlsProjectArn":          "sls_project_arn",
+						"SlsWriteRoleArn":        "sls_write_role_arn",
+						"MaxComputeProjectArn":   "max_compute_project_arn",
+						"MaxComputeWriteRoleArn": "max_compute_write_role_arn",
+						"Status":                 "Enable",
+						"TrailRegion":            "trail_region",
+						"Name":                   "MockName",
 					},
 				},
 				"Status": "Disable",
@@ -519,16 +529,18 @@ func TestUnitAlicloudActiontrailTrail(t *testing.T) {
 			result := map[string]interface{}{
 				"TrailList": []interface{}{
 					map[string]interface{}{
-						"EventRW":             "event_rw",
-						"IsOrganizationTrail": true,
-						"OssBucketName":       "MockName",
-						"OssKeyPrefix":        "oss_key_prefix",
-						"OssWriteRoleArn":     "oss_write_role_arn",
-						"SlsProjectArn":       "sls_project_arn",
-						"SlsWriteRoleArn":     "sls_write_role_arn",
-						"Status":              "Enable",
-						"TrailRegion":         "trail_region",
-						"Name":                "MockName",
+						"EventRW":                "event_rw",
+						"IsOrganizationTrail":    true,
+						"OssBucketName":          "MockName",
+						"OssKeyPrefix":           "oss_key_prefix",
+						"OssWriteRoleArn":        "oss_write_role_arn",
+						"SlsProjectArn":          "sls_project_arn",
+						"SlsWriteRoleArn":        "sls_write_role_arn",
+						"MaxComputeProjectArn":   "max_compute_project_arn",
+						"MaxComputeWriteRoleArn": "max_compute_write_role_arn",
+						"Status":                 "Enable",
+						"TrailRegion":            "trail_region",
+						"Name":                   "MockName",
 					},
 				},
 				"Status": "Enable",
@@ -749,16 +761,18 @@ func TestUnitAlicloudActiontrailTrail(t *testing.T) {
 		patchActiontrailTrailStateRefreshFunc := gomonkey.ApplyMethod(reflect.TypeOf(&ActiontrailService{}), "ActiontrailTrailStateRefreshFunc", func(*ActiontrailService, string, []string) resource.StateRefreshFunc {
 			return func() (interface{}, string, error) {
 				object := map[string]interface{}{
-					"EventRW":             "event_rw",
-					"IsOrganizationTrail": true,
-					"OssBucketName":       "MockName",
-					"OssKeyPrefix":        "oss_key_prefix",
-					"OssWriteRoleArn":     "oss_write_role_arn",
-					"SlsProjectArn":       "sls_project_arn",
-					"SlsWriteRoleArn":     "sls_write_role_arn",
-					"Status":              "Disable",
-					"TrailRegion":         "trail_region",
-					"Name":                "MockName",
+					"EventRW":                "event_rw",
+					"IsOrganizationTrail":    true,
+					"OssBucketName":          "MockName",
+					"OssKeyPrefix":           "oss_key_prefix",
+					"OssWriteRoleArn":        "oss_write_role_arn",
+					"SlsProjectArn":          "sls_project_arn",
+					"SlsWriteRoleArn":        "sls_write_role_arn",
+					"MaxComputeProjectArn":   "max_compute_project_arn",
+					"MaxComputeWriteRoleArn": "max_compute_write_role_arn",
+					"Status":                 "Disable",
+					"TrailRegion":            "trail_region",
+					"Name":                   "MockName",
 				}
 				return object, "Disable", nil
 			}
@@ -847,14 +861,16 @@ func TestUnitAlicloudActiontrailTrail(t *testing.T) {
 				object := map[string]interface{}{
 					"EventRW":             "event_rw",
 					"IsOrganizationTrail": true,
-					"OssBucketName":       "MockName",
-					"OssKeyPrefix":        "oss_key_prefix",
-					"OssWriteRoleArn":     "oss_write_role_arn",
-					"SlsProjectArn":       "sls_project_arn",
-					"SlsWriteRoleArn":     "sls_write_role_arn",
-					"Status":              "Enable",
-					"TrailRegion":         "trail_region",
-					"Name":                "MockName",
+					"OssBucketName":          "MockName",
+					"OssKeyPrefix":           "oss_key_prefix",
+					"OssWriteRoleArn":        "oss_write_role_arn",
+					"SlsProjectArn":          "sls_project_arn",
+					"SlsWriteRoleArn":        "sls_write_role_arn",
+					"MaxComputeProjectArn":   "max_compute_project_arn",
+					"MaxComputeWriteRoleArn": "max_compute_write_role_arn",
+					"Status":                 "Enable",
+					"TrailRegion":            "trail_region",
+					"Name":                   "MockName",
 				}
 				return object, "Enable", nil
 			}


### PR DESCRIPTION
As documented in API doc https://next.api.alibabacloud.com/api/Actiontrail/2020-07-06/CreateTrail?RegionId=cn-beijing We can now create a trail that writes in a MaxCompute project. This PR adds these changes