### PR TITLE
testcase: rename TestAccAlicloudService_catalog* to TestAccAliCloudServiceCatalog* in alicloud_service_catalog_provisioned_product tests

### DIFF
--- a/alicloud/resource_alicloud_service_catalog_provisioned_product_test.go
+++ b/alicloud/resource_alicloud_service_catalog_provisioned_product_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Case 3
-func TestAccAlicloudService_catalogProvisionedProduct_basic1956(t *testing.T) {
+func TestAccAliCloudServiceCatalogProvisionedProduct_basic1956(t *testing.T) {
 	// This resource depends on other unconnected resources, so skip the tests temporarily.
 	t.Skip()
 	var v map[string]interface{}


### PR DESCRIPTION
## Summary
Align legacy test function naming with the current `TestAccAliCloud` convention so the remote ACC runner's `TestAccAliCloud{Namespace}{ResourceTypeCode}*` pattern can match these tests. Previously these were silently skipped under the current runner.

## Why
- Remote ACC runner pattern is case-sensitive: `TestAccAliCloud*` (uppercase C). Tests named `TestAccAlicloud*` (lowercase c) are silently dropped → 0 coverage.
- Renamed function naming surfaced while running SDKv2 upgrade regression on the v2 branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test (under SDKv2 branch) confirms tests now match the pattern and execute
- [ ] CI