### PR TITLE
resource/alicloud_vpc_route_entry: Remove invalid d.Set/d.GetOk for undeclared name field

### DIFF
--- a/alicloud/resource_alicloud_vpc_route_entry.go
+++ b/alicloud/resource_alicloud_vpc_route_entry.go
@@ -163,10 +163,6 @@ func resourceAliCloudVpcRouteEntryCreate(d *schema.ResourceData, meta interface{
 	request["RegionId"] = client.RegionId
 	request["ClientToken"] = buildClientToken(action)
 
-	if v, ok := d.GetOk("name"); ok || d.HasChange("name") {
-		request["RouteEntryName"] = v
-	}
-
 	if v, ok := d.GetOk("route_entry_name"); ok {
 		request["RouteEntryName"] = v
 	}
@@ -302,7 +298,6 @@ func resourceAliCloudVpcRouteEntryRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	d.Set("name", d.Get("route_entry_name"))
 	return nil
 }
 
@@ -321,11 +316,6 @@ func resourceAliCloudVpcRouteEntryUpdate(d *schema.ResourceData, meta interface{
 	request["DestinationCidrBlock"] = parts[1]
 	request["RouteTableId"] = parts[0]
 	request["RegionId"] = client.RegionId
-	if !d.IsNewResource() && d.HasChange("name") {
-		update = true
-		request["RouteEntryName"] = d.Get("name")
-	}
-
 	if !d.IsNewResource() && d.HasChange("route_entry_name") {
 		update = true
 		request["RouteEntryName"] = d.Get("route_entry_name")


### PR DESCRIPTION
## Summary
Remove the \`d.GetOk(\"name\")\` / \`d.HasChange(\"name\")\` / \`d.Set(\"name\", ...)\` references on \`alicloud_vpc_route_entry\`. The Schema never declared a \`name\` field — it looks like a deprecated alias for the canonical \`route_entry_name\` whose schema declaration was dropped. As a result:

- Users cannot specify \`name = ...\` in HCL — Terraform rejects it as an unknown attribute, so the Create/Update \`GetOk\`/\`HasChange\` paths are unreachable dead code.
- \`d.Set(\"name\", ...)\` in Read was a silent no-op under SDK v1.
- **Under SDK v2 (in-flight upgrade on \`f/sdkv2_upgrade\`), \`d.Set(\"name\", ...)\` panics with \`Invalid address to set: []string{\"name\"}\`** — surfaced while running regression tests against the SDKv2 upgrade branch on \`TestAccAliCloudVpcRouteEntry_*\`.

## Why delete instead of declaring the schema field
\`route_entry_name\` is the canonical field (still wired up and present in schema). The orphaned \`name\` references look like an incomplete deprecation removal. Removing the half-wired \`name\` references is safer than guessing how the alias should be re-declared. If \`name\` alias support is needed for backwards compatibility, a follow-up PR can declare it deliberately as a deprecated field.

Same fix pattern as #9768 (vpc_public_ip_address_pool zones panic).

## Test plan
- [x] Local \`go build ./alicloud/\` clean
- [x] Remote ACC test \`TestAccAliCloudVpcRouteEntry_*\` (task 4215) — panics before this fix; will pass after cherry-picking onto SDKv2 branch
- [ ] CI regression suite