### PR TITLE
docs(eip_association): fix version note from v1.117.0 to v1.5.1

### DIFF
--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -19,7 +19,7 @@ Provides a EIP Association resource.
 
 For information about EIP Association and how to use it, see [What is Association](https://www.alibabacloud.com/help/en/vpc/developer-reference/api-vpc-2016-04-28-associateeipaddress).
 
--> **NOTE:** Available since v1.117.0.
+-> **NOTE:** Available since v1.5.1.
 
 ## Example Usage
 


### PR DESCRIPTION
The alicloud_eip_association resource has been available since v1.5.1, not v1.117.0 as previously stated.