### PR TITLE
New Resource: alicloud_amqp_open_source_account; New Data Source: alicloud_amqp_open_source_accounts

### DIFF
--- a/alicloud/data_source_alicloud_amqp_open_source_accounts.go
+++ b/alicloud/data_source_alicloud_amqp_open_source_accounts.go
@@ -1,0 +1,195 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudAmqpOpenSourceAccounts() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudAmqpOpenSourceAccountRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"accounts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"password": {
+							Type:      schema.TypeString,
+							Computed:  true,
+							Sensitive: true,
+						},
+						"user_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudAmqpOpenSourceAccountRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListOpenSourceAccounts"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("instance_id"); ok {
+		request["InstanceId"] = v
+	}
+	request["InstanceId"] = d.Get("instance_id")
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		response, err = client.RpcPost("amqp-open", "2019-12-12", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	resp, _ := jsonpath.Get("$.Data[*]", response)
+
+	result, _ := resp.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		id := fmt.Sprint(item["Name"], ":", item["CInstanceId"])
+		if len(idsMap) > 0 {
+			if _, ok := idsMap[id]; !ok {
+				continue
+			}
+		}
+		objects = append(objects, item)
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(objectRaw["Name"], ":", objectRaw["CInstanceId"])
+
+		mapping["password"] = objectRaw["PasswordHash"]
+		mapping["instance_id"] = objectRaw["CInstanceId"]
+		mapping["user_name"] = objectRaw["Name"]
+		mapping["description"] = amqpOpenSourceAccountDescription(objectRaw)
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["Name"], ":", objectRaw["CInstanceId"])
+		mapping, err = dataSourceAliCloudAmqpOpenSourceAccountReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("accounts", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudAmqpOpenSourceAccountReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	amqpServiceV2 := AmqpServiceV2{client}
+	getResp, err := amqpServiceV2.DescribeAmqpOpenSourceAccount(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["password"] = objectRaw["PasswordHash"]
+	mapping["instance_id"] = objectRaw["CInstanceId"]
+	mapping["user_name"] = objectRaw["Name"]
+	mapping["description"] = amqpOpenSourceAccountDescription(objectRaw)
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_amqp_open_source_accounts_test.go
+++ b/alicloud/data_source_alicloud_amqp_open_source_accounts_test.go
@@ -1,0 +1,158 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudAmqpOpenSourceAccountDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudAmqpOpenSourceAccountSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_amqp_open_source_account.default.id}"]`,
+			"instance_id": `"${alicloud_amqp_instance.CreateInstance.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudAmqpOpenSourceAccountSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_amqp_open_source_account.default.id}_fake"]`,
+			"instance_id": `"${alicloud_amqp_instance.CreateInstance.id}"`,
+		}),
+	}
+
+	enableDetailsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudAmqpOpenSourceAccountSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_amqp_open_source_account.default.id}"]`,
+			"instance_id":    `"${alicloud_amqp_instance.CreateInstance.id}"`,
+			"enable_details": `true`,
+		}),
+		fakeConfig: testAccCheckAlicloudAmqpOpenSourceAccountSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_amqp_open_source_account.default.id}_fake"]`,
+			"instance_id":    `"${alicloud_amqp_instance.CreateInstance.id}"`,
+			"enable_details": `false`,
+		}),
+	}
+
+	outputFileConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudAmqpOpenSourceAccountSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_amqp_open_source_account.default.id}"]`,
+			"instance_id": `"${alicloud_amqp_instance.CreateInstance.id}"`,
+			"output_file": `"./tf-testacc-amqp-open-source-accounts.txt"`,
+		}),
+		fakeConfig: testAccCheckAlicloudAmqpOpenSourceAccountSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_amqp_open_source_account.default.id}_fake"]`,
+			"instance_id": `"${alicloud_amqp_instance.CreateInstance.id}"`,
+			"output_file": `"./tf-testacc-amqp-open-source-accounts-fake.txt"`,
+		}),
+	}
+
+	AmqpOpenSourceAccountCheckInfo.dataSourceTestCheck(t, rand, idsConf, enableDetailsConf, outputFileConf)
+}
+
+var existAmqpOpenSourceAccountMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"accounts.#":             "1",
+		"accounts.0.user_name":   CHECKSET,
+		"accounts.0.description": CHECKSET,
+		"accounts.0.instance_id": CHECKSET,
+		"accounts.0.password":    CHECKSET,
+	}
+}
+
+var fakeAmqpOpenSourceAccountMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"accounts.#": "0",
+	}
+}
+
+var AmqpOpenSourceAccountCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_amqp_open_source_accounts.default",
+	existMapFunc: existAmqpOpenSourceAccountMapFunc,
+	fakeMapFunc:  fakeAmqpOpenSourceAccountMapFunc,
+}
+
+func testAccCheckAlicloudAmqpOpenSourceAccountSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccAmqpOpenSourceAccount%d"
+}
+variable "instance_name" {
+  default = "测试开源鉴权实例"
+}
+
+variable "user_name" {
+  default = "Suhao123_"
+}
+
+variable "user_name_update" {
+  default = "Suhao456_"
+}
+
+resource "alicloud_amqp_instance" "CreateInstance" {
+  renewal_duration      = "1"
+  max_tps               = "3000"
+  period_cycle          = "Month"
+  max_connections       = "2000"
+  support_eip           = true
+  auto_renew            = false
+  renewal_status        = "AutoRenewal"
+  period                = "12"
+  instance_name         = var.instance_name
+  support_tracing       = false
+  payment_type          = "Subscription"
+  renewal_duration_unit = "Month"
+  instance_type         = "enterprise"
+  queue_capacity        = "200"
+  max_eip_tps           = "128"
+  vpc_id                = alicloud_vpc.default.id
+  vswitch_ids           = [alicloud_vswitch.default_b.id, alicloud_vswitch.default_g.id]
+  security_group_id     = alicloud_security_group.default.id
+}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default_b" {
+  vswitch_name = "${var.name}-b"
+  cidr_block   = "172.16.0.0/24"
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-hangzhou-b"
+}
+
+resource "alicloud_vswitch" "default_g" {
+  vswitch_name = "${var.name}-g"
+  cidr_block   = "172.16.1.0/24"
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-hangzhou-g"
+}
+
+resource "alicloud_security_group" "default" {
+  security_group_name = var.name
+  vpc_id              = alicloud_vpc.default.id
+}
+
+
+resource "alicloud_amqp_open_source_account" "default" {
+  user_name   = var.user_name
+  description = var.user_name
+  password    = var.user_name
+  instance_id = alicloud_amqp_instance.CreateInstance.id
+}
+
+data "alicloud_amqp_open_source_accounts" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -171,6 +171,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_amqp_open_source_accounts":                  dataSourceAliCloudAmqpOpenSourceAccounts(),
 			"alicloud_amqp_open_source_permissions":               dataSourceAliCloudAmqpOpenSourcePermissions(),
 			"alicloud_vpn_gateway_enhanced_vpn_gateways":          dataSourceAliCloudVpnGatewayEnhancedVpnGateways(),
 			"alicloud_cdn_domain_configs":                         dataSourceAliCloudCdnDomainConfigs(),
@@ -922,6 +923,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_amqp_open_source_account":                             resourceAliCloudAmqpOpenSourceAccount(),
 			"alicloud_amqp_open_source_permission":                          resourceAliCloudAmqpOpenSourcePermission(),
 			"alicloud_vpn_gateway_enhanced_vpn_gateway":                     resourceAliCloudVpnGatewayEnhancedVpnGateway(),
 			"alicloud_oss_bucket_object_worm_configuration":                 resourceAliCloudOssBucketObjectWormConfiguration(),

--- a/alicloud/resource_alicloud_amqp_open_source_account.go
+++ b/alicloud/resource_alicloud_amqp_open_source_account.go
@@ -1,0 +1,223 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudAmqpOpenSourceAccount() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudAmqpOpenSourceAccountCreate,
+		Read:   resourceAliCloudAmqpOpenSourceAccountRead,
+		Update: resourceAliCloudAmqpOpenSourceAccountUpdate,
+		Delete: resourceAliCloudAmqpOpenSourceAccountDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudAmqpOpenSourceAccountCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateOpenSourceAccount"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("instance_id"); ok {
+		request["InstanceId"] = v
+	}
+	if v, ok := d.GetOk("user_name"); ok {
+		request["UserName"] = v
+	}
+	request["RegionId"] = client.RegionId
+	request["ClientToken"] = buildClientToken(action)
+
+	if v, ok := d.GetOk("description"); ok {
+		request["Description"] = v
+	}
+	request["Password"] = d.Get("password")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("amqp-open", "2019-12-12", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_amqp_open_source_account", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", request["UserName"], request["InstanceId"]))
+
+	return resourceAliCloudAmqpOpenSourceAccountRead(d, meta)
+}
+
+func resourceAliCloudAmqpOpenSourceAccountRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	amqpServiceV2 := AmqpServiceV2{client}
+
+	objectRaw, err := amqpServiceV2.DescribeAmqpOpenSourceAccount(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_amqp_open_source_account DescribeAmqpOpenSourceAccount Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("instance_id", objectRaw["CInstanceId"])
+	d.Set("user_name", objectRaw["Name"])
+	d.Set("description", amqpOpenSourceAccountDescription(objectRaw))
+
+	return nil
+}
+
+func resourceAliCloudAmqpOpenSourceAccountUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	action := "UpdateOpenSourceAccount"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["InstanceId"] = parts[1]
+	request["UserName"] = parts[0]
+	request["RegionId"] = client.RegionId
+	request["ClientToken"] = buildClientToken(action)
+	if d.HasChange("description") {
+		update = true
+		request["Description"] = d.Get("description")
+	}
+
+	if d.HasChange("password") {
+		update = true
+	}
+	request["Password"] = d.Get("password")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("amqp-open", "2019-12-12", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudAmqpOpenSourceAccountRead(d, meta)
+}
+
+func resourceAliCloudAmqpOpenSourceAccountDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := "DeleteOpenSourceAccount"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["InstanceId"] = parts[1]
+	request["UserName"] = parts[0]
+	request["RegionId"] = client.RegionId
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("amqp-open", "2019-12-12", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}
+
+func amqpOpenSourceAccountDescription(objectRaw map[string]interface{}) interface{} {
+	extraJsonRaw, _ := jsonpath.Get("$.ExtraJson", objectRaw)
+	if extraJsonRaw == nil {
+		return ""
+	}
+
+	switch v := extraJsonRaw.(type) {
+	case map[string]interface{}:
+		return v["description"]
+	case string:
+		extraJson := make(map[string]interface{})
+		if err := json.Unmarshal([]byte(v), &extraJson); err == nil {
+			return extraJson["description"]
+		}
+	}
+	return ""
+}

--- a/alicloud/resource_alicloud_amqp_open_source_account_test.go
+++ b/alicloud/resource_alicloud_amqp_open_source_account_test.go
@@ -1,0 +1,143 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Amqp OpenSourceAccount. >>> Resource test cases, automatically generated.
+// Case 开源用户 12792
+func TestAccAliCloudAmqpOpenSourceAccount_basic12792(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_amqp_open_source_account.default"
+	ra := resourceAttrInit(resourceId, AlicloudAmqpOpenSourceAccountMap12792)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AmqpServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAmqpOpenSourceAccount")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccamqp%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAmqpOpenSourceAccountBasicDependence12792)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"user_name":   "${var.user_name}",
+					"description": "${var.user_name}",
+					"password":    "${var.user_name}",
+					"instance_id": "${alicloud_amqp_instance.CreateInstance.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"user_name":   CHECKSET,
+						"description": CHECKSET,
+						"password":    CHECKSET,
+						"instance_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "${var.user_name_update}",
+					"password":    "${var.user_name_update}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": CHECKSET,
+						"password":    CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+var AlicloudAmqpOpenSourceAccountMap12792 = map[string]string{}
+
+func AlicloudAmqpOpenSourceAccountBasicDependence12792(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "instance_name" {
+  default = "测试开源鉴权实例"
+}
+
+variable "user_name" {
+  default = "Suhao123_"
+}
+
+variable "user_name_update" {
+  default = "Suhao456_"
+}
+
+resource "alicloud_amqp_instance" "CreateInstance" {
+  renewal_duration      = "1"
+  max_tps               = "3000"
+  period_cycle          = "Month"
+  max_connections       = "2000"
+  support_eip           = true
+  auto_renew            = false
+  renewal_status        = "AutoRenewal"
+  period                = "12"
+  instance_name         = var.instance_name
+  support_tracing       = false
+  payment_type          = "Subscription"
+  renewal_duration_unit = "Month"
+  instance_type         = "enterprise"
+  queue_capacity        = "200"
+  max_eip_tps           = "128"
+  vpc_id                = alicloud_vpc.default.id
+  vswitch_ids           = [alicloud_vswitch.default_b.id, alicloud_vswitch.default_g.id]
+  security_group_id     = alicloud_security_group.default.id
+}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default_b" {
+  vswitch_name = "${var.name}-b"
+  cidr_block   = "172.16.0.0/24"
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-hangzhou-b"
+}
+
+resource "alicloud_vswitch" "default_g" {
+  vswitch_name = "${var.name}-g"
+  cidr_block   = "172.16.1.0/24"
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-hangzhou-g"
+}
+
+resource "alicloud_security_group" "default" {
+  security_group_name = var.name
+  vpc_id              = alicloud_vpc.default.id
+}
+
+
+`, name)
+}
+
+// Test Amqp OpenSourceAccount. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_amqp_v2.go
+++ b/alicloud/service_alicloud_amqp_v2.go
@@ -431,3 +431,95 @@ func (s *AmqpServiceV2) AmqpOpenSourcePermissionStateRefreshFuncWithApi(id strin
 }
 
 // DescribeAmqpOpenSourcePermission >>> Encapsulated.
+// DescribeAmqpOpenSourceAccount <<< Encapsulated get interface for Amqp OpenSourceAccount.
+
+func (s *AmqpServiceV2) DescribeAmqpOpenSourceAccount(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["InstanceId"] = parts[1]
+	request["RegionId"] = client.RegionId
+	action := "ListOpenSourceAccounts"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("amqp-open", "2019-12-12", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"InstanceNotExist"}) {
+			return object, WrapErrorf(NotFoundErr("OpenSourceAccount", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Data[*]", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Data[*]", response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("OpenSourceAccount", id), NotFoundMsg, response)
+	}
+
+	result, _ := v.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		if fmt.Sprint(item["Name"]) != parts[0] {
+			continue
+		}
+		return item, nil
+	}
+	return object, WrapErrorf(NotFoundErr("OpenSourceAccount", id), NotFoundMsg, response)
+}
+
+func (s *AmqpServiceV2) AmqpOpenSourceAccountStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.AmqpOpenSourceAccountStateRefreshFuncWithApi(id, field, failStates, s.DescribeAmqpOpenSourceAccount)
+}
+
+func (s *AmqpServiceV2) AmqpOpenSourceAccountStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeAmqpOpenSourceAccount >>> Encapsulated.

--- a/website/docs/d/amqp_open_source_accounts.html.markdown
+++ b/website/docs/d/amqp_open_source_accounts.html.markdown
@@ -1,0 +1,119 @@
+---
+subcategory: "RabbitMQ (AMQP)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_amqp_open_source_accounts"
+sidebar_current: "docs-alicloud-datasource-amqp-open-source-accounts"
+description: |-
+  Provides a list of RabbitMQ (AMQP) Open Source Account owned by an Alibaba Cloud account.
+---
+
+# alicloud_amqp_open_source_accounts
+
+This data source provides RabbitMQ (AMQP) Open Source Account available to the user.[What is Open Source Account](https://next.api.alibabacloud.com/document/amqp-open/2019-12-12/CreateOpenSourceAccount)
+
+-> **NOTE:** Available since v1.280.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "instance_name" {
+  default = "测试开源鉴权实例"
+}
+
+variable "user_name" {
+  default = "Suhao123_"
+}
+
+variable "user_name_update" {
+  default = "Suhao456_"
+}
+
+resource "alicloud_amqp_instance" "CreateInstance" {
+  renewal_duration      = "1"
+  max_tps               = "3000"
+  period_cycle          = "Month"
+  max_connections       = "2000"
+  support_eip           = true
+  auto_renew            = false
+  renewal_status        = "AutoRenewal"
+  period                = "12"
+  instance_name         = var.instance_name
+  support_tracing       = false
+  payment_type          = "Subscription"
+  renewal_duration_unit = "Month"
+  instance_type         = "enterprise"
+  queue_capacity        = "200"
+  max_eip_tps           = "128"
+  vpc_id                = alicloud_vpc.default.id
+  vswitch_ids           = [alicloud_vswitch.default_b.id, alicloud_vswitch.default_g.id]
+  security_group_id     = alicloud_security_group.default.id
+}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default_b" {
+  vswitch_name = "${var.name}-b"
+  cidr_block   = "172.16.0.0/24"
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-hangzhou-b"
+}
+
+resource "alicloud_vswitch" "default_g" {
+  vswitch_name = "${var.name}-g"
+  cidr_block   = "172.16.1.0/24"
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-hangzhou-g"
+}
+
+resource "alicloud_security_group" "default" {
+  security_group_name = var.name
+  vpc_id              = alicloud_vpc.default.id
+}
+
+resource "alicloud_amqp_open_source_account" "default" {
+  user_name   = var.user_name
+  description = var.user_name
+  password    = var.user_name
+  instance_id = alicloud_amqp_instance.CreateInstance.id
+}
+
+data "alicloud_amqp_open_source_accounts" "default" {
+  ids         = ["${alicloud_amqp_open_source_account.default.id}"]
+  instance_id = alicloud_amqp_instance.CreateInstance.id
+}
+
+output "alicloud_amqp_open_source_account_example_id" {
+  value = data.alicloud_amqp_open_source_accounts.default.accounts.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `instance_id` - (Required) Instance ID.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` to query detailed attributes for each account.
+* `ids` - (Optional, Computed) A list of Open Source Account IDs. The value is formulated as `<user_name>:<instance_id>`.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Open Source Account IDs.
+* `accounts` - A list of Open Source Account Entries. Each element contains the following attributes:
+    * `description` - Description.
+    * `instance_id` - Instance ID.
+    * `password` - User password.
+    * `user_name` - User name.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/amqp_open_source_account.html.markdown
+++ b/website/docs/r/amqp_open_source_account.html.markdown
@@ -1,0 +1,123 @@
+---
+subcategory: "RabbitMQ (AMQP)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_amqp_open_source_account"
+description: |-
+  Provides a Alicloud RabbitMQ (AMQP) Open Source Account resource.
+---
+
+# alicloud_amqp_open_source_account
+
+Provides a RabbitMQ (AMQP) Open Source Account resource.
+
+An account under the open-source authentication and permission management system.  .
+
+For information about RabbitMQ (AMQP) Open Source Account and how to use it, see [What is Open Source Account](https://next.api.alibabacloud.com/document/amqp-open/2019-12-12/CreateOpenSourceAccount).
+
+-> **NOTE:** Available since v1.280.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "instance_name" {
+  default = "example开源鉴权实例"
+}
+
+variable "user_name" {
+  default = "Suhao123_"
+}
+
+variable "user_name_update" {
+  default = "Suhao456_"
+}
+
+resource "alicloud_amqp_instance" "CreateInstance" {
+  renewal_duration      = "1"
+  max_tps               = "3000"
+  period_cycle          = "Month"
+  max_connections       = "2000"
+  support_eip           = true
+  auto_renew            = false
+  renewal_status        = "AutoRenewal"
+  period                = "12"
+  instance_name         = var.instance_name
+  support_tracing       = false
+  payment_type          = "Subscription"
+  renewal_duration_unit = "Month"
+  instance_type         = "enterprise"
+  queue_capacity        = "200"
+  max_eip_tps           = "128"
+  vpc_id                = alicloud_vpc.default.id
+  vswitch_ids           = [alicloud_vswitch.default_b.id, alicloud_vswitch.default_g.id]
+  security_group_id     = alicloud_security_group.default.id
+}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default_b" {
+  vswitch_name = "${var.name}-b"
+  cidr_block   = "172.16.0.0/24"
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-hangzhou-b"
+}
+
+resource "alicloud_vswitch" "default_g" {
+  vswitch_name = "${var.name}-g"
+  cidr_block   = "172.16.1.0/24"
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-hangzhou-g"
+}
+
+resource "alicloud_security_group" "default" {
+  security_group_name = var.name
+  vpc_id              = alicloud_vpc.default.id
+}
+
+resource "alicloud_amqp_open_source_account" "default" {
+  user_name   = var.user_name
+  description = var.user_name
+  password    = var.user_name
+  instance_id = alicloud_amqp_instance.CreateInstance.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `description` - (Optional) Description  
+* `instance_id` - (Required, ForceNew) Instance ID  
+* `password` - (Required) User password  
+* `user_name` - (Required, ForceNew) User name  
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<user_name>:<instance_id>`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Open Source Account.
+* `delete` - (Defaults to 5 mins) Used when delete the Open Source Account.
+* `update` - (Defaults to 5 mins) Used when update the Open Source Account.
+
+## Import
+
+RabbitMQ (AMQP) Open Source Account can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_amqp_open_source_account.example <user_name>:<instance_id>
+```


### PR DESCRIPTION
Acceptance Tests

=== RUN   TestAccAliCloudAmqpOpenSourceAccount_basic12792
--- PASS: TestAccAliCloudAmqpOpenSourceAccount_basic12792 (470.88s)

=== RUN   TestAccAlicloudAmqpOpenSourceAccountDataSource
--- PASS: TestAccAlicloudAmqpOpenSourceAccountDataSource (493.43s)

Additional Checks

```
go run scripts/testing/testing_coverage_rate_check.go -resource alicloud_amqp_open_source_account
resource amqp_open_source_account attributes has 100% testing coverage rate
resource amqp_open_source_account attributes has 100% modified coverage rate
--- PASS!
```

```
make tflint
tfproviderlint: No issues in changed files.
```