### PR TITLE
testcase: rename TestAccAlicloud* to TestAccAliCloud* in alicloud_smartag_flow_log tests

### DIFF
--- a/alicloud/resource_alicloud_smartag_flow_log_test.go
+++ b/alicloud/resource_alicloud_smartag_flow_log_test.go
@@ -110,7 +110,7 @@ func testSweepSmartagFlowLog(region string) error {
 	return nil
 }
 
-func TestAccAlicloudSmartagFlowLog_basic_netflow(t *testing.T) {
+func TestAccAliCloudSmartagFlowLog_basic_netflow(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_smartag_flow_log.default"
 	checkoutSupportedRegions(t, true, connectivity.SmartagSupportedRegions)
@@ -156,7 +156,7 @@ func TestAccAlicloudSmartagFlowLog_basic_netflow(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudSmartagFlowLog_basic_sls(t *testing.T) {
+func TestAccAliCloudSmartagFlowLog_basic_sls(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_smartag_flow_log.default"
 	checkoutSupportedRegions(t, true, connectivity.SmartagSupportedRegions)
@@ -202,7 +202,7 @@ func TestAccAlicloudSmartagFlowLog_basic_sls(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudSmartagFlowLog_basic_all(t *testing.T) {
+func TestAccAliCloudSmartagFlowLog_basic_all(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_smartag_flow_log.default"
 	checkoutSupportedRegions(t, true, connectivity.SmartagSupportedRegions)


### PR DESCRIPTION
## Summary
Align legacy test function naming with the current `TestAccAliCloud` convention so the remote ACC runner's `TestAccAliCloud{Namespace}{ResourceTypeCode}*` pattern can match these tests. Previously these were silently skipped under the current runner.

## Why
- Remote ACC runner pattern is case-sensitive: `TestAccAliCloud*` (uppercase C). Tests named `TestAccAlicloud*` (lowercase c) are silently dropped → 0 coverage.
- Renamed function naming surfaced while running SDKv2 upgrade regression on the v2 branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test (under SDKv2 branch) confirms tests now match the pattern and execute
- [ ] CI