### PR TITLE
New Resource: alicloud_api_gateway_stage_model

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1949,6 +1949,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_polardb_global_database_network":                       resourceAlicloudPolarDBGlobalDatabaseNetwork(),
 			"alicloud_vpc_ipv4_gateway":                                      resourceAliCloudVpcIpv4Gateway(),
 			"alicloud_api_gateway_backend":                                   resourceAlicloudApiGatewayBackend(),
+			"alicloud_api_gateway_stage_model":                               resourceAlicloudApiGatewayStageModel(),
 			"alicloud_vpc_prefix_list":                                       resourceAliCloudVpcPrefixList(),
 			"alicloud_cms_event_rule":                                        resourceAliCloudCloudMonitorServiceEventRule(),
 			"alicloud_ddos_basic_threshold":                                  resourceAliCloudDdosBasicThreshold(),

--- a/alicloud/resource_alicloud_api_gateway_stage_model.go
+++ b/alicloud/resource_alicloud_api_gateway_stage_model.go
@@ -1,0 +1,202 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAlicloudApiGatewayStageModel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudApiGatewayStageModelCreate,
+		Read:   resourceAlicloudApiGatewayStageModelRead,
+		Update: resourceAlicloudApiGatewayStageModelUpdate,
+		Delete: resourceAlicloudApiGatewayStageModelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"stage_model_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile("^[A-Z0-9]{2,10}$"), "must be 2-10 uppercase letters or digits"),
+					validation.StringNotInSlice([]string{"RELEASE", "PRE", "TEST"}, false),
+				),
+			},
+			"stage_model_alias": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 200),
+			},
+			"stage_model_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modified_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAlicloudApiGatewayStageModelCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	request := make(map[string]interface{})
+
+	request["StageName"] = d.Get("stage_model_name").(string)
+	request["StageAlias"] = d.Get("stage_model_alias").(string)
+	if v, ok := d.GetOk("description"); ok {
+		request["Description"] = v
+	}
+
+	var response map[string]interface{}
+	action := "CreateStageModel"
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		resp, err := client.RpcPost("CloudAPI", "2016-07-14", action, nil, request, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		response = resp
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_api_gateway_stage_model", action, AlibabaCloudSdkGoERROR)
+	}
+
+	if v, err := jsonpath.Get("$.StageModelId", response); err != nil || v == nil {
+		return WrapErrorf(err, IdMsg, "alicloud_api_gateway_stage_model")
+	} else {
+		d.SetId(fmt.Sprint(v))
+	}
+
+	return resourceAlicloudApiGatewayStageModelRead(d, meta)
+}
+
+func resourceAlicloudApiGatewayStageModelRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cloudApiService := CloudApiService{client}
+
+	object, err := cloudApiService.DescribeApiGatewayStageModel(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_api_gateway_stage_model cloudApiService.DescribeApiGatewayStageModel Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("stage_model_name", object["StageName"])
+	d.Set("stage_model_alias", object["StageAlias"])
+	d.Set("description", object["Description"])
+	d.Set("stage_model_id", object["StageModelId"])
+	d.Set("type", object["Type"])
+	d.Set("created_time", object["CreatedTime"])
+	d.Set("modified_time", object["ModifiedTime"])
+	return nil
+}
+
+func resourceAlicloudApiGatewayStageModelUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var err error
+	update := false
+
+	request := map[string]interface{}{
+		"StageModelId": d.Id(),
+	}
+
+	if d.HasChange("stage_model_alias") {
+		update = true
+		request["StageAlias"] = d.Get("stage_model_alias").(string)
+	}
+
+	if d.HasChange("description") {
+		update = true
+		request["Description"] = d.Get("description")
+	}
+
+	if update {
+		action := "ModifyStageModel"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			resp, err := client.RpcPost("CloudAPI", "2016-07-14", action, nil, request, false)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, resp, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAlicloudApiGatewayStageModelRead(d, meta)
+}
+
+func resourceAlicloudApiGatewayStageModelDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := map[string]interface{}{
+		"StageModelId": d.Id(),
+	}
+
+	action := "DeleteStageModel"
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		resp, err := client.RpcPost("CloudAPI", "2016-07-14", action, nil, request, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, resp, request)
+		return nil
+	})
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NotFoundStageModel"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+	return nil
+}

--- a/alicloud/resource_alicloud_api_gateway_stage_model_test.go
+++ b/alicloud/resource_alicloud_api_gateway_stage_model_test.go
@@ -1,0 +1,88 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudApiGatewayStageModel_basic0(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_api_gateway_stage_model.default"
+	ra := resourceAttrInit(resourceId, AlicloudApiGatewayStageModelMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudApiService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApiGatewayStageModel")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("TF%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApiGatewayStageModelBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"stage_model_name":  name,
+					"stage_model_alias": "tf-testAcc-alias",
+					"description":       "tf-testAcc-desc",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"stage_model_name":  name,
+						"stage_model_alias": "tf-testAcc-alias",
+						"description":       "tf-testAcc-desc",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"stage_model_alias": "tf-testAcc-alias-update",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"stage_model_alias": "tf-testAcc-alias-update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "tf-testAcc-desc-update",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "tf-testAcc-desc-update",
+					}),
+				),
+			},
+		},
+	})
+}
+
+var AlicloudApiGatewayStageModelMap0 = map[string]string{
+	"stage_model_id": CHECKSET,
+	"type":           CHECKSET,
+	"created_time":   CHECKSET,
+	"modified_time":  CHECKSET,
+}
+
+func AlicloudApiGatewayStageModelBasicDependence0(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+`, name)
+}

--- a/alicloud/service_alicloud_api_gateway.go
+++ b/alicloud/service_alicloud_api_gateway.go
@@ -688,3 +688,49 @@ func (s *CloudApiService) DescribeApiGatewayModel(id string) (object map[string]
 
 	return object, nil
 }
+
+func (s *CloudApiService) DescribeApiGatewayStageModel(id string) (object map[string]interface{}, err error) {
+	var response map[string]interface{}
+	action := "DescribeStageModels"
+	client := s.client
+
+	request := map[string]interface{}{
+		"PageNumber": 1,
+		"PageSize":   PageSizeXLarge,
+	}
+
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("CloudAPI", "2016-07-14", action, nil, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.StageModelInfoList", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.StageModelInfoList", response)
+	}
+
+	if v == nil {
+		return object, WrapErrorf(NotFoundErr("ApiGateway", id), NotFoundWithResponse, response)
+	}
+
+	for _, item := range v.([]interface{}) {
+		itemMap := item.(map[string]interface{})
+		if fmt.Sprint(itemMap["StageModelId"]) == id {
+			return itemMap, nil
+		}
+	}
+
+	return object, WrapErrorf(NotFoundErr("ApiGateway", id), NotFoundWithResponse, response)
+}

--- a/website/docs/r/api_gateway_stage_model.html.markdown
+++ b/website/docs/r/api_gateway_stage_model.html.markdown
@@ -1,0 +1,62 @@
+---
+subcategory: "Api Gateway"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_api_gateway_stage_model"
+sidebar_current: "docs-alicloud-resource-api-gateway-stage-model"
+description: |-
+  Provides a Alicloud Api Gateway Stage Model resource.
+---
+
+# alicloud_api_gateway_stage_model
+
+Provides a Api Gateway Stage Model resource.
+
+For information about Api Gateway Stage Model and how to use it, see [What is Stage Model](https://www.alibabacloud.com/help/en/api-gateway/developer-reference/api-cloudapi-2016-07-14-createstagemodel).
+
+-> **NOTE:** Available since v1.280.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_api_gateway_stage_model" "default" {
+  stage_model_name  = "DEVELOP"
+  stage_model_alias = "Develop Environment"
+  description       = "Develop stage for testing"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `stage_model_name` - (Required, ForceNew) The name of the Stage Model. It must be 2-10 uppercase letters or digits. Valid values: cannot be `RELEASE`, `PRE`, or `TEST`.
+* `stage_model_alias` - (Required) The alias of the Stage Model.
+* `description` - (Optional) The description of the Stage Model.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The resource ID in terraform of Stage Model. The value is the `stage_model_id`.
+* `stage_model_id` - The ID of the Stage Model.
+* `type` - The type of the Stage Model. Valid values: `SYSTEM`, `CUSTOM`.
+* `created_time` - The creation time of the Stage Model.
+* `modified_time` - The last modified time of the Stage Model.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 5 mins) Used when create the Stage Model.
+* `delete` - (Defaults to 5 mins) Used when delete the Stage Model.
+* `update` - (Defaults to 5 mins) Used when update the Stage Model.
+
+## Import
+
+Api Gateway Stage Model can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_api_gateway_stage_model.example <stage_model_id>
+```


### PR DESCRIPTION
## Summary
- Add new resource `alicloud_api_gateway_stage_model` to support API Gateway custom environment management
- Supports creating, updating (alias/description), deleting, and importing custom stage models
- Stage model name must match `[A-Z0-9]{2,10}` and cannot be RELEASE/PRE/TEST

## Test plan
- [x] `TestAccAliCloudApiGatewayStageModel_basic0` passed locally (create, import, update alias, update description)

🤖 Generated with [Qoder][https://qoder.com]