### PR TITLE
testcase: rename TestAccAlicloud* to TestAccAliCloud* in alicloud_quotas_quota_alarm tests

### DIFF
--- a/alicloud/resource_alicloud_quotas_quota_alarm_test.go
+++ b/alicloud/resource_alicloud_quotas_quota_alarm_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAccAlicloudQuotasQuotaAlarm_basic(t *testing.T) {
+func TestAccAliCloudQuotasQuotaAlarm_basic(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_quota_alarm.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasQuotaAlarmMap)
@@ -375,7 +375,7 @@ func TestUnitAlicloudQuotasQuotaAlarm(t *testing.T) {
 
 }
 
-func TestAccAlicloudQuotasQuotaAlarm_basic1(t *testing.T) {
+func TestAccAliCloudQuotasQuotaAlarm_basic1(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_quota_alarm.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasQuotaAlarmMap2901)
@@ -541,7 +541,7 @@ func TestAccAlicloudQuotasQuotaAlarm_basic1(t *testing.T) {
 
 // Test Quotas QuotaAlarm. >>> Resource test cases, automatically generated.
 // Case 2901
-func TestAccAlicloudQuotasQuotaAlarm_basic2901(t *testing.T) {
+func TestAccAliCloudQuotasQuotaAlarm_basic2901(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_quota_alarm.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasQuotaAlarmMap2901)
@@ -689,7 +689,7 @@ variable "name" {
 }
 
 // Case 2936
-func TestAccAlicloudQuotasQuotaAlarm_basic2936(t *testing.T) {
+func TestAccAliCloudQuotasQuotaAlarm_basic2936(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_quota_alarm.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasQuotaAlarmMap2936)
@@ -797,7 +797,7 @@ variable "name" {
 }
 
 // Case 2901  twin
-func TestAccAlicloudQuotasQuotaAlarm_basic2901_twin(t *testing.T) {
+func TestAccAliCloudQuotasQuotaAlarm_basic2901_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_quota_alarm.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasQuotaAlarmMap2901)
@@ -855,7 +855,7 @@ func TestAccAlicloudQuotasQuotaAlarm_basic2901_twin(t *testing.T) {
 }
 
 // Case 2936  twin
-func TestAccAlicloudQuotasQuotaAlarm_basic2936_twin(t *testing.T) {
+func TestAccAliCloudQuotasQuotaAlarm_basic2936_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_quota_alarm.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasQuotaAlarmMap2936)


### PR DESCRIPTION
## Summary
Align legacy test function naming with the current `TestAccAliCloud` convention so the remote ACC runner's `TestAccAliCloud{Namespace}{ResourceTypeCode}*` pattern can match these tests. Previously these were silently skipped under the current runner.

## Why
- Remote ACC runner pattern is case-sensitive: `TestAccAliCloud*` (uppercase C). Tests named `TestAccAlicloud*` (lowercase c) are silently dropped → 0 coverage.
- Renamed function naming surfaced while running SDKv2 upgrade regression on the v2 branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test (under SDKv2 branch) confirms tests now match the pattern and execute
- [ ] CI