### PR TITLE
testcase: rename TestAccAlicloud* to TestAccAliCloud* in alicloud_actiontrail_global_events_storage_region tests

### DIFF
--- a/alicloud/resource_alicloud_actiontrail_global_events_storage_region_test.go
+++ b/alicloud/resource_alicloud_actiontrail_global_events_storage_region_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAlicloudActiontrailGlobalEventsStorageRegion_basic0(t *testing.T) {
+func TestAccAliCloudActiontrailGlobalEventsStorageRegion_basic0(t *testing.T) {
 	var v map[string]interface{}
 	checkoutSupportedRegions(t, true, connectivity.ActiontrailGlobalEventsStorageRegionSupportRegions)
 	resourceId := "alicloud_actiontrail_global_events_storage_region.default"


### PR DESCRIPTION
## Summary
Align legacy test function naming with the current `TestAccAliCloud` convention so the remote ACC runner's `TestAccAliCloud{Namespace}{ResourceTypeCode}*` pattern can match these tests. Previously these were silently skipped under the current runner.

## Why
- Remote ACC runner pattern is case-sensitive: `TestAccAliCloud*` (uppercase C). Tests named `TestAccAlicloud*` (lowercase c) are silently dropped → 0 coverage.
- Renamed function naming surfaced while running SDKv2 upgrade regression on the v2 branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test (under SDKv2 branch) confirms tests now match the pattern and execute
- [ ] CI