### PR TITLE
resource/alicloud_redis_tair_instance: Fixed the bug of security_ips perpetual diff

### DIFF
--- a/alicloud/resource_alicloud_redis_tair_instance.go
+++ b/alicloud/resource_alicloud_redis_tair_instance.go
@@ -3,6 +3,9 @@ package alicloud
 import (
 	"fmt"
 	"log"
+	"reflect"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/PaesslerAG/jsonpath"
@@ -211,6 +214,16 @@ func resourceAliCloudRedisTairInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old != "" && new != "" && old != new {
+						oldParts := strings.Split(old, ",")
+						sort.Strings(oldParts)
+						newParts := strings.Split(new, ",")
+						sort.Strings(newParts)
+						return reflect.DeepEqual(newParts, oldParts)
+					}
+					return false
+				},
 			},
 			"shard_count": {
 				Type:     schema.TypeInt,

--- a/alicloud/resource_alicloud_redis_tair_instance_test.go
+++ b/alicloud/resource_alicloud_redis_tair_instance_test.go
@@ -129,7 +129,7 @@ func TestAccAliCloudRedisTairInstance_basic3314(t *testing.T) {
 					"instance_class":     "tair.rdb.2g",
 					"tair_instance_name": name + "_update",
 					"shard_count":        "2",
-					"secondary_zone_id":  "${local.zone_id}",
+					"secondary_zone_id":  "${data.alicloud_kvstore_zones.default.zones.1.id}",
 					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.groups.0.id}",
 					"vswitch_id":         "${local.vswitch_id}",
 					"vpc_id":             "${data.alicloud_vpcs.default.ids.0}",
@@ -388,7 +388,7 @@ func TestAccAliCloudRedisTairInstance_basic3340(t *testing.T) {
 					"instance_class":     "tair.rdb.1g",
 					"tair_instance_name": name + "_update",
 					"shard_count":        "2",
-					"secondary_zone_id":  "${local.zone_id}",
+					"secondary_zone_id":  "${data.alicloud_kvstore_zones.default.zones.1.id}",
 					"vswitch_id":         "${local.vswitch_id}",
 					"vpc_id":             "${data.alicloud_vpcs.default.ids.0}",
 					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.groups.0.id}",
@@ -624,7 +624,7 @@ func TestAccAliCloudRedisTairInstance_basic3549(t *testing.T) {
 					"zone_id":            "${local.zone_id}",
 					"instance_class":     "tair.rdb.2g",
 					"tair_instance_name": name + "_update",
-					"secondary_zone_id":  "${local.zone_id}",
+					"secondary_zone_id":  "${data.alicloud_kvstore_zones.default.zones.1.id}",
 					"vswitch_id":         "${local.vswitch_id}",
 					"vpc_id":             "${data.alicloud_vpcs.default.ids.0}",
 					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.groups.0.id}",
@@ -738,7 +738,7 @@ func TestAccAliCloudRedisTairInstance_basic3314_twin(t *testing.T) {
 					"instance_class":     "tair.rdb.2g",
 					"tair_instance_name": name,
 					"shard_count":        "2",
-					"secondary_zone_id":  "${data.alicloud_vswitches.default.vswitches.0.zone_id}",
+					"secondary_zone_id":  "${data.alicloud_kvstore_zones.default.zones.1.id}",
 					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.groups.0.id}",
 					"vswitch_id":         "${data.alicloud_vswitches.default.vswitches.0.id}",
 					"vpc_id":             "${data.alicloud_vswitches.default.vswitches.0.vpc_id}",
@@ -822,7 +822,7 @@ func TestAccAliCloudRedisTairInstance_basic3340_twin(t *testing.T) {
 					"instance_class":     "tair.rdb.1g",
 					"tair_instance_name": name,
 					"shard_count":        "2",
-					"secondary_zone_id":  "${data.alicloud_vswitches.default.vswitches.0.zone_id}",
+					"secondary_zone_id":  "${data.alicloud_kvstore_zones.default.zones.1.id}",
 					"vswitch_id":         "${data.alicloud_vswitches.default.vswitches.0.id}",
 					"vpc_id":             "${data.alicloud_vswitches.default.vswitches.0.vpc_id}",
 					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.groups.0.id}",
@@ -890,7 +890,7 @@ func TestAccAliCloudRedisTairInstance_basic3549_twin(t *testing.T) {
 					"zone_id":            "${local.zone_id}",
 					"instance_class":     "tair.rdb.2g",
 					"tair_instance_name": name,
-					"secondary_zone_id":  "${local.zone_id}",
+					"secondary_zone_id":  "${data.alicloud_kvstore_zones.default.zones.1.id}",
 					"vswitch_id":         "${data.alicloud_vswitches.default.vswitches.0.id}",
 					"vpc_id":             "${data.alicloud_vswitches.default.vswitches.0.vpc_id}",
 					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.groups.0.id}",
@@ -1112,6 +1112,10 @@ variable "zone_id" {
   default = "cn-beijing-h"
 }
 
+variable "secondary_zone_id" {
+  default = "cn-beijing-i"
+}
+
 variable "region_id" {
   default = "cn-beijing"
 }
@@ -1328,11 +1332,7 @@ func TestAccAliCloudRedisTairInstance_basic6639_raw(t *testing.T) {
 					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
 					"password":           "123456Tf",
 					"engine_version":     "5.0",
-					"period":             "12",
-					"auto_renew_period":  "12",
 					"port":               "6379",
-					"cluster_backup_id":  "cb-hyxdof5x9kqb333",
-					"secondary_zone_id":  "${var.zone_id}",
 					"node_type":          "STAND_ALONE",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -1347,11 +1347,7 @@ func TestAccAliCloudRedisTairInstance_basic6639_raw(t *testing.T) {
 						"resource_group_id":  CHECKSET,
 						"password":           "123456Tf",
 						"engine_version":     "5.0",
-						"period":             "12",
-						"auto_renew_period":  "12",
 						"port":               "6379",
-						"cluster_backup_id":  "cb-hyxdof5x9kqb333",
-						"secondary_zone_id":  CHECKSET,
 						"node_type":          "STAND_ALONE",
 					}),
 				),
@@ -1510,6 +1506,10 @@ variable "zone_id" {
   default = "cn-beijing-h"
 }
 
+variable "secondary_zone_id" {
+  default = "cn-beijing-i"
+}
+
 variable "region_id" {
   default = "cn-beijing"
 }
@@ -1591,10 +1591,8 @@ func TestAccAliCloudRedisTairInstance_basic6823_raw(t *testing.T) {
 					"resource_group_id":  "${alicloud_resource_manager_resource_group.defaultRg.id}",
 					"password":           "123456Tf",
 					"engine_version":     "1.0",
-					"period":             "12",
 					"port":               "6379",
-					"secondary_zone_id":  "${var.zone_id}",
-					"auto_renew":         "false",
+					"secondary_zone_id":  "${var.secondary_zone_id}",
 					"security_group_id":  "${alicloud_security_group.defaultEcsSg.id}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -1609,10 +1607,8 @@ func TestAccAliCloudRedisTairInstance_basic6823_raw(t *testing.T) {
 						"resource_group_id":  CHECKSET,
 						"password":           "123456Tf",
 						"engine_version":     "1.0",
-						"period":             "12",
 						"port":               "6379",
 						"secondary_zone_id":  CHECKSET,
-						"auto_renew":         "false",
 						"security_group_id":  CHECKSET,
 					}),
 				),
@@ -2047,6 +2043,18 @@ func TestAccAliCloudRedisTairInstance_basic8729(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"security_ips":           "127.0.0.2",
+						"security_ip_group_name": "default",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"security_ips":           "127.0.0.5,127.0.0.1,127.0.0.3",
+					"security_ip_group_name": "default",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_ips":           CHECKSET,
 						"security_ip_group_name": "default",
 					}),
 				),


### PR DESCRIPTION
# resource/alicloud_redis_tair_instance: fix perpetual diff on security_ips when IPs are out of order

Fixes Aone#81663160.

## ACC test results

```
=== RUN   TestAccAliCloudRedisTairInstance_basic8747
--- PASS: TestAccAliCloudRedisTairInstance_basic8747 (1113.34s)
=== RUN   TestAccAliCloudRedisTairInstance_basic8703
--- PASS: TestAccAliCloudRedisTairInstance_basic8703 (1366.43s)
=== RUN   TestAccAliCloudRedisTairInstance_basic8729
--- PASS: TestAccAliCloudRedisTairInstance_basic8729 (1039.40s)
=== RUN   TestAccAliCloudRedisTairInstance_basic8732
--- PASS: TestAccAliCloudRedisTairInstance_basic8732 (771.77s)
=== RUN   TestAccAliCloudRedisTairInstance_basic3314
--- PASS: TestAccAliCloudRedisTairInstance_basic3314 (1423.90s)
=== RUN   TestAccAliCloudRedisTairInstance_basic3314_twin
--- PASS: TestAccAliCloudRedisTairInstance_basic3314_twin (661.72s)
=== RUN   TestAccAliCloudRedisTairInstance_basic3340
--- PASS: TestAccAliCloudRedisTairInstance_basic3340 (3180.99s)
=== RUN   TestAccAliCloudRedisTairInstance_basic3340_twin
--- PASS: TestAccAliCloudRedisTairInstance_basic3340_twin (621.63s)
=== RUN   TestAccAliCloudRedisTairInstance_basic3549
--- PASS: TestAccAliCloudRedisTairInstance_basic3549 (2177.96s)
=== RUN   TestAccAliCloudRedisTairInstance_basic3549_twin
--- PASS: TestAccAliCloudRedisTairInstance_basic3549_twin (631.24s)
=== RUN   TestAccAliCloudRedisTairInstance_basic4491_twin
--- PASS: TestAccAliCloudRedisTairInstance_basic4491_twin (1515.20s)
=== RUN   TestAccAliCloudRedisTairInstance_basic6500_raw
--- PASS: TestAccAliCloudRedisTairInstance_basic6500_raw (844.90s)
=== RUN   TestAccAliCloudRedisTairInstance_basic6639_raw
--- PASS: TestAccAliCloudRedisTairInstance_basic6639_raw (1046.06s)
=== RUN   TestAccAliCloudRedisTairInstance_basic6473_raw
--- PASS: TestAccAliCloudRedisTairInstance_basic6473_raw (2109.86s)
=== RUN   TestAccAliCloudRedisTairInstance_basic6823_raw
--- PASS: TestAccAliCloudRedisTairInstance_basic6823_raw (785.56s)
PASS
```

## Summary

1. **Provider fix** — `alicloud_redis_tair_instance.security_ips` was a `TypeString` of comma-separated IPs. `DescribeSecurityIps` returns IPs in a server-side-sorted order that may differ from the user's HCL order, which triggered a perpetual `plan` diff and an unnecessary `ModifySecurityIps` on every apply. Added a `DiffSuppressFunc` that compares the two lists order-independently (consistent with `alicloud_gpdb_instance.security_ip_list`).

2. **Regression coverage** — Added a step in `TestAccAliCloudRedisTairInstance_basic8729` that uses an out-of-order IP list (`127.0.0.5,127.0.0.1,127.0.0.3`); the SDK test framework's post-apply empty-plan check now exercises the fix.

3. **Pre-existing fixture repairs** — Full-suite verification surfaced 8 tests broken on `upstream/master` (independent of this PR). Repaired:
   - **basic3314 / 3340 / 3549 + their _twin variants**: `secondary_zone_id` was assigned the same value as `zone_id` (API rejects with `SecondaryZone.NotSupport`). Switched to `data.alicloud_kvstore_zones.default.zones.1.id`.
   - **basic6639_raw**: dropped `period` / `auto_renew_period` (Subscription-only fields used under `PayAsYouGo`), removed `cluster_backup_id` (hardcoded `cb-hyxdof5x9kqb333` no longer exists), and dropped `secondary_zone_id` (`STAND_ALONE` node type does not allow it).
   - **basic6823_raw**: dropped `period` / `auto_renew` (Subscription-only fields under `PayAsYouGo`) and introduced `var.secondary_zone_id` so the secondary AZ differs from primary.

## Verification

All 15 test functions (12 `go test` invocations after regex prefix dedup) pass on the fix branch. Submitted to ACC test platform `pre-acube.aliyun-inc.com`, region `cn-beijing` (auto-switched to `cn-hangzhou` for `basic4491_twin` per `TestSalveRegions`).

### Regression coverage — the 4 tests using `security_ips`

| Test | Result | Duration | taskId |
|------|--------|----------|--------|
| `TestAccAliCloudRedisTairInstance_basic8729` ⭐ | ✅ PASS | 1056s | 2123 |
| `TestAccAliCloudRedisTairInstance_basic8747` | ✅ PASS | 1128s | 2125 |
| `TestAccAliCloudRedisTairInstance_basic8703` | ✅ PASS | 1380s | 2125 |
| `TestAccAliCloudRedisTairInstance_basic8732` | ✅ PASS | 787s | 2125 |

⭐ `basic8729` includes the new step exercising the `DiffSuppressFunc`. tf-debug confirms the bug-reproducing scenario:

```
HCL config:                  security_ips = "127.0.0.5,127.0.0.1,127.0.0.3"
API request body:            "SecurityIps":"127.0.0.5,127.0.0.1,127.0.0.3"
API DescribeSecurityIps:     "SecurityIPList":"127.0.0.5,127.0.0.3,127.0.0.1"   # server reordered
plugin-sdk drift warning:    .security_ips: was cty.StringVal("127.0.0.5,127.0.0.1,127.0.0.3"),
                                              but now cty.StringVal("127.0.0.5,127.0.0.3,127.0.0.1")
SDK post-apply empty-plan check: PASS    # DiffSuppressFunc absorbs the order difference
```

### Fixture repairs verified

| Test | Result | Duration | taskId |
|------|--------|----------|--------|
| `basic3314` + `basic3314_twin` | ✅ PASS | 2233s (combined invocation) | 2129 |
| `basic3340` | ✅ PASS | 3181s | 2142 |
| `basic3340_twin` | ✅ PASS | 622s | 2143 |
| `basic3549` | ✅ PASS | 2178s | 2144 |
| `basic3549_twin` | ✅ PASS | 631s | 2145 |
| `basic6639_raw` | ✅ PASS | 1046s | 2141 |
| `basic6823_raw` | ✅ PASS | 786s | 2139 |

### Baseline (unrelated to this PR's changes, already passing)

| Test | Result | Duration | taskId |
|------|--------|----------|--------|
| `basic4491_twin` | ✅ PASS | 1530s | 2125 |
| `basic6500_raw` | ✅ PASS | 860s | 2125 |
| `basic6473_raw` | ✅ PASS | 2125s | 2125 |

## API call RequestIds (per test)

R-kvstore API call traces extracted from `tf-debug.log` for each PASS run. Reviewers can use any RequestId to drill into server-side logs.

### basic8729 (taskId=2123, the regression target)
- `CreateTairInstance`: `3083CA4B-F2BE-571C-BEC3-BDF72A2EA76A`
- `ModifyInstanceVpcAuthMode`: `495BAE91-006B-59EF-9461-4EBE8069DE8F`
- `ModifySecurityIps` (step 2, `127.0.0.2`): `687504F5-F598-5B91-A4AB-D881D2ABA239`
- `ModifyInstanceTDE`: `99878F9D-FAAA-5644-A119-EE7FAF1651DD`
- `ModifyInstanceVpcAuthMode`: `E8A966DA-B7B1-5DA4-9185-F6FE300C49EA`
- `ModifySecurityIps` (step 3, group `test1` → `127.0.0.2`): `4729BE75-8FBD-5F92-B0F0-00A783F14703`
- `ModifySecurityIps` (step 4, group `default` → `127.0.0.2`): `A8A80215-C720-5253-86A3-9E71085397CC`
- `ModifySecurityIps` (**step 5 — new step**, out-of-order `127.0.0.5,127.0.0.1,127.0.0.3`): `D6B107B7-32CA-5916-8A24-30A198F04A0D`
- `DeleteInstance`: `6F23AD0A-2AF6-5A8A-9DC3-E8EB9BF473B5`

### basic8747 (taskId=2125)
- `CreateTairInstance`: `2B295327-FA82-59DC-98BD-0EA92D805225`
- `ModifySecurityIps`: `1E5E121D-F850-55F4-93C5-E7B2F0BD61C8`
- `ModifyInstanceConfig`: `A74F8DC6-88CE-546B-AFFA-C794A8F50AC7`
- `ModifySecurityIps`: `54D8BE0B-6E2F-5983-8813-1B594C63C6FC`
- `ModifyInstanceConfig`: `08CD50A5-CC10-532B-9D95-E39297579E09`
- `ModifySecurityIps`: `DB681CAC-6C21-51B3-8511-ABC4644425E3`
- `DeleteInstance`: `8FF182BA-8A4E-5638-93A2-26F639D72E3F`

### basic8703 (taskId=2125)
- `CreateTairInstance`: `984F8E5D-1839-5358-B082-B27E5585191B`
- `ModifySecurityIps`: `50B0DDE4-1741-5DA0-B3F3-BDAEDB384231`
- `ModifyInstanceConfig`: `AF148056-E46D-5AB0-97B1-C7FE815FA8A9`
- `ModifySecurityIps`: `24488172-CCD1-513E-B0C6-7E3B82E71E4E`
- `ModifyInstanceConfig`: `E2719D2B-FAEC-5492-9F82-9497FC9A7CBC`
- `ModifySecurityIps`: `124EBFD9-F212-5138-AB7A-D6366C3273AB`
- `ModifyInstanceConfig`: `8550A3B7-0D94-5C80-A7BC-E12D16CC490D`
- `DeleteInstance`: `8823CCBE-AC87-5077-BF52-B24292575B2E`

### basic8732 (taskId=2125)
- `CreateTairInstance`: `3D6B266F-D210-54DA-BE35-5369AA9EF7F6`
- `ModifySecurityIps`: `0BA90597-2335-5B24-BABA-64D692802011`
- `DeleteInstance`: `8AE461A1-481C-5F07-A1A0-FD4471B7C6A7`
- `CreateTairInstance` (import re-create): `E966501D-5F63-539E-89B5-378931440120`

### basic3314 + basic3314_twin (taskId=2129)
- `CreateTairInstance`: `E69C1D3F-A318-515E-A9FE-D263FCC6CED7`
- `ModifyInstanceAttribute`: `219A173D-9654-5E9A-A007-F9A454DA7745`
- `ModifyInstanceSpec`: `F5BACC27-048F-5DE0-BFC5-2175AF6E2AD7`
- `CreateTairInstance` (twin step 1): `B4CC4451-5ADE-5689-848E-0EAFC75DCC66`
- `TransformInstanceChargeType`: `E08291E8-90BE-55EF-B183-1B6080D4AB9A`
- `DeleteInstance`: `4AB65EED-33D6-544F-9EBF-0B92C72C1934`
- `CreateTairInstance` (twin step 2): `E44CF8FB-1215-56D3-B1F4-A49A4047282E`
- `TransformInstanceChargeType`: `5CDBB5B9-2929-5FEF-86D2-EB8FF2E04474`
- `DeleteInstance`: `D2887B72-8243-5174-9291-EE61BC4385FE`

### basic3340 (taskId=2142)
- `CreateTairInstance`: `9E760B07-439F-5BCD-AFC7-4CDB08E865F8`
- `ModifyInstanceSpec`: `89B779AC-DE1F-5754-94DF-3B6A8D07B85A`
- `ModifyInstanceAttribute`: `6E136E92-5618-5BDD-8236-095FD2B9524A`
- `ModifyResourceGroup`: `2795C88B-D80B-5865-B2AF-D9579F5A9B9A`
- `ModifyInstanceAttribute`: `62D74822-2B6A-5087-9770-C8090661D6CF`
- `ModifyInstanceBandwidth`: `D5728546-C243-5684-B6E8-CD7D9E9BD862`
- `DeleteInstance`: `62144A25-AB5C-51C5-A3F1-B0B8B27C2890`
- `CreateTairInstance` (re-create): `4731F9F2-9BA5-5809-9D5B-54AA5156E684`
- `ModifyInstanceBandwidth`: `00CCB766-0911-5375-B70D-638780434AB0`
- `DeleteInstance`: `F404401E-16DB-5056-9FA6-9473CEC7D99A`

### basic3340_twin (taskId=2143)
- `CreateTairInstance`: `A347E8A9-9AA0-5F55-A97D-C0F040C273DF`
- `DeleteInstance`: `00AD63CC-D628-5A70-BE3F-C5EE858E8A01`

### basic3549 (taskId=2144)
- `CreateTairInstance`: `E0957EC3-C652-5366-A751-5A0696FA64B0`
- `ModifyInstanceBandwidth`: `EB896B0D-CE4B-5C64-B63B-E822F9A2F104`
- `ModifyInstanceAttribute`: `58E4F139-56D7-5427-88C0-32536224F87F`
- `ModifyInstanceAttribute`: `DD664422-B692-5E69-A51F-F722CFF86A01`
- `ModifyInstanceAttribute`: `7C3B5B13-5412-559A-BE2B-DAB4E77F4A7D`
- `ModifyResourceGroup`: `F2C727AC-1840-5900-AC23-B746F4B47E02`
- `DeleteInstance`: `0724B789-2781-5548-A06A-EB44A95F5AD3`
- `CreateTairInstance` (re-create): `520F1A0F-414F-5A8E-9D0C-17F4D927D3D8`
- `ModifyInstanceBandwidth`: `203805A8-E750-53B4-AD51-DF31FECC5D41`
- `DeleteInstance`: `667EF5F9-BAA0-5317-BB5E-1361DF587430`

### basic3549_twin (taskId=2145)
- `CreateTairInstance`: `D54F168E-D63E-559B-97B8-F6A1B5189A43`
- `DeleteInstance`: `BAA5808E-7C24-57AA-BE37-91243158F503`

### basic6639_raw (taskId=2141)
- `CreateTairInstance`: `E9D9F6CE-E8A1-54AF-B05C-B12518A3038F`
- `ModifyInstanceSpec`: `E610E8E5-8C96-52B8-A339-2D20DB4CF410`
- `DeleteInstance`: `F618F0DF-ED5F-57BE-8A7D-158F59315D1F`

### basic6823_raw (taskId=2139)
- `CreateTairInstance`: `A8EB73C4-BAD2-5263-8F57-0BE6E13220FB`
- `ModifySecurityGroupConfiguration`: `B070F2F4-DADD-58F0-A6D5-081DE7E179E4`
- `ModifySecurityGroupConfiguration`: `8FB18135-75F4-5072-B4E4-3B815B367A7C`
- `DeleteInstance`: `C20C8705-7BAB-58C0-BF17-00FE9BC29164`

### basic4491_twin (taskId=2125)
- `CreateTairInstance`: `2C942CD7-4B63-5111-AEBA-21CE7E81E504`
- `DeleteInstance`: `07F4C278-5421-5556-B74B-DB88C19BBA87`

### basic6500_raw (taskId=2125)
- `DeleteInstance`: `6C6E8D1E-CFC3-5564-8543-515D9FD62AE8`

### basic6473_raw (taskId=2125)
- `CreateTairInstance`: `81DFC816-8C8C-542E-B6E7-14D9DE045EAB`
- `ModifyInstanceSSL`: `10FC1E4D-DA38-50E0-BE78-CC07CC451650`
- `ModifyInstanceMajorVersion`: `7119DF3C-53B4-5930-9F3D-7AE87EFD124A`

## Test plan

- [x] `TestAccAliCloudRedisTairInstance_basic8729` (security_ips regression, includes new out-of-order IP step) — PASS
- [x] `TestAccAliCloudRedisTairInstance_basic8747` (security_ips) — PASS
- [x] `TestAccAliCloudRedisTairInstance_basic8703` (security_ips) — PASS
- [x] `TestAccAliCloudRedisTairInstance_basic8732` (security_ips) — PASS
- [x] `TestAccAliCloudRedisTairInstance_basic3314` + `_twin` (fixture fix) — PASS
- [x] `TestAccAliCloudRedisTairInstance_basic3340` (fixture fix) — PASS
- [x] `TestAccAliCloudRedisTairInstance_basic3340_twin` (fixture fix) — PASS
- [x] `TestAccAliCloudRedisTairInstance_basic3549` (fixture fix) — PASS
- [x] `TestAccAliCloudRedisTairInstance_basic3549_twin` (fixture fix) — PASS
- [x] `TestAccAliCloudRedisTairInstance_basic6639_raw` (fixture fix) — PASS
- [x] `TestAccAliCloudRedisTairInstance_basic6823_raw` (fixture fix) — PASS
- [x] `TestAccAliCloudRedisTairInstance_basic4491_twin` — PASS (unchanged)
- [x] `TestAccAliCloudRedisTairInstance_basic6500_raw` — PASS (unchanged)
- [x] `TestAccAliCloudRedisTairInstance_basic6473_raw` — PASS (unchanged)