### PR TITLE
testcase: rename TestAccAlicloud* to TestAccAliCloud* in alicloud_quotas_template_quota tests

### DIFF
--- a/alicloud/resource_alicloud_quotas_template_quota_test.go
+++ b/alicloud/resource_alicloud_quotas_template_quota_test.go
@@ -11,7 +11,7 @@ import (
 
 // Test Quotas TemplateQuota. >>> Resource test cases, automatically generated.
 // Case 3099
-func TestAccAlicloudQuotasTemplateQuota_basic3099(t *testing.T) {
+func TestAccAliCloudQuotasTemplateQuota_basic3099(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_template_quota.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasTemplateQuotaMap3099)
@@ -157,7 +157,7 @@ variable "name" {
 }
 
 // Case 3298
-func TestAccAlicloudQuotasTemplateQuota_basic3298(t *testing.T) {
+func TestAccAliCloudQuotasTemplateQuota_basic3298(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_template_quota.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasTemplateQuotaMap3298)
@@ -303,7 +303,7 @@ variable "name" {
 }
 
 // Case 3099  twin
-func TestAccAlicloudQuotasTemplateQuota_basic3099_twin(t *testing.T) {
+func TestAccAliCloudQuotasTemplateQuota_basic3099_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_template_quota.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasTemplateQuotaMap3099)
@@ -361,7 +361,7 @@ func TestAccAlicloudQuotasTemplateQuota_basic3099_twin(t *testing.T) {
 }
 
 // Case 3298  twin
-func TestAccAlicloudQuotasTemplateQuota_basic3298_twin(t *testing.T) {
+func TestAccAliCloudQuotasTemplateQuota_basic3298_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_quotas_template_quota.default"
 	ra := resourceAttrInit(resourceId, AlicloudQuotasTemplateQuotaMap3298)


### PR DESCRIPTION
## Summary
Align legacy test function naming with the current `TestAccAliCloud` convention so the remote ACC runner's `TestAccAliCloud{Namespace}{ResourceTypeCode}*` pattern can match these tests. Previously these were silently skipped under the current runner.

## Why
- Remote ACC runner pattern is case-sensitive: `TestAccAliCloud*` (uppercase C). Tests named `TestAccAlicloud*` (lowercase c) are silently dropped → 0 coverage.
- Renamed function naming surfaced while running SDKv2 upgrade regression on the v2 branch.

## Test plan
- [x] Local `go build ./alicloud/` clean
- [x] Remote ACC test (under SDKv2 branch) confirms tests now match the pattern and execute
- [ ] CI