### PR TITLE
resource/alicloud_api_gateway_api: remove stage_names restriction to support custom stages

### DIFF
--- a/alicloud/resource_alicloud_api_gateway_api.go
+++ b/alicloud/resource_alicloud_api_gateway_api.go
@@ -337,8 +337,7 @@ func resourceAliyunApigatewayApi() *schema.Resource {
 			"stage_names": {
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{"PRE", "RELEASE", "TEST"}, false),
+					Type: schema.TypeString,
 				},
 				Optional: true,
 			},
@@ -572,11 +571,10 @@ func resourceAliyunApigatewayApiUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if update || d.HasChange("stage_names") {
-		if l, ok := d.GetOk("stage_names"); ok {
-			err = updateApiStages(d, l.(*schema.Set), meta)
-			if err != nil {
-				return WrapError(err)
-			}
+		stageNames := d.Get("stage_names").(*schema.Set)
+		err = updateApiStages(d, stageNames, meta)
+		if err != nil {
+			return WrapError(err)
 		}
 		d.SetPartial("stage_names")
 	}
@@ -597,25 +595,28 @@ func resourceAliyunApigatewayApiDelete(d *schema.ResourceData, meta interface{})
 	request.ApiId = parts[1]
 	request.GroupId = parts[0]
 
-	for _, stageName := range ApiGatewayStageNames {
-		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-			err := cloudApiService.AbolishApi(d.Id(), stageName)
-			if err != nil {
-				if IsExpectedErrors(err, []string{"ConcurrencyLockTimeout"}) {
-					time.Sleep(3 * time.Second)
-					return resource.RetryableError(err)
+	if v, ok := d.GetOk("stage_names"); ok {
+		for _, sn := range v.(*schema.Set).List() {
+			stageName := sn.(string)
+			err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+				err := cloudApiService.AbolishApi(d.Id(), stageName)
+				if err != nil {
+					if IsExpectedErrors(err, []string{"ConcurrencyLockTimeout"}) {
+						time.Sleep(3 * time.Second)
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
 				}
-				return resource.NonRetryableError(err)
-			}
-			return nil
-		})
-		if err != nil {
-			return WrapError(err)
-		}
-		_, err = cloudApiService.DescribeDeployedApi(d.Id(), stageName)
-		if err != nil {
-			if !NotFoundError(err) {
+				return nil
+			})
+			if err != nil {
 				return WrapError(err)
+			}
+			_, err = cloudApiService.DescribeDeployedApi(d.Id(), stageName)
+			if err != nil {
+				if !NotFoundError(err) {
+					return WrapError(err)
+				}
 			}
 		}
 	}
@@ -1005,8 +1006,16 @@ func setRequestParameters(d *schema.ResourceData, requestParameters []ApiGateway
 
 func getStageNameList(d *schema.ResourceData, cloudApiService CloudApiService) ([]string, error) {
 	var stageNames []string
-
-	for _, stageName := range ApiGatewayStageNames {
+	var checkList []string
+	if v, ok := d.GetOk("stage_names"); ok {
+		for _, sn := range v.(*schema.Set).List() {
+			checkList = append(checkList, sn.(string))
+		}
+	} else {
+		// Fallback for ImportState: no config available, check system stages
+		checkList = ApiGatewayStageNames
+	}
+	for _, stageName := range checkList {
 		_, err := cloudApiService.DescribeDeployedApi(d.Id(), stageName)
 		if err != nil {
 			if NotFoundError(err) {
@@ -1024,29 +1033,25 @@ func updateApiStages(d *schema.ResourceData, stageNames *schema.Set, meta interf
 	client := meta.(*connectivity.AliyunClient)
 	cloudApiService := CloudApiService{client}
 
-	for _, stageName := range ApiGatewayStageNames {
-		if stageNames.Contains(stageName) {
-			err := cloudApiService.DeployedApi(d.Id(), stageName)
+	// Deploy to all stages in the user's stage_names list
+	for _, stageName := range stageNames.List() {
+		err := cloudApiService.DeployedApi(d.Id(), stageName.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		_, err = cloudApiService.DescribeDeployedApi(d.Id(), stageName.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+	}
 
+	// Abolish from old stages that are no longer in the new list
+	o, _ := d.GetChange("stage_names")
+	if oldSet, ok := o.(*schema.Set); ok {
+		for _, stageName := range oldSet.Difference(stageNames).List() {
+			err := cloudApiService.AbolishApi(d.Id(), stageName.(string))
 			if err != nil {
 				return WrapError(err)
-			}
-
-			_, err = cloudApiService.DescribeDeployedApi(d.Id(), stageName)
-			if err != nil {
-				return WrapError(err)
-			}
-
-		} else {
-			err := cloudApiService.AbolishApi(d.Id(), stageName)
-			if err != nil {
-				return WrapError(err)
-			}
-			_, err = cloudApiService.DescribeDeployedApi(d.Id(), stageName)
-			if err != nil {
-				if !NotFoundError(err) {
-					return WrapError(err)
-				}
 			}
 		}
 	}

--- a/alicloud/resource_alicloud_api_gateway_api_test.go
+++ b/alicloud/resource_alicloud_api_gateway_api_test.go
@@ -173,6 +173,16 @@ func TestAccAliCloudApigatewayApi_basic(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"stage_names": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"stage_names.#": "0",
+					}),
+				),
+			},
 			//{
 			//	Config: testAccConfig(map[string]interface{}{
 			//		"request_config": []map[string]string{{
@@ -1451,16 +1461,16 @@ func TestAccAliCloudApigatewayApi_backend(t *testing.T) {
 						"path":    "/web/cloudapi",
 						"timeout": "20",
 					}},
-					"backend_id":     "${alicloud_api_gateway_backend.default.id}",
+					"backend_id":      "${alicloud_api_gateway_backend.default.id}",
 					"backend_enabled": "true",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"name":           name,
-						"description":    "tf_testAcc_api backend_id",
-						"auth_type":      "ANONYMOUS",
-						"service_type":   "HTTP",
-						"backend_id":     CHECKSET,
+						"name":            name,
+						"description":     "tf_testAcc_api backend_id",
+						"auth_type":       "ANONYMOUS",
+						"service_type":    "HTTP",
+						"backend_id":      CHECKSET,
 						"backend_enabled": "true",
 					}),
 				),

--- a/website/docs/r/api_gateway_api.html.markdown
+++ b/website/docs/r/api_gateway_api.html.markdown
@@ -147,7 +147,7 @@ The following arguments are supported:
 * `request_parameters` - (Optional, List) request_parameters defines the request parameters of the api. See [`request_parameters`](#request_parameters) below.
 * `constant_parameters` - (Optional, List) constant_parameters defines the constant parameters of the api. See [`constant_parameters`](#constant_parameters) below.
 * `system_parameters` - (Optional, List) system_parameters defines the system parameters of the api. See [`system_parameters`](#system_parameters) below.
-* `stage_names` - (Optional, Type: list) Stages that the api need to be deployed. Valid value: `RELEASE`,`PRE`,`TEST`.
+* `stage_names` - (Optional, Type: list) Stages that the api need to be deployed. Valid values: `RELEASE`, `PRE`, `TEST`, or any custom stage name created via `alicloud_api_gateway_stage_model`.
 * `force_nonce_check` - (Optional, Type: bool, Available in v1.140+) Whether to prevent API replay attack. Default value: `false`.
 * `backend_id` - (Optional, Available since v1.279.0) The ID of the API Gateway Backend. When specified, the API references an existing backend created by `alicloud_api_gateway_backend`.
 * `backend_enabled` - (Optional, Available since v1.279.0) Specifies whether to enable the backend service. When set to `true`, the `backend_id` will be sent to the API.


### PR DESCRIPTION
## Summary
- Remove `ValidateFunc(StringInSlice PRE/RELEASE/TEST)` from `stage_names` to allow deploying APIs to custom stage environments created via `alicloud_api_gateway_stage_model`.
- Update `updateApiStages` to deploy from user's stage list and abolish via old/new diff.
- Update `getStageNameList` to only check user-specified `stage_names`.
- Update Delete function to abolish from user's `stage_names` instead of hardcoded system stages.

## Test plan
- [x] Run `TestAccAliCloudApiGatewayApi` acceptance tests
- [x] Verify API can be deployed to a custom stage (e.g., DEVELOP) created by `alicloud_api_gateway_stage_model`
- [x] Verify removing a stage from `stage_names` correctly abolishes the API from that stage
- [x] Verify Delete correctly abolishes API from all configured custom stages before deletion

	🤖 Generated with [Qoder][https://qoder.com]