### PR TITLE
New Resource: alicloud_alidns_cloud_gtm_monitor_template.

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -917,6 +917,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_alidns_cloud_gtm_instance_config":                     resourceAliCloudAlidnsCloudGtmInstanceConfig(),
+			"alicloud_alidns_cloud_gtm_monitor_template":                    resourceAliCloudAlidnsCloudGtmMonitorTemplate(),
 			"alicloud_ecs_disk_encryption_by_default":                       resourceAliCloudEcsDiskEncryptionByDefault(),
 			"alicloud_cms_integration_policy":                               resourceAliCloudCmsIntegrationPolicy(),
 			"alicloud_cms_workspace":                                        resourceAliCloudCmsWorkspace(),

--- a/alicloud/resource_alicloud_alidns_cloud_gtm_monitor_template.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_monitor_template.go
@@ -1,0 +1,347 @@
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudAlidnsCloudGtmMonitorTemplate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudAlidnsCloudGtmMonitorTemplateCreate,
+		Read:   resourceAliCloudAlidnsCloudGtmMonitorTemplateRead,
+		Update: resourceAliCloudAlidnsCloudGtmMonitorTemplateUpdate,
+		Delete: resourceAliCloudAlidnsCloudGtmMonitorTemplateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"evaluation_count": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: IntInSlice([]int{0, 1, 2, 3}),
+			},
+			"extend_info": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+			},
+			"failure_rate": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: IntInSlice([]int{0, 20, 50, 80, 100}),
+			},
+			"interval": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringInSlice([]string{"15", "60", "300", "900", "1800", "3600"}, false),
+			},
+			"ip_version": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"IPv4", "IPv6"}, false),
+			},
+			"isp_city_nodes": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"city_code": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"isp_code": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"protocol": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"ping", "tcp", "http", "https"}, false),
+			},
+			"remark": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"timeout": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringInSlice([]string{"2000", "3000", "5000", "10000"}, false),
+			},
+		},
+	}
+}
+
+func resourceAliCloudAlidnsCloudGtmMonitorTemplateCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateCloudGtmMonitorTemplate"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["ClientToken"] = buildClientToken(action)
+
+	request["Interval"] = d.Get("interval")
+	request["Protocol"] = d.Get("protocol")
+	request["IpVersion"] = d.Get("ip_version")
+	if v, ok := d.GetOk("isp_city_nodes"); ok {
+		ispCityNodesMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(v) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := make(map[string]interface{})
+			dataLoopMap["CityCode"] = dataLoopTmp["city_code"]
+			dataLoopMap["IspCode"] = dataLoopTmp["isp_code"]
+			ispCityNodesMapsArray = append(ispCityNodesMapsArray, dataLoopMap)
+		}
+		ispCityNodesMapsJson, err := json.Marshal(ispCityNodesMapsArray)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["IspCityNodes"] = string(ispCityNodesMapsJson)
+	}
+
+	request["EvaluationCount"] = d.Get("evaluation_count")
+	request["Timeout"] = d.Get("timeout")
+	if v, ok := d.GetOk("extend_info"); ok {
+		request["ExtendInfo"] = v
+	}
+	request["FailureRate"] = d.Get("failure_rate")
+	request["Name"] = d.Get("name")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_alidns_cloud_gtm_monitor_template", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["TemplateId"]))
+
+	return resourceAliCloudAlidnsCloudGtmMonitorTemplateUpdate(d, meta)
+}
+
+func resourceAliCloudAlidnsCloudGtmMonitorTemplateRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	alidnsServiceV2 := AlidnsServiceV2{client}
+
+	objectRaw, err := alidnsServiceV2.DescribeAlidnsCloudGtmMonitorTemplate(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_alidns_cloud_gtm_monitor_template DescribeAlidnsCloudGtmMonitorTemplate Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("evaluation_count", objectRaw["EvaluationCount"])
+	d.Set("extend_info", objectRaw["ExtendInfo"])
+	d.Set("failure_rate", objectRaw["FailureRate"])
+	d.Set("interval", objectRaw["Interval"])
+	d.Set("ip_version", objectRaw["IpVersion"])
+	d.Set("name", objectRaw["Name"])
+	d.Set("protocol", objectRaw["Protocol"])
+	d.Set("remark", objectRaw["Remark"])
+	d.Set("timeout", objectRaw["Timeout"])
+
+	ispCityNodeRaw, _ := jsonpath.Get("$.IspCityNodes.IspCityNode", objectRaw)
+	ispCityNodesMaps := make([]map[string]interface{}, 0)
+	if ispCityNodeRaw != nil {
+		for _, ispCityNodeChildRaw := range convertToInterfaceArray(ispCityNodeRaw) {
+			ispCityNodesMap := make(map[string]interface{})
+			ispCityNodeChildRaw := ispCityNodeChildRaw.(map[string]interface{})
+			ispCityNodesMap["city_code"] = ispCityNodeChildRaw["CityCode"]
+			ispCityNodesMap["isp_code"] = ispCityNodeChildRaw["IspCode"]
+
+			ispCityNodesMaps = append(ispCityNodesMaps, ispCityNodesMap)
+		}
+	}
+	if err := d.Set("isp_city_nodes", ispCityNodesMaps); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAliCloudAlidnsCloudGtmMonitorTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+	d.Partial(true)
+
+	var err error
+	action := "UpdateCloudGtmMonitorTemplate"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["TemplateId"] = d.Id()
+
+	request["ClientToken"] = buildClientToken(action)
+	if !d.IsNewResource() && d.HasChange("interval") {
+		update = true
+	}
+	request["Interval"] = d.Get("interval")
+	if !d.IsNewResource() && d.HasChange("isp_city_nodes") {
+		update = true
+	}
+	if v, ok := d.GetOk("isp_city_nodes"); ok || d.HasChange("isp_city_nodes") {
+		ispCityNodesMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(v) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := make(map[string]interface{})
+			dataLoopMap["CityCode"] = dataLoopTmp["city_code"]
+			dataLoopMap["IspCode"] = dataLoopTmp["isp_code"]
+			ispCityNodesMapsArray = append(ispCityNodesMapsArray, dataLoopMap)
+		}
+		ispCityNodesMapsJson, err := json.Marshal(ispCityNodesMapsArray)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["IspCityNodes"] = string(ispCityNodesMapsJson)
+	}
+
+	if !d.IsNewResource() && d.HasChange("evaluation_count") {
+		update = true
+	}
+	request["EvaluationCount"] = d.Get("evaluation_count")
+	if !d.IsNewResource() && d.HasChange("timeout") {
+		update = true
+	}
+	request["Timeout"] = d.Get("timeout")
+	if !d.IsNewResource() && d.HasChange("extend_info") {
+		update = true
+	}
+	request["ExtendInfo"] = d.Get("extend_info")
+
+	if !d.IsNewResource() && d.HasChange("failure_rate") {
+		update = true
+	}
+	request["FailureRate"] = d.Get("failure_rate")
+	if !d.IsNewResource() && d.HasChange("name") {
+		update = true
+	}
+	request["Name"] = d.Get("name")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	action = "UpdateCloudGtmMonitorTemplateRemark"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["TemplateId"] = d.Id()
+
+	request["ClientToken"] = buildClientToken(action)
+	if d.HasChange("remark") {
+		update = true
+		request["Remark"] = d.Get("remark")
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	d.Partial(false)
+	return resourceAliCloudAlidnsCloudGtmMonitorTemplateRead(d, meta)
+}
+
+func resourceAliCloudAlidnsCloudGtmMonitorTemplateDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteCloudGtmMonitorTemplate"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["TemplateId"] = d.Id()
+
+	request["ClientToken"] = buildClientToken(action)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_alidns_cloud_gtm_monitor_template_test.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_monitor_template_test.go
@@ -1,0 +1,430 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12684(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alidns_cloud_gtm_monitor_template.default"
+	ra := resourceAttrInit(resourceId, AlicloudAlidnsCloudGtmMonitorTemplateMap12684)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlidnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlidnsCloudGtmMonitorTemplate")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalidns%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlidnsCloudGtmMonitorTemplateBasicDependence12684)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ip_version": "IPv4",
+					"timeout":    "2000",
+					"isp_city_nodes": []map[string]interface{}{
+						{
+							"city_code": "357",
+							"isp_code":  "465",
+						},
+						{
+							"city_code": "738",
+							"isp_code":  "465",
+						},
+					},
+					"evaluation_count": "2",
+					"protocol":         "http",
+					"failure_rate":     "50",
+					"extend_info":      "{\\\"code\\\":500,\\\"followRedirect\\\":true,\\\"path\\\":\\\"/\\\"}",
+					"name":             name,
+					"interval":         "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ip_version":       "IPv4",
+						"timeout":          CHECKSET,
+						"isp_city_nodes.#": "2",
+						"evaluation_count": "2",
+						"protocol":         "http",
+						"failure_rate":     "50",
+						"extend_info":      CHECKSET,
+						"name":             name,
+						"interval":         CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudAlidnsCloudGtmMonitorTemplateMap12684 = map[string]string{}
+
+func AlicloudAlidnsCloudGtmMonitorTemplateBasicDependence12684(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_20260325_z3jf7s 12685
+func TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12685(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alidns_cloud_gtm_monitor_template.default"
+	ra := resourceAttrInit(resourceId, AlicloudAlidnsCloudGtmMonitorTemplateMap12685)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlidnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlidnsCloudGtmMonitorTemplate")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalidns%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlidnsCloudGtmMonitorTemplateBasicDependence12685)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ip_version": "IPv6",
+					"timeout":    "3000",
+					"isp_city_nodes": []map[string]interface{}{
+						{
+							"city_code": "357",
+							"isp_code":  "465",
+						},
+						{
+							"city_code": "738",
+							"isp_code":  "465",
+						},
+					},
+					"evaluation_count": "2",
+					"protocol":         "tcp",
+					"failure_rate":     "50",
+					"name":             name,
+					"interval":         "60",
+					"remark":           "test",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ip_version":       "IPv6",
+						"timeout":          CHECKSET,
+						"isp_city_nodes.#": "2",
+						"evaluation_count": "2",
+						"protocol":         "tcp",
+						"failure_rate":     "50",
+						"name":             name,
+						"interval":         CHECKSET,
+						"remark":           "test",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name": name + "_update",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name": name + "_update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"remark": name + "_update",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"remark": name + "_update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"interval": "300",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"interval": "300",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"failure_rate": "20",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"failure_rate": "20",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudAlidnsCloudGtmMonitorTemplateMap12685 = map[string]string{}
+
+func AlicloudAlidnsCloudGtmMonitorTemplateBasicDependence12685(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_20260325_u2rOov 12690
+func TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12690(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alidns_cloud_gtm_monitor_template.default"
+	ra := resourceAttrInit(resourceId, AlicloudAlidnsCloudGtmMonitorTemplateMap12690)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlidnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlidnsCloudGtmMonitorTemplate")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalidns%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlidnsCloudGtmMonitorTemplateBasicDependence12690)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ip_version": "IPv4",
+					"timeout":    "2000",
+					"isp_city_nodes": []map[string]interface{}{
+						{
+							"city_code": "357",
+							"isp_code":  "465",
+						},
+						{
+							"city_code": "738",
+							"isp_code":  "465",
+						},
+					},
+					"evaluation_count": "1",
+					"protocol":         "ping",
+					"failure_rate":     "20",
+					"extend_info":      "{\\\"packetLossRate\\\":10,\\\"packetNum\\\":20}",
+					"name":             name,
+					"interval":         "60",
+					"remark":           "test",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ip_version":       "IPv4",
+						"timeout":          CHECKSET,
+						"isp_city_nodes.#": "2",
+						"evaluation_count": "1",
+						"protocol":         "ping",
+						"failure_rate":     "20",
+						"extend_info":      CHECKSET,
+						"name":             name,
+						"interval":         CHECKSET,
+						"remark":           "test",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"isp_city_nodes": []map[string]interface{}{
+						{
+							"city_code": "304",
+							"isp_code":  "5",
+						},
+						{
+							"city_code": "738",
+							"isp_code":  "465",
+						},
+						{
+							"city_code": "304",
+							"isp_code":  "465",
+						},
+					},
+					"failure_rate": "50",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"isp_city_nodes.#": "3",
+						"failure_rate":     "50",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"extend_info": "{\\\"packetLossRate\\\":80,\\\"packetNum\\\":20}",
+					"timeout":     "3000",
+					"isp_city_nodes": []map[string]interface{}{
+						{
+							"city_code": "357",
+							"isp_code":  "465",
+						},
+						{
+							"city_code": "738",
+							"isp_code":  "465",
+						},
+					},
+					"evaluation_count": "2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"timeout":          CHECKSET,
+						"isp_city_nodes.#": "2",
+						"evaluation_count": "2",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudAlidnsCloudGtmMonitorTemplateMap12690 = map[string]string{}
+
+func AlicloudAlidnsCloudGtmMonitorTemplateBasicDependence12690(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_20260325_9q5Tgr 12691
+func TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12691(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alidns_cloud_gtm_monitor_template.default"
+	ra := resourceAttrInit(resourceId, AlicloudAlidnsCloudGtmMonitorTemplateMap12691)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlidnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlidnsCloudGtmMonitorTemplate")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalidns%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlidnsCloudGtmMonitorTemplateBasicDependence12691)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ip_version": "IPv4",
+					"timeout":    "3000",
+					"isp_city_nodes": []map[string]interface{}{
+						{
+							"city_code": "357",
+							"isp_code":  "465",
+						},
+						{
+							"city_code": "738",
+							"isp_code":  "465",
+						},
+					},
+					"evaluation_count": "2",
+					"protocol":         "https",
+					"failure_rate":     "80",
+					"extend_info":      "{\\\"code\\\":500,\\\"followRedirect\\\":true,\\\"path\\\":\\\"/\\\",\\\"sni\\\":true}",
+					"name":             name,
+					"interval":         "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ip_version":       "IPv4",
+						"timeout":          CHECKSET,
+						"isp_city_nodes.#": "2",
+						"evaluation_count": "2",
+						"protocol":         "https",
+						"failure_rate":     "80",
+						"extend_info":      CHECKSET,
+						"name":             name,
+						"interval":         CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"evaluation_count": "1",
+					"failure_rate":     "50",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"evaluation_count": "1",
+						"failure_rate":     "50",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudAlidnsCloudGtmMonitorTemplateMap12691 = map[string]string{}
+
+func AlicloudAlidnsCloudGtmMonitorTemplateBasicDependence12691(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}

--- a/alicloud/service_alicloud_alidns_v2.go
+++ b/alicloud/service_alicloud_alidns_v2.go
@@ -171,3 +171,76 @@ func (s *AlidnsServiceV2) AlidnsCloudGtmInstanceConfigStateRefreshFuncWithApi(id
 }
 
 // DescribeAlidnsCloudGtmInstanceConfig >>> Encapsulated.
+
+// DescribeAlidnsCloudGtmMonitorTemplate <<< Encapsulated get interface for Alidns CloudGtmMonitorTemplate.
+
+func (s *AlidnsServiceV2) DescribeAlidnsCloudGtmMonitorTemplate(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["TemplateId"] = id
+
+	action := "DescribeCloudGtmMonitorTemplate"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Alidns", "2015-01-09", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	currentStatus := response["TemplateId"]
+	if currentStatus == nil {
+		return object, WrapErrorf(NotFoundErr("CloudGtmMonitorTemplate", id), NotFoundMsg, response)
+	}
+
+	return response, nil
+}
+
+func (s *AlidnsServiceV2) AlidnsCloudGtmMonitorTemplateStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.AlidnsCloudGtmMonitorTemplateStateRefreshFuncWithApi(id, field, failStates, s.DescribeAlidnsCloudGtmMonitorTemplate)
+}
+
+func (s *AlidnsServiceV2) AlidnsCloudGtmMonitorTemplateStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeAlidnsCloudGtmMonitorTemplate >>> Encapsulated.

--- a/website/docs/r/alidns_cloud_gtm_monitor_template.html.markdown
+++ b/website/docs/r/alidns_cloud_gtm_monitor_template.html.markdown
@@ -1,0 +1,124 @@
+---
+subcategory: "Alidns"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_alidns_cloud_gtm_monitor_template"
+description: |-
+  Provides a Alicloud Alidns Cloud Gtm Monitor Template resource.
+---
+
+# alicloud_alidns_cloud_gtm_monitor_template
+
+Provides a Alidns Cloud Gtm Monitor Template resource.
+
+A Cloud GTM monitor template defines reusable health-check probe configurations (protocol, interval, failure thresholds, probe nodes) that can be attached to Cloud GTM address pools.
+
+For information about Alidns Cloud Gtm Monitor Template and how to use it, see [What is Cloud Gtm Monitor Template](https://next.api.alibabacloud.com/document/Alidns/2015-01-09/CreateCloudGtmMonitorTemplate).
+
+-> **NOTE:** Available since v1.277.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_alidns_cloud_gtm_monitor_template" "default" {
+  name             = var.name
+  protocol         = "http"
+  ip_version       = "IPv4"
+  interval         = "60"
+  timeout          = "2000"
+  evaluation_count = 2
+  failure_rate     = 50
+  extend_info = jsonencode({
+    code           = 500
+    followRedirect = true
+    path           = "/"
+  })
+  remark = "terraform-example-remark"
+
+  isp_city_nodes {
+    city_code = "357"
+    isp_code  = "465"
+  }
+
+  isp_city_nodes {
+    city_code = "738"
+    isp_code  = "465"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the monitor template. It is recommended to use a name that reflects the health-check protocol for easier identification.
+* `protocol` - (Required, ForceNew) The probing protocol of the template. Valid values: `ping`, `tcp`, `http`, `https`.
+* `ip_version` - (Required, ForceNew) The IP version of the probing node. Valid values: `IPv4`, `IPv6`.
+* `interval` - (Required) The interval between consecutive probes, in seconds. Valid values: `15`, `60`, `300`, `900`, `1800`, `3600`. The `15` seconds interval is only available for Flagship Edition instances.
+* `timeout` - (Required) Probe request timeout, in milliseconds. Probe packets that do not return within this duration are treated as timeouts. Valid values: `2000`, `3000`, `5000`, `10000`.
+* `evaluation_count` - (Required, Int) The number of retries after a probe failure. A service is marked abnormal only after this many consecutive failures, preventing transient network fluctuations from triggering false alarms. Valid values: `0`, `1`, `2`, `3`.
+* `failure_rate` - (Required, Int) The failure-rate threshold (%) among selected probe nodes. If the percentage of failing nodes exceeds this value, the service address is marked as abnormal. Valid values: `0`, `20`, `50`, `80`, `100`.
+* `isp_city_nodes` - (Required, Set) The set of monitoring nodes that this template will probe from. Use the [ListCloudGtmMonitorNodes](https://help.aliyun.com/document_detail/2797349.html) API to look up available `city_code` / `isp_code` combinations. See [`isp_city_nodes`](#isp_city_nodes) below.
+* `extend_info` - (Optional, Computed) A JSON string containing protocol-specific probe configuration. The supported keys depend on `protocol`. See [`extend_info`](#extend_info) below.
+* `remark` - (Optional) The remark of the monitor template. Passing an empty value clears the existing remark.
+
+### `isp_city_nodes`
+
+The `isp_city_nodes` block supports:
+
+* `city_code` - (Optional) The city code of the monitoring node.
+* `isp_code` - (Optional) The ISP (Internet Service Provider) code of the monitoring node.
+
+### `extend_info`
+
+The `extend_info` argument takes a JSON-encoded string. The supported keys depend on `protocol`.
+
+Keys for `http` / `https`:
+
+| Key              | Description                                                                                                                                                                                                                         |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `host`           | The value of the `Host` header carried in the HTTP(S) request. Defaults to the primary domain of the target. Set this when the target site requires a specific Host header.                                                        |
+| `path`           | The URL path to probe. Defaults to `/`.                                                                                                                                                                                             |
+| `code`           | HTTP response-code threshold used to classify the service as abnormal. Valid values: `400` (Bad Request — use when the probe URL includes parameters and you want to detect invalid-request responses), `500` (Server Error, default). |
+| `sni`            | Whether to enable Server Name Indication during the TLS handshake (HTTPS only). Valid values: `true`, `false`.                                                                                                                      |
+| `followRedirect` | Whether to follow HTTP 3XX redirects (`301`, `302`, `303`, `307`, `308`). Valid values: `true`, `false`.                                                                                                                             |
+
+Keys for `ping`:
+
+| Key              | Description                                                                                                                                                             |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `packetNum`      | The number of ICMP packets sent in each probe cycle. Valid values: `20`, `50`, `100`.                                                                                   |
+| `packetLossRate` | The packet-loss rate (%) that triggers an alert. Computed as `lost_packets / total_packets * 100`. Valid values: `10`, `30`, `40`, `80`, `90`, `100`.                   |
+
+No additional keys are required for `tcp` probes.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the monitor template. It is the same as the `template_id` returned by the API.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 5 mins) Used when creating the Cloud Gtm Monitor Template.
+* `update` - (Defaults to 5 mins) Used when updating the Cloud Gtm Monitor Template.
+* `delete` - (Defaults to 5 mins) Used when deleting the Cloud Gtm Monitor Template.
+
+## Import
+
+Alidns Cloud Gtm Monitor Template can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_alidns_cloud_gtm_monitor_template.example <template_id>
+```


### PR DESCRIPTION
## Summary

Adds `alicloud_alidns_cloud_gtm_monitor_template` — a reusable Cloud GTM health-check probe template (protocol / interval / failure thresholds / probe nodes) that can later be attached to Cloud GTM address pools.

## What's in the PR

- **Resource** (`alicloud/resource_alicloud_alidns_cloud_gtm_monitor_template.go`) — full Create / Read / Update / Delete / Import lifecycle.
- **Service layer** (`alicloud/service_alicloud_alidns_v2.go`) — `DescribeAlidnsCloudGtmMonitorTemplate` + state-refresh helpers.
- **Registration** in `alicloud/provider.go`.
- **Acceptance tests** — 4 cases covering the attribute matrix across `ping` / `tcp` / `http` / `https` protocols and `IPv4` / `IPv6`: `basic12684`, `basic12685`, `basic12690`, `basic12691`.
- **Documentation** (`website/docs/r/alidns_cloud_gtm_monitor_template.html.markdown`) — written to render cleanly on the Terraform Registry and aligned with the actual schema:
  - `isp_city_nodes` labelled `(Required, Set)` to match `schema.TypeSet`.
  - Enum values match schema validators (`evaluation_count`: `0`/`1`/`2`/`3`; `failure_rate`: `0`/`20`/`50`/`80`/`100`; `interval`: `15`/`60`/`300`/`900`/`1800`/`3600`; `timeout`: `2000`/`3000`/`5000`/`10000`).
  - `extend_info` documented as a dedicated section split by `protocol` (`http`/`https`, `ping`, `tcp`) so the nested JSON fields render as proper GFM lists on the Registry.
  - `extend_info` labelled `(Optional, Computed)` to match `Computed: true` in the schema.

## Test plan

- [ ] `IntegrationTest` CI job passes all 4 acceptance cases
- [ ] `DocsExampleTest` CI job passes (init → plan → apply → no-drift → import → apply import plan → destroy)