### PR TITLE
resource/alicloud_cen_transit_router_vpc_attachment: add options support; data-source/alicloud_cen_transit_router_vpc_attachments: add options output

### DIFF
--- a/alicloud/data_source_alicloud_cen_transit_router_vpc_attachments.go
+++ b/alicloud/data_source_alicloud_cen_transit_router_vpc_attachments.go
@@ -98,6 +98,22 @@ func dataSourceAliCloudCenTransitRouterVpcAttachments() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"options": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"appliance_mode_support": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ipv6_support": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
 						"transit_router_attachment_name": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -246,6 +262,15 @@ func dataSourceAliCloudCenTransitRouterVpcAttachmentsRead(d *schema.ResourceData
 			"transit_router_attachment_description": object["TransitRouterAttachmentDescription"],
 			"status":                                object["Status"],
 		}
+
+		optionsMaps := make([]map[string]interface{}, 0)
+		if optionsRaw, ok := object["Options"].(map[string]interface{}); ok && len(optionsRaw) > 0 {
+			optionsMap := make(map[string]interface{})
+			optionsMap["appliance_mode_support"] = optionsRaw["ApplianceModeSupport"]
+			optionsMap["ipv6_support"] = optionsRaw["Ipv6Support"]
+			optionsMaps = append(optionsMaps, optionsMap)
+		}
+		mapping["options"] = optionsMaps
 
 		if zoneMappings, ok := object["ZoneMappings"]; ok {
 			zoneMappingsMaps := make([]map[string]interface{}, 0)

--- a/alicloud/data_source_alicloud_cen_transit_router_vpc_attachments_test.go
+++ b/alicloud/data_source_alicloud_cen_transit_router_vpc_attachments_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
@@ -119,6 +120,7 @@ func TestAccAliCloudCenTransitRouterVpcAttachmentsDataSource(t *testing.T) {
 	}
 
 	preCheck := func() {
+		testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Hangzhou})
 		testAccPreCheck(t)
 	}
 
@@ -132,56 +134,177 @@ func testAccCheckAliCloudCenTransitRouterVpcAttachmentsDataSourceName(rand int, 
 	}
 
 	config := fmt.Sprintf(`
-	variable "name" {
-  		default = "tf-testAcc-CenTransitRouterVpcAttachment-%d"
-	}
+variable "name" {
+  default = "tf-testAcc-CenTransitRouterVpcAttachment-%d"
+}
 
-	data "alicloud_zones" "default" {
-	}
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
 
-	data "alicloud_vpcs" "default" {
-  		name_regex = "^default-NODELETING$"
-	}
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "192.168.0.0/16"
+}
 
-	data "alicloud_vswitches" "default" {
-  		vpc_id  = data.alicloud_vpcs.default.ids.0
-  		zone_id = data.alicloud_zones.default.ids.0
-	}
+resource "alicloud_vswitch" "default" {
+  vpc_id       = alicloud_vpc.default.id
+  cidr_block   = "192.168.1.0/24"
+  zone_id      = "cn-hangzhou-h"
+  vswitch_name = var.name
+}
 
-	data "alicloud_vswitches" "default_master" {
-  		vpc_id  = data.alicloud_vpcs.default.ids.0
-  		zone_id = data.alicloud_zones.default.ids.1
-	}
+resource "alicloud_vswitch" "default_master" {
+  vpc_id       = alicloud_vpc.default.id
+  cidr_block   = "192.168.2.0/24"
+  zone_id      = "cn-hangzhou-i"
+  vswitch_name = "${var.name}-master"
+}
 
-	resource "alicloud_cen_instance" "default" {
-  		cen_instance_name = var.name
-  		protection_level  = "REDUCED"
-	}
+resource "alicloud_cen_instance" "default" {
+  cen_instance_name = var.name
+  protection_level  = "REDUCED"
+}
 
-	resource "alicloud_cen_transit_router" "default" {
-  		cen_id = alicloud_cen_instance.default.id
-	}
+resource "alicloud_cen_transit_router" "default" {
+  cen_id = alicloud_cen_instance.default.id
+}
 
-	resource "alicloud_cen_transit_router_vpc_attachment" "default" {
-  		cen_id                                = alicloud_cen_instance.default.id
-  		vpc_id                                = data.alicloud_vpcs.default.ids.0
-  		transit_router_id                     = alicloud_cen_transit_router.default.transit_router_id
-  		transit_router_attachment_name        = var.name
-  		transit_router_attachment_description = var.name
-  		zone_mappings {
-    		vswitch_id = data.alicloud_vswitches.default_master.vswitches.0.id
-    		zone_id    = data.alicloud_vswitches.default_master.vswitches.0.zone_id
-  		}
-  		zone_mappings {
-    		vswitch_id = data.alicloud_vswitches.default.vswitches.0.id
-    		zone_id    = data.alicloud_vswitches.default.vswitches.0.zone_id
-  		}
-	}
+resource "alicloud_cen_transit_router_vpc_attachment" "default" {
+  cen_id                                = alicloud_cen_instance.default.id
+  vpc_id                                = alicloud_vpc.default.id
+  transit_router_id                     = alicloud_cen_transit_router.default.transit_router_id
+  transit_router_attachment_name        = var.name
+  transit_router_attachment_description = var.name
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.default_master.id
+    zone_id    = alicloud_vswitch.default_master.zone_id
+  }
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.default.id
+    zone_id    = alicloud_vswitch.default.zone_id
+  }
+}
 
-	data "alicloud_cen_transit_router_vpc_attachments" "default" {
-  		cen_id = alicloud_cen_instance.default.id
- 		%s
-	}
+data "alicloud_cen_transit_router_vpc_attachments" "default" {
+  cen_id = alicloud_cen_instance.default.id
+  %s
+}
 `, rand, strings.Join(pairs, " \n "))
 	return config
+}
+
+func TestAccAliCloudCenTransitRouterVpcAttachmentsDataSource_options(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+
+	optionsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudCenTransitRouterVpcAttachmentsDataSourceOptions(rand),
+	}
+
+	existMapFunc := func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":                                "1",
+			"names.#":                              "1",
+			"attachments.#":                        "1",
+			"attachments.0.options.#":              "1",
+			"attachments.0.options.0.ipv6_support": "enable",
+			"attachments.0.options.0.appliance_mode_support":      "enable",
+			"attachments.0.transit_router_attachment_id":          CHECKSET,
+			"attachments.0.transit_router_attachment_name":        CHECKSET,
+			"attachments.0.transit_router_attachment_description": CHECKSET,
+		}
+	}
+
+	fakeMapFunc := func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":         "0",
+			"names.#":       "0",
+			"attachments.#": "0",
+		}
+	}
+
+	checkInfo := dataSourceAttr{
+		resourceId:   "data.alicloud_cen_transit_router_vpc_attachments.default",
+		existMapFunc: existMapFunc,
+		fakeMapFunc:  fakeMapFunc,
+	}
+
+	preCheck := func() {
+		testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Hangzhou})
+		testAccPreCheck(t)
+	}
+
+	checkInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, optionsConf)
+}
+
+func testAccCheckAliCloudCenTransitRouterVpcAttachmentsDataSourceOptions(rand int) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "tf-testacc-cen-tr-vpc-attachment-options-%d"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_vpc" "default" {
+  cidr_block  = "192.168.0.0/16"
+  enable_ipv6 = true
+  ipv6_isp    = "BGP"
+  vpc_name    = var.name
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id               = alicloud_vpc.default.id
+  cidr_block           = "192.168.3.0/24"
+  zone_id              = "cn-hangzhou-h"
+  vswitch_name         = var.name
+  ipv6_cidr_block_mask = "3"
+}
+
+resource "alicloud_vswitch" "default_master" {
+  vpc_id               = alicloud_vpc.default.id
+  cidr_block           = "192.168.4.0/24"
+  zone_id              = "cn-hangzhou-i"
+  vswitch_name         = "${var.name}-master"
+  ipv6_cidr_block_mask = "4"
+}
+
+resource "alicloud_cen_instance" "default" {
+  cen_instance_name = var.name
+}
+
+resource "alicloud_cen_transit_router" "default" {
+  cen_id = alicloud_cen_instance.default.id
+}
+
+resource "alicloud_cen_transit_router_vpc_attachment" "default" {
+  cen_id                                = alicloud_cen_instance.default.id
+  vpc_id                                = alicloud_vpc.default.id
+  transit_router_id                     = alicloud_cen_transit_router.default.transit_router_id
+  transit_router_attachment_name        = var.name
+  transit_router_attachment_description = var.name
+  payment_type                          = "PayAsYouGo"
+
+  options {
+    ipv6_support           = "enable"
+    appliance_mode_support = "enable"
+  }
+
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.default.id
+    zone_id    = alicloud_vswitch.default.zone_id
+  }
+
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.default_master.id
+    zone_id    = alicloud_vswitch.default_master.zone_id
+  }
+}
+
+data "alicloud_cen_transit_router_vpc_attachments" "default" {
+  cen_id = alicloud_cen_instance.default.id
+  ids    = [alicloud_cen_transit_router_vpc_attachment.default.id]
+}
+`, rand)
 }

--- a/alicloud/resource_alicloud_cen_transit_router_vpc_attachment.go
+++ b/alicloud/resource_alicloud_cen_transit_router_vpc_attachment.go
@@ -1,10 +1,12 @@
 package alicloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"time"
 
+	"github.com/PaesslerAG/jsonpath"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -44,6 +46,26 @@ func resourceAliCloudCenTransitRouterVpcAttachment() *schema.Resource {
 			"force_delete": {
 				Type:     schema.TypeBool,
 				Optional: true,
+			},
+			"options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ipv6_support": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"appliance_mode_support": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"order_type": {
 				Type:         schema.TypeString,
@@ -196,6 +218,26 @@ func resourceAliCloudCenTransitRouterVpcAttachmentCreate(d *schema.ResourceData,
 	if v, ok := d.GetOk("transit_router_vpc_attachment_name"); ok {
 		request["TransitRouterAttachmentName"] = v
 	}
+	if v, ok := d.GetOk("options"); ok {
+		options := make(map[string]interface{})
+		applianceModeSupport1, _ := jsonpath.Get("$[0].appliance_mode_support", v)
+		if applianceModeSupport1 != nil && applianceModeSupport1 != "" {
+			options["ApplianceModeSupport"] = applianceModeSupport1
+		}
+		ipv6Support1, _ := jsonpath.Get("$[0].ipv6_support", v)
+		if ipv6Support1 != nil && ipv6Support1 != "" {
+			options["Ipv6Support"] = ipv6Support1
+		}
+
+		if len(options) > 0 {
+			optionsJson, err := json.Marshal(options)
+			if err != nil {
+				return WrapError(err)
+			}
+			request["Options"] = string(optionsJson)
+		}
+	}
+
 	if v, ok := d.GetOkExists("vpc_owner_id"); ok {
 		request["VpcOwnerId"] = v
 	}
@@ -282,6 +324,16 @@ func resourceAliCloudCenTransitRouterVpcAttachmentRead(d *schema.ResourceData, m
 	d.Set("resource_type", objectRaw["ResourceType"])
 	d.Set("cen_id", objectRaw["CenId"])
 
+	optionsMaps := make([]map[string]interface{}, 0)
+	if optionsRaw, ok := objectRaw["Options"].(map[string]interface{}); ok && len(optionsRaw) > 0 {
+		optionsMap := make(map[string]interface{})
+		optionsMap["appliance_mode_support"] = optionsRaw["ApplianceModeSupport"]
+		optionsMap["ipv6_support"] = optionsRaw["Ipv6Support"]
+		optionsMaps = append(optionsMaps, optionsMap)
+	}
+	if err := d.Set("options", optionsMaps); err != nil {
+		return err
+	}
 	tagsMaps := objectRaw["Tags"]
 	d.Set("tags", tagsToMap(tagsMaps))
 	zoneMappingsRaw := objectRaw["ZoneMappings"]
@@ -346,6 +398,29 @@ func resourceAliCloudCenTransitRouterVpcAttachmentUpdate(d *schema.ResourceData,
 	if !d.IsNewResource() && d.HasChange("transit_router_vpc_attachment_name") {
 		update = true
 		request["TransitRouterAttachmentName"] = d.Get("transit_router_vpc_attachment_name")
+	}
+
+	if !d.IsNewResource() && d.HasChange("options") {
+		if v, ok := d.GetOk("options"); ok {
+			options := make(map[string]interface{})
+			applianceModeSupport1, _ := jsonpath.Get("$[0].appliance_mode_support", v)
+			if applianceModeSupport1 != nil && applianceModeSupport1 != "" {
+				options["ApplianceModeSupport"] = applianceModeSupport1
+			}
+			ipv6Support1, _ := jsonpath.Get("$[0].ipv6_support", v)
+			if ipv6Support1 != nil && ipv6Support1 != "" {
+				options["Ipv6Support"] = ipv6Support1
+			}
+
+			if len(options) > 0 {
+				update = true
+				optionsJson, err := json.Marshal(options)
+				if err != nil {
+					return WrapError(err)
+				}
+				request["Options"] = string(optionsJson)
+			}
+		}
 	}
 
 	if !d.IsNewResource() && d.HasChange("transit_router_attachment_description") {

--- a/alicloud/resource_alicloud_cen_transit_router_vpc_attachment_test.go
+++ b/alicloud/resource_alicloud_cen_transit_router_vpc_attachment_test.go
@@ -34,6 +34,7 @@ func TestAccAliCloudCenTransitRouterVpcAttachment_basic0(t *testing.T) {
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCenTransitRouterVpcAttachmentBasicDependence0)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Hangzhou})
 			testAccPreCheck(t)
 		},
 		IDRefreshName: resourceId,
@@ -43,16 +44,16 @@ func TestAccAliCloudCenTransitRouterVpcAttachment_basic0(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"cen_id":       "${alicloud_cen_transit_router.default.cen_id}",
-					"vpc_id":       "${data.alicloud_vpcs.default.ids.0}",
+					"vpc_id":       "${alicloud_vpc.default.id}",
 					"force_delete": "true",
 					"zone_mappings": []map[string]interface{}{
 						{
-							"vswitch_id": "${data.alicloud_vswitches.default_master.vswitches.0.id}",
-							"zone_id":    "${data.alicloud_vswitches.default_master.vswitches.0.zone_id}",
+							"vswitch_id": "${alicloud_vswitch.default_master.id}",
+							"zone_id":    "${alicloud_vswitch.default_master.zone_id}",
 						},
 						{
-							"vswitch_id": "${data.alicloud_vswitches.default.vswitches.0.id}",
-							"zone_id":    "${data.alicloud_vswitches.default.vswitches.0.zone_id}",
+							"vswitch_id": "${alicloud_vswitch.default.id}",
+							"zone_id":    "${alicloud_vswitch.default.zone_id}",
 						},
 					},
 					"route_table_association_enabled": "false",
@@ -102,8 +103,8 @@ func TestAccAliCloudCenTransitRouterVpcAttachment_basic0(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"zone_mappings": []map[string]interface{}{
 						{
-							"vswitch_id": "${data.alicloud_vswitches.default_master.vswitches.0.id}",
-							"zone_id":    "${data.alicloud_vswitches.default_master.vswitches.0.zone_id}",
+							"vswitch_id": "${alicloud_vswitch.default_master.id}",
+							"zone_id":    "${alicloud_vswitch.default_master.zone_id}",
 						},
 					},
 				}),
@@ -117,8 +118,8 @@ func TestAccAliCloudCenTransitRouterVpcAttachment_basic0(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"zone_mappings": []map[string]interface{}{
 						{
-							"vswitch_id": "${data.alicloud_vswitches.default.vswitches.0.id}",
-							"zone_id":    "${data.alicloud_vswitches.default.vswitches.0.zone_id}",
+							"vswitch_id": "${alicloud_vswitch.default.id}",
+							"zone_id":    "${alicloud_vswitch.default.zone_id}",
 						},
 					},
 				}),
@@ -177,7 +178,7 @@ func TestAccAliCloudCenTransitRouterVpcAttachment_basic0_twin(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"cen_id":                                "${alicloud_cen_transit_router.default.cen_id}",
-					"vpc_id":                                "${data.alicloud_vpcs.default.ids.0}",
+					"vpc_id":                                "${alicloud_vpc.default.id}",
 					"transit_router_id":                     "${alicloud_cen_transit_router.default.transit_router_id}",
 					"resource_type":                         "VPC",
 					"payment_type":                          "PayAsYouGo",
@@ -187,12 +188,12 @@ func TestAccAliCloudCenTransitRouterVpcAttachment_basic0_twin(t *testing.T) {
 					"transit_router_attachment_description": name,
 					"zone_mappings": []map[string]interface{}{
 						{
-							"vswitch_id": "${data.alicloud_vswitches.default_master.vswitches.0.id}",
-							"zone_id":    "${data.alicloud_vswitches.default_master.vswitches.0.zone_id}",
+							"vswitch_id": "${alicloud_vswitch.default_master.id}",
+							"zone_id":    "${alicloud_vswitch.default_master.zone_id}",
 						},
 						{
-							"vswitch_id": "${data.alicloud_vswitches.default.vswitches.0.id}",
-							"zone_id":    "${data.alicloud_vswitches.default.vswitches.0.zone_id}",
+							"vswitch_id": "${alicloud_vswitch.default.id}",
+							"zone_id":    "${alicloud_vswitch.default.zone_id}",
 						},
 					},
 					"tags": map[string]string{
@@ -357,39 +358,44 @@ var AliCloudCenTransitRouterVpcAttachmentMap0 = map[string]string{
 
 func AliCloudCenTransitRouterVpcAttachmentBasicDependence0(name string) string {
 	return fmt.Sprintf(`
-	variable "name" {
-  		default = "%s"
-	}
+variable "name" {
+  default = "%s"
+}
 
-	data "alicloud_account" "default" {
-	}
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
 
-	data "alicloud_vpcs" "default" {
-  		name_regex = "^default-NODELETING$"
-	}
+data "alicloud_account" "default" {
+}
 
-	data "alicloud_zones" "default" {
-  		available_resource_creation = "VSwitch"
-	}
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "192.168.0.0/16"
+}
 
-	data "alicloud_vswitches" "default" {
-  		vpc_id  = data.alicloud_vpcs.default.ids.0
-  		zone_id = data.alicloud_zones.default.ids.0
-	}
+resource "alicloud_vswitch" "default" {
+  vpc_id       = alicloud_vpc.default.id
+  cidr_block   = "192.168.1.0/24"
+  zone_id      = "cn-hangzhou-h"
+  vswitch_name = var.name
+}
 
-	data "alicloud_vswitches" "default_master" {
-  		vpc_id  = data.alicloud_vpcs.default.ids.0
-  		zone_id = data.alicloud_zones.default.ids.1
-	}
+resource "alicloud_vswitch" "default_master" {
+  vpc_id       = alicloud_vpc.default.id
+  cidr_block   = "192.168.2.0/24"
+  zone_id      = "cn-hangzhou-i"
+  vswitch_name = "${var.name}-master"
+}
 
-	resource "alicloud_cen_instance" "default" {
-  		cen_instance_name = var.name
-  		protection_level  = "REDUCED"
-	}
+resource "alicloud_cen_instance" "default" {
+  cen_instance_name = var.name
+  protection_level  = "REDUCED"
+}
 
-	resource "alicloud_cen_transit_router" "default" {
-  		cen_id = alicloud_cen_instance.default.id
-	}
+resource "alicloud_cen_transit_router" "default" {
+  cen_id = alicloud_cen_instance.default.id
+}
 `, name)
 }
 
@@ -1154,6 +1160,313 @@ resource "alicloud_cen_instance" "defaultJ6HrUE" {
 
 resource "alicloud_cen_transit_router" "defaults5WvfD" {
   cen_id = alicloud_cen_instance.defaultJ6HrUE.id
+}
+
+
+`, name)
+}
+
+// Case VPC Attachment支持ApplianceMode+IPv6测试用例 12197
+func TestAccAliCloudCenTransitRouterVpcAttachment_basic12197(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cen_transit_router_vpc_attachment.default"
+	ra := resourceAttrInit(resourceId, AlicloudCenTransitRouterVpcAttachmentMap12197)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CenServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCenTransitRouterVpcAttachment")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccen%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCenTransitRouterVpcAttachmentBasicDependence12197)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"options": []map[string]interface{}{
+						{
+							"ipv6_support":           "enable",
+							"appliance_mode_support": "enable",
+						},
+					},
+					"zone_mappings": []map[string]interface{}{
+						{
+							"vswitch_id": "${alicloud_vswitch.defaultWZIJKW.id}",
+							"zone_id":    "${alicloud_vswitch.defaultWZIJKW.zone_id}",
+						},
+						{
+							"vswitch_id": "${alicloud_vswitch.default5XiiOt.id}",
+							"zone_id":    "${alicloud_vswitch.default5XiiOt.zone_id}",
+						},
+					},
+					"auto_publish_route_enabled":            "true",
+					"vpc_id":                                "${alicloud_vpc.defaultpzLsWV.id}",
+					"transit_router_vpc_attachment_name":    name,
+					"cen_id":                                "${alicloud_cen_instance.defaultv7lEPH.id}",
+					"payment_type":                          "PayAsYouGo",
+					"transit_router_attachment_description": "tf-test",
+					"transit_router_id":                     "${alicloud_cen_transit_router.defaultrjuavE.transit_router_id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_mappings.#":                       "2",
+						"auto_publish_route_enabled":            "true",
+						"vpc_id":                                CHECKSET,
+						"transit_router_vpc_attachment_name":    name,
+						"cen_id":                                CHECKSET,
+						"payment_type":                          "PayAsYouGo",
+						"transit_router_attachment_description": "tf-test",
+						"transit_router_id":                     CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"options": []map[string]interface{}{
+						{
+							"ipv6_support":           "disable",
+							"appliance_mode_support": "enable",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_mappings": []map[string]interface{}{
+						{
+							"vswitch_id": "${alicloud_vswitch.defaultjQs0qh.id}",
+							"zone_id":    "${alicloud_vswitch.defaultjQs0qh.zone_id}",
+						},
+						{
+							"vswitch_id": "${alicloud_vswitch.defaultWZIJKW.id}",
+							"zone_id":    "${alicloud_vswitch.defaultWZIJKW.zone_id}",
+						},
+						{
+							"vswitch_id": "${alicloud_vswitch.default5XiiOt.id}",
+							"zone_id":    "${alicloud_vswitch.default5XiiOt.zone_id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_mappings.#": "3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"options": []map[string]interface{}{
+						{
+							"ipv6_support":           "disable",
+							"appliance_mode_support": "disable",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"transit_router_vpc_attachment_name":    name + "_update",
+					"transit_router_attachment_description": "ss",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"transit_router_vpc_attachment_name":    name + "_update",
+						"transit_router_attachment_description": "ss",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_mappings": []map[string]interface{}{
+						{
+							"vswitch_id": "${alicloud_vswitch.defaultWZIJKW.id}",
+							"zone_id":    "${alicloud_vswitch.defaultWZIJKW.zone_id}",
+						},
+						{
+							"vswitch_id": "${alicloud_vswitch.default5XiiOt.id}",
+							"zone_id":    "${alicloud_vswitch.default5XiiOt.zone_id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_mappings.#": "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_mappings": []map[string]interface{}{
+						{
+							"vswitch_id": "${alicloud_vswitch.default5XiiOt.id}",
+							"zone_id":    "${alicloud_vswitch.default5XiiOt.zone_id}",
+						},
+						{
+							"vswitch_id": "${alicloud_vswitch.defaultjQs0qh.id}",
+							"zone_id":    "${alicloud_vswitch.defaultjQs0qh.zone_id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_mappings.#": "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto_publish_route_enabled": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"auto_publish_route_enabled": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "Test",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.For":     "Test",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF-update",
+						"For":     "Test-update",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF-update",
+						"tags.For":     "Test-update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "0",
+						"tags.Created": REMOVEKEY,
+						"tags.For":     REMOVEKEY,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cen_id", "dry_run"},
+			},
+		},
+	})
+}
+
+var AlicloudCenTransitRouterVpcAttachmentMap12197 = map[string]string{
+	"transit_router_attachment_id": CHECKSET,
+	"status":                       CHECKSET,
+	"create_time":                  CHECKSET,
+	"region_id":                    CHECKSET,
+}
+
+func AlicloudCenTransitRouterVpcAttachmentBasicDependence12197(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_vpc" "defaultpzLsWV" {
+  ipv6_isp    = "BGP"
+  description = "jiatu-terraform-test"
+  cidr_block  = "192.168.0.0/16"
+  enable_ipv6 = true
+  vpc_name    = "jiatu-terraform-test"
+}
+
+resource "alicloud_vswitch" "defaultWZIJKW" {
+  ipv6_cidr_block_mask = "3"
+  vpc_id               = alicloud_vpc.defaultpzLsWV.id
+  zone_id              = "cn-hangzhou-h"
+  cidr_block           = "192.168.3.0/24"
+  vswitch_name         = "tf"
+}
+
+resource "alicloud_vswitch" "default5XiiOt" {
+  vpc_id               = alicloud_vpc.defaultpzLsWV.id
+  zone_id              = "cn-hangzhou-i"
+  cidr_block           = "192.168.4.0/24"
+  vswitch_name         = "tf2"
+  ipv6_cidr_block_mask = "4"
+}
+
+resource "alicloud_vswitch" "defaultjQs0qh" {
+  description          = "tf"
+  ipv6_cidr_block_mask = "6"
+  vpc_id               = alicloud_vpc.defaultpzLsWV.id
+  zone_id              = "cn-hangzhou-j"
+  cidr_block           = "192.168.6.0/24"
+  vswitch_name         = "tf"
+}
+
+resource "alicloud_cen_instance" "defaultv7lEPH" {
+  cen_instance_name = "tf-test"
+}
+
+resource "alicloud_cen_transit_router" "defaultrjuavE" {
+  cen_id = alicloud_cen_instance.defaultv7lEPH.id
 }
 
 

--- a/website/docs/d/cen_transit_router_vpc_attachments.html.markdown
+++ b/website/docs/d/cen_transit_router_vpc_attachments.html.markdown
@@ -102,6 +102,9 @@ The following attributes are exported in addition to the arguments listed above:
   * `payment_type` - The payment type of the resource.
   * `vpc_owner_id` - The Owner ID of the VPC.
   * `auto_publish_route_enabled` - (Available since v1.224.0) Whether the transit router is automatically published to the VPC instance.
+  * `options` - (Available since v1.279.0) A collection of feature attributes.
+    * `appliance_mode_support` - Indicates whether appliance mode is enabled.
+    * `ipv6_support` - Indicates whether IPv6 is supported.
   * `transit_router_attachment_name` - The name of the Transit Router VPC Attachment.
   * `transit_router_attachment_description` - The description of the Transit Router VPC Attachment.
   * `status` - The status of the Transit Router VPC Attachment.

--- a/website/docs/r/cen_transit_router_vpc_attachment.html.markdown
+++ b/website/docs/r/cen_transit_router_vpc_attachment.html.markdown
@@ -112,6 +112,7 @@ The following arguments are supported:
 
 -> **NOTE:** This parameter configures deletion behavior and is only evaluated when Terraform attempts to destroy the resource. Changes to this parameter during updates are stored but have no immediate effect.
 
+* `options` - (Optional, Computed, List, Available since v1.279.0) A collection of feature attributes. See [`options`](#options) below.
 * `order_type` - (Optional, Computed, Available since v1.276.0) The entity that pays the fees of the network instance. Valid values:
 
   - `PayByCenOwner`: the Alibaba Cloud account that owns the CEN instance.
@@ -133,6 +134,12 @@ The following arguments will be discarded. Please use new fields as soon as poss
 * `transit_router_attachment_name` - (Deprecated since v1.230.1) Field 'transit_router_attachment_name' has been deprecated from provider version 1.230.1. New field 'transit_router_vpc_attachment_name' instead.
 * `route_table_association_enabled` - (Optional, Bool, Deprecated since v1.192.0) Whether to enabled route table association. **NOTE:** "Field `route_table_association_enabled` has been deprecated from provider version 1.192.0. Please use the resource `alicloud_cen_transit_router_route_table_association` instead, [how to use alicloud_cen_transit_router_route_table_association](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cen_transit_router_route_table_association)."
 * `route_table_propagation_enabled` - (Optional, Bool, Deprecated since v1.192.0) Whether to enabled route table propagation. **NOTE:** "Field `route_table_propagation_enabled` has been deprecated from provider version 1.192.0. Please use the resource `alicloud_cen_transit_router_route_table_propagation` instead, [how to use alicloud_cen_transit_router_route_table_propagation](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cen_transit_router_route_table_propagation)."
+
+### `options`
+
+The options supports the following:
+* `appliance_mode_support` - (Optional, Computed, Available since v1.279.0) Indicates whether appliance mode is enabled.
+* `ipv6_support` - (Optional, Computed, Available since v1.279.0) Indicates whether IPv6 is supported.
 
 ### `zone_mappings`
 


### PR DESCRIPTION
## Tests

Remote ACC:

```text
=== RUN   TestAccAliCloudCenTransitRouterVpcAttachment_basic12197
--- PASS: TestAccAliCloudCenTransitRouterVpcAttachment_basic12197 (375.94s)

=== RUN   TestAccAliCloudCenTransitRouterVpcAttachmentsDataSource_options
--- PASS: TestAccAliCloudCenTransitRouterVpcAttachmentsDataSource_options (146.04s)

=== RUN   TestAccAliCloudCenTransitRouterVpcAttachment_basic0
--- PASS: TestAccAliCloudCenTransitRouterVpcAttachment_basic0 (327.14s)

=== RUN   TestAccAliCloudCenTransitRouterVpcAttachmentsDataSource
--- PASS: TestAccAliCloudCenTransitRouterVpcAttachmentsDataSource (203.32s)

=== RUN   TestAccAliCloudCenTransitRouterVpcAttachment_basic0_twin
--- PASS: TestAccAliCloudCenTransitRouterVpcAttachment_basic0_twin (147.42s)

=== RUN   TestAccAliCloudCenTransitRouterVpcAttachment_basic7866
--- PASS: TestAccAliCloudCenTransitRouterVpcAttachment_basic7866 (273.19s)

=== RUN   TestAccAliCloudCenTransitRouterVpcAttachment_basic7248
--- PASS: TestAccAliCloudCenTransitRouterVpcAttachment_basic7248 (295.81s)