### PR TITLE
resource/alicloud_ess_scaling_group: add attributes of compensate_with_on_demand, capacity_options_on_demand_base_capacity, capacity_options_on_demand_percentage_above_base_capacity, capacity_options_compensate_with_on_demand and capacity_options_spot_auto_replace_on_demand.

### DIFF
--- a/alicloud/resource_alicloud_ess_scaling_group_test.go
+++ b/alicloud/resource_alicloud_ess_scaling_group_test.go
@@ -904,6 +904,182 @@ func TestAccAliCloudEssScalingGroup_costoptimized(t *testing.T) {
 					"on_demand_base_capacity": "10",
 					"on_demand_percentage_above_base_capacity": "10",
 					"spot_instance_pools":                      "10",
+					"compensate_with_on_demand":                "false",
+					"spot_instance_remedy":                     "true",
+					"group_deletion_protection":                "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group_deletion_protection": "true",
+						"compensate_with_on_demand": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "0",
+					"on_demand_percentage_above_base_capacity": "0",
+					"spot_instance_pools":                      "10",
+					"compensate_with_on_demand":                "true",
+					"spot_instance_remedy":                     "true",
+					"group_deletion_protection":                "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"on_demand_base_capacity":                  "0",
+						"on_demand_percentage_above_base_capacity": "0",
+						"compensate_with_on_demand":                "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "8",
+					"on_demand_percentage_above_base_capacity": "8",
+					"spot_instance_pools":                      "10",
+					"spot_instance_remedy":                     "true",
+					"compensate_with_on_demand":                "true",
+					"group_deletion_protection":                "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"on_demand_base_capacity":                  "8",
+						"on_demand_percentage_above_base_capacity": "8",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "8",
+					"on_demand_percentage_above_base_capacity": "8",
+					"spot_instance_pools":                      "8",
+					"compensate_with_on_demand":                "false",
+					"spot_instance_remedy":                     "true",
+					"group_deletion_protection":                "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"spot_instance_pools":       "8",
+						"compensate_with_on_demand": "false",
+						"group_deletion_protection": "false",
+					}),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccAliCloudEssScalingGroup_costoptimizedSupply(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 999999)
+	var v ess.ScalingGroup
+	resourceId := "alicloud_ess_scaling_group.default"
+
+	basicMap := map[string]string{
+		"min_size":                                 "1",
+		"max_size":                                 "1",
+		"default_cooldown":                         "20",
+		"scaling_group_name":                       fmt.Sprintf("tf-testAccEssScalingGroup-%d", rand),
+		"vswitch_ids.#":                            "2",
+		"removal_policies.#":                       "2",
+		"on_demand_base_capacity":                  "10",
+		"spot_instance_pools":                      "10",
+		"spot_instance_remedy":                     "false",
+		"group_deletion_protection":                "false",
+		"on_demand_percentage_above_base_capacity": "10",
+		"compensate_with_on_demand":                "false",
+	}
+
+	ra := resourceAttrInit(resourceId, basicMap)
+	rc := resourceCheckInit(resourceId, &v, func() interface{} {
+		return &EssService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	})
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAccEssScalingGroup-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceEssScalingGroupDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: resourceId,
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEssScalingGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "10",
+					"on_demand_percentage_above_base_capacity": "10",
+					"spot_instance_pools":                      "10",
+					"compensate_with_on_demand":                "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(nil),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "10",
+					"on_demand_percentage_above_base_capacity": "10",
+					"spot_instance_pools":                      "10",
+					"spot_instance_remedy":                     "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"spot_instance_remedy": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "10",
+					"on_demand_percentage_above_base_capacity": "10",
+					"spot_instance_pools":                      "10",
 					"spot_instance_remedy":                     "true",
 					"group_deletion_protection":                "true",
 				}),
@@ -976,6 +1152,395 @@ func TestAccAliCloudEssScalingGroup_costoptimized(t *testing.T) {
 					testAccCheck(map[string]string{
 						"spot_instance_pools":       "8",
 						"group_deletion_protection": "false",
+					}),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccAliCloudEssScalingGroup_costoptimized_capacityOptions(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 999999)
+	var v ess.ScalingGroup
+	resourceId := "alicloud_ess_scaling_group.default"
+
+	basicMap := map[string]string{
+		"min_size":                                 "1",
+		"max_size":                                 "1",
+		"default_cooldown":                         "20",
+		"scaling_group_name":                       fmt.Sprintf("tf-testAccEssScalingGroup-%d", rand),
+		"vswitch_ids.#":                            "2",
+		"removal_policies.#":                       "2",
+		"on_demand_base_capacity":                  "10",
+		"spot_instance_pools":                      "10",
+		"spot_instance_remedy":                     "false",
+		"group_deletion_protection":                "false",
+		"on_demand_percentage_above_base_capacity": "10",
+		"capacity_options_on_demand_base_capacity": "10",
+		"capacity_options_on_demand_percentage_above_base_capacity": "10",
+		"capacity_options_compensate_with_on_demand":                "true",
+		"capacity_options_spot_auto_replace_on_demand":              "true",
+	}
+
+	ra := resourceAttrInit(resourceId, basicMap)
+	rc := resourceCheckInit(resourceId, &v, func() interface{} {
+		return &EssService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	})
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAccEssScalingGroup-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceEssScalingGroupDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: resourceId,
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEssScalingGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "10",
+					"on_demand_percentage_above_base_capacity":                  "10",
+					"spot_instance_pools":                                       "10",
+					"capacity_options_on_demand_base_capacity":                  "10",
+					"capacity_options_on_demand_percentage_above_base_capacity": "10",
+					"capacity_options_compensate_with_on_demand":                "true",
+					"capacity_options_spot_auto_replace_on_demand":              "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(nil),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "1",
+					"on_demand_percentage_above_base_capacity":                  "1",
+					"spot_instance_pools":                                       "10",
+					"spot_instance_remedy":                                      "true",
+					"capacity_options_on_demand_base_capacity":                  "1",
+					"capacity_options_on_demand_percentage_above_base_capacity": "1",
+					"capacity_options_compensate_with_on_demand":                "false",
+					"capacity_options_spot_auto_replace_on_demand":              "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"spot_instance_remedy":                                      "true",
+						"capacity_options_on_demand_base_capacity":                  "1",
+						"capacity_options_on_demand_percentage_above_base_capacity": "1",
+						"capacity_options_compensate_with_on_demand":                "false",
+						"capacity_options_spot_auto_replace_on_demand":              "false",
+						"on_demand_base_capacity":                                   "1",
+						"on_demand_percentage_above_base_capacity":                  "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "1",
+					"on_demand_percentage_above_base_capacity":                  "1",
+					"spot_instance_pools":                                       "10",
+					"spot_instance_remedy":                                      "true",
+					"group_deletion_protection":                                 "true",
+					"capacity_options_on_demand_base_capacity":                  "1",
+					"capacity_options_on_demand_percentage_above_base_capacity": "1",
+					"capacity_options_compensate_with_on_demand":                "false",
+					"capacity_options_spot_auto_replace_on_demand":              "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group_deletion_protection": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "0",
+					"on_demand_percentage_above_base_capacity":                  "0",
+					"spot_instance_pools":                                       "10",
+					"spot_instance_remedy":                                      "true",
+					"group_deletion_protection":                                 "true",
+					"capacity_options_on_demand_base_capacity":                  "0",
+					"capacity_options_on_demand_percentage_above_base_capacity": "0",
+					"capacity_options_compensate_with_on_demand":                "true",
+					"capacity_options_spot_auto_replace_on_demand":              "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"on_demand_base_capacity":                                   "0",
+						"on_demand_percentage_above_base_capacity":                  "0",
+						"capacity_options_compensate_with_on_demand":                "true",
+						"capacity_options_on_demand_base_capacity":                  "0",
+						"capacity_options_on_demand_percentage_above_base_capacity": "0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "8",
+					"on_demand_percentage_above_base_capacity":                  "8",
+					"spot_instance_pools":                                       "10",
+					"spot_instance_remedy":                                      "true",
+					"group_deletion_protection":                                 "true",
+					"capacity_options_on_demand_base_capacity":                  "8",
+					"capacity_options_on_demand_percentage_above_base_capacity": "8",
+					"capacity_options_compensate_with_on_demand":                "true",
+					"capacity_options_spot_auto_replace_on_demand":              "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"on_demand_base_capacity":                                   "8",
+						"on_demand_percentage_above_base_capacity":                  "8",
+						"capacity_options_on_demand_base_capacity":                  "8",
+						"capacity_options_on_demand_percentage_above_base_capacity": "8",
+						"capacity_options_compensate_with_on_demand":                "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "8",
+					"on_demand_percentage_above_base_capacity":                  "8",
+					"spot_instance_pools":                                       "8",
+					"spot_instance_remedy":                                      "true",
+					"group_deletion_protection":                                 "false",
+					"capacity_options_on_demand_base_capacity":                  "8",
+					"capacity_options_on_demand_percentage_above_base_capacity": "8",
+					"capacity_options_compensate_with_on_demand":                "false",
+					"capacity_options_spot_auto_replace_on_demand":              "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"spot_instance_pools":                                       "8",
+						"group_deletion_protection":                                 "false",
+						"capacity_options_compensate_with_on_demand":                "false",
+						"capacity_options_on_demand_percentage_above_base_capacity": "8",
+						"on_demand_base_capacity":                                   "8",
+						"capacity_options_on_demand_base_capacity":                  "8",
+					}),
+				),
+			},
+		},
+	})
+
+}
+
+func TestAccAliCloudEssScalingGroup_costoptimized_capacityOptionsSupply(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 999999)
+	var v ess.ScalingGroup
+	resourceId := "alicloud_ess_scaling_group.default"
+
+	basicMap := map[string]string{
+		"min_size":                                 "1",
+		"max_size":                                 "1",
+		"default_cooldown":                         "20",
+		"scaling_group_name":                       fmt.Sprintf("tf-testAccEssScalingGroup-%d", rand),
+		"vswitch_ids.#":                            "2",
+		"removal_policies.#":                       "2",
+		"on_demand_base_capacity":                  "10",
+		"spot_instance_pools":                      "10",
+		"spot_instance_remedy":                     "false",
+		"group_deletion_protection":                "false",
+		"on_demand_percentage_above_base_capacity": "10",
+	}
+
+	ra := resourceAttrInit(resourceId, basicMap)
+	rc := resourceCheckInit(resourceId, &v, func() interface{} {
+		return &EssService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	})
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAccEssScalingGroup-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceEssScalingGroupDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		// module name
+		IDRefreshName: resourceId,
+
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEssScalingGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "10",
+					"on_demand_percentage_above_base_capacity": "10",
+					"spot_instance_pools":                      "10",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(nil),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "1",
+					"on_demand_percentage_above_base_capacity":                  "1",
+					"spot_instance_pools":                                       "10",
+					"spot_instance_remedy":                                      "true",
+					"capacity_options_on_demand_base_capacity":                  "1",
+					"capacity_options_on_demand_percentage_above_base_capacity": "1",
+					"capacity_options_compensate_with_on_demand":                "false",
+					"capacity_options_spot_auto_replace_on_demand":              "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"spot_instance_remedy":                                      "true",
+						"capacity_options_on_demand_base_capacity":                  "1",
+						"capacity_options_on_demand_percentage_above_base_capacity": "1",
+						"capacity_options_compensate_with_on_demand":                "false",
+						"capacity_options_spot_auto_replace_on_demand":              "false",
+						"on_demand_base_capacity":                                   "1",
+						"on_demand_percentage_above_base_capacity":                  "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "0",
+					"on_demand_percentage_above_base_capacity":                  "0",
+					"spot_instance_pools":                                       "10",
+					"spot_instance_remedy":                                      "true",
+					"capacity_options_on_demand_base_capacity":                  "0",
+					"capacity_options_on_demand_percentage_above_base_capacity": "0",
+					"capacity_options_compensate_with_on_demand":                "true",
+					"capacity_options_spot_auto_replace_on_demand":              "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"on_demand_base_capacity":                                   "0",
+						"on_demand_percentage_above_base_capacity":                  "0",
+						"capacity_options_compensate_with_on_demand":                "true",
+						"capacity_options_on_demand_base_capacity":                  "0",
+						"capacity_options_on_demand_percentage_above_base_capacity": "0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "8",
+					"on_demand_percentage_above_base_capacity":                  "8",
+					"spot_instance_pools":                                       "10",
+					"spot_instance_remedy":                                      "true",
+					"capacity_options_on_demand_base_capacity":                  "8",
+					"capacity_options_on_demand_percentage_above_base_capacity": "8",
+					"capacity_options_compensate_with_on_demand":                "true",
+					"capacity_options_spot_auto_replace_on_demand":              "false",
+					"group_deletion_protection":                                 "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"on_demand_base_capacity":                                   "8",
+						"on_demand_percentage_above_base_capacity":                  "8",
+						"capacity_options_on_demand_base_capacity":                  "8",
+						"capacity_options_on_demand_percentage_above_base_capacity": "8",
+						"capacity_options_compensate_with_on_demand":                "true",
+						"group_deletion_protection":                                 "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"min_size":                "1",
+					"max_size":                "1",
+					"scaling_group_name":      "${var.name}",
+					"default_cooldown":        "20",
+					"vswitch_ids":             []string{"${alicloud_vswitch.default.id}", "${alicloud_vswitch.default2.id}"},
+					"removal_policies":        []string{"OldestInstance", "NewestInstance"},
+					"multi_az_policy":         "COST_OPTIMIZED",
+					"on_demand_base_capacity": "8",
+					"on_demand_percentage_above_base_capacity":                  "8",
+					"spot_instance_pools":                                       "8",
+					"spot_instance_remedy":                                      "true",
+					"group_deletion_protection":                                 "false",
+					"capacity_options_on_demand_base_capacity":                  "8",
+					"capacity_options_on_demand_percentage_above_base_capacity": "8",
+					"capacity_options_compensate_with_on_demand":                "false",
+					"capacity_options_spot_auto_replace_on_demand":              "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"spot_instance_pools":                                       "8",
+						"group_deletion_protection":                                 "false",
+						"capacity_options_compensate_with_on_demand":                "false",
+						"capacity_options_on_demand_percentage_above_base_capacity": "8",
+						"on_demand_base_capacity":                                   "8",
+						"capacity_options_on_demand_base_capacity":                  "8",
 					}),
 				),
 			},
@@ -2467,14 +3032,15 @@ func resourceEssScalingAttachmentConfigDependence(name string) string {
   		most_recent = true
   		owners      = "system"
 	}
-	data "alicloud_instance_types" "c6" {
+	data "alicloud_instance_types" "sn1" {
+      instance_type_family = "ecs.sn1"
 	  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 	}
 
 	resource "alicloud_ess_scaling_configuration" "default" {
 		scaling_group_id = "${alicloud_ess_scaling_group.default.id}"
 		image_id = "${data.alicloud_images.default1.images.0.id}"
-		instance_type = "${data.alicloud_instance_types.c6.instance_types.0.id}"
+		instance_type = "${data.alicloud_instance_types.sn1.instance_types.0.id}"
 		security_group_id = "${alicloud_security_group.default.id}"
 		force_delete = true
 		active = true
@@ -2485,7 +3051,7 @@ func resourceEssScalingAttachmentConfigDependence(name string) string {
 
 	resource "alicloud_instance" "default" {
 		image_id = "${data.alicloud_images.default1.images.0.id}"
-		instance_type = "${data.alicloud_instance_types.c6.instance_types.0.id}"
+		instance_type = "${data.alicloud_instance_types.sn1.instance_types.0.id}"
 		count = 1
 		security_groups = ["${alicloud_security_group.default.id}"]
 		internet_charge_type = "PayByTraffic"
@@ -2571,14 +3137,14 @@ func resourceEssScalingGroupInstance(name string) string {
   		most_recent = true
   		owners      = "system"
 	}
-	data "alicloud_instance_types" "c6" {
-      //instance_type_family = "ecs.c6"
+	data "alicloud_instance_types" "sn1" {
+      instance_type_family = "ecs.sn1"
 	  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 	}
 
 	resource "alicloud_instance" "default" {
 		image_id = "${data.alicloud_images.default1.images.0.id}"
-		instance_type = "${data.alicloud_instance_types.c6.instance_types.0.id}"
+		instance_type = "${data.alicloud_instance_types.sn1.instance_types.0.id}"
 		security_groups = ["${alicloud_security_group.default1.id}"]
 		internet_charge_type = "PayByTraffic"
 		internet_max_bandwidth_out = "10"
@@ -2689,7 +3255,8 @@ func resourceEssScalingGroupTemplate(name string) string {
   		most_recent = true
   		owners      = "system"
 	}
-	data "alicloud_instance_types" "c6" {
+	data "alicloud_instance_types" "sn1" {
+	 instance_type_family = "ecs.sn1"
      availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 	}
 
@@ -2697,7 +3264,7 @@ func resourceEssScalingGroupTemplate(name string) string {
   		launch_template_name = "tf-test3"
   		image_id             =  data.alicloud_images.default3.images.0.id
   		instance_charge_type = "PrePaid"
-  		instance_type        =  data.alicloud_instance_types.c6.instance_types.0.id
+  		instance_type        =  data.alicloud_instance_types.sn1.instance_types.0.id
   		internet_charge_type          = "PayByBandwidth"
   		internet_max_bandwidth_in     = "5"
   		internet_max_bandwidth_out    = "0"
@@ -2713,7 +3280,7 @@ func resourceEssScalingGroupTemplate(name string) string {
   		launch_template_name = "tf-test4"
   		image_id             =  data.alicloud_images.default3.images.0.id
   		instance_charge_type = "PrePaid"
-  		instance_type        =  data.alicloud_instance_types.c6.instance_types.0.id
+  		instance_type        =  data.alicloud_instance_types.sn1.instance_types.0.id
   		internet_charge_type          = "PayByBandwidth"
   		internet_max_bandwidth_in     = "5"
   		internet_max_bandwidth_out    = "0"
@@ -2837,7 +3404,8 @@ func resourceEssScalingGroupAlbServerGroup(name string) string {
   		most_recent = true
   		owners      = "system"
 	}
-	data "alicloud_instance_types" "c6" {
+	data "alicloud_instance_types" "sn1" {
+       instance_type_family = "ecs.sn1"
        availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 	}
 
@@ -2845,7 +3413,7 @@ func resourceEssScalingGroupAlbServerGroup(name string) string {
   		launch_template_name = "tf-test3"
   		image_id             =  data.alicloud_images.default3.images.0.id
   		instance_charge_type = "PrePaid"
-  		instance_type        =  data.alicloud_instance_types.c6.instance_types.0.id
+  		instance_type        =  data.alicloud_instance_types.sn1.instance_types.0.id
   		internet_charge_type          = "PayByBandwidth"
   		internet_max_bandwidth_in     = "5"
   		internet_max_bandwidth_out    = "0"
@@ -2861,7 +3429,7 @@ func resourceEssScalingGroupAlbServerGroup(name string) string {
   		launch_template_name = "tf-test4"
   		image_id             =  data.alicloud_images.default3.images.0.id
   		instance_charge_type = "PrePaid"
-  		instance_type        =  data.alicloud_instance_types.c6.instance_types.0.id
+  		instance_type        =  data.alicloud_instance_types.sn1.instance_types.0.id
   		internet_charge_type          = "PayByBandwidth"
   		internet_max_bandwidth_in     = "5"
   		internet_max_bandwidth_out    = "0"
@@ -2896,6 +3464,14 @@ func resourceEssScalingGroupAlbServerGroup(name string) string {
 		health_check_config {
 		  health_check_enabled = "false"
 		}
+		slow_start_config {
+		  slow_start_duration = 30
+		  slow_start_enabled  = "true"
+	  }
+       connection_drain_config {
+		  connection_drain_enabled = "true"
+		  connection_drain_timeout = 300
+	  }
 		sticky_session_config {
 		  sticky_session_enabled = true
 		  cookie                 = "tf-testAcc"

--- a/website/docs/r/ess_scaling_group.html.markdown
+++ b/website/docs/r/ess_scaling_group.html.markdown
@@ -71,8 +71,8 @@ resource "alicloud_vswitch" "default" {
 }
 
 resource "alicloud_security_group" "default" {
-  name   = local.name
-  vpc_id = alicloud_vpc.default.id
+  security_group_name = local.name
+  vpc_id              = alicloud_vpc.default.id
 }
 
 resource "alicloud_security_group_rule" "default" {
@@ -140,6 +140,11 @@ The following arguments are supported:
 * `spot_allocation_strategy` - (Optional, Available since v1.225.1) The allocation policy of preemptible instances. You can use this parameter to individually specify the allocation policy for preemptible instances. This parameter takes effect only if you set MultiAZPolicy to COMPOSABLE.
 * `allocation_strategy` - (Optional, Available since v1.225.1) The allocation policy of instances. Auto Scaling selects instance types based on the allocation policy to create instances. The policy can be applied to pay-as-you-go instances and preemptible instances. This parameter takes effect only if you set MultiAZPolicy to COMPOSABLE.
 * `on_demand_base_capacity` - (Optional, Available since v1.54.0) The minimum amount of the Auto Scaling group's capacity that must be fulfilled by On-Demand Instances. This base portion is provisioned first as your group scales.
+* `compensate_with_on_demand` - (Optional, Available since v1.245.0) Specifies whether to automatically create pay-as-you-go instances to meet the requirement on the number of ECS instances when the expected capacity of preemptible instances cannot be provided due to reasons such as cost-related issues and insufficient resources. This parameter is supported only if you set 'multi_az_policy' to COST_OPTIMIZED. Valid values: true, false.
+* `capacity_options_on_demand_base_capacity` - (Optional, Available since v1.245.0) The minimum number of pay-as-you-go instances that must be contained in the scaling group. When the actual number of pay-as-you-go instances in the scaling group drops below the value of this parameter, Auto Scaling preferentially creates pay-as-you-go instances. Valid values: 0 to 1000. If you set 'multi_az_policy' to COMPOSABLE, the default value of this parameter is 0.
+* `capacity_options_on_demand_percentage_above_base_capacity` - (Optional, Available since v1.245.0) The percentage of pay-as-you-go instances in the excess instances when the minimum number of pay-as-you-go instances is reached. 'on_demand_base_capacity' specifies the minimum number of pay-as-you-go instances that must be contained in the scaling group. Valid values: 0 to 100. If you set 'multi_az_policy' to COMPOSABLE, the default value of this parameter is 100.
+* `capacity_options_compensate_with_on_demand` - (Optional, Available since v1.245.0) Specifies whether to automatically create pay-as-you-go instances to meet the requirement on the number of ECS instances when the expected capacity of preemptible instances cannot be provided due to reasons such as cost-related issues and insufficient resources. This parameter is supported only if you set 'multi_az_policy' to COST_OPTIMIZED. Valid values: true, false.
+* `capacity_options_spot_auto_replace_on_demand` - (Optional, Available since v1.245.0) Specifies whether to replace pay-as-you-go instances with preemptible instances. If you specify 'compensate_with_on_demand', it may result in a higher percentage of pay-as-you-go instances compared to the value of 'on_demand_percentage_above_base_capacity'. If you specify this parameter, Auto Scaling preferentially deploys preemptible instances to replace the surplus pay-as-you-go instances when preemptible instance types are available. If you specify 'compensate_with_on_demand', Auto Scaling creates pay-as-you-go instances when preemptible instance types are insufficient. To avoid retaining these pay-as-you-go instances for extended periods, Auto Scaling attempts to replace them with preemptible instances when sufficient preemptible instance types become available. Valid values: true, false.
 * `on_demand_percentage_above_base_capacity` - (Optional, Available since v1.54.0) Controls the percentages of On-Demand Instances and Spot Instances for your additional capacity beyond OnDemandBaseCapacity.  
 * `spot_instance_pools` - (Optional, Available since v1.54.0) The number of Spot pools to use to allocate your Spot capacity. The Spot pools is composed of instance types of lowest price.
 * `spot_instance_remedy` - (Optional, Available since v1.54.0) Whether to replace spot instances with newly created spot/onDemand instance when receive a spot recycling message.


### PR DESCRIPTION
resource/alicloud_ess_scaling_group: add attributes of compensate_with_on_demand, capacity_options_on_demand_base_capacity, capacity_options_on_demand_percentage_above_base_capacity, capacity_options_compensate_with_on_demand and capacity_options_spot_auto_replace_on_demand.