### PR TITLE
testcase: rename TestAccAlicloud* to TestAccAliCloud* in alicloud_quotas_quota_application tests

### DIFF
--- a/alicloud/resource_alicloud_quotas_quota_application_test.go
+++ b/alicloud/resource_alicloud_quotas_quota_application_test.go
@@ -21,7 +21,7 @@ import (
 
 // The quota product does not support deletion, so skip the test.
 // lintignore: AT001
-func SkipTestAccAlicloudQuotasQuotaApplication_basic(t *testing.T) {
+func SkipTestAccAliCloudQuotasQuotaApplication_basic(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_quota_application.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasQuotaApplicationMap)
@@ -256,7 +256,7 @@ func TestUnitAlicloudQuotasQuotaApplication(t *testing.T) {
 // Test Quotas QuotaApplication. >>> Resource test cases, automatically generated.
 // Case 3294
 // lintignore: AT001
-func SkipTestAccAlicloudQuotasQuotaApplication_basic3294(t *testing.T) {
+func SkipTestAccAliCloudQuotasQuotaApplication_basic3294(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_quota_application.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasQuotaApplicationMap3294)
@@ -335,7 +335,7 @@ variable "name" {
 
 // Case 3289
 // lintignore: AT001
-func TestAccAlicloudQuotasQuotaApplication_basic3289(t *testing.T) {
+func TestAccAliCloudQuotasQuotaApplication_basic3289(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_quota_application.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasQuotaApplicationMap3289)


### PR DESCRIPTION
## Summary
Align legacy test function naming with the current `TestAccAliCloud` convention so the remote ACC runner's `TestAccAliCloud{Namespace}{ResourceTypeCode}*` pattern can match these tests. Previously these were silently skipped under the current runner.

## Why
- Remote ACC runner pattern is case-sensitive: `TestAccAliCloud*` (uppercase C). Tests named `TestAccAlicloud*` (lowercase c) are silently dropped → 0 coverage.
- Renamed function naming surfaced while running SDKv2 upgrade regression on the v2 branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test (under SDKv2 branch) confirms tests now match the pattern and execute
- [ ] CI