### PR TITLE
resource/alicloud_vpc_public_ip_address_pool: Remove invalid d.Set/d.GetOk for undeclared zones field

### DIFF
--- a/alicloud/resource_alicloud_vpc_public_ip_address_pool.go
+++ b/alicloud/resource_alicloud_vpc_public_ip_address_pool.go
@@ -1,4 +1,3 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
@@ -120,10 +119,6 @@ func resourceAliCloudVpcPublicIpAddressPoolCreate(d *schema.ResourceData, meta i
 	if v, ok := d.GetOk("biz_type"); ok {
 		request["BizType"] = v
 	}
-	if v, ok := d.GetOk("zones"); ok {
-		zonesMaps := v.([]interface{})
-		request["Zones"] = zonesMaps
-	}
 
 	if v, ok := d.GetOk("security_protection_types"); ok {
 		securityProtectionTypesMaps := v.([]interface{})
@@ -215,12 +210,6 @@ func resourceAliCloudVpcPublicIpAddressPoolRead(d *schema.ResourceData, meta int
 	d.Set("security_protection_types", securityProtectionTypes1Raw)
 	tagsMaps := objectRaw["Tags"]
 	d.Set("tags", tagsToMap(tagsMaps))
-	zones1Raw := make([]interface{}, 0)
-	if objectRaw["Zones"] != nil {
-		zones1Raw = objectRaw["Zones"].([]interface{})
-	}
-
-	d.Set("zones", zones1Raw)
 
 	return nil
 }


### PR DESCRIPTION
## Summary
Remove the `d.GetOk("zones")` and `d.Set("zones", ...)` calls on `alicloud_vpc_public_ip_address_pool`. The Schema never declared `zones`, so:

- Users cannot specify `zones = [...]` in HCL — Terraform rejects it as an unknown attribute, so the `d.GetOk` in Create is unreachable dead code.
- `d.Set("zones", ...)` in Read was a silent no-op under SDK v1.
- **Under SDK v2 (in-flight upgrade on `f/sdkv2_upgrade`), `d.Set("zones", ...)` panics with `Invalid address to set: []string{"zones"}`** — surfaced while running regression tests against the SDKv2 upgrade branch.

## Why delete instead of declaring the schema field
It is unclear whether `zones` is a stable API attribute or how it should be modeled (Optional? Computed? ForceNew? TypeList of which Elem?). Removing the half-wired references is safer than guessing at the schema. If `zones` support is needed in the future, a follow-up PR can declare the field deliberately.

Also drops the auto-generated header comment since the file is now hand-edited.

Supersedes #9767 — that PR's branch shared its name with closed PR #9756 and GitHub Actions never picked up the new commits there. Same commit content as #9767, on a fresh branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test `TestAccAliCloudEIPAddress_basic1` (depends on `alicloud_vpc_public_ip_address_pool`) — panics before this fix, passes after (validated by cherry-picking onto SDKv2 branch and running on ACube)
- [ ] CI regression suite