### PR TITLE
resource/alicloud_cloud_firewall_vpc_firewall_ips_config:  Add member_uid for get operation

### DIFF
--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_ips_config.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_ips_config.go
@@ -113,7 +113,7 @@ func resourceAliCloudCloudFirewallVpcFirewallIpsConfigRead(d *schema.ResourceDat
 	client := meta.(*connectivity.AliyunClient)
 	cloudFirewallServiceV2 := CloudFirewallServiceV2{client}
 
-	objectRaw, err := cloudFirewallServiceV2.DescribeCloudFirewallVpcFirewallIpsConfig(d.Id())
+	objectRaw, err := cloudFirewallServiceV2.DescribeCloudFirewallVpcFirewallIpsConfig(d.Id(), d.Get("member_uid").(string))
 	if err != nil {
 		if !d.IsNewResource() && NotFoundError(err) {
 			log.Printf("[DEBUG] Resource alicloud_cloud_firewall_vpc_firewall_ips_config DescribeCloudFirewallVpcFirewallIpsConfig Failed!!! %s", err)

--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_ips_config_test.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_ips_config_test.go
@@ -18,7 +18,7 @@ func TestAccAliCloudCloudFirewallVpcFirewallIpsConfig_basic7786(t *testing.T) {
 	ra := resourceAttrInit(resourceId, AlicloudCloudFirewallVpcFirewallIpsConfigMap7786)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
 		return &CloudFirewallServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
-	}, "DescribeCloudFirewallVpcFirewallIpsConfig")
+	}, "DescribeCloudFirewallVpcFirewallIpsConfig", "member_uid")
 	rac := resourceAttrCheckInit(rc, ra)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)

--- a/alicloud/service_alicloud_cloud_firewall_v2.go
+++ b/alicloud/service_alicloud_cloud_firewall_v2.go
@@ -941,7 +941,7 @@ func (s *CloudFirewallServiceV2) CloudFirewallVpcFirewallAclEngineModeStateRefre
 
 // DescribeCloudFirewallVpcFirewallIpsConfig <<< Encapsulated get interface for CloudFirewall VpcFirewallIpsConfig.
 
-func (s *CloudFirewallServiceV2) DescribeCloudFirewallVpcFirewallIpsConfig(id string) (object map[string]interface{}, err error) {
+func (s *CloudFirewallServiceV2) DescribeCloudFirewallVpcFirewallIpsConfig(id string, memberUid string) (object map[string]interface{}, err error) {
 	client := s.client
 	var request map[string]interface{}
 	var response map[string]interface{}
@@ -949,6 +949,9 @@ func (s *CloudFirewallServiceV2) DescribeCloudFirewallVpcFirewallIpsConfig(id st
 	request = make(map[string]interface{})
 	query = make(map[string]interface{})
 	request["VpcFirewallId"] = id
+	if memberUid != "" {
+		request["MemberUid"] = memberUid
+	}
 
 	action := "DescribeVpcFirewallDefaultIPSConfig"
 
@@ -974,7 +977,9 @@ func (s *CloudFirewallServiceV2) DescribeCloudFirewallVpcFirewallIpsConfig(id st
 }
 
 func (s *CloudFirewallServiceV2) CloudFirewallVpcFirewallIpsConfigStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
-	return s.CloudFirewallVpcFirewallIpsConfigStateRefreshFuncWithApi(id, field, failStates, s.DescribeCloudFirewallVpcFirewallIpsConfig)
+	return s.CloudFirewallVpcFirewallIpsConfigStateRefreshFuncWithApi(id, field, failStates, func(id string) (map[string]interface{}, error) {
+		return s.DescribeCloudFirewallVpcFirewallIpsConfig(id, "")
+	})
 }
 
 func (s *CloudFirewallServiceV2) CloudFirewallVpcFirewallIpsConfigStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {


### PR DESCRIPTION
Read now forwards member_uid to DescribeVpcFirewallDefaultIPSConfig so the correct member's config is returned in multi-account setups

```log
=== RUN   TestAccAliCloudCloudFirewallVpcFirewallIpsConfig_basic7786
--- PASS: TestAccAliCloudCloudFirewallVpcFirewallIpsConfig_basic7786 (354.61s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  359.376s
```