### PR TITLE
improvement: sync resource/data source deprecation notice from docs to code

### DIFF
--- a/alicloud/data_source_alicloud_arms_remote_writes.go
+++ b/alicloud/data_source_alicloud_arms_remote_writes.go
@@ -14,7 +14,8 @@ import (
 
 func dataSourceAlicloudArmsRemoteWrites() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudArmsRemoteWritesRead,
+		Read:               dataSourceAlicloudArmsRemoteWritesRead,
+		DeprecationMessage: "This data source has been deprecated since v1.228.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"ids": {
 				Type:     schema.TypeList,

--- a/alicloud/data_source_alicloud_brain_industrial_pid_loops.go
+++ b/alicloud/data_source_alicloud_brain_industrial_pid_loops.go
@@ -12,7 +12,8 @@ import (
 
 func dataSourceAlicloudBrainIndustrialPidLoops() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudBrainIndustrialPidLoopsRead,
+		Read:               dataSourceAlicloudBrainIndustrialPidLoopsRead,
+		DeprecationMessage: "This data source has been deprecated since v1.229.1 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"name_regex": {
 				Type:         schema.TypeString,

--- a/alicloud/data_source_alicloud_brain_industrial_pid_organizations.go
+++ b/alicloud/data_source_alicloud_brain_industrial_pid_organizations.go
@@ -12,7 +12,8 @@ import (
 
 func dataSourceAlicloudBrainIndustrialPidOrganizations() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudBrainIndustrialPidOrganizationsRead,
+		Read:               dataSourceAlicloudBrainIndustrialPidOrganizationsRead,
+		DeprecationMessage: "This data source has been deprecated since v1.229.1 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"parent_organization_id": {
 				Type:     schema.TypeString,

--- a/alicloud/data_source_alicloud_brain_industrial_pid_projects.go
+++ b/alicloud/data_source_alicloud_brain_industrial_pid_projects.go
@@ -12,7 +12,8 @@ import (
 
 func dataSourceAlicloudBrainIndustrialPidProjects() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudBrainIndustrialPidProjectsRead,
+		Read:               dataSourceAlicloudBrainIndustrialPidProjectsRead,
+		DeprecationMessage: "This data source has been deprecated since v1.229.1 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"pid_organization_id": {
 				Type:     schema.TypeString,

--- a/alicloud/data_source_alicloud_brain_industrial_service.go
+++ b/alicloud/data_source_alicloud_brain_industrial_service.go
@@ -11,7 +11,8 @@ import (
 
 func dataSourceAlicloudBrainIndustrialService() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudBrainIndustrialServiceRead,
+		Read:               dataSourceAlicloudBrainIndustrialServiceRead,
+		DeprecationMessage: "This data source has been deprecated since v1.229.1 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"enable": {
 				Type:         schema.TypeString,

--- a/alicloud/data_source_alicloud_cassandra_backup_plans.go
+++ b/alicloud/data_source_alicloud_cassandra_backup_plans.go
@@ -12,7 +12,8 @@ import (
 
 func dataSourceAlicloudCassandraBackupPlans() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudCassandraBackupPlansRead,
+		Read:               dataSourceAlicloudCassandraBackupPlansRead,
+		DeprecationMessage: "This data source has been deprecated since v1.220.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"cluster_id": {
 				Type:     schema.TypeString,

--- a/alicloud/data_source_alicloud_cassandra_clusters.go
+++ b/alicloud/data_source_alicloud_cassandra_clusters.go
@@ -12,7 +12,8 @@ import (
 
 func dataSourceAlicloudCassandraClusters() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudCassandraClustersRead,
+		Read:               dataSourceAlicloudCassandraClustersRead,
+		DeprecationMessage: "This data source has been deprecated since v1.220.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"ids": {
 				Type:     schema.TypeList,

--- a/alicloud/data_source_alicloud_cassandra_data_centers.go
+++ b/alicloud/data_source_alicloud_cassandra_data_centers.go
@@ -12,7 +12,8 @@ import (
 
 func dataSourceAlicloudCassandraDataCenters() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudCassandraDataCentersRead,
+		Read:               dataSourceAlicloudCassandraDataCentersRead,
+		DeprecationMessage: "This data source has been deprecated since v1.220.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"ids": {
 				Type:     schema.TypeList,

--- a/alicloud/data_source_alicloud_cassandra_zones.go
+++ b/alicloud/data_source_alicloud_cassandra_zones.go
@@ -14,6 +14,8 @@ func dataSourceAlicloudCassandraZones() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAlicloudZonesCassandraRead,
 
+		DeprecationMessage: "This data source has been deprecated since v1.220.0 and will be removed in the future.",
+
 		Schema: map[string]*schema.Schema{
 			"multi": {
 				Type:     schema.TypeBool,

--- a/alicloud/data_source_alicloud_cms_service.go
+++ b/alicloud/data_source_alicloud_cms_service.go
@@ -13,6 +13,8 @@ func dataSourceAlicloudCmsService() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAlicloudCmsServiceRead,
 
+		DeprecationMessage: "This data source has been deprecated since v1.219.0 and will be removed in the future.",
+
 		Schema: map[string]*schema.Schema{
 			"enable": {
 				Type:         schema.TypeString,

--- a/alicloud/data_source_alicloud_config_delivery_channels.go
+++ b/alicloud/data_source_alicloud_config_delivery_channels.go
@@ -12,7 +12,8 @@ import (
 
 func dataSourceAlicloudConfigDeliveryChannels() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudConfigDeliveryChannelsRead,
+		Read:               dataSourceAlicloudConfigDeliveryChannelsRead,
+		DeprecationMessage: "This data source has been deprecated since v1.173.0 and will be removed in the future. Please use 'alicloud_config_deliveries' instead.",
 		Schema: map[string]*schema.Schema{
 			"name_regex": {
 				Type:         schema.TypeString,

--- a/alicloud/data_source_alicloud_emr_clusters.go
+++ b/alicloud/data_source_alicloud_emr_clusters.go
@@ -14,7 +14,8 @@ import (
 
 func dataSourceAlicloudEmrClusters() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudEmrClustersRead,
+		Read:               dataSourceAlicloudEmrClustersRead,
+		DeprecationMessage: "This data source has been deprecated since v1.204.0 and will be removed in the future. Please use 'alicloud_emrv2_clusters' instead.",
 		Schema: map[string]*schema.Schema{
 			"ids": {
 				Type:     schema.TypeList,

--- a/alicloud/data_source_alicloud_log_alert_resource.go
+++ b/alicloud/data_source_alicloud_log_alert_resource.go
@@ -15,7 +15,8 @@ import (
 
 func dataSourceAlicloudLogAlertResource() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudLogAlertResourceRead,
+		Read:               dataSourceAlicloudLogAlertResourceRead,
+		DeprecationMessage: "This data source has been deprecated since v1.219.0 and will be removed in the future. Please use 'alicloud_log_alert_resource' resource instead.",
 		Schema: map[string]*schema.Schema{
 			"type": {
 				Type:         schema.TypeString,

--- a/alicloud/data_source_alicloud_mns_queues.go
+++ b/alicloud/data_source_alicloud_mns_queues.go
@@ -8,7 +8,8 @@ import (
 
 func dataSourceAlicloudMNSQueues() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudMNSQueueRead,
+		Read:               dataSourceAlicloudMNSQueueRead,
+		DeprecationMessage: "This data source has been deprecated since v1.188.0 and will be removed in the future. Please use 'alicloud_message_service_queues' instead.",
 		Schema: map[string]*schema.Schema{
 			"name_prefix": {
 				Type:     schema.TypeString,

--- a/alicloud/data_source_alicloud_mns_service.go
+++ b/alicloud/data_source_alicloud_mns_service.go
@@ -14,6 +14,8 @@ func dataSourceAlicloudMnsService() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAlicloudMnsServiceRead,
 
+		DeprecationMessage: "This data source has been deprecated since v1.252.0 and will be removed in the future. Please use 'alicloud_message_service_service' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"enable": {
 				Type:         schema.TypeString,

--- a/alicloud/data_source_alicloud_mns_topic_subscriptions.go
+++ b/alicloud/data_source_alicloud_mns_topic_subscriptions.go
@@ -8,7 +8,8 @@ import (
 
 func dataSourceAlicloudMNSTopicSubscriptions() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudMNSTopicSubscriptionRead,
+		Read:               dataSourceAlicloudMNSTopicSubscriptionRead,
+		DeprecationMessage: "This data source has been deprecated since v1.188.0 and will be removed in the future. Please use 'alicloud_message_service_subscriptions' instead.",
 		Schema: map[string]*schema.Schema{
 			"topic_name": {
 				Type:     schema.TypeString,

--- a/alicloud/data_source_alicloud_mns_topics.go
+++ b/alicloud/data_source_alicloud_mns_topics.go
@@ -8,7 +8,8 @@ import (
 
 func dataSourceAlicloudMNSTopics() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudMNSTopicRead,
+		Read:               dataSourceAlicloudMNSTopicRead,
+		DeprecationMessage: "This data source has been deprecated since v1.188.0 and will be removed in the future. Please use 'alicloud_message_service_topics' instead.",
 		Schema: map[string]*schema.Schema{
 			"name_prefix": {
 				Type:     schema.TypeString,

--- a/alicloud/data_source_alicloud_rdc_organizations.go
+++ b/alicloud/data_source_alicloud_rdc_organizations.go
@@ -14,7 +14,8 @@ import (
 
 func dataSourceAlicloudRdcOrganizations() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudRdcOrganizationsRead,
+		Read:               dataSourceAlicloudRdcOrganizationsRead,
+		DeprecationMessage: "This data source has been deprecated since v1.238.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"ids": {
 				Type:     schema.TypeList,

--- a/alicloud/data_source_alicloud_router_interfaces.go
+++ b/alicloud/data_source_alicloud_router_interfaces.go
@@ -14,6 +14,8 @@ func dataSourceAlicloudRouterInterfaces() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAlicloudRouterInterfacesRead,
 
+		DeprecationMessage: "This data source has been deprecated since v1.199.0 and will be removed in the future. Please use 'alicloud_express_connect_router_interfaces' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"status": {
 				Type:         schema.TypeString,

--- a/alicloud/data_source_alicloud_service_catalog_product_as_end_users.go
+++ b/alicloud/data_source_alicloud_service_catalog_product_as_end_users.go
@@ -14,7 +14,8 @@ import (
 
 func dataSourceAlicloudServiceCatalogProductAsEndUsers() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudServiceCatalogProductAsEndUsersRead,
+		Read:               dataSourceAlicloudServiceCatalogProductAsEndUsersRead,
+		DeprecationMessage: "This data source has been deprecated since v1.197.0 and will be removed in the future. Please use 'alicloud_service_catalog_end_user_products' instead.",
 		Schema: map[string]*schema.Schema{
 			"sort_by": {
 				Optional: true,

--- a/alicloud/resource_alicloud_arms_remote_write.go
+++ b/alicloud/resource_alicloud_arms_remote_write.go
@@ -26,6 +26,7 @@ func resourceAliCloudArmsRemoteWrite() *schema.Resource {
 			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.228.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"cluster_id": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_brain_industrial_pid_loop.go
+++ b/alicloud/resource_alicloud_brain_industrial_pid_loop.go
@@ -20,6 +20,7 @@ func resourceAlicloudBrainIndustrialPidLoop() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.229.1 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"pid_loop_configuration": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_brain_industrial_pid_organization.go
+++ b/alicloud/resource_alicloud_brain_industrial_pid_organization.go
@@ -19,6 +19,7 @@ func resourceAlicloudBrainIndustrialPidOrganization() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.222.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"parent_pid_organization_id": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_brain_industrial_pid_project.go
+++ b/alicloud/resource_alicloud_brain_industrial_pid_project.go
@@ -19,6 +19,7 @@ func resourceAlicloudBrainIndustrialPidProject() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.222.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"pid_organization_id": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_cassandra_backup_plan.go
+++ b/alicloud/resource_alicloud_cassandra_backup_plan.go
@@ -20,6 +20,7 @@ func resourceAlicloudCassandraBackupPlan() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.220.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"active": {
 				Type:     schema.TypeBool,

--- a/alicloud/resource_alicloud_cassandra_cluster.go
+++ b/alicloud/resource_alicloud_cassandra_cluster.go
@@ -27,6 +27,7 @@ func resourceAlicloudCassandraCluster() *schema.Resource {
 			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.220.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"auto_renew": {
 				Type:     schema.TypeBool,

--- a/alicloud/resource_alicloud_cassandra_data_center.go
+++ b/alicloud/resource_alicloud_cassandra_data_center.go
@@ -26,6 +26,7 @@ func resourceAlicloudCassandraDataCenter() *schema.Resource {
 			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.220.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"auto_renew": {
 				Type:     schema.TypeBool,

--- a/alicloud/resource_alicloud_cddc_dedicated_host.go
+++ b/alicloud/resource_alicloud_cddc_dedicated_host.go
@@ -26,6 +26,7 @@ func resourceAlicloudCddcDedicatedHost() *schema.Resource {
 			Update: schema.DefaultTimeout(20 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.225.1 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"allocation_status": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_cddc_dedicated_host_account.go
+++ b/alicloud/resource_alicloud_cddc_dedicated_host_account.go
@@ -21,6 +21,7 @@ func resourceAlicloudCddcDedicatedHostAccount() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.225.1 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"account_name": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_cddc_dedicated_host_group.go
+++ b/alicloud/resource_alicloud_cddc_dedicated_host_group.go
@@ -19,6 +19,7 @@ func resourceAlicloudCddcDedicatedHostGroup() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.225.1 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"allocation_policy": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_cddc_dedicated_propre_host.go
+++ b/alicloud/resource_alicloud_cddc_dedicated_propre_host.go
@@ -28,6 +28,7 @@ func resourceAliCloudCddcDedicatedPropreHost() *schema.Resource {
 			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.225.1 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"auto_pay": {
 				Type:     schema.TypeBool,

--- a/alicloud/resource_alicloud_config_delivery_channel.go
+++ b/alicloud/resource_alicloud_config_delivery_channel.go
@@ -24,6 +24,7 @@ func resourceAlicloudConfigDeliveryChannel() *schema.Resource {
 			Create: schema.DefaultTimeout(3 * time.Minute),
 			Update: schema.DefaultTimeout(3 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.171.0 and will be removed in the future. Please use 'alicloud_config_delivery' instead.",
 		Schema: map[string]*schema.Schema{
 			"delivery_channel_assume_role_arn": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_das_switch_das_pro.go
+++ b/alicloud/resource_alicloud_das_switch_das_pro.go
@@ -22,6 +22,7 @@ func resourceAlicloudDasSwitchDasPro() *schema.Resource {
 			Create: schema.DefaultTimeout(3 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.249.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"instance_id": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_dns.go
+++ b/alicloud/resource_alicloud_dns.go
@@ -20,6 +20,8 @@ func resourceAlicloudDns() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.95.0 and will be removed in the future. Please use 'alicloud_alidns_domain' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_dns_group.go
+++ b/alicloud/resource_alicloud_dns_group.go
@@ -16,6 +16,8 @@ func resourceAlicloudDnsGroup() *schema.Resource {
 		Update: resourceAlicloudDnsGroupUpdate,
 		Delete: resourceAlicloudDnsGroupDelete,
 
+		DeprecationMessage: "This resource has been deprecated since v1.84.0 and will be removed in the future. Please use 'alicloud_alidns_domain_group' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_dns_record.go
+++ b/alicloud/resource_alicloud_dns_record.go
@@ -22,6 +22,8 @@ func resourceAlicloudDnsRecord() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.85.0 and will be removed in the future. Please use 'alicloud_alidns_record' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_ecd_ram_directory.go
+++ b/alicloud/resource_alicloud_ecd_ram_directory.go
@@ -24,6 +24,7 @@ func resourceAlicloudEcdRamDirectory() *schema.Resource {
 			Create: schema.DefaultTimeout(1 * time.Minute),
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.239.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"desktop_access_type": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_ehpc_cluster.go
+++ b/alicloud/resource_alicloud_ehpc_cluster.go
@@ -26,6 +26,7 @@ func resourceAlicloudEhpcCluster() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.272.0 and will be removed in the future. Please use 'alicloud_ehpc_cluster_v2' instead.",
 		Schema: map[string]*schema.Schema{
 			"account_type": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_emr_cluster.go
+++ b/alicloud/resource_alicloud_emr_cluster.go
@@ -29,6 +29,8 @@ func resourceAlicloudEmrCluster() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.204.0 and will be removed in the future. Please use 'alicloud_emrv2_cluster' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_event_bridge_event_source.go
+++ b/alicloud/resource_alicloud_event_bridge_event_source.go
@@ -19,6 +19,7 @@ func resourceAliCloudEventBridgeEventSource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.269.0 and will be removed in the future. Please use 'alicloud_event_bridge_event_source_v2' instead.",
 		Schema: map[string]*schema.Schema{
 			"event_bus_name": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_fc_alias.go
+++ b/alicloud/resource_alicloud_fc_alias.go
@@ -21,6 +21,8 @@ func resourceAlicloudFCAlias() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.272.0 and will be removed in the future. Please use 'alicloud_fcv3_alias' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"service_name": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_fc_custom_domain.go
+++ b/alicloud/resource_alicloud_fc_custom_domain.go
@@ -20,6 +20,7 @@ func resourceAlicloudFCCustomDomain() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.272.0 and will be removed in the future. Please use 'alicloud_fcv3_custom_domain' instead.",
 		Schema: map[string]*schema.Schema{
 			"domain_name": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_fc_function.go
+++ b/alicloud/resource_alicloud_fc_function.go
@@ -24,6 +24,8 @@ func resourceAlicloudFCFunction() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.272.0 and will be removed in the future. Please use 'alicloud_fcv3_function' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"service": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_fc_function_async_invoke_config.go
+++ b/alicloud/resource_alicloud_fc_function_async_invoke_config.go
@@ -23,6 +23,7 @@ func resourceAlicloudFCFunctionAsyncInvokeConfig() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.272.0 and will be removed in the future. Please use 'alicloud_fcv3_async_invoke_config' instead.",
 		Schema: map[string]*schema.Schema{
 			"service_name": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_fc_layer_version.go
+++ b/alicloud/resource_alicloud_fc_layer_version.go
@@ -24,6 +24,7 @@ func resourceAlicloudFcLayerVersion() *schema.Resource {
 			Create: schema.DefaultTimeout(1 * time.Minute),
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.272.0 and will be removed in the future. Please use FCV3 layer resources instead.",
 		Schema: map[string]*schema.Schema{
 			"acl": {
 				Computed: true,

--- a/alicloud/resource_alicloud_fc_service.go
+++ b/alicloud/resource_alicloud_fc_service.go
@@ -24,6 +24,8 @@ func resourceAlicloudFCService() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.272.0 and will be removed in the future. Please use 'alicloud_fcv3_function' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:          schema.TypeString,

--- a/alicloud/resource_alicloud_fc_trigger.go
+++ b/alicloud/resource_alicloud_fc_trigger.go
@@ -22,6 +22,8 @@ func resourceAlicloudFCTrigger() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.272.0 and will be removed in the future. Please use 'alicloud_fcv3_trigger' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"service": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_gpdb_elastic_instance.go
+++ b/alicloud/resource_alicloud_gpdb_elastic_instance.go
@@ -26,6 +26,7 @@ func resourceAlicloudGpdbElasticInstance() *schema.Resource {
 			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.147.0 and will be removed in the future. Please use 'alicloud_gpdb_instance' instead.",
 		Schema: map[string]*schema.Schema{
 			"engine": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_hbr_ecs_backup_plan.go
+++ b/alicloud/resource_alicloud_hbr_ecs_backup_plan.go
@@ -21,6 +21,7 @@ func resourceAlicloudHbrEcsBackupPlan() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.249.0 and will be removed in the future. Please use 'alicloud_hbr_policy' and 'alicloud_hbr_policy_binding' instead.",
 		Schema: map[string]*schema.Schema{
 			"ecs_backup_plan_name": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_hbr_nas_backup_plan.go
+++ b/alicloud/resource_alicloud_hbr_nas_backup_plan.go
@@ -22,6 +22,7 @@ func resourceAlicloudHbrNasBackupPlan() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.249.0 and will be removed in the future. Please use 'alicloud_hbr_policy' and 'alicloud_hbr_policy_binding' instead.",
 		Schema: map[string]*schema.Schema{
 			"backup_type": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_hbr_oss_backup_plan.go
+++ b/alicloud/resource_alicloud_hbr_oss_backup_plan.go
@@ -21,6 +21,7 @@ func resourceAlicloudHbrOssBackupPlan() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.249.0 and will be removed in the future. Please use 'alicloud_hbr_policy' and 'alicloud_hbr_policy_binding' instead.",
 		Schema: map[string]*schema.Schema{
 			"backup_type": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_hbr_ots_backup_plan.go
+++ b/alicloud/resource_alicloud_hbr_ots_backup_plan.go
@@ -22,6 +22,7 @@ func resourceAlicloudHbrOtsBackupPlan() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.249.0 and will be removed in the future. Please use 'alicloud_hbr_policy' and 'alicloud_hbr_policy_binding' instead.",
 		Schema: map[string]*schema.Schema{
 			"backup_type": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_hbr_server_backup_plan.go
+++ b/alicloud/resource_alicloud_hbr_server_backup_plan.go
@@ -21,6 +21,7 @@ func resourceAlicloudHbrServerBackupPlan() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.249.0 and will be removed in the future. Please use 'alicloud_hbr_policy' and 'alicloud_hbr_policy_binding' instead.",
 		Schema: map[string]*schema.Schema{
 			"disabled": {
 				Type:     schema.TypeBool,

--- a/alicloud/resource_alicloud_kvstore_backup_policy.go
+++ b/alicloud/resource_alicloud_kvstore_backup_policy.go
@@ -22,6 +22,7 @@ func resourceAliCloudKvStoreBackupPolicy() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Update: schema.DefaultTimeout(40 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.104.0 and will be removed in the future. Please use 'alicloud_kvstore_instance' instead.",
 		Schema: map[string]*schema.Schema{
 			"instance_id": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_max_compute_tunnel_quota_timer.go
+++ b/alicloud/resource_alicloud_max_compute_tunnel_quota_timer.go
@@ -26,6 +26,7 @@ func resourceAliCloudMaxComputeTunnelQuotaTimer() *schema.Resource {
 			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.260.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"nickname": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_mns_queue.go
+++ b/alicloud/resource_alicloud_mns_queue.go
@@ -17,6 +17,8 @@ func resourceAlicloudMNSQueue() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.188.0 and will be removed in the future. Please use 'alicloud_message_service_queue' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_mns_topic.go
+++ b/alicloud/resource_alicloud_mns_topic.go
@@ -16,6 +16,7 @@ func resourceAlicloudMNSTopic() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.188.0 and will be removed in the future. Please use 'alicloud_message_service_topic' instead.",
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_mns_topic_subscription.go
+++ b/alicloud/resource_alicloud_mns_topic_subscription.go
@@ -18,6 +18,7 @@ func resourceAlicloudMNSSubscription() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.188.0 and will be removed in the future. Please use 'alicloud_message_service_subscription' instead.",
 		Schema: map[string]*schema.Schema{
 			"topic_name": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_mongodb_serverless_instance.go
+++ b/alicloud/resource_alicloud_mongodb_serverless_instance.go
@@ -25,6 +25,7 @@ func resourceAlicloudMongodbServerlessInstance() *schema.Resource {
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.214.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"account_password": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_network_acl_attachment.go
+++ b/alicloud/resource_alicloud_network_acl_attachment.go
@@ -20,6 +20,7 @@ func resourceAliyunNetworkAclAttachment() *schema.Resource {
 			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.124.0 and will be removed in the future. Please use 'resources' in 'alicloud_network_acl' instead.",
 		Schema: map[string]*schema.Schema{
 			"network_acl_id": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_network_acl_entries.go
+++ b/alicloud/resource_alicloud_network_acl_entries.go
@@ -19,6 +19,7 @@ func resourceAliyunNetworkAclEntries() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.122.0 and will be removed in the future. Please use 'ingress_acl_entries' and 'egress_acl_entries' in 'alicloud_network_acl' instead.",
 		Schema: map[string]*schema.Schema{
 
 			"network_acl_id": {

--- a/alicloud/resource_alicloud_ram_group_membership.go
+++ b/alicloud/resource_alicloud_ram_group_membership.go
@@ -19,6 +19,8 @@ func resourceAlicloudRamGroupMembership() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.267.0 and will be removed in the future. Please use 'alicloud_ram_user_group_attachment' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"group_name": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_ram_role_attachment.go
+++ b/alicloud/resource_alicloud_ram_role_attachment.go
@@ -15,6 +15,8 @@ func resourceAlicloudRamRoleAttachment() *schema.Resource {
 		Read:   resourceAlicloudInstanceRoleAttachmentRead,
 		Delete: resourceAlicloudInstanceRoleAttachmentDelete,
 
+		DeprecationMessage: "This resource has been deprecated since v1.250.0 and will be removed in the future. Please use 'alicloud_ecs_ram_role_attachment' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"role_name": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_rdc_organization.go
+++ b/alicloud/resource_alicloud_rdc_organization.go
@@ -19,6 +19,7 @@ func resourceAlicloudRdcOrganization() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.238.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"desired_member_count": {
 				Type:     schema.TypeInt,

--- a/alicloud/resource_alicloud_router_interface.go
+++ b/alicloud/resource_alicloud_router_interface.go
@@ -22,6 +22,8 @@ func resourceAlicloudRouterInterface() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.199.0 and will be removed in the future. Please use 'alicloud_express_connect_router_interface' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"opposite_region": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_router_interface_connection.go
+++ b/alicloud/resource_alicloud_router_interface_connection.go
@@ -20,6 +20,8 @@ func resourceAlicloudRouterInterfaceConnection() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.199.0 and will be removed in the future. Please use 'alicloud_express_connect_router_interface' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"interface_id": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_scdn_domain.go
+++ b/alicloud/resource_alicloud_scdn_domain.go
@@ -25,6 +25,7 @@ func resourceAlicloudScdnDomain() *schema.Resource {
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 			Update: schema.DefaultTimeout(11 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.219.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"biz_name": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_scdn_domain_config.go
+++ b/alicloud/resource_alicloud_scdn_domain_config.go
@@ -20,6 +20,7 @@ func resourceAlicloudScdnDomainConfig() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.219.0 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"config_id": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_slb_attachment.go
+++ b/alicloud/resource_alicloud_slb_attachment.go
@@ -22,6 +22,8 @@ func resourceAliyunSlbAttachment() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "This resource has been deprecated since v1.153.0 and will be removed in the future. Please use 'alicloud_slb_backend_server' instead.",
+
 		Schema: map[string]*schema.Schema{
 			"load_balancer_id": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_tsdb_instance.go
+++ b/alicloud/resource_alicloud_tsdb_instance.go
@@ -24,6 +24,7 @@ func resourceAlicloudTsdbInstance() *schema.Resource {
 			Create: schema.DefaultTimeout(31 * time.Minute),
 			Update: schema.DefaultTimeout(31 * time.Minute),
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.223.1 and will be removed in the future.",
 		Schema: map[string]*schema.Schema{
 			"app_key": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_waf_domain.go
+++ b/alicloud/resource_alicloud_waf_domain.go
@@ -20,6 +20,7 @@ func resourceAlicloudWafDomain() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.211.0 and will be removed in the future. Please use 'alicloud_wafv3_domain' instead.",
 		Schema: map[string]*schema.Schema{
 			"cluster_type": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_waf_instance.go
+++ b/alicloud/resource_alicloud_waf_instance.go
@@ -19,6 +19,7 @@ func resourceAlicloudWafInstance() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		DeprecationMessage: "This resource has been deprecated since v1.211.0 and will be removed in the future. Please use 'alicloud_wafv3_instance' instead.",
 		Schema: map[string]*schema.Schema{
 			"big_screen": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Add `DeprecationMessage` to the `schema.Resource` of 52 resources and 20 data sources whose markdown docs already carried a deprecation notice but the Go code did not. This ensures users receive a plan-time warning, not just a docs-only notice.
