### PR TITLE
testcase: fix regression test cases for alicloud_route_entry and alicloud_havip_attachment

### DIFF
--- a/alicloud/resource_alicloud_havip_attachment_test.go
+++ b/alicloud/resource_alicloud_havip_attachment_test.go
@@ -357,6 +357,7 @@ func AliCloudHavipAttachmentBasicDependence0(name string) string {
 	data "alicloud_zones" "default" {
   		available_disk_category     = "cloud_efficiency"
   		available_resource_creation = "VSwitch"
+  		available_instance_type     = "ecs.g6.large"
 	}
 
 	data "alicloud_images" "default" {
@@ -419,6 +420,7 @@ func AliCloudHavipAttachmentBasicDependence1(name string) string {
 	data "alicloud_zones" "default" {
   		available_disk_category     = "cloud_efficiency"
   		available_resource_creation = "VSwitch"
+  		available_instance_type     = "ecs.g6.large"
 	}
 
 	data "alicloud_images" "default" {
@@ -481,6 +483,7 @@ func AliCloudHavipAttachmentBasicDependence2(name string) string {
 	data "alicloud_zones" "default" {
   		available_disk_category     = "cloud_efficiency"
   		available_resource_creation = "VSwitch"
+  		available_instance_type     = "ecs.g6.large"
 	}
 
 	data "alicloud_images" "default" {
@@ -554,6 +557,7 @@ func AliCloudHavipAttachmentBasicDependence_bug_fix(name string) string {
 	data "alicloud_zones" "default" {
   		available_disk_category     = "cloud_efficiency"
   		available_resource_creation = "VSwitch"
+  		available_instance_type     = "ecs.g6.large"
 	}
 
 	data "alicloud_images" "default" {

--- a/alicloud/resource_alicloud_route_entry_test.go
+++ b/alicloud/resource_alicloud_route_entry_test.go
@@ -392,6 +392,7 @@ func AliCloudRouteEntryBasicDependence0(name string) string {
 	data "alicloud_zones" "default" {
   		available_disk_category     = "cloud_efficiency"
   		available_resource_creation = "VSwitch"
+  		available_instance_type     = "ecs.g6.large"
 	}
 
 	data "alicloud_images" "default" {
@@ -447,6 +448,7 @@ func AliCloudRouteEntryBasicDependence1(name string) string {
 	data "alicloud_zones" "default" {
   		available_disk_category     = "cloud_efficiency"
   		available_resource_creation = "VSwitch"
+  		available_instance_type     = "ecs.g6.large"
 	}
 
 	data "alicloud_images" "default" {


### PR DESCRIPTION
## Summary

Pin `available_instance_type = "ecs.g6.large"` inside the `data "alicloud_zones"` blocks of dependence templates that go on to create an `alicloud_instance`. Without the pin, `data.alicloud_instance_types` returns an empty set in some zones and the apply fails with "no available instance type".

Only test config is touched; no production code changes.

## Validation (AccTest / ACube)

| Resource | Test case | taskId | Result |
|---|---|---|---|
| `alicloud_route_entry` | `TestAccAliCloudRouteEntry_basic0` | 3639 | passed |
| `alicloud_havip_attachment` | `TestAccAliCloudVpcHaVipAttachment_basic0` | 3640 / 3637 | passed |

## Test plan

- [x] Remote AccTest passed for each affected resource
- [ ] CI on this branch