### PR TITLE
resource/alicloud_api_gateway_log_config: strip acs_apigateway- prefix from sls_log_store on read

### DIFF
--- a/alicloud/resource_alicloud_api_gateway_log_config.go
+++ b/alicloud/resource_alicloud_api_gateway_log_config.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -89,7 +90,9 @@ func resourceAlicloudApiGatewayLogConfigRead(d *schema.ResourceData, meta interf
 	}
 
 	d.Set("sls_project", object["SlsProject"])
-	d.Set("sls_log_store", object["SlsLogStore"])
+	// The SLS Project will be automatically created with prefix `acs_apigateway-` by API Gateway service.
+	// Strip the prefix so that the state matches the user-provided value and avoid perpetual diff/import drift.
+	d.Set("sls_log_store", strings.TrimPrefix(fmt.Sprint(object["SlsLogStore"]), "acs_apigateway-"))
 	d.Set("log_type", object["LogType"])
 
 	return nil


### PR DESCRIPTION
## Summary

The API Gateway service automatically creates the underlying SLS log store with the prefix `acs_apigateway-` applied to the user-provided `sls_log_store` value. The `DescribeLogConfig` API returns the prefixed name (e.g. `acs_apigateway-foo` for input `foo`), which caused the persisted state to diverge from the user-configured value. This produced a perpetual diff and broke `ImportStateVerify`/test attribute checks.

This change strips the `acs_apigateway-` prefix in the resource Read function so the state matches the user-provided value.

## Validation

| Test case | ACube taskId | Result |
|---|---|---|
| TestAccAlicloudApiGatewayLogConfig_basic0 | 4129 | passed (24.16s) |

## Test plan
- [x] Verified on remote ACube against \`xuzhang3/f/sdkv2_upgrade\` base
- [ ] CI on master PR