### PR TITLE
testcase: rename TestAccAlicloud* to TestAccAliCloud* in alicloud_vpc_gateway_endpoint_route_table_attachment tests

### DIFF
--- a/alicloud/resource_alicloud_vpc_gateway_endpoint_route_table_attachment_test.go
+++ b/alicloud/resource_alicloud_vpc_gateway_endpoint_route_table_attachment_test.go
@@ -11,7 +11,7 @@ import (
 
 // Test Vpc GatewayEndpointRouteTableAttachment. >>> Resource test cases, automatically generated.
 // Case 3634
-func TestAccAlicloudVpcGatewayEndpointRouteTableAttachment_basic3634(t *testing.T) {
+func TestAccAliCloudVpcGatewayEndpointRouteTableAttachment_basic3634(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vpc_gateway_endpoint_route_table_attachment.default"
 	ra := resourceAttrInit(resourceId, AlicloudVpcGatewayEndpointRouteTableAttachmentMap3634)


### PR DESCRIPTION
## Summary
Align legacy test function naming with the current `TestAccAliCloud` convention so the remote ACC runner's `TestAccAliCloud{Namespace}{ResourceTypeCode}*` pattern can match these tests. Previously these were silently skipped under the current runner.

## Why
- Remote ACC runner pattern is case-sensitive: `TestAccAliCloud*` (uppercase C). Tests named `TestAccAlicloud*` (lowercase c) are silently dropped → 0 coverage.
- Renamed function naming surfaced while running SDKv2 upgrade regression on the v2 branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test (under SDKv2 branch) confirms tests now match the pattern and execute
- [ ] CI