### PR TITLE
resource/alicloud_db_instance: Add force_encryption read support for SQLServer DB instance

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -2351,7 +2351,15 @@ func resourceAliCloudDBInstanceRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("replication_acl", sslAction["ReplicationACL"])
 	d.Set("ssl_connection_string", sslAction["ConnectionString"])
 	if v, ok := sslAction["ForceEncryption"]; ok && v != nil {
-		d.Set("force_encryption", v)
+		forceEncryptionEnabled, err := strconv.ParseBool(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		if forceEncryptionEnabled {
+			d.Set("force_encryption", 1)
+		} else {
+			d.Set("force_encryption", 0)
+		}
 	}
 
 	//When the instance schema is docker on ECS, TDE encryption is not supported, so the query is not executed.


### PR DESCRIPTION
Fix the bug that `ForceEncryption` not correctly handled.  
Note the API doc has a bug. The real value of `ForceEncryption` is bool type with `true` and `false` but the [DescribeDBInstanceSSL](https://api.aliyun.com/api/Rds/2014-08-15/DescribeDBInstanceSSL) API document show it is `0`, `1` which is incorrect.

<img width="2212" height="286" alt="image" src="https://github.com/user-attachments/assets/100ba522-5087-45ec-8e26-7405a3fa0840" />

PR changs:
- Read ForceEncryption from DescribeDBInstanceSSL and map to force_encryption attribute (0/1)
- Use `strconv.ParseBool` to convert API string value to int for TypeInt schema

Not all test cases have been run:
```log
=== RUN   TestAccAliCloudRdsDBInstance_SQLServer
--- PASS: TestAccAliCloudRdsDBInstance_SQLServer (6668.13s)
PASS
```