### PR TITLE
resource/alicloud_security_group_rule: Remove the cidr_ip and ipv6_cidr_ip constraint

### DIFF
--- a/alicloud/resource_alicloud_security_group_rule.go
+++ b/alicloud/resource_alicloud_security_group_rule.go
@@ -62,7 +62,6 @@ func resourceAliyunSecurityGroupRule() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				AtLeastOneOf: []string{"cidr_ip", "ipv6_cidr_ip", "source_security_group_id", "prefix_list_id"},
-				ValidateFunc: validation.IsCIDR,
 			},
 			"ipv6_cidr_ip": {
 				Type:          schema.TypeString,
@@ -73,7 +72,6 @@ func resourceAliyunSecurityGroupRule() *schema.Resource {
 					v, _ := compressIPv6OrCIDR(new)
 					return v == old
 				},
-				ValidateFunc: validation.IsCIDR,
 			},
 			"source_security_group_id": {
 				Type:          schema.TypeString,


### PR DESCRIPTION
Rremove the `cidr_ip` and `ipv6_cidr_ip` constraint

```log
=== RUN   TestAccAliCloudECSSecurityGroupRuleBasic
--- PASS: TestAccAliCloudECSSecurityGroupRuleBasic (56.78s)
=== RUN   TestAccAliCloudECSSecurityGroupRuleEgress
--- PASS: TestAccAliCloudECSSecurityGroupRuleEgress (28.89s)
=== RUN   TestAccAliCloudECSSecurityGroupRuleMulti
--- PASS: TestAccAliCloudECSSecurityGroupRuleMulti (25.15s)
=== RUN   TestAccAliCloudECSSecurityGroupRulePrefixList
--- PASS: TestAccAliCloudECSSecurityGroupRulePrefixList (15.24s)
=== RUN   TestAccAliCloudECSSecurityGroupRuleEgressIpv6
--- PASS: TestAccAliCloudECSSecurityGroupRuleEgressIpv6 (15.24s)
=== RUN   TestAccAliCloudECSSecurityGroupRuleIngressIpv6
--- PASS: TestAccAliCloudECSSecurityGroupRuleIngressIpv6 (15.57s)
=== RUN   TestAccAliCloudECSSecurityGroupRuleEgressOtherIpv6
--- PASS: TestAccAliCloudECSSecurityGroupRuleEgressOtherIpv6 (14.89s)
=== RUN   TestAccAliCloudECSSecurityGroupRuleIngressOtherIpv6
--- PASS: TestAccAliCloudECSSecurityGroupRuleIngressOtherIpv6 (14.88s)
=== RUN   TestAccAliCloudECSSecurityGroupRuleEgressICMPv6
--- PASS: TestAccAliCloudECSSecurityGroupRuleEgressICMPv6 (15.31s)

```