### PR TITLE
resource/alicloud_rds_custom: update generated implementation and tests

### DIFF
--- a/alicloud/resource_alicloud_rds_custom.go
+++ b/alicloud/resource_alicloud_rds_custom.go
@@ -41,10 +41,6 @@ func resourceAliCloudRdsCustom() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"create_extra_param": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
 			"create_mode": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -82,7 +78,7 @@ func resourceAliCloudRdsCustom() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
+				Computed: true,
 			},
 			"direction": {
 				Type:         schema.TypeString,
@@ -112,6 +108,11 @@ func resourceAliCloudRdsCustom() *schema.Resource {
 			"instance_charge_type": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"instance_type": {
 				Type:     schema.TypeString,
@@ -144,6 +145,12 @@ func resourceAliCloudRdsCustom() *schema.Resource {
 			"period_unit": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"private_ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"region_id": {
 				Type:     schema.TypeString,
@@ -180,19 +187,26 @@ func resourceAliCloudRdsCustom() *schema.Resource {
 			"system_disk": {
 				Type:     schema.TypeList,
 				Optional: true,
+				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"category": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 						"size": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},
+			},
+			"system_disk_id": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"tags": tagsSchema(),
 			"vswitch_id": {
@@ -203,7 +217,12 @@ func resourceAliCloudRdsCustom() *schema.Resource {
 			"zone_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
+			},
+			"create_extra_param": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}
@@ -220,14 +239,13 @@ func resourceAliCloudRdsCustomCreate(d *schema.ResourceData, meta interface{}) e
 	var err error
 	request = make(map[string]interface{})
 	request["RegionId"] = client.RegionId
-	// request["ClientToken"] = buildClientToken(action)
 
 	if v, ok := d.GetOk("period_unit"); ok {
 		request["PeriodUnit"] = v
 	}
 	if v, ok := d.GetOk("data_disk"); ok {
 		dataDiskMapsArray := make([]interface{}, 0)
-		for _, dataLoop := range v.([]interface{}) {
+		for _, dataLoop := range convertToInterfaceArray(v) {
 			dataLoopTmp := dataLoop.(map[string]interface{})
 			dataLoopMap := make(map[string]interface{})
 			dataLoopMap["Size"] = dataLoopTmp["size"]
@@ -246,29 +264,32 @@ func resourceAliCloudRdsCustomCreate(d *schema.ResourceData, meta interface{}) e
 	if v, ok := d.GetOk("password"); ok {
 		request["Password"] = v
 	}
+	if v, ok := d.GetOk("private_ip_address"); ok {
+		request["PrivateIpAddress"] = v
+	}
 	if v, ok := d.GetOkExists("auto_pay"); ok {
 		request["AutoPay"] = v
 	}
 	if v, ok := d.GetOk("key_pair_name"); ok {
 		request["KeyPairName"] = v
 	}
-	objectDataLocalMap := make(map[string]interface{})
+	systemDisk := make(map[string]interface{})
 
 	if v := d.Get("system_disk"); !IsNil(v) {
 		category3, _ := jsonpath.Get("$[0].category", v)
 		if category3 != nil && category3 != "" {
-			objectDataLocalMap["Category"] = category3
+			systemDisk["Category"] = category3
 		}
 		size3, _ := jsonpath.Get("$[0].size", v)
 		if size3 != nil && size3 != "" {
-			objectDataLocalMap["Size"] = size3
+			systemDisk["Size"] = size3
 		}
 
-		objectDataLocalMapJson, err := json.Marshal(objectDataLocalMap)
+		systemDiskJson, err := json.Marshal(systemDisk)
 		if err != nil {
 			return WrapError(err)
 		}
-		request["SystemDisk"] = string(objectDataLocalMapJson)
+		request["SystemDisk"] = string(systemDiskJson)
 	}
 
 	if v, ok := d.GetOk("io_optimized"); ok {
@@ -278,11 +299,15 @@ func resourceAliCloudRdsCustomCreate(d *schema.ResourceData, meta interface{}) e
 		request["DeploymentSetId"] = v
 	}
 	if v, ok := d.GetOk("security_group_ids"); ok {
-		jsonPathResult7, err := jsonpath.Get("$", v)
-		if err == nil && jsonPathResult7 != "" {
-			request["SecurityGroupId"] = jsonPathResult7.([]interface{})[0]
+		securityGroupIdsMapsArray := convertToInterfaceArray(v)
+
+		securityGroupIdsMapsJson, err := json.Marshal(securityGroupIdsMapsArray)
+		if err != nil {
+			return WrapError(err)
 		}
+		request["SecurityGroupIds"] = string(securityGroupIdsMapsJson)
 	}
+
 	request["InstanceType"] = d.Get("instance_type")
 	if v, ok := d.GetOk("create_mode"); ok {
 		request["CreateMode"] = v
@@ -313,6 +338,9 @@ func resourceAliCloudRdsCustomCreate(d *schema.ResourceData, meta interface{}) e
 	if v, ok := d.GetOk("description"); ok {
 		request["Description"] = v
 	}
+	if v, ok := d.GetOk("instance_name"); ok {
+		request["InstanceName"] = v
+	}
 	if v, ok := d.GetOk("image_id"); ok {
 		request["ImageId"] = v
 	}
@@ -328,9 +356,6 @@ func resourceAliCloudRdsCustomCreate(d *schema.ResourceData, meta interface{}) e
 	if v, ok := d.GetOkExists("internet_max_bandwidth_out"); ok {
 		request["InternetMaxBandwidthOut"] = v
 	}
-	if v, ok := d.GetOk("create_extra_param"); ok {
-		request["CreateExtraParam"] = v
-	}
 	if v, ok := d.GetOk("security_enhancement_strategy"); ok {
 		request["SecurityEnhancementStrategy"] = v
 	}
@@ -339,6 +364,9 @@ func resourceAliCloudRdsCustomCreate(d *schema.ResourceData, meta interface{}) e
 	}
 	if v, ok := d.GetOk("zone_id"); ok {
 		request["ZoneId"] = v
+	}
+	if v, ok := d.GetOk("create_extra_param"); ok {
+		request["CreateExtraParam"] = v
 	}
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
@@ -386,6 +414,7 @@ func resourceAliCloudRdsCustomRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("deployment_set_id", objectRaw["DeploymentSetId"])
 	d.Set("description", objectRaw["Description"])
+	d.Set("instance_name", objectRaw["InstanceName"])
 	d.Set("instance_type", objectRaw["InstanceType"])
 	d.Set("region_id", objectRaw["RegionId"])
 	d.Set("resource_group_id", objectRaw["ResourceGroupId"])
@@ -399,10 +428,15 @@ func resourceAliCloudRdsCustomRead(d *schema.ResourceData, meta interface{}) err
 	}
 	d.Set("vswitch_id", vpcAttributesRaw["VSwitchId"])
 
+	privateIpAddressRaw, _ := jsonpath.Get("$.VpcAttributes.PrivateIpAddress.IpAddress", objectRaw)
+	if arr, ok := privateIpAddressRaw.([]interface{}); ok && len(arr) > 0 {
+		d.Set("private_ip_address", arr[0])
+	}
+
 	dataDiskRaw, _ := jsonpath.Get("$.DataDisks.DataDisk", objectRaw)
 	dataDiskMaps := make([]map[string]interface{}, 0)
 	if dataDiskRaw != nil {
-		for _, dataDiskChildRaw := range dataDiskRaw.([]interface{}) {
+		for _, dataDiskChildRaw := range convertToInterfaceArray(dataDiskRaw) {
 			dataDiskMap := make(map[string]interface{})
 			dataDiskChildRaw := dataDiskChildRaw.(map[string]interface{})
 			dataDiskMap["category"] = dataDiskChildRaw["Category"]
@@ -417,6 +451,21 @@ func resourceAliCloudRdsCustomRead(d *schema.ResourceData, meta interface{}) err
 	}
 	securityGroupIdRaw, _ := jsonpath.Get("$.SecurityGroupIds.SecurityGroupId", objectRaw)
 	d.Set("security_group_ids", securityGroupIdRaw)
+	systemDiskMaps := make([]map[string]interface{}, 0)
+	systemDiskMap := make(map[string]interface{})
+	systemDiskRaw := make(map[string]interface{})
+	if objectRaw["SystemDisk"] != nil {
+		systemDiskRaw = objectRaw["SystemDisk"].(map[string]interface{})
+	}
+	if len(systemDiskRaw) > 0 {
+		systemDiskMap["category"] = systemDiskRaw["SystemDiskCategory"]
+		systemDiskMap["size"] = systemDiskRaw["SystemDiskSize"]
+
+		systemDiskMaps = append(systemDiskMaps, systemDiskMap)
+	}
+	if err := d.Set("system_disk", systemDiskMaps); err != nil {
+		return err
+	}
 
 	objectRaw, err = rdsServiceV2.DescribeCustomListTagResources(d.Id())
 	if err != nil && !NotFoundError(err) {
@@ -425,6 +474,13 @@ func resourceAliCloudRdsCustomRead(d *schema.ResourceData, meta interface{}) err
 
 	tagsMaps, _ := jsonpath.Get("$.TagResources.TagResource", objectRaw)
 	d.Set("tags", tagsToMap(tagsMaps))
+
+	objectRaw, err = rdsServiceV2.DescribeCustomDescribeRCDisks(d.Id())
+	if err != nil && !NotFoundError(err) {
+		return WrapError(err)
+	}
+
+	d.Set("system_disk_id", objectRaw["DiskId"])
 
 	return nil
 }
@@ -435,25 +491,27 @@ func resourceAliCloudRdsCustomUpdate(d *schema.ResourceData, meta interface{}) e
 	var response map[string]interface{}
 	var query map[string]interface{}
 	update := false
-	d.Partial(true)
+
+	rdsServiceV2 := RdsServiceV2{client}
+	objectRaw, _ := rdsServiceV2.DescribeRdsCustom(d.Id())
 
 	if d.HasChange("status") {
 		var err error
-		rdsServiceV2 := RdsServiceV2{client}
-		object, err := rdsServiceV2.DescribeRdsCustom(d.Id())
-		if err != nil {
-			return WrapError(err)
-		}
-
 		target := d.Get("status").(string)
-		if object["Status"].(string) != target {
+
+		currentStatus, err := jsonpath.Get("Status", objectRaw)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, d.Id(), "Status", objectRaw)
+		}
+		if fmt.Sprint(currentStatus) != target {
 			if target == "Running" {
 				action := "StartRCInstance"
 				request = make(map[string]interface{})
 				query = make(map[string]interface{})
 				request["InstanceId"] = d.Id()
 				request["RegionId"] = client.RegionId
-				wait := incrementalWait(3*time.Second, 5*time.Second)
+
+				wait := incrementalWait(5*time.Second, 5*time.Second)
 				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 					response, err = client.RpcPost("Rds", "2014-08-15", action, query, request, true)
 					if err != nil {
@@ -485,7 +543,8 @@ func resourceAliCloudRdsCustomUpdate(d *schema.ResourceData, meta interface{}) e
 				if v, ok := d.GetOkExists("force_stop"); ok {
 					request["ForceStop"] = v
 				}
-				wait := incrementalWait(3*time.Second, 5*time.Second)
+
+				wait := incrementalWait(5*time.Second, 5*time.Second)
 				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 					response, err = client.RpcPost("Rds", "2014-08-15", action, query, request, true)
 					if err != nil {
@@ -517,12 +576,12 @@ func resourceAliCloudRdsCustomUpdate(d *schema.ResourceData, meta interface{}) e
 	query = make(map[string]interface{})
 	request["DBInstanceId"] = d.Id()
 	request["RegionId"] = client.RegionId
-	request["ClientToken"] = buildClientToken(action)
 	if _, ok := d.GetOk("resource_group_id"); ok && !d.IsNewResource() && d.HasChange("resource_group_id") {
 		update = true
 	}
 	request["ResourceGroupId"] = d.Get("resource_group_id")
 	request["ResourceType"] = "Custom"
+
 	if update {
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
@@ -551,17 +610,18 @@ func resourceAliCloudRdsCustomUpdate(d *schema.ResourceData, meta interface{}) e
 		update = true
 	}
 	request["InstanceType"] = d.Get("instance_type")
-	if v, ok := d.GetOk("auto_pay"); ok {
+	if v, ok := d.GetOkExists("auto_pay"); ok {
 		request["AutoPay"] = v
 	}
 	if v, ok := d.GetOk("direction"); ok {
 		request["Direction"] = v
 	}
-	if v, ok := d.GetOk("dry_run"); ok {
+	if v, ok := d.GetOkExists("dry_run"); ok {
 		request["DryRun"] = v
 	}
+
 	if update {
-		wait := incrementalWait(3*time.Second, 5*time.Second)
+		wait := incrementalWait(20*time.Second, 20*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			response, err = client.RpcPost("Rds", "2014-08-15", action, query, request, true)
 			if err != nil {
@@ -583,6 +643,84 @@ func resourceAliCloudRdsCustomUpdate(d *schema.ResourceData, meta interface{}) e
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
 	}
+	update = false
+	action = "ModifyRCInstanceDescription"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["InstanceId"] = d.Id()
+	request["RegionId"] = client.RegionId
+	if !d.IsNewResource() && d.HasChange("description") {
+		update = true
+		request["InstanceDescription"] = d.Get("description")
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Rds", "2014-08-15", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	action = "ModifyRCInstanceAttribute"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["InstanceId"] = d.Id()
+	request["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("host_name"); ok {
+		request["HostName"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("security_group_ids") {
+		update = true
+		if v, ok := d.GetOk("security_group_ids"); ok || d.HasChange("security_group_ids") {
+			securityGroupIdsMapsArray := convertToInterfaceArray(v)
+
+			securityGroupIdsMapsJson, err := json.Marshal(securityGroupIdsMapsArray)
+			if err != nil {
+				return WrapError(err)
+			}
+			request["SecurityGroupIds"] = string(securityGroupIdsMapsJson)
+		}
+	}
+
+	if !d.IsNewResource() && d.HasChange("instance_name") {
+		update = true
+		request["InstanceName"] = d.Get("instance_name")
+	}
+
+	if v, ok := d.GetOk("password"); ok {
+		request["Password"] = v
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Rds", "2014-08-15", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
 
 	if d.HasChange("tags") {
 		rdsServiceV2 := RdsServiceV2{client}
@@ -590,7 +728,6 @@ func resourceAliCloudRdsCustomUpdate(d *schema.ResourceData, meta interface{}) e
 			return WrapError(err)
 		}
 	}
-	d.Partial(false)
 	return resourceAliCloudRdsCustomRead(d, meta)
 }
 
@@ -609,12 +746,11 @@ func resourceAliCloudRdsCustomDelete(d *schema.ResourceData, meta interface{}) e
 	if v, ok := d.GetOkExists("force"); ok {
 		request["Force"] = v
 	}
-	wait := incrementalWait(3*time.Second, 5*time.Second)
+	wait := incrementalWait(5*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		response, err = client.RpcPost("Rds", "2014-08-15", action, query, request, true)
-
 		if err != nil {
-			if NeedRetry(err) {
+			if IsExpectedErrors(err, []string{"IncorrectInstanceStatus"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}
@@ -632,7 +768,7 @@ func resourceAliCloudRdsCustomDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	rdsServiceV2 := RdsServiceV2{client}
-	stateConf := BuildStateConf([]string{}, []string{}, d.Timeout(schema.TimeoutDelete), 60*time.Second, rdsServiceV2.RdsCustomStateRefreshFunc(d.Id(), "$.InstanceId", []string{}))
+	stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 60*time.Second, rdsServiceV2.RdsCustomStateRefreshFunc(d.Id(), "$.InstanceId", []string{}))
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}

--- a/alicloud/resource_alicloud_rds_custom_test.go
+++ b/alicloud/resource_alicloud_rds_custom_test.go
@@ -35,7 +35,7 @@ func TestAccAliCloudRdsCustom_basic10836(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"amount":        "1",
-					"vswitch_id":    "${alicloud_vswitch.vSwitchId.id}",
+					"vswitch_id":    "${data.alicloud_vswitches.default.ids.0}",
 					"auto_renew":    "false",
 					"period":        "1",
 					"auto_pay":      "true",
@@ -49,7 +49,7 @@ func TestAccAliCloudRdsCustom_basic10836(t *testing.T) {
 					},
 					"status": "Running",
 					"security_group_ids": []string{
-						"${alicloud_security_group.securityGroupId.id}"},
+						"${data.alicloud_security_groups.default.ids.0}"},
 					"io_optimized":                  "optimized",
 					"description":                   "ran_test_ram_code",
 					"key_pair_name":                 "${alicloud_ecs_key_pair.KeyPairName.id}",
@@ -193,7 +193,7 @@ func TestAccAliCloudRdsCustom_basic10836(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"amount", "auto_pay", "auto_renew", "create_extra_param", "create_mode", "direction", "dry_run", "force_stop", "host_name", "image_id", "instance_charge_type", "internet_charge_type", "internet_max_bandwidth_out", "io_optimized", "key_pair_name", "password", "period", "period_unit", "security_enhancement_strategy", "spot_strategy", "support_case", "system_disk"},
+				ImportStateVerifyIgnore: []string{"amount", "auto_pay", "auto_renew", "create_extra_param", "create_mode", "direction", "dry_run", "force_stop", "host_name", "image_id", "instance_charge_type", "internet_charge_type", "internet_max_bandwidth_out", "io_optimized", "key_pair_name", "password", "period", "period_unit", "security_enhancement_strategy", "spot_strategy", "support_case"},
 			},
 		},
 	})
@@ -219,26 +219,21 @@ variable "test_zone_id" {
 
 data "alicloud_resource_manager_resource_groups" "default" {}
 
-resource "alicloud_vpc" "vpcId" {
-  cidr_block = "172.16.0.0/12"
+data "alicloud_vpcs" "default" {
+  ids = [data.alicloud_vswitches.default.vswitches.0.vpc_id]
 }
 
-resource "alicloud_vswitch" "vSwitchId" {
-  vpc_id       = alicloud_vpc.vpcId.id
-  cidr_block   = "172.16.5.0/24"
-  zone_id      = var.test_zone_id
-  vswitch_name = "test_vswitch"
+data "alicloud_vswitches" "default" {
+  status  = "Available"
+  zone_id = var.test_zone_id
 }
 
-resource "alicloud_security_group" "securityGroupId" {
-  vpc_id = alicloud_vpc.vpcId.id
-}
-
-resource "alicloud_ecs_deployment_set" "deploymentSet" {
+data "alicloud_security_groups" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
 }
 
 resource "alicloud_ecs_key_pair" "KeyPairName" {
-  key_pair_name = alicloud_vswitch.vSwitchId.id
+  key_pair_name = var.name
 }
 
 
@@ -246,3 +241,403 @@ resource "alicloud_ecs_key_pair" "KeyPairName" {
 }
 
 // Test Rds Custom. <<< Resource test cases, automatically generated.
+
+// Case resourceCase_20260415_01_clone_1_clone_0 12788
+func TestAccAliCloudRdsCustom_basic12788(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_rds_custom.default"
+	ra := resourceAttrInit(resourceId, AlicloudRdsCustomMap12788)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RdsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRdsCustom")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccrds%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRdsCustomBasicDependence12788)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":          "ran资源用名称050801",
+					"instance_charge_type": "PostPaid",
+					"auto_renew":           "false",
+					"amount":               "1",
+					"vswitch_id":           "${data.alicloud_vswitches.default.ids.0}",
+					"dry_run":              "false",
+					"deployment_set_id":    "${alicloud_rds_custom_deployment_set.deploymentSet.id}",
+					"auto_pay":             "true",
+					"force":                "false",
+					"support_case":         "eni",
+					"security_group_ids": []string{
+						"${data.alicloud_security_groups.default.ids.0}"},
+					"system_disk": []map[string]interface{}{
+						{
+							"category": "cloud_essd",
+							"size":     "40",
+						},
+					},
+					"instance_name": "namecreate",
+					"data_disk": []map[string]interface{}{
+						{
+							"category":          "cloud_essd",
+							"performance_level": "PL0",
+							"size":              "40",
+						},
+					},
+					"create_mode":   "0",
+					"instance_type": "mysql.x2.large.9cm",
+					"spot_strategy": "NoSpot",
+					"host_name":     "testhostNameran",
+					"period_unit":   "Month",
+					"password":      "@MY7yxqc9YXQC",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":          "ran资源用名称050801",
+						"instance_charge_type": "PostPaid",
+						"auto_renew":           "false",
+						"amount":               "1",
+						"vswitch_id":           CHECKSET,
+						"dry_run":              "false",
+						"deployment_set_id":    CHECKSET,
+						"auto_pay":             "true",
+						"force":                "false",
+						"support_case":         "eni",
+						"security_group_ids.#": "1",
+						"instance_name":        "namecreate",
+						"data_disk.#":          "1",
+						"create_mode":          CHECKSET,
+						"instance_type":        "mysql.x2.large.9cm",
+						"spot_strategy":        "NoSpot",
+						"host_name":            "testhostNameran",
+						"period_unit":          "Month",
+						"password":             "@MY7yxqc9YXQC",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "修改描述",
+					"force_stop":  "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "修改描述",
+						"force_stop":  "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_name": "update名称",
+					"host_name":     "hostnameupdate",
+					"password":      "@MY7yxqc9YXQCUPDATE",
+					"force":         "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_name": "update名称",
+						"host_name":     "hostnameupdate",
+						"password":      "@MY7yxqc9YXQCUPDATE",
+						"force":         "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "Test",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.For":     "Test",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF-update",
+						"For":     "Test-update",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF-update",
+						"tags.For":     "Test-update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "0",
+						"tags.Created": REMOVEKEY,
+						"tags.For":     REMOVEKEY,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":     "Stopped",
+					"force_stop": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":     "Stopped",
+						"force_stop": "true",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"amount", "auto_pay", "auto_renew", "create_mode", "direction", "dry_run", "force", "force_stop", "host_name", "image_id", "instance_charge_type", "internet_charge_type", "internet_max_bandwidth_out", "io_optimized", "key_pair_name", "password", "period", "period_unit", "security_enhancement_strategy", "spot_strategy", "support_case"},
+			},
+		},
+	})
+}
+
+var AlicloudRdsCustomMap12788 = map[string]string{
+	"system_disk_id": CHECKSET,
+	"region_id":      CHECKSET,
+}
+
+func AlicloudRdsCustomBasicDependence12788(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_vpcs" "default" {
+  ids = [data.alicloud_vswitches.default.vswitches.0.vpc_id]
+}
+
+data "alicloud_vswitches" "default" {
+  status  = "Available"
+  zone_id = "cn-beijing-i"
+}
+
+data "alicloud_security_groups" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_rds_custom_deployment_set" "deploymentSet" {
+  custom_deployment_set_name            = var.name
+  description                           = var.name
+  group_count                           = 3
+  on_unable_to_redeploy_failed_instance = "CancelMembershipAndStart"
+  strategy                              = "Availability"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_20260415_01 12772
+func TestAccAliCloudRdsCustom_basic12772(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_rds_custom.default"
+	ra := resourceAttrInit(resourceId, AlicloudRdsCustomMap12772)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RdsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRdsCustom")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccrds%d", rand)
+	privateIpAddress := fmt.Sprintf("172.16.1.%d", acctest.RandIntRange(10, 240))
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRdsCustomBasicDependence12772)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":          "ran资源用例描述042001",
+					"private_ip_address":   privateIpAddress,
+					"instance_charge_type": "PostPaid",
+					"auto_renew":           "false",
+					"amount":               "1",
+					"vswitch_id":           "${data.alicloud_vswitches.default.ids.0}",
+					"dry_run":              "false",
+					"auto_pay":             "true",
+					"security_group_ids": []string{
+						"${data.alicloud_security_groups.default.ids.0}"},
+					"system_disk": []map[string]interface{}{
+						{
+							"category": "cloud_essd",
+							"size":     "40",
+						},
+					},
+					"data_disk": []map[string]interface{}{
+						{
+							"category":          "cloud_essd",
+							"performance_level": "PL0",
+							"size":              "40",
+						},
+					},
+					"create_mode":   "0",
+					"instance_type": "mysql.x2.large.9cm",
+					"spot_strategy": "NoSpot",
+					"host_name":     "testhostNameran",
+					"period_unit":   "Month",
+					"password":      "@MY7yxqc9YXQC",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":          "ran资源用例描述042001",
+						"private_ip_address":   privateIpAddress,
+						"instance_charge_type": "PostPaid",
+						"auto_renew":           "false",
+						"amount":               "1",
+						"vswitch_id":           CHECKSET,
+						"dry_run":              "false",
+						"auto_pay":             "true",
+						"security_group_ids.#": "1",
+						"data_disk.#":          "1",
+						"create_mode":          CHECKSET,
+						"instance_type":        "mysql.x2.large.9cm",
+						"spot_strategy":        "NoSpot",
+						"host_name":            "testhostNameran",
+						"period_unit":          "Month",
+						"password":             "@MY7yxqc9YXQC",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "修改描述",
+					"force_stop":  "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "修改描述",
+						"force_stop":  "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"password":      "@MY7yxqc9YXQCUPDATE",
+					"instance_name": "update名称",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"password":      "@MY7yxqc9YXQCUPDATE",
+						"instance_name": "update名称",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "Test",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.For":     "Test",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF-update",
+						"For":     "Test-update",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF-update",
+						"tags.For":     "Test-update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "0",
+						"tags.Created": REMOVEKEY,
+						"tags.For":     REMOVEKEY,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":     "Stopped",
+					"force_stop": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":     "Stopped",
+						"force_stop": "true",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"amount", "auto_pay", "auto_renew", "create_mode", "direction", "dry_run", "force_stop", "host_name", "image_id", "instance_charge_type", "internet_charge_type", "internet_max_bandwidth_out", "io_optimized", "key_pair_name", "password", "period", "period_unit", "security_enhancement_strategy", "spot_strategy", "support_case"},
+			},
+		},
+	})
+}
+
+var AlicloudRdsCustomMap12772 = map[string]string{
+	"system_disk_id": CHECKSET,
+	"region_id":      CHECKSET,
+}
+
+func AlicloudRdsCustomBasicDependence12772(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_vpcs" "default" {
+  ids = [data.alicloud_vswitches.default.vswitches.0.vpc_id]
+}
+
+data "alicloud_vswitches" "default" {
+  cidr_block = "172.16.0.0/23"
+  status     = "Available"
+  zone_id    = "cn-beijing-i"
+}
+
+data "alicloud_security_groups" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+
+`, name)
+}

--- a/alicloud/service_alicloud_rds_v2.go
+++ b/alicloud/service_alicloud_rds_v2.go
@@ -83,17 +83,64 @@ func (s *RdsServiceV2) DescribeCustomListTagResources(id string) (object map[str
 
 	return response, nil
 }
+func (s *RdsServiceV2) DescribeCustomDescribeRCDisks(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	query["InstanceId"] = id
+	query["RegionId"] = client.RegionId
+	query["DiskType"] = "system"
+	action := "DescribeRCDisks"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcGet("Rds", "2014-08-15", action, query, request)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"InvalidParameter.InstanceId"}) {
+			return object, WrapErrorf(NotFoundErr("Custom", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Disks[*]", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Disks[*]", response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("Custom", id), NotFoundMsg, response)
+	}
+
+	return v.([]interface{})[0].(map[string]interface{}), nil
+}
 
 func (s *RdsServiceV2) RdsCustomStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.RdsCustomStateRefreshFuncWithApi(id, field, failStates, s.DescribeRdsCustom)
+}
+
+func (s *RdsServiceV2) RdsCustomStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		object, err := s.DescribeRdsCustom(id)
+		object, err := call(id)
 		if err != nil {
 			if NotFoundError(err) {
-				return nil, "", nil
+				return object, "", nil
 			}
 			return nil, "", WrapError(err)
 		}
-
 		v, err := jsonpath.Get(field, object)
 		currentStatus := fmt.Sprint(v)
 

--- a/website/docs/r/rds_custom.html.markdown
+++ b/website/docs/r/rds_custom.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a RDS Custom resource.
 
-Dedicated RDS User host.
+RDS dedicated host for users.
 
 For information about RDS Custom and how to use it, see [What is Custom](https://next.api.alibabacloud.com/document/Rds/2014-08-15/RunRCInstances).
 
@@ -19,12 +19,6 @@ For information about RDS Custom and how to use it, see [What is Custom](https:/
 ## Example Usage
 
 Basic Usage
-
-<div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
-  <a href="https://api.aliyun.com/terraform?resource=alicloud_rds_custom&exampleId=7388d26a-1040-3267-d420-d727119fb608686878c5&activeTab=example&spm=docs.r.rds_custom.0.7388d26a10&intl_lang=EN_US" target="_blank">
-    <img alt="Open in AliCloud" src="https://img.alicdn.com/imgextra/i1/O1CN01hjjqXv1uYUlY56FyX_!!6000000006049-55-tps-254-36.svg" style="max-height: 44px; max-width: 100%;">
-  </a>
-</div></div>
 
 ```terraform
 variable "name" {
@@ -130,93 +124,201 @@ resource "alicloud_rds_custom" "default" {
 }
 ```
 
-📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_rds_custom&spm=docs.r.rds_custom.example&intl_lang=EN_US)
-
 ## Argument Reference
 
 The following arguments are supported:
-* `amount` - (Optional, Int) Represents the number of instances created
-* `auto_pay` - (Optional) Whether to pay automatically. Value range:
-  - `true` (default): automatic payment. You need to ensure that your account balance is sufficient.
-  - `false`: only orders are generated without deduction.
 
--> **NOTE:**  If the balance of your payment method is insufficient, you can set the parameter AutoPay to false, and an unpaid order will be generated. You can log on to the RDS management console to pay by yourself.
+* `amount` - (Optional, Int) Specifies the number of RDS Custom instances to create. This parameter applies only when creating multiple RDS Custom instances at once.
+Valid values: `1` to `5`. Default value: `1`.
 
--> **NOTE:** >
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
 
-* `auto_renew` - (Optional) Whether the instance is automatically renewed. Valid values: true/false. The default is false.
-* `create_extra_param` - (Optional, Available since v1.252.0) Reserved parameters are not supported.
-* `create_mode` - (Optional) Whether to allow joining the ACK cluster. When this parameter is set to `1`, the created instance can be added to the ACK cluster through The `AttachRCInstances` API to efficiently manage container applications.
+* `auto_pay` - (Optional) Specifies whether to enable automatic payment. Valid values:
+  - `true` (default): Enable automatic payment. You must ensure that your account balance is sufficient.
+  - `false`: Generate an order without charging your account.
+
+-> **NOTE:**  If your payment method has insufficient funds, you can set the AutoPay parameter to false. In this case, an unpaid order is generated, and you can log on to the RDS console to complete the payment manually.
+
+-> **NOTE:** This parameter only takes effect when other resource properties are also modified. Changing this parameter alone will not trigger a resource update.
+
+* `auto_renew` - (Optional) Specifies whether the instance is automatically renewed. This parameter applies only when you create a subscription instance. Valid values:
+  - `true`: Enable auto-renewal.
+  - `false`: Disable auto-renewal.
+
+-> **NOTE:**  * If you purchase the instance on a monthly basis, the auto-renewal period is one month.
+
+-> **NOTE:**  * If you purchase the instance on an annual basis, the auto-renewal period is one year.
+
+
+-> **NOTE:** This parameter is only evaluated during resource creation and update. Modifying it in isolation will not trigger any action.
+
+* `create_mode` - (Optional) Specifies whether the instance can be added to an ACK cluster. When this parameter is set to `1`, the created instance can be added to an ACK cluster by using the `AttachRCInstances` API operation, enabling efficient management of containerized applications.
   - `1`: Yes.
   - `0` (default): No.
-* `data_disk` - (Optional, ForceNew, Computed, Set) Data disk See [`data_disk`](#data_disk) below.
 
-->**NOTE:** From version 1.275.0, If you want to use `data_disk`, We recommend you to use the resource [alicloud_rds_custom_disk_attachment](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/rds_custom_disk_attachment).
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
 
-* `deployment_set_id` - (Optional, ForceNew) The ID of the deployment set.
-* `description` - (Optional, ForceNew) Instance description. It must be 2 to 256 characters in length and cannot start with http:// or https.
-* `direction` - (Optional) Instance configuration type, value range:
+* `data_disk` - (Optional, ForceNew, Computed, List) List of data disks.   See [`data_disk`](#data_disk) below.
+* `deployment_set_id` - (Optional, ForceNew) Deployment set ID.
+* `description` - (Optional, Computed) The instance description. It must be 2 to 256 characters in length and cannot start with http:// or https://.
+* `direction` - (Optional) The instance specification change type. Valid values:
 
--> **NOTE:**  This parameter does not need to be uploaded, and the system can automatically determine whether to upgrade or downgrade. If you want to upload, please follow the following logic rules.
-  - `Up` (default): upgrade the instance specification. Please ensure that your account balance is sufficient.
-  - `Down`: Downgrade instance specifications. When the instance type set to InstanceType is lower than the current instance type, set Direction = down.
-* `dry_run` - (Optional) Whether to pre-check the operation of creating an instance. Valid values:
-  - `true`: The PreCheck operation is performed without creating an instance. Check items include request parameters, request formats, business restrictions, and inventory.
-  - `false` (default): Sends a normal request and directly creates an instance after the check is passed.
-* `force` - (Optional) Whether to forcibly release the running instance. Value: true/false
-* `force_stop` - (Optional) Whether to force shutdown. Value range:
-  - `true`: Force shutdown.
-  - `false` (default): Normal shutdown.
-* `host_name` - (Optional) The instance host name.
+-> **NOTE:**  You do not need to specify this parameter because the system can automatically determine whether to upgrade or downgrade the instance. If you choose to specify it, follow the rules below:
+  - `Up` (default): Upgrade the instance specification. Ensure that your account has sufficient balance.
+  - `Down`: Downgrade the instance specification. Set Direction=Down when the instance type specified by InstanceType is lower than the current instance type.
+
+-> **NOTE:** This parameter only takes effect when other resource properties are also modified. Changing this parameter alone will not trigger a resource update.
+
+* `dry_run` - (Optional) Specifies whether to perform a dry run of the instance creation request. Valid values:
+  - `true`: performs a dry run without creating the instance. The system checks the request parameters, request format, service limits, and available inventory.
+  - `false` (default): sends the actual request and creates the instance if all checks pass.
+
+-> **NOTE:** This parameter only takes effect when other resource properties are also modified. Changing this parameter alone will not trigger a resource update.
+
+* `force` - (Optional) Specifies whether to forcibly release a running instance. Valid values:
+  - `true`: Force release.
+  - `false` (default): Do not force release.
+
+-> **NOTE:** This parameter configures deletion behavior and is only evaluated when Terraform attempts to destroy the resource. Changes to this parameter during updates are stored but have no immediate effect.
+
+* `force_stop` - (Optional) Specifies whether to force shut down the instance. Valid values:
+  - `true`: Force shut down.
+  - `false` (default): Shut down normally.
+
+-> **NOTE:** This parameter only takes effect when other resource properties are also modified. Changing this parameter alone will not trigger a resource update.
+
+* `host_name` - (Optional) The hostname of the instance.
+
+-> **NOTE:** This parameter is only evaluated during resource creation and update. Modifying it in isolation will not trigger any action.
+
 * `image_id` - (Optional) The ID of the image used by the instance.
-* `instance_charge_type` - (Optional) The Payment type. Currently, only `Prepaid` (package year and month) types are supported.
-* `instance_type` - (Required) The type of the created RDS Custom dedicated host instance.
-* `internet_charge_type` - (Optional) Reserved parameters are not supported.
-* `internet_max_bandwidth_out` - (Optional, Int) Reserved parameters are not supported.
-* `io_optimized` - (Optional) Reserved parameters are not supported.
-* `key_pair_name` - (Optional) The key pair name. Only flyer names are supported.
-* `password` - (Optional) The account and password of the instance.
-* `period` - (Optional, Int) Prepaid renewal duration, unit: Month/Year. 
-* `period_unit` - (Optional) The unit of duration of the year-to-month billing method. Value range:
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `instance_charge_type` - (Optional) The billing method. Valid values:
+  - `Prepaid`: subscription.
+  - `Postpaid`: pay-as-you-go.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `instance_name` - (Optional, Computed, Available since v1.279.0) The name must be 2 to 128 characters in length, start with a letter or Chinese character, and can contain letters, Chinese characters, digits, periods (.), underscores (_), colons (:), or hyphens (-). By default, the instance name is the same as the InstanceId. When creating multiple RdsCustom instances, you can specify sequential instance names in batches by using square brackets ([]) and commas (,). For more information, see [Create an RDS Custom instance](https://help.aliyun.com/zh/rds/apsaradb-rds-for-mysql/create-an-rds-custom-instance?spm=a2c4g.11186623.0.0.36ef7288jg7aZD#00481f9ba381u).
+* `instance_type` - (Required) The target instance type for configuration changes. For the list of instance types supported by RDS Custom instances, see [RDS Custom Instance Types](https://help.aliyun.com/document_detail/2844823.html).
+* `internet_charge_type` - (Optional) Reserved parameter. Not supported currently.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `internet_max_bandwidth_out` - (Optional, Int) The maximum outbound public bandwidth for Custom for SQL Server, measured in Mbit/s.
+Valid values: 0 to 1024. Default value: 0.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `io_optimized` - (Optional) This parameter is reserved and currently unsupported.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `key_pair_name` - (Optional) The name of the key pair. Only a single key pair name is supported.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `password` - (Optional) The account password for the instance. It must be 8 to 30 characters in length and contain at least three of the following character types: uppercase letters, lowercase letters, digits, and special characters. Supported special characters include: `()~!@#$%^&*-_+=|{}[]:;',.?/`.
+
+-> **NOTE:** This parameter is only evaluated during resource creation and update. Modifying it in isolation will not trigger any action.
+
+* `period` - (Optional, Int) The subscription duration of the resource. Default value: `1`.
+
+-> **NOTE:** This parameter is only evaluated during resource creation and update. Modifying it in isolation will not trigger any action.
+
+* `period_unit` - (Optional) The unit of subscription duration for the subscription billing method. Valid values:
   - `Year`: Year
   - `Month` (default): Month
-* `resource_group_id` - (Optional, Computed) The ID of the resource group
-* `security_enhancement_strategy` - (Optional) Reserved parameters are not supported.
-* `security_group_ids` - (Optional, ForceNew, List) Security group list
-* `spot_strategy` - (Optional, Available since v1.252.0) The bidding strategy for pay-as-you-go instances. This parameter takes effect when the value of `InstanceChargeType` is set to **PostPaid. Value range:
-  - `NoSpot`: normal pay-as-you-go instances.
-  - `SpotAsPriceGo`: The system automatically bids and follows the actual price in the current market.
 
-Default value: **NoSpot * *.
-* `status` - (Optional, Computed) The status of the resource
-* `support_case` - (Optional, Available since v1.252.0) Supported scenarios: createMode:supportCase, for example: NATIVE("0", "eni"),RCK("1", "rck"),ACK_EDGE("1", "edge");
-* `system_disk` - (Optional, List) System disk specifications. See [`system_disk`](#system_disk) below.
-* `tags` - (Optional, Map) The tag of the resource
-* `vswitch_id` - (Required, ForceNew) The ID of the virtual switch. The zone in which the vSwitch is located must correspond to the zone ID entered in ZoneId.
-The network type InstanceNetworkType must be VPC.
-* `zone_id` - (Optional, ForceNew) The zone ID  of the resource
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `private_ip_address` - (Optional, ForceNew, Computed, Available since v1.279.0) The private IP address of the instance. When assigning a private IP address to an ECS instance in a Virtual Private Cloud (VPC), you must select an available IP address from the CIDR block of the specified vSwitch (VSwitchId).
+* `resource_group_id` - (Optional, Computed) The resource group ID. You can call ListResourceGroups to obtain it.
+* `security_enhancement_strategy` - (Optional) This is a reserved parameter and is not currently supported.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `security_group_ids` - (Optional, ForceNew, List) The ID of the security group to which the instance belongs. Instances in the same security group can access each other. The maximum number of instances that a security group can contain depends on the security group type. For more information, see the "Security groups" section in [Limits](https://help.aliyun.com/document_detail/25412.html).
+
+-> **NOTE:**  The SecurityGroupId determines the network type of the instance. For example, if the specified security group uses the Virtual Private Cloud (VPC) network type, the instance is of the VPC type and you must also specify the VSwitchId parameter.
+
+* `spot_strategy` - (Optional, Available since v1.252.0) The spot strategy for pay-as-you-go instances. This parameter takes effect only when `InstanceChargeType` is set to `PostPaid`. Valid values:
+  - `NoSpot`: A regular pay-as-you-go instance.
+  - `SpotAsPriceGo`: The system automatically bids based on the current market price.
+
+Default value: `NoSpot`.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `status` - (Optional, Computed) The status of the instance. Valid values:
+  - `Pending`: The instance is being created.
+  - `Running`: The instance is running.
+  - `Starting`: The instance is starting.
+  - `Stopping`: The instance is stopping.
+  - `Stopped`: The instance is stopped.
+* `support_case` - (Optional, Available since v1.252.0) The deployment type of RDS Custom. Valid values:
+  - `eni`: Dual ENI.
+  - `edge`: Edge node pool.
+  - `share`: VPC.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `system_disk` - (Optional, ForceNew, List) The system disk specification. See [`system_disk`](#system_disk) below.
+
+-> **NOTE:** Since v1.279.0, `system_disk` is treated as a ForceNew field. Any change to this field, including its nested `category` and `size` values, will force replacement of the `alicloud_rds_custom` resource.
+
+* `tags` - (Optional, Map) Details of the queried instances and their tags.
+* `vswitch_id` - (Required, ForceNew) The virtual switch ID of the target instance. If you are creating a VPC-type RDS Custom instance, you must specify the virtual switch ID, and the security group and virtual switch must belong to the same Virtual Private Cloud (VPC).
+
+-> **NOTE:**  If you specify the VSwitchId parameter, the ZoneId parameter you set must match the zone where the virtual switch is located. Alternatively, you can omit the ZoneId parameter, and the system will automatically select the zone of the specified virtual switch.
+
+* `zone_id` - (Optional, ForceNew, Computed) The zone ID of the instance. You can call DescribeZones to obtain the list of available zones.
+
+-> **NOTE:**  If you specify the VSwitchId parameter, the specified ZoneId must match the zone where the vSwitch is located. Alternatively, you can omit ZoneId, and the system will automatically select the zone of the specified vSwitch.
+
+* `create_extra_param` - (Optional, Available since v1.252.0) Reserved parameters are not supported.
 
 ### `data_disk`
 
 The data_disk supports the following:
-* `category` - (Optional, ForceNew) Instance storage type
-local_ssd: local SSD disk
-cloud_essd:ESSD PL1 cloud disk
-* `performance_level` - (Optional, ForceNew) Cloud Disk Performance
-Currently only supports PL1
-* `size` - (Optional, ForceNew, Int) Instance storage space. Unit: GB.
+* `category` - (Optional, ForceNew) The type of data disk. Valid values:
+  - `cloud_efficiency`: Ultra disk.
+  - `cloud_ssd`: SSD cloud disk.
+  - `cloud_essd` (default): ESSD cloud disk.
+  - `cloud_auto`: High-performance cloud disk.
+* `performance_level` - (Optional, ForceNew) The performance level for an ESSD cloud disk. For information about performance differences among ESSD cloud disks, see [ESSD cloud disks](https://help.aliyun.com/document_detail/2859916.html). Valid values:
+  - `PL0`
+  - `PL1` (default)
+  - `PL2`
+  - `PL3`.
+* `size` - (Optional, ForceNew, Int) The size of the data disk, in GiB. Valid values:
+  - cloud_efficiency: 20 to 32,768.
+  - cloud_ssd: 20 to 32,768.
+  - cloud_auto: 1 to 65,536.
+  - cloud_essd: The valid range depends on the value of **DataDisk.PerformanceLevel**.
+  - PL0: 1 to 65,536.
+  - PL1: 20 to 65,536.
+  - PL2: 461 to 65,536.
+  - PL3: 1,261 to 65,536.
 
 ### `system_disk`
 
 The system_disk supports the following:
-* `category` - (Optional) The cloud disk type of the system disk. Currently, only `cloud_essd`(ESSD cloud disk) is supported.
-* `size` - (Optional) System disk size, unit: GiB. Only ESSD PL1 is supported. Valid values range from 20 to 2048.
+* `category` - (Optional, ForceNew) The system disk category. Valid values:
+  - `cloud_efficiency`: ultra disk.
+  - `cloud_ssd`: standard SSD.
+  - `cloud_essd` (default): ESSD.
+  - `cloud_auto`: high-performance cloud disk.
+* `size` - (Optional, ForceNew) The size of the system disk, in GiB. The value must be greater than or equal to the size of the image specified by the `ImageId` parameter.
 
 ## Attributes Reference
 
 The following attributes are exported:
 * `id` - The ID of the resource supplied above.
-* `region_id` - The region ID. Callable DescribeRegions to get.
+* `region_id` - The region ID.
+* `system_disk_id` - The ID of the system disk attached to the Custom instance.
 
 ## Timeouts
 
@@ -230,5 +332,5 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 RDS Custom can be imported using the id, e.g.
 
 ```shell
-$ terraform import alicloud_rds_custom.example <id>
+$ terraform import alicloud_rds_custom.example <instance_id>
 ```


### PR DESCRIPTION
## What Updated

- Regenerated `alicloud_rds_custom` resource implementation from the pre-release resource spec.
- Added support for generated RDS Custom fields and read mappings, including `instance_name`, `private_ip_address`, `system_disk`, and `system_disk_id`.
- Updated RDS Custom service helpers for the related describe APIs.
- Added/kept acceptance coverage for generated cases `10836`, `12788`, and `12772`; switched VPC/VSwitch/security group dependencies to data sources to avoid delayed cleanup issues after RDS Custom destroy.
- Regenerated the RDS Custom documentation and removed unsupported auto-generated attributes so the docs align with the current resource schema.

## Testing

```text
go run scripts/testing/testing_coverage_rate_check.go -fileNames=<current-diff>
resource rds_custom attributes has 100% testing coverage rate
resource rds_custom attributes has 100% modified coverage rate
--- PASS!

=== RUN   TestAccAliCloudRdsCustom_basic10836
--- PASS: TestAccAliCloudRdsCustom_basic10836 (373.13s)

=== RUN   TestAccAliCloudRdsCustom_basic12788
--- PASS: TestAccAliCloudRdsCustom_basic12788 (319.48s)

=== RUN   TestAccAliCloudRdsCustom_basic12772
--- PASS: TestAccAliCloudRdsCustom_basic12772 (312.73s)