### PR TITLE
resource/alicloud_image_import: add nvme_support to features block

### DIFF
--- a/alicloud/resource_alicloud_image_import.go
+++ b/alicloud/resource_alicloud_image_import.go
@@ -104,6 +104,23 @@ func resourceAliCloudImageImport() *schema.Resource {
 					},
 				},
 			},
+			"features": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nvme_support": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							Computed:     true,
+							ValidateFunc: StringInSlice([]string{"supported", "unsupported"}, false),
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -140,6 +157,17 @@ func resourceAliCloudImageImportCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("description"); ok {
 		request.Description = v.(string)
+	}
+
+	// Handle features including NVMe support
+	if v, ok := d.GetOk("features"); ok {
+		featuresList := v.([]interface{})
+		if len(featuresList) > 0 {
+			featuresMap := featuresList[0].(map[string]interface{})
+			if nvmeSupport, ok := featuresMap["nvme_support"]; ok && nvmeSupport.(string) != "" {
+				request.QueryParams["Features.NvmeSupport"] = nvmeSupport.(string)
+			}
+		}
 	}
 
 	diskDeviceMappings := d.Get("disk_device_mapping")
@@ -233,6 +261,15 @@ func resourceAliCloudImageImportRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("disk_device_mapping", diskDeviceMappings)
+
+	// Set features
+	featuresMaps := make([]map[string]interface{}, 0)
+	featuresMap := make(map[string]interface{})
+	if object.Features.NvmeSupport != "" {
+		featuresMap["nvme_support"] = object.Features.NvmeSupport
+		featuresMaps = append(featuresMaps, featuresMap)
+		d.Set("features", featuresMaps)
+	}
 
 	return nil
 }

--- a/alicloud/resource_alicloud_image_import_test.go
+++ b/alicloud/resource_alicloud_image_import_test.go
@@ -139,6 +139,77 @@ func TestAccAliCloudImageImport_basic0_twin(t *testing.T) {
 
 }
 
+func TestAccAliCloudImageImport_features(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_image_import.default"
+	ra := resourceAttrInit(resourceId, AliCloudImageImportMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EcsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeImageById")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("tf-testacc%simageimport%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudImageImportBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"image_name": name,
+					"features": []map[string]interface{}{
+						{
+							"nvme_support": "supported",
+						},
+					},
+					"disk_device_mapping": []map[string]interface{}{
+						{
+							"oss_bucket": "${alicloud_oss_bucket.default.id}",
+							"oss_object": "${alicloud_oss_bucket_object.default.id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"image_name":              name,
+						"features.#":              "1",
+						"features.0.nvme_support": "supported",
+						"disk_device_mapping.#":   "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"image_name": name + "-update",
+					"features": []map[string]interface{}{
+						{
+							"nvme_support": "unsupported",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"image_name":              name + "-update",
+						"features.0.nvme_support": "unsupported",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"license_type"},
+			},
+		},
+	})
+
+}
+
 var AliCloudImageImportMap0 = map[string]string{
 	"platform":   CHECKSET,
 	"boot_mode":  CHECKSET,

--- a/website/docs/r/image_import.html.markdown
+++ b/website/docs/r/image_import.html.markdown
@@ -61,6 +61,9 @@ resource "alicloud_image_import" "default" {
   license_type = "Auto"
   image_name   = var.name
   description  = var.name
+  features {
+    nvme_support = "supported"
+  }
   disk_device_mapping {
     oss_bucket      = alicloud_oss_bucket.default.id
     oss_object      = alicloud_oss_bucket_object.default.id
@@ -84,6 +87,7 @@ The following arguments are supported:
 * `image_name` - (Optional) The name of the image. The `image_name` must be `2` to `128` characters in length. The `image_name` must start with a letter and cannot start with acs: or aliyun. The `image_name` cannot contain http:// or https://. The `image_name` can contain letters, digits, periods (.), colons (:), underscores (_), and hyphens (-).
 * `description` - (Optional) The description of the image. The `description` must be 2 to 256 characters in length and cannot start with http:// or https://.
 * `disk_device_mapping` - (Required, ForceNew, Set) The information about the custom image. See [`disk_device_mapping`](#disk_device_mapping) below.
+* `features` - (Optional, Computed) Features for the image. See [`features`](#features) below.
 
 ### `disk_device_mapping`
 
@@ -94,6 +98,14 @@ The disk_device_mapping supports the following:
 * `oss_object` - (Optional, ForceNew) The name (key) of the object that the uploaded image is stored as in the OSS bucket.
 * `device` - (Optional, ForceNew) The device name of the disk.
 * `disk_image_size` - (Optional, ForceNew, Int) The size of the disk. Default value: `5`.
+
+### `features`
+
+The features supports the following:
+
+* `nvme_support` - (Optional, ForceNew, Computed) Specifies whether to support the Non-Volatile Memory Express (NVMe) protocol. Valid values:
+  - `supported`: The image supports NVMe. Instances created from this image also support NVMe.
+  - `unsupported`: The image does not support NVMe. Instances created from this image do not support NVMe.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary

- Migrate `nvme_support` parameter from `disk_device_mapping` block to the new `features` block in `alicloud_image_import` resource, aligned with the `ImportImageFeatures` struct in alibaba-cloud-sdk-go
- Add input validation for `nvme_support` values (`supported` / `unsupported`)
- Update documentation and add test cases for the `features` block
- Bump `alibaba-cloud-sdk-go` to v1.63.28 (required for `ImportImageFeatures` API support)

## Changes

- `alicloud/resource_alicloud_image_import.go` — add `features` block with `nvme_support` field
- `alicloud/resource_alicloud_image_import_test.go` — add acceptance tests
- `website/docs/r/image_import.html.markdown` — update documentation
- `go.mod` / `go.sum` — bump alibaba-cloud-sdk-go to v1.63.28