### PR TITLE
doc: update alicloud_cr_ee_instance doc for international site

### DIFF
--- a/website/docs/r/cr_ee_instance.html.markdown
+++ b/website/docs/r/cr_ee_instance.html.markdown
@@ -17,6 +17,8 @@ For information about CR Instance and how to use it, see [What is Instance](http
 
 -> **NOTE:** Available since v1.124.0.
 
+-> **NOTE:** Internation site only support `Basic` and `Advance` instance types.
+
 ## Example Usage
 
 Basic Usage


### PR DESCRIPTION
International site`alicloud_cr_ee_instance` only support `Basic` and `Advanced` instance types.
Relate issue: #9701