### PR TITLE
resource/alicloud_cr_ee_instance: Add support for repo_quota, vpc_quota, namespace_quota

### DIFF
--- a/alicloud/resource_alicloud_cr_ee_instance_test.go
+++ b/alicloud/resource_alicloud_cr_ee_instance_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAliCloudCREEInstance_Basic(t *testing.T) {
+func TestAccAliCloudCrInstance_Basic(t *testing.T) {
 	var v *cr_ee.GetInstanceResponse
 	resourceId := "alicloud_cr_ee_instance.default"
 	ra := resourceAttrInit(resourceId, nil)
@@ -84,7 +84,7 @@ func TestAccAliCloudCREEInstance_Basic(t *testing.T) {
 	})
 }
 
-func TestAccAliCloudCREEInstance_Standard(t *testing.T) {
+func TestAccAliCloudCrInstance_Standard(t *testing.T) {
 	var v *cr_ee.GetInstanceResponse
 	resourceId := "alicloud_cr_ee_instance.default"
 	ra := resourceAttrInit(resourceId, nil)
@@ -159,7 +159,7 @@ func TestAccAliCloudCREEInstance_Standard(t *testing.T) {
 	})
 }
 
-func TestAccAliCloudCREEInstance_Advanced(t *testing.T) {
+func TestAccAliCloudCrInstance_Advanced(t *testing.T) {
 	var v *cr_ee.GetInstanceResponse
 	resourceId := "alicloud_cr_ee_instance.default"
 	ra := resourceAttrInit(resourceId, nil)
@@ -484,3 +484,553 @@ resource "alicloud_oss_bucket" "defaultkcvHCP" {
 
 `, name)
 }
+
+//
+//// Test Cr Instance. >>> Resource test cases, automatically generated.
+//// Case 实例生命周期测试_ DefaultOssBucket 8613
+//func TestAccAliCloudCrInstance_basic8613(t *testing.T) {
+//	var v map[string]interface{}
+//	resourceId := "alicloud_cr_ee_instance.default"
+//	ra := resourceAttrInit(resourceId, AlicloudCrInstanceMap8613)
+//	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+//		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+//	}, "DescribeCrInstance")
+//	rac := resourceAttrCheckInit(rc, ra)
+//	testAccCheck := rac.resourceAttrMapUpdateSet()
+//	rand := acctest.RandIntRange(10000, 99999)
+//	name := fmt.Sprintf("tfacccr%d", rand)
+//	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrInstanceBasicDependence8613)
+//	resource.Test(t, resource.TestCase{
+//		PreCheck: func() {
+//			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+//			testAccPreCheck(t)
+//		},
+//		IDRefreshName: resourceId,
+//		Providers:     testAccProviders,
+//		CheckDestroy:  rac.checkResourceDestroy(),
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"instance_name":      name,
+//					"period":             "1",
+//					"renewal_status":     "AutoRenewal",
+//					"image_scanner":      "ACR",
+//					"instance_type":      "Advanced",
+//					"payment_type":       "Subscription",
+//					"renew_period":       "1",
+//					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+//					"default_oss_bucket": "true",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"instance_name":      name,
+//						"period":             "1",
+//						"renewal_status":     "AutoRenewal",
+//						"image_scanner":      "ACR",
+//						"instance_type":      "Advanced",
+//						"payment_type":       "Subscription",
+//						"renew_period":       "1",
+//						"resource_group_id":  CHECKSET,
+//						"default_oss_bucket": CHECKSET,
+//					}),
+//				),
+//			},
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"resource_group_id": CHECKSET,
+//					}),
+//				),
+//			},
+//			{
+//				ResourceName:            resourceId,
+//				ImportState:             true,
+//				ImportStateVerify:       true,
+//				ImportStateVerifyIgnore: []string{"custom_oss_bucket", "default_oss_bucket", "image_scanner", "instance_type", "namespace_quota", "password", "period", "repo_quota", "vpc_quota"},
+//			},
+//		},
+//	})
+//}
+//
+//var AlicloudCrInstanceMap8613 = map[string]string{
+//	"end_time":             CHECKSET,
+//	"status":               CHECKSET,
+//	"create_time":          CHECKSET,
+//	"instance_endpoints.#": CHECKSET,
+//	"region_id":            CHECKSET,
+//}
+//
+//func AlicloudCrInstanceBasicDependence8613(name string) string {
+//	return fmt.Sprintf(`
+//variable "name" {
+//    default = "%s"
+//}
+//
+//data "alicloud_resource_manager_resource_groups" "default" {}
+//
+//
+//`, name)
+//}
+//
+//// Case 实例生命周期测试 7970
+//func TestAccAliCloudCrInstance_basic7970(t *testing.T) {
+//	var v map[string]interface{}
+//	resourceId := "alicloud_cr_ee_instance.default"
+//	ra := resourceAttrInit(resourceId, AlicloudCrInstanceMap7970)
+//	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+//		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+//	}, "DescribeCrInstance")
+//	rac := resourceAttrCheckInit(rc, ra)
+//	testAccCheck := rac.resourceAttrMapUpdateSet()
+//	rand := acctest.RandIntRange(10000, 99999)
+//	name := fmt.Sprintf("tfacccr%d", rand)
+//	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrInstanceBasicDependence7970)
+//	resource.Test(t, resource.TestCase{
+//		PreCheck: func() {
+//			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+//			testAccPreCheck(t)
+//		},
+//		IDRefreshName: resourceId,
+//		Providers:     testAccProviders,
+//		CheckDestroy:  rac.checkResourceDestroy(),
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"instance_name":      name,
+//					"period":             "1",
+//					"renewal_status":     "AutoRenewal",
+//					"image_scanner":      "SAS",
+//					"instance_type":      "Standard",
+//					"payment_type":       "Subscription",
+//					"renew_period":       "1",
+//					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+//					"default_oss_bucket": "false",
+//					"custom_oss_bucket":  "${alicloud_oss_bucket.defaultkcvHCP.id}",
+//					"password":           "terraformtest123",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"instance_name":      name,
+//						"period":             "1",
+//						"renewal_status":     "AutoRenewal",
+//						"image_scanner":      "SAS",
+//						"instance_type":      "Standard",
+//						"payment_type":       "Subscription",
+//						"renew_period":       "1",
+//						"resource_group_id":  CHECKSET,
+//						"default_oss_bucket": CHECKSET,
+//						"custom_oss_bucket":  CHECKSET,
+//						"password":           "terraformtest123",
+//					}),
+//				),
+//			},
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+//					"password":          "terraformtest124",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"resource_group_id": CHECKSET,
+//						"password":          "terraformtest124",
+//					}),
+//				),
+//			},
+//			{
+//				ResourceName:            resourceId,
+//				ImportState:             true,
+//				ImportStateVerify:       true,
+//				ImportStateVerifyIgnore: []string{"custom_oss_bucket", "default_oss_bucket", "image_scanner", "instance_type", "namespace_quota", "password", "period", "repo_quota", "vpc_quota"},
+//			},
+//		},
+//	})
+//}
+//
+//var AlicloudCrInstanceMap7970 = map[string]string{
+//	"end_time":             CHECKSET,
+//	"status":               CHECKSET,
+//	"create_time":          CHECKSET,
+//	"instance_endpoints.#": CHECKSET,
+//	"region_id":            CHECKSET,
+//}
+//
+//func AlicloudCrInstanceBasicDependence7970(name string) string {
+//	return fmt.Sprintf(`
+//variable "name" {
+//    default = "%s"
+//}
+//
+//data "alicloud_resource_manager_resource_groups" "default" {}
+//
+//resource "alicloud_oss_bucket" "defaultkcvHCP" {
+//  storage_class = "Standard"
+//}
+//
+//
+//`, name)
+//}
+//
+//// Case 实例生命周期测试_3 7574
+//func TestAccAliCloudCrInstance_basic7574(t *testing.T) {
+//	var v map[string]interface{}
+//	resourceId := "alicloud_cr_ee_instance.default"
+//	ra := resourceAttrInit(resourceId, AlicloudCrInstanceMap7574)
+//	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+//		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+//	}, "DescribeCrInstance")
+//	rac := resourceAttrCheckInit(rc, ra)
+//	testAccCheck := rac.resourceAttrMapUpdateSet()
+//	rand := acctest.RandIntRange(10000, 99999)
+//	name := fmt.Sprintf("tfacccr%d", rand)
+//	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrInstanceBasicDependence7574)
+//	resource.Test(t, resource.TestCase{
+//		PreCheck: func() {
+//			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+//			testAccPreCheck(t)
+//		},
+//		IDRefreshName: resourceId,
+//		Providers:     testAccProviders,
+//		CheckDestroy:  rac.checkResourceDestroy(),
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"instance_name":      name,
+//					"period":             "1",
+//					"renewal_status":     "AutoRenewal",
+//					"image_scanner":      "ACR",
+//					"instance_type":      "Advanced",
+//					"payment_type":       "Subscription",
+//					"renew_period":       "1",
+//					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+//					"default_oss_bucket": "true",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"instance_name":      name,
+//						"period":             "1",
+//						"renewal_status":     "AutoRenewal",
+//						"image_scanner":      "ACR",
+//						"instance_type":      "Advanced",
+//						"payment_type":       "Subscription",
+//						"renew_period":       "1",
+//						"resource_group_id":  CHECKSET,
+//						"default_oss_bucket": CHECKSET,
+//					}),
+//				),
+//			},
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"resource_group_id": CHECKSET,
+//					}),
+//				),
+//			},
+//			{
+//				ResourceName:            resourceId,
+//				ImportState:             true,
+//				ImportStateVerify:       true,
+//				ImportStateVerifyIgnore: []string{"custom_oss_bucket", "default_oss_bucket", "image_scanner", "instance_type", "namespace_quota", "password", "period", "repo_quota", "vpc_quota"},
+//			},
+//		},
+//	})
+//}
+//
+//var AlicloudCrInstanceMap7574 = map[string]string{
+//	"end_time":             CHECKSET,
+//	"status":               CHECKSET,
+//	"create_time":          CHECKSET,
+//	"instance_endpoints.#": CHECKSET,
+//	"region_id":            CHECKSET,
+//}
+//
+//func AlicloudCrInstanceBasicDependence7574(name string) string {
+//	return fmt.Sprintf(`
+//variable "name" {
+//    default = "%s"
+//}
+//
+//data "alicloud_resource_manager_resource_groups" "default" {}
+//
+//
+//`, name)
+//}
+//
+//// Case 实例生命周期测试_2_new_more_api 8614
+//func TestAccAliCloudCrInstance_basic8614(t *testing.T) {
+//	var v map[string]interface{}
+//	resourceId := "alicloud_cr_ee_instance.default"
+//	ra := resourceAttrInit(resourceId, AlicloudCrInstanceMap8614)
+//	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+//		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+//	}, "DescribeCrInstance")
+//	rac := resourceAttrCheckInit(rc, ra)
+//	testAccCheck := rac.resourceAttrMapUpdateSet()
+//	rand := acctest.RandIntRange(10000, 99999)
+//	name := fmt.Sprintf("tfacccr%d", rand)
+//	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrInstanceBasicDependence8614)
+//	resource.Test(t, resource.TestCase{
+//		PreCheck: func() {
+//			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+//			testAccPreCheck(t)
+//		},
+//		IDRefreshName: resourceId,
+//		Providers:     testAccProviders,
+//		CheckDestroy:  rac.checkResourceDestroy(),
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"instance_name":      name,
+//					"period":             "1",
+//					"renewal_status":     "ManualRenewal",
+//					"image_scanner":      "SAS",
+//					"instance_type":      "Standard",
+//					"payment_type":       "Subscription",
+//					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+//					"default_oss_bucket": "false",
+//					"custom_oss_bucket":  "${alicloud_oss_bucket.defaultkcvHCP.id}",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"instance_name":      name,
+//						"period":             "1",
+//						"renewal_status":     "ManualRenewal",
+//						"image_scanner":      "SAS",
+//						"instance_type":      "Standard",
+//						"payment_type":       "Subscription",
+//						"resource_group_id":  CHECKSET,
+//						"default_oss_bucket": CHECKSET,
+//						"custom_oss_bucket":  CHECKSET,
+//					}),
+//				),
+//			},
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"resource_group_id": CHECKSET,
+//					}),
+//				),
+//			},
+//			{
+//				ResourceName:            resourceId,
+//				ImportState:             true,
+//				ImportStateVerify:       true,
+//				ImportStateVerifyIgnore: []string{"custom_oss_bucket", "default_oss_bucket", "image_scanner", "instance_type", "namespace_quota", "password", "period", "repo_quota", "vpc_quota"},
+//			},
+//		},
+//	})
+//}
+//
+//var AlicloudCrInstanceMap8614 = map[string]string{
+//	"end_time":             CHECKSET,
+//	"status":               CHECKSET,
+//	"create_time":          CHECKSET,
+//	"instance_endpoints.#": CHECKSET,
+//	"region_id":            CHECKSET,
+//}
+//
+//func AlicloudCrInstanceBasicDependence8614(name string) string {
+//	return fmt.Sprintf(`
+//variable "name" {
+//    default = "%s"
+//}
+//
+//data "alicloud_resource_manager_resource_groups" "default" {}
+//
+//resource "alicloud_oss_bucket" "defaultkcvHCP" {
+//  storage_class = "Standard"
+//}
+//
+//
+//`, name)
+//}
+//
+//// Case 实例生命周期测试_3_more_api_cn 8662
+//func TestAccAliCloudCrInstance_basic8662(t *testing.T) {
+//	var v map[string]interface{}
+//	resourceId := "alicloud_cr_ee_instance.default"
+//	ra := resourceAttrInit(resourceId, AlicloudCrInstanceMap8662)
+//	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+//		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+//	}, "DescribeCrInstance")
+//	rac := resourceAttrCheckInit(rc, ra)
+//	testAccCheck := rac.resourceAttrMapUpdateSet()
+//	rand := acctest.RandIntRange(10000, 99999)
+//	name := fmt.Sprintf("tfacccr%d", rand)
+//	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrInstanceBasicDependence8662)
+//	resource.Test(t, resource.TestCase{
+//		PreCheck: func() {
+//			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+//			testAccPreCheck(t)
+//		},
+//		IDRefreshName: resourceId,
+//		Providers:     testAccProviders,
+//		CheckDestroy:  rac.checkResourceDestroy(),
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"instance_name":      name,
+//					"period":             "1",
+//					"renewal_status":     "AutoRenewal",
+//					"image_scanner":      "ACR",
+//					"instance_type":      "Advanced",
+//					"payment_type":       "Subscription",
+//					"renew_period":       "1",
+//					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+//					"default_oss_bucket": "true",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"instance_name":      name,
+//						"period":             "1",
+//						"renewal_status":     "AutoRenewal",
+//						"image_scanner":      "ACR",
+//						"instance_type":      "Advanced",
+//						"payment_type":       "Subscription",
+//						"renew_period":       "1",
+//						"resource_group_id":  CHECKSET,
+//						"default_oss_bucket": CHECKSET,
+//					}),
+//				),
+//			},
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"resource_group_id": CHECKSET,
+//					}),
+//				),
+//			},
+//			{
+//				ResourceName:            resourceId,
+//				ImportState:             true,
+//				ImportStateVerify:       true,
+//				ImportStateVerifyIgnore: []string{"custom_oss_bucket", "default_oss_bucket", "image_scanner", "instance_type", "namespace_quota", "password", "period", "repo_quota", "vpc_quota"},
+//			},
+//		},
+//	})
+//}
+//
+//var AlicloudCrInstanceMap8662 = map[string]string{
+//	"end_time":             CHECKSET,
+//	"status":               CHECKSET,
+//	"create_time":          CHECKSET,
+//	"instance_endpoints.#": CHECKSET,
+//	"region_id":            CHECKSET,
+//}
+//
+//func AlicloudCrInstanceBasicDependence8662(name string) string {
+//	return fmt.Sprintf(`
+//variable "name" {
+//    default = "%s"
+//}
+//
+//data "alicloud_resource_manager_resource_groups" "default" {}
+//
+//
+//`, name)
+//}
+//
+//// Case 实例生命周期测试_1_cn 8646
+//func TestAccAliCloudCrInstance_basic8646(t *testing.T) {
+//	var v map[string]interface{}
+//	resourceId := "alicloud_cr_ee_instance.default"
+//	ra := resourceAttrInit(resourceId, AlicloudCrInstanceMap8646)
+//	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+//		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+//	}, "DescribeCrInstance")
+//	rac := resourceAttrCheckInit(rc, ra)
+//	testAccCheck := rac.resourceAttrMapUpdateSet()
+//	rand := acctest.RandIntRange(10000, 99999)
+//	name := fmt.Sprintf("tfacccr%d", rand)
+//	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrInstanceBasicDependence8646)
+//	resource.Test(t, resource.TestCase{
+//		PreCheck: func() {
+//			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+//			testAccPreCheck(t)
+//		},
+//		IDRefreshName: resourceId,
+//		Providers:     testAccProviders,
+//		CheckDestroy:  rac.checkResourceDestroy(),
+//		Steps: []resource.TestStep{
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"instance_name":      name,
+//					"period":             "1",
+//					"renewal_status":     "AutoRenewal",
+//					"image_scanner":      "ACR",
+//					"instance_type":      "Basic",
+//					"renew_period":       "1",
+//					"default_oss_bucket": "false",
+//					"payment_type":       "Subscription",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"instance_name":      name,
+//						"period":             "1",
+//						"renewal_status":     "AutoRenewal",
+//						"image_scanner":      "ACR",
+//						"instance_type":      "Basic",
+//						"renew_period":       "1",
+//						"default_oss_bucket": CHECKSET,
+//						"payment_type":       "Subscription",
+//					}),
+//				),
+//			},
+//			{
+//				Config: testAccConfig(map[string]interface{}{
+//					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+//					"password":          "QQQqwer1234",
+//				}),
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheck(map[string]string{
+//						"resource_group_id": CHECKSET,
+//						"password":          "QQQqwer1234",
+//					}),
+//				),
+//			},
+//			{
+//				ResourceName:            resourceId,
+//				ImportState:             true,
+//				ImportStateVerify:       true,
+//				ImportStateVerifyIgnore: []string{"custom_oss_bucket", "default_oss_bucket", "image_scanner", "instance_type", "namespace_quota", "password", "period", "repo_quota", "vpc_quota"},
+//			},
+//		},
+//	})
+//}
+//
+//var AlicloudCrInstanceMap8646 = map[string]string{
+//	"end_time":             CHECKSET,
+//	"status":               CHECKSET,
+//	"create_time":          CHECKSET,
+//	"instance_endpoints.#": CHECKSET,
+//	"region_id":            CHECKSET,
+//}
+//
+//func AlicloudCrInstanceBasicDependence8646(name string) string {
+//	return fmt.Sprintf(`
+//variable "name" {
+//    default = "%s"
+//}
+//
+//data "alicloud_resource_manager_resource_groups" "default" {}
+//
+//resource "alicloud_oss_bucket" "defaultkcvHCP" {
+//  storage_class = "Standard"
+//}
+//
+//
+//`, name)
+//}
+//
+//// Test Cr Instance. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_cr_v2.go
+++ b/alicloud/service_alicloud_cr_v2.go
@@ -29,11 +29,11 @@ func (s *CrServiceV2) DescribeCrInstance(id string) (object map[string]interface
 	action := "GetInstance"
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
 		response, err = client.RpcPost("cr", "2018-12-01", action, query, request, true)
 
 		if err != nil {
-			if NeedRetry(err) || IsExpectedErrors(err, []string{"InvalidAction.NotFound"}) {
+			if NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}
@@ -49,8 +49,9 @@ func (s *CrServiceV2) DescribeCrInstance(id string) (object map[string]interface
 
 	return response, nil
 }
-func (s *CrServiceV2) DescribeInstanceQueryAvailableInstances(id string) (object map[string]interface{}, err error) {
+func (s *CrServiceV2) DescribeInstanceQueryAvailableInstances(d *schema.ResourceData) (object map[string]interface{}, err error) {
 	client := s.client
+	id := d.Id()
 	var request map[string]interface{}
 	var response map[string]interface{}
 	var query map[string]interface{}

--- a/website/docs/r/cr_ee_instance.html.markdown
+++ b/website/docs/r/cr_ee_instance.html.markdown
@@ -10,19 +10,16 @@ description: |-
 
 Provides a CR Instance resource.
 
-For information about Container Registry Enterprise Edition instances and how to use it, see [Create a Instance](https://www.alibabacloud.com/help/en/doc-detail/208144.htm)
+
+For information about Container Registry Instance and how to use it, see [What is Container Registry](https://www.alibabacloud.com/help/en/acr/product-overview/what-is-container-registry).
+
+For information about CR Instance and how to use it, see [What is Instance](https://www.alibabacloud.com/help/en/doc-detail/208144.htm).
 
 -> **NOTE:** Available since v1.124.0.
 
 ## Example Usage
 
 Basic Usage
-
-<div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
-  <a href="https://api.aliyun.com/terraform?resource=alicloud_cr_ee_instance&exampleId=25749ea8-d0d9-59b9-d587-cf2975510050df3b0d18&activeTab=example&spm=docs.r.cr_ee_instance.0.25749ea8d0&intl_lang=EN_US" target="_blank">
-    <img alt="Open in AliCloud" src="https://img.alicdn.com/imgextra/i1/O1CN01hjjqXv1uYUlY56FyX_!!6000000006049-55-tps-254-36.svg" style="max-height: 44px; max-width: 100%;">
-  </a>
-</div></div>
 
 ```terraform
 variable "name" {
@@ -73,6 +70,7 @@ The following arguments are supported:
 
 -> **NOTE:** The parameter is immutable after resource creation. It only applies during resource creation and has no effect when modified post-creation.
 
+* `namespace_quota` - (Optional, ForceNew, Int, Available since v1.268.0) The number of additional namespaces to purchase. Changing this forces a new resource to be created.
 * `password` - (Optional) Login password, 8-32 digits, must contain at least two letters, symbols, or numbers
 * `payment_type` - (Required, ForceNew) Payment type, value:
   - Subscription: Prepaid.
@@ -87,12 +85,15 @@ The following arguments are supported:
 
 -> **NOTE:**  When `RenewalStatus` is set to `AutoRenewal`, it must be set.
 
-* `renewal_status` - (Optional, ForceNew, Computed) Automatic renewal status, value:
-  - AutoRenewal: automatic renewal.
-  - ManualRenewal: manual renewal.
+* `renewal_status` - (Optional, ForceNew, Computed) Automatic renewal status, possible values are:
+  - `AutoRenewal`: automatic renewal.
+  - `ManualRenewal`: manual renewal.
 
-  Default ManualRenewal.
+  Defaults to `ManualRenewal`.
+
+* `repo_quota` - (Optional, ForceNew, Int, Available since v1.268.0) The number of additional repositories to purchase. Changing this forces a new resource to be created.
 * `resource_group_id` - (Optional, Computed, Available since v1.235.0) The ID of the resource group
+* `vpc_quota` - (Optional, ForceNew, Int, Available since v1.268.0) The number of VPC access controls. Changing this forces a new resource to be created.
 
 The following arguments will be discarded. Please use new fields as soon as possible:
 * `created_time` - (Deprecated since v1.235.0). Field 'created_time' has been deprecated from provider version 1.235.0. New field 'create_time' instead.
@@ -105,7 +106,7 @@ The following attributes are exported:
 * `id` - The ID of the resource supplied above.
 * `create_time` - The creation time of the resource
 * `end_time` - Expiration Time
-* `instance_endpoints` - (Available since v1.240.0) Instance Network Access Endpoint List
+* `instance_endpoints` - Instance Network Access Endpoint List
   * `domains` - Domain List
     * `domain` - Domain
     * `type` - Domain Type


### PR DESCRIPTION
Add support for `repo_quota`, `vpc_quota`, `namespace_quota`

```log
=== RUN   TestAccAliCloudCrInstance_Basic
--- PASS: TestAccAliCloudCrInstance_Basic (157.30s)
=== RUN   TestAccAliCloudCrInstance_Standard
--- PASS: TestAccAliCloudCrInstance_Standard (186.72s)
=== RUN   TestAccAliCloudCrInstance_Advanced
--- PASS: TestAccAliCloudCrInstance_Advanced (156.94s)
=== RUN   TestAccAliCloudCrInstance_basic7970_modified
--- PASS: TestAccAliCloudCrInstance_basic7970_modified (250.20s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  755.938s
```