### PR TITLE
resource/alicloud_fc_layer_version: fix loading the file content instead of base64 encoded payload for uploading the zipfile

### DIFF
--- a/alicloud/resource_alicloud_fc_layer_version.go
+++ b/alicloud/resource_alicloud_fc_layer_version.go
@@ -1,6 +1,7 @@
 package alicloud
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log"
 	"time"
@@ -106,7 +107,7 @@ func resourceAlicloudFcLayerVersionCreate(d *schema.ResourceData, meta interface
 		if err != nil {
 			return WrapError(err)
 		}
-		codeMaps["zipFile"] = file
+		codeMaps["zipFile"] = base64.StdEncoding.EncodeToString(file)
 	}
 	if v, ok := d.GetOk("oss_bucket_name"); ok && fmt.Sprint(v) != "" {
 		codeMaps["ossBucketName"] = v

--- a/alicloud/resource_alicloud_fc_layer_version.go
+++ b/alicloud/resource_alicloud_fc_layer_version.go
@@ -101,8 +101,12 @@ func resourceAlicloudFcLayerVersionCreate(d *schema.ResourceData, meta interface
 	body["compatibleRuntime"] = compatibleRuntimes
 
 	codeMaps := make(map[string]interface{}, 0)
-	if v, ok := d.GetOk("zip_file"); ok && fmt.Sprint(v) != "" {
-		codeMaps["zipFile"] = v
+	if v, ok := d.GetOk("zip_file"); ok && fmt.Sprint(v) != "" && v.(string) != "" {
+		file, err := loadFileContent(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		codeMaps["zipFile"] = file
 	}
 	if v, ok := d.GetOk("oss_bucket_name"); ok && fmt.Sprint(v) != "" {
 		codeMaps["ossBucketName"] = v


### PR DESCRIPTION
**What's the problem?**

With the current version, a FC layer can be created with a local zipfile, but the plugin is unable to do any follow-up `terraform plan` or `terraform apply`. In my testing ,my custom layer was only 1.2 MB, but still exceeding the grpc maximum input limit. I think it's because the provider plugin is trying to compare the encoded base64 contents. For a zipfile, it's payload can be incredibly large...

Error message:
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Plugin error
│
│   with module.ami-manager.alicloud_fc_layer_version.ecs_layer,
│   on ../../../core-alicloud-ami-manager/function.tf line 25, in resource "alicloud_fc_layer_version" "ecs_layer":
│   25: resource "alicloud_fc_layer_version" "ecs_layer" {
│
│ The plugin returned an unexpected error from plugin.(*GRPCProvider).PlanResourceChange: rpc error: code = ResourceExhausted desc = grpc: received message
│ larger than max (4706981 vs. 4194304)
```

**How to reproduce the problem?**

Create a resource as follows:
```hcl
resource "alicloud_fc_layer_version" "ecs_layer" {
  layer_name         = "ecs_layer"
  description        = "A layer for python module alibabacloud_ecs20140526"
  compatible_runtime = ["python3.10"]
  zip_file           = filebase64("${path.module}/function_compute/alibabacloud_ecs20140526.zip")
}
```

**My changes**

As following the code block in the `resource_alicloud_fc_function.go`, I think it would be wise to use the same approach to load the content, rather than loading the raw payload of a zipfile. ref: https://github.com/aliyun/terraform-provider-alicloud/blob/master/alicloud/resource_alicloud_fc_function.go#L448-L453

Please verify my changes, or let me know how shall I test them properly. I can submit another change regarding the similar code block in resource `resource_alicloud_fcv3_layer_version.go` too if this is deemed good enough. Thanks.