### PR TITLE
New Resource/alicloud_oss_bucket_object_worm_configuration: Add new resource

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -916,6 +916,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_oss_bucket_object_worm_configuration":                 resourceAliCloudOssBucketObjectWormConfiguration(),
 			"alicloud_alidns_cloud_gtm_instance_config":                     resourceAliCloudAlidnsCloudGtmInstanceConfig(),
 			"alicloud_alidns_cloud_gtm_monitor_template":                    resourceAliCloudAlidnsCloudGtmMonitorTemplate(),
 			"alicloud_alidns_cloud_gtm_address":                             resourceAliCloudAlidnsCloudGtmAddress(),

--- a/alicloud/resource_alicloud_oss_bucket_object_worm_configuration.go
+++ b/alicloud/resource_alicloud_oss_bucket_object_worm_configuration.go
@@ -1,0 +1,276 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudOssBucketObjectWormConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudOssBucketObjectWormConfigurationCreate,
+		Read:   resourceAliCloudOssBucketObjectWormConfigurationRead,
+		Update: resourceAliCloudOssBucketObjectWormConfigurationUpdate,
+		Delete: resourceAliCloudOssBucketObjectWormConfigurationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"bucket_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"object_worm_enabled": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringInSlice([]string{"Enabled"}, false),
+			},
+			"rule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"default_retention": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1, // only 1 retention is supported
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"years": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"mode": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: StringInSlice([]string{"COMPLIANCE"}, false),
+									},
+									"days": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAliCloudOssBucketObjectWormConfigurationCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/?objectWorm")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	hostMap := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+	hostMap["bucket"] = StringPointer(d.Get("bucket_name").(string))
+
+	objectWormConfiguration := make(map[string]interface{})
+
+	if v := d.Get("object_worm_enabled"); !IsNil(v) {
+		objectWormConfiguration["ObjectWormEnabled"] = v
+	}
+
+	if v, ok := d.GetOk("rule"); ok {
+		rule := expandOssBucketObjectWormConfigurationRule(v.([]interface{}))
+		if rule != nil {
+			objectWormConfiguration["Rule"] = rule
+		}
+	}
+
+	request["ObjectWormConfiguration"] = objectWormConfiguration
+
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlParam("PUT", "2019-05-17", "PutBucketObjectWormConfiguration", action), query, body, nil, hostMap, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_oss_bucket_object_worm_configuration", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(*hostMap["bucket"]))
+
+	return resourceAliCloudOssBucketObjectWormConfigurationRead(d, meta)
+}
+
+func resourceAliCloudOssBucketObjectWormConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ossServiceV2 := OssServiceV2{client}
+
+	objectRaw, err := ossServiceV2.DescribeOssBucketObjectWormConfiguration(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_oss_bucket_object_worm_configuration DescribeOssBucketObjectWormConfiguration Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("object_worm_enabled", objectRaw["ObjectWormEnabled"])
+
+	if err := d.Set("rule", flattenOssBucketObjectWormConfigurationRule(objectRaw["Rule"])); err != nil {
+		return WrapError(err)
+	}
+
+	d.Set("bucket_name", d.Id())
+
+	return nil
+}
+
+func resourceAliCloudOssBucketObjectWormConfigurationUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var body map[string]interface{}
+	update := false
+
+	var err error
+	action := fmt.Sprintf("/?objectWorm")
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+	hostMap := make(map[string]*string)
+	hostMap["bucket"] = StringPointer(d.Id())
+
+	if d.HasChange("object_worm_enabled") {
+		update = true
+	}
+	if d.HasChange("rule") {
+		update = true
+	}
+	objectWormConfiguration := make(map[string]interface{})
+
+	if v, ok := d.GetOk("object_worm_enabled"); ok {
+		objectWormConfiguration["ObjectWormEnabled"] = v
+	}
+
+	if v, ok := d.GetOk("rule"); ok {
+		rule := expandOssBucketObjectWormConfigurationRule(v.([]interface{}))
+		if rule != nil {
+			objectWormConfiguration["Rule"] = rule
+		}
+	}
+
+	request["ObjectWormConfiguration"] = objectWormConfiguration
+
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.Do("Oss", xmlParam("PUT", "2019-05-17", "PutBucketObjectWormConfiguration", action), query, body, nil, hostMap, false)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudOssBucketObjectWormConfigurationRead(d, meta)
+}
+
+func resourceAliCloudOssBucketObjectWormConfigurationDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource AliCloud Resource Bucket Object Worm Configuration. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}
+
+func expandOssBucketObjectWormConfigurationRule(ruleList []interface{}) map[string]interface{} {
+	if len(ruleList) == 0 || ruleList[0] == nil {
+		return nil
+	}
+	ruleRaw := ruleList[0].(map[string]interface{})
+	rule := make(map[string]interface{})
+
+	if v, ok := ruleRaw["default_retention"]; ok {
+		retentionList := v.([]interface{})
+		if len(retentionList) > 0 && retentionList[0] != nil {
+			retRaw := retentionList[0].(map[string]interface{})
+			retention := make(map[string]interface{})
+			if days, ok := retRaw["days"]; ok {
+				retention["Days"] = days
+			}
+			if mode, ok := retRaw["mode"]; ok {
+				retention["Mode"] = mode
+			}
+			if years, ok := retRaw["years"]; ok {
+				retention["Years"] = years
+			}
+			rule["DefaultRetention"] = retention
+		}
+	}
+
+	return rule
+}
+
+func flattenOssBucketObjectWormConfigurationRule(v interface{}) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	ruleRaw, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	ruleMap := make(map[string]interface{})
+
+	if drRaw, ok := ruleRaw["DefaultRetention"]; ok && drRaw != nil {
+		drList, ok := drRaw.([]interface{})
+		if !ok {
+			return nil
+		}
+		defaultRetentionMaps := make([]map[string]interface{}, 0, len(drList))
+		for _, item := range drList {
+			dr, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			defaultRetentionMaps = append(defaultRetentionMaps, map[string]interface{}{
+				"days":  dr["Days"],
+				"mode":  dr["Mode"],
+				"years": dr["Years"],
+			})
+		}
+		ruleMap["default_retention"] = defaultRetentionMaps
+	}
+
+	return []map[string]interface{}{ruleMap}
+}

--- a/alicloud/resource_alicloud_oss_bucket_object_worm_configuration_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_object_worm_configuration_test.go
@@ -1,0 +1,216 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Oss BucketObjectWormConfiguration. >>> Resource test cases, automatically generated.
+// Case 测试ObjectWorm_依赖资源 12777
+// lintignore: AT001
+func TestAccAliCloudOssBucketObjectWormConfiguration_basic12777(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_oss_bucket_object_worm_configuration.default"
+	ra := resourceAttrInit(resourceId, AlicloudOssBucketObjectWormConfigurationMap12777)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OssServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOssBucketObjectWormConfiguration")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccoss%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudOssBucketObjectWormConfigurationBasicDependence12777)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"bucket_name":         "${alicloud_oss_bucket.defaultQf8G0L.id}",
+					"object_worm_enabled": "Enabled",
+					"rule": []map[string]interface{}{
+						{
+							"default_retention": []map[string]interface{}{
+								{
+									"mode": "COMPLIANCE",
+									"days": "1",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"bucket_name":         CHECKSET,
+						"object_worm_enabled": "Enabled",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rule": []map[string]interface{}{
+						{
+							"default_retention": []map[string]interface{}{
+								{
+									"mode": "COMPLIANCE",
+									"days": "2",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rule": []map[string]interface{}{
+						{
+							"default_retention": []map[string]interface{}{
+								{
+									"mode":  "COMPLIANCE",
+									"years": "1",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rule": []map[string]interface{}{
+						{
+							"default_retention": []map[string]interface{}{
+								{
+									"mode":  "COMPLIANCE",
+									"years": "2",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudOssBucketObjectWormConfigurationMap12777 = map[string]string{}
+
+func AlicloudOssBucketObjectWormConfigurationBasicDependence12777(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+resource "alicloud_oss_bucket" "defaultQf8G0L" {
+  bucket        = var.name
+  storage_class = "Standard"
+  versioning {
+    status = "Enabled"
+  }
+}
+`, name)
+}
+
+// Case 测试ObjectWorm_Year 12778
+// lintignore: AT001
+func TestAccAliCloudOssBucketObjectWormConfiguration_basic12778(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_oss_bucket_object_worm_configuration.default"
+	ra := resourceAttrInit(resourceId, AlicloudOssBucketObjectWormConfigurationMap12778)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OssServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOssBucketObjectWormConfiguration")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccoss%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudOssBucketObjectWormConfigurationBasicDependence12778)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"bucket_name":         "${alicloud_oss_bucket.defaultQf8G0L.id}",
+					"object_worm_enabled": "Enabled",
+					"rule": []map[string]interface{}{
+						{
+							"default_retention": []map[string]interface{}{
+								{
+									"mode":  "COMPLIANCE",
+									"years": "1",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"bucket_name":         CHECKSET,
+						"object_worm_enabled": "Enabled",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rule": []map[string]interface{}{
+						{},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudOssBucketObjectWormConfigurationMap12778 = map[string]string{}
+
+func AlicloudOssBucketObjectWormConfigurationBasicDependence12778(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+resource "alicloud_oss_bucket" "defaultQf8G0L" {
+  bucket        = var.name
+  storage_class = "Standard"
+  versioning {
+    status = "Enabled"
+  }
+}
+`, name)
+}
+
+// Test Oss BucketObjectWormConfiguration. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_oss_v2.go
+++ b/alicloud/service_alicloud_oss_v2.go
@@ -1912,3 +1912,76 @@ func (s *OssServiceV2) OssBucketResponseHeaderStateRefreshFuncWithApi(id string,
 }
 
 // DescribeOssBucketResponseHeader >>> Encapsulated.
+// DescribeOssBucketObjectWormConfiguration <<< Encapsulated get interface for Oss BucketObjectWormConfiguration.
+
+func (s *OssServiceV2) DescribeOssBucketObjectWormConfiguration(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	hostMap := make(map[string]*string)
+	hostMap["bucket"] = StringPointer(id)
+
+	action := fmt.Sprintf("/?objectWorm")
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlParam("GET", "2019-05-17", "GetBucketObjectWormConfiguration", action), query, nil, nil, hostMap, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.ObjectWormConfiguration", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.ObjectWormConfiguration", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *OssServiceV2) OssBucketObjectWormConfigurationStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.OssBucketObjectWormConfigurationStateRefreshFuncWithApi(id, field, failStates, s.DescribeOssBucketObjectWormConfiguration)
+}
+
+func (s *OssServiceV2) OssBucketObjectWormConfigurationStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeOssBucketObjectWormConfiguration >>> Encapsulated.

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 )
 
 require (
-	github.com/alibabacloud-go/alibabacloud-gateway-oss v0.0.23
+	github.com/alibabacloud-go/alibabacloud-gateway-oss v0.0.26
 	github.com/alibabacloud-go/alibabacloud-gateway-sls v0.3.0
 	github.com/alibabacloud-go/cs-20151215/v7 v7.6.0
 	github.com/alibabacloud-go/darabonba-openapi/v2 v2.1.14
@@ -65,7 +65,7 @@ require (
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/alibabacloud-go/alibabacloud-gateway-fc-util v0.0.6 // indirect
-	github.com/alibabacloud-go/alibabacloud-gateway-oss-util v0.0.12 // indirect
+	github.com/alibabacloud-go/alibabacloud-gateway-oss-util v0.0.14 // indirect
 	github.com/alibabacloud-go/alibabacloud-gateway-sls-util v0.3.0 // indirect
 	github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5 // indirect
 	github.com/alibabacloud-go/darabonba-array v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,10 +227,10 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAu
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/alibabacloud-go/alibabacloud-gateway-fc-util v0.0.6 h1:b0SCK7Y4WUllc8podpyYA7LE665irOzxcr+KLHRHSII=
 github.com/alibabacloud-go/alibabacloud-gateway-fc-util v0.0.6/go.mod h1:H0RPHXHP/ICfEQrKzQcCqXI15jcV4zaDPCOAmh3U9O8=
-github.com/alibabacloud-go/alibabacloud-gateway-oss v0.0.23 h1:NozbmS/KnlaeSiD7pP/HT82NL++ScXmQ2RGkdqxbX9k=
-github.com/alibabacloud-go/alibabacloud-gateway-oss v0.0.23/go.mod h1:CZJg8uOTBi943d3DAovJYdKq9J2m/ppHF2YZf3dV0hc=
-github.com/alibabacloud-go/alibabacloud-gateway-oss-util v0.0.12 h1:PeA8+z4K3vep1fHsUBTp7RKtzQjy/s1CWzsGkQU9J0s=
-github.com/alibabacloud-go/alibabacloud-gateway-oss-util v0.0.12/go.mod h1:bMrMQIlkH6zAvG7rTaKHyIcEokmBUM2ML+R2VyRimJ8=
+github.com/alibabacloud-go/alibabacloud-gateway-oss v0.0.26 h1:6+kNhwMl9OqmxEHSJ36QY/3bmfGatjg0fMTFG3ZPJ9k=
+github.com/alibabacloud-go/alibabacloud-gateway-oss v0.0.26/go.mod h1:x5tV0OTHUYj8+HpXm2Yw6vQ/Blp+UPYtb9HdRHuTxgQ=
+github.com/alibabacloud-go/alibabacloud-gateway-oss-util v0.0.14 h1:/vAsUKtOIl9Yag0W3Qw6IU4noRe1RgOPdy3N2OUTs/0=
+github.com/alibabacloud-go/alibabacloud-gateway-oss-util v0.0.14/go.mod h1:bMrMQIlkH6zAvG7rTaKHyIcEokmBUM2ML+R2VyRimJ8=
 github.com/alibabacloud-go/alibabacloud-gateway-pop v0.0.6 h1:eIf+iGJxdU4U9ypaUfbtOWCsZSbTb8AUHvyPrxu6mAA=
 github.com/alibabacloud-go/alibabacloud-gateway-pop v0.0.6/go.mod h1:4EUIoxs/do24zMOGGqYVWgw0s9NtiylnJglOeEB5UJo=
 github.com/alibabacloud-go/alibabacloud-gateway-sls v0.3.0 h1:Cw8bt/gW9BXfy2RKfrhDiNfjLIcwiw8IUV7whK7PIGU=

--- a/website/docs/r/oss_bucket_object_worm_configuration.html.markdown
+++ b/website/docs/r/oss_bucket_object_worm_configuration.html.markdown
@@ -1,0 +1,94 @@
+---
+subcategory: "OSS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_oss_bucket_object_worm_configuration"
+description: |-
+  Provides a Alicloud OSS Bucket Object Worm Configuration resource.
+---
+
+# alicloud_oss_bucket_object_worm_configuration
+
+Provides a OSS Bucket Object Worm Configuration resource.
+
+Stores the Object-level compliant retention policy configuration for a bucket.
+
+For information about OSS Bucket Object Worm Configuration and how to use it, see [What is Bucket Object Worm Configuration](https://next.api.alibabacloud.com/document/Oss/2019-05-17/PutBucketObjectWormConfiguration).
+
+-> **NOTE:** Available since v1.278.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = ""
+}
+
+resource "alicloud_oss_bucket" "defaultQf8G0L" {
+  storage_class = "Standard"
+}
+
+resource "alicloud_oss_bucket_versioning" "defaultosxikW" {
+  status = "Enabled"
+  bucket = alicloud_oss_bucket.defaultQf8G0L.id
+}
+
+
+resource "alicloud_oss_bucket_object_worm_configuration" "default" {
+  bucket_name         = alicloud_oss_bucket.defaultQf8G0L.id
+  object_worm_enabled = "Enabled"
+  rule {
+    default_retention {
+      mode = "COMPLIANCE"
+      days = "1"
+    }
+  }
+}
+```
+
+### Deleting `alicloud_oss_bucket_object_worm_configuration` or removing it from your configuration
+
+Terraform cannot destroy resource `alicloud_oss_bucket_object_worm_configuration`. Terraform will remove this resource from the state file, however resources may remain.
+
+## Argument Reference
+
+The following arguments are supported:
+* `bucket_name` - (Required, ForceNew) Bucket name  
+* `object_worm_enabled` - (Required) Specifies whether to enable the object-level compliance retention policy configuration.  
+* `rule` - (Optional, Set) Container that stores the list of retention policies.   See [`rule`](#rule) below.
+
+### `rule`
+
+The rule supports the following:
+* `default_retention` - (Optional, List) Container for the default retention policy.   See [`default_retention`](#rule-default_retention) below.
+
+### `rule-default_retention`
+
+The rule-default_retention supports the following:
+* `days` - (Optional, Int) The number of days for compliant retention. This parameter is mutually exclusive with the Years parameter; only one of them can be specified.
+* `mode` - (Optional) Compliance retention mode.  
+* `years` - (Optional, Int) Default retention period in years. Valid values: 1 to 100. You can specify either Days or Years, but not both.  
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Bucket Object Worm Configuration.
+* `update` - (Defaults to 5 mins) Used when update the Bucket Object Worm Configuration.
+
+## Import
+
+OSS Bucket Object Worm Configuration can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_oss_bucket_object_worm_configuration.example <bucket_name>
+```


### PR DESCRIPTION
* New resource: `alicloud_oss_bucket_object_worm_configuration`
* Bump alibabacloud-gateway-oss to `v0.0.26`

```log
=== RUN   TestAccAliCloudOssBucketObjectWormConfiguration_basic12777
--- PASS: TestAccAliCloudOssBucketObjectWormConfiguration_basic12777 (17.88s)
=== RUN   TestAccAliCloudOssBucketObjectWormConfiguration_basic12778
--- PASS: TestAccAliCloudOssBucketObjectWormConfiguration_basic12778 (11.18s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  33.016s

```