### PR TITLE
resource/alicloud_hbr_policy: Add support for tag_filters and data_source_filters #9382

### DIFF
--- a/alicloud/resource_alicloud_hbr_policy_test.go
+++ b/alicloud/resource_alicloud_hbr_policy_test.go
@@ -9,22 +9,21 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-// Test Hbr Policy. >>> Resource test cases, automatically generated.
-// Case Policy 6287
-func TestAccAliCloudHbrPolicy_basic6287(t *testing.T) {
+func TestAccAliCloudHbrPolicy_basic(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_hbr_policy.default"
-	ra := resourceAttrInit(resourceId, AliCloudHbrPolicyMap6287)
+	ra := resourceAttrInit(resourceId, AlicloudHbrPolicyMap)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
 		return &HbrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}, "DescribeHbrPolicy")
 	rac := resourceAttrCheckInit(rc, ra)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc%shbrpolicy%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudHbrPolicyBasicDependence6287)
+	name := fmt.Sprintf("tfacchbr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudHbrPolicyBasicDependence)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 			testAccPreCheck(t)
 		},
 		IDRefreshName: resourceId,
@@ -33,264 +32,113 @@ func TestAccAliCloudHbrPolicy_basic6287(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"policy_name": name,
+					"policy_description": "镇元Policy-创建",
+					"policy_name":        name,
 					"rules": []map[string]interface{}{
 						{
-							"rule_type":    "BACKUP",
-							"backup_type":  "COMPLETE",
-							"schedule":     "I|1631685600|P1D",
-							"archive_days": "0",
-							"vault_id":     "${alicloud_hbr_vault.defaultL7kwwD.id}",
-						},
-						{
-							"rule_type":    "TRANSITION",
-							"backup_type":  "COMPLETE",
-							"retention":    "120",
-							"archive_days": "0",
-						},
-						{
-							"rule_type":             "REPLICATION",
-							"backup_type":           "COMPLETE",
-							"retention":             "135",
-							"replication_region_id": "cn-chengdu",
-							"archive_days":          "0",
-						},
-					},
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"policy_name": name,
-						"rules.#":     "3",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"policy_description": "policy creation",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"policy_description": "policy creation",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"rules": []map[string]interface{}{
-						{
-							"rule_type":    "TRANSITION",
-							"retention":    "120",
-							"archive_days": "30",
-							"retention_rules": []map[string]interface{}{
+							"rule_type":             "TRANSITION",
+							"retention":             "120",
+							"archive_days":          "30",
+							"replication_region_id": "cn-shanghai",
+							"keep_latest_snapshots": "1",
+							"tag_filters": []map[string]interface{}{
 								{
-									"advanced_retention_type": "WEEKLY",
-									"retention":               "240",
+									"key":      "key1",
+									"value":    "val1",
+									"operator": "EQUAL",
+								},
+								{
+									"key":      "key2",
+									"value":    "val2",
+									"operator": "NOT",
 								},
 							},
-							"backup_type": "COMPLETE",
+							"data_source_filters": []map[string]interface{}{
+								{"source_type": "UDM_ECS"},
+							},
 						},
 						{
 							"rule_type":             "BACKUP",
 							"backup_type":           "COMPLETE",
 							"schedule":              "I|1631685600|P1D",
-							"keep_latest_snapshots": "0",
-							"archive_days":          "0",
+							"keep_latest_snapshots": "1",
+							"archive_days":          "30",
 							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
-						},
-						{
-							"rule_type":             "REPLICATION",
-							"retention":             "175",
-							"replication_region_id": "cn-qingdao",
-							"archive_days":          "0",
-							"backup_type":           "COMPLETE",
+							"tag_filters": []map[string]interface{}{
+								{
+									"key":      "key1",
+									"value":    "val1",
+									"operator": "EQUAL",
+								},
+							},
+							"data_source_filters": []map[string]interface{}{
+								{"source_type": "UDM_ECS"},
+							},
 						},
 					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"rules.#": "3",
+						"policy_description":            "镇元Policy-创建",
+						"policy_name":                   name,
+						"rules.#":                       "2",
+						"rules.0.tag_filters.#":         "2",
+						"rules.1.tag_filters.#":         "1",
+						"rules.0.data_source_filters.#": "1",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"policy_description": "policy update",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"policy_description": "policy update",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"policy_name": name + "_update",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"policy_name": name + "_update",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
+					"policy_description": "镇元-修改",
+					"policy_name":        name + "_update",
 					"rules": []map[string]interface{}{
 						{
-							"rule_type":    "TRANSITION",
-							"retention":    "240",
-							"archive_days": "85",
-							"retention_rules": []map[string]interface{}{
+							"rule_type":             "TRANSITION",
+							"retention":             "240",
+							"archive_days":          "85",
+							"backup_type":           "COMPLETE",
+							"replication_region_id": "cn-beijing",
+							"keep_latest_snapshots": "1",
+							"tag_filters": []map[string]interface{}{
 								{
-									"advanced_retention_type": "WEEKLY",
-									"retention":               "480",
-								},
-								{
-									"advanced_retention_type": "MONTHLY",
-									"retention":               "960",
-								},
-								{
-									"advanced_retention_type": "YEARLY",
-									"retention":               "1200",
+									"key":      "key1",
+									"value":    "val1",
+									"operator": "EQUAL",
 								},
 							},
-							"backup_type": "COMPLETE",
+							"data_source_filters": []map[string]interface{}{
+								{"source_type": "OSS"},
+							},
 						},
 						{
 							"rule_type":             "BACKUP",
 							"backup_type":           "COMPLETE",
 							"schedule":              "I|1631685600|P2D",
-							"retention":             "7",
-							"vault_id":              "${alicloud_hbr_vault.defaultL7kwwD.id}",
+							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
 							"keep_latest_snapshots": "1",
-							"archive_days":          "0",
-						},
-						{
-							"rule_type":             "REPLICATION",
-							"retention":             "120",
-							"replication_region_id": "cn-zhangjiakou",
-							"archive_days":          "50",
-							"backup_type":           "COMPLETE",
-						},
-						{
-							"rule_type":    "BACKUP",
-							"backup_type":  "INCREMENTAL",
-							"schedule":     "I|1631685600|PT1H",
-							"retention":    "7",
-							"vault_id":     "${alicloud_hbr_vault.defaultL7kwwD.id}",
-							"archive_days": "0",
-						},
-					},
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"rules.#": "4",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"policy_name": name + "_update",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"policy_name": name + "_update",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"rules": []map[string]interface{}{
-						{
-							"rule_type":    "BACKUP",
-							"backup_type":  "COMPLETE",
-							"schedule":     "I|1631685600|P1D",
-							"archive_days": "0",
-							"vault_id":     "${alicloud_hbr_vault.defaultL7kwwD.id}",
-						},
-						{
-							"rule_type":    "TRANSITION",
-							"retention":    "120",
-							"archive_days": "0",
-							"backup_type":  "COMPLETE",
-						},
-						{
-							"rule_type":             "REPLICATION",
-							"retention":             "135",
-							"replication_region_id": "cn-chengdu",
-							"archive_days":          "0",
-							"backup_type":           "COMPLETE",
-						},
-					},
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"rules.#": "3",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"rules": []map[string]interface{}{
-						{
-							"rule_type":    "BACKUP",
-							"backup_type":  "COMPLETE",
-							"schedule":     "I|1631685600|P1D",
-							"vault_id":     "${alicloud_hbr_vault.defaultL7kwwD.id}",
-							"archive_days": "0",
-						},
-						{
-							"rule_type":    "TRANSITION",
-							"retention":    "145",
-							"archive_days": "0",
-							"backup_type":  "COMPLETE",
-						},
-					},
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"rules.#": "2",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"policy_description": "policy creation",
-					"policy_name":        name + "_update",
-					"rules": []map[string]interface{}{
-						{
-							"rule_type":    "TRANSITION",
-							"retention":    "120",
-							"archive_days": "30",
-							"retention_rules": []map[string]interface{}{
+							"archive_days":          "85",
+							"tag_filters": []map[string]interface{}{
 								{
-									"advanced_retention_type": "WEEKLY",
-									"retention":               "240",
+									"key":      "key2",
+									"value":    "val2",
+									"operator": "EQUAL",
 								},
 							},
-							"backup_type": "COMPLETE",
-						},
-						{
-							"rule_type":             "BACKUP",
-							"backup_type":           "COMPLETE",
-							"schedule":              "I|1631685600|P1D",
-							"keep_latest_snapshots": "0",
-							"archive_days":          "0",
-							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
-						},
-						{
-							"rule_type":             "REPLICATION",
-							"retention":             "175",
-							"replication_region_id": "cn-qingdao",
-							"archive_days":          "0",
-							"backup_type":           "COMPLETE",
+							"data_source_filters": []map[string]interface{}{
+								{"source_type": "OSS"},
+							},
 						},
 					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"policy_description": "policy creation",
-						"policy_name":        name + "_update",
-						"rules.#":            "3",
+						"policy_description":            "镇元-修改",
+						"policy_name":                   name + "_update",
+						"rules.#":                       "2",
+						"rules.0.tag_filters.#":         "1",
+						"rules.1.tag_filters.#":         "1",
+						"rules.0.data_source_filters.#": "1",
 					}),
 				),
 			},
@@ -304,48 +152,41 @@ func TestAccAliCloudHbrPolicy_basic6287(t *testing.T) {
 	})
 }
 
-var AliCloudHbrPolicyMap6287 = map[string]string{
+var AlicloudHbrPolicyMap = map[string]string{
 	"create_time": CHECKSET,
-	"policy_type": CHECKSET,
 }
 
-func AliCloudHbrPolicyBasicDependence6287(name string) string {
+func AlicloudHbrPolicyBasicDependence(name string) string {
 	return fmt.Sprintf(`
-	variable "name" {
-  		default = "%s"
-	}
-
-	resource "alicloud_hbr_vault" "defaulth4dKAG" {
-  		vault_type          = "STANDARD"
-  		encrypt_type        = "HBR_PRIVATE"
-  		vault_name          = var.name
-  		vault_storage_class = "STANDARD"
-	}
-
-	resource "alicloud_hbr_vault" "defaultL7kwwD" {
-  		vault_type          = "STANDARD"
-  		encrypt_type        = "HBR_PRIVATE"
-  		vault_name          = join("-", [var.name, 1])
-  		vault_storage_class = "STANDARD"
-	}
-`, name)
+variable "name" {
+    default = "%s"
 }
 
+resource "alicloud_hbr_vault" "defaulth4dKAG" {
+  vault_type          = "STANDARD"
+  encrypt_type        = "HBR_PRIVATE"
+  vault_name          = "ault-example-1767865533"
+  vault_storage_class = "STANDARD"
+}`, name)
+}
+
+// Test Hbr Policy. >>> Resource test cases, automatically generated.
 // Case Policy测试用例 5320
 func TestAccAliCloudHbrPolicy_basic5320(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_hbr_policy.default"
-	ra := resourceAttrInit(resourceId, AliCloudHbrPolicyMap5320)
+	ra := resourceAttrInit(resourceId, AlicloudHbrPolicyMap5320)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
 		return &HbrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}, "DescribeHbrPolicy")
 	rac := resourceAttrCheckInit(rc, ra)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc%shbrpolicy%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudHbrPolicyBasicDependence5320)
+	name := fmt.Sprintf("tfacchbr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudHbrPolicyBasicDependence5320)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 			testAccPreCheck(t)
 		},
 		IDRefreshName: resourceId,
@@ -354,149 +195,60 @@ func TestAccAliCloudHbrPolicy_basic5320(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"policy_name": name,
+					"policy_description": "镇元Policy-创建",
+					"policy_name":        name,
 					"rules": []map[string]interface{}{
 						{
-							"rule_type":    "TRANSITION",
-							"backup_type":  "COMPLETE",
-							"retention":    "120",
-							"archive_days": "30",
-							"retention_rules": []map[string]interface{}{
-								{
-									"advanced_retention_type": "WEEKLY",
-									"retention":               "240",
-								},
-							},
+							"rule_type":             "TRANSITION",
+							"retention":             "120",
+							"archive_days":          "30",
 							"replication_region_id": "cn-shanghai",
+							"keep_latest_snapshots": "1",
 						},
 						{
 							"rule_type":             "BACKUP",
 							"backup_type":           "COMPLETE",
 							"schedule":              "I|1631685600|P1D",
-							"keep_latest_snapshots": "0",
-							"archive_days":          "0",
+							"keep_latest_snapshots": "1",
+							"archive_days":          "30",
 							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
-							"replication_region_id": "cn-beijing",
 						},
 					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"policy_name": name,
-						"rules.#":     "2",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"policy_description": "镇元Policy-创建",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
 						"policy_description": "镇元Policy-创建",
+						"policy_name":        name,
+						"rules.#":            "2",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"policy_description": "镇元-修改",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"policy_description": "镇元-修改",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"policy_name": name + "_update",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"policy_name": name + "_update",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
+					"policy_name":        name + "_update",
 					"rules": []map[string]interface{}{
 						{
-							"rule_type":    "TRANSITION",
-							"retention":    "240",
-							"archive_days": "85",
-							"retention_rules": []map[string]interface{}{
-								{
-									"advanced_retention_type": "WEEKLY",
-									"retention":               "480",
-								},
-								{
-									"advanced_retention_type": "MONTHLY",
-									"retention":               "960",
-								},
-								{
-									"advanced_retention_type": "YEARLY",
-									"retention":               "1200",
-								},
-							},
+							"rule_type":             "TRANSITION",
+							"retention":             "240",
+							"archive_days":          "85",
 							"backup_type":           "COMPLETE",
 							"replication_region_id": "cn-beijing",
+							"keep_latest_snapshots": "1",
 						},
 						{
 							"rule_type":             "BACKUP",
 							"backup_type":           "COMPLETE",
 							"schedule":              "I|1631685600|P2D",
-							"vault_id":              "${alicloud_hbr_vault.defaultL7kwwD.id}",
-							"keep_latest_snapshots": "1",
-							"archive_days":          "0",
-							"replication_region_id": "cn-shanghai",
-						},
-						{
-							"rule_type":             "REPLICATION",
-							"retention":             "8",
-							"replication_region_id": "cn-beijing",
-							"archive_days":          "50",
-							"backup_type":           "COMPLETE",
-						},
-					},
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"rules.#": "3",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"policy_description": "镇元Policy-创建",
-					"policy_name":        name + "_update",
-					"rules": []map[string]interface{}{
-						{
-							"rule_type":    "TRANSITION",
-							"backup_type":  "COMPLETE",
-							"retention":    "120",
-							"archive_days": "30",
-							"retention_rules": []map[string]interface{}{
-								{
-									"advanced_retention_type": "WEEKLY",
-									"retention":               "240",
-								},
-							},
-							"replication_region_id": "cn-shanghai",
-						},
-						{
-							"rule_type":             "BACKUP",
-							"backup_type":           "COMPLETE",
-							"schedule":              "I|1631685600|P1D",
-							"keep_latest_snapshots": "0",
-							"archive_days":          "0",
 							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
-							"replication_region_id": "cn-beijing",
+							"keep_latest_snapshots": "1",
+							"archive_days":          "85",
 						},
 					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"policy_description": "镇元Policy-创建",
+						"policy_description": "镇元-修改",
 						"policy_name":        name + "_update",
 						"rules.#":            "2",
 					}),
@@ -512,260 +264,43 @@ func TestAccAliCloudHbrPolicy_basic5320(t *testing.T) {
 	})
 }
 
-var AliCloudHbrPolicyMap5320 = map[string]string{
+var AlicloudHbrPolicyMap5320 = map[string]string{
 	"create_time": CHECKSET,
-	"policy_type": CHECKSET,
 }
 
-func AliCloudHbrPolicyBasicDependence5320(name string) string {
+func AlicloudHbrPolicyBasicDependence5320(name string) string {
 	return fmt.Sprintf(`
-	variable "name" {
-  		default = "%s"
-	}
+variable "name" {
+    default = "%s"
+}
 
-	resource "alicloud_hbr_vault" "defaulth4dKAG" {
-  		vault_type          = "STANDARD"
-  		encrypt_type        = "HBR_PRIVATE"
-  		vault_name          = var.name
-  		vault_storage_class = "STANDARD"
-	}
+resource "alicloud_hbr_vault" "defaulth4dKAG" {
+  vault_type          = "STANDARD"
+  encrypt_type        = "HBR_PRIVATE"
+  vault_name          = "ault-example-1767865533"
+  vault_storage_class = "STANDARD"
+}
 
-	resource "alicloud_hbr_vault" "defaultL7kwwD" {
-  		vault_type          = "STANDARD"
-  		encrypt_type        = "HBR_PRIVATE"
-  		vault_name          = join("-", [var.name, 1])
-  		vault_storage_class = "STANDARD"
-	}
+
 `, name)
 }
 
-// Case Policy 6287  twin
-func TestAccAliCloudHbrPolicy_basic6287_twin(t *testing.T) {
+// Case Policy 6287
+func TestAccAliCloudHbrPolicy_basic6287(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_hbr_policy.default"
-	ra := resourceAttrInit(resourceId, AliCloudHbrPolicyMap6287)
+	ra := resourceAttrInit(resourceId, AlicloudHbrPolicyMap6287)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
 		return &HbrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}, "DescribeHbrPolicy")
 	rac := resourceAttrCheckInit(rc, ra)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc%shbrpolicy%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudHbrPolicyBasicDependence6287)
+	name := fmt.Sprintf("tfacchbr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudHbrPolicyBasicDependence6287)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		IDRefreshName: resourceId,
-		Providers:     testAccProviders,
-		CheckDestroy:  rac.checkResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"policy_description": "policy update",
-					"policy_name":        name,
-					"policy_type":        "STANDARD",
-					"rules": []map[string]interface{}{
-						{
-							"rule_type":    "BACKUP",
-							"retention":    "240",
-							"archive_days": "0",
-							"retention_rules": []map[string]interface{}{
-								{
-									"advanced_retention_type": "WEEKLY",
-									"retention":               "480",
-								},
-								{
-									"advanced_retention_type": "MONTHLY",
-									"retention":               "960",
-								},
-								{
-									"advanced_retention_type": "YEARLY",
-									"retention":               "1200",
-								},
-							},
-							"backup_type": "COMPLETE",
-							"schedule":    "I|1631685600|P1D",
-							"vault_id":    "${alicloud_hbr_vault.defaultL7kwwD.id}",
-						},
-						{
-							"rule_type":             "TRANSITION",
-							"backup_type":           "COMPLETE",
-							"schedule":              "I|1631685600|P2D",
-							"keep_latest_snapshots": "1",
-							"archive_days":          "0",
-							"vault_id":              "${alicloud_hbr_vault.defaultL7kwwD.id}",
-							"retention":             "145",
-						},
-						{
-							"rule_type":             "REPLICATION",
-							"retention":             "135",
-							"replication_region_id": "cn-chengdu",
-							"archive_days":          "0",
-							"backup_type":           "COMPLETE",
-						},
-						{
-							"rule_type":    "BACKUP",
-							"backup_type":  "INCREMENTAL",
-							"schedule":     "I|1631685600|PT1H",
-							"retention":    "240",
-							"vault_id":     "${alicloud_hbr_vault.defaultL7kwwD.id}",
-							"archive_days": "0",
-						},
-					},
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"policy_description": "policy update",
-						"policy_name":        name,
-						"policy_type":        "STANDARD",
-						"rules.#":            "4",
-					}),
-				),
-			},
-			{
-				ResourceName:            resourceId,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
-			},
-		},
-	})
-}
-
-// Case Policy测试用例 5320  twin
-func TestAccAliCloudHbrPolicy_basic5320_twin(t *testing.T) {
-	var v map[string]interface{}
-	resourceId := "alicloud_hbr_policy.default"
-	ra := resourceAttrInit(resourceId, AliCloudHbrPolicyMap5320)
-	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
-		return &HbrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
-	}, "DescribeHbrPolicy")
-	rac := resourceAttrCheckInit(rc, ra)
-	testAccCheck := rac.resourceAttrMapUpdateSet()
-	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc%shbrpolicy%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudHbrPolicyBasicDependence5320)
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		IDRefreshName: resourceId,
-		Providers:     testAccProviders,
-		CheckDestroy:  rac.checkResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"policy_description": "镇元-修改",
-					"policy_name":        name,
-					"policy_type":        "UDM_ECS_ONLY",
-					"rules": []map[string]interface{}{
-						{
-							"rule_type":    "BACKUP",
-							"retention":    "8",
-							"archive_days": "0",
-							"retention_rules": []map[string]interface{}{
-								{
-									"advanced_retention_type": "WEEKLY",
-									"retention":               "480",
-								},
-								{
-									"advanced_retention_type": "MONTHLY",
-									"retention":               "960",
-								},
-								{
-									"advanced_retention_type": "YEARLY",
-									"retention":               "1200",
-								},
-							},
-							"vault_id":              "${alicloud_hbr_vault.defaultL7kwwD.id}",
-							"replication_region_id": "cn-chengdu",
-							"backup_type":           "COMPLETE",
-							"schedule":              "I|1631685600|P1D",
-						},
-						{
-							"rule_type":             "BACKUP",
-							"backup_type":           "INCREMENTAL",
-							"schedule":              "I|1631685600|P2D",
-							"keep_latest_snapshots": "1",
-							"archive_days":          "0",
-							"retention_rules": []map[string]interface{}{
-								{
-									"advanced_retention_type": "WEEKLY",
-									"retention":               "480",
-								},
-								{
-									"advanced_retention_type": "MONTHLY",
-									"retention":               "960",
-								},
-								{
-									"advanced_retention_type": "YEARLY",
-									"retention":               "1200",
-								},
-							},
-							"vault_id":              "${alicloud_hbr_vault.defaultL7kwwD.id}",
-							"replication_region_id": "cn-chengdu",
-							"retention":             "8",
-						},
-						{
-							"rule_type":             "REPLICATION",
-							"retention":             "8",
-							"replication_region_id": "cn-beijing",
-							"archive_days":          "50",
-							"retention_rules": []map[string]interface{}{
-								{
-									"advanced_retention_type": "WEEKLY",
-									"retention":               "480",
-								},
-								{
-									"advanced_retention_type": "MONTHLY",
-									"retention":               "960",
-								},
-								{
-									"advanced_retention_type": "YEARLY",
-									"retention":               "1200",
-								},
-							},
-							"backup_type": "COMPLETE",
-						},
-					},
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"policy_description": "镇元-修改",
-						"policy_name":        name,
-						"policy_type":        "UDM_ECS_ONLY",
-						"rules.#":            "3",
-					}),
-				),
-			},
-			{
-				ResourceName:            resourceId,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
-			},
-		},
-	})
-}
-
-// The original test case on the api management
-
-// Case Policy 6287   raw
-func TestAccAliCloudHbrPolicy_basic6287_raw(t *testing.T) {
-	var v map[string]interface{}
-	resourceId := "alicloud_hbr_policy.default"
-	ra := resourceAttrInit(resourceId, AliCloudHbrPolicyMap6287)
-	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
-		return &HbrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
-	}, "DescribeHbrPolicy")
-	rac := resourceAttrCheckInit(rc, ra)
-	testAccCheck := rac.resourceAttrMapUpdateSet()
-	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc%shbrpolicy%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudHbrPolicyBasicDependence6287)
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 			testAccPreCheck(t)
 		},
 		IDRefreshName: resourceId,
@@ -803,13 +338,20 @@ func TestAccAliCloudHbrPolicy_basic6287_raw(t *testing.T) {
 							"replication_region_id": "cn-qingdao",
 							"archive_days":          "0",
 						},
+						{
+							"rule_type":    "BACKUP",
+							"backup_type":  "INCREMENTAL",
+							"schedule":     "I|1631685600|P1M",
+							"vault_id":     "${alicloud_hbr_vault.defaulth4dKAG.id}",
+							"archive_days": "0",
+						},
 					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"policy_description": "policy creation",
 						"policy_name":        name,
-						"rules.#":            "3",
+						"rules.#":            "4",
 					}),
 				),
 			},
@@ -841,7 +383,6 @@ func TestAccAliCloudHbrPolicy_basic6287_raw(t *testing.T) {
 						{
 							"rule_type":             "BACKUP",
 							"backup_type":           "COMPLETE",
-							"retention":             "7",
 							"schedule":              "I|1631685600|P2D",
 							"vault_id":              "${alicloud_hbr_vault.defaultL7kwwD.id}",
 							"keep_latest_snapshots": "1",
@@ -858,7 +399,6 @@ func TestAccAliCloudHbrPolicy_basic6287_raw(t *testing.T) {
 							"rule_type":    "BACKUP",
 							"backup_type":  "INCREMENTAL",
 							"schedule":     "I|1631685600|PT1H",
-							"retention":    "7",
 							"vault_id":     "${alicloud_hbr_vault.defaultL7kwwD.id}",
 							"archive_days": "0",
 						},
@@ -877,16 +417,18 @@ func TestAccAliCloudHbrPolicy_basic6287_raw(t *testing.T) {
 					"policy_name": name + "_update",
 					"rules": []map[string]interface{}{
 						{
-							"rule_type":    "BACKUP",
-							"backup_type":  "COMPLETE",
-							"schedule":     "I|1631685600|P1D",
-							"archive_days": "0",
-							"vault_id":     "${alicloud_hbr_vault.defaultL7kwwD.id}",
+							"rule_type":             "TRANSITION",
+							"retention":             "120",
+							"archive_days":          "0",
+							"replication_region_id": "cn-chengdu",
 						},
 						{
-							"rule_type":    "TRANSITION",
-							"retention":    "120",
-							"archive_days": "0",
+							"rule_type":             "BACKUP",
+							"backup_type":           "COMPLETE",
+							"schedule":              "I|1631685600|P1D",
+							"archive_days":          "0",
+							"vault_id":              "${alicloud_hbr_vault.defaultL7kwwD.id}",
+							"replication_region_id": "cn-chengdu",
 						},
 						{
 							"rule_type":             "REPLICATION",
@@ -907,15 +449,15 @@ func TestAccAliCloudHbrPolicy_basic6287_raw(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"rules": []map[string]interface{}{
 						{
+							"rule_type":    "TRANSITION",
+							"retention":    "145",
+							"archive_days": "0",
+						},
+						{
 							"rule_type":    "BACKUP",
 							"backup_type":  "COMPLETE",
 							"schedule":     "I|1631685600|P1D",
 							"vault_id":     "${alicloud_hbr_vault.defaultL7kwwD.id}",
-							"archive_days": "0",
-						},
-						{
-							"rule_type":    "TRANSITION",
-							"retention":    "145",
 							"archive_days": "0",
 						},
 					},
@@ -936,21 +478,182 @@ func TestAccAliCloudHbrPolicy_basic6287_raw(t *testing.T) {
 	})
 }
 
-// Case Policy测试用例 5320   raw
-func TestAccAliCloudHbrPolicy_basic5320_raw(t *testing.T) {
+var AlicloudHbrPolicyMap6287 = map[string]string{
+	"create_time": CHECKSET,
+}
+
+func AlicloudHbrPolicyBasicDependence6287(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_hbr_vault" "defaulth4dKAG" {
+  vault_type          = "STANDARD"
+  encrypt_type        = "HBR_PRIVATE"
+  vault_name          = "vault-example-1767865534"
+  vault_storage_class = "STANDARD"
+}
+
+resource "alicloud_hbr_vault" "defaultL7kwwD" {
+  vault_type          = "STANDARD"
+  encrypt_type        = "HBR_PRIVATE"
+  vault_name          = "vault-example-1767865535"
+  vault_storage_class = "STANDARD"
+}
+
+
+`, name)
+}
+
+// Case Policy 6963
+func TestAccAliCloudHbrPolicy_basic6963(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_hbr_policy.default"
-	ra := resourceAttrInit(resourceId, AliCloudHbrPolicyMap5320)
+	ra := resourceAttrInit(resourceId, AlicloudHbrPolicyMap6963)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
 		return &HbrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}, "DescribeHbrPolicy")
 	rac := resourceAttrCheckInit(rc, ra)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc%shbrpolicy%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudHbrPolicyBasicDependence5320)
+	name := fmt.Sprintf("tfacchbr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudHbrPolicyBasicDependence6963)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"policy_description": "policy creation",
+					"policy_name":        name,
+					"rules": []map[string]interface{}{
+						{
+							"rule_type":    "TRANSITION",
+							"retention":    "120",
+							"archive_days": "30",
+							"retention_rules": []map[string]interface{}{
+								{
+									"advanced_retention_type": "WEEKLY",
+									"retention":               "240",
+								},
+								{
+									"advanced_retention_type": "DAILY",
+									"retention":               "170",
+								},
+							},
+							"backup_type": "COMPLETE",
+						},
+						{
+							"rule_type":             "BACKUP",
+							"backup_type":           "COMPLETE",
+							"schedule":              "I|1631685600|P1D",
+							"keep_latest_snapshots": "0",
+							"archive_days":          "0",
+							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"policy_description": "policy creation",
+						"policy_name":        name,
+						"rules.#":            "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"policy_description": "policy update",
+					"policy_name":        name + "_update",
+					"rules": []map[string]interface{}{
+						{
+							"rule_type":    "TRANSITION",
+							"retention":    "2",
+							"archive_days": "85",
+							"retention_rules": []map[string]interface{}{
+								{
+									"advanced_retention_type": "DAILY",
+									"retention":               "920",
+								},
+								{
+									"advanced_retention_type": "MONTHLY",
+									"retention":               "1000",
+								},
+							},
+							"backup_type": "COMPLETE",
+						},
+						{
+							"rule_type":             "BACKUP",
+							"backup_type":           "COMPLETE",
+							"schedule":              "I|1631685600|PT1H",
+							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
+							"keep_latest_snapshots": "1",
+							"archive_days":          "0",
+							"retention":             "2",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"policy_description": "policy update",
+						"policy_name":        name + "_update",
+						"rules.#":            "2",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudHbrPolicyMap6963 = map[string]string{
+	"create_time": CHECKSET,
+}
+
+func AlicloudHbrPolicyBasicDependence6963(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_hbr_vault" "defaulth4dKAG" {
+  vault_type          = "STANDARD"
+  encrypt_type        = "HBR_PRIVATE"
+  vault_name          = "vault-example-1767865535"
+  vault_storage_class = "STANDARD"
+}
+
+
+`, name)
+}
+
+// Case PolicyV1.2.0 7188
+func TestAccAliCloudHbrPolicy_basic7188(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_hbr_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudHbrPolicyMap7188)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &HbrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeHbrPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacchbr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudHbrPolicyBasicDependence7188)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 			testAccPreCheck(t)
 		},
 		IDRefreshName: resourceId,
@@ -963,25 +666,19 @@ func TestAccAliCloudHbrPolicy_basic5320_raw(t *testing.T) {
 					"policy_name":        name,
 					"rules": []map[string]interface{}{
 						{
-							"rule_type":    "TRANSITION",
-							"retention":    "120",
-							"archive_days": "30",
-							"retention_rules": []map[string]interface{}{
-								{
-									"advanced_retention_type": "WEEKLY",
-									"retention":               "240",
-								},
-							},
+							"rule_type":             "TRANSITION",
+							"retention":             "120",
+							"archive_days":          "30",
 							"replication_region_id": "cn-shanghai",
+							"keep_latest_snapshots": "1",
 						},
 						{
 							"rule_type":             "BACKUP",
 							"backup_type":           "COMPLETE",
 							"schedule":              "I|1631685600|P1D",
-							"keep_latest_snapshots": "0",
-							"archive_days":          "0",
+							"keep_latest_snapshots": "1",
+							"archive_days":          "30",
 							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
-							"replication_region_id": "cn-beijing",
 						},
 					},
 				}),
@@ -996,6 +693,354 @@ func TestAccAliCloudHbrPolicy_basic5320_raw(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"policy_description": "镇元-修改",
+					"policy_name":        name + "_update",
+					"rules": []map[string]interface{}{
+						{
+							"rule_type":             "TRANSITION",
+							"retention":             "240",
+							"archive_days":          "85",
+							"backup_type":           "COMPLETE",
+							"replication_region_id": "cn-beijing",
+							"keep_latest_snapshots": "1",
+						},
+						{
+							"rule_type":             "BACKUP",
+							"backup_type":           "COMPLETE",
+							"schedule":              "I|1631685600|P2D",
+							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
+							"keep_latest_snapshots": "1",
+							"archive_days":          "85",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"policy_description": "镇元-修改",
+						"policy_name":        name + "_update",
+						"rules.#":            "2",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudHbrPolicyMap7188 = map[string]string{
+	"create_time": CHECKSET,
+}
+
+func AlicloudHbrPolicyBasicDependence7188(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_hbr_vault" "defaulth4dKAG" {
+  vault_type          = "STANDARD"
+  encrypt_type        = "HBR_PRIVATE"
+  vault_name          = "ault-example-1767865536"
+  vault_storage_class = "STANDARD"
+}
+
+
+`, name)
+}
+
+// Case PolicyV1.2.0 7189
+func TestAccAliCloudHbrPolicy_basic7189(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_hbr_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudHbrPolicyMap7189)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &HbrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeHbrPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacchbr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudHbrPolicyBasicDependence7189)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"policy_description": "policy creation",
+					"policy_name":        name,
+					"rules": []map[string]interface{}{
+						{
+							"rule_type":    "TRANSITION",
+							"retention":    "120",
+							"archive_days": "30",
+							"retention_rules": []map[string]interface{}{
+								{
+									"advanced_retention_type": "WEEKLY",
+									"retention":               "240",
+								},
+								{
+									"advanced_retention_type": "DAILY",
+									"retention":               "170",
+								},
+							},
+							"backup_type": "COMPLETE",
+						},
+						{
+							"rule_type":             "BACKUP",
+							"backup_type":           "COMPLETE",
+							"schedule":              "I|1631685600|P1D",
+							"keep_latest_snapshots": "0",
+							"archive_days":          "0",
+							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"policy_description": "policy creation",
+						"policy_name":        name,
+						"rules.#":            "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"policy_description": "policy update",
+					"policy_name":        name + "_update",
+					"rules": []map[string]interface{}{
+						{
+							"rule_type":    "TRANSITION",
+							"retention":    "2",
+							"archive_days": "85",
+							"retention_rules": []map[string]interface{}{
+								{
+									"advanced_retention_type": "DAILY",
+									"retention":               "920",
+								},
+								{
+									"advanced_retention_type": "MONTHLY",
+									"retention":               "1000",
+								},
+							},
+							"backup_type": "COMPLETE",
+						},
+						{
+							"rule_type":             "BACKUP",
+							"backup_type":           "COMPLETE",
+							"schedule":              "I|1631685600|PT1H",
+							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
+							"keep_latest_snapshots": "1",
+							"archive_days":          "0",
+							"retention":             "2",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"policy_description": "policy update",
+						"policy_name":        name + "_update",
+						"rules.#":            "2",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudHbrPolicyMap7189 = map[string]string{
+	"create_time": CHECKSET,
+}
+
+func AlicloudHbrPolicyBasicDependence7189(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_hbr_vault" "defaulth4dKAG" {
+  vault_type          = "STANDARD"
+  encrypt_type        = "HBR_PRIVATE"
+  vault_name          = "vault-example-1767865536"
+  vault_storage_class = "STANDARD"
+}
+
+
+`, name)
+}
+
+// Case ECS整机备份策略 10119
+func TestAccAliCloudHbrPolicy_basic10119(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_hbr_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudHbrPolicyMap10119)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &HbrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeHbrPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacchbr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudHbrPolicyBasicDependence10119)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"policy_description": "policy creation",
+					"policy_name":        name,
+					"rules": []map[string]interface{}{
+						{
+							"rule_type":    "TRANSITION",
+							"retention":    "120",
+							"archive_days": "30",
+							"retention_rules": []map[string]interface{}{
+								{
+									"advanced_retention_type": "WEEKLY",
+									"retention":               "240",
+								},
+							},
+							"backup_type": "COMPLETE",
+						},
+						{
+							"rule_type":             "BACKUP",
+							"backup_type":           "COMPLETE",
+							"schedule":              "I|1631685600|P1D",
+							"keep_latest_snapshots": "0",
+							"archive_days":          "0",
+						},
+					},
+					"policy_type": "UDM_ECS_ONLY",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"policy_description": "policy creation",
+						"policy_name":        name,
+						"rules.#":            "2",
+						"policy_type":        "UDM_ECS_ONLY",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudHbrPolicyMap10119 = map[string]string{
+	"create_time": CHECKSET,
+}
+
+func AlicloudHbrPolicyBasicDependence10119(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case 通用备份策略 7187
+func TestAccAliCloudHbrPolicy_basic7187(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_hbr_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudHbrPolicyMap7187)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &HbrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeHbrPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacchbr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudHbrPolicyBasicDependence7187)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"policy_description": "policy creation",
+					"policy_name":        name,
+					"rules": []map[string]interface{}{
+						{
+							"rule_type":    "TRANSITION",
+							"retention":    "120",
+							"archive_days": "30",
+							"retention_rules": []map[string]interface{}{
+								{
+									"advanced_retention_type": "WEEKLY",
+									"retention":               "240",
+								},
+							},
+							"backup_type": "COMPLETE",
+						},
+						{
+							"rule_type":             "BACKUP",
+							"backup_type":           "COMPLETE",
+							"schedule":              "I|1631685600|P1D",
+							"keep_latest_snapshots": "0",
+							"archive_days":          "0",
+							"vault_id":              "${alicloud_hbr_vault.defaulth4dKAG.id}",
+						},
+						{
+							"rule_type":             "REPLICATION",
+							"retention":             "175",
+							"replication_region_id": "cn-qingdao",
+							"archive_days":          "0",
+						},
+						{
+							"rule_type":    "BACKUP",
+							"backup_type":  "INCREMENTAL",
+							"schedule":     "I|1631685600|P1M",
+							"vault_id":     "${alicloud_hbr_vault.defaulth4dKAG.id}",
+							"archive_days": "0",
+						},
+					},
+					"policy_type": "STANDARD",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"policy_description": "policy creation",
+						"policy_name":        name,
+						"rules.#":            "4",
+						"policy_type":        "STANDARD",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"policy_description": "policy update",
 					"policy_name":        name + "_update",
 					"rules": []map[string]interface{}{
 						{
@@ -1016,8 +1061,7 @@ func TestAccAliCloudHbrPolicy_basic5320_raw(t *testing.T) {
 									"retention":               "1200",
 								},
 							},
-							"backup_type":           "COMPLETE",
-							"replication_region_id": "cn-beijing",
+							"backup_type": "COMPLETE",
 						},
 						{
 							"rule_type":             "BACKUP",
@@ -1026,22 +1070,84 @@ func TestAccAliCloudHbrPolicy_basic5320_raw(t *testing.T) {
 							"vault_id":              "${alicloud_hbr_vault.defaultL7kwwD.id}",
 							"keep_latest_snapshots": "1",
 							"archive_days":          "0",
-							"replication_region_id": "cn-shanghai",
 						},
 						{
 							"rule_type":             "REPLICATION",
-							"retention":             "8",
-							"replication_region_id": "cn-beijing",
+							"retention":             "120",
+							"replication_region_id": "cn-zhangjiakou",
 							"archive_days":          "50",
 							"backup_type":           "COMPLETE",
+						},
+						{
+							"rule_type":    "BACKUP",
+							"backup_type":  "INCREMENTAL",
+							"schedule":     "I|1631685600|PT1H",
+							"vault_id":     "${alicloud_hbr_vault.defaultL7kwwD.id}",
+							"archive_days": "0",
 						},
 					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"policy_description": "镇元-修改",
+						"policy_description": "policy update",
 						"policy_name":        name + "_update",
-						"rules.#":            "3",
+						"rules.#":            "4",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"policy_name": name + "_update",
+					"rules": []map[string]interface{}{
+						{
+							"rule_type":             "TRANSITION",
+							"retention":             "120",
+							"archive_days":          "0",
+							"replication_region_id": "cn-chengdu",
+						},
+						{
+							"rule_type":             "BACKUP",
+							"backup_type":           "COMPLETE",
+							"schedule":              "I|1631685600|P1D",
+							"archive_days":          "0",
+							"vault_id":              "${alicloud_hbr_vault.defaultL7kwwD.id}",
+							"replication_region_id": "cn-chengdu",
+						},
+						{
+							"rule_type":             "REPLICATION",
+							"retention":             "135",
+							"replication_region_id": "cn-chengdu",
+							"archive_days":          "0",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"policy_name": name + "_update",
+						"rules.#":     "3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rules": []map[string]interface{}{
+						{
+							"rule_type":    "TRANSITION",
+							"retention":    "145",
+							"archive_days": "0",
+						},
+						{
+							"rule_type":    "BACKUP",
+							"backup_type":  "COMPLETE",
+							"schedule":     "I|1631685600|P1D",
+							"vault_id":     "${alicloud_hbr_vault.defaultL7kwwD.id}",
+							"archive_days": "0",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rules.#": "2",
 					}),
 				),
 			},
@@ -1053,6 +1159,34 @@ func TestAccAliCloudHbrPolicy_basic5320_raw(t *testing.T) {
 			},
 		},
 	})
+}
+
+var AlicloudHbrPolicyMap7187 = map[string]string{
+	"create_time": CHECKSET,
+}
+
+func AlicloudHbrPolicyBasicDependence7187(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_hbr_vault" "defaulth4dKAG" {
+  vault_type          = "STANDARD"
+  encrypt_type        = "HBR_PRIVATE"
+  vault_name          = "vault-example-1767865538"
+  vault_storage_class = "STANDARD"
+}
+
+resource "alicloud_hbr_vault" "defaultL7kwwD" {
+  vault_type          = "STANDARD"
+  encrypt_type        = "HBR_PRIVATE"
+  vault_name          = "vault-example-1767865539"
+  vault_storage_class = "STANDARD"
+}
+
+
+`, name)
 }
 
 // Test Hbr Policy. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_hbr_v2.go
+++ b/alicloud/service_alicloud_hbr_v2.go
@@ -60,15 +60,18 @@ func (s *HbrServiceV2) DescribeHbrPolicy(id string) (object map[string]interface
 }
 
 func (s *HbrServiceV2) HbrPolicyStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.HbrPolicyStateRefreshFuncWithApi(id, field, failStates, s.DescribeHbrPolicy)
+}
+
+func (s *HbrServiceV2) HbrPolicyStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		object, err := s.DescribeHbrPolicy(id)
+		object, err := call(id)
 		if err != nil {
 			if NotFoundError(err) {
 				return object, "", nil
 			}
 			return nil, "", WrapError(err)
 		}
-
 		v, err := jsonpath.Get(field, object)
 		currentStatus := fmt.Sprint(v)
 

--- a/website/docs/r/hbr_policy.html.markdown
+++ b/website/docs/r/hbr_policy.html.markdown
@@ -11,6 +11,7 @@ description: |-
 Provides a Hybrid Backup Recovery (HBR) Policy resource.
 
 
+
 For information about Hybrid Backup Recovery (HBR) Policy and how to use it, see [What is Policy](https://www.alibabacloud.com/help/en/cloud-backup/developer-reference/api-hbr-2017-09-08-createpolicyv2).
 
 -> **NOTE:** Available since v1.221.0.
@@ -18,12 +19,6 @@ For information about Hybrid Backup Recovery (HBR) Policy and how to use it, see
 ## Example Usage
 
 Basic Usage
-
-<div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
-  <a href="https://api.aliyun.com/terraform?resource=alicloud_hbr_policy&exampleId=1815e3cf-c5d0-cd30-ebab-0d1865f44adaa392e053&activeTab=example&spm=docs.r.hbr_policy.0.1815e3cfc5&intl_lang=EN_US" target="_blank">
-    <img alt="Open in AliCloud" src="https://img.alicdn.com/imgextra/i1/O1CN01hjjqXv1uYUlY56FyX_!!6000000006049-55-tps-254-36.svg" style="max-height: 44px; max-width: 100%;">
-  </a>
-</div></div>
 
 ```terraform
 variable "name" {
@@ -65,31 +60,43 @@ resource "alicloud_hbr_policy" "defaultoqWvHQ" {
 The following arguments are supported:
 * `policy_description` - (Optional) The policy description.
 * `policy_name` - (Optional) Policy Name
-* `policy_type` - (Optional, ForceNew, Available since v1.243.0) The policy type. Valid values:
-  - `STANDARD`: The general backup policy. This type of policy applies to backups other than Elastic Compute Service (ECS) instance backup.
-  - `UDM_ECS_ONLY`: The ECS instance backup policy. This type of policy applies only to ECS instance backup.
-* `rules` - (Optional, Set) A list of policy rules See [`rules`](#rules) below.
+* `policy_type` - (Optional, ForceNew, Computed, Available since v1.243.0) The policy type. The UDM_ECS_ONLY and STANDARD types are supported. The policy with PolicyType = UDM_ECS_ONLY can only be used for ECS instances. The policy with PolicyType = STANDARD can only be used for data sources other than ECS instances.
+* `rules` - (Optional, List) A list of policy rules See [`rules`](#rules) below.
 
 ### `rules`
 
 The rules supports the following:
-* `archive_days` - (Optional, Computed, Int) This parameter is required only when the value of `RuleType` is **TRANSITION. The minimum value is 30, and the Retention-ArchiveDays needs to be greater than or equal to 60.
-* `backup_type` - (Optional) This parameter is required only when the `RuleType` value is **BACKUP. Backup Type.
-* `keep_latest_snapshots` - (Optional, Int) This parameter is required only when `RuleType` is set to `BACKUP`.
-* `replication_region_id` - (Optional) Only when the `RuleType` value is.
-* `retention` - (Optional, Int) This parameter is required only when the value of `RuleType` is `TRANSITION` or **REPLICATION.
+* `archive_days` - (Optional, Computed, Int) This parameter is required only when the value of `RuleType` is **TRANSITION. The minimum value is 30, and the Retention-ArchiveDays needs to be greater than or equal to 60
+* `backup_type` - (Optional) This parameter is required only when the `RuleType` value is **BACKUP. Backup Type
+* `data_source_filters` - (Optional, List, Available since v1.268.0) This parameter is required only when the value of RuleType is TAG. See [`data_source_filters`](#rules-data_source_filters) below.
+* `keep_latest_snapshots` - (Optional, Int) This parameter is required only when `RuleType` is set to `BACKUP`
+* `replication_region_id` - (Optional) Only when the `RuleType` value is
+* `retention` - (Optional, Int) This parameter is required only when the value of `RuleType` is `TRANSITION` or `REPLICATION`.
   - `RuleType`: `TRANSITION`: the backup retention time. The minimum value is 1 and the maximum value is 364635, in days.
   - `RuleType`: `REPLICATION`: The minimum value is 1 and the maximum value is 364635. The unit is days.
 * `retention_rules` - (Optional, List) This parameter is required only when the value of `RuleType` is `TRANSITION`. See [`retention_rules`](#rules-retention_rules) below.
-* `rule_type` - (Required) Rule Type.
+* `rule_type` - (Required) Rule Type
 * `schedule` - (Optional) This parameter is required only if you set the `RuleType` parameter to `BACKUP`. This parameter specifies the backup schedule settings. Format: `I|{startTime}|{interval}`. The system runs the first backup job at a point in time that is specified in the {startTime} parameter and the subsequent backup jobs at an interval that is specified in the {interval} parameter. The system does not run a backup job before the specified point in time. Each backup job, except the first one, starts only after the previous backup job is complete. For example, `I|1631685600|P1D` specifies that the system runs the first backup job at 14:00:00 on September 15, 2021 and the subsequent backup jobs once a day.  *   startTime: the time at which the system starts to run a backup job. The time must follow the UNIX time format. Unit: seconds. *   interval: the interval at which the system runs a backup job. The interval must follow the ISO 8601 standard. For example, PT1H specifies an interval of one hour. P1D specifies an interval of one day.
-* `vault_id` - (Optional) Vault ID.
+* `tag_filters` - (Optional, List, Available since v1.268.0) This parameter is required only when the value of RuleType is TAG. Resource label filtering rules. See [`tag_filters`](#rules-tag_filters) below.
+* `vault_id` - (Optional) Vault ID
+
+### `rules-data_source_filters`
+
+The rules-data_source_filters supports the following:
+* `source_type` - (Optional, Available since v1.268.0) The data source type. Value range: UDM_ECS: indicates that the ECS machine is backed up. This data source type is supported only when PolicyType is set to UDM_ECS_ONLY. OSS: indicates an OSS backup. This data source type is supported only when the PolicyType value is STANDARD. NAS: indicates an Alibaba Cloud NAS backup. This data source type is supported only when the PolicyType value is STANDARD. ECS_FILE: indicates an ECS file backup. This data source type is supported only when the PolicyType value is STANDARD. OTS: indicates the Tablestore backup. This data source type is supported only when the PolicyType value is STANDARD.
 
 ### `rules-retention_rules`
 
 The rules-retention_rules supports the following:
 * `advanced_retention_type` - (Optional) Valid values: `annually`, `MONTHLY`, and `WEEKLY`:- `annually`: the first backup of each year. - `MONTHLY`: The first backup of the month. - `WEEKLY`: The first backup of the week. - `DAILY`: The first backup of the day.
-* `retention` - (Optional, Int) Retention time, in days.
+* `retention` - (Optional, Int) Retention time, in days
+
+### `rules-tag_filters`
+
+The rules-tag_filters supports the following:
+* `key` - (Optional, Available since v1.268.0) The tag key.
+* `operator` - (Optional, Available since v1.268.0) Tag matching rules, support EQUAL: Match tag key and tag value. NOT: matches the tag key, but does NOT match the tag value.
+* `value` - (Optional, Available since v1.268.0) The label value, which is empty and represents any value.
 
 ## Attributes Reference
 
@@ -97,7 +104,7 @@ The following attributes are exported:
 * `id` - The ID of the resource supplied above.
 * `create_time` - Policy creation time
 * `rules` - A list of policy rules
-  * `rule_id` - Rule ID.
+  * `rule_id` - Rule ID
 
 ## Timeouts
 


### PR DESCRIPTION
Add support for `tag_filters` and `data_source_filters`
```log
=== RUN   TestAccAliCloudHbrPolicy_basic
--- PASS: TestAccAliCloudHbrPolicy_basic (19.83s)
=== RUN   TestAccAliCloudHbrPolicy_basic5320
--- PASS: TestAccAliCloudHbrPolicy_basic5320 (18.15s)
=== RUN   TestAccAliCloudHbrPolicy_basic6287
--- PASS: TestAccAliCloudHbrPolicy_basic6287 (26.97s)
=== RUN   TestAccAliCloudHbrPolicy_basic6963
--- PASS: TestAccAliCloudHbrPolicy_basic6963 (18.47s)
=== RUN   TestAccAliCloudHbrPolicy_basic7188
--- PASS: TestAccAliCloudHbrPolicy_basic7188 (18.42s)
=== RUN   TestAccAliCloudHbrPolicy_basic7189
--- PASS: TestAccAliCloudHbrPolicy_basic7189 (18.54s)
=== RUN   TestAccAliCloudHbrPolicy_basic10119
--- PASS: TestAccAliCloudHbrPolicy_basic10119 (4.93s)
=== RUN   TestAccAliCloudHbrPolicy_basic7187
--- PASS: TestAccAliCloudHbrPolicy_basic7187 (26.61s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  155.187s```