### PR TITLE
resource/alicloud_vpc_public_ip_address_pool: declare missing zones schema field

### DIFF
--- a/alicloud/resource_alicloud_vpc_public_ip_address_pool.go
+++ b/alicloud/resource_alicloud_vpc_public_ip_address_pool.go
@@ -83,6 +83,13 @@ func resourceAliCloudVpcPublicIpAddressPool() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"zones": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }

--- a/website/docs/r/vpc_public_ip_address_pool.html.markdown
+++ b/website/docs/r/vpc_public_ip_address_pool.html.markdown
@@ -55,6 +55,7 @@ The following arguments are supported:
   - If the configuration is empty, the default value is DDoS protection (Basic edition).
   - `AntiDDoS_Enhanced` indicates DDoS protection (enhanced version).
 * `tags` - (Optional, Map) The tags of PrefixList.
+* `zones` - (Optional, ForceNew, Computed, List) The available zones of the VPC Public IP address pool. Required when `biz_type` is `CloudBox`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary

`alicloud_vpc_public_ip_address_pool` has been internally inconsistent since commit `21d849688`: Create reads `d.GetOk("zones")` and Read calls `d.Set("zones", ...)`, but the schema map never declared the `zones` field. Consequences today:

- Users cannot specify `zones = [...]` in HCL — Terraform rejects it as an unknown attribute, so the `d.GetOk` branch in Create is unreachable.
- `d.Set("zones", ...)` in Read is a silent no-op, so the value is never persisted to state.
- `biz_type = "CloudBox"` pools require `Zones` per the API contract, so the CloudBox path is effectively unusable via Terraform today.

This PR adds the missing schema declaration (Optional, Computed, ForceNew, TypeList of strings) so the existing Create/Read paths become reachable, and documents the field in the resource markdown.

## Behavior

- **Backwards compatible**: `zones` is `Optional` with no default. Existing configurations that omit the field are unaffected.
- `ForceNew` is set because the underlying API has no "update zones" operation — changing the value recreates the pool.
- `Computed` because the API returns `Zones` on describe, which matches the existing Read behavior.

## Test plan

- [ ] CI on this branch
- [ ] Manual AccTest if a CloudBox-capable test case is added (none exists today)