### PR TITLE
resource/alicloud_alb_rule: retry UpdateRuleAttribute on LbStatusNotSupport

### DIFF
--- a/alicloud/resource_alicloud_alb_rule.go
+++ b/alicloud/resource_alicloud_alb_rule.go
@@ -1483,7 +1483,7 @@ func resourceAliCloudAlbRuleUpdate(d *schema.ResourceData, meta interface{}) err
 		err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
 			response, err = client.RpcPost("Alb", "2020-06-16", action, nil, request, true)
 			if err != nil {
-				if IsExpectedErrors(err, []string{"ResourceInConfiguring.Listener"}) || NeedRetry(err) {
+				if IsExpectedErrors(err, []string{"-21013", "IdempotenceProcessing", "IncorrectStatus.Rule", "SystemBusy", "ResourceInConfiguring.Listener"}) || NeedRetry(err) {
 					wait()
 					return resource.RetryableError(err)
 				}


### PR DESCRIPTION
## Summary

The Update path of `alicloud_alb_rule` issues `UpdateRuleAttribute` and only retries on `ResourceInConfiguring.Listener` plus `NeedRetry(err)`. When the parent load balancer is transiently in a non-`Active` state the API returns:

```
StatusCode: 400
Code: -21013
Message: LbStatusNotSupport
```

This is a 400 (not a 5xx), so `NeedRetry` does not match, and the Update fails immediately — breaking any multi-step ACC test that flips several `rule_actions` / `rule_conditions` in sequence.

The Delete path of the same resource (line 1528) already retries on `-21013`, `IdempotenceProcessing`, `IncorrectStatus.Rule`, `SystemBusy`. Mirror that same set into the Update retry list so transient LB-not-`Active` states stop tripping the test.

## Validation (ACube AccTest)

Verified against the `xuzhang3/f/sdkv2_upgrade` staging base with the same one-line fix applied (the bug is present on both `master` and the SDKv2 branch):

| Test case | ACube taskId | Result |
|---|---|---|
| `TestAccAliCloudALBRule_basic0` | 3970 | All 19 test steps Apply + Read + Update pass — `UpdateRuleAttribute` is now called 30+ times successfully with 0 occurrences of `LbStatusNotSupport` in tf-debug.log. Remaining post-test destroy failure (`DependencyViolation.SecurityGroup` on a leftover VPC) is the shared ALB/VPC cleanup-ordering issue affecting many ALB cases — unrelated to this fix. |

## Test plan

- [x] Remote ACube AccTest passes through every Update step (previously failed at Step 3 with `LbStatusNotSupport`)
- [x] Originally-failing case no longer hits `-21013` in tf-debug.log
- [ ] Upstream CI — local `make ci-check` reports `vendor/modules.txt requires go >= 1.25.0` (local Go 1.24.1), unrelated to this change; relying on upstream CI for fmt/vet/build verification