### PR TITLE
resource/alicloud_cs_managed_kubernetes: Added the field upgrade_policy, control_plane_only; resource/alicloud_cs_kubernetes_node_pool: Added the field pause_policy, batch_interval, node_names, upgrade_policy, kubernetes_version, use_replace, runtime, image_id, runtime_version.

### DIFF
--- a/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
@@ -1,4 +1,3 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
@@ -10,12 +9,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/PaesslerAG/jsonpath"
 	roacs "github.com/alibabacloud-go/cs-20151215/v5/client"
+	"github.com/denverdino/aliyungo/cs"
+
+	"github.com/PaesslerAG/jsonpath"
 	"github.com/alibabacloud-go/tea/tea"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/denverdino/aliyungo/common"
-	"github.com/denverdino/aliyungo/cs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -681,6 +681,19 @@ func resourceAliCloudAckNodepool() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"pause_policy": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"batch_interval": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"node_names": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 						"max_parallelism": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -735,7 +748,7 @@ func resourceAliCloudAckNodepool() *schema.Resource {
 						"max_size": {
 							Type:         schema.TypeInt,
 							Optional:     true,
-							ValidateFunc: IntBetween(0, 1000),
+							ValidateFunc: IntBetween(0, 2000),
 						},
 						"eip_internet_charge_type": {
 							Type:          schema.TypeString,
@@ -907,6 +920,35 @@ func resourceAliCloudAckNodepool() *schema.Resource {
 			"update_nodes": {
 				Type:     schema.TypeBool,
 				Optional: true,
+			},
+			"upgrade_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kubernetes_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"use_replace": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"runtime": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"image_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"runtime_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 			"user_data": {
 				Type:     schema.TypeString,
@@ -3194,6 +3236,114 @@ func resourceAliCloudAckNodepoolUpdate(d *schema.ResourceData, meta interface{})
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			response, err = client.RoaPut("CS", "2015-12-15", action, query, header, body, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		ackServiceV2 := AckServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{"success"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ackServiceV2.DescribeAsyncAckNodepoolStateRefreshFunc(d, response, "$.state", []string{"fail", "failed"}))
+		if jobDetail, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id(), jobDetail)
+		}
+	}
+	update = false
+	parts = strings.Split(d.Id(), ":")
+	ClusterId = parts[0]
+	NodepoolId = parts[1]
+	action = fmt.Sprintf("/clusters/%s/nodepools/%s/upgrade", ClusterId, NodepoolId)
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+
+	if v, ok := d.GetOk("upgrade_policy"); ok {
+		upgradePolicyKubernetesVersionJsonPath, err := jsonpath.Get("$[0].kubernetes_version", v)
+		if err == nil && upgradePolicyKubernetesVersionJsonPath != "" {
+			request["kubernetes_version"] = upgradePolicyKubernetesVersionJsonPath
+		}
+		update = true
+	}
+	if v, ok := d.GetOkExists("upgrade_policy"); ok {
+		upgradePolicyUseReplaceJsonPath, err := jsonpath.Get("$[0].use_replace", v)
+		if err == nil && upgradePolicyUseReplaceJsonPath != "" {
+			request["use_replace"] = upgradePolicyUseReplaceJsonPath
+		}
+	}
+	if v, ok := d.GetOk("upgrade_policy"); ok {
+		upgradePolicyImageIdJsonPath, err := jsonpath.Get("$[0].image_id", v)
+		npVal := d.Get("image_id").(string)
+		if npVal != upgradePolicyImageIdJsonPath {
+			return WrapError(fmt.Errorf("[ERROR] image_id is not equal to upgrade_policy.image_id"))
+		}
+		if err == nil && upgradePolicyImageIdJsonPath != "" {
+			request["image_id"] = upgradePolicyImageIdJsonPath
+		}
+		update = true
+	}
+	if v, ok := d.GetOk("upgrade_policy"); ok {
+		upgradePolicyRuntimeJsonPath, err := jsonpath.Get("$[0].runtime", v)
+		npVal := d.Get("runtime_name").(string)
+		if npVal != upgradePolicyRuntimeJsonPath {
+			return WrapError(fmt.Errorf("[ERROR] runtime_name is not equal to upgrade_policy.runtime"))
+		}
+		if err == nil && upgradePolicyRuntimeJsonPath != "" {
+			request["runtime_type"] = upgradePolicyRuntimeJsonPath
+		}
+		update = true
+	}
+	if v, ok := d.GetOk("upgrade_policy"); ok {
+		upgradePolicyRuntimeVersionJsonPath, err := jsonpath.Get("$[0].runtime_version", v)
+		npVal := d.Get("runtime_version").(string)
+		if npVal != upgradePolicyRuntimeVersionJsonPath {
+			return WrapError(fmt.Errorf("[ERROR] runtime_version is not equal to upgrade_policy.runtime_version"))
+		}
+		if err == nil && upgradePolicyRuntimeVersionJsonPath != "" {
+			request["runtime_version"] = upgradePolicyRuntimeVersionJsonPath
+		}
+		update = true
+	}
+	rolling_policy = make(map[string]interface{})
+
+	if v := d.Get("rolling_policy"); v != nil {
+		batchIntervalRaw, _ := jsonpath.Get("$[0].batch_interval", v)
+		if batchIntervalRaw != nil && batchIntervalRaw != "" {
+			batchInterval, _ := strconv.ParseInt(batchIntervalRaw.(string), 10, 64)
+			rolling_policy["batch_interval"] = batchInterval
+		}
+		maxParallelism, _ := jsonpath.Get("$[0].max_parallelism", v)
+		if maxParallelism != nil && maxParallelism != "" {
+			rolling_policy["max_parallelism"] = maxParallelism
+		}
+		pausePolicy, _ := jsonpath.Get("$[0].pause_policy", v)
+		if pausePolicy != nil && pausePolicy != "" {
+			rolling_policy["pause_policy"] = pausePolicy
+		}
+
+		request["rolling_policy"] = rolling_policy
+
+		localData, err := jsonpath.Get("$[0].node_names", v)
+		if err != nil {
+			return WrapError(err)
+		}
+		if localData != nil && localData != "" {
+			node_namesMapsArray := convertToInterfaceArray(localData)
+			request["node_names"] = node_namesMapsArray
+		}
+	}
+
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPost("CS", "2015-12-15", action, query, header, body, true)
 			if err != nil {
 				if NeedRetry(err) {
 					wait()

--- a/alicloud/resource_alicloud_cs_kubernetes_node_pool_test.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_node_pool_test.go
@@ -5756,7 +5756,6 @@ func TestAccAliCloudAckNodepool_basic5291(t *testing.T) {
 	})
 }
 
-// Test Ack Nodepool. >>> Resource test cases, automatically generated.
 // Case np-instancepattern 11802
 func TestAccAliCloudAckNodepool_basic11802(t *testing.T) {
 	var v map[string]interface{}
@@ -6804,7 +6803,6 @@ func TestAccAliCloudAckNodepool_basic11829(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tfaccack%d", rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAckNodepoolBasicDependence11829)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
@@ -6932,81 +6930,121 @@ resource "alicloud_cs_kubernetes_node_pool" "default" {
 				),
 			},
 			{
-				Config: testAccConfig(map[string]interface{}{
-					"instance_patterns": []map[string]interface{}{
-						{
-							"instance_family_level": "EnterpriseLevel",
-							"min_cpu_cores":         "4",
-							"max_cpu_cores":         "8",
-							"min_memory_size":       "4",
-							"max_memory_size":       "16",
-							"instance_categories": []string{
-								"General-purpose"},
-							"cpu_architectures": []string{
-								"X86"},
-						},
-					},
-					"data_disks": []map[string]interface{}{
-						{
-							"size":     "130",
-							"category": "cloud_essd",
-						},
-					},
-				}),
+				Config: AlicloudAckNodepoolBasicDependence11829(name) + fmt.Sprintf(`
+resource "alicloud_cs_kubernetes_node_pool" "default" {
+  node_pool_name = "%s"
+  cluster_id     = alicloud_cs_managed_kubernetes.defaultC02XDz.id
+  vswitch_ids    = ["${alicloud_vswitch.defaultziRRat.id}", "${alicloud_vswitch.defaultT8D8ss.id}", "${alicloud_vswitch.defaultFsk7cj.id}"]
+
+  auto_mode {
+    enabled = true
+  }
+
+  scaling_config {
+    max_size = 50
+    min_size = 0
+  }
+
+  instance_patterns {
+    min_cpu_cores           = 4
+    max_cpu_cores           = 8
+    min_memory_size         = 4
+    max_memory_size         = 16
+    instance_family_level   = "EnterpriseLevel"
+    excluded_instance_types = ["ecs.c6.*"]
+    instance_categories     = ["General-purpose"]
+    cpu_architectures       = ["X86"]
+  }
+
+  data_disks {
+    size     = 130
+    encrypted = "false"
+    category = "cloud_essd"
+  }
+
+  labels {
+    key   = "test"
+    value = "test"
+  }
+
+  taints {
+    key    = "test_taint_key"
+    effect = "NoSchedule"
+    value  = "test_taint_val"
+  }
+
+  resource_group_id = data.alicloud_resource_manager_resource_groups.default.ids.0
+
+  lifecycle {
+    ignore_changes = [
+      management,
+      install_cloud_monitor,
+      cpu_policy,
+      node_name_mode,
+      runtime_name,
+      runtime_version,
+      unschedulable,
+      user_data,
+      pre_user_data,
+      auto_renew,
+      auto_renew_period,
+      cis_enabled,
+      compensate_with_on_demand,
+      deployment_set_id,
+      image_id,
+      image_type,
+      instance_charge_type,
+      instance_metadata_options,
+      internet_charge_type,
+      internet_max_bandwidth_out,
+      key_name,
+      login_as_non_root,
+      password,
+      multi_az_policy,
+      on_demand_base_capacity,
+      on_demand_percentage_above_base_capacity,
+      period,
+      period_unit,
+      platform,
+      private_pool_options,
+      ram_role_name,
+      rds_instances,
+      scaling_policy,
+      security_group_id,
+      security_group_ids,
+      security_hardening_os,
+      soc_enabled,
+      spot_instance_pools,
+      spot_instance_remedy,
+      spot_price_limit,
+      spot_strategy,
+      system_disk_category,
+      system_disk_categories,
+      system_disk_size,
+      system_disk_bursting_enabled,
+      system_disk_performance_level,
+      system_disk_encrypted,
+      system_disk_kms_key,
+      system_disk_snapshot_policy_id,
+      system_disk_encrypt_algorithm,
+      system_disk_provisioned_iops,
+      tee_config,
+    ]
+  }
+}
+`, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
+						"node_pool_name":      name,
+						"labels.#":            "1",
+						"taints.#":            "1",
+						"vswitch_ids.#":       "3",
+						"resource_group_id":   CHECKSET,
 						"instance_patterns.#": "1",
 						"data_disks.#":        "1",
+						"cluster_id":          CHECKSET,
 					}),
 				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"tags": map[string]string{
-						"Created": "TF",
-						"For":     "Test",
-					},
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"tags.%":       "2",
-						"tags.Created": "TF",
-						"tags.For":     "Test",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"tags": map[string]string{
-						"Created": "TF-update",
-						"For":     "Test-update",
-					},
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"tags.%":       "2",
-						"tags.Created": "TF-update",
-						"tags.For":     "Test-update",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"tags": REMOVEKEY,
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"tags.%":       "0",
-						"tags.Created": REMOVEKEY,
-						"tags.For":     REMOVEKEY,
-					}),
-				),
-			},
-			{
-				ResourceName:            resourceId,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"eflo_node_group", "password", "rolling_policy", "update_nodes"},
 			},
 		},
 	})
@@ -7692,6 +7730,283 @@ resource "alicloud_cs_managed_kubernetes" "defaultC02XDz" {
   pod_cidr        = var.container_cidr
   deletion_protection = false
   is_enterprise_security_group = true
+}
+
+
+`, name)
+}
+
+// Test Ack Nodepool. >>> Resource test cases, automatically generated.
+// Case np-upgrade 12069
+func TestAccAliCloudAckNodepool_basic12069(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cs_kubernetes_node_pool.default"
+	ra := resourceAttrInit(resourceId, AlicloudAckNodepoolMap12069)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AckServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAckNodepool")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccack%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAckNodepoolBasicDependence12069)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_id":             "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"image_type":                    "AliyunLinux",
+					"image_id":                      "aliyun_2_1903_x64_20G_alibase_20231221.vhd",
+					"runtime_name":                  "containerd",
+					"system_disk_performance_level": "PL0",
+					"system_disk_size":              "40",
+					"system_disk_category":          "cloud_essd",
+					"vswitch_ids": []string{
+						"${alicloud_vswitch.defaultziRRat.id}", "${alicloud_vswitch.defaultT8D8ss.id}", "${alicloud_vswitch.defaultFsk7cj.id}"},
+					"instance_types": []string{
+						"ecs.c6.xlarge", "ecs.c7.xlarge"},
+					"cluster_id":           "${alicloud_cs_managed_kubernetes.defaultNppPcz.id}",
+					"instance_charge_type": "PostPaid",
+					"runtime_version":      "1.6.28",
+					"node_pool_name":       name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id":             CHECKSET,
+						"image_type":                    "AliyunLinux",
+						"image_id":                      "aliyun_2_1903_x64_20G_alibase_20231221.vhd",
+						"runtime_name":                  "containerd",
+						"system_disk_performance_level": "PL0",
+						"system_disk_size":              "40",
+						"system_disk_category":          "cloud_essd",
+						"vswitch_ids.#":                 "3",
+						"instance_types.#":              "2",
+						"cluster_id":                    CHECKSET,
+						"instance_charge_type":          "PostPaid",
+						"runtime_version":               "1.6.28",
+						"node_pool_name":                name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"image_type": "AliyunLinux3ContainerOptimized",
+					"image_id":   "aliyun_3_x64_20G_container_optimized_alibase_20250629.vhd",
+					"vswitch_ids": []string{
+						"${alicloud_vswitch.defaultT8D8ss.id}", "${alicloud_vswitch.defaultVTblQn.id}", "${alicloud_vswitch.defaultFsk7cj.id}"},
+					"runtime_version": "1.6.39",
+					"node_pool_name":  name + "_update",
+					"rolling_policy": []map[string]interface{}{
+						{
+							"max_parallelism": "1",
+							"pause_policy":    "NoPause",
+							"batch_interval":  "0",
+						},
+					},
+					"scaling_config": []map[string]interface{}{
+						{
+							"enable":      "false",
+							"is_bond_eip": "false",
+						},
+					},
+					"upgrade_policy": []map[string]interface{}{
+						{
+							"runtime":            "containerd",
+							"runtime_version":    "1.6.39",
+							"image_id":           "aliyun_3_x64_20G_container_optimized_alibase_20250629.vhd",
+							"kubernetes_version": "${alicloud_cs_managed_kubernetes.defaultNppPcz.version}",
+							"use_replace":        "true",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"image_type":      "AliyunLinux3ContainerOptimized",
+						"image_id":        "aliyun_3_x64_20G_container_optimized_alibase_20250629.vhd",
+						"vswitch_ids.#":   "3",
+						"runtime_version": "1.6.39",
+						"node_pool_name":  name + "_update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "Test",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.For":     "Test",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF-update",
+						"For":     "Test-update",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF-update",
+						"tags.For":     "Test-update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "0",
+						"tags.Created": REMOVEKEY,
+						"tags.For":     REMOVEKEY,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"eflo_node_group", "password", "rolling_policy", "update_nodes", "upgrade_policy"},
+			},
+		},
+	})
+}
+
+var AlicloudAckNodepoolMap12069 = map[string]string{
+	"scaling_group_id": CHECKSET,
+	"node_pool_id":     CHECKSET,
+}
+
+func AlicloudAckNodepoolBasicDependence12069(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "zone_1" {
+  default = "cn-hangzhou-k"
+}
+
+variable "zone_2" {
+  default = "cn-hangzhou-g"
+}
+
+variable "vsw1_cidr" {
+  default = "10.1.0.0/24"
+}
+
+variable "vsw4_cidr" {
+  default = "10.1.3.0/24"
+}
+
+variable "rg_name_1" {
+  default = "tf-test-resource-group-1"
+}
+
+variable "vsw2_cidr" {
+  default = "10.1.1.0/24"
+}
+
+variable "rg_name_2" {
+  default = "tf-test-resource-group-2"
+}
+
+variable "container_cidr" {
+  default = "172.17.3.0/24"
+}
+
+variable "user_data" {
+  default = "I18vYmluL3No"
+}
+
+variable "service_cidr" {
+  default = "172.17.2.0/24"
+}
+
+variable "vsw3_cidr" {
+  default = "10.1.2.0/24"
+}
+
+variable "kubernetes_version" {
+  default = "1.32.1-aliyun.1"
+}
+
+variable "user_data_1" {
+  default = "IyEvYmluL3NoIGVjaG8gIkhlbGxvIFdvcmxkLiBUaGUgdGltZSBpcyBudWcgJChkYXRlIC1SKSkhfCB0ZWUgL3Jvb3QvdXNlcmRhdGFfdGVzdC50eHQ="
+}
+
+variable "zone_3" {
+  default = "cn-hangzhou-i"
+}
+
+variable "zone_4" {
+  default = "cn-hangzhou-j"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+resource "alicloud_vpc" "defaultqe0KHK" {
+  cidr_block = "10.0.0.0/8"
+}
+
+resource "alicloud_security_group" "defaultKHUbRj" {
+  vpc_id              = alicloud_vpc.defaultqe0KHK.id
+  security_group_name = "tf-test-security-group"
+  security_group_type = "normal"
+}
+
+resource "alicloud_security_group" "defaultKYDOFD" {
+  security_group_name = "tf-test-security-group-2"
+  vpc_id              = alicloud_vpc.defaultqe0KHK.id
+  security_group_type = "normal"
+}
+
+resource "alicloud_vswitch" "defaultVTblQn" {
+  vpc_id     = alicloud_vpc.defaultqe0KHK.id
+  cidr_block = var.vsw1_cidr
+  zone_id    = var.zone_1
+}
+
+resource "alicloud_vswitch" "defaultziRRat" {
+  vpc_id     = alicloud_vpc.defaultqe0KHK.id
+  zone_id    = var.zone_2
+  cidr_block = var.vsw2_cidr
+}
+
+resource "alicloud_vswitch" "defaultT8D8ss" {
+  vpc_id     = alicloud_vpc.defaultqe0KHK.id
+  zone_id    = var.zone_3
+  cidr_block = var.vsw3_cidr
+}
+
+resource "alicloud_vswitch" "defaultFsk7cj" {
+  vpc_id     = alicloud_vpc.defaultqe0KHK.id
+  zone_id    = var.zone_4
+  cidr_block = var.vsw4_cidr
+}
+
+resource "alicloud_cs_managed_kubernetes" "defaultNppPcz" {
+  pod_cidr          = var.container_cidr
+  vswitch_ids       = ["${alicloud_vswitch.defaultT8D8ss.id}", "${alicloud_vswitch.defaultziRRat.id}"]
+  service_cidr      = var.service_cidr
+  security_group_id = alicloud_security_group.defaultKHUbRj.id
+  cluster_spec      = "ack.pro.small"
 }
 
 

--- a/alicloud/resource_alicloud_cs_managed_kubernetes_test.go
+++ b/alicloud/resource_alicloud_cs_managed_kubernetes_test.go
@@ -892,3 +892,173 @@ var csManagedKubernetesBasicMap = map[string]string{
 	"cluster_spec":                       CHECKSET,
 	"slb_id":                             CHECKSET,
 }
+
+// Test Ack Cluster. >>> Resource test cases, automatically generated.
+// Case 集群测试-升级 12341
+func TestAccAliCloudAckCluster_basic12341(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cs_managed_kubernetes.default"
+	ra := resourceAttrInit(resourceId, map[string]string{})
+
+	serviceFunc := func() interface{} {
+		return &CsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccack%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAckClusterBasicDependence12341)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name":         name,
+					"service_cidr": "${var.service_cidr}",
+					"addons": []map[string]interface{}{
+						{
+							"name": "terway-eniip",
+						},
+					},
+					"is_enterprise_security_group": "true",
+					"zone_ids": []string{
+						"${var.zone_id}"},
+					"cluster_spec":        "ack.pro.small",
+					"deletion_protection": "false",
+					"version":             "1.32.7-aliyun.1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":                         name,
+						"service_cidr":                 CHECKSET,
+						"addons.#":                     "1",
+						"is_enterprise_security_group": "true",
+						"zone_ids.#":                   "1",
+						"cluster_spec":                 "ack.pro.small",
+						"deletion_protection":          "false",
+						"version":                      "1.32.7-aliyun.1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"timezone": "Asia/Singapore",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"timezone": "Asia/Singapore",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"version": "1.33.3-aliyun.1",
+					"upgrade_policy": []map[string]interface{}{
+						{
+							"control_plane_only": true,
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"version": "1.33.3-aliyun.1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "Test",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.For":     "Test",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF-update",
+						"For":     "Test-update",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF-update",
+						"tags.For":     "Test-update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "0",
+						"tags.Created": REMOVEKEY,
+						"tags.For":     REMOVEKEY,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_set_certificate_authority", "addons", "new_nat_gateway", "user_ca", "name_prefix", "load_balancer_spec", "slb_internet_enabled", "zone_ids", "is_enterprise_security_group", "upgrade_policy"},
+			},
+		},
+	})
+}
+
+func AlicloudAckClusterBasicDependence12341(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "service_cidr" {
+  default = "192.168.0.0/16"
+}
+
+variable "cluster_name" {
+  default = "test-create-cluster"
+}
+
+variable "zone_id" {
+  default = "cn-hangzhou-g"
+}
+
+variable "cluster_name_update" {
+  default = "test-create-cluster-update"
+}
+
+variable "region_id" {
+  default = "cn-hangzhou"
+}
+
+variable "container_cidr" {
+  default = "10.53.0.0/16"
+}
+
+variable "cluster_type" {
+  default = "ManagedKubernetes"
+}
+
+
+`, name)
+}
+
+// Test Ack Cluster. <<< Resource test cases, automatically generated.

--- a/website/docs/r/cs_managed_kubernetes.html.markdown
+++ b/website/docs/r/cs_managed_kubernetes.html.markdown
@@ -402,6 +402,8 @@ The following arguments are supported:
 * `delete_options` - (Optional, Available since v1.223.2) Delete options, only work for deleting resource. Make sure you have run `terraform apply` to make the configuration applied. See [`delete_options`](#delete_options) below.
 * `addons` - (Optional, Available since v1.88.0) The addon you want to install in cluster. See [`addons`](#addons) below. Only works for **Create** Operation, use [resource cs_kubernetes_addon](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cs_kubernetes_addon) to manage addons if cluster is created.
 * `skip_set_certificate_authority` - (Optional) Configure whether to save certificate authority data for your cluster to attribute `certificate_authority`. For cluster security, recommended configuration as `true`. Will be removed with attribute certificate_authority removed.
+* `upgrade_policy` - (Optional, Set, Available since v1.269.0) Configuration block for cluster upgrade operations. See [`upgrade_policy`](#upgrade_policy) below.
+-> **NOTE:** This parameter only applies during resource update.
 
 *Network params*
 
@@ -513,6 +515,23 @@ Audit log config. If `enabled` is set to `true`, a Logstore is created in the sp
 Auto mode cluster config.  
 
 * `enabled` - (Optional, ForceNew) Whether to enable auto mode. Valid values: `true`, `false`. Only ACK managed Pro clusters support Auto Mode.
+
+### `upgrade_policy`
+Configuration block for cluster upgrade operations. This is a transient parameter that controls upgrade behavior when updating the `version` field.
+
+* `control_plane_only` - (Optional) Whether to upgrade only the control plane without upgrading worker nodes. Valid values: `true`, `false`. When set to `true`, only the cluster control plane components will be upgraded, and worker nodes will remain at their current version. Default is `false`.
+
+for example:
+```
+  # Upgrade cluster version with control plane only
+  version = "1.32.1-aliyun.1"
+  
+  upgrade_policy {
+    control_plane_only = true
+  }
+```
+
+-> **NOTE:** After the upgrade completes, you may remove the `upgrade_policy` block from your configuration to prevent unintended re-upgrades on subsequent applies.
 
 ### `addons`
 


### PR DESCRIPTION
resource/alicloud_cs_managed_kubernetes: Added the field upgrade_policy, control_plane_only; resource/alicloud_cs_kubernetes_node_pool: Added the field pause_policy, batch_interval, node_names, upgrade_policy, kubernetes_version, use_replace, runtime, image_id, runtime_version.