### PR TITLE
data-source/alicloud_ram_groups: Handle 404 error

### DIFF
--- a/alicloud/data_source_alicloud_ram_groups.go
+++ b/alicloud/data_source_alicloud_ram_groups.go
@@ -152,7 +152,7 @@ func dataSourceAlicloudRamGroupsRead(d *schema.ResourceData, meta interface{}) e
 			addDebug(request.GetActionName(), raw, request.RpcRequest, request)
 			return nil
 		})
-		if err != nil {
+		if err != nil && !NotFoundError(err) {
 			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_ram_groups", request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 


### PR DESCRIPTION
Fix the issue that no groups found. 

Test log:
```log
=== RUN   TestAccAlicloudRAMGroupsDataSource
--- PASS: TestAccAlicloudRAMGroupsDataSource (50.73s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  53.848s
```

404 Error not handled:
```log
│ Error: [ERROR] terraform-provider-alicloud/alicloud/data_source_alicloud_ram_groups.go:156: Datasource alicloud_ram_groups ListGroupsForUser Failed!!! [SDK alibaba-cloud-sdk-go ERROR]:
│ SDK.ServerError
│ ErrorCode: EntityNotExist.User
│ Recommend: https://api.aliyun.com/troubleshoot?q=EntityNotExist.User&product=Ram&requestId=xxx
│ RequestId: xxxx
│ Message: account not exists
│ RespHeaders: map[Access-Control-Allow-Origin:[*] Access-Control-Expose-Headers:[*] Connection:[keep-alive] Content-Length:[271] Content-Type:[application/json;charset=utf-8] Date:[Wed, 04 Mar 2026 12:34:05 GMT] Keep-Alive:[timeout=25] X-Acs-Request-Id:[xxxx] X-Acs-Trace-Id:[xxx]]

```