### PR TITLE
New Resource: alicloud_cloud_firewall_vpc_firewall_acl_engine_mode

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -918,6 +918,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_alikafka_scheduled_scaling_rule":                      resourceAliCloudAlikafkaScheduledScalingRule(),
 			"alicloud_event_bridge_event_source_v2":                         resourceAliCloudEventBridgeEventSourceV2(),
+			"alicloud_cloud_firewall_vpc_firewall_acl_engine_mode":          resourceAliCloudCloudFirewallVpcFirewallAclEngineMode(),
 			"alicloud_cloud_firewall_instance_v2":                           resourceAliCloudCloudFirewallInstanceV2(),
 			"alicloud_cloud_firewall_vpc_firewall_ips_config":               resourceAliCloudCloudFirewallVpcFirewallIpsConfig(),
 			"alicloud_rds_ai_instance":                                      resourceAliCloudRdsAiInstance(),

--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_acl_engine_mode.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_acl_engine_mode.go
@@ -1,0 +1,157 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAliCloudCloudFirewallVpcFirewallAclEngineMode() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCloudFirewallVpcFirewallAclEngineModeCreate,
+		Read:   resourceAliCloudCloudFirewallVpcFirewallAclEngineModeRead,
+		Update: resourceAliCloudCloudFirewallVpcFirewallAclEngineModeUpdate,
+		Delete: resourceAliCloudCloudFirewallVpcFirewallAclEngineModeDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"strict_mode": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntInSlice([]int{0, 1}),
+			},
+			"vpc_firewall_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"member_uid": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCloudFirewallVpcFirewallAclEngineModeCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "ModifyVpcFirewallAclEngineMode"
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+
+	request := map[string]interface{}{
+		"VpcFirewallId": d.Get("vpc_firewall_id"),
+		"StrictMode":    d.Get("strict_mode"),
+	}
+	if v, ok := d.GetOk("member_uid"); ok {
+		request["MemberUid"] = v
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Cloudfw", "2017-12-07", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cloud_firewall_vpc_firewall_acl_engine_mode", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(request["VpcFirewallId"]))
+
+	return resourceAliCloudCloudFirewallVpcFirewallAclEngineModeRead(d, meta)
+}
+
+func resourceAliCloudCloudFirewallVpcFirewallAclEngineModeRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cloudFirewallServiceV2 := CloudFirewallServiceV2{client}
+
+	objectRaw, err := cloudFirewallServiceV2.DescribeCloudFirewallVpcFirewallAclEngineMode(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cloud_firewall_vpc_firewall_acl_engine_mode DescribeCloudFirewallVpcFirewallAclEngineMode Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("member_uid", objectRaw["MemberUid"])
+	d.Set("vpc_firewall_id", objectRaw["AclGroupId"])
+
+	aclConfigRawObj, _ := jsonpath.Get("$.AclConfig", objectRaw)
+	aclConfigRaw := make(map[string]interface{})
+	if aclConfigRawObj != nil {
+		aclConfigRaw = aclConfigRawObj.(map[string]interface{})
+	}
+	d.Set("strict_mode", aclConfigRaw["StrictMode"])
+	return nil
+}
+
+func resourceAliCloudCloudFirewallVpcFirewallAclEngineModeUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "ModifyVpcFirewallAclEngineMode"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["VpcFirewallId"] = d.Id()
+
+	if d.HasChange("strict_mode") {
+		update = true
+		request["StrictMode"] = d.Get("strict_mode")
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Cloudfw", "2017-12-07", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudCloudFirewallVpcFirewallAclEngineModeRead(d, meta)
+}
+
+func resourceAliCloudCloudFirewallVpcFirewallAclEngineModeDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource AliCloud Resource Vpc Firewall Acl Engine Mode. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_acl_engine_mode_test.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_acl_engine_mode_test.go
@@ -1,0 +1,185 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test CloudFirewall VpcFirewallAclEngineMode. >>> Resource test cases, automatically generated.
+// Case ACL引擎管理-VPC边界防火墙 12344
+func TestAccAliCloudCloudFirewallVpcFirewallAclEngineMode_basic12344(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_firewall_vpc_firewall_acl_engine_mode.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudFirewallVpcFirewallAclEngineModeMap12344)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudFirewallServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudFirewallVpcFirewallAclEngineMode")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudfirewall%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudFirewallVpcFirewallAclEngineModeBasicDependence12344)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"strict_mode":     "0",
+					"vpc_firewall_id": "${alicloud_cloud_firewall_vpc_firewall.test.id}",
+					"member_uid":      "${data.alicloud_account.test.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"strict_mode":     "0",
+						"vpc_firewall_id": CHECKSET,
+						"member_uid":      CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"strict_mode": "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"strict_mode": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCloudFirewallVpcFirewallAclEngineModeMap12344 = map[string]string{}
+
+func AlicloudCloudFirewallVpcFirewallAclEngineModeBasicDependence12344(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_cen_transit_router_available_resources" "test" {}
+
+data "alicloud_account" "test" {}
+
+data "alicloud_regions" "test" {
+  current = true
+}
+
+data "alicloud_zones" "test" {
+  available_instance_type     = "ecs.sn1ne.large"
+  available_resource_creation = "VSwitch"
+}
+
+resource "alicloud_vpc" "peer" {
+  vpc_name   = "${var.name}-peer"
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vpc" "local" {
+  vpc_name   = "${var.name}-local"
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "peer01" {
+  vpc_id       = alicloud_vpc.peer.id
+  cidr_block   = "192.168.10.0/24"
+  zone_id      = data.alicloud_zones.test.zones.0.id
+  vswitch_name = "${var.name}-peer-01"
+}
+
+resource "alicloud_vswitch" "peer02" {
+  vpc_id       = alicloud_vpc.peer.id
+  cidr_block   = "192.168.20.0/24"
+  zone_id      = data.alicloud_zones.test.zones.1.id
+  vswitch_name = "${var.name}-peer-02"
+}
+
+resource "alicloud_vswitch" "local01" {
+  vpc_id       = alicloud_vpc.local.id
+  cidr_block   = "172.16.10.0/24"
+  zone_id      = data.alicloud_zones.test.zones.0.id
+  vswitch_name = "${var.name}-local-01"
+}
+
+resource "alicloud_vswitch" "local02" {
+  vpc_id       = alicloud_vpc.local.id
+  cidr_block   = "172.16.20.0/24"
+  zone_id      = data.alicloud_zones.test.zones.1.id
+  vswitch_name = "${var.name}-local-02"
+}
+
+resource "alicloud_vpc_peer_connection" "test" {
+  peer_connection_name = var.name
+  vpc_id               = alicloud_vpc.local.id
+  accepting_ali_uid    = data.alicloud_account.test.id
+  accepting_region_id  = data.alicloud_regions.test.ids.0
+  accepting_vpc_id     = alicloud_vpc.peer.id
+  description          = "terraform-example"
+  force_delete         = true
+}
+
+resource "alicloud_vpc_peer_connection_accepter" "test" {
+  instance_id  = alicloud_vpc_peer_connection.test.id
+  force_delete = true
+}
+
+resource "alicloud_route_entry" "local" {
+  route_table_id        = alicloud_vpc.local.route_table_id
+  destination_cidrblock = "1.2.3.4/32"
+  nexthop_type          = "VpcPeer"
+  nexthop_id            = alicloud_vpc_peer_connection.test.id
+}
+
+resource "alicloud_route_entry" "peer" {
+  route_table_id        = alicloud_vpc.peer.route_table_id
+  destination_cidrblock = "4.3.2.1/32"
+  nexthop_type          = "VpcPeer"
+  nexthop_id            = alicloud_vpc_peer_connection.test.id
+}
+
+resource "alicloud_cloud_firewall_vpc_firewall" "test" {
+  vpc_firewall_name = var.name
+  member_uid        = data.alicloud_account.test.id
+  peer_vpc {
+    vpc_id    = alicloud_vpc.peer.id
+    region_no = data.alicloud_regions.test.ids.0
+    peer_vpc_cidr_table_list {
+      peer_route_table_id = alicloud_vpc.peer.route_table_id
+      peer_route_entry_list {
+        peer_destination_cidr     = alicloud_route_entry.peer.destination_cidrblock
+        peer_next_hop_instance_id = alicloud_vpc_peer_connection.test.id
+      }
+    }
+  }
+  local_vpc {
+    vpc_id    = alicloud_vpc.local.id
+    region_no = data.alicloud_regions.test.ids.0
+    local_vpc_cidr_table_list {
+      local_route_table_id = alicloud_vpc.local.route_table_id
+      local_route_entry_list {
+        local_next_hop_instance_id = alicloud_vpc_peer_connection.test.id
+        local_destination_cidr     = alicloud_route_entry.local.destination_cidrblock
+      }
+    }
+  }
+status = "open"
+}
+`, name)
+}
+
+// Test CloudFirewall VpcFirewallAclEngineMode. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_cloud_firewall_v2.go
+++ b/alicloud/service_alicloud_cloud_firewall_v2.go
@@ -856,6 +856,85 @@ func (s *CloudFirewallServiceV2) CloudFirewallVpcFirewallControlPolicyStateRefre
 }
 
 // DescribeCloudFirewallVpcFirewallControlPolicy >>> Encapsulated.
+// DescribeCloudFirewallVpcFirewallAclEngineMode <<< Encapsulated get interface for CloudFirewall VpcFirewallAclEngineMode.
+
+func (s *CloudFirewallServiceV2) DescribeCloudFirewallVpcFirewallAclEngineMode(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["FirewallId"] = id
+
+	action := "DescribeVpcFirewallAclGroupList"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Cloudfw", "2017-12-07", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"ErrorConfigureStatus"}) {
+			return object, WrapErrorf(NotFoundErr("VpcFirewallAclEngineMode", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.AclGroupList[*]", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.AclGroupList[*]", response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("VpcFirewallAclEngineMode", id), NotFoundMsg, response)
+	}
+
+	return v.([]interface{})[0].(map[string]interface{}), nil
+}
+
+func (s *CloudFirewallServiceV2) CloudFirewallVpcFirewallAclEngineModeStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.CloudFirewallVpcFirewallAclEngineModeStateRefreshFuncWithApi(id, field, failStates, s.DescribeCloudFirewallVpcFirewallAclEngineMode)
+}
+
+func (s *CloudFirewallServiceV2) CloudFirewallVpcFirewallAclEngineModeStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeCloudFirewallVpcFirewallAclEngineMode >>> Encapsulated.
 
 // DescribeCloudFirewallVpcFirewallIpsConfig <<< Encapsulated get interface for CloudFirewall VpcFirewallIpsConfig.
 

--- a/website/docs/r/cloud_firewall_vpc_firewall_acl_engine_mode.html.markdown
+++ b/website/docs/r/cloud_firewall_vpc_firewall_acl_engine_mode.html.markdown
@@ -1,0 +1,111 @@
+---
+subcategory: "Cloud Firewall"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cloud_firewall_vpc_firewall_acl_engine_mode"
+description: |-
+  Provides a Alicloud Cloud Firewall Vpc Firewall Acl Engine Mode resource.
+---
+
+# alicloud_cloud_firewall_vpc_firewall_acl_engine_mode
+
+Provides a Cloud Firewall Vpc Firewall Acl Engine Mode resource.
+
+VPC boundary firewall engine mode.
+
+For information about Cloud Firewall Vpc Firewall Acl Engine Mode and how to use it, see [What is Vpc Firewall Acl Engine Mode](https://next.api.alibabacloud.com/document/Cloudfw/2017-12-07/ModifyVpcFirewallAclEngineMode).
+
+-> **NOTE:** Available since v1.269.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = ""
+}
+
+resource "alicloud_cen_instance" "cen" {
+  description       = "yqc-example001"
+  cen_instance_name = "yqc-example-CenInstance001"
+}
+
+resource "alicloud_cen_transit_router" "TR" {
+  cen_id = alicloud_cen_instance.cen.id
+}
+
+resource "alicloud_vpc" "vpc1" {
+  cidr_block = "172.16.0.0/12"
+  vpc_name   = "yqc-vpc-example-001"
+}
+
+resource "alicloud_vswitch" "vpc1vsw1" {
+  vpc_id     = alicloud_vpc.vpc1.id
+  zone_id    = "cn-hangzhou-h"
+  cidr_block = "172.16.1.0/24"
+}
+
+resource "alicloud_vswitch" "vpc1vsw2" {
+  vpc_id     = alicloud_vpc.vpc1.id
+  zone_id    = "cn-hangzhou-i"
+  cidr_block = "172.16.2.0/24"
+}
+
+resource "alicloud_cen_transit_router_vpc_attachment" "tr-vpc1" {
+  vpc_id = alicloud_vpc.vpc1.id
+  cen_id = alicloud_cen_instance.cen.id
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.vpc1vsw1.id
+    zone_id    = alicloud_vswitch.vpc1vsw1.zone_id
+  }
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.vpc1vsw2.id
+    zone_id    = alicloud_vswitch.vpc1vsw2.zone_id
+  }
+  transit_router_vpc_attachment_name    = "example"
+  transit_router_attachment_description = "111"
+  auto_publish_route_enabled            = true
+  transit_router_id                     = alicloud_cen_transit_router.TR.transit_router_id
+}
+
+
+resource "alicloud_cloud_firewall_vpc_firewall_acl_engine_mode" "default" {
+  strict_mode     = "0"
+  vpc_firewall_id = alicloud_cen_instance.cen.id
+  member_uid      = "1511928242963727"
+}
+```
+
+### Deleting `alicloud_cloud_firewall_vpc_firewall_acl_engine_mode` or removing it from your configuration
+
+Terraform cannot destroy resource `alicloud_cloud_firewall_vpc_firewall_acl_engine_mode`. Terraform will remove this resource from the state file, however resources may remain.
+
+## Argument Reference
+
+The following arguments are supported:
+* `strict_mode` - (Required, Int) The mode of the ACL engine. Possible values are `0`, `1`.
+* `vpc_firewall_id` - (Required, ForceNew) The ID of the VPC firewall.
+* `member_uid` - (Optional, ForceNew) The ID of member account.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Vpc Firewall Acl Engine Mode.
+* `update` - (Defaults to 5 mins) Used when update the Vpc Firewall Acl Engine Mode.
+
+## Import
+
+Cloud Firewall Vpc Firewall Acl Engine Mode can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cloud_firewall_vpc_firewall_acl_engine_mode.example <vpc_firewall_id>
+```


### PR DESCRIPTION
New Resource: alicloud_cloud_firewall_vpc_firewall_acl_engine_mode
Add support for mange firewall ACL engine mode.

API Ref: [ModifyVpcFirewallAclEngineMode](https://www.alibabacloud.com/help/en/cloud-firewall/cloudfirewall/developer-reference/api-cloudfw-2017-12-07-modifyvpcfirewallaclenginemode)

```log
=== RUN   TestAccAliCloudCloudFirewallVpcFirewallAclEngineMode_basic12344
--- PASS: TestAccAliCloudCloudFirewallVpcFirewallAclEngineMode_basic12344 (822.97s)
```
