### PR TITLE
fix: terrafrom set log endpoints not work

### DIFF
--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -813,7 +813,7 @@ func (client *AliyunClient) WithLogClient(do func(*sls.Client) (interface{}, err
 	if client.logconn != nil && !client.config.needRefreshCredential() {
 		return do(client.logconn)
 	}
-	product := "sls"
+	product := "log"
 	endpoint, err := client.loadApiEndpoint(product)
 	if err != nil {
 		return nil, err
@@ -822,6 +822,11 @@ func (client *AliyunClient) WithLogClient(do func(*sls.Client) (interface{}, err
 	if !strings.HasPrefix(endpoint, "http") {
 		endpoint = fmt.Sprintf("https://%s", strings.TrimPrefix(endpoint, "://"))
 	}
+
+	if endpoint != "" {
+		endpoints.AddEndpointMapping(client.config.RegionId, product, endpoint)
+	}
+
 	accessKey, secretKey, securityToken := client.config.GetRefreshCredential()
 	client.logconn = &sls.Client{
 		AccessKeyID:     accessKey,


### PR DESCRIPTION
[log service code](https://github.com/aliyun/terraform-provider-alicloud/blob/1fbf55444ac9a50109c1ee581b01683726e46d6c/alicloud/connectivity/endpoint.go#L59)
定义了log service code为字符串`log`

```
endpoints = {
  log = ***
}
```
terraform 设置了自定义endpoints却无法生效