### PR TITLE
resource/alicloud_cs_kubernetes_addon: marks next_version and can_upgrade attributes as deprecated, fix potential panic when updating addon; improve tests

### DIFF
--- a/alicloud/data_source_alicloud_cs_kubernetes_addon_metadata_test.go
+++ b/alicloud/data_source_alicloud_cs_kubernetes_addon_metadata_test.go
@@ -24,7 +24,10 @@ func TestAccAliCloudCSKubernetesAddonMetadataDataSource(t *testing.T) {
 				Config: dataSourceCSAddonMetadataConfigDependence(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"cluster_id": CHECKSET,
+						"cluster_id":    CHECKSET,
+						"name":          CHECKSET,
+						"version":       "v0.16.6",
+						"config_schema": REGEXMATCH + `[\s\S]+`,
 					}),
 				),
 			},
@@ -35,22 +38,22 @@ func TestAccAliCloudCSKubernetesAddonMetadataDataSource(t *testing.T) {
 func dataSourceCSAddonMetadataConfigDependence(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
-	default = "%s"
+  default = "%s"
 }
 
 data "alicloud_zones" "default" {
-  available_resource_creation  = "VSwitch"
+  available_resource_creation = "VSwitch"
 }
 
 data "alicloud_instance_types" "default" {
-	availability_zone          = data.alicloud_zones.default.zones.0.id
-	cpu_core_count             = 4
-	memory_size                = 8
-	kubernetes_node_role       = "Worker"
+  availability_zone    = data.alicloud_zones.default.zones.0.id
+  cpu_core_count       = 4
+  memory_size          = 8
+  kubernetes_node_role = "Worker"
 }
 
 data "alicloud_vpcs" "default" {
-    name_regex = "^default-NODELETING-ACK$"
+  name_regex = "^default-NODELETING-ACK$"
 }
 
 data "alicloud_vswitches" "default" {
@@ -59,11 +62,11 @@ data "alicloud_vswitches" "default" {
 }
 
 resource "alicloud_vswitch" "vswitch" {
-  count             = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
-  vpc_id            = data.alicloud_vpcs.default.ids.0
-  cidr_block        = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 8)
-  zone_id           = data.alicloud_zones.default.zones.0.id
-  vswitch_name      = var.name
+  count        = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
+  vpc_id       = data.alicloud_vpcs.default.ids.0
+  cidr_block   = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 8)
+  zone_id      = data.alicloud_zones.default.zones.0.id
+  vswitch_name = var.name
 }
 
 locals {
@@ -74,17 +77,44 @@ locals {
 resource "alicloud_cs_managed_kubernetes" "default" {
   name                 = var.name
   cluster_spec         = "ack.pro.small"
-  worker_vswitch_ids   = [local.vswitch_id]
+  vswitch_ids          = [local.vswitch_id]
+  pod_vswitch_ids      = [local.vswitch_id]
   new_nat_gateway      = false
-  pod_cidr             = cidrsubnet("10.0.0.0/8", 8, 37)
   service_cidr         = cidrsubnet("172.16.0.0/16", 4, 7)
-  slb_internet_enabled = true
+  slb_internet_enabled = false
+  addons {
+    name = "terway-eniip"
+  }
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "ALB"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "SLB"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "SLS_Data"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "SLS_ControlPlane"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "PrivateZone"
+  }
 }
 
 data "alicloud_cs_kubernetes_addon_metadata" "default" {
   cluster_id = alicloud_cs_managed_kubernetes.default.id
-  name       = "migrate-controller"
-  version    = "v1.6.3-6fd55d8-aliyun"
+  name       = "security-inspector"
+  version    = "v0.16.6"
 }
 `, name)
 }

--- a/alicloud/data_source_alicloud_cs_kubernetes_addons_test.go
+++ b/alicloud/data_source_alicloud_cs_kubernetes_addons_test.go
@@ -24,7 +24,72 @@ func TestAccAliCloudCSKubernetesAddonsDataSource(t *testing.T) {
 				Config: dataSourceCSAddonsConfigDependence(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"cluster_id": CHECKSET,
+						"cluster_id":    CHECKSET,
+						"names.#":       CHECKSET,
+						"addons.#":      CHECKSET,
+						"addons.0.name": CHECKSET,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAliCloudCSKubernetesAddonsDataSource_installed(t *testing.T) {
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccCSKubernetesAddons-%d", rand)
+
+	resourceId := "data.alicloud_cs_kubernetes_addons.installed-metrics-server"
+	testAccCheck := resourceAttrInit(resourceId, map[string]string{}).resourceAttrMapUpdateSet()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataSourceCSAddonsConfigDependence(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cluster_id":               CHECKSET,
+						"addons.#":                 "1",
+						"names.#":                  "1",
+						"addons.0.name":            "metrics-server",
+						"addons.0.current_config":  REGEXMATCH + "^.+$",
+						"addons.0.current_version": REGEXMATCH + "^.+$",
+						"addons.0.next_version":    "",
+						"addons.0.required":        CHECKSET,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAliCloudCSKubernetesAddonsDataSource_notInstalled(t *testing.T) {
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccCSKubernetesAddons-%d", rand)
+
+	resourceId := "data.alicloud_cs_kubernetes_addons.not-installed-alb-ingress-controller"
+	testAccCheck := resourceAttrInit(resourceId, map[string]string{}).resourceAttrMapUpdateSet()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dataSourceCSAddonsConfigDependence(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cluster_id":               CHECKSET,
+						"names.#":                  "1",
+						"addons.#":                 "1",
+						"addons.0.name":            "alb-ingress-controller",
+						"addons.0.current_config":  "",
+						"addons.0.current_version": "",
+						"addons.0.next_version":    CHECKSET,
+						"addons.0.required":        CHECKSET,
 					}),
 				),
 			},
@@ -70,13 +135,61 @@ resource "alicloud_cs_managed_kubernetes" "default" {
   cluster_spec                 = "ack.pro.small"
   is_enterprise_security_group = true
   deletion_protection          = false
-  pod_cidr                     = cidrsubnet("10.0.0.0/8", 8, 32)
   service_cidr                 = cidrsubnet("172.16.0.0/16", 4, 3)
-  worker_vswitch_ids           = [local.vswitch_id]
+  vswitch_ids                  = [local.vswitch_id]
+  pod_vswitch_ids              = [local.vswitch_id]
+  new_nat_gateway              = false
+  slb_internet_enabled         = false
+  addons {
+    name = "terway-eniip"
+  }
+  addons {
+    name = "metrics-server"
+    config = jsonencode({
+      MemoryRequest = "500Mi"
+      CpuRequest    = "250m"
+      MemoryLimit   = "8Gi"
+      CpuLimit      = "4"
+    })
+  }
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "ALB"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "SLB"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "SLS_Data"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "SLS_ControlPlane"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "PrivateZone"
+  }
 }
 
 data "alicloud_cs_kubernetes_addons" "default" {
   cluster_id = alicloud_cs_managed_kubernetes.default.0.id
+}
+
+data "alicloud_cs_kubernetes_addons" "installed-metrics-server" {
+  cluster_id = alicloud_cs_managed_kubernetes.default.0.id
+  name_regex = "^metrics-server"
+}
+
+data "alicloud_cs_kubernetes_addons" "not-installed-alb-ingress-controller" {
+  cluster_id = alicloud_cs_managed_kubernetes.default.0.id
+  name_regex = "^alb-ingress-controller"
 }
 `, name)
 }

--- a/alicloud/resource_alicloud_cs_kubernetes_addon.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_addon.go
@@ -46,12 +46,14 @@ func resourceAlicloudCSKubernetesAddon() *schema.Resource {
 				Computed: true,
 			},
 			"next_version": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "Field 'next_version' has been deprecated from provider version 1.273.0. Please use 'next_version' of DataSource 'alicloud_cs_kubernetes_addons' to replace it",
 			},
 			"can_upgrade": {
-				Type:     schema.TypeBool,
-				Computed: true,
+				Type:       schema.TypeBool,
+				Computed:   true,
+				Deprecated: "Field 'can_upgrade' has been deprecated from provider version 1.273.0. Please compare 'next_version' and 'current_version' of DataSource 'alicloud_cs_kubernetes_addons' to replace it",
 			},
 			"required": {
 				Type:     schema.TypeBool,
@@ -147,13 +149,6 @@ func resourceAlicloudCSKubernetesAddonCreate(d *schema.ResourceData, meta interf
 				return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "installAddon", err)
 			}
 
-			stateConf := BuildStateConf([]string{}, []string{"active", "Success", "NoUpgrade"}, d.Timeout(schema.TimeoutCreate), 10*time.Second, csClient.CsKubernetesAddonStateRefreshFunc(clusterId, name, []string{"Failed", "Canceled", "unhealthy"}))
-			if _, err = stateConf.WaitForState(); err != nil {
-				status, _ := csClient.DescribeCsKubernetesAddonStatus(clusterId, name)
-				if status != nil && status.Status != "Success" && status.Error != nil {
-					return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "WaitForSuccessAfterCreate", status.Error)
-				}
-			}
 			// double check addon installed
 			_, err = csClient.DescribeCsKubernetesAddon(d.Id())
 			if NotFoundError(err) {
@@ -172,15 +167,26 @@ func resourceAlicloudCSKubernetesAddonCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceAlicloudCSKubernetesAddonUpdate(d *schema.ResourceData, meta interface{}) error {
+	parts, err := ParseResourceId(d.Id(), 2)
+	if err != nil {
+		return WrapError(err)
+	}
+	clusterId := parts[0]
+	addonName := parts[1]
+
 	client, err := meta.(*connectivity.AliyunClient).NewRoaCsClient()
 	if err != nil {
 		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "InitializeClient", err)
 	}
 	csClient := CsClient{client}
 
-	addon, err := csClient.DescribeCsKubernetesAddon(d.Id())
-	if err != nil && !NotFoundError(err) {
+	addon, err := csClient.GetCsKubernetesAddonInstance(clusterId, addonName)
+	if err != nil {
 		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeCsKubernetesAddonStatus", err)
+	}
+
+	if addon == nil {
+		return WrapError(fmt.Errorf("addon %s not found", d.Id()))
 	}
 
 	if d.HasChange("version") || d.HasChange("config") {
@@ -194,8 +200,12 @@ func resourceAlicloudCSKubernetesAddonUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourceAlicloudCSKubernetesAddonDelete(d *schema.ResourceData, meta interface{}) error {
-	clusterId := d.Get("cluster_id").(string)
-	name := d.Get("name").(string)
+	parts, err := ParseResourceId(d.Id(), 2)
+	if err != nil {
+		return WrapError(err)
+	}
+	clusterId := parts[0]
+	addonName := parts[1]
 
 	client, err := meta.(*connectivity.AliyunClient).NewRoaCsClient()
 	if err != nil {
@@ -203,44 +213,36 @@ func resourceAlicloudCSKubernetesAddonDelete(d *schema.ResourceData, meta interf
 	}
 	csClient := CsClient{client}
 
-	addonsMetadata, err := csClient.DescribeClusterAddonsMetadata(clusterId)
+	addon, err := csClient.GetCsKubernetesAddonInstance(clusterId, addonName)
 	if err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeCsKubernetesAddonsMetadata", err)
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeCsKubernetesAddon", err)
 	}
-	addon, ok := addonsMetadata[name]
-	if !ok {
-		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeCsKubernetesAddonMetadata", err)
-	}
+
 	if addon.Required || !IsContain(addon.SupportedActions, "Uninstall") {
-		log.Printf("[DEBUG] Skip delete system addon %s\n", name)
+		log.Printf("[DEBUG] Skip delete system addon %s\n", addonName)
 		return nil
 	}
 
 	err = csClient.uninstallAddon(d)
 	if err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "uninstallAddon", err)
-	}
-
-	stateConf := BuildStateConf([]string{"deleting"}, []string{"deleted"}, d.Timeout(schema.TimeoutDelete), 10*time.Second, csClient.CsKubernetesAddonExistRefreshFunc(clusterId, name))
-	if _, err := stateConf.WaitForState(); err != nil {
-		status, _ := csClient.DescribeCsKubernetesAddonStatus(clusterId, name)
-		if status != nil && status.Error != nil {
-			return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "WaitForSuccessAfterDelete", status.Error)
+		if NotFoundError(err) {
+			return nil
 		}
-		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "WaitForSuccessAfterDelete", d.Id())
+		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "uninstallAddon", err)
 	}
 
 	return nil
 }
 
 func updateAddon(csClient CsClient, d *schema.ResourceData, addon *Component) error {
-	clusterId := d.Get("cluster_id").(string)
-	name := d.Get("name").(string)
-
 	updateVersion, updateConfig, err := needUpgrade(d, addon)
 	if err != nil {
 		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "upgradeAddon", err)
 	}
+
 	if updateVersion {
 		err := csClient.upgradeAddon(d, updateVersion, updateConfig)
 		if err != nil {
@@ -251,18 +253,6 @@ func updateAddon(csClient CsClient, d *schema.ResourceData, addon *Component) er
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "updateAddonConfig", err)
 		}
-	}
-	if !updateVersion && !updateConfig {
-		return nil
-	}
-
-	stateConf := BuildStateConf([]string{}, []string{"Success"}, d.Timeout(schema.TimeoutUpdate), 10*time.Second, csClient.CsKubernetesAddonTaskRefreshFunc(clusterId, name, []string{"Failed"}))
-	if _, err := stateConf.WaitForState(); err != nil {
-		status, _ := csClient.DescribeCsKubernetesAddonStatus(clusterId, name)
-		if status != nil && status.Error != nil {
-			return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "WaitForSuccessAfterUpdate", status.Error)
-		}
-		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "WaitForSuccessAfterUpdate", d.Id())
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_cs_kubernetes_addon_test.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_addon_test.go
@@ -381,10 +381,10 @@ data "alicloud_zones" "default" {
 data "alicloud_resource_manager_resource_groups" "default" {}
 
 data "alicloud_instance_types" "default" {
-  availability_zone    = data.alicloud_zones.default.zones.0.id
-  cpu_core_count       = 4
-  memory_size          = 8
-  eni_amount           = 4
+  availability_zone = data.alicloud_zones.default.zones.0.id
+  cpu_core_count    = 4
+  memory_size       = 8
+  eni_amount        = 4
 }
 
 data "alicloud_vpcs" "default" {
@@ -404,29 +404,48 @@ resource "alicloud_vswitch" "vswitch" {
   vswitch_name = var.name
 }
 
-data "alicloud_cs_managed_kubernetes_clusters" "default" {
-  name_regex = "^Terway-Default"
-}
 
 resource "alicloud_cs_managed_kubernetes" "default" {
-  count                = length(data.alicloud_cs_managed_kubernetes_clusters.default.ids) > 0 ? 0 : 1
-  name_prefix          = var.name
-  cluster_spec         = "ack.pro.small"
-  worker_vswitch_ids   = [local.vswitch_id]
-  pod_vswitch_ids      = [local.vswitch_id]
-  new_nat_gateway      = false
-  service_cidr         = cidrsubnet("172.16.0.0/16", 4, 7)
-  slb_internet_enabled = false
+  name_prefix                  = var.name
+  cluster_spec                 = "ack.pro.small"
+  vswitch_ids                  = [local.vswitch_id]
+  pod_vswitch_ids              = [local.vswitch_id]
+  new_nat_gateway              = false
+  service_cidr                 = cidrsubnet("172.16.0.0/16", 4, 7)
+  slb_internet_enabled         = false
   is_enterprise_security_group = true
   addons {
     name = "terway-eniip"
   }
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "ALB"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "SLB"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "SLS_Data"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "SLS_ControlPlane"
+  }
+
+  delete_options {
+    delete_mode   = "delete"
+    resource_type = "PrivateZone"
+  }
 }
 
 resource "alicloud_cs_kubernetes_node_pool" "default" {
-  count                = length(data.alicloud_cs_managed_kubernetes_clusters.default.ids) > 0 ? 0 : 1
-  name                 = var.name
-  cluster_id           = local.cluster_id
+  node_pool_name       = var.name
+  cluster_id           = alicloud_cs_managed_kubernetes.default.id
   vswitch_ids          = [local.vswitch_id]
   instance_types       = [data.alicloud_instance_types.default.instance_types.0.id]
   system_disk_category = "cloud_essd"
@@ -436,7 +455,7 @@ resource "alicloud_cs_kubernetes_node_pool" "default" {
 
 locals {
   vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : concat(alicloud_vswitch.vswitch.*.id, [""])[0]
-  cluster_id = length(data.alicloud_cs_managed_kubernetes_clusters.default.ids) > 0 ? data.alicloud_cs_managed_kubernetes_clusters.default.ids.0 : alicloud_cs_managed_kubernetes.default.0.id
+  cluster_id = alicloud_cs_managed_kubernetes.default.id
 }
 `, name)
 }

--- a/alicloud/service_alicloud_cs.go
+++ b/alicloud/service_alicloud_cs.go
@@ -231,36 +231,6 @@ func (s *CsClient) DescribeClusterDetail(id string) (*client.DescribeClusterDeta
 	return response.Body, nil
 }
 
-// DescribeClusterKubeConfig return cluster kube_config credential.
-// It's used for kubernetes/managed_kubernetes/serverless_kubernetes.
-// Deprecated, use CsClient.DescribeClusterKubeConfigWithExpiration
-func (s *CsService) DescribeClusterKubeConfig(clusterId string, isResource bool) (*cs.ClusterConfig, error) {
-	invoker := NewInvoker()
-	var response interface{}
-	var requestInfo *cs.Client
-	var config *cs.ClusterConfig
-	if err := invoker.Run(func() error {
-		raw, err := s.client.WithCsClient(func(csClient *cs.Client) (interface{}, error) {
-			requestInfo = csClient
-			return csClient.DescribeClusterUserConfig(clusterId, false)
-		})
-		response = raw
-		return err
-	}); err != nil {
-		if isResource {
-			return nil, WrapErrorf(err, DefaultErrorMsg, clusterId, "DescribeClusterUserConfig", DenverdinoAliyungo)
-		}
-		return nil, WrapErrorf(err, DataDefaultErrorMsg, clusterId, "DescribeClusterUserConfig", DenverdinoAliyungo)
-	}
-	if debugOn() {
-		requestMap := make(map[string]interface{})
-		requestMap["Id"] = clusterId
-		addDebug("DescribeClusterUserConfig", response, requestInfo, requestMap)
-	}
-	config, _ = response.(*cs.ClusterConfig)
-	return config, nil
-}
-
 // DescribeClusterKubeConfigWithExpiration return cluster kube_config credential with expiration time.
 // It's used for kubernetes/managed_kubernetes/serverless_kubernetes.
 func (s *CsClient) DescribeClusterKubeConfigWithExpiration(clusterId string, temporaryDurationMinutes int64) (*client.DescribeClusterUserKubeconfigResponseBody, error) {
@@ -302,15 +272,18 @@ func (s *CsClient) DescribeClusterKubeConfigWithExpiration(clusterId string, tem
 	return kubeConfig.Body, nil
 }
 
-// This function returns all available addons metadata of the cluster
-func (s *CsClient) DescribeClusterAddonsMetadata(clusterId string) (map[string]*Component, error) {
-	result := make(map[string]*Component)
+// ListAddons returns all available addons info of the cluster
+func (s *CsClient) ListAddons(clusterId string) (map[string]*client.ListAddonsResponseBodyAddons, error) {
+	result := make(map[string]*client.ListAddonsResponseBodyAddons)
 
+	request := &client.ListAddonsRequest{
+		ClusterId: tea.String(clusterId),
+	}
 	var err error
-	var resp *client.DescribeClusterAddonsVersionResponse
+	var resp *client.ListAddonsResponse
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		resp, err = s.client.DescribeClusterAddonsVersion(&clusterId)
+		resp, err = s.client.ListAddons(request)
 		if err != nil {
 			if NeedRetry(err) {
 				wait()
@@ -322,26 +295,22 @@ func (s *CsClient) DescribeClusterAddonsMetadata(clusterId string) (map[string]*
 	})
 
 	if err != nil {
-		return nil, WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeClusterAddonsVersion", err)
+		return nil, WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "ListAddons", err)
 	}
 
-	for name, addon := range resp.Body {
-		c := &Component{}
-		bytes, err := json.Marshal(addon)
-		if err != nil {
-			continue
-		}
-		err = json.Unmarshal(bytes, c)
-		if err != nil {
-			continue
-		}
-		result[name] = c
+	if resp == nil || resp.Body == nil || resp.Body.Addons == nil {
+		return nil, WrapErrorf(fmt.Errorf("ListAddons response body is nil"), DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "ListAddons", err)
+	}
+
+	for _, addon := range resp.Body.Addons {
+		ca := addon
+		result[tea.StringValue(addon.Name)] = ca
 	}
 
 	return result, nil
 }
 
-// This function returns the latest addon status information
+// Deprecated This function returns the latest addon status information
 func (s *CsClient) DescribeCsKubernetesAddonStatus(clusterId string, addonName string) (*Component, error) {
 	result := &Component{}
 	var err error
@@ -386,54 +355,6 @@ func (s *CsClient) DescribeCsKubernetesAddonStatus(clusterId string, addonName s
 }
 
 // This function returns the latest addon instance
-func (s *CsClient) DescribeCsKubernetesAddonInstance(clusterId string, addonName string) (*Component, error) {
-	component := &Component{}
-	var err error
-	var resp *client.DescribeClusterAddonInstanceResponse
-	wait := incrementalWait(3*time.Second, 3*time.Second)
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		resp, err = s.client.DescribeClusterAddonInstance(&clusterId, tea.String(addonName))
-		if err != nil {
-			if NeedRetry(err) {
-				wait()
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-
-	if err != nil {
-		if IsExpectedErrors(err, []string{"AddonNotFound"}) {
-			err = WrapErrorf(NotFoundErr("alicloud_cs_kubernetes_addon", addonName), ResourceNotfound)
-			return component, err
-		}
-		return nil, err
-	}
-
-	// FixMe: Currently, the addon does not support the initial state and needs to be returned in a task state.
-	if resp.Body.State == nil || *resp.Body.State == "" {
-		result, err := s.DescribeCsKubernetesAddonStatus(clusterId, addonName)
-		return result, err
-	}
-
-	if resp.Body.Name != nil {
-		component.ComponentName = *resp.Body.Name
-	}
-	if resp.Body.Version != nil {
-		component.Version = *resp.Body.Version
-	}
-	if resp.Body.State != nil {
-		component.Status = *resp.Body.State
-	}
-
-	if resp.Body.Config != nil {
-		component.Config = *resp.Body.Config
-	}
-
-	return component, nil
-}
-
 func (s *CsClient) GetCsKubernetesAddonInstance(clusterId string, addonName string) (*Component, error) {
 	component := &Component{}
 	var err error
@@ -452,7 +373,7 @@ func (s *CsClient) GetCsKubernetesAddonInstance(clusterId string, addonName stri
 	})
 
 	if err != nil {
-		if IsExpectedErrors(err, []string{"AddonNotFound"}) {
+		if IsExpectedErrors(err, []string{"AddonNotFound"}) || NotFoundError(err) {
 			err = WrapErrorf(NotFoundErr("alicloud_cs_kubernetes_addon", addonName), ResourceNotfound)
 			return component, err
 		}
@@ -476,58 +397,62 @@ func (s *CsClient) GetCsKubernetesAddonInstance(clusterId string, addonName stri
 	return component, nil
 }
 
-// This function returns the status of all available addons of the cluster
+// DescribeCsKubernetesAllAvailableAddons returns the status of all cluster addons, including both installed instances and available addons that can be installed.
 func (s *CsClient) DescribeCsKubernetesAllAvailableAddons(clusterId string) (map[string]*Component, error) {
-	availableAddons, err := s.DescribeClusterAddonsMetadata(clusterId)
+	// ListAddons
+	availableAddons, err := s.ListAddons(clusterId)
 	if err != nil {
 		return nil, err
 	}
 
-	queryList := make([]*string, 0)
-	for name := range availableAddons {
-		queryList = append(queryList, tea.String(name))
-	}
+	result := make(map[string]*Component)
+	for name, addonInfo := range availableAddons {
+		addon := &Component{}
+		result[name] = addon
 
-	status, err := s.DescribeCsKubernetesAllAddonsStatus(clusterId, queryList)
-	if err != nil {
-		return nil, WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeCsKubernetesExistedAddons", err)
-	}
+		addon.ComponentName = name
+		addon.Required = tea.BoolValue(addonInfo.InstallByDefault)
+		// DescribeAddon
+		addonInfoDetail, err := s.DescribeAddon(clusterId, name, "")
+		if err != nil {
+			return nil, WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeAddon", err)
+		}
 
-	for name, addon := range availableAddons {
-		if _, ok := status[name]; !ok {
-			continue
+		if addonInfoDetail == nil || addonInfoDetail.Body == nil {
+			return nil, WrapErrorf(fmt.Errorf("DescribeAddon response body is nil"), DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeAddon", err)
 		}
-		addon.Version = status[name].Version
-		addon.CanUpgrade = status[name].CanUpgrade
-		addon.ErrMessage = status[name].ErrMessage
-		addon.Config = status[name].Config
-		if addon.Version == "" {
-			continue
-		}
-		addonInstance, err := s.DescribeCsKubernetesAddonInstance(clusterId, name)
+
+		addon.NextVersion = getNextVersion(addonInfoDetail)
+
+		// GetClusterAddonInstance
+		addonInstance, err := s.GetCsKubernetesAddonInstance(clusterId, name)
 		if err != nil {
 			if NotFoundError(err) {
+				// Update if addon not installed
+				addon.NextVersion = tea.StringValue(addonInfo.Version)
 				continue
 			}
 			return nil, WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeCsKubernetesExistedAddons", err)
 		}
+		// Update if addon installed
+		addon.Version = addonInstance.Version
 		addon.Config = addonInstance.Config
 		addon.Status = addonInstance.Status
 	}
 
-	return availableAddons, nil
+	return result, nil
 }
 
-// This function returns the latest multiple addons status information
-func (s *CsClient) DescribeCsKubernetesAllAddonsStatus(clusterId string, addons []*string) (map[string]*Component, error) {
-	addonsStatus := make(map[string]*Component)
+func (s *CsClient) DescribeAddon(clusterId, name, version string) (*client.DescribeAddonResponse, error) {
 	var err error
-	var resp *client.DescribeClusterAddonsUpgradeStatusResponse
+	req := &client.DescribeAddonRequest{
+		ClusterId: tea.String(clusterId),
+		Version:   tea.String(version),
+	}
+	var resp *client.DescribeAddonResponse
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		resp, err = s.client.DescribeClusterAddonsUpgradeStatus(&clusterId, &client.DescribeClusterAddonsUpgradeStatusRequest{
-			ComponentIds: addons,
-		})
+		resp, err = s.client.DescribeAddon(&name, req)
 		if err != nil {
 			if NeedRetry(err) {
 				wait()
@@ -538,25 +463,7 @@ func (s *CsClient) DescribeCsKubernetesAllAddonsStatus(clusterId string, addons 
 		return nil
 	})
 
-	if err != nil {
-		return nil, WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeClusterAddonsUpgradeStatus", err)
-	}
-
-	for name, status := range resp.Body {
-		c := &Component{}
-		addonInfo := status.(map[string]interface{})["addon_info"]
-		tasks := status.(map[string]interface{})["tasks"]
-		c.Version = addonInfo.(map[string]interface{})["version"].(string)
-		c.CanUpgrade = status.(map[string]interface{})["can_upgrade"].(bool)
-		c.Status = tasks.(map[string]interface{})["status"].(string)
-		if message, ok := tasks.(map[string]interface{})["message"]; ok {
-			c.ErrMessage = message.(string)
-		}
-
-		addonsStatus[name] = c
-	}
-
-	return addonsStatus, nil
+	return resp, err
 }
 
 func (s *CsClient) DescribeCsKubernetesAddon(id string) (*Component, error) {
@@ -567,7 +474,7 @@ func (s *CsClient) DescribeCsKubernetesAddon(id string) (*Component, error) {
 	clusterId := parts[0]
 	addonName := parts[1]
 
-	addonInstance, err := s.DescribeCsKubernetesAddonInstance(clusterId, addonName)
+	addonInstance, err := s.GetCsKubernetesAddonInstance(clusterId, addonName)
 	if err != nil {
 		if IsExpectedErrors(err, []string{"AddonNotFound", "ErrorClusterNotFound"}) || NotFoundError(err) {
 			return nil, WrapErrorf(NotFoundErr("alicloud_cs_kubernetes_addon", id), ResourceNotfound)
@@ -575,27 +482,36 @@ func (s *CsClient) DescribeCsKubernetesAddon(id string) (*Component, error) {
 		return nil, err
 	}
 
-	addonsMetadata, err := s.DescribeClusterAddonsMetadata(clusterId)
+	addonInfo, err := s.DescribeAddon(clusterId, addonName, addonInstance.Version)
 	if err != nil {
 		return nil, err
 	}
 
-	addonStatus, err := s.DescribeCsKubernetesAddonStatus(clusterId, addonName)
-	if err != nil {
-		return nil, err
+	if addonInfo == nil || addonInfo.Body == nil {
+		return nil, WrapErrorf(fmt.Errorf("DescribeAddon response body is nil"), DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeAddon", err)
 	}
 
-	// Update some fields
-	if addon, existed := addonsMetadata[addonName]; existed {
-		addon.Version = addonStatus.Version
-		addon.Status = addonStatus.Status
-		addon.CanUpgrade = addonStatus.CanUpgrade
-		addon.ErrMessage = addonStatus.ErrMessage
-		addon.Config = addonInstance.Config
-		return addon, nil
+	addonInstance.Required = tea.BoolValue(addonInfo.Body.InstallByDefault)
+	// compat for old behavior: if the addon cannot be upgraded, use the current version as the next version
+	addonInstance.NextVersion = addonInstance.Version
+	if nextVersion := getNextVersion(addonInfo); nextVersion != "" {
+		addonInstance.NextVersion = nextVersion
+	}
+	addonInstance.CanUpgrade = addonInstance.Version != addonInstance.NextVersion
+	addonInstance.SupportedActions = tea.StringSliceValue(addonInfo.Body.SupportedActions)
+
+	return addonInstance, nil
+}
+
+func getNextVersion(addonInfo *client.DescribeAddonResponse) string {
+	newerVersions := addonInfo.Body.NewerVersions
+	for _, version := range newerVersions {
+		if tea.BoolValue(version.Upgradable) {
+			return *version.Version
+		}
 	}
 
-	return nil, WrapErrorf(NotFoundErr("alicloud_cs_kubernetes_addon", id), ResourceNotfound)
+	return ""
 }
 
 func (s *CsClient) CsKubernetesAddonTaskRefreshFunc(clusterId string, addonName string, failStates []string) resource.StateRefreshFunc {
@@ -618,7 +534,7 @@ func (s *CsClient) CsKubernetesAddonTaskRefreshFunc(clusterId string, addonName 
 
 func (s *CsClient) CsKubernetesAddonStateRefreshFunc(clusterId string, addonName string, failStates []string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		object, err := s.DescribeCsKubernetesAddonInstance(clusterId, addonName)
+		object, err := s.GetCsKubernetesAddonInstance(clusterId, addonName)
 		if err != nil {
 			if NotFoundError(err) {
 				// Set this to nil as if we didn't find anything.
@@ -633,31 +549,6 @@ func (s *CsClient) CsKubernetesAddonStateRefreshFunc(clusterId string, addonName
 		}
 		return object, object.Status, nil
 	}
-}
-
-func (s *CsClient) CsKubernetesAddonExistRefreshFunc(clusterId string, addonName string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		object, err := s.DescribeCsKubernetesAddonInstance(clusterId, addonName)
-		if err != nil {
-			if NotFoundError(err) {
-				// Set this to nil as if we didn't find anything.
-				return object, "deleted", nil
-			}
-			return nil, "", WrapError(err)
-		}
-
-		return object, object.Status, nil
-	}
-}
-func (s *CsClient) DescribeCsAutoscalingConfig(id string) (*client.CreateAutoscalingConfigRequest, error) {
-	request := &client.CreateAutoscalingConfigRequest{
-		CoolDownDuration:        tea.String("10m"),
-		UnneededDuration:        tea.String("10m"),
-		UtilizationThreshold:    tea.String("0.5"),
-		GpuUtilizationThreshold: tea.String("0.5"),
-		ScanInterval:            tea.String("30s"),
-	}
-	return request, nil
 }
 
 func (s *CsClient) installAddon(d *schema.ResourceData) error {
@@ -678,10 +569,11 @@ func (s *CsClient) installAddon(d *schema.ResourceData) error {
 		Body: body,
 	}
 
+	var resp *client.InstallClusterAddonsResponse
 	var err error
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err = s.client.InstallClusterAddons(&clusterId, creationArgs)
+		resp, err = s.client.InstallClusterAddons(&clusterId, creationArgs)
 		if err != nil {
 			if NeedRetry(err) {
 				wait()
@@ -694,6 +586,16 @@ func (s *CsClient) installAddon(d *schema.ResourceData) error {
 
 	if err != nil {
 		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "installAddon", err)
+	}
+
+	if resp == nil || resp.Body == nil || tea.StringValue(resp.Body.TaskId) == "" {
+		return WrapErrorf(fmt.Errorf("failed to get taskId"), DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "installAddon", err)
+	}
+
+	taskId := tea.StringValue(resp.Body.TaskId)
+	stateConf := BuildStateConf([]string{}, []string{"success"}, d.Timeout(schema.TimeoutCreate), 10*time.Second, s.DescribeTaskRefreshFunc(d, taskId, []string{"fail", "failed"}))
+	if jobDetail, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, ResponseCodeMsg, d.Id(), "InstallClusterAddons", jobDetail)
 	}
 
 	return nil
@@ -723,9 +625,11 @@ func (s *CsClient) upgradeAddon(d *schema.ResourceData, updateVersion, updateCon
 		Body: body,
 	}
 
+	var resp *client.UpgradeClusterAddonsResponse
+	var err error
 	wait := incrementalWait(3*time.Second, 3*time.Second)
-	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err := s.client.UpgradeClusterAddons(&clusterId, upgradeArgs)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		resp, err = s.client.UpgradeClusterAddons(&clusterId, upgradeArgs)
 		if err != nil {
 			if NeedRetry(err) {
 				wait()
@@ -738,6 +642,16 @@ func (s *CsClient) upgradeAddon(d *schema.ResourceData, updateVersion, updateCon
 
 	if err != nil {
 		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "upgradeAddon", err)
+	}
+
+	if resp == nil || resp.Body == nil || tea.StringValue(resp.Body.TaskId) == "" {
+		return WrapErrorf(fmt.Errorf("failed to get taskId"), DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "upgradeAddon", err)
+	}
+
+	taskId := tea.StringValue(resp.Body.TaskId)
+	stateConf := BuildStateConf([]string{}, []string{"success"}, d.Timeout(schema.TimeoutUpdate), 10*time.Second, s.DescribeTaskRefreshFunc(d, taskId, []string{"fail", "failed"}))
+	if jobDetail, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, ResponseCodeMsg, d.Id(), "UpgradeClusterAddons", jobDetail)
 	}
 
 	return nil
@@ -763,9 +677,10 @@ func (s *CsClient) uninstallAddon(d *schema.ResourceData) error {
 		Addons: body,
 	}
 
+	var resp *client.UnInstallClusterAddonsResponse
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		_, err = s.client.UnInstallClusterAddons(&clusterId, uninstallArgs)
+		resp, err = s.client.UnInstallClusterAddons(&clusterId, uninstallArgs)
 		if err != nil {
 			if NeedRetry(err) {
 				wait()
@@ -778,6 +693,16 @@ func (s *CsClient) uninstallAddon(d *schema.ResourceData) error {
 
 	if err != nil {
 		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "uninstallAddon", err)
+	}
+
+	if resp == nil || resp.Body == nil || tea.StringValue(resp.Body.TaskId) == "" {
+		return WrapErrorf(fmt.Errorf("failed to get taskId"), DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "uninstallAddon", err)
+	}
+
+	taskId := tea.StringValue(resp.Body.TaskId)
+	stateConf := BuildStateConf([]string{}, []string{"success"}, d.Timeout(schema.TimeoutDelete), 10*time.Second, s.DescribeTaskRefreshFunc(d, taskId, []string{"fail", "failed"}))
+	if jobDetail, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, ResponseCodeMsg, d.Id(), "UnInstallClusterAddons", jobDetail)
 	}
 
 	return nil
@@ -809,32 +734,26 @@ func (s *CsClient) updateAddonConfig(d *schema.ResourceData) error {
 		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "upgradeAddonConfig", err)
 	}
 
+	stateConf := BuildStateConf([]string{}, []string{"Success"}, d.Timeout(schema.TimeoutUpdate), 10*time.Second, s.CsKubernetesAddonTaskRefreshFunc(clusterId, ComponentName, []string{"Failed"}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		status, _ := s.DescribeCsKubernetesAddonStatus(clusterId, ComponentName)
+		if status != nil && status.Error != nil {
+			return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "WaitForSuccessAfterUpdate", status.Error)
+		}
+		return WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "WaitForSuccessAfterUpdate", d.Id())
+	}
+
 	return nil
 }
 
-// This function returns the status of all available addons of the cluster
+// DescribeCsKubernetesAddonMetadata returns metadata of an addon with name and version
 func (s *CsClient) DescribeCsKubernetesAddonMetadata(clusterId string, name string, version string) (*Component, error) {
-	var err error
-	req := &client.DescribeClusterAddonMetadataRequest{
-		Version: tea.String(version),
-	}
-	var resp *client.DescribeClusterAddonMetadataResponse
-	wait := incrementalWait(3*time.Second, 3*time.Second)
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		resp, err = s.client.DescribeClusterAddonMetadata(&clusterId, &name, req)
-		if err != nil {
-			if NeedRetry(err) {
-				wait()
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
+	resp, err := s.DescribeAddon(clusterId, name, version)
 
 	if err != nil {
 		return nil, WrapErrorf(err, DefaultErrorMsg, ResourceAlicloudCSKubernetesAddon, "DescribeCsKubernetesExistedAddons", err)
 	}
+
 	result := &Component{
 		ComponentName: *resp.Body.Name,
 		Version:       *resp.Body.Version,
@@ -882,31 +801,6 @@ func (s *CsService) DescribeCsKubernetesNodePool(id string) (nodePool *cs.NodePo
 	return
 }
 
-func (s *CsService) WaitForCsKubernetes(id string, status Status, timeout int) error {
-	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
-
-	for {
-		object, err := s.DescribeCsKubernetes(id)
-		if err != nil {
-			if NotFoundError(err) {
-				if status == Deleted {
-					return nil
-				}
-			} else {
-				return WrapError(err)
-			}
-		}
-		if object.ClusterId == id && status != Deleted {
-			return nil
-		}
-		if time.Now().After(deadline) {
-			return WrapErrorf(err, WaitTimeoutMsg, id, GetFunc(1), timeout, object.ClusterId, id, ProviderERROR)
-		}
-		time.Sleep(DefaultIntervalShort * time.Second)
-
-	}
-}
-
 func (s *CsService) DescribeCsManagedKubernetes(id string) (cluster *cs.KubernetesClusterDetail, err error) {
 	var requestInfo *cs.Client
 	invoker := NewInvoker()
@@ -938,31 +832,6 @@ func (s *CsService) DescribeCsManagedKubernetes(id string) (cluster *cs.Kubernet
 
 }
 
-func (s *CsService) WaitForCSManagedKubernetes(id string, status Status, timeout int) error {
-	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
-
-	for {
-		object, err := s.DescribeCsManagedKubernetes(id)
-		if err != nil {
-			if NotFoundError(err) {
-				if status == Deleted {
-					return nil
-				}
-			} else {
-				return WrapError(err)
-			}
-		}
-		if object.ClusterId == id && status != Deleted {
-			return nil
-		}
-		if time.Now().After(deadline) {
-			return WrapErrorf(err, WaitTimeoutMsg, id, GetFunc(1), timeout, object.ClusterId, id, ProviderERROR)
-		}
-		time.Sleep(DefaultIntervalShort * time.Second)
-
-	}
-}
-
 func (s *CsService) CsKubernetesInstanceStateRefreshFunc(id string, failStates []string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		object, err := s.DescribeCsKubernetes(id)
@@ -986,26 +855,6 @@ func (s *CsService) CsKubernetesInstanceStateRefreshFunc(id string, failStates [
 func (s *CsService) CsKubernetesNodePoolStateRefreshFunc(id string, failStates []string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		object, err := s.DescribeCsKubernetesNodePool(id)
-		if err != nil {
-			if NotFoundError(err) {
-				// Set this to nil as if we didn't find anything.
-				return nil, "", nil
-			}
-			return nil, "", WrapError(err)
-		}
-
-		for _, failState := range failStates {
-			if string(object.State) == failState {
-				return object, string(object.State), WrapError(Error(FailedToReachTargetStatus, string(object.State)))
-			}
-		}
-		return object, string(object.State), nil
-	}
-}
-
-func (s *CsService) CsManagedKubernetesInstanceStateRefreshFunc(id string, failStates []string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		object, err := s.DescribeCsManagedKubernetes(id)
 		if err != nil {
 			if NotFoundError(err) {
 				// Set this to nil as if we didn't find anything.
@@ -1073,31 +922,6 @@ func (s *CsService) DescribeCsServerlessKubernetes(id string) (*cs.ServerlessClu
 	}
 	return cluster, nil
 
-}
-
-func (s *CsService) WaitForCSServerlessKubernetes(id string, status Status, timeout int) error {
-	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
-
-	for {
-		object, err := s.DescribeCsServerlessKubernetes(id)
-		if err != nil {
-			if NotFoundError(err) {
-				if status == Deleted {
-					return nil
-				}
-			} else {
-				return WrapError(err)
-			}
-		}
-		if object.ClusterId == id && status != Deleted {
-			return nil
-		}
-		if time.Now().After(deadline) {
-			return WrapErrorf(err, WaitTimeoutMsg, id, GetFunc(1), timeout, object.ClusterId, id, ProviderERROR)
-		}
-		time.Sleep(DefaultIntervalShort * time.Second)
-
-	}
 }
 
 func (s *CsService) tagsToMap(tags []cs.Tag) map[string]string {
@@ -1265,15 +1089,6 @@ func GetKubernetesNetworkName(cluster *cs.KubernetesClusterDetail) (network stri
 		}
 	}
 	return "", fmt.Errorf("no network addon found")
-}
-
-func (s *CsClient) DescribeUserPermission(uid string) ([]*client.DescribeUserPermissionResponseBody, error) {
-	body, err := s.client.DescribeUserPermission(tea.String(uid))
-	if err != nil {
-		return nil, err
-	}
-
-	return body.Body, err
 }
 
 func setCerts(d *schema.ResourceData, meta interface{}, skipSetCertificateAuthority bool) error {

--- a/website/docs/r/cs_kubernetes_addon.html.markdown
+++ b/website/docs/r/cs_kubernetes_addon.html.markdown
@@ -105,8 +105,8 @@ The following arguments are supported:
 
 The following attributes are exported:
 * `id` - The id of addon, which consists of the cluster id and the addon name, with the structure <cluster_ud>:<addon_name>.
-* `next_version` - The version which addon can be upgraded to.
-* `can_upgrade` - Is the addon ready for upgrade.
+* `next_version` - (Deprecated since v1.273.0) The version which addon can be upgraded to.
+* `can_upgrade` - (Deprecated since v1.273.0) Is the addon ready for upgrade.
 * `required` - Is it a mandatory addon to be installed.
 
 ## Timeouts


### PR DESCRIPTION
resource/alicloud_cs_kubernetes_addon: 
- marks next_version and can_upgrade attributes as deprecated
- fix potential panic when updating addon; improve tests

data-source/alicloud_cs_kubernetes_addons: 
- use ListAddons, GetClusterAddonInstance and DescribeAddon to replace deprecated APIs
- improve tests. 

data-source/alicloud_cs_kubernetes_addon_metadata:
- use DescribeAddon to replace deprecated APIs
- improve tests.