### PR TITLE
fix: increase assume_role default session expiration from 3600 to 43200

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -2198,7 +2198,7 @@ func providerConfigure(d *schema.ResourceData, p *schema.Provider) (interface{},
 				}
 			}
 			if config.RamRoleSessionExpiration == 0 {
-				config.RamRoleSessionExpiration = 3600
+				config.RamRoleSessionExpiration = 43200
 			}
 		} else {
 			config.RamRoleSessionExpiration = assumeRole["session_expiration"].(int)
@@ -2469,7 +2469,7 @@ func init() {
 
 		"assume_role_policy": "The permissions applied when assuming a role. You cannot use, this policy to grant further permissions that are in excess to those of the, role that is being assumed.",
 
-		"assume_role_session_expiration": "The time after which the established session for assuming role expires. Valid value range: [900-3600] seconds. Default to 0 (in this case Alicloud use own default value).",
+		"assume_role_session_expiration": "The time after which the established session for assuming role expires. Valid value range: [900-43200] seconds, and must not exceed the MaxSessionDuration of the RAM role. Default to 0 (in this case Alicloud uses its own default value of 3600).",
 
 		"skip_region_validation": "Skip static validation of region ID. Used by users of alternative AlibabaCloud-like APIs or users w/ access to regions that are not public (yet).",
 


### PR DESCRIPTION
## What

Increase the default `assume_role_session_expiration` from 3600 to 43200 seconds (12 hours) in the Terraform AliCloud provider.

## Why

The schema validation (`ValidateFunc: IntBetween(900, 43200)`) already allows up to 43200 seconds, matching the AliCloud RAM role `MaxSessionDuration` limit. However:

1. The hardcoded default in `providerConfigure` was still `3600` — silently overriding the schema bounds
2. The description said `[900-3600]` — contradicting the actual validation range
3. Users relying on the default got 1-hour STS tokens even when their RAM roles supported 12 hours

## Changes

- `provider.go`: Change default from `3600` → `43200`
- `provider.go`: Update description to reflect actual bounds (`[900-43200]`) and clarify that the value must not exceed the RAM role's `MaxSessionDuration`

## Testing

```hcl
provider "alicloud" {
  assume_role {
    # No session_expiration → now defaults to 43200 instead of 3600
    role_arn = "acs:ram::123456789:role/MyLongRunningRole"
  }
}
```