### PR TITLE
resource/alicloud_oss_bucket_object: support object_worm_mode, object_worm_retain_until_date. resource/alicloud_oss_bucket_object_worm_configuration: mark rule as Optional+Computed

### DIFF
--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -1,6 +1,7 @@
 package connectivity
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -65,6 +66,8 @@ import (
 	sls "github.com/aliyun/aliyun-log-go-sdk"
 	slsutil "github.com/aliyun/aliyun-log-go-sdk/util"
 	ali_mns "github.com/aliyun/aliyun-mns-go-sdk"
+	ossv2 "github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
+	ossv2cred "github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss/credentials"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
 	otsTunnel "github.com/aliyun/aliyun-tablestore-go-sdk/tunnel"
@@ -98,6 +101,7 @@ type AliyunClient struct {
 	slbconn                      *slb.Client
 	alikafkaconn                 *alikafka.Client
 	ossconn                      *oss.Client
+	ossconnV2                    *ossv2.Client
 	dnsconn                      *alidns.Client
 	ramconn                      *ram.Client
 	csconn                       *cs.Client
@@ -582,6 +586,48 @@ func (client *AliyunClient) WithOssBucketByName(bucketName string, do func(*oss.
 		}
 		return do(bucket)
 	})
+}
+
+func (client *AliyunClient) WithOssClientV2(do func(*ossv2.Client) (interface{}, error)) (interface{}, error) {
+	goSdkMutex.Lock()
+	defer goSdkMutex.Unlock()
+
+	if client.ossconnV2 != nil && !client.config.needRefreshCredential() {
+		return do(client.ossconnV2)
+	}
+	product := "oss"
+	endpoint, err := client.loadApiEndpoint(product)
+	if err != nil {
+		return nil, err
+	}
+	schma := strings.ToLower(client.config.Protocol)
+	if !strings.HasPrefix(endpoint, "http") {
+		endpoint = fmt.Sprintf("%s://%s", schma, endpoint)
+	}
+
+	cfg := ossv2.LoadDefaultConfig().
+		WithRegion(client.config.RegionId).
+		WithEndpoint(endpoint).
+		WithCredentialsProvider(&ossV2CredentialsProvider{client: client}).
+		WithUserAgent(client.config.getUserAgent())
+
+	if proxy, perr := client.getHttpProxy(); perr == nil && proxy != nil {
+		if skip, _ := client.skipProxy(endpoint); !skip {
+			cfg = cfg.WithProxyHost(proxy.String())
+		}
+	}
+
+	if ossV, ok := client.config.SignVersion.Load("oss"); ok {
+		switch fmt.Sprintf("%v", ossV) {
+		case "v4":
+			cfg = cfg.WithSignatureVersion(ossv2.SignatureVersionV4)
+		case "v1":
+			cfg = cfg.WithSignatureVersion(ossv2.SignatureVersionV1)
+		}
+	}
+
+	client.ossconnV2 = ossv2.NewClient(cfg)
+	return do(client.ossconnV2)
 }
 
 func (client *AliyunClient) WithDnsClient(do func(*alidns.Client) (interface{}, error)) (interface{}, error) {
@@ -2850,6 +2896,19 @@ type ossCredentialsProvider struct {
 
 func (defBuild *ossCredentialsProvider) GetCredentials() oss.Credentials {
 	return &ossCredentials{client: defBuild.client}
+}
+
+type ossV2CredentialsProvider struct {
+	client *AliyunClient
+}
+
+func (p *ossV2CredentialsProvider) GetCredentials(_ context.Context) (ossv2cred.Credentials, error) {
+	ak, sk, token := p.client.config.GetRefreshCredential()
+	return ossv2cred.Credentials{
+		AccessKeyID:     ak,
+		AccessKeySecret: sk,
+		SecurityToken:   token,
+	}, nil
 }
 
 func (client *AliyunClient) GetRetryTimeout(defaultTimeout time.Duration) time.Duration {

--- a/alicloud/data_source_alicloud_oss_bucket_objects_test.go
+++ b/alicloud/data_source_alicloud_oss_bucket_objects_test.go
@@ -186,8 +186,13 @@ resource "alicloud_oss_bucket" "default" {
 	acl = "private"
 }
 
+resource "alicloud_oss_bucket_public_access_block" "default" {
+	bucket              = alicloud_oss_bucket.default.bucket
+	block_public_access = false
+}
+
 resource "alicloud_oss_bucket_object" "default" {
-	bucket = "${alicloud_oss_bucket.default.bucket}"
+	bucket = "${alicloud_oss_bucket_public_access_block.default.bucket}"
 	key = "tf-sample/${var.name}-object"
 	content = "sample content"
 	content_type = "text/plain"

--- a/alicloud/resource_alicloud_oss_bucket_object.go
+++ b/alicloud/resource_alicloud_oss_bucket_object.go
@@ -2,12 +2,14 @@ package alicloud
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log"
 	"strings"
 	"time"
 
+	ossv2 "github.com/aliyun/alibabacloud-oss-go-sdk-v2/oss"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -17,9 +19,9 @@ import (
 
 func resourceAlicloudOssBucketObject() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAlicloudOssBucketObjectPut,
+		Create: resourceAlicloudOssBucketObjectCreate,
 		Read:   resourceAlicloudOssBucketObjectRead,
-		Update: resourceAlicloudOssBucketObjectPut,
+		Update: resourceAlicloudOssBucketObjectUpdate,
 		Delete: resourceAlicloudOssBucketObjectDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -107,6 +109,40 @@ func resourceAlicloudOssBucketObject() *schema.Resource {
 				},
 			},
 
+			"object_worm_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"COMPLIANCE"}, false),
+				RequiredWith: []string{"object_worm_retain_until_date"},
+			},
+
+			"object_worm_retain_until_date": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"object_worm_mode"},
+				// OSS expects ISO8601 with millisecond precision, e.g.
+				// "2026-09-30T00:00:00.000Z". The second-precision form
+				// is also accepted by the server, which normalizes it to
+				// millisecond precision on read; suppress diff when both
+				// values represent the same instant either way.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old == "" || new == "" {
+						return false
+					}
+					oldT, err := time.Parse(time.RFC3339, old)
+					if err != nil {
+						return false
+					}
+					newT, err := time.Parse(time.RFC3339, new)
+					if err != nil {
+						return false
+					}
+					return oldT.Equal(newT)
+				},
+			},
+
 			"etag": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -120,7 +156,54 @@ func resourceAlicloudOssBucketObject() *schema.Resource {
 	}
 }
 
-func resourceAlicloudOssBucketObjectPut(d *schema.ResourceData, meta interface{}) error {
+func resourceAlicloudOssBucketObjectCreate(d *schema.ResourceData, meta interface{}) error {
+	return resourceAlicloudOssBucketObjectUpload(d, meta)
+}
+
+func resourceAlicloudOssBucketObjectUpdate(d *schema.ResourceData, meta interface{}) error {
+	if hasObjectContentChanges(d) {
+		return resourceAlicloudOssBucketObjectUpload(d, meta)
+	}
+
+	client := meta.(*connectivity.AliyunClient)
+	bucket := d.Get("bucket").(string)
+	key := d.Get("key").(string)
+
+	if d.HasChange("acl") {
+		_, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
+			b, err := ossClient.Bucket(bucket)
+			if err != nil {
+				return nil, err
+			}
+			return nil, b.SetObjectACL(key, oss.ACLType(d.Get("acl").(string)))
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "SetObjectACL", AliyunOssGoSdk)
+		}
+	}
+
+	if d.HasChange("object_worm_mode") || d.HasChange("object_worm_retain_until_date") {
+		mode := d.Get("object_worm_mode").(string)
+		until := d.Get("object_worm_retain_until_date").(string)
+		_, err := client.WithOssClientV2(func(c *ossv2.Client) (interface{}, error) {
+			return c.PutObjectRetention(context.Background(), &ossv2.PutObjectRetentionRequest{
+				Bucket: ossv2.Ptr(bucket),
+				Key:    ossv2.Ptr(key),
+				Retention: &ossv2.ObjectWormRetention{
+					Mode:            ossv2.Ptr(mode),
+					RetainUntilDate: ossv2.Ptr(until),
+				},
+			})
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "PutObjectRetention", AliyunOssGoSdk)
+		}
+	}
+
+	return resourceAlicloudOssBucketObjectRead(d, meta)
+}
+
+func resourceAlicloudOssBucketObjectUpload(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	var requestInfo *oss.Client
 	raw, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
@@ -152,6 +235,8 @@ func resourceAlicloudOssBucketObjectPut(d *schema.ResourceData, meta interface{}
 
 	key := d.Get("key").(string)
 	options, err := buildObjectHeaderOptions(d)
+
+	options = append(options, buildObjectWormOptions(d)...)
 
 	if v, ok := d.GetOk("server_side_encryption"); ok {
 		options = append(options, oss.ServerSideEncryption(v.(string)))
@@ -218,6 +303,8 @@ func resourceAlicloudOssBucketObjectRead(d *schema.ResourceData, meta interface{
 	d.Set("expires", object.Get("Expires"))
 	d.Set("etag", strings.Trim(object.Get("ETag"), `"`))
 	d.Set("version_id", object.Get("x-oss-version-id"))
+	d.Set("object_worm_mode", object.Get("x-oss-object-worm-mode"))
+	d.Set("object_worm_retain_until_date", object.Get("x-oss-object-worm-retain-until-date"))
 
 	return nil
 }
@@ -246,6 +333,26 @@ func resourceAlicloudOssBucketObjectDelete(d *schema.ResourceData, meta interfac
 
 	return WrapError(ossService.WaitForOssBucketObject(bucket, d.Id(), Deleted, DefaultTimeoutMedium))
 
+}
+
+func hasObjectContentChanges(d *schema.ResourceData) bool {
+	for _, k := range []string{
+		"source",
+		"content",
+		"content_type",
+		"cache_control",
+		"content_disposition",
+		"content_encoding",
+		"content_md5",
+		"expires",
+		"server_side_encryption",
+		"kms_key_id",
+	} {
+		if d.HasChange(k) {
+			return true
+		}
+	}
+	return false
 }
 
 func buildObjectHeaderOptions(d *schema.ResourceData) (options []oss.Option, err error) {
@@ -287,4 +394,21 @@ func buildObjectHeaderOptions(d *schema.ResourceData) (options []oss.Option, err
 		log.Printf("[WARN] Object header options is nil.")
 	}
 	return options, nil
+}
+
+// buildObjectWormOptions returns the worm-related headers for a PutObject
+// call. These MUST NOT be sent on HEAD/GET (e.g. GetObjectDetailedMeta in
+// Read), because OSS validates "x-oss-object-worm-retain-until-date" must
+// be in the future on every request that carries it — and Read is naturally
+// invoked long after the original retention has expired, which would then
+// fail with InvalidArgument and break refresh forever.
+func buildObjectWormOptions(d *schema.ResourceData) []oss.Option {
+	var options []oss.Option
+	if v, ok := d.GetOk("object_worm_mode"); ok {
+		options = append(options, oss.SetHeader("x-oss-object-worm-mode", v.(string)))
+	}
+	if v, ok := d.GetOk("object_worm_retain_until_date"); ok {
+		options = append(options, oss.SetHeader("x-oss-object-worm-retain-until-date", v.(string)))
+	}
+	return options
 }

--- a/alicloud/resource_alicloud_oss_bucket_object_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_object_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -47,7 +48,7 @@ func TestAccAlicloudOssBucketObject_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"bucket":       "${alicloud_oss_bucket.default.bucket}",
+					"bucket":       "${alicloud_oss_bucket_public_access_block.default.bucket}",
 					"key":          "test-object-source-key",
 					"source":       tmpFile.Name(),
 					"content_type": "binary/octet-stream",
@@ -96,7 +97,7 @@ func TestAccAlicloudOssBucketObject_basic(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"bucket":                 "${alicloud_oss_bucket.default.bucket}",
+					"bucket":                 "${alicloud_oss_bucket_public_access_block.default.bucket}",
 					"server_side_encryption": "AES256",
 					"kms_key_id":             REMOVEKEY,
 					"key":                    "test-object-source-key",
@@ -122,11 +123,140 @@ func TestAccAlicloudOssBucketObject_basic(t *testing.T) {
 	})
 }
 
+func TestAccAlicloudOssBucketObject_worm(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "tf-oss-object-worm-source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if err := ioutil.WriteFile(tmpFile.Name(), []byte("worm content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var v http.Header
+	resourceId := "alicloud_oss_bucket_object.default"
+	ra := resourceAttrInit(resourceId, ossBucketObjectBasicMap)
+	testAccCheck := ra.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testacc-object-worm-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceOssBucketObjectVersioningDependence)
+
+	// Retention windows are computed at test start. They must satisfy two
+	// conflicting constraints:
+	//   1. They must still be in the future when the corresponding Apply
+	//      reaches the OSS API — otherwise OSS rejects with
+	//      "The retain until date must be in the future."
+	//   2. They must have expired by the time the test framework destroys
+	//      the object — otherwise DeleteObject is blocked by COMPLIANCE.
+	// 60s/90s gives Step 0 (bucket + worm config + object create) and
+	// Step 1 (extend) ample time, and the final Check below sleeps past
+	// extendedUntil so destroy can succeed without retries.
+	//
+	// The OSS retain-until-date parameter is ISO8601 with millisecond
+	// precision (e.g. 2026-09-30T00:00:00.000Z). Use the same layout so
+	// testCheck's literal string compare matches what OSS echoes back.
+	const iso8601Ms = "2006-01-02T15:04:05.000Z"
+	initialUntil := time.Now().UTC().Add(60 * time.Second).Format(iso8601Ms)
+	extendedUntilTime := time.Now().UTC().Add(90 * time.Second)
+	extendedUntil := extendedUntilTime.Format(iso8601Ms)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAlicloudOssBucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				// The bucket field references
+				// alicloud_oss_bucket_object_worm_configuration so that the
+				// object is created only after object-level worm has been
+				// enabled on the bucket — without this, PutObject would be
+				// rejected because the worm header is not yet accepted.
+				Config: testAccConfig(map[string]interface{}{
+					"bucket":                        "${alicloud_oss_bucket_object_worm_configuration.default.bucket_name}",
+					"key":                           "test-object-worm-key",
+					"source":                        tmpFile.Name(),
+					"content_type":                  "binary/octet-stream",
+					"object_worm_mode":              "COMPLIANCE",
+					"object_worm_retain_until_date": initialUntil,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudOssBucketObjectExists(resourceId, name, v),
+					testAccCheck(map[string]string{
+						"bucket":                        name,
+						"key":                           "test-object-worm-key",
+						"object_worm_mode":              "COMPLIANCE",
+						"object_worm_retain_until_date": initialUntil,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"bucket":                        "${alicloud_oss_bucket_object_worm_configuration.default.bucket_name}",
+					"key":                           "test-object-worm-key",
+					"source":                        tmpFile.Name(),
+					"content_type":                  "binary/octet-stream",
+					"object_worm_mode":              "COMPLIANCE",
+					"object_worm_retain_until_date": extendedUntil,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudOssBucketObjectExists(resourceId, name, v),
+					testAccCheck(map[string]string{
+						"object_worm_retain_until_date": extendedUntil,
+					}),
+					// Block until the retention has expired so the framework
+					// can DeleteObject during destroy without hitting the
+					// COMPLIANCE-mode worm.
+					func(s *terraform.State) error {
+						wait := time.Until(extendedUntilTime) + 10*time.Second
+						if wait > 0 {
+							t.Logf("waiting %v for object worm retention to expire before destroy", wait)
+							time.Sleep(wait)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func resourceOssBucketObjectConfigDependence(name string) string {
 
 	return fmt.Sprintf(`
 resource "alicloud_oss_bucket" "default" {
 	bucket = "%s"
+}
+resource "alicloud_oss_bucket_public_access_block" "default" {
+	bucket              = alicloud_oss_bucket.default.bucket
+	block_public_access = false
+}
+data "alicloud_kms_keys" "enabled" {
+	status = "Enabled"
+}
+`, name)
+}
+
+// resourceOssBucketObjectVersioningDependence is like
+// resourceOssBucketObjectConfigDependence but tailored for the worm test:
+// bucket versioning is enabled (a prerequisite for object-level worm),
+// force_destroy = true so DeleteBucket can clean up the original versions
+// (DeleteObject on a versioned bucket only writes a delete marker), and an
+// alicloud_oss_bucket_object_worm_configuration resource turns on
+// object-level worm so PutObject accepts x-oss-object-worm-* headers.
+func resourceOssBucketObjectVersioningDependence(name string) string {
+	return fmt.Sprintf(`
+resource "alicloud_oss_bucket" "default" {
+	bucket = "%s"
+	force_destroy = true
+	versioning {
+		status = "Enabled"
+	}
+}
+resource "alicloud_oss_bucket_object_worm_configuration" "default" {
+	bucket_name         = alicloud_oss_bucket.default.bucket
+	object_worm_enabled = "Enabled"
 }
 data "alicloud_kms_keys" "enabled" {
 	status = "Enabled"

--- a/alicloud/resource_alicloud_oss_bucket_object_worm_configuration.go
+++ b/alicloud/resource_alicloud_oss_bucket_object_worm_configuration.go
@@ -38,6 +38,7 @@ func resourceAliCloudOssBucketObjectWormConfiguration() *schema.Resource {
 			"rule": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/alicloud/resource_alicloud_oss_bucket_object_worm_configuration_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_object_worm_configuration_test.go
@@ -213,4 +213,70 @@ resource "alicloud_oss_bucket" "defaultQf8G0L" {
 `, name)
 }
 
+// Case 测试ObjectWorm_无rule 12779
+// lintignore: AT001
+func TestAccAliCloudOssBucketObjectWormConfiguration_basic12779(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_oss_bucket_object_worm_configuration.default"
+	ra := resourceAttrInit(resourceId, AlicloudOssBucketObjectWormConfigurationMap12779)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OssServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOssBucketObjectWormConfiguration")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccoss%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudOssBucketObjectWormConfigurationBasicDependence12779)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Configuration without any "rule" block. The server still
+				// returns an empty <Rule/> element on read so state ends up
+				// with rule.# = 1, but the CustomizeDiff hook suppresses the
+				// resulting rule.# 1 vs 0 plan diff so that "after apply,
+				// plan must be empty" still holds.
+				Config: testAccConfig(map[string]interface{}{
+					"bucket_name":         "${alicloud_oss_bucket.defaultQf8G0L.id}",
+					"object_worm_enabled": "Enabled",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"bucket_name":         CHECKSET,
+						"object_worm_enabled": "Enabled",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudOssBucketObjectWormConfigurationMap12779 = map[string]string{}
+
+func AlicloudOssBucketObjectWormConfigurationBasicDependence12779(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+resource "alicloud_oss_bucket" "defaultQf8G0L" {
+  bucket        = var.name
+  storage_class = "Standard"
+  versioning {
+    status = "Enabled"
+  }
+}
+`, name)
+}
+
 // Test Oss BucketObjectWormConfiguration. <<< Resource test cases, automatically generated.

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/alibabacloud-go/fc-open-20210406/v2 v2.0.7
 	github.com/alibabacloud-go/sts-20150401/v2 v2.0.2
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.7
+	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.5.0
 	github.com/blues/jsonata-go v1.5.4
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ github.com/alibabacloud-go/tea-xml v1.1.3 h1:7LYnm+JbOq2B+T/B0fHC4Ies4/FofC4zHzY
 github.com/alibabacloud-go/tea-xml v1.1.3/go.mod h1:Rq08vgCcCAjHyRi/M7xlHKUykZCEtyBy9+DPF6GgEu8=
 github.com/aliyun/alibaba-cloud-sdk-go v1.62.590 h1:Cvekl0SVm0+gHPBdhdA3XA/ZghLOThyof4GaPLz7c1I=
 github.com/aliyun/alibaba-cloud-sdk-go v1.62.590/go.mod h1:CJJYa1ZMxjlN/NbXEwmejEnBkhi0DV+Yb3B2lxf+74o=
+github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.5.0 h1:3qbrAiouDwR8bh6P25vDiyU9qjIDU6TNefDiFFc+Jt0=
+github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.5.0/go.mod h1:FTzydeQVmR24FI0D6XWUOMKckjXehM/jgMn1xC+DA9M=
 github.com/aliyun/aliyun-datahub-sdk-go v0.1.5 h1:c2TFcJ5PjkqkHr2use7Av2wHB8jVgoKxX1gmLDsysR4=
 github.com/aliyun/aliyun-datahub-sdk-go v0.1.5/go.mod h1:GwtZxKUD+aLBrtlkEcyPNAx+jRkBioEC7EKOlQ26lTc=
 github.com/aliyun/aliyun-log-go-sdk v0.1.108 h1:ZHCt5pqwol14k5QP7n//uonF9jkea9nzZPE77Nyk+WA=

--- a/website/docs/r/oss_bucket_object.html.markdown
+++ b/website/docs/r/oss_bucket_object.html.markdown
@@ -7,7 +7,7 @@ description: |-
   Provides a resource to create a oss bucket object.
 ---
 
-# alicloud\_oss\_bucket\_object
+# alicloud_oss_bucket_object
 
 Provides a resource to put a object(content or file) to a oss bucket.
 
@@ -86,7 +86,7 @@ The following arguments are supported:
 * `key` - (Required, ForceNew) The name of the object once it is in the bucket.
 * `source` - (Optional) The path to the source file being uploaded to the bucket.
 * `content` - (Optional unless `source` given) The literal content being uploaded to the bucket.
-* `acl` - (Optional) The [canned ACL](https://www.alibabacloud.com/help/doc-detail/52284.htm) to apply. Defaults to "private".
+* `acl` - (Optional) The [canned ACL](https://www.alibabacloud.com/help/doc-detail/52284.htm) to apply. Defaults to `private`.
 * `content_type` - (Optional) A standard MIME type describing the format of the object data, e.g. application/octet-stream. All Valid MIME Types are valid for this input.
 * `cache_control` - (Optional) Specifies caching behavior along the request/reply chain. Read [RFC2616 Cache-Control](https://www.ietf.org/rfc/rfc2616.txt) for further details.
 * `content_disposition` - (Optional) Specifies presentational information for the object. Read [RFC2616 Content-Disposition](https://www.ietf.org/rfc/rfc2616.txt) for further details.
@@ -95,9 +95,10 @@ The following arguments are supported:
 * `expires` - (Optional) Specifies expire date for the the request/response. Read [RFC2616 Expires](https://www.ietf.org/rfc/rfc2616.txt) for further details.
 * `server_side_encryption` - (Optional) Specifies server-side encryption of the object in OSS. Valid values are `AES256`, `KMS`. Default value is `AES256`.
 * `kms_key_id` - (Optional, Available in 1.62.1+) Specifies the primary key managed by KMS. This parameter is valid when the value of `server_side_encryption` is set to KMS.
+* `object_worm_mode` - (Optional, Available in 1.278.0+) The retention mode of the object worm policy. Valid value: `COMPLIANCE`. Must be set together with `object_worm_retain_until_date`. The bucket must have object worm enabled. Updating only this attribute (or `object_worm_retain_until_date`) calls `PutObjectRetention` and does not re-upload the object.
+* `object_worm_retain_until_date` - (Optional, Available in 1.278.0+) The UTC time at which the object retention expires, in ISO8601 format with millisecond precision (for example `2026-09-30T00:00:00.000Z`). Must be set together with `object_worm_mode`.
 
-Either `source` or `content` must be provided to specify the bucket content.
-These two arguments are mutually-exclusive.
+-> **Note:** Either `source` or `content` must be provided to specify the bucket content. These two arguments are mutually-exclusive.
 
 ## Attributes Reference
 


### PR DESCRIPTION
…attributes

  - object_worm_mode (currently only COMPLIANCE)
  - object_worm_retain_until_date (ISO8601 with millisecond precision, e.g. 2026-09-30T00:00:00.000Z)

resource/alicloud_oss_bucket_object_worm_configuration: mark rule as Optional+Computed.