### PR TITLE
testcase: fix regression test cases for alicloud_privatelink_vpc_endpoint_service and related resources

### DIFF
--- a/alicloud/resource_alicloud_privatelink_vpc_endpoint_service_test.go
+++ b/alicloud/resource_alicloud_privatelink_vpc_endpoint_service_test.go
@@ -486,7 +486,6 @@ func TestAccAliCloudPrivateLinkVpcEndpointService_basic4837(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"service_description":    "test-zejun",
-					"connect_bandwidth":      "3072",
 					"auto_accept_connection": "false",
 					"payer":                  "Endpoint",
 					"service_resource_type":  "nlb",
@@ -498,7 +497,6 @@ func TestAccAliCloudPrivateLinkVpcEndpointService_basic4837(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"service_description":    "test-zejun",
-						"connect_bandwidth":      "3072",
 						"auto_accept_connection": "false",
 						"payer":                  "Endpoint",
 						"service_resource_type":  "nlb",
@@ -512,7 +510,6 @@ func TestAccAliCloudPrivateLinkVpcEndpointService_basic4837(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"service_description":   "test-zejun-2",
-					"connect_bandwidth":     "3073",
 					"zone_affinity_enabled": "true",
 					"resource_group_id":     "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
 					//"service_support_ipv6":  "true",
@@ -520,7 +517,6 @@ func TestAccAliCloudPrivateLinkVpcEndpointService_basic4837(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"service_description":   "test-zejun-2",
-						"connect_bandwidth":     "3073",
 						"zone_affinity_enabled": "true",
 						"resource_group_id":     CHECKSET,
 						//"service_support_ipv6":  "true",
@@ -530,14 +526,12 @@ func TestAccAliCloudPrivateLinkVpcEndpointService_basic4837(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"service_description":    "test-zejun",
-					"connect_bandwidth":      "3072",
 					"auto_accept_connection": "true",
 					"resource_group_id":      "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"service_description":    "test-zejun",
-						"connect_bandwidth":      "3072",
 						"auto_accept_connection": "true",
 						"resource_group_id":      CHECKSET,
 					}),
@@ -631,6 +625,7 @@ func TestAccAliCloudPrivateLinkVpcEndpointService_basic9628(t *testing.T) {
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudPrivateLinkVpcEndpointServiceBasicDependence9628)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.WuLanChaBu})
 			testAccPreCheck(t)
 		},
 		IDRefreshName: resourceId,

--- a/alicloud/resource_alicloud_privatelink_vpc_endpoint_test.go
+++ b/alicloud/resource_alicloud_privatelink_vpc_endpoint_test.go
@@ -937,7 +937,6 @@ resource "alicloud_security_group" "default97JOJ3" {
 
 resource "alicloud_privatelink_vpc_endpoint_service" "defaultr0WBYX" {
   service_description   = "test-zejun-service"
-  connect_bandwidth     = "3072"
   service_resource_type = "nlb"
 }
 

--- a/alicloud/resource_alicloud_privatelink_vpc_endpoint_zone_test.go
+++ b/alicloud/resource_alicloud_privatelink_vpc_endpoint_zone_test.go
@@ -446,7 +446,6 @@ resource "alicloud_security_group" "default1FTFrP" {
 
 resource "alicloud_privatelink_vpc_endpoint_service" "defaultr0WBYX" {
   service_description   = "test-zejun-service"
-  connect_bandwidth     = "3072"
   service_resource_type = "nlb"
 }
 


### PR DESCRIPTION
## Summary

Fix recurring PrivateLink regression failures in three test files:

1. **`connect_bandwidth` on nlb-typed service** — The `CreateVpcEndpointService` / `UpdateVpcEndpointServiceAttribute` PrivateLink APIs silently ignore the `ConnectBandwidth` parameter when `service_resource_type` is `nlb` or `gwlb` (it is only meaningful for `slb`/`alb`). The Read response then returns `0`, producing a permanent diff `connect_bandwidth: "0" => "3072"` that fails the AccTest assertions on every run. Removed the field from:
   - `TestAccAliCloudPrivateLinkVpcEndpointService_basic4837` (all 3 steps)
   - `AlicloudPrivateLinkVpcEndpointBasicDependence4793` (shared by `_basic4793` / `_basic4793_twin`)
   - `AlicloudPrivateLinkVpcEndpointZoneBasicDependence4898` (shared by `_basic4898` / `_basic_without_zoneid`)

2. **GWLB region restriction** — `TestAccAliCloudPrivateLinkVpcEndpointService_basic9628` uses `service_resource_type = "gwlb"`, which is currently only supported in `cn-wulanchabu`. Added `testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.WuLanChaBu})` so the case skips cleanly in other regions instead of failing with `UnsupportedFeature.GWLB`.

No resource (provider) code is changed — these are all test-config / test-precheck fixes.

## Validation (AccTest / ACube)

All three targeted cases passed remotely (`status=success`, `测试通过`):

| Resource | Test case | taskId | Result |
|---|---|---|---|
| alicloud_privatelink_vpc_endpoint_service | TestAccAliCloudPrivateLinkVpcEndpointService_basic4837 | 3972 | passed |
| alicloud_privatelink_vpc_endpoint         | TestAccAliCloudPrivateLinkVpcEndpoint_basic4793        | 3973 | passed |
| alicloud_privatelink_vpc_endpoint_zone    | TestAccAliCloudPrivateLinkVpcEndpointZone_basic4898    | 3976 | passed |

## Test plan

- [x] Remote AccTest passed for each affected case (taskIds above)
- [ ] Upstream CI on this branch