### PR TITLE
resource/alicloud_cs_kubernetes_node_pool: add Custom image_type

### DIFF
--- a/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
@@ -174,7 +174,7 @@ func resourceAliCloudAckNodepool() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: StringInSlice([]string{"AliyunLinux", "AliyunLinux3", "AliyunLinux3Arm64", "AliyunLinuxUEFI", "CentOS", "Windows", "WindowsCore", "AliyunLinux Qboot", "ContainerOS", "AliyunLinuxSecurity", "Ubuntu", "AliyunLinux3ContainerOptimized"}, false),
+				ValidateFunc: StringInSlice([]string{"AliyunLinux", "AliyunLinux3", "AliyunLinux3Arm64", "AliyunLinuxUEFI", "CentOS", "Windows", "WindowsCore", "AliyunLinux Qboot", "ContainerOS", "AliyunLinuxSecurity", "Ubuntu", "AliyunLinux3ContainerOptimized", "Custom"}, false),
 			},
 			"install_cloud_monitor": {
 				Type:     schema.TypeBool,

--- a/website/docs/r/cs_kubernetes_node_pool.html.markdown
+++ b/website/docs/r/cs_kubernetes_node_pool.html.markdown
@@ -337,6 +337,7 @@ The following arguments are supported:
   - `ContainerOS` : container-optimized image.
   - `Ubuntu`: Ubuntu image.
   - `AliyunLinux3ContainerOptimized`: Alinux3 container-optimized image.
+  - `Custom`: Custom image.
 * `install_cloud_monitor` - (Optional) Whether to install cloud monitoring on the ECS node. After installation, you can view the monitoring information of the created ECS instance in the cloud monitoring console and recommend enable it. Default value: `false`. Valid values:
   - `true` : install cloud monitoring on the ECS node.
   - `false` : does not install cloud monitoring on the ECS node.


### PR DESCRIPTION
Added the image_type `Custom` to avoid the following resource change on Terraform. 

When using customized `AliyunLinux3` image as input param, the value is actually `Custom` in the state file:

```
  # module.blueprint.module.ack-managed-node-pool["spot_node_group"].alicloud_cs_kubernetes_node_pool.default will be updated in-place
  ~ resource "alicloud_cs_kubernetes_node_pool" "default" {
        id                                       = "c1956a705a04c4a82bxxxxx:np7805649xxxxxxx"
      ~ image_type                               = "Custom" -> "AliyunLinux3"
        name                                     = "spot-node-group"
        # (54 unchanged attributes hidden)

        # (5 unchanged blocks hidden)
    }
```

Currently the option isn't available, Terraform provider will throw an error when using `Custom`:
```
│ Error: expected image_type to be one of [AliyunLinux AliyunLinux3 AliyunLinux3Arm64 AliyunLinuxUEFI CentOS Windows WindowsCore AliyunLinux Qboot ContainerOS AliyunLinuxSecurity Ubuntu], got Custom
│ [NOTE] set env variable TF_SKIP_RESOURCE_SCHEMA_VALIDATION to true can skip the error and get a warning
```