### PR TITLE
Bump golangci-linter to v2.7.2

### DIFF
--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -2,7 +2,7 @@ name: Golangci-Lint
 on:
   pull_request:
     paths:
-      - .github/workflows/acctest-terraform-lint.yml.yml
+      - .github/workflows/acctest-terraform-lint.yml
       - alicloud/*.go
 jobs:
 #  golangci-lint-review-log:
@@ -29,9 +29,9 @@ jobs:
       - name: errcheck
         uses: reviewdog/action-golangci-lint@v2
         with:
-          golangci_lint_flags: '--tests=false --timeout=25m --disable-all -E errcheck'
+          golangci_lint_flags: '--tests=false --timeout=25m --default=none -E errcheck'
           tool_name: errcheck
           level: info
-          reviewdog_version: 'v0.20.2'
-          golangci_lint_version: 'v1.59.1'
+          reviewdog_version: 'v0.21.0'
+          golangci_lint_version: 'v2.7.2'
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,31 @@
+version: "2"
+linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: scripts/
+    paths:
+      - examples
+      - scripts
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-dirs:
-    - examples
-    - scripts
-  exclude-rules:
-    - path: scripts/
-      linters:
-        - errcheck
-  new: true
   new-from-rev: HEAD
+  new: true
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 run:
   timeout: 10m


### PR DESCRIPTION
1. Bump golangci-linter to v2.7.2
2. Bump reviewdog_version to v0.21.0