### PR TITLE
testcase: rename TestAccAlicloud* to TestAccAliCloud* in alicloud_ros_stack_instance tests

### DIFF
--- a/alicloud/resource_alicloud_ros_stack_instance_test.go
+++ b/alicloud/resource_alicloud_ros_stack_instance_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAlicloudROSStackInstance_basic0(t *testing.T) {
+func TestAccAliCloudROSStackInstance_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ros_stack_instance.default"
 	ra := resourceAttrInit(resourceId, AlicloudROSStackInstanceMap0)
@@ -97,7 +97,7 @@ func TestAccAlicloudROSStackInstance_basic0(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudROSStackInstance_basic1(t *testing.T) {
+func TestAccAliCloudROSStackInstance_basic1(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ros_stack_instance.default"
 	ra := resourceAttrInit(resourceId, AlicloudROSStackInstanceMap0)


### PR DESCRIPTION
## Summary
Align legacy test function naming with the current `TestAccAliCloud` convention so the remote ACC runner's `TestAccAliCloud{Namespace}{ResourceTypeCode}*` pattern can match these tests. Previously these were silently skipped under the current runner.

## Why
- Remote ACC runner pattern is case-sensitive: `TestAccAliCloud*` (uppercase C). Tests named `TestAccAlicloud*` (lowercase c) are silently dropped → 0 coverage.
- Renamed function naming surfaced while running SDKv2 upgrade regression on the v2 branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test (under SDKv2 branch) confirms tests now match the pattern and execute
- [ ] CI