### PR TITLE
resource/alicloud_redis_tair_instance: fix perpetual diff on security…

### DIFF
--- a/alicloud/resource_alicloud_redis_tair_instance.go
+++ b/alicloud/resource_alicloud_redis_tair_instance.go
@@ -3,6 +3,9 @@ package alicloud
 import (
 	"fmt"
 	"log"
+	"reflect"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/PaesslerAG/jsonpath"
@@ -211,6 +214,16 @@ func resourceAliCloudRedisTairInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old != "" && new != "" && old != new {
+						oldParts := strings.Split(old, ",")
+						sort.Strings(oldParts)
+						newParts := strings.Split(new, ",")
+						sort.Strings(newParts)
+						return reflect.DeepEqual(newParts, oldParts)
+					}
+					return false
+				},
 			},
 			"shard_count": {
 				Type:     schema.TypeInt,

--- a/alicloud/resource_alicloud_redis_tair_instance_test.go
+++ b/alicloud/resource_alicloud_redis_tair_instance_test.go
@@ -2052,6 +2052,18 @@ func TestAccAliCloudRedisTairInstance_basic8729(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"security_ips":           "127.0.0.5,127.0.0.1,127.0.0.3",
+					"security_ip_group_name": "default",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_ips":           CHECKSET,
+						"security_ip_group_name": "default",
+					}),
+				),
+			},
+			{
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,


### PR DESCRIPTION
Title: fix(redis_tair_instance): suppress security_ips diff caused by IP order mismatch

Summary:
- Fixes perpetual plan diff on alicloud_redis_tair_instance.security_ips (Aone#81663160).
  The field is a TypeString of comma-separated IPs; the DescribeSecurityIps API
  may return IPs in a different order than the user's config, causing every plan
  to report a change and trigger an unnecessary ModifySecurityIps call.
- Adds DiffSuppressFunc comparing IP lists order-independently, consistent with
  alicloud_gpdb_instance.security_ip_list.
- Adds a new step in TestAccAliCloudRedisTairInstance_basic8729 using an
  out-of-order IP list (127.0.0.5,127.0.0.1,127.0.0.3); SDK's post-apply
  empty-plan check now exercises the fix.

Test plan:
- [ ] TestAccAliCloudRedisTairInstance_basic8729 passes