### PR TITLE
New Resource: alicloud_alidns_cloud_gtm_instance_config

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -916,6 +916,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_alidns_cloud_gtm_instance_config":                     resourceAliCloudAlidnsCloudGtmInstanceConfig(),
 			"alicloud_ecs_disk_encryption_by_default":                       resourceAliCloudEcsDiskEncryptionByDefault(),
 			"alicloud_cms_integration_policy":                               resourceAliCloudCmsIntegrationPolicy(),
 			"alicloud_cms_workspace":                                        resourceAliCloudCmsWorkspace(),

--- a/alicloud/resource_alicloud_alidns_cloud_gtm_instance_config.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_instance_config.go
@@ -1,0 +1,358 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudAlidnsCloudGtmInstanceConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudAlidnsCloudGtmInstanceConfigCreate,
+		Read:   resourceAliCloudAlidnsCloudGtmInstanceConfigRead,
+		Update: resourceAliCloudAlidnsCloudGtmInstanceConfigUpdate,
+		Delete: resourceAliCloudAlidnsCloudGtmInstanceConfigDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"address_pool_lb_strategy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"round_robin", "sequence", "weight", "source_nearest"}, false),
+			},
+			"config_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_status": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringInSlice([]string{"enable", "disable"}, false),
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"remark": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"schedule_host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"schedule_rr_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"A", "AAAA", "CNAME"}, false),
+			},
+			"schedule_zone_mode": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"custom"}, false),
+			},
+			"schedule_zone_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"sequence_lb_strategy_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"preemptive", "nonPreemptive"}, false),
+			},
+			"ttl": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudAlidnsCloudGtmInstanceConfigCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateCloudGtmInstanceConfig"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["ClientToken"] = buildClientToken(action)
+
+	request["EnableStatus"] = d.Get("enable_status")
+	if v, ok := d.GetOk("remark"); ok {
+		request["Remark"] = v
+	}
+	request["Ttl"] = d.Get("ttl")
+	request["ChargeType"] = "postpay"
+	request["ScheduleZoneMode"] = d.Get("schedule_zone_mode")
+	if v, ok := d.GetOk("schedule_host_name"); ok {
+		request["ScheduleHostname"] = v
+	}
+	request["ScheduleRrType"] = d.Get("schedule_rr_type")
+	if v, ok := d.GetOk("schedule_zone_name"); ok {
+		request["ScheduleZoneName"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_alidns_cloud_gtm_instance_config", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", response["ConfigId"], response["InstanceId"]))
+
+	return resourceAliCloudAlidnsCloudGtmInstanceConfigUpdate(d, meta)
+}
+
+func resourceAliCloudAlidnsCloudGtmInstanceConfigRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	alidnsServiceV2 := AlidnsServiceV2{client}
+
+	objectRaw, err := alidnsServiceV2.DescribeAlidnsCloudGtmInstanceConfig(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_alidns_cloud_gtm_instance_config DescribeAlidnsCloudGtmInstanceConfig Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("address_pool_lb_strategy", objectRaw["AddressPoolLbStrategy"])
+	d.Set("enable_status", objectRaw["EnableStatus"])
+	d.Set("remark", objectRaw["Remark"])
+	d.Set("schedule_host_name", objectRaw["ScheduleHostname"])
+	d.Set("schedule_rr_type", objectRaw["ScheduleRrType"])
+	d.Set("schedule_zone_mode", objectRaw["ScheduleZoneMode"])
+	d.Set("schedule_zone_name", objectRaw["ScheduleZoneName"])
+	d.Set("sequence_lb_strategy_mode", objectRaw["SequenceLbStrategyMode"])
+	d.Set("ttl", objectRaw["Ttl"])
+	d.Set("config_id", objectRaw["ConfigId"])
+	d.Set("instance_id", objectRaw["InstanceId"])
+
+	return nil
+}
+
+func resourceAliCloudAlidnsCloudGtmInstanceConfigUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+	d.Partial(true)
+
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	action := "UpdateCloudGtmInstanceConfigBasic"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ConfigId"] = parts[0]
+	request["InstanceId"] = parts[1]
+
+	request["ClientToken"] = buildClientToken(action)
+	if !d.IsNewResource() && d.HasChange("ttl") {
+		update = true
+	}
+	request["Ttl"] = d.Get("ttl")
+	if !d.IsNewResource() && d.HasChange("schedule_host_name") {
+		update = true
+	}
+	if v, ok := d.GetOk("schedule_host_name"); ok || d.HasChange("schedule_host_name") {
+		request["ScheduleHostname"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("schedule_zone_name") {
+		update = true
+	}
+	if v, ok := d.GetOk("schedule_zone_name"); ok || d.HasChange("schedule_zone_name") {
+		request["ScheduleZoneName"] = v
+	}
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	parts = strings.Split(d.Id(), ":")
+	action = "UpdateCloudGtmInstanceConfigEnableStatus"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ConfigId"] = parts[0]
+	request["InstanceId"] = parts[1]
+
+	request["ClientToken"] = buildClientToken(action)
+	if !d.IsNewResource() && d.HasChange("enable_status") {
+		update = true
+	}
+	request["EnableStatus"] = d.Get("enable_status")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	parts = strings.Split(d.Id(), ":")
+	action = "UpdateCloudGtmInstanceConfigLbStrategy"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ConfigId"] = parts[0]
+	request["InstanceId"] = parts[1]
+
+	request["ClientToken"] = buildClientToken(action)
+	if d.HasChange("sequence_lb_strategy_mode") {
+		update = true
+	}
+	if v, ok := d.GetOk("sequence_lb_strategy_mode"); ok || d.HasChange("sequence_lb_strategy_mode") {
+		request["SequenceLbStrategyMode"] = v
+	}
+	if d.HasChange("address_pool_lb_strategy") {
+		update = true
+	}
+	request["AddressPoolLbStrategy"] = d.Get("address_pool_lb_strategy")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	parts = strings.Split(d.Id(), ":")
+	action = "UpdateCloudGtmInstanceConfigRemark"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ConfigId"] = parts[0]
+	request["InstanceId"] = parts[1]
+
+	request["ClientToken"] = buildClientToken(action)
+	if !d.IsNewResource() && d.HasChange("remark") {
+		update = true
+	}
+	if v, ok := d.GetOk("remark"); ok || d.HasChange("remark") {
+		request["Remark"] = v
+	}
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	d.Partial(false)
+	return resourceAliCloudAlidnsCloudGtmInstanceConfigRead(d, meta)
+}
+
+func resourceAliCloudAlidnsCloudGtmInstanceConfigDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := "DeleteCloudGtmInstanceConfig"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["ConfigId"] = parts[0]
+	request["InstanceId"] = parts[1]
+
+	request["ClientToken"] = buildClientToken(action)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_alidns_cloud_gtm_instance_config_test.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_instance_config_test.go
@@ -1,0 +1,268 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Case resourceCase_20260320_bH90dh 12689
+func TestAccAliCloudAlidnsCloudGtmInstanceConfig_basic12689(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alidns_cloud_gtm_instance_config.default"
+	ra := resourceAttrInit(resourceId, AlicloudAlidnsCloudGtmInstanceConfigMap12689)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlidnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlidnsCloudGtmInstanceConfig")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalidns%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlidnsCloudGtmInstanceConfigBasicDependence12689)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"address_pool_lb_strategy":  "sequence",
+					"schedule_rr_type":          "A",
+					"schedule_zone_name":        "${alicloud_alidns_domain.default.domain_name}",
+					"enable_status":             "disable",
+					"schedule_host_name":        "example",
+					"schedule_zone_mode":        "custom",
+					"ttl":                       "600",
+					"sequence_lb_strategy_mode": "preemptive",
+					"remark":                    "remark",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"address_pool_lb_strategy":  "sequence",
+						"schedule_rr_type":          "A",
+						"schedule_zone_name":        CHECKSET,
+						"enable_status":             "disable",
+						"schedule_host_name":        "example",
+						"schedule_zone_mode":        "custom",
+						"ttl":                       "600",
+						"sequence_lb_strategy_mode": "preemptive",
+						"remark":                    "remark",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_zone_name":        "${alicloud_alidns_domain.default2.domain_name}",
+					"enable_status":             "enable",
+					"schedule_host_name":        "example-2",
+					"ttl":                       "60",
+					"sequence_lb_strategy_mode": "nonPreemptive",
+					"remark":                    "modify-test",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"schedule_zone_name":        CHECKSET,
+						"enable_status":             "enable",
+						"schedule_host_name":        "example-2",
+						"ttl":                       "60",
+						"sequence_lb_strategy_mode": "nonPreemptive",
+						"remark":                    "modify-test",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudAlidnsCloudGtmInstanceConfigMap12689 = map[string]string{
+	"config_id":   CHECKSET,
+	"instance_id": CHECKSET,
+}
+
+func AlicloudAlidnsCloudGtmInstanceConfigBasicDependence12689(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_alidns_domain" "default" {
+    domain_name = "%s.abc"
+}
+
+resource "alicloud_alidns_domain" "default2" {
+    domain_name = "%s-2.abc"
+}
+
+
+`, name, name, name)
+}
+
+// Case resourceCase_20260323_w4vWin 12679
+func TestAccAliCloudAlidnsCloudGtmInstanceConfig_basic12679(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alidns_cloud_gtm_instance_config.default"
+	ra := resourceAttrInit(resourceId, AlicloudAlidnsCloudGtmInstanceConfigMap12679)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlidnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlidnsCloudGtmInstanceConfig")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalidns%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlidnsCloudGtmInstanceConfigBasicDependence12679)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"address_pool_lb_strategy": "round_robin",
+					"schedule_rr_type":         "CNAME",
+					"schedule_zone_name":       "${alicloud_alidns_domain.default.domain_name}",
+					"enable_status":            "disable",
+					"schedule_host_name":       "www",
+					"schedule_zone_mode":       "custom",
+					"ttl":                      "600",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"address_pool_lb_strategy": "round_robin",
+						"schedule_rr_type":         "CNAME",
+						"schedule_zone_name":       CHECKSET,
+						"enable_status":            "disable",
+						"schedule_host_name":       "www",
+						"schedule_zone_mode":       "custom",
+						"ttl":                      "600",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudAlidnsCloudGtmInstanceConfigMap12679 = map[string]string{
+	"config_id":   CHECKSET,
+	"instance_id": CHECKSET,
+}
+
+func AlicloudAlidnsCloudGtmInstanceConfigBasicDependence12679(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_alidns_domain" "default" {
+    domain_name = "%s.abc"
+}
+
+
+`, name, name)
+}
+
+// Case resourceCase_20260323_zV1Ijx 12682
+func TestAccAliCloudAlidnsCloudGtmInstanceConfig_basic12682(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alidns_cloud_gtm_instance_config.default"
+	ra := resourceAttrInit(resourceId, AlicloudAlidnsCloudGtmInstanceConfigMap12682)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlidnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlidnsCloudGtmInstanceConfig")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalidns%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlidnsCloudGtmInstanceConfigBasicDependence12682)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"address_pool_lb_strategy": "round_robin",
+					"schedule_rr_type":         "AAAA",
+					"schedule_zone_name":       "${alicloud_alidns_domain.default.domain_name}",
+					"enable_status":            "disable",
+					"schedule_host_name":       "www",
+					"schedule_zone_mode":       "custom",
+					"ttl":                      "600",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"address_pool_lb_strategy": "round_robin",
+						"schedule_rr_type":         "AAAA",
+						"schedule_zone_name":       CHECKSET,
+						"enable_status":            "disable",
+						"schedule_host_name":       "www",
+						"schedule_zone_mode":       "custom",
+						"ttl":                      "600",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"address_pool_lb_strategy": "weight",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"address_pool_lb_strategy": "weight",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudAlidnsCloudGtmInstanceConfigMap12682 = map[string]string{
+	"config_id":   CHECKSET,
+	"instance_id": CHECKSET,
+}
+
+func AlicloudAlidnsCloudGtmInstanceConfigBasicDependence12682(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_alidns_domain" "default" {
+    domain_name = "%s.abc"
+}
+
+
+`, name, name)
+}

--- a/alicloud/service_alicloud_alidns_v2.go
+++ b/alicloud/service_alicloud_alidns_v2.go
@@ -90,3 +90,84 @@ func (s *AlidnsServiceV2) AlidnsCloudGtmAddressPoolStateRefreshFuncWithApi(id st
 }
 
 // DescribeAlidnsCloudGtmAddressPool >>> Encapsulated.
+
+// DescribeAlidnsCloudGtmInstanceConfig <<< Encapsulated get interface for Alidns CloudGtmInstanceConfig.
+
+func (s *AlidnsServiceV2) DescribeAlidnsCloudGtmInstanceConfig(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ConfigId"] = parts[0]
+	request["InstanceId"] = parts[1]
+
+	action := "DescribeCloudGtmInstanceConfigFullInfo"
+	request["ClientToken"] = buildClientToken(action)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+		request["ClientToken"] = buildClientToken(action)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	currentStatus := response["ConfigId"]
+	if currentStatus == nil {
+		return object, WrapErrorf(NotFoundErr("CloudGtmInstanceConfig", id), NotFoundMsg, response)
+	}
+
+	return response, nil
+}
+
+func (s *AlidnsServiceV2) AlidnsCloudGtmInstanceConfigStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.AlidnsCloudGtmInstanceConfigStateRefreshFuncWithApi(id, field, failStates, s.DescribeAlidnsCloudGtmInstanceConfig)
+}
+
+func (s *AlidnsServiceV2) AlidnsCloudGtmInstanceConfigStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeAlidnsCloudGtmInstanceConfig >>> Encapsulated.

--- a/website/docs/r/alidns_cloud_gtm_instance_config.html.markdown
+++ b/website/docs/r/alidns_cloud_gtm_instance_config.html.markdown
@@ -1,0 +1,95 @@
+---
+subcategory: "Alidns"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_alidns_cloud_gtm_instance_config"
+description: |-
+  Provides a Alicloud Alidns Cloud Gtm Instance Config resource.
+---
+
+# alicloud_alidns_cloud_gtm_instance_config
+
+Provides a Alidns Cloud Gtm Instance Config resource.
+
+CloudGtm Instance Configuration  .
+
+For information about Alidns Cloud Gtm Instance Config and how to use it, see [What is Cloud Gtm Instance Config](https://next.api.alibabacloud.com/document/Alidns/2015-01-09/CreateCloudGtmInstanceConfig).
+
+-> **NOTE:** Available since v1.277.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_alidns_domain" "default" {
+  domain_name = "${var.name}.abc"
+}
+
+resource "alicloud_alidns_cloud_gtm_instance_config" "default" {
+  address_pool_lb_strategy  = "sequence"
+  schedule_rr_type          = "A"
+  schedule_zone_name        = alicloud_alidns_domain.default.domain_name
+  enable_status             = "disable"
+  schedule_host_name        = "example"
+  schedule_zone_mode        = "custom"
+  ttl                       = "600"
+  sequence_lb_strategy_mode = "preemptive"
+  remark                    = "remark"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `address_pool_lb_strategy` - (Optional) The load balancing strategy among address pools:
+  - round_robin: Round-robin. For any incoming DNS resolution request, all address pools are returned, and the order of these address pools is rotated with each request.
+  - sequence: Sequential. For any incoming DNS resolution request, the address pool with the smallest sequence number is returned (the sequence number indicates the priority of the address pool, where a smaller number means higher priority). If the address pool with the smallest sequence number is unavailable, the next address pool with the next smallest sequence number is returned.
+  - weight: Weighted. You can assign different weights to each address pool so that DNS queries return address pools in proportion to their weights.
+  - source_nearest: Source proximity. This is the intelligent DNS resolution feature. GTM returns different address pools based on the geographic location of the DNS query source, enabling users to access the nearest available endpoint.
+* `enable_status` - (Required) The enable status of the domain instance:
+  - enable: Enabled. The GTM instance's intelligent scheduling policy is active.
+  - disable: Disabled. The GTM instance's intelligent scheduling policy is inactive.
+* `remark` - (Optional) Remarks. The provided parameter value becomes the updated remark content.  
+* `schedule_host_name` - (Optional) The host record of the GTM access domain.
+* `schedule_rr_type` - (Required, ForceNew) Record type for the access domain name:  
+  - A: IPv4 address  
+  - AAAA: IPv6 address  
+  - CNAME: domain name.  
+* `schedule_zone_mode` - (Required, ForceNew) Access domain name assignment mode:  
+  - custom: Custom access domain name. You define the host record and associate it with a primary or subdomain under the same account as the GTM instance to generate the access domain name.  
+  - sys_assign: System-assigned access domain name. This mode is no longer supported. Do not select it.
+* `schedule_zone_name` - (Optional) Zone name, which is the parent zone of the GTM access domain name. It is typically a hosted domain under the same account as the GTM instance in the Alibaba Cloud DNS console, and can be either a primary domain or a subdomain.  
+* `sequence_lb_strategy_mode` - (Optional) When the load balancing policy between address pools is set to sequential mode, the service restoration mode for preceding resources after an anomaly is resolved is as follows:  
+  - preemptive: Preemptive mode. When a preceding resource recovers, the address pool with the smaller sequence number is prioritized.  
+  - non_preemptive: Non-preemptive mode. When a preceding resource recovers, the current address pool continues to be used.  
+* `ttl` - (Required, Int) Global TTL (in seconds). This value determines how long the DNS records resolving the access domain name to addresses in the address pool are cached by the ISP's LocalDNS. Custom TTL values are supported.  
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<config_id>:<instance_id>`.
+* `config_id` - The domain name instance configuration ID.
+* `instance_id` - The instance ID associated with the GTM 3.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Cloud Gtm Instance Config.
+* `delete` - (Defaults to 5 mins) Used when delete the Cloud Gtm Instance Config.
+* `update` - (Defaults to 5 mins) Used when update the Cloud Gtm Instance Config.
+
+## Import
+
+Alidns Cloud Gtm Instance Config can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_alidns_cloud_gtm_instance_config.example <config_id>:<instance_id>
+```


### PR DESCRIPTION
## Summary

Adds a new resource `alicloud_alidns_cloud_gtm_instance_config` for managing Alidns Cloud GTM (Global Traffic Manager) instance configurations.

- Full CRUD + import lifecycle backed by the CloudGtmInstanceConfig APIs (Alidns 2015-01-09)
- Supports scheduling attributes (`schedule_rr_type`, `schedule_zone_mode`, `schedule_zone_name`, `schedule_host_name`), load-balancing strategies (`round_robin`, `sequence`, `weight`), and enable-status toggling
- Partial updates via separate APIs: `UpdateCloudGtmInstanceConfigBasic`, `UpdateCloudGtmInstanceConfigLbStrategy`, `UpdateCloudGtmInstanceConfigEnableStatus`, `UpdateCloudGtmInstanceConfigRemark`
- Acceptance tests and reference documentation included

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` clean
- [ ] Acceptance tests run: `TF_ACC=1 go test ./alicloud -v -run=TestAccAliCloudAlidnsCloudGtmInstanceConfig -timeout 120m`
- [ ] Documentation preview looks correct in `website/docs/r/alidns_cloud_gtm_instance_config.html.markdown`