### PR TITLE
testcase: fix CloudStorageGateway GatewayCacheDisk regression

### DIFF
--- a/alicloud/resource_alicloud_cloud_storage_gateway_gateway_cache_disk_test.go
+++ b/alicloud/resource_alicloud_cloud_storage_gateway_gateway_cache_disk_test.go
@@ -33,6 +33,7 @@ func TestAccAliCloudCloudStorageGatewayGatewayCacheDisk_basic0(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-shanghai"})
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
@@ -42,17 +43,23 @@ func TestAccAliCloudCloudStorageGatewayGatewayCacheDisk_basic0(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"gateway_id":            "${alicloud_cloud_storage_gateway_gateway.default.id}",
 					"cache_disk_size_in_gb": "50",
+					"cache_disk_category":   "cloud_essd",
+					"performance_level":     "PL1",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"gateway_id":            CHECKSET,
 						"cache_disk_size_in_gb": "50",
+						"cache_disk_category":   "cloud_essd",
+						"performance_level":     "PL1",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"cache_disk_size_in_gb": "100",
+					"cache_disk_category":   "cloud_essd",
+					"performance_level":     "PL1",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -84,6 +91,7 @@ func TestAccAliCloudCloudStorageGatewayGatewayCacheDisk_basic0_twin(t *testing.T
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-shanghai"})
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,


### PR DESCRIPTION
## Summary

Fix the regression of `TestAccAliCloudCloudStorageGatewayGatewayCacheDisk_basic0(_twin)`:

1. **Pin region to `cn-shanghai`.** Cloud Storage Gateway has limited region availability and the previous open-region test was hitting endpoints that no longer accept the call.
2. **Set `cache_disk_category = "cloud_essd"` and `performance_level = "PL1"`.** SGW cache disks only support Enhanced SSD (`cloud_essd`), and the SGW API requires `PerformanceLevel` when `CacheDiskCategory = cloud_essd`. Previously the test omitted both, so the API received an incomplete payload and rejected the create with `BadRequest: Invalid request`.

Test-only change — no resource source code touched.

## Validation (ACube remote)

| Resource | Test case | taskId | Result |
|---|---|---|---|
| alicloud_cloud_storage_gateway_gateway_cache_disk | TestAccAliCloudCloudStorageGatewayGatewayCacheDisk_basic0 | 4141 | passed |

Earlier attempt taskId 4130 (region-pin only, missing disk_category) failed with `BadRequest: Invalid request` from the SGW API; tf-debug.log confirmed the request body was missing `CacheDiskCategory`/`PerformanceLevel`. Adding the two fields resolved it on taskId 4141.

## Test plan

- [x] ACube remote AccTest — passed (taskId 4141)
- [ ] Upstream CI on this branch