### PR TITLE
testcase: rename TestAccAlicloud* to TestAccAliCloud* in alicloud_vpc_ha_vip tests

### DIFF
--- a/alicloud/resource_alicloud_vpc_ha_vip_test.go
+++ b/alicloud/resource_alicloud_vpc_ha_vip_test.go
@@ -11,7 +11,7 @@ import (
 
 // Test Vpc HaVip. >>> Resource test cases, automatically generated.
 // Case 2535
-func TestAccAlicloudVpcHaVip_basic2535(t *testing.T) {
+func TestAccAliCloudVpcHaVip_basic2535(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vpc_ha_vip.default"
 	ra := resourceAttrInit(resourceId, AlicloudVpcHaVipMap2535)
@@ -208,7 +208,7 @@ data "alicloud_resource_manager_resource_groups" "default" {
 }
 
 // Case 2535  twin
-func TestAccAlicloudVpcHaVip_basic2535_twin(t *testing.T) {
+func TestAccAliCloudVpcHaVip_basic2535_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vpc_ha_vip.default"
 	ra := resourceAttrInit(resourceId, AlicloudVpcHaVipMap2535)


### PR DESCRIPTION
## Summary
Align legacy test function naming with the current `TestAccAliCloud` convention so the remote ACC runner's `TestAccAliCloud{Namespace}{ResourceTypeCode}*` pattern can match these tests. Previously these were silently skipped under the current runner.

## Why
- Remote ACC runner pattern is case-sensitive: `TestAccAliCloud*` (uppercase C). Tests named `TestAccAlicloud*` (lowercase c) are silently dropped → 0 coverage.
- Renamed function naming surfaced while running SDKv2 upgrade regression on the v2 branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test (under SDKv2 branch) confirms tests now match the pattern and execute
- [ ] CI