### PR TITLE
data-source/alicloud_cs_kubernetes_clusters: deprecated data-source/alicloud_cs_managed_kubernetes_clusters:deprecated data-source/alicloud_cs_edge_kubernetes_clusters:deprecated data-source/alicloud_cs_serverless_kubernetes_clusters:deprecated

### DIFF
--- a/alicloud/data_source_alicloud_cs_edge_kubernetes_clusters.go
+++ b/alicloud/data_source_alicloud_cs_edge_kubernetes_clusters.go
@@ -15,7 +15,8 @@ import (
 
 func dataSourceAlicloudCSEdgeKubernetesClusters() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudCSEdgeKubernetesClustersRead,
+		Read:               dataSourceAlicloudCSEdgeKubernetesClustersRead,
+		DeprecationMessage: "This data source has been deprecated since v1.276.0 and will be removed in the future. Please use 'alicloud_cs_clusters' instead.",
 
 		Schema: map[string]*schema.Schema{
 			"ids": {

--- a/alicloud/data_source_alicloud_cs_kubernetes_clusters.go
+++ b/alicloud/data_source_alicloud_cs_kubernetes_clusters.go
@@ -19,7 +19,8 @@ import (
 
 func dataSourceAlicloudCSKubernetesClusters() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudCSKubernetesClustersRead,
+		Read:               dataSourceAlicloudCSKubernetesClustersRead,
+		DeprecationMessage: "This data source has been deprecated since v1.276.0 and will be removed in the future. Please use 'alicloud_cs_clusters' instead.",
 
 		Schema: map[string]*schema.Schema{
 			"ids": {

--- a/alicloud/data_source_alicloud_cs_managed_kubernetes_clusters.go
+++ b/alicloud/data_source_alicloud_cs_managed_kubernetes_clusters.go
@@ -19,7 +19,8 @@ import (
 
 func dataSourceAlicloudCSManagerKubernetesClusters() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudCSManagerKubernetesClustersRead,
+		Read:               dataSourceAlicloudCSManagerKubernetesClustersRead,
+		DeprecationMessage: "This data source has been deprecated since v1.276.0 and will be removed in the future. Please use 'alicloud_cs_clusters' instead.",
 
 		Schema: map[string]*schema.Schema{
 			"ids": {

--- a/alicloud/data_source_alicloud_cs_serverless_kubernetes_clusters.go
+++ b/alicloud/data_source_alicloud_cs_serverless_kubernetes_clusters.go
@@ -15,7 +15,8 @@ import (
 
 func dataSourceAlicloudCSServerlessKubernetesClusters() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudCSServerlessKubernetesClustersRead,
+		Read:               dataSourceAlicloudCSServerlessKubernetesClustersRead,
+		DeprecationMessage: "This data source has been deprecated since v1.276.0 and will be removed in the future. Please use 'alicloud_cs_clusters' instead.",
 		Schema: map[string]*schema.Schema{
 			"ids": {
 				Type:     schema.TypeList,

--- a/website/docs/d/cs_edge_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_edge_kubernetes_clusters.html.markdown
@@ -7,7 +7,9 @@ description: |-
   Provides a list of Container Service Edge Kubernetes Clusters to be used by the alicloud_cs_edge_kubernetes_clusters resource.
 ---
 
-# alicloud\_cs\_edge\_kubernetes\_clusters
+# alicloud_cs_edge_kubernetes_clusters
+
+-> **DEPRECATION NOTICE:** This data source has been deprecated since v1.276.0 and will be removed in a future release. Please use `alicloud_cs_clusters` instead.
 
 This data source provides a list Container Service Edge Kubernetes Clusters on Alibaba Cloud.
 

--- a/website/docs/d/cs_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_kubernetes_clusters.html.markdown
@@ -7,7 +7,9 @@ description: |-
   Provides a list of Container Service Kubernetes Clusters to be used by the alicloud_cs_kubernetes_clusters resource.
 ---
 
-# alicloud\_cs\_kubernetes\_clusters
+# alicloud_cs_kubernetes_clusters
+
+-> **DEPRECATION NOTICE:** This data source has been deprecated since v1.276.0 and will be removed in a future release. Please use `alicloud_cs_clusters` instead.
 
 This data source provides a list Container Service Kubernetes Clusters on Alibaba Cloud.
 

--- a/website/docs/d/cs_managed_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_managed_kubernetes_clusters.html.markdown
@@ -7,7 +7,9 @@ description: |-
   Provides a list of Container Service Managed Kubernetes Clusters to be used by the alicloud_cs_managed_kubernetes_clusters resource.
 ---
 
-# alicloud\_cs\_managed\_kubernetes\_clusters
+# alicloud_cs_managed_kubernetes_clusters
+
+-> **DEPRECATION NOTICE:** This data source has been deprecated since v1.276.0 and will be removed in a future release. Please use `alicloud_cs_clusters` instead.
 
 This data source provides a list Container Service Managed Kubernetes Clusters on Alibaba Cloud.
 

--- a/website/docs/d/cs_serverless_kubernetes_clusters.html.markdown
+++ b/website/docs/d/cs_serverless_kubernetes_clusters.html.markdown
@@ -7,7 +7,9 @@ description: |-
   Provides a list of Container Service Serverless Kubernetes Clusters to be used by the alicloud_cs_serverless_kubernetes_clusters resource.
 ---
 
-# alicloud\_cs\_serverless\_kubernetes\_clusters
+# alicloud_cs_serverless_kubernetes_clusters
+
+-> **DEPRECATION NOTICE:** This data source has been deprecated since v1.276.0 and will be removed in a future release. Please use `alicloud_cs_clusters` instead.
 
 This data source provides a list Container Service Serverless Kubernetes Clusters on Alibaba Cloud.
 


### PR DESCRIPTION
Deprecate data sources (since v1.276.0):
- `alicloud_cs_kubernetes_clusters` → use `alicloud_cs_clusters`
- `alicloud_cs_managed_kubernetes_clusters` → `use alicloud_cs_clusters`
- `alicloud_cs_edge_kubernetes_clusters` → use `alicloud_cs_clusters`
- `alicloud_cs_serverless_kubernetes_clusters` → use `alicloud_cs_clusters`