### PR TITLE
resource/alicloud_security_group: Add computed to resource_group_id

### DIFF
--- a/alicloud/resource_alicloud_security_group.go
+++ b/alicloud/resource_alicloud_security_group.go
@@ -49,6 +49,7 @@ func resourceAliCloudEcsSecurityGroup() *schema.Resource {
 			"resource_group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"security_group_name": {
 				Type:     schema.TypeString,

--- a/website/docs/r/security_group.html.markdown
+++ b/website/docs/r/security_group.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 * `inner_access_policy` - (Optional, Available since v1.55.3) The internal access control policy of the security group. Valid values:
   - `Accept`: The internal interconnectivity policy.
   - `Drop`: The internal isolation policy.
-* `resource_group_id` - (Optional, Available since v1.58.0) The ID of the resource group to which the security group belongs. **NOTE:** From version 1.115.0, `resource_group_id` can be modified.
+* `resource_group_id` - (Optional, Computed, Available since v1.58.0) The ID of the resource group to which the security group belongs. **NOTE:** From version 1.115.0, `resource_group_id` can be modified.
 * `security_group_name` - (Optional, Available since v1.239.0) The name of the security group. The name must be `2` to `128` characters in length. The name must start with a letter and cannot start with `http://` or `https://`. The name can contain Unicode characters under the Decimal Number category and the categories whose names contain Letter. The name can also contain colons (:), underscores (\_), periods (.), and hyphens (-).
 * `security_group_type` - (Optional, ForceNew, Available since v1.58.0) The type of the security group. Default value: `normal`. Valid values:
   - `normal`: Basic security group.


### PR DESCRIPTION
Add `computed=true` to `resource_group_id` in `alicloud_security_group` resource to avoid diff when auto grouping is enabled

Ref: https://help.aliyun.com/zh/resource-management/resource-group/user-guide/auto-group-of-custom-rules

```log
=== RUN   TestAccAliCloudECSSecurityGroup_basic8588
--- PASS: TestAccAliCloudECSSecurityGroup_basic8588 (110.05s)
=== RUN   TestAccAliCloudECSSecurityGroup_basic8588_twin
--- PASS: TestAccAliCloudECSSecurityGroup_basic8588_twin (13.13s)
=== RUN   TestAccAliCloudECSSecurityGroup_basic8600
--- PASS: TestAccAliCloudECSSecurityGroup_basic8600 (98.15s)
=== RUN   TestAccAliCloudECSSecurityGroup_basic8600_twin
--- PASS: TestAccAliCloudECSSecurityGroup_basic8600_twin (13.07s)
=== RUN   TestAccAliCloudECSSecurityGroup_Multi
--- PASS: TestAccAliCloudECSSecurityGroup_Multi (22.29s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  259.447s
```