### PR TITLE
support a cpu_options block to specify accelerators options.

### DIFF
--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -696,6 +696,23 @@ func resourceAliCloudInstance() *schema.Resource {
 					},
 				},
 			},
+			"cpu_options": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"accelerators": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							MaxItems: 10,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -1116,6 +1133,19 @@ func resourceAliCloudInstanceCreate(d *schema.ResourceData, meta interface{}) er
 			imageOptionsArg := raw.(map[string]interface{})
 			if v, ok := imageOptionsArg["login_as_non_root"]; ok {
 				request["ImageOptions.LoginAsNonRoot"] = v
+			}
+		}
+	}
+
+	if v, ok := d.GetOk("cpu_options"); ok {
+		for _, raw := range v.(*schema.Set).List() {
+			cpuOptionsArg := raw.(map[string]interface{})
+			if v, ok := cpuOptionsArg["accelerators"]; ok {
+				count := 1
+				for _, accelerator := range v.(*schema.Set).List() {
+					request[fmt.Sprintf("CpuOptions.Accelerators.%d", count)] = accelerator
+					count++
+				}
 			}
 		}
 	}

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -238,6 +238,7 @@ The following arguments are supported:
 -> **NOTE:** If you set `password_inherit` to `true`, make sure that you have not specified `password` or `kms_encrypted_password` and the selected image has a preset password.
 
 * `image_options` - (Optional, Available since v1.237.0) The options of images. See [`image_options`](#image_options) below.
+* `cpu_options` - (Optional, Available since v1.245.0) The options of cpus. See [`cpu_options`](#cpu_options) below.
 
 -> **NOTE:** System disk category `cloud` has been outdated and it only can be used none I/O Optimized ECS instances. Recommend `cloud_efficiency` and `cloud_ssd` disk.
 
@@ -311,6 +312,12 @@ The maintenance_time supports the following:
 The image_options supports the following:
 
 * `login_as_non_root` - (Optional, ForceNew) Whether to allow the instance logging in with the ecs-user user.
+
+### `cpu_options`
+
+The cpu_options supports the following:
+
+* `accelerators` - (Optional) The list of accelerators to enable with the instance.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Use the cpu_options block to specify any cpu related options.
For now, support the following elements:
```
cpu_options {
   accelerators: ["vqat"],
}
```

#8458 
