### PR TITLE
resource/alicloud_nlb_load_balancer: retry Delete on ResourceInConfiguring.loadbalancer

### DIFF
--- a/alicloud/resource_alicloud_nlb_load_balancer.go
+++ b/alicloud/resource_alicloud_nlb_load_balancer.go
@@ -930,7 +930,7 @@ func resourceAliCloudNlbLoadBalancerDelete(d *schema.ResourceData, meta interfac
 		request["ClientToken"] = buildClientToken(action)
 
 		if err != nil {
-			if NeedRetry(err) {
+			if IsExpectedErrors(err, []string{"ResourceInConfiguring.loadbalancer"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}


### PR DESCRIPTION
## Summary

When deleting an NLB load balancer that is still in `Configuring` state, the API returns `ResourceInConfiguring.loadbalancer`. The previous Delete relied only on `NeedRetry(err)`, which did not match this code, so the delete failed immediately instead of waiting for the LB to stabilize.

Adds `ResourceInConfiguring.loadbalancer` to the retryable error list — same pattern already used in sibling resources (e.g. `resource_alicloud_alb_listener.go:1410`).

## Validation (ACube AccTest)

Verified against the `xuzhang3/f/sdkv2_upgrade` staging base with the same one-line fix applied (the bug is present on both `master` and the SDKv2 branch):

| Test case | ACube taskId | Result |
|---|---|---|
| `TestAccAliCloudNlbSecurityPolicy_basic0` | 3786 | ✅ PASS |
| `TestAccAliCloudNlbLoadBalancer_basic0` | 3787 | ✅ PASS |
| `TestAccAliCloudNlbListenerAdditionalCertificateAttachment_basic5384` | 3788 | Apply + Import both pass — no longer fails on `ResourceInConfiguring.loadbalancer`. Remaining destroy-time `DependencyViolation.SecurityGroup` is a separate downstream issue (NLB-managed SG cleanup vs VPC delete timing) unrelated to this fix. |

## Test plan
- [x] Remote ACube AccTest passes for NLB SecurityPolicy and NLB LoadBalancer basic cases
- [x] Originally-failing case no longer hits `ResourceInConfiguring.loadbalancer` during NLB LB destroy
- [ ] Upstream CI (Go 1.25) — local `make ci-check` reported `vendor/modules.txt requires go >= 1.25.0` (local Go 1.24.1), unrelated to this change; relying on upstream CI for fmt/vet/build verification