### PR TITLE
testcase: rename TestAccAlicloud* to TestAccAliCloud* in alicloud_ros_template_scratch tests

### DIFF
--- a/alicloud/resource_alicloud_ros_template_scratch_test.go
+++ b/alicloud/resource_alicloud_ros_template_scratch_test.go
@@ -102,7 +102,7 @@ func testSweepRosTemplateScratch(region string) error {
 	return nil
 }
 
-func TestAccAlicloudROSTemplateScratch_basic0(t *testing.T) {
+func TestAccAliCloudROSTemplateScratch_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ros_template_scratch.default"
 	checkoutSupportedRegions(t, true, connectivity.ROSSupportRegions)
@@ -198,7 +198,7 @@ func TestAccAlicloudROSTemplateScratch_basic0(t *testing.T) {
 		},
 	})
 }
-func TestAccAlicloudROSTemplateScratch_basic1(t *testing.T) {
+func TestAccAliCloudROSTemplateScratch_basic1(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ros_template_scratch.default"
 	checkoutSupportedRegions(t, true, connectivity.ROSSupportRegions)
@@ -294,7 +294,7 @@ func TestAccAlicloudROSTemplateScratch_basic1(t *testing.T) {
 		},
 	})
 }
-func TestAccAlicloudROSTemplateScratch_basic2(t *testing.T) {
+func TestAccAliCloudROSTemplateScratch_basic2(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ros_template_scratch.default"
 	checkoutSupportedRegions(t, true, connectivity.ROSSupportRegions)
@@ -415,7 +415,7 @@ func TestAccAlicloudROSTemplateScratch_basic2(t *testing.T) {
 		},
 	})
 }
-func TestAccAlicloudROSTemplateScratch_basic3(t *testing.T) {
+func TestAccAliCloudROSTemplateScratch_basic3(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ros_template_scratch.default"
 	checkoutSupportedRegions(t, true, connectivity.ROSSupportRegions)


### PR DESCRIPTION
## Summary
Align legacy test function naming with the current `TestAccAliCloud` convention so the remote ACC runner's `TestAccAliCloud{Namespace}{ResourceTypeCode}*` pattern can match these tests. Previously these were silently skipped under the current runner.

## Why
- Remote ACC runner pattern is case-sensitive: `TestAccAliCloud*` (uppercase C). Tests named `TestAccAlicloud*` (lowercase c) are silently dropped → 0 coverage.
- Renamed function naming surfaced while running SDKv2 upgrade regression on the v2 branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test (under SDKv2 branch) confirms tests now match the pattern and execute
- [ ] CI