### PR TITLE
deprecate: mark all DBFS resources and data sources as deprecated

### DIFF
--- a/alicloud/data_source_alicloud_dbfs_auto_snap_shot_policies.go
+++ b/alicloud/data_source_alicloud_dbfs_auto_snap_shot_policies.go
@@ -14,7 +14,8 @@ import (
 
 func dataSourceAlicloudDbfsAutoSnapShotPolicies() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudDbfsAutoSnapShotPoliciesRead,
+		Read:               dataSourceAlicloudDbfsAutoSnapShotPoliciesRead,
+		DeprecationMessage: "This data source has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/",
 		Schema: map[string]*schema.Schema{
 			"ids": {
 				Optional: true,

--- a/alicloud/data_source_alicloud_dbfs_auto_snap_shot_policies_test.go
+++ b/alicloud/data_source_alicloud_dbfs_auto_snap_shot_policies_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccAlicloudDbfsAutoSnapShotPolicyDataSource(t *testing.T) {
+	t.Skip("This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/")
 	rand := acctest.RandIntRange(1000000, 9999999)
 	checkoutSupportedRegions(t, true, connectivity.DBFSSystemSupportRegions)
 	idsConf := dataSourceTestAccConfig{

--- a/alicloud/data_source_alicloud_dbfs_instances.go
+++ b/alicloud/data_source_alicloud_dbfs_instances.go
@@ -14,7 +14,8 @@ import (
 
 func dataSourceAlicloudDbfsInstances() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudDbfsInstancesRead,
+		Read:               dataSourceAlicloudDbfsInstancesRead,
+		DeprecationMessage: "This data source has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/",
 		Schema: map[string]*schema.Schema{
 			"ids": {
 				Type:     schema.TypeList,

--- a/alicloud/data_source_alicloud_dbfs_instances_test.go
+++ b/alicloud/data_source_alicloud_dbfs_instances_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAccAlicloudDBFSInstancesDataSource(t *testing.T) {
-
+	t.Skip("This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/")
 	rand := acctest.RandInt()
 	resourceId := "data.alicloud_dbfs_instances.default"
 	name := fmt.Sprintf("tf-testacc-dbfsInstance%v", rand)

--- a/alicloud/data_source_alicloud_dbfs_snapshots.go
+++ b/alicloud/data_source_alicloud_dbfs_snapshots.go
@@ -14,7 +14,8 @@ import (
 
 func dataSourceAlicloudDbfsSnapshots() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudDbfsSnapshotsRead,
+		Read:               dataSourceAlicloudDbfsSnapshotsRead,
+		DeprecationMessage: "This data source has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/",
 		Schema: map[string]*schema.Schema{
 			"ids": {
 				Type:     schema.TypeList,

--- a/alicloud/data_source_alicloud_dbfs_snapshots_test.go
+++ b/alicloud/data_source_alicloud_dbfs_snapshots_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccAlicloudDBFSSnapshotsDataSource(t *testing.T) {
+	t.Skip("This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/")
 	rand := acctest.RandInt()
 	checkoutSupportedRegions(t, true, connectivity.DBFSSystemSupportRegions)
 	idsConf := dataSourceTestAccConfig{

--- a/alicloud/resource_alicloud_dbfs_auto_snap_shot_policy.go
+++ b/alicloud/resource_alicloud_dbfs_auto_snap_shot_policy.go
@@ -14,10 +14,11 @@ import (
 
 func resourceAlicloudDbfsAutoSnapShotPolicy() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAlicloudDbfsAutoSnapShotPolicyCreate,
-		Read:   resourceAlicloudDbfsAutoSnapShotPolicyRead,
-		Update: resourceAlicloudDbfsAutoSnapShotPolicyUpdate,
-		Delete: resourceAlicloudDbfsAutoSnapShotPolicyDelete,
+		Create:             resourceAlicloudDbfsAutoSnapShotPolicyCreate,
+		Read:               resourceAlicloudDbfsAutoSnapShotPolicyRead,
+		Update:             resourceAlicloudDbfsAutoSnapShotPolicyUpdate,
+		Delete:             resourceAlicloudDbfsAutoSnapShotPolicyDelete,
+		DeprecationMessage: "This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/",
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/alicloud/resource_alicloud_dbfs_auto_snap_shot_policy_test.go
+++ b/alicloud/resource_alicloud_dbfs_auto_snap_shot_policy_test.go
@@ -12,6 +12,7 @@ import (
 // Case 1
 func TestAccAlicloudDbfsAutoSnapShotPolicy_basic2601(t *testing.T) {
 	var v map[string]interface{}
+	t.Skip("This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/")
 	checkoutSupportedRegions(t, true, connectivity.DBFSSystemSupportRegions)
 	resourceId := "alicloud_dbfs_auto_snap_shot_policy.default"
 	ra := resourceAttrInit(resourceId, AlicloudDbfsAutoSnapShotPolicyMap2601)

--- a/alicloud/resource_alicloud_dbfs_instance.go
+++ b/alicloud/resource_alicloud_dbfs_instance.go
@@ -13,10 +13,11 @@ import (
 
 func resourceAliCloudDbfsDbfsInstance() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAliCloudDbfsDbfsInstanceCreate,
-		Read:   resourceAliCloudDbfsDbfsInstanceRead,
-		Update: resourceAliCloudDbfsDbfsInstanceUpdate,
-		Delete: resourceAliCloudDbfsDbfsInstanceDelete,
+		Create:             resourceAliCloudDbfsDbfsInstanceCreate,
+		Read:               resourceAliCloudDbfsDbfsInstanceRead,
+		Update:             resourceAliCloudDbfsDbfsInstanceUpdate,
+		Delete:             resourceAliCloudDbfsDbfsInstanceDelete,
+		DeprecationMessage: "This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/",
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/alicloud/resource_alicloud_dbfs_instance_attachment.go
+++ b/alicloud/resource_alicloud_dbfs_instance_attachment.go
@@ -12,9 +12,10 @@ import (
 
 func resourceAliCloudDbfsInstanceAttachment() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAliCloudDbfsInstanceAttachmentCreate,
-		Read:   resourceAliCloudDbfsInstanceAttachmentRead,
-		Delete: resourceAliCloudDbfsInstanceAttachmentDelete,
+		Create:             resourceAliCloudDbfsInstanceAttachmentCreate,
+		Read:               resourceAliCloudDbfsInstanceAttachmentRead,
+		Delete:             resourceAliCloudDbfsInstanceAttachmentDelete,
+		DeprecationMessage: "This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/",
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/alicloud/resource_alicloud_dbfs_instance_attachment_test.go
+++ b/alicloud/resource_alicloud_dbfs_instance_attachment_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestAccAliCloudDbfsInstanceAttachment_basic0(t *testing.T) {
 	var v map[string]interface{}
+	t.Skip("This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/")
 	checkoutSupportedRegions(t, true, connectivity.DBFSSystemSupportRegions)
 	resourceId := "alicloud_dbfs_instance_attachment.default"
 	ra := resourceAttrInit(resourceId, AliCloudDbfsInstanceAttachmentMap0)

--- a/alicloud/resource_alicloud_dbfs_instance_test.go
+++ b/alicloud/resource_alicloud_dbfs_instance_test.go
@@ -105,6 +105,7 @@ func testSweepDBFSInstance(region string) error {
 
 func TestAccAliCloudDBFSInstance_basic0(t *testing.T) {
 	var v map[string]interface{}
+	t.Skip("This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/")
 	resourceId := "alicloud_dbfs_instance.default"
 	ra := resourceAttrInit(resourceId, AlicloudDBFSInstanceMap0)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
@@ -286,6 +287,7 @@ resource "alicloud_instance" "default" {
 // Case 5069
 func TestAccAliCloudDbfsDbfsInstance_basic5069(t *testing.T) {
 	var v map[string]interface{}
+	t.Skip("This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/")
 	resourceId := "alicloud_dbfs_instance.default"
 	ra := resourceAttrInit(resourceId, AlicloudDbfsDbfsInstanceMap5069)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
@@ -502,6 +504,7 @@ variable "name" {
 // Case 5069  twin
 func TestAccAliCloudDbfsDbfsInstance_basic5069_twin(t *testing.T) {
 	var v map[string]interface{}
+	t.Skip("This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/")
 	resourceId := "alicloud_dbfs_instance.default"
 	ra := resourceAttrInit(resourceId, AlicloudDbfsDbfsInstanceMap5069)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {

--- a/alicloud/resource_alicloud_dbfs_service_linked_role.go
+++ b/alicloud/resource_alicloud_dbfs_service_linked_role.go
@@ -12,9 +12,10 @@ import (
 
 func resourceAlicloudDbfsServiceLinkedRole() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAlicloudDbfsServiceLinkedRoleCreate,
-		Read:   resourceAlicloudDbfsServiceLinkedRoleRead,
-		Delete: resourceAlicloudDbfsServiceLinkedRoleDelete,
+		Create:             resourceAlicloudDbfsServiceLinkedRoleCreate,
+		Read:               resourceAlicloudDbfsServiceLinkedRoleRead,
+		Delete:             resourceAlicloudDbfsServiceLinkedRoleDelete,
+		DeprecationMessage: "This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/",
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/alicloud/resource_alicloud_dbfs_service_linked_role_test.go
+++ b/alicloud/resource_alicloud_dbfs_service_linked_role_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestAccAlicloudDBFSServiceLinkedRole_basic0(t *testing.T) {
 	var v map[string]interface{}
+	t.Skip("This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/")
 	resourceId := "alicloud_dbfs_service_linked_role.default"
 	checkoutSupportedRegions(t, true, connectivity.DBFSSystemSupportRegions)
 	ra := resourceAttrInit(resourceId, AlicloudDbfsEventServiceLinkedRoleMap0)

--- a/alicloud/resource_alicloud_dbfs_snapshot.go
+++ b/alicloud/resource_alicloud_dbfs_snapshot.go
@@ -14,10 +14,11 @@ import (
 
 func resourceAliCloudDbfsSnapshot() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceAliCloudDbfsSnapshotCreate,
-		Read:   resourceAliCloudDbfsSnapshotRead,
-		Update: resourceAliCloudDbfsSnapshotUpdate,
-		Delete: resourceAliCloudDbfsSnapshotDelete,
+		Create:             resourceAliCloudDbfsSnapshotCreate,
+		Read:               resourceAliCloudDbfsSnapshotRead,
+		Update:             resourceAliCloudDbfsSnapshotUpdate,
+		Delete:             resourceAliCloudDbfsSnapshotDelete,
+		DeprecationMessage: "This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/",
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/alicloud/resource_alicloud_dbfs_snapshot_test.go
+++ b/alicloud/resource_alicloud_dbfs_snapshot_test.go
@@ -113,6 +113,7 @@ func testSweepDbfsSnapshot(region string) error {
 
 func TestAccAliCloudDbfsSnapshot_basic0(t *testing.T) {
 	var v map[string]interface{}
+	t.Skip("This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/")
 	checkoutSupportedRegions(t, true, connectivity.DBFSSystemSupportRegions)
 	resourceId := "alicloud_dbfs_snapshot.default"
 	ra := resourceAttrInit(resourceId, AliCloudDbfsSnapshotMap0)
@@ -174,6 +175,7 @@ func TestAccAliCloudDbfsSnapshot_basic0(t *testing.T) {
 
 func TestAccAliCloudDbfsSnapshot_basic0_twin(t *testing.T) {
 	var v map[string]interface{}
+	t.Skip("This resource has been deprecated since v1.279.0 and will be removed in the future. See: https://help.aliyun.com/en/dbfs/")
 	checkoutSupportedRegions(t, true, connectivity.DBFSSystemSupportRegions)
 	resourceId := "alicloud_dbfs_snapshot.default"
 	ra := resourceAttrInit(resourceId, AliCloudDbfsSnapshotMap0)

--- a/website/docs/d/dbfs_auto_snap_shot_policies.html.markdown
+++ b/website/docs/d/dbfs_auto_snap_shot_policies.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 # alicloud_dbfs_auto_snap_shot_policies
 
+~> **NOTE:** This data source has been deprecated since v1.279.0 and will be removed in the future. See: [DBFS](https://help.aliyun.com/en/dbfs/).
+
 This data source provides Dbfs Auto Snap Shot Policy available to the user.[What is Auto Snap Shot Policy](https://help.aliyun.com/document_detail/469597.html)
 
 -> **NOTE:** Available in 1.202.0+

--- a/website/docs/d/dbfs_instances.html.markdown
+++ b/website/docs/d/dbfs_instances.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 # alicloud\_dbfs\_instances
 
+~> **NOTE:** This data source has been deprecated since v1.279.0 and will be removed in the future. See: [DBFS](https://help.aliyun.com/en/dbfs/).
+
 This data source provides the DBFS Instances of the current Alibaba Cloud user.
 
 -> **NOTE:** Available in v1.136.0+.

--- a/website/docs/d/dbfs_snapshots.html.markdown
+++ b/website/docs/d/dbfs_snapshots.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 # alicloud\_dbfs\_snapshots
 
+~> **NOTE:** This data source has been deprecated since v1.279.0 and will be removed in the future. See: [DBFS](https://help.aliyun.com/en/dbfs/).
+
 This data source provides the Dbfs Snapshots of the current Alibaba Cloud user.
 
 -> **NOTE:** Available in v1.156.0+.

--- a/website/docs/r/dbfs_auto_snap_shot_policy.html.markdown
+++ b/website/docs/r/dbfs_auto_snap_shot_policy.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 # alicloud_dbfs_auto_snap_shot_policy
 
+~> **NOTE:** This resource has been deprecated since v1.279.0 and will be removed in the future. See: [DBFS](https://help.aliyun.com/en/dbfs/).
+
 Provides a Dbfs Auto Snap Shot Policy resource.
 
 For information about Dbfs Auto Snap Shot Policy and how to use it.

--- a/website/docs/r/dbfs_instance.html.markdown
+++ b/website/docs/r/dbfs_instance.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # alicloud_dbfs_instance
 
+~> **NOTE:** This resource has been deprecated since v1.279.0 and will be removed in the future. See: [DBFS](https://help.aliyun.com/en/dbfs/).
+
 Provides a DBFS Dbfs Instance resource. An instance of a database file system is equivalent to a file system and can store data of file types.
 
 For information about DBFS Dbfs Instance and how to use it, see [What is Dbfs Instance](https://next.api.alibabacloud.com/document/DBFS/2020-04-18/CreateDbfs).

--- a/website/docs/r/dbfs_instance_attachment.html.markdown
+++ b/website/docs/r/dbfs_instance_attachment.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 # alicloud_dbfs_instance_attachment
 
+~> **NOTE:** This resource has been deprecated since v1.279.0 and will be removed in the future. See: [DBFS](https://help.aliyun.com/en/dbfs/).
+
 Provides a Database File System (DBFS) Instance Attachment resource.
 
 For information about Database File System (DBFS) Instance Attachment and how to use it, see [What is Snapshot](https://help.aliyun.com/zh/dbfs/developer-reference/api-dbfs-2020-04-18-attachdbfs).

--- a/website/docs/r/dbfs_service_linked_role.html.markdown
+++ b/website/docs/r/dbfs_service_linked_role.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 # alicloud_dbfs_service_linked_role
 
+~> **NOTE:** This resource has been deprecated since v1.279.0 and will be removed in the future. See: [DBFS](https://help.aliyun.com/en/dbfs/).
+
 Using this data source can create Dbfs service-linked roles(SLR). Dbfs may need to access another Alibaba Cloud service to implement a specific feature. In this case, Dbfs must assume a specific service-linked role, which is a Resource Access Management (RAM) role, to obtain permissions to access another Alibaba Cloud service. 
 
 For information about Dbfs service-linked roles(SLR) and how to use it, see [What is service-linked roles](https://www.alibabacloud.com/help/en/resource-management/resource-group/developer-reference/api-resourcemanager-2020-03-31-createservicelinkedrole-rg).

--- a/website/docs/r/dbfs_snapshot.html.markdown
+++ b/website/docs/r/dbfs_snapshot.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 # alicloud_dbfs_snapshot
 
+~> **NOTE:** This resource has been deprecated since v1.279.0 and will be removed in the future. See: [DBFS](https://help.aliyun.com/en/dbfs/).
+
 Provides a Database File System (DBFS) Snapshot resource.
 
 For information about Database File System (DBFS) Snapshot and how to use it, see [What is Snapshot](https://help.aliyun.com/zh/dbfs/developer-reference/api-dbfs-2020-04-18-createsnapshot).


### PR DESCRIPTION
Resources: 
`alicloud_dbfs_instance, alicloud_dbfs_instance_attachment, alicloud_dbfs_service_linked_role, alicloud_dbfs_snapshot, alicloud_dbfs_auto_snap_shot_policy`

Data Sources: `alicloud_dbfs_instances, alicloud_dbfs_snapshots, alicloud_dbfs_auto_snap_shot_policies`

- Add DeprecationMessage to all DBFS resources and data sources
- Add t.Skip() to all DBFS acceptance tests
- DBFS API v2020-04-18 is deprecated and no longer supports creating new resources