### PR TITLE
resource/alicloud_cloud_firewall_vpc_cen_tr_firewall: Add support for firewall_eni_id, firewall_eni_vpc_id, tr_attachment_id

### DIFF
--- a/alicloud/resource_alicloud_cloud_firewall_vpc_cen_tr_firewall.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_cen_tr_firewall.go
@@ -22,9 +22,9 @@ func resourceAliCloudCloudFirewallVpcCenTrFirewall() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(20 * time.Minute),
+			Create: schema.DefaultTimeout(41 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(46 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"cen_id": {
@@ -89,6 +89,18 @@ func resourceAliCloudCloudFirewallVpcCenTrFirewall() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"firewall_eni_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"firewall_eni_vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tr_attachment_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -105,24 +117,24 @@ func resourceAliCloudCloudFirewallVpcCenTrFirewallCreate(d *schema.ResourceData,
 	var endpoint string
 	request = make(map[string]interface{})
 
-	request["FirewallName"] = d.Get("firewall_name")
-	request["RouteMode"] = d.Get("route_mode")
-	request["TransitRouterId"] = d.Get("transit_router_id")
-	request["RegionNo"] = d.Get("region_no")
-	request["FirewallVpcCidr"] = d.Get("firewall_vpc_cidr")
-	request["FirewallSubnetCidr"] = d.Get("firewall_subnet_cidr")
-	request["TrAttachmentSlaveCidr"] = d.Get("tr_attachment_slave_cidr")
-	request["TrAttachmentMasterCidr"] = d.Get("tr_attachment_master_cidr")
 	request["CenId"] = d.Get("cen_id")
+	request["TrAttachmentMasterCidr"] = d.Get("tr_attachment_master_cidr")
 	if v, ok := d.GetOk("firewall_description"); ok {
 		request["FirewallDescription"] = v
 	}
 	if v, ok := d.GetOk("tr_attachment_slave_zone"); ok {
 		request["TrAttachmentSlaveZone"] = v
 	}
+	request["FirewallSubnetCidr"] = d.Get("firewall_subnet_cidr")
+	request["RouteMode"] = d.Get("route_mode")
+	request["RegionNo"] = d.Get("region_no")
+	request["TransitRouterId"] = d.Get("transit_router_id")
+	request["FirewallName"] = d.Get("firewall_name")
+	request["TrAttachmentSlaveCidr"] = d.Get("tr_attachment_slave_cidr")
 	if v, ok := d.GetOk("tr_attachment_master_zone"); ok {
 		request["TrAttachmentMasterZone"] = v
 	}
+	request["FirewallVpcCidr"] = d.Get("firewall_vpc_cidr")
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPostWithEndpoint("Cloudfw", "2017-12-07", action, query, request, false, endpoint)
@@ -169,40 +181,49 @@ func resourceAliCloudCloudFirewallVpcCenTrFirewallRead(d *schema.ResourceData, m
 		return WrapError(err)
 	}
 
-	if objectRaw["CenId"] != nil {
-		d.Set("cen_id", objectRaw["CenId"])
+	if v, ok := objectRaw["CenId"]; ok {
+		d.Set("cen_id", v)
 	}
-	if objectRaw["FirewallDescription"] != nil {
-		d.Set("firewall_description", objectRaw["FirewallDescription"])
+	if v, ok := objectRaw["FirewallDescription"]; ok {
+		d.Set("firewall_description", v)
 	}
-	if objectRaw["FirewallName"] != nil {
-		d.Set("firewall_name", objectRaw["FirewallName"])
+	if v, ok := objectRaw["FirewallName"]; ok {
+		d.Set("firewall_name", v)
 	}
-	if objectRaw["FirewallSubnetCidr"] != nil {
-		d.Set("firewall_subnet_cidr", objectRaw["FirewallSubnetCidr"])
+	if v, ok := objectRaw["FirewallSubnetCidr"]; ok {
+		d.Set("firewall_subnet_cidr", v)
 	}
-	if objectRaw["FirewallVpcCidr"] != nil {
-		d.Set("firewall_vpc_cidr", objectRaw["FirewallVpcCidr"])
+	if v, ok := objectRaw["FirewallVpcCidr"]; ok {
+		d.Set("firewall_vpc_cidr", v)
 	}
-	if objectRaw["RegionNo"] != nil {
-		d.Set("region_no", objectRaw["RegionNo"])
+	if v, ok := objectRaw["RegionNo"]; ok {
+		d.Set("region_no", v)
 	}
-	if objectRaw["RouteMode"] != nil {
-		d.Set("route_mode", objectRaw["RouteMode"])
+	if v, ok := objectRaw["RouteMode"]; ok {
+		d.Set("route_mode", v)
 	}
-	if objectRaw["FirewallStatus"] != nil {
-		d.Set("status", objectRaw["FirewallStatus"])
+	if v, ok := objectRaw["FirewallStatus"]; ok {
+		d.Set("status", v)
 	}
-	if objectRaw["TrAttachmentMasterCidr"] != nil {
-		d.Set("tr_attachment_master_cidr", objectRaw["TrAttachmentMasterCidr"])
+	if v, ok := objectRaw["TrAttachmentMasterCidr"]; ok {
+		d.Set("tr_attachment_master_cidr", v)
 	}
-	if objectRaw["TrAttachmentSlaveCidr"] != nil {
-		d.Set("tr_attachment_slave_cidr", objectRaw["TrAttachmentSlaveCidr"])
+	if v, ok := objectRaw["TrAttachmentSlaveCidr"]; ok {
+		d.Set("tr_attachment_slave_cidr", v)
 	}
-	if objectRaw["TransitRouterId"] != nil {
-		d.Set("transit_router_id", objectRaw["TransitRouterId"])
+	if v, ok := objectRaw["TransitRouterId"]; ok {
+		d.Set("transit_router_id", v)
 	}
 
+	if v, ok := objectRaw["FirewallEniId"]; ok {
+		d.Set("firewall_eni_id", v)
+	}
+	if v, ok := objectRaw["FirewallEniVpcId"]; ok {
+		d.Set("firewall_eni_vpc_id", v)
+	}
+	if v, ok := objectRaw["TrAttachmentId"]; ok {
+		d.Set("tr_attachment_id", v)
+	}
 	return nil
 }
 
@@ -217,7 +238,7 @@ func resourceAliCloudCloudFirewallVpcCenTrFirewallUpdate(d *schema.ResourceData,
 	var endpoint string
 	request = make(map[string]interface{})
 	query = make(map[string]interface{})
-	query["FirewallId"] = d.Id()
+	request["FirewallId"] = d.Id()
 
 	if d.HasChange("firewall_name") {
 		update = true
@@ -260,7 +281,7 @@ func resourceAliCloudCloudFirewallVpcCenTrFirewallDelete(d *schema.ResourceData,
 	var err error
 	var endpoint string
 	request = make(map[string]interface{})
-	query["FirewallId"] = d.Id()
+	request["FirewallId"] = d.Id()
 
 	runtime := util.RuntimeOptions{}
 	runtime.SetAutoretry(true)
@@ -283,14 +304,14 @@ func resourceAliCloudCloudFirewallVpcCenTrFirewallDelete(d *schema.ResourceData,
 	})
 
 	if err != nil {
-		if IsExpectedErrors(err, []string{"ErrorTrFirewallNotExist"}) {
+		if IsExpectedErrors(err, []string{"ErrorTrFirewallNotExist"}) || NotFoundError(err) {
 			return nil
 		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 
 	cloudFirewallServiceV2 := CloudFirewallServiceV2{client}
-	stateConf := BuildStateConf([]string{}, []string{}, d.Timeout(schema.TimeoutDelete), 30*time.Second, cloudFirewallServiceV2.CloudFirewallVpcCenTrFirewallStateRefreshFunc(d.Id(), "FirewallStatus", []string{}))
+	stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 30*time.Second, cloudFirewallServiceV2.CloudFirewallVpcCenTrFirewallStateRefreshFunc(d.Id(), "FirewallStatus", []string{}))
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}

--- a/alicloud/resource_alicloud_cloud_firewall_vpc_cen_tr_firewall_test.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_cen_tr_firewall_test.go
@@ -10,14 +10,89 @@ import (
 )
 
 // Test CloudFirewall VpcCenTrFirewall. >>> Resource test cases, automatically generated.
+// Case VpcCenTrFirewall全生命周期测试_副本1689148389922 3609
+func TestAccAliCloudCloudFirewallVpcCenTrFirewall_basic3609(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_firewall_vpc_cen_tr_firewall.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudFirewallVpcCenTrFirewallMap3609)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudFirewallServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudFirewallVpcCenTrFirewall")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudfirewall%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudFirewallVpcCenTrFirewallBasicDependence3609)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"firewall_description":      "VpcCenTrFirewall created by terraform",
+					"region_no":                 "${var.region}",
+					"route_mode":                "managed",
+					"cen_id":                    "${alicloud_cen_instance.cen.id}",
+					"firewall_vpc_cidr":         "${var.firewall_vpc_cidr}",
+					"transit_router_id":         "${alicloud_cen_transit_router.tr.transit_router_id}",
+					"tr_attachment_master_cidr": "${var.tr_attachment_master_cidr}",
+					"firewall_name":             name,
+					"firewall_subnet_cidr":      "${var.firewall_subnet_cidr}",
+					"tr_attachment_slave_cidr":  "${var.tr_attachment_slave_cidr}",
+					"tr_attachment_master_zone": "${var.zone1}",
+					"tr_attachment_slave_zone":  "${var.zone2}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"firewall_description":      "VpcCenTrFirewall created by terraform",
+						"region_no":                 CHECKSET,
+						"route_mode":                "managed",
+						"cen_id":                    CHECKSET,
+						"firewall_vpc_cidr":         CHECKSET,
+						"transit_router_id":         CHECKSET,
+						"tr_attachment_master_cidr": CHECKSET,
+						"firewall_name":             CHECKSET,
+						"firewall_subnet_cidr":      CHECKSET,
+						"tr_attachment_slave_cidr":  CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"firewall_name": "${var.firewall_name_update}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"firewall_name": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"tr_attachment_master_zone", "tr_attachment_slave_zone"},
+			},
+		},
+	})
+}
+
 var AlicloudCloudFirewallVpcCenTrFirewallMap3609 = map[string]string{
-	"status": CHECKSET,
+	"firewall_eni_vpc_id": CHECKSET,
+	"firewall_eni_id":     CHECKSET,
+	"tr_attachment_id":    CHECKSET,
+	"status":              CHECKSET,
 }
 
 func AlicloudCloudFirewallVpcCenTrFirewallBasicDependence3609(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
-    default = "%s"
+  default = "%s"
 }
 
 variable "description" {
@@ -105,6 +180,7 @@ resource "alicloud_route_table" "foo" {
 }
 
 resource "alicloud_cen_transit_router_vpc_attachment" "tr-vpc1" {
+  auto_publish_route_enabled = false
   zone_mappings {
     vswitch_id = alicloud_vswitch.vpc1vsw1.id
     zone_id    = data.alicloud_cen_transit_router_available_resources.default.resources[0].master_zones[1]
@@ -113,87 +189,11 @@ resource "alicloud_cen_transit_router_vpc_attachment" "tr-vpc1" {
     zone_id    = data.alicloud_cen_transit_router_available_resources.default.resources[0].master_zones[2]
     vswitch_id = alicloud_vswitch.vpc1vsw2.id
   }
-  vpc_id = alicloud_vpc.vpc1.id
-  cen_id = alicloud_cen_instance.cen.id
+  vpc_id            = alicloud_vpc.vpc1.id
+  cen_id            = alicloud_cen_instance.cen.id
   transit_router_id = alicloud_cen_transit_router.tr.transit_router_id
-  depends_on = [alicloud_route_table.foo]
-}
-
-
-
-`, name)
-}
-
-// Case VpcCenTrFirewall全生命周期测试_副本1689148389922 3609  raw
-func TestAccAliCloudCloudFirewallVpcCenTrFirewall_basic3609_raw(t *testing.T) {
-	var v map[string]interface{}
-	checkoutSupportedRegions(t, true, []connectivity.Region{"cn-hangzhou"})
-	resourceId := "alicloud_cloud_firewall_vpc_cen_tr_firewall.default"
-	ra := resourceAttrInit(resourceId, AlicloudCloudFirewallVpcCenTrFirewallMap3609)
-	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
-		return &CloudFirewallServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
-	}, "DescribeCloudFirewallVpcCenTrFirewall")
-	rac := resourceAttrCheckInit(rc, ra)
-	testAccCheck := rac.resourceAttrMapUpdateSet()
-	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc%scloudfirewallvpccentrfirewall%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudFirewallVpcCenTrFirewallBasicDependence3609)
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testAccPreCheck(t)
-		},
-		IDRefreshName: resourceId,
-		Providers:     testAccProviders,
-		CheckDestroy:  rac.checkResourceDestroy(),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"firewall_description":      "VpcCenTrFirewall created by terraform",
-					"region_no":                 "${var.region}",
-					"route_mode":                "managed",
-					"cen_id":                    "${alicloud_cen_transit_router_vpc_attachment.tr-vpc1.cen_id}",
-					"firewall_vpc_cidr":         "${var.firewall_vpc_cidr}",
-					"transit_router_id":         "${alicloud_cen_transit_router.tr.transit_router_id}",
-					"tr_attachment_master_cidr": "${var.tr_attachment_master_cidr}",
-					"firewall_name":             name,
-					"firewall_subnet_cidr":      "${var.firewall_subnet_cidr}",
-					"tr_attachment_slave_cidr":  "${var.tr_attachment_slave_cidr}",
-					"tr_attachment_master_zone": "${data.alicloud_cen_transit_router_available_resources.default.resources[0].master_zones[1]}",
-					"tr_attachment_slave_zone":  "${data.alicloud_cen_transit_router_available_resources.default.resources[0].master_zones[2]}",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"firewall_description":      "VpcCenTrFirewall created by terraform",
-						"region_no":                 CHECKSET,
-						"route_mode":                "managed",
-						"cen_id":                    CHECKSET,
-						"firewall_vpc_cidr":         CHECKSET,
-						"transit_router_id":         CHECKSET,
-						"tr_attachment_master_cidr": CHECKSET,
-						"firewall_name":             CHECKSET,
-						"firewall_subnet_cidr":      CHECKSET,
-						"tr_attachment_slave_cidr":  CHECKSET,
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"firewall_name": "${var.firewall_name_update}",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"firewall_name": CHECKSET,
-					}),
-				),
-			},
-			{
-				ResourceName:            resourceId,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"tr_attachment_master_zone", "tr_attachment_slave_zone"},
-			},
-		},
-	})
+  depends_on        = [alicloud_route_table.foo]
+}`, name)
 }
 
 // Test CloudFirewall VpcCenTrFirewall. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_cloud_firewall_v2.go
+++ b/alicloud/service_alicloud_cloud_firewall_v2.go
@@ -203,15 +203,18 @@ func (s *CloudFirewallServiceV2) DescribeCloudFirewallVpcCenTrFirewall(id string
 }
 
 func (s *CloudFirewallServiceV2) CloudFirewallVpcCenTrFirewallStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.CloudFirewallVpcCenTrFirewallStateRefreshFuncWithApi(id, field, failStates, s.DescribeCloudFirewallVpcCenTrFirewall)
+}
+
+func (s *CloudFirewallServiceV2) CloudFirewallVpcCenTrFirewallStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		object, err := s.DescribeCloudFirewallVpcCenTrFirewall(id)
+		object, err := call(id)
 		if err != nil {
 			if NotFoundError(err) {
-				return nil, "", nil
+				return object, "", nil
 			}
 			return nil, "", WrapError(err)
 		}
-
 		v, err := jsonpath.Get(field, object)
 		currentStatus := fmt.Sprint(v)
 

--- a/website/docs/r/cloud_firewall_vpc_cen_tr_firewall.html.markdown
+++ b/website/docs/r/cloud_firewall_vpc_cen_tr_firewall.html.markdown
@@ -20,12 +20,6 @@ For information about Cloud Firewall Vpc Cen Tr Firewall and how to use it, see 
 
 Basic Usage
 
-<div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
-  <a href="https://api.aliyun.com/terraform?resource=alicloud_cloud_firewall_vpc_cen_tr_firewall&exampleId=37a1e48f-5e2b-3aa6-5c58-4d9edb62f71ef8f83c50&activeTab=example&spm=docs.r.cloud_firewall_vpc_cen_tr_firewall.0.37a1e48f5e&intl_lang=EN_US" target="_blank">
-    <img alt="Open in AliCloud" src="https://img.alicdn.com/imgextra/i1/O1CN01hjjqXv1uYUlY56FyX_!!6000000006049-55-tps-254-36.svg" style="max-height: 44px; max-width: 100%;">
-  </a>
-</div></div>
-
 ```terraform
 variable "name" {
   default = "terraform-example"
@@ -161,33 +155,44 @@ resource "alicloud_cloud_firewall_vpc_cen_tr_firewall" "default" {
 ## Argument Reference
 
 The following arguments are supported:
-* `cen_id` - (Required, ForceNew) The ID of the CEN instance.
-* `firewall_description` - (Optional, ForceNew) Firewall description.
-* `firewall_name` - (Required) The name of Cloud Firewall.
-* `firewall_subnet_cidr` - (Required, ForceNew) Required in automatic mode, the CIDR of subnet used to store the firewall ENI in the firewall VPC.
-* `firewall_vpc_cidr` - (Required, ForceNew) Required in automatic mode,  th CIDR of firewall VPC.
+* `cen_id` - (Required, ForceNew) The ID of the Cloud Enterprise Network (CEN) instance.
+* `firewall_description` - (Optional, ForceNew) The description of the firewall.
+* `firewall_name` - (Required) The name of the Cloud Firewall.
+* `firewall_subnet_cidr` - (Required, ForceNew) The CIDR block of the subnet in the firewall VPC that hosts the firewall ENI in automatic mode.
+* `firewall_vpc_cidr` - (Required, ForceNew) The CIDR block of the firewall VPC in automatic mode.
 * `region_no` - (Required, ForceNew) The region ID of the transit router instance.
-* `route_mode` - (Required, ForceNew) The routing pattern. Value: managed: indicates automatic mode
+* `route_mode` - (Required, ForceNew) The routing mode. Valid values:
+  - `managed`: indicates automatic mode.
+  - `manual`: indicates manual mode.
 
-* `tr_attachment_master_cidr` - (Required, ForceNew) Required in automatic mode, the primary CIDR of network used to connect to the TR in the firewall VPC.
-* `tr_attachment_master_zone` - (Optional) The primary zone of the switch.
+ ~> **NOTE:**  If this parameter is not specified, VPC border firewalls in all routing modes are queried.
 
-* `tr_attachment_slave_cidr` - (Required, ForceNew) Required in automatic mode, the the secondary CIDR of the subnet in the firewall VPC used to connect to TR.
-* `tr_attachment_slave_zone` - (Optional) Switch standby area.
+* `tr_attachment_master_cidr` - (Required, ForceNew) The primary CIDR block of the subnet in the firewall VPC used to connect to the transit router (TR) in automatic mode.
+* `tr_attachment_master_zone` - (Optional) The primary zone of the vSwitch.
+ 
+ ~> **NOTE:** The parameter is immutable after resource creation. It only applies during resource creation and has no effect when modified post-creation.
 
-* `transit_router_id` - (Required, ForceNew) The ID of the transit router instance.
+* `tr_attachment_slave_cidr` - (Required, ForceNew) The secondary CIDR block of the subnet in the firewall VPC used to connect to TR in automatic mode.
+* `tr_attachment_slave_zone` - (Optional) The secondary zone of the vSwitch.
+
+ ~> **NOTE:** The parameter is immutable after resource creation. It only applies during resource creation and has no effect when modified post-creation.
+
+* `transit_router_id` - (Required, ForceNew) The ID of the Transit Router instance.
 
 ## Attributes Reference
 
 The following attributes are exported:
-* `id` - The ID of the resource supplied above.
-* `status` - Firewall status. Value:
+* `id` - The ID of the resource supplied above. 
+* `firewall_eni_id` - The ID of the firewall ENI.
+* `firewall_eni_vpc_id` - The ID of the VPC where the firewall ENI resides.
+* `tr_attachment_id` - The ID of the VPC where the firewall ENI resides.
+* `status` - The status of the firewall.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
-* `create` - (Defaults to 5 mins) Used when create the Vpc Cen Tr Firewall.
-* `delete` - (Defaults to 5 mins) Used when delete the Vpc Cen Tr Firewall.
+* `create` - (Defaults to 41 mins) Used when create the Vpc Cen Tr Firewall.
+* `delete` - (Defaults to 46 mins) Used when delete the Vpc Cen Tr Firewall.
 * `update` - (Defaults to 5 mins) Used when update the Vpc Cen Tr Firewall.
 
 ## Import
@@ -195,5 +200,5 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 Cloud Firewall Vpc Cen Tr Firewall can be imported using the id, e.g.
 
 ```shell
-$ terraform import alicloud_cloud_firewall_vpc_cen_tr_firewall.example <id>
+$ terraform import alicloud_cloud_firewall_vpc_cen_tr_firewall.example <firewall_id>
 ```


### PR DESCRIPTION
Add support for `firewall_eni_id`, `firewall_eni_vpc_id`, `tr_attachment_id`
```log
=== RUN   TestAccAliCloudCloudFirewallVpcCenTrFirewall_basic3609
--- PASS: TestAccAliCloudCloudFirewallVpcCenTrFirewall_basic3609 (615.74s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  618.743s

```