### PR TITLE
testcase: rename TestAccAlicloud* to TestAccAliCloud* in alicloud_event_bridge_event_bus tests

### DIFF
--- a/alicloud/resource_alicloud_event_bridge_event_bus_test.go
+++ b/alicloud/resource_alicloud_event_bridge_event_bus_test.go
@@ -150,7 +150,7 @@ func testSweepEventBridgeEventBus(region string) error {
 	return nil
 }
 
-func TestAccAlicloudEventBridgeEventBus_basic(t *testing.T) {
+func TestAccAliCloudEventBridgeEventBus_basic(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_event_bridge_event_bus.default"
 	ra := resourceAttrInit(resourceId, AlicloudEventBridgeEventBusMap0)


### PR DESCRIPTION
## Summary
Align legacy test function naming with the current `TestAccAliCloud` convention so the remote ACC runner's `TestAccAliCloud{Namespace}{ResourceTypeCode}*` pattern can match these tests. Previously these were silently skipped under the current runner.

## Why
- Remote ACC runner pattern is case-sensitive: `TestAccAliCloud*` (uppercase C). Tests named `TestAccAlicloud*` (lowercase c) are silently dropped → 0 coverage.
- Renamed function naming surfaced while running SDKv2 upgrade regression on the v2 branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test (under SDKv2 branch) confirms tests now match the pattern and execute
- [ ] CI