### PR TITLE
resource/alicloud_nlb_server_group: support health_check_http_version; data-source/alicloud_nlb_server_groups: support health_check_http_version

### DIFF
--- a/alicloud/data_source_alicloud_nlb_server_groups.go
+++ b/alicloud/data_source_alicloud_nlb_server_groups.go
@@ -107,6 +107,10 @@ func dataSourceAlicloudNlbServerGroups() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"health_check_http_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 									"health_check_url": {
 										Type:     schema.TypeString,
 										Computed: true,
@@ -301,6 +305,7 @@ func dataSourceAlicloudNlbServerGroupsRead(d *schema.ResourceData, meta interfac
 				healthCheckMap["health_check_interval"] = healthCheck["HealthCheckInterval"]
 				healthCheckMap["health_check_type"] = healthCheck["HealthCheckType"]
 				healthCheckMap["health_check_url"] = healthCheck["HealthCheckUrl"]
+				healthCheckMap["health_check_http_version"] = healthCheck["HealthCheckHttpVersion"]
 				healthCheckMap["healthy_threshold"] = healthCheck["HealthyThreshold"]
 				healthCheckMap["unhealthy_threshold"] = healthCheck["UnhealthyThreshold"]
 				healthCheckMap["http_check_method"] = healthCheck["HttpCheckMethod"]

--- a/alicloud/resource_alicloud_nlb_server_group.go
+++ b/alicloud/resource_alicloud_nlb_server_group.go
@@ -129,6 +129,12 @@ func resourceAliCloudNlbServerGroup() *schema.Resource {
 							Computed:     true,
 							ValidateFunc: StringInSlice([]string{"TCP", "HTTP", "UDP"}, false),
 						},
+						"health_check_http_version": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: StringInSlice([]string{"HTTP1.0", "HTTP1.1"}, false),
+						},
 					},
 				},
 			},
@@ -291,6 +297,10 @@ func resourceAliCloudNlbServerGroupCreate(d *schema.ResourceData, meta interface
 		if healthCheckExp1 != nil && healthCheckExp1 != "" {
 			objectDataLocalMap["HealthCheckExp"] = healthCheckExp1
 		}
+		healthCheckHttpVersion1, _ := jsonpath.Get("$[0].health_check_http_version", v)
+		if healthCheckHttpVersion1 != nil && healthCheckHttpVersion1 != "" {
+			objectDataLocalMap["HealthCheckHttpVersion"] = healthCheckHttpVersion1
+		}
 
 		request["HealthCheckConfig"] = objectDataLocalMap
 	}
@@ -375,6 +385,7 @@ func resourceAliCloudNlbServerGroupRead(d *schema.ResourceData, meta interface{}
 		healthCheckMap["healthy_threshold"] = healthCheckRaw["HealthyThreshold"]
 		healthCheckMap["http_check_method"] = healthCheckRaw["HttpCheckMethod"]
 		healthCheckMap["unhealthy_threshold"] = healthCheckRaw["UnhealthyThreshold"]
+		healthCheckMap["health_check_http_version"] = healthCheckRaw["HealthCheckHttpVersion"]
 
 		healthCheckHttpCodeRaw := make([]interface{}, 0)
 		if healthCheckRaw["HealthCheckHttpCode"] != nil {
@@ -490,6 +501,10 @@ func resourceAliCloudNlbServerGroupUpdate(d *schema.ResourceData, meta interface
 			healthCheckExp1, _ := jsonpath.Get("$[0].health_check_exp", v)
 			if healthCheckExp1 != nil && (d.HasChange("health_check.0.health_check_exp") || healthCheckExp1 != "") {
 				objectDataLocalMap["HealthCheckExp"] = healthCheckExp1
+			}
+			healthCheckHttpVersion1, _ := jsonpath.Get("$[0].health_check_http_version", v)
+			if healthCheckHttpVersion1 != nil && (d.HasChange("health_check.0.health_check_http_version") || healthCheckHttpVersion1 != "") {
+				objectDataLocalMap["HealthCheckHttpVersion"] = healthCheckHttpVersion1
 			}
 
 			request["HealthCheckConfig"] = objectDataLocalMap

--- a/alicloud/resource_alicloud_nlb_server_group_test.go
+++ b/alicloud/resource_alicloud_nlb_server_group_test.go
@@ -172,6 +172,7 @@ func TestAccAliCloudNlbServerGroup_basic0(t *testing.T) {
 							"health_check_domain":          "tf-testAcc.com",
 							"health_check_http_code":       []string{"http_2xx", "http_3xx", "http_4xx"},
 							"health_check_type":            "HTTP",
+							"health_check_http_version":    "HTTP1.0",
 						},
 					},
 				}),
@@ -210,12 +211,39 @@ func TestAccAliCloudNlbServerGroup_basic0(t *testing.T) {
 							"health_check_domain":          "tf-testAcc.com",
 							"health_check_http_code":       []string{"http_2xx", "http_3xx", "http_4xx"},
 							"health_check_type":            "HTTP",
+							"health_check_http_version":    "HTTP1.0",
 						},
 					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"health_check.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"health_check": []map[string]interface{}{
+						{
+							"health_check_interval":        "2",
+							"health_check_url":             "/tf-testAcc",
+							"unhealthy_threshold":          "3",
+							"health_check_connect_timeout": "1",
+							"health_check_enabled":         "true",
+							"health_check_connect_port":    "46325",
+							"healthy_threshold":            "3",
+							"http_check_method":            "HEAD",
+							"health_check_domain":          "tf-testAcc.com",
+							"health_check_http_code":       []string{"http_2xx", "http_3xx", "http_4xx"},
+							"health_check_type":            "HTTP",
+							"health_check_http_version":    "HTTP1.1",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"health_check.#":                           "1",
+						"health_check.0.health_check_http_version": "HTTP1.1",
 					}),
 				),
 			},
@@ -349,6 +377,7 @@ func TestAccAliCloudNlbServerGroup_basic0_twin(t *testing.T) {
 							"health_check_domain":          "tf-testAcc.com",
 							"health_check_http_code":       []string{"http_2xx", "http_3xx", "http_4xx"},
 							"health_check_type":            "HTTP",
+							"health_check_http_version":    "HTTP1.0",
 						},
 					},
 					"preserve_client_ip_enabled": "false",
@@ -405,7 +434,7 @@ var AliCloudNLBServerGroupMap0 = map[string]string{
 }
 
 func AliCloudNLBServerGroupBasicDependence0(name string) string {
-	return fmt.Sprintf(` 
+	return fmt.Sprintf(`
 variable "name" {
   default = "%s"
 }
@@ -628,6 +657,7 @@ func TestUnitAccAliCloudNlbServerGroup(t *testing.T) {
 					"HealthCheckUrl":            "CreateNlbServerGroupValue",
 					"HealthCheckHttpCode":       []string{"CreateNlbServerGroupValue"},
 					"HttpCheckMethod":           "CreateNlbServerGroupValue",
+					"HealthCheckHttpVersion":    "CreateNlbServerGroupValue",
 				},
 				"ConnectionDrainEnabled":  true,
 				"ConnectionDrainTimeout":  60,
@@ -763,6 +793,7 @@ func TestUnitAccAliCloudNlbServerGroup(t *testing.T) {
 					"HealthCheckUrl":            "UpdateNlbServerGroupValue",
 					"HealthCheckHttpCode":       []string{"UpdateNlbServerGroupValue"},
 					"HttpCheckMethod":           "UpdateNlbServerGroupValue",
+					"HealthCheckHttpVersion":    "UpdateNlbServerGroupValue",
 				},
 			},
 		},
@@ -1275,7 +1306,8 @@ func TestAccAliCloudNlbServerGroup_basic4668(t *testing.T) {
 							"health_check_url":             "/rdk",
 							"health_check_http_code": []string{
 								"http_2xx", "http_3xx", "http_4xx"},
-							"http_check_method": "HEAD",
+							"http_check_method":         "HEAD",
+							"health_check_http_version": "HTTP1.0",
 						},
 					},
 					"scheduler":                "Qch",
@@ -2155,7 +2187,8 @@ func TestAccAliCloudNlbServerGroup_basic5353(t *testing.T) {
 							"health_check_url":             "/rdktest",
 							"health_check_http_code": []string{
 								"http_2xx"},
-							"http_check_method": "HEAD",
+							"http_check_method":         "HEAD",
+							"health_check_http_version": "HTTP1.0",
 						},
 					},
 					"connection_drain_timeout": "10",
@@ -2353,7 +2386,8 @@ func TestAccAliCloudNlbServerGroup_basic4668_twin(t *testing.T) {
 							"health_check_url":             "/rdk",
 							"health_check_http_code": []string{
 								"http_2xx", "http_3xx", "http_4xx"},
-							"http_check_method": "HEAD",
+							"http_check_method":         "HEAD",
+							"health_check_http_version": "HTTP1.0",
 						},
 					},
 					"scheduler":                "Qch",
@@ -2433,7 +2467,8 @@ func TestAccAliCloudNlbServerGroup_basic4639_twin(t *testing.T) {
 							"health_check_url":             "/rdk",
 							"health_check_http_code": []string{
 								"http_2xx", "http_3xx", "http_4xx"},
-							"http_check_method": "HEAD",
+							"http_check_method":         "HEAD",
+							"health_check_http_version": "HTTP1.0",
 						},
 					},
 					"scheduler":                "Tch",
@@ -2512,7 +2547,8 @@ func TestAccAliCloudNlbServerGroup_basic4662_twin(t *testing.T) {
 							"health_check_url":             "/rdk",
 							"health_check_http_code": []string{
 								"http_2xx", "http_3xx", "http_4xx"},
-							"http_check_method": "HEAD",
+							"http_check_method":         "HEAD",
+							"health_check_http_version": "HTTP1.0",
 						},
 					},
 					"scheduler":                "Wrr",

--- a/website/docs/d/nlb_server_groups.html.markdown
+++ b/website/docs/d/nlb_server_groups.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 This data source provides the Nlb Server Groups of the current Alibaba Cloud user.
 
--> **NOTE:** Available in v1.186.0+.
+-> **NOTE:** Available since v1.186.0+.
 
 ## Example Usage
 
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `server_group_type` - (Optional, ForceNew) The type of the server group. Valid values: `Instance`, `Ip`.
 * `status` - (Optional, ForceNew) The status of the resource. Valid values: `Available`, `Configuring`, `Creating`.
 
-## Argument Reference
+## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
 
@@ -55,6 +55,7 @@ The following attributes are exported in addition to the arguments listed above:
 	* `health_check` - The configurations of health checks.
 		* `health_check_interval` - The interval between two consecutive health checks.
 		* `health_check_type` - The protocol that is used for health checks.
+		* `health_check_http_version` - The HTTP protocol version for health checks.
 		* `healthy_threshold` - The number of times that an unhealthy backend server must consecutively pass health checks before it is declared healthy.
 		* `unhealthy_threshold` - The number of times that a healthy backend server must consecutively fail health checks before it is declared unhealthy.
 		* `health_check_http_code` - The HTTP status codes returned for health checks.

--- a/website/docs/r/nlb_server_group.html.markdown
+++ b/website/docs/r/nlb_server_group.html.markdown
@@ -142,6 +142,10 @@ Valid values: `5` to `50`.
 Default value: `10`.
 * `health_check_req` - (Optional, Available since v1.243.0) UDP healthy check request string, the value is a character string of 512 characters
 * `health_check_type` - (Optional, Computed) The protocol that you want to use for health checks. Valid values: `TCP` (default) and `HTTP`.
+* `health_check_http_version` - (Optional, Computed) The HTTP protocol version for health checks. Valid values: `HTTP1.0` (default) and `HTTP1.1`.
+
+-> **NOTE:**  This parameter takes effect only when `HealthCheckType` is set to `HTTP`.
+
 * `health_check_url` - (Optional, Computed) The path to which health check requests are sent.
 
 The path must be 1 to 80 characters in length, and can contain only letters, digits, and the following special characters: `- / . % ? # & =`. It can also contain the following extended characters: `_ ; ~ ! ( ) * [ ] @ $ ^ : ' , +`. The path must start with a forward slash (/).


### PR DESCRIPTION
Support `health_check_http_version` in nlb server group resource and datasource.

Ref:
- [CreateServerGroup](https://help.aliyun.com/zh/slb/network-load-balancer/developer-reference/api-nlb-2022-04-30-createservergroup?spm=a2c4g.11186623.help-menu-27537.d_4_0_4_5_0.165b519440v9Ts&scm=20140722.H_2399217._.OR_help-T_cn~zh-V_1)
- [ListServerGroups](https://help.aliyun.com/zh/slb/network-load-balancer/developer-reference/api-nlb-2022-04-30-listservergroups?spm=a2c4g.11186623.help-menu-27537.d_4_0_4_5_6.dbf85194eFRWCR&scm=20140722.H_2399223._.OR_help-T_cn~zh-V_1)