### PR TITLE
resource/cms_site_monitor fix incorrect isp_cities documentation

### DIFF
--- a/website/docs/r/cms_site_monitor.html.markdown
+++ b/website/docs/r/cms_site_monitor.html.markdown
@@ -34,6 +34,14 @@ resource "alicloud_cms_site_monitor" "basic" {
     city = "546"
     isp  = "465"
   }
+  isp_cities {
+    city = "572"
+    isp  = "465"
+  }
+  isp_cities {
+    city = "738"
+    isp  = "465"
+  }
   options_json = <<EOT
 {
     "http_method": "get",
@@ -64,7 +72,7 @@ The following arguments are supported:
 * `alert_ids` - (Optional, List) The IDs of existing alert rules to be associated with the site monitoring task.
 * `interval` - (Optional, Int) The monitoring interval of the site monitoring task. Unit: minutes. Valid values: `1`, `5`, `15`, `30` and `60`. Default value: `1`. **NOTE:** From version 1.207.0, `interval` can be set to `30`, `60`.
 * `options_json` - (Optional) The extended options of the protocol of the site monitoring task. The options vary according to the protocol. See [extended options](https://www.alibabacloud.com/help/en/cms/developer-reference/api-cms-2019-01-01-createsitemonitor#api-detail-35).
-* `isp_cities` - (Optional, Set) The detection points in a JSON array. For example, `[{"city":"546","isp":"465"},{"city":"572","isp":"465"},{"city":"738","isp":"465"}]` indicates the detection points in Beijing, Hangzhou, and Qingdao respectively. You can call the [DescribeSiteMonitorISPCityList](https://www.alibabacloud.com/help/en/doc-detail/115045.htm) operation to query detection point information. If this parameter is not specified, three detection points will be chosen randomly for monitoring. See [`isp_cities`](#isp_cities) below.
+* `isp_cities` - (Optional, Set) The detection points specified as configuration blocks. For example, to configure detection points in Beijing, Hangzhou, and Qingdao, you would use multiple `isp_cities` blocks as shown in the example above. You can call the [DescribeSiteMonitorISPCityList](https://www.alibabacloud.com/help/en/doc-detail/115045.htm) operation to query detection point information. If this parameter is not specified, three detection points will be chosen randomly for monitoring. See [`isp_cities`](#isp_cities) below.
 
 ### `isp_cities`
 


### PR DESCRIPTION
It the [Terraform documentation](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cms_site_monitor#isp_cities), isp_cities sited as:

> [isp_cities](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cms_site_monitor#isp_cities-1) - (Optional, Set) The detection points in a JSON array. For example, [{"city":"546","isp":"465"},{"city":"572","isp":"465"},{"city":"738","isp":"465"}] indicates the detection points in Beijing, Hangzhou, and Qingdao respectively.

However this is actually incorrect.

It has to be in below format:
```
isp_cities {
    city = "546"
    isp  = "465"
  }
  
  isp_cities {
    city = "572"
    isp  = "465"
  }
  
  isp_cities {
    city = "738"
    isp  = "465"
  }
```

Looks like it's just copy & pasted from API documentation without verifying it.