### PR TITLE
resource/alicloud_mse_nacos_config: Support import nacos config when dataId contains colons; data-source/alicloud_mse_nacos_configs: Escape dataId, group, namespace when build Id

### DIFF
--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -977,6 +977,37 @@ func ParseResourceIdN(id string, length int) (parts []string, err error) {
 	return parts, err
 }
 
+func ParseResourceIdWithEscaped(id string, length int) (parts []string, err error) {
+	parts = make([]string, 0)
+	var currentPart strings.Builder
+	for i := 0; i < len(id); i++ {
+		if id[i] == '\\' {
+			i++
+			if i < len(id) {
+				currentPart.WriteByte(id[i])
+			}
+		} else if id[i] == ':' {
+			parts = append(parts, currentPart.String())
+			currentPart.Reset()
+		} else {
+			currentPart.WriteByte(id[i])
+		}
+	}
+
+	if currentPart.Len() > 0 {
+		parts = append(parts, currentPart.String())
+	}
+
+	if len(parts) != length {
+		err = WrapError(fmt.Errorf("Invalid Resource Id %s. Expected parts' length %d, got %d", id, length, len(parts)))
+	}
+	return parts, err
+}
+
+func EscapeColons(s string) string {
+	return strings.ReplaceAll(s, ":", "\\:")
+}
+
 func ParseSlbListenerId(id string) (parts []string, err error) {
 	parts = strings.Split(id, ":")
 	if len(parts) != 2 && len(parts) != 3 {

--- a/alicloud/data_source_alicloud_mse_nacos_configs.go
+++ b/alicloud/data_source_alicloud_mse_nacos_configs.go
@@ -208,7 +208,10 @@ func dataSourceAlicloudMseNacosConfigsRead(d *schema.ResourceData, meta interfac
 				if namespaceId == nil {
 					namespaceId = ""
 				}
-				if _, ok := idsMap[fmt.Sprint(request["InstanceId"], ":", namespaceId, ":", item["DataId"], ":", item["Group"])]; !ok {
+				instanceId := request["InstanceId"].(string)
+				dataId := item["DataId"].(string)
+				group := item["Group"].(string)
+				if _, ok := idsMap[fmt.Sprint(EscapeColons(instanceId), ":", EscapeColons(namespaceId.(string)), ":", EscapeColons(dataId), ":", EscapeColons(group))]; !ok {
 					continue
 				}
 			}
@@ -234,7 +237,10 @@ func dataSourceAlicloudMseNacosConfigsRead(d *schema.ResourceData, meta interfac
 			namespaceId = ""
 		}
 
-		id := fmt.Sprint(request["InstanceId"], ":", namespaceId, ":", object["DataId"], ":", object["Group"])
+		instanceId := request["InstanceId"].(string)
+		dataId := object["DataId"].(string)
+		group := object["Group"].(string)
+		id := fmt.Sprint(EscapeColons(instanceId), ":", EscapeColons(namespaceId.(string)), ":", EscapeColons(dataId), ":", EscapeColons(group))
 		mapping["id"] = id
 
 		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {

--- a/alicloud/resource_alicloud_mse_nacos_config.go
+++ b/alicloud/resource_alicloud_mse_nacos_config.go
@@ -146,7 +146,11 @@ func resourceAlicloudMseNacosConfigCreate(d *schema.ResourceData, meta interface
 		namespaceId = ""
 	}
 
-	d.SetId(fmt.Sprint(request["InstanceId"], ":", namespaceId, ":", request["DataId"], ":", request["Group"]))
+	dataId := request["DataId"].(string)
+	group := request["Group"].(string)
+	instanceId := request["InstanceId"].(string)
+
+	d.SetId(fmt.Sprint(EscapeColons(instanceId), ":", EscapeColons(namespaceId.(string)), ":", EscapeColons(dataId), ":", EscapeColons(group)))
 
 	return resourceAlicloudMseNacosConfigRead(d, meta)
 }
@@ -165,7 +169,7 @@ func resourceAlicloudMseNacosConfigRead(d *schema.ResourceData, meta interface{}
 		return WrapError(err)
 	}
 
-	parts, err := ParseResourceId(d.Id(), 4)
+	parts, err := ParseResourceIdWithEscaped(d.Id(), 4)
 
 	err = d.Set("instance_id", parts[0])
 	if err != nil {
@@ -188,7 +192,7 @@ func resourceAlicloudMseNacosConfigUpdate(d *schema.ResourceData, meta interface
 	var err error
 	var response map[string]interface{}
 	update := false
-	parts, err := ParseResourceId(d.Id(), 4)
+	parts, err := ParseResourceIdWithEscaped(d.Id(), 4)
 	if err != nil {
 		return WrapError(err)
 	}
@@ -239,7 +243,7 @@ func resourceAlicloudMseNacosConfigDelete(d *schema.ResourceData, meta interface
 	action := "DeleteNacosConfig"
 	var response map[string]interface{}
 	var err error
-	parts, err := ParseResourceId(d.Id(), 4)
+	parts, err := ParseResourceIdWithEscaped(d.Id(), 4)
 	if err != nil {
 		return WrapError(err)
 	}

--- a/alicloud/resource_alicloud_mse_nacos_config_test.go
+++ b/alicloud/resource_alicloud_mse_nacos_config_test.go
@@ -34,8 +34,8 @@ func TestAccAliCloudMseNacosConfig_basic0(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"instance_id":     "${alicloud_mse_cluster.example.id}",
-					"data_id":         "${var.name}",
-					"group":           "${var.name}",
+					"data_id":         "${var.name}:dataId",
+					"group":           "${var.name}:group",
 					"namespace_id":    "${alicloud_mse_engine_namespace.example.namespace_id}",
 					"content":         "test",
 					"app_name":        "test",
@@ -47,8 +47,8 @@ func TestAccAliCloudMseNacosConfig_basic0(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"data_id":  name,
-						"group":    name,
+						"data_id":  name + ":dataId",
+						"group":    name + ":group",
 						"content":  "test",
 						"app_name": "test",
 					}),

--- a/alicloud/service_alicloud_mse.go
+++ b/alicloud/service_alicloud_mse.go
@@ -317,7 +317,7 @@ func (s *MseService) DescribeMseZnode(id string) (object map[string]interface{},
 func (s *MseService) DescribeMseNacosConfig(id string) (object map[string]interface{}, err error) {
 	var response map[string]interface{}
 	client := s.client
-	parts, err := ParseResourceId(id, 4)
+	parts, err := ParseResourceIdWithEscaped(id, 4)
 	if err != nil {
 		return nil, WrapError(err)
 	}

--- a/website/docs/r/mse_nacos_config.html.markdown
+++ b/website/docs/r/mse_nacos_config.html.markdown
@@ -109,6 +109,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 Microservice Engine (MSE) Nacos Config can be imported using the id, e.g.
 
+**Note**: If instance_id, namespace_id, data_id, and group contain ":", please replace it with "\\\\:", available since v1.243.0
 ```shell
 $ terraform import alicloud_mse_nacos_config.example <instance_id>:<namespace_id>:<data_id>:<group>
 ```


### PR DESCRIPTION
to #8365 