### PR TITLE
New Resource:alicloud_cloud_firewall_vpc_firewall_control_policy_order resource/alicloud_cloud_firewall_vpc_firewall_control_policy: Change order to optional and support for update

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -916,6 +916,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_cloud_firewall_vpc_firewall_control_policy_order":     resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrder(),
 			"alicloud_cloud_firewall_nat_firewall_control_policy_order":     resourceAliCloudCloudFirewallNatFirewallControlPolicyOrder(),
 			"alicloud_rds_custom_disk_attachment":                           resourceAliCloudRdsCustomDiskAttachment(),
 			"alicloud_sls_logtail_pipeline_config":                          resourceAliCloudSlsLogtailPipelineConfig(),

--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy.go
@@ -1,4 +1,3 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
@@ -118,8 +117,8 @@ func resourceAliCloudCloudFirewallVpcFirewallControlPolicy() *schema.Resource {
 			},
 			"order": {
 				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
+				Optional: true,
+				Computed: true, // Default to -1. Change to `Computed` is to compromise the `order` in resource `alicloud_cloud_firewall_vpc_firewall_control_policy_order`
 			},
 			"proto": {
 				Type:     schema.TypeString,
@@ -203,7 +202,13 @@ func resourceAliCloudCloudFirewallVpcFirewallControlPolicyCreate(d *schema.Resou
 	if v, ok := d.GetOkExists("start_time"); ok {
 		request["StartTime"] = v
 	}
-	request["NewOrder"] = d.Get("order")
+
+	if d.Get("order") == 0 {
+		request["NewOrder"] = -1
+	} else {
+		request["NewOrder"] = d.Get("order")
+	}
+
 	if v, ok := d.GetOk("repeat_start_time"); ok {
 		request["RepeatStartTime"] = v
 	}
@@ -484,6 +489,26 @@ func resourceAliCloudCloudFirewallVpcFirewallControlPolicyUpdate(d *schema.Resou
 	if d.HasChange("end_time") {
 		update = true
 		request["EndTime"] = d.Get("end_time")
+	}
+
+	if d.HasChange("order") {
+		orderReq := map[string]interface{}{
+			"VpcFirewallId": parts[0],
+			"AclUuid":       parts[1],
+			"NewOrder":      -1,
+		}
+
+		if d.Get("order") != 0 {
+			orderReq["NewOrder"] = d.Get("order")
+		}
+
+		response, err = client.RpcPostWithEndpoint(
+			"Cloudfw", "2017-12-07",
+			"ModifyVpcFirewallControlPolicyPosition", query, orderReq, true, endpoint)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "ModifyVpcFirewallControlPolicyPosition", AlibabaCloudSdkGoERROR)
+		}
+		addDebug(action, response, request)
 	}
 
 	if update {

--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy_order.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy_order.go
@@ -1,0 +1,160 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrder() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderCreate,
+		Read:   resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderRead,
+		Update: resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderUpdate,
+		Delete: resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"acl_uuid": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"lang": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"order": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"vpc_firewall_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "ModifyVpcFirewallControlPolicyPosition"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("vpc_firewall_id"); ok {
+		request["VpcFirewallId"] = v
+	}
+	if v, ok := d.GetOk("acl_uuid"); ok {
+		request["AclUuid"] = v
+	}
+
+	request["NewOrder"] = d.Get("order")
+	wait := incrementalWait(3*time.Second, 0*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Cloudfw", "2017-12-07", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cloud_firewall_vpc_firewall_control_policy_order", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", request["VpcFirewallId"], request["AclUuid"]))
+
+	return resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderRead(d, meta)
+}
+
+func resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cloudFirewallServiceV2 := CloudFirewallServiceV2{client}
+
+	objectRaw, err := cloudFirewallServiceV2.DescribeCloudFirewallVpcFirewallControlPolicyOrder(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cloud_firewall_vpc_firewall_control_policy_order DescribeCloudFirewallVpcFirewallControlPolicyOrder Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("order", objectRaw["Order"])
+
+	parts := strings.Split(d.Id(), ":")
+	d.Set("vpc_firewall_id", parts[0])
+	d.Set("acl_uuid", parts[1])
+
+	return nil
+}
+
+func resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	action := "ModifyVpcFirewallControlPolicyPosition"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["VpcFirewallId"] = parts[0]
+	request["AclUuid"] = parts[1]
+
+	if d.HasChange("order") {
+		update = true
+	}
+	request["NewOrder"] = d.Get("order")
+	if update {
+		wait := incrementalWait(3*time.Second, 0*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Cloudfw", "2017-12-07", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderRead(d, meta)
+}
+
+func resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource AliCloud Resource Vpc Firewall Control Policy Order. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy_order_test.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy_order_test.go
@@ -1,0 +1,94 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test CloudFirewall VpcFirewallControlPolicyOrder. >>> Resource test cases, automatically generated.
+// Case test1 12717
+func TestAccAliCloudCloudFirewallVpcFirewallControlPolicyOrder_basic12717(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_firewall_vpc_firewall_control_policy_order.test.0"
+	ra := resourceAttrInit(resourceId, AlicloudCloudFirewallVpcFirewallControlPolicyOrderMap12717)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudFirewallServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudFirewallVpcFirewallControlPolicyOrder")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudfirewall%d", rand)
+	resourceTestAccConfigFunc(resourceId, name, alicloudCloudFirewallVpcFirewallControlPolicyOrderBasicDependence12717)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: alicloudCloudFirewallVpcFirewallControlPolicyOrderBasicDependence12717(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"order":           CHECKSET,
+						"vpc_firewall_id": CHECKSET,
+						"lang":            "zh",
+						"acl_uuid":        CHECKSET,
+					}),
+				),
+			},
+		},
+	})
+}
+
+var AlicloudCloudFirewallVpcFirewallControlPolicyOrderMap12717 = map[string]string{}
+
+func alicloudCloudFirewallVpcFirewallControlPolicyOrderBasicDependence12717(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_account" "test" {
+}
+
+resource "alicloud_cen_instance" "test" {
+  cen_instance_name = var.name
+}
+
+resource "alicloud_cloud_firewall_vpc_firewall_control_policy" "test" {
+  count            = 3
+  order            = "-1"
+  destination      = "127.0.0.2/32"
+  application_name = "ANY"
+  description      = "example_value"
+  source_type      = "net"
+  dest_port        = "80/88"
+  acl_action       = "accept"
+  lang             = "zh"
+  destination_type = "net"
+  source           = "127.0.0.1/32"
+  dest_port_type   = "port"
+  proto            = "TCP"
+  release          = true
+  vpc_firewall_id  = alicloud_cen_instance.test.id
+  lifecycle {
+    ignore_changes = [order]
+  }
+}
+
+resource "alicloud_cloud_firewall_vpc_firewall_control_policy_order" "test" {
+  count           = 3
+  order           = "${count.index + 1}"
+  vpc_firewall_id = alicloud_cen_instance.test.id
+  lang            = "zh"
+  acl_uuid        = split(":", alicloud_cloud_firewall_vpc_firewall_control_policy.test[count.index].id)[1]
+}`, name)
+}
+
+// Test CloudFirewall VpcFirewallControlPolicyOrder. <<< Resource test cases, automatically generated.

--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy_test.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy_test.go
@@ -329,6 +329,66 @@ func TestUnitAliCloudCloudFirewallVpcFirewallControlPolicy(t *testing.T) {
 	}
 }
 
+func TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic_no_order(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_firewall_vpc_firewall_control_policy.default"
+	ra := resourceAttrInit(resourceId, AliCloudCloudFirewallVpcFirewallControlPolicyMap11929)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudFirewallServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudFirewallVpcFirewallControlPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudfirewall%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudFirewallVpcFirewallControlPolicyBasicDependence11929)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"acl_action":       "accept",
+					"description":      name,
+					"destination":      "127.0.0.2/32",
+					"destination_type": "net",
+					"proto":            "TCP",
+					"source":           "127.0.0.1/32",
+					"source_type":      "net",
+					"vpc_firewall_id":  "${alicloud_cen_instance.default.id}",
+					"application_name": "ANY",
+					"dest_port":        "80/88",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"acl_action":       "accept",
+						"description":      name,
+						"destination":      "127.0.0.2/32",
+						"destination_type": "net",
+						"proto":            "TCP",
+						"order":            "1", // if only one policy and order not set, the default order should be 1
+						"source":           "127.0.0.1/32",
+						"source_type":      "net",
+						"vpc_firewall_id":  CHECKSET,
+						"application_name": "ANY",
+						"dest_port":        "80/88",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"lang"},
+			},
+		},
+	})
+}
+
 // Test CloudFirewall VpcFirewallControlPolicy. >>> Resource test cases, automatically generated.
 // Case VPC边界安全策略_ip修改为域名 11929
 func TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic11929(t *testing.T) {
@@ -734,30 +794,30 @@ var AliCloudCloudFirewallVpcFirewallControlPolicyMap11929 = map[string]string{
 
 func AliCloudCloudFirewallVpcFirewallControlPolicyBasicDependence11929(name string) string {
 	return fmt.Sprintf(`
-	variable "name" {
-  		default = "%s"
-	}
+variable "name" {
+  default = "%s"
+}
 
-	data "alicloud_account" "current" {
-	}
+data "alicloud_account" "current" {
+}
 
-	resource "alicloud_cen_instance" "default" {
-  		cen_instance_name = var.name
-	}
+resource "alicloud_cen_instance" "default" {
+  cen_instance_name = var.name
+}
 
-	resource "alicloud_cloud_firewall_address_book" "port" {
-  		description  = "${var.name}-port"
-  		group_name   = "${var.name}-port"
-  		group_type   = "port"
-  		address_list = ["8081/8081"]
-	}
+resource "alicloud_cloud_firewall_address_book" "port" {
+  description  = "${var.name}-port"
+  group_name   = "${var.name}-port"
+  group_type   = "port"
+  address_list = ["8081/8081"]
+}
 
-	resource "alicloud_cloud_firewall_address_book" "ip" {
-  		description  = var.name
-  		group_name   = var.name
-  		group_type   = "ip"
-  		address_list = ["10.21.0.0/16", "10.168.0.0/16"]
-	}
+resource "alicloud_cloud_firewall_address_book" "ip" {
+  description  = var.name
+  group_name   = var.name
+  group_type   = "ip"
+  address_list = ["10.21.0.0/16", "10.168.0.0/16"]
+}
 `, name)
 }
 
@@ -1165,30 +1225,30 @@ var AliCloudCloudFirewallVpcFirewallControlPolicyMap12022 = map[string]string{
 
 func AliCloudCloudFirewallVpcFirewallControlPolicyBasicDependence12022(name string) string {
 	return fmt.Sprintf(`
-	variable "name" {
-  		default = "%s"
-	}
+variable "name" {
+  default = "%s"
+}
 
-	data "alicloud_account" "current" {
-	}
+data "alicloud_account" "current" {
+}
 
-	resource "alicloud_cen_instance" "default" {
-  		cen_instance_name = var.name
-	}
+resource "alicloud_cen_instance" "default" {
+  cen_instance_name = var.name
+}
 
-	resource "alicloud_cloud_firewall_address_book" "port" {
-  		description  = "${var.name}-port"
-  		group_name   = "${var.name}-port"
-  		group_type   = "port"
-  		address_list = ["8081/8081"]
-	}
+resource "alicloud_cloud_firewall_address_book" "port" {
+  description  = "${var.name}-port"
+  group_name   = "${var.name}-port"
+  group_type   = "port"
+  address_list = ["8081/8081"]
+}
 
-	resource "alicloud_cloud_firewall_address_book" "ip" {
-  		description  = var.name
-  		group_name   = var.name
-  		group_type   = "ip"
-  		address_list = ["10.21.0.0/16", "10.168.0.0/16"]
-	}
+resource "alicloud_cloud_firewall_address_book" "ip" {
+  description  = var.name
+  group_name   = var.name
+  group_type   = "ip"
+  address_list = ["10.21.0.0/16", "10.168.0.0/16"]
+}
 `, name)
 }
 

--- a/alicloud/service_alicloud_cloud_firewall_v2.go
+++ b/alicloud/service_alicloud_cloud_firewall_v2.go
@@ -1193,6 +1193,94 @@ func (s *CloudFirewallServiceV2) CloudFirewallUserAlarmConfigStateRefreshFuncWit
 }
 
 // DescribeCloudFirewallUserAlarmConfig >>> Encapsulated.
+// DescribeCloudFirewallVpcFirewallControlPolicyOrder <<< Encapsulated get interface for CloudFirewall VpcFirewallControlPolicyOrder.
+
+func (s *CloudFirewallServiceV2) DescribeCloudFirewallVpcFirewallControlPolicyOrder(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["AclUuid"] = parts[1]
+	request["VpcFirewallId"] = parts[0]
+	request["CurrentPage"] = 1
+	request["PageSize"] = PageSizeLarge
+
+	action := "DescribeVpcFirewallControlPolicy"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Cloudfw", "2017-12-07", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"ErrorParameters"}) {
+			return object, WrapErrorf(NotFoundErr("VpcFirewallControlPolicyOrder", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Policys[*]", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Policys[*]", response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("VpcFirewallControlPolicyOrder", id), NotFoundMsg, response)
+	}
+
+	return v.([]interface{})[0].(map[string]interface{}), nil
+}
+
+func (s *CloudFirewallServiceV2) CloudFirewallVpcFirewallControlPolicyOrderStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.CloudFirewallVpcFirewallControlPolicyOrderStateRefreshFuncWithApi(id, field, failStates, s.DescribeCloudFirewallVpcFirewallControlPolicyOrder)
+}
+
+func (s *CloudFirewallServiceV2) CloudFirewallVpcFirewallControlPolicyOrderStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeCloudFirewallVpcFirewallControlPolicyOrder >>> Encapsulated.
+
 // DescribeCloudFirewallNatFirewallControlPolicyOrder <<< Encapsulated get interface for CloudFirewall NatFirewallControlPolicyOrder.
 
 func (s *CloudFirewallServiceV2) DescribeCloudFirewallNatFirewallControlPolicyOrder(id string) (object map[string]interface{}, err error) {

--- a/website/docs/r/cloud_firewall_vpc_firewall_control_policy.html.markdown
+++ b/website/docs/r/cloud_firewall_vpc_firewall_control_policy.html.markdown
@@ -16,6 +16,10 @@ For information about Cloud Firewall Vpc Firewall Control Policy and how to use 
 
 -> **NOTE:** Available since v1.194.0.
 
+~> **NOTE** Since v1.276.0. Set `new_order = -1` or omit the argument to let the Cloud Backend manage policy ordering automatically. You can also use `alicloud_cloud_firewall_vpc_firewall_control_policy_order` to manage the policy ordering.<br>
+  If you want manged the policy order in parallel **do not** set the `new_order`, instead use `alicloud_cloud_firewall_vpc_firewall_control_policy_order` manage the policy order.
+
+
 ## Example Usage
 
 Basic Usage
@@ -71,8 +75,10 @@ The following arguments are supported:
   - When the VPC firewall protects traffic between two VPCs connected through the cloud enterprise network, the policy group ID uses the cloud enterprise network instance ID.
   - When the VPC firewall protects traffic between two VPCs connected through the express connection, the policy group ID uses the ID of the VPC firewall instance.
 * `application_name` - (Optional) The type of the applications that the access control policy supports. Valid values: `FTP`, `HTTP`, `HTTPS`, `MySQL`, `SMTP`, `SMTPS`, `RDP`, `VNC`, `SSH`, `Redis`, `MQTT`, `MongoDB`, `Memcache`, `SSL`, `ANY`.
-* `application_name_list` - (Optional, List, Available since v1.267.0) The list of application types that the access control policy supports. 
--> **NOTE:** If `proto` is set to `TCP`, you can set `application_name_list` to any valid value. If `proto` is set to `UDP`, `ICMP`, or `ANY`, you can only set `application_name_list` to `["ANY"]`. From version 1.267.0, You must specify at least one of the `application_name_list` and `application_name`. If you specify both `application_name_list` and `application_name`, only the `application_name_list` takes effect.
+* `application_name_list` - (Optional, List, Available since v1.267.0) The list of application types that the access control policy supports.
+
+  -> **NOTE:** If `proto` is set to `TCP`, you can set `application_name_list` to any valid value. If `proto` is set to `UDP`, `ICMP`, or `ANY`, you can only set `application_name_list` to `["ANY"]`. From version 1.267.0, You must specify at least one of the `application_name_list` and `application_name`. If you specify both `application_name_list` and `application_name`, only the `application_name_list` takes effect.
+
 * `description` - (Required) Access control over VPC firewalls description of the strategy information.
 * `acl_action` - (Required) The action that Cloud Firewall performs on the traffic. Valid values: `accept`, `drop`, `log`.
 * `source` - (Required) Access control over VPC firewalls strategy in the source address.
@@ -83,9 +89,15 @@ The following arguments are supported:
   - If `destination_type` is set to `domain`, the value of `destination` must be a domain name.
 * `destination_type` - (Required) The type of the destination address in the access control policy. Valid values: `net`, `group`, `domain`.
 * `proto` - (Required) The type of the protocol in the access control policy. Valid values: `ANY`, `TCP`, `UDP`, `ICMP`.
-* `order` - (Required, ForceNew, Int) The priority of the access control policy. The priority value starts from 1. A smaller priority value indicates a higher priority.
-* `dest_port` - (Optional) The destination port in the access control policy. **Note:** If `dest_port_type` is set to `port`, you must specify this parameter.
-* `dest_port_group` - (Optional) Access control policy in the access traffic of the destination port address book name. **Note:** If `dest_port_type` is set to `group`, you must specify this parameter.
+* `order` - (Optional, Computed, Int) The priority of the access control policy. The priority value starts from 1. A smaller priority value indicates a higher priority.
+* `dest_port` - (Optional) The destination port in the access control policy.
+
+  ->**Note:** If `dest_port_type` is set to `port`, `dest_port` is mandatory.
+
+* `dest_port_group` - (Optional) Access control policy in the access traffic of the destination port address book name.
+
+  ->**Note:** If `dest_port_type` is set to `group`, `dest_port_group` is mandatory.
+
 * `dest_port_type` - (Optional) The type of the destination port in the access control policy. Valid values: `port`, `group`.
 * `release` - (Optional) The enabled status of the access control policy. The policy is enabled by default after it is created.. Valid values:
   - `true`: Enable access control policies.

--- a/website/docs/r/cloud_firewall_vpc_firewall_control_policy_order.html.markdown
+++ b/website/docs/r/cloud_firewall_vpc_firewall_control_policy_order.html.markdown
@@ -1,0 +1,89 @@
+---
+subcategory: "Cloud Firewall"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cloud_firewall_vpc_firewall_control_policy_order"
+description: |-
+  Provides a Alicloud Cloud Firewall Vpc Firewall Control Policy Order resource.
+---
+
+# alicloud_cloud_firewall_vpc_firewall_control_policy_order
+
+Provides a Cloud Firewall Vpc Firewall Control Policy Order resource.
+
+ACL priority of the VPC border firewall.
+
+For information about Cloud Firewall Vpc Firewall Control Policy Order and how to use it, see [What is Vpc Firewall Control Policy Order](https://next.api.alibabacloud.com/document/Cloudfw/2017-12-07/ModifyVpcFirewallControlPolicyPosition).
+
+-> **NOTE:** Available since v1.276.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = ""
+}
+
+
+resource "alicloud_cloud_firewall_vpc_firewall_control_policy_order" "default" {
+  order           = "1"
+  vpc_firewall_id = "cen-38mhpjiqwbkfullqdj"
+  lang            = "zh"
+  acl_uuid        = "b71137c7-23f0-411d-b6a0-8a2f1977fe6f"
+}
+```
+
+### Deleting `alicloud_cloud_firewall_vpc_firewall_control_policy_order` or removing it from your configuration
+
+Terraform cannot destroy resource `alicloud_cloud_firewall_vpc_firewall_control_policy_order`. Terraform will remove this resource from the state file, however resources may remain.
+
+## Argument Reference
+
+The following arguments are supported:
+* `acl_uuid` - (Optional, ForceNew, Computed) The unique identifier ID of the access control policy.  
+  When modifying an access control policy, you must provide its unique identifier ID. You can obtain this ID by calling the [DescribeVpcFirewallControlPolicy](https://help.aliyun.com/document_detail/159758.html) API.
+* `lang` - (Optional) The language type used for requests and responses.  
+
+  Valid values:  
+  - `zh`: Chinese  
+  - `en`: English
+
+  -> **NOTE:** This parameter is only evaluated during resource creation and update. Modifying it in isolation will not trigger any action.
+
+* `order` - (Required) The new priority of the access control policy after modification.  
+
+  -> **NOTE:**  For the valid range of the new priority, see the [API for querying the effective priority range](https://help.aliyun.com/document_detail/474145.html).
+
+* `vpc_firewall_id` - (Required, ForceNew) The ID of the access control policy group for the VPC border firewall. You can obtain this ID by calling the [DescribeVpcFirewallAclGroupList](https://help.aliyun.com/document_detail/159760.html) API.  
+
+    Valid values:  
+  - When the VPC border firewall protects Cloud Enterprise Network (CEN), the policy group ID is the CEN instance ID.  
+
+  Example: cen-ervw0g12b5jbw*\*\*\*  
+  - When the VPC border firewall protects Express Connect, the policy group ID is the VPC border firewall instance ID.  
+
+  Example: vfw-a42bbb7b887148c9*\*\*\*.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<vpc_firewall_id>:<acl_uuid>`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Vpc Firewall Control Policy Order.
+* `update` - (Defaults to 5 mins) Used when update the Vpc Firewall Control Policy Order.
+
+## Import
+
+Cloud Firewall Vpc Firewall Control Policy Order can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cloud_firewall_vpc_firewall_control_policy_order.example <vpc_firewall_id>:<acl_uuid>
+```


### PR DESCRIPTION
New resource `alicloud_cloud_firewall_vpc_firewall_control_policy_order`

`alicloud_cloud_firewall_vpc_firewall_control_policy` 
- Change `order` to optional.
- Add support for update `order` without recreate the policy.

```log
=== RUN   TestAccAliCloudCloudFirewallVpcFirewallControlPolicyOrder_basic12717
--- PASS: TestAccAliCloudCloudFirewallVpcFirewallControlPolicyOrder_basic12717 (27.50s)
=== RUN   TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic_no_order
--- PASS: TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic_no_order (20.22s)
=== RUN   TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic11929
--- PASS: TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic11929 (68.67s)
=== RUN   TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic11929_twin0
--- PASS: TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic11929_twin0 (18.96s)
=== RUN   TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic11929_twin1
--- PASS: TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic11929_twin1 (19.81s)
=== RUN   TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic12022
--- PASS: TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic12022 (80.12s)
=== RUN   TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic12022_twin0
--- PASS: TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic12022_twin0 (20.30s)
=== RUN   TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic12022_twin1
--- PASS: TestAccAliCloudCloudFirewallVpcFirewallControlPolicy_basic12022_twin1 (21.05s)
```