### PR TITLE
resource/alicloud_threat_detection_baseline_strategy: Custom 404 error and update test case

### DIFF
--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -304,7 +304,7 @@ func GetNotFoundMessage(product, id string) string {
 }
 
 func GetTimeoutMessage(product, status string) string {
-	return fmt.Sprintf("Waitting for %s %s is timeout.", product, status)
+	return fmt.Sprintf("Waiting for %s %s is timeout.", product, status)
 }
 
 func GetCreateFailedMessage(product string) string {

--- a/alicloud/resource_alicloud_threat_detection_baseline_strategy_test.go
+++ b/alicloud/resource_alicloud_threat_detection_baseline_strategy_test.go
@@ -83,9 +83,6 @@ var AlicloudThreatDetectionBaselineStrategyMap1862 = map[string]string{}
 func AlicloudThreatDetectionBaselineStrategyBasicDependence1862(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
-    default = "%s"
-}
-
-
-`, name)
+  default = "%s"
+}`, name)
 }

--- a/alicloud/service_alicloud_sas.go
+++ b/alicloud/service_alicloud_sas.go
@@ -169,6 +169,12 @@ func (s *SasService) DescribeThreatDetectionBaselineStrategy(id string) (object 
 		}
 		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
 	}
+
+	// This is an API behavior change. An HTTP status code of 200 will be returned when the resource deleted.
+	// Customize this error message to handle this API change.
+	if response == nil {
+		return nil, WrapErrorf(NotFoundErr("ThreatDetection:BaselineStrategy", id), NotFoundMsg)
+	}
 	v, err := jsonpath.Get("$.Strategy", response)
 	if err != nil {
 		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Strategy", response)


### PR DESCRIPTION
Custom 404 error due to service will not return 404 for deleted resource.

```log
=== RUN   TestAccAlicloudThreatDetectionBaselineStrategy_basic1862
--- PASS: TestAccAlicloudThreatDetectionBaselineStrategy_basic1862 (6.83s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  10.197s

```