### PR TITLE
resource/alicloud_config_aggregator: Fix the number parsing overflow issue

### DIFF
--- a/alicloud/resource_alicloud_config_aggregator.go
+++ b/alicloud/resource_alicloud_config_aggregator.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -162,7 +163,13 @@ func resourceAliCloudConfigAggregatorRead(d *schema.ResourceData, meta interface
 
 	d.Set("aggregator_name", objectRaw["AggregatorName"])
 	d.Set("aggregator_type", objectRaw["AggregatorType"])
-	d.Set("create_time", formatInt(objectRaw["AggregatorCreateTimestamp"]))
+
+	createTime, err := strconv.ParseInt(objectRaw["AggregatorCreateTimestamp"].(json.Number).String(), 10, 64)
+	if err != nil {
+		return WrapError(err)
+	}
+	d.Set("create_time", createTime)
+
 	d.Set("description", objectRaw["Description"])
 	d.Set("folder_id", objectRaw["FolderId"])
 	d.Set("status", convertConfigAggregatorAggregatorAggregatorStatusResponse(objectRaw["AggregatorStatus"]))


### PR DESCRIPTION
Fix the number parse overflow issue.

```log
=== RUN   TestAccAliCloudConfigAggregator_basic11746
--- PASS: TestAccAliCloudConfigAggregator_basic11746 (19.65s)
=== RUN   TestAccAliCloudConfigAggregator_basic11746_twin
--- PASS: TestAccAliCloudConfigAggregator_basic11746_twin (12.72s)
=== RUN   TestAccAliCloudConfigAggregator_basic11747
--- PASS: TestAccAliCloudConfigAggregator_basic11747 (30.00s)
=== RUN   TestAccAliCloudConfigAggregator_basic11747_twin
--- PASS: TestAccAliCloudConfigAggregator_basic11747_twin (11.58s)
=== RUN   TestAccAliCloudConfigAggregator_basic11748
--- PASS: TestAccAliCloudConfigAggregator_basic11748 (22.32s)
=== RUN   TestAccAliCloudConfigAggregator_basic11748_twin
--- PASS: TestAccAliCloudConfigAggregator_basic11748_twin (11.05s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  110.306s

```