### PR TITLE
New Resource: alicloud_alidns_cloud_gtm_address_pool.

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -921,6 +921,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cloud_firewall_vpc_firewall_control_policy_order":     resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrder(),
 			"alicloud_cloud_firewall_nat_firewall_control_policy_order":     resourceAliCloudCloudFirewallNatFirewallControlPolicyOrder(),
 			"alicloud_esa_custom_response_code_rule":                        resourceAliCloudEsaCustomResponseCodeRule(),
+			"alicloud_alidns_cloud_gtm_address_pool":                        resourceAliCloudAlidnsCloudGtmAddressPool(),
 			"alicloud_rds_custom_disk_attachment":                           resourceAliCloudRdsCustomDiskAttachment(),
 			"alicloud_sls_logtail_pipeline_config":                          resourceAliCloudSlsLogtailPipelineConfig(),
 			"alicloud_simple_application_server_disk":                       resourceAliCloudSimpleApplicationServerDisk(),

--- a/alicloud/resource_alicloud_alidns_cloud_gtm_address_pool.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_address_pool.go
@@ -1,0 +1,314 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudAlidnsCloudGtmAddressPool() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudAlidnsCloudGtmAddressPoolCreate,
+		Read:   resourceAliCloudAlidnsCloudGtmAddressPoolRead,
+		Update: resourceAliCloudAlidnsCloudGtmAddressPoolUpdate,
+		Delete: resourceAliCloudAlidnsCloudGtmAddressPoolDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"address_lb_strategy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"round_robin", "sequence", "weight", "source_nearest"}, false),
+			},
+			"address_pool_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"address_pool_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"IPv4", "IPv6", "domain"}, false),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_status": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringInSlice([]string{"enable", "disable"}, false),
+			},
+			"health_judgement": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringInSlice([]string{"any_ok", "p30_ok", "p50_ok", "p70_ok", "all_ok"}, false),
+			},
+			"remark": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sequence_lb_strategy_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"preemptive", "nonPreemptive"}, false),
+			},
+		},
+	}
+}
+
+func resourceAliCloudAlidnsCloudGtmAddressPoolCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateCloudGtmAddressPool"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["ClientToken"] = buildClientToken(action)
+
+	request["EnableStatus"] = d.Get("enable_status")
+	if v, ok := d.GetOk("remark"); ok {
+		request["Remark"] = v
+	}
+	request["AddressPoolName"] = d.Get("address_pool_name")
+	request["AddressPoolType"] = d.Get("address_pool_type")
+	request["HealthJudgement"] = d.Get("health_judgement")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_alidns_cloud_gtm_address_pool", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["AddressPoolId"]))
+
+	return resourceAliCloudAlidnsCloudGtmAddressPoolUpdate(d, meta)
+}
+
+func resourceAliCloudAlidnsCloudGtmAddressPoolRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	alidnsServiceV2 := AlidnsServiceV2{client}
+
+	objectRaw, err := alidnsServiceV2.DescribeAlidnsCloudGtmAddressPool(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_alidns_cloud_gtm_address_pool DescribeAlidnsCloudGtmAddressPool Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("address_lb_strategy", objectRaw["AddressLbStrategy"])
+	d.Set("address_pool_name", objectRaw["AddressPoolName"])
+	d.Set("address_pool_type", objectRaw["AddressPoolType"])
+	d.Set("create_time", objectRaw["CreateTime"])
+	d.Set("enable_status", objectRaw["EnableStatus"])
+	d.Set("health_judgement", objectRaw["HealthJudgement"])
+	d.Set("remark", objectRaw["Remark"])
+	d.Set("sequence_lb_strategy_mode", objectRaw["SequenceLbStrategyMode"])
+
+	return nil
+}
+
+func resourceAliCloudAlidnsCloudGtmAddressPoolUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+	d.Partial(true)
+
+	var err error
+	action := "UpdateCloudGtmAddressPoolBasicConfig"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["AddressPoolId"] = d.Id()
+
+	request["ClientToken"] = buildClientToken(action)
+	if !d.IsNewResource() && d.HasChange("address_pool_name") {
+		update = true
+	}
+	request["AddressPoolName"] = d.Get("address_pool_name")
+	if !d.IsNewResource() && d.HasChange("health_judgement") {
+		update = true
+	}
+	request["HealthJudgement"] = d.Get("health_judgement")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	action = "UpdateCloudGtmAddressPoolEnableStatus"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["AddressPoolId"] = d.Id()
+
+	request["ClientToken"] = buildClientToken(action)
+	if !d.IsNewResource() && d.HasChange("enable_status") {
+		update = true
+	}
+	request["EnableStatus"] = d.Get("enable_status")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	action = "UpdateCloudGtmAddressPoolLbStrategy"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["AddressPoolId"] = d.Id()
+
+	request["ClientToken"] = buildClientToken(action)
+	if d.HasChange("sequence_lb_strategy_mode") {
+		update = true
+		request["SequenceLbStrategyMode"] = d.Get("sequence_lb_strategy_mode")
+	}
+
+	if d.HasChange("address_lb_strategy") {
+		update = true
+	}
+	request["AddressLbStrategy"] = d.Get("address_lb_strategy")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	action = "UpdateCloudGtmAddressPoolRemark"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["AddressPoolId"] = d.Id()
+
+	request["ClientToken"] = buildClientToken(action)
+	if !d.IsNewResource() && d.HasChange("remark") {
+		update = true
+		request["Remark"] = d.Get("remark")
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	d.Partial(false)
+	return resourceAliCloudAlidnsCloudGtmAddressPoolRead(d, meta)
+}
+
+func resourceAliCloudAlidnsCloudGtmAddressPoolDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteCloudGtmAddressPool"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["AddressPoolId"] = d.Id()
+
+	request["ClientToken"] = buildClientToken(action)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_alidns_cloud_gtm_address_pool_test.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_address_pool_test.go
@@ -1,0 +1,248 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Case resourceCase_20260318_o7cRMj 12688
+func TestAccAliCloudAlidnsCloudGtmAddressPool_basic12688(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alidns_cloud_gtm_address_pool.default"
+	ra := resourceAttrInit(resourceId, AlicloudAlidnsCloudGtmAddressPoolMap12688)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlidnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlidnsCloudGtmAddressPool")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalidns%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlidnsCloudGtmAddressPoolBasicDependence12688)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"address_pool_name":         "pool-test-1",
+					"health_judgement":          "all_ok",
+					"address_pool_type":         "IPv4",
+					"enable_status":             "enable",
+					"address_lb_strategy":       "sequence",
+					"sequence_lb_strategy_mode": "preemptive",
+					"remark":                    "remark",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"address_pool_name":         "pool-test-1",
+						"health_judgement":          "all_ok",
+						"address_pool_type":         "IPv4",
+						"enable_status":             "enable",
+						"address_lb_strategy":       "sequence",
+						"sequence_lb_strategy_mode": "preemptive",
+						"remark":                    "remark",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"address_pool_name":         "pool-modify",
+					"health_judgement":          "any_ok",
+					"enable_status":             "disable",
+					"sequence_lb_strategy_mode": "nonPreemptive",
+					"remark":                    "add-test",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"address_pool_name":         "pool-modify",
+						"health_judgement":          "any_ok",
+						"enable_status":             "disable",
+						"sequence_lb_strategy_mode": "nonPreemptive",
+						"remark":                    "add-test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudAlidnsCloudGtmAddressPoolMap12688 = map[string]string{
+	"create_time": CHECKSET,
+}
+
+func AlicloudAlidnsCloudGtmAddressPoolBasicDependence12688(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_20260323_nenn2G 12681
+func TestAccAliCloudAlidnsCloudGtmAddressPool_basic12681(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alidns_cloud_gtm_address_pool.default"
+	ra := resourceAttrInit(resourceId, AlicloudAlidnsCloudGtmAddressPoolMap12681)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlidnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlidnsCloudGtmAddressPool")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalidns%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlidnsCloudGtmAddressPoolBasicDependence12681)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"address_pool_name":   "resoure-test-pool-3",
+					"health_judgement":    "p30_ok",
+					"address_pool_type":   "domain",
+					"enable_status":       "enable",
+					"address_lb_strategy": "round_robin",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"address_pool_name":   "resoure-test-pool-3",
+						"health_judgement":    "p30_ok",
+						"address_pool_type":   "domain",
+						"enable_status":       "enable",
+						"address_lb_strategy": "round_robin",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"health_judgement": "p50_ok",
+					"enable_status":    "disable",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"health_judgement": "p50_ok",
+						"enable_status":    "disable",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudAlidnsCloudGtmAddressPoolMap12681 = map[string]string{
+	"create_time": CHECKSET,
+}
+
+func AlicloudAlidnsCloudGtmAddressPoolBasicDependence12681(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_20260323_ZeTYRG 12686
+func TestAccAliCloudAlidnsCloudGtmAddressPool_basic12686(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alidns_cloud_gtm_address_pool.default"
+	ra := resourceAttrInit(resourceId, AlicloudAlidnsCloudGtmAddressPoolMap12686)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlidnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlidnsCloudGtmAddressPool")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalidns%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlidnsCloudGtmAddressPoolBasicDependence12686)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"address_pool_name":   "resource-test-pool-2",
+					"health_judgement":    "any_ok",
+					"address_pool_type":   "IPv6",
+					"enable_status":       "enable",
+					"address_lb_strategy": "round_robin",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"address_pool_name":   "resource-test-pool-2",
+						"health_judgement":    "any_ok",
+						"address_pool_type":   "IPv6",
+						"enable_status":       "enable",
+						"address_lb_strategy": "round_robin",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"health_judgement":    "p30_ok",
+					"remark":              "test",
+					"address_lb_strategy": "weight",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"health_judgement":    "p30_ok",
+						"remark":              "test",
+						"address_lb_strategy": "weight",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudAlidnsCloudGtmAddressPoolMap12686 = map[string]string{
+	"create_time": CHECKSET,
+}
+
+func AlicloudAlidnsCloudGtmAddressPoolBasicDependence12686(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}

--- a/alicloud/service_alicloud_alidns_v2.go
+++ b/alicloud/service_alicloud_alidns_v2.go
@@ -1,0 +1,92 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+type AlidnsServiceV2 struct {
+	client *connectivity.AliyunClient
+}
+
+// DescribeAlidnsCloudGtmAddressPool <<< Encapsulated get interface for Alidns CloudGtmAddressPool.
+
+func (s *AlidnsServiceV2) DescribeAlidnsCloudGtmAddressPool(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["AddressPoolId"] = id
+
+	action := "DescribeCloudGtmAddressPool"
+	request["ClientToken"] = buildClientToken(action)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+		request["ClientToken"] = buildClientToken(action)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	currentStatus := response["AddressPoolId"]
+	if currentStatus == nil {
+		return object, WrapErrorf(NotFoundErr("CloudGtmAddressPool", id), NotFoundMsg, response)
+	}
+
+	return response, nil
+}
+
+func (s *AlidnsServiceV2) AlidnsCloudGtmAddressPoolStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.AlidnsCloudGtmAddressPoolStateRefreshFuncWithApi(id, field, failStates, s.DescribeAlidnsCloudGtmAddressPool)
+}
+
+func (s *AlidnsServiceV2) AlidnsCloudGtmAddressPoolStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeAlidnsCloudGtmAddressPool >>> Encapsulated.

--- a/website/docs/r/alidns_cloud_gtm_address_pool.html.markdown
+++ b/website/docs/r/alidns_cloud_gtm_address_pool.html.markdown
@@ -1,0 +1,90 @@
+---
+subcategory: "Alidns"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_alidns_cloud_gtm_address_pool"
+description: |-
+  Provides a Alicloud Alidns Cloud Gtm Address Pool resource.
+---
+
+# alicloud_alidns_cloud_gtm_address_pool
+
+Provides a Alidns Cloud Gtm Address Pool resource.
+
+CloudGtm Address Pool  .
+
+For information about Alidns Cloud Gtm Address Pool and how to use it, see [What is Cloud Gtm Address Pool](https://next.api.alibabacloud.com/document/Alidns/2015-01-09/CreateCloudGtmAddressPool).
+
+-> **NOTE:** Available since v1.277.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_alidns_cloud_gtm_address_pool" "default" {
+  address_pool_name         = "pool-example-1"
+  health_judgement          = "all_ok"
+  address_pool_type         = "IPv4"
+  enable_status             = "enable"
+  address_lb_strategy       = "sequence"
+  sequence_lb_strategy_mode = "preemptive"
+  remark                    = "remark"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `address_lb_strategy` - (Optional) Load balancing strategy among addresses in the address pool:
+  - round_robin: Round robin. For any incoming DNS query, all addresses are returned, and their order is rotated with each request.
+  - sequence: Sequential. For any incoming DNS query, addresses with lower sequence numbers are returned first (the sequence number indicates the priority of an address, where a lower number means higher priority). If an address with a lower sequence number is unavailable, the next available address with the next lowest sequence number is returned.
+  - weight: Weighted. Each address can be assigned a different weight, allowing DNS responses to return addresses according to their weight ratios.
+  - source_nearest: Source proximity. This intelligent resolution feature allows GTM to return different addresses based on the geographic location of the DNS query source, enabling users to access the nearest available endpoint.
+* `address_pool_name` - (Required) The name of the address pool. Fuzzy search is supported for the entered address pool name.  
+* `address_pool_type` - (Required, ForceNew) Address pool type:
+  - IPv4: Indicates that the service address to be resolved is an IPv4 address.
+  - IPv6: Indicates that the service address to be resolved is an IPv6 address.
+  - domain: Indicates that the service address to be resolved is a domain name.
+* `enable_status` - (Required) Enable status of the address pool:
+  - enable: Enabled. The address pool participates in DNS resolution when its health check is normal.
+  - disable: Disabled. The address pool does not participate in DNS resolution regardless of its health check status.
+* `health_judgement` - (Required) Conditions for determining the health status of the address pool:  
+  - any_ok: At least one address in the address pool is available.  
+  - p30_ok: At least 30% of the addresses in the address pool are available.  
+  - p50_ok: At least 50% of the addresses in the address pool are available.  
+  - p70_ok: At least 70% of the addresses in the address pool are available.  
+  - all_ok: All addresses in the address pool are available.  
+* `remark` - (Optional) A remark for the address pool to help users distinguish its usage scenario.  
+* `sequence_lb_strategy_mode` - (Optional) Service recovery mode for preceding resources when the load balancing strategy among addresses is set to sequential mode:  
+  - preemptive: Preemptive mode. When a preceding resource recovers, the address with the smaller sequence number is prioritized.  
+  - non_preemptive: Non-preemptive mode. When a preceding resource recovers, the current address continues to be used.  
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+* `create_time` - Creation time of the address pool.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Cloud Gtm Address Pool.
+* `delete` - (Defaults to 5 mins) Used when delete the Cloud Gtm Address Pool.
+* `update` - (Defaults to 5 mins) Used when update the Cloud Gtm Address Pool.
+
+## Import
+
+Alidns Cloud Gtm Address Pool can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_alidns_cloud_gtm_address_pool.example <address_pool_id>
+```


### PR DESCRIPTION
### New Resource
- `alicloud_alidns_cloud_gtm_address_pool`

## Summary

Adds a new resource `alicloud_alidns_cloud_gtm_address_pool` for managing Alidns Cloud GTM (Global Traffic Manager) address pools.

- Full CRUD + import lifecycle backed by the CloudGtmAddressPool APIs (Alidns 2015-01-09)
- Supports all documented address pool types (`IPv4`, `IPv6`, `domain`), load-balancing strategies (`round_robin`, `sequence`, `weight`, `source_nearest`), and health-judgement policies (`all_ok`, `any_ok`, `ratio_based`)
- Introduces helper file `service_alicloud_alidns_v2.go` for shared Alidns v2 service logic
- Acceptance tests and reference documentation included

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` clean
- [ ] Acceptance tests run: `TF_ACC=1 go test ./alicloud -v -run=TestAccAliCloudAlidnsCloudGtmAddressPool -timeout 120m`
- [ ] Documentation preview looks correct in `website/docs/r/alidns_cloud_gtm_address_pool.html.markdown`

