### PR TITLE
resource/alicloud_vswitch: support IPv6 attributes; data-source/alicloud_vswitches: add enable_ipv6

### DIFF
--- a/alicloud/data_source_alicloud_vswitches.go
+++ b/alicloud/data_source_alicloud_vswitches.go
@@ -101,6 +101,10 @@ func dataSourceAlicloudVswitches() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"enable_ipv6": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 						"resource_group_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -258,12 +262,17 @@ func dataSourceAlicloudVswitchesRead(d *schema.ResourceData, meta interface{}) e
 	names := make([]interface{}, 0)
 	s := make([]map[string]interface{}, 0)
 	for _, object := range objects {
+		ipv6CidrBlock := fmt.Sprint(object["Ipv6CidrBlock"])
+		if object["Ipv6CidrBlock"] == nil {
+			ipv6CidrBlock = ""
+		}
 		mapping := map[string]interface{}{
 			"creation_time":              object["CreationTime"],
 			"available_ip_address_count": object["AvailableIpAddressCount"],
 			"cidr_block":                 object["CidrBlock"],
 			"description":                object["Description"],
 			"is_default":                 object["IsDefault"],
+			"enable_ipv6":                ipv6CidrBlock != "",
 			"resource_group_id":          object["ResourceGroupId"],
 			"route_table_id":             object["RouteTable"].(map[string]interface{})["RouteTableId"],
 			"status":                     object["Status"],
@@ -273,7 +282,7 @@ func dataSourceAlicloudVswitchesRead(d *schema.ResourceData, meta interface{}) e
 			"name":                       object["VSwitchName"],
 			"vpc_id":                     object["VpcId"],
 			"zone_id":                    object["ZoneId"],
-			"ipv6_cidr_block":            object["Ipv6CidrBlock"],
+			"ipv6_cidr_block":            ipv6CidrBlock,
 		}
 
 		tags := make(map[string]interface{})

--- a/alicloud/data_source_alicloud_vswitches_test.go
+++ b/alicloud/data_source_alicloud_vswitches_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAlicloudVPCVSwitchesDataSourceBasic(t *testing.T) {
+func TestAccAliCloudVPCVSwitchesDataSourceBasic(t *testing.T) {
 	rand := acctest.RandInt()
 	nameRegexConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudVSwitchesDataSourceConfig(rand, map[string]string{
@@ -137,6 +138,125 @@ func TestAccAlicloudVPCVSwitchesDataSourceBasic(t *testing.T) {
 
 }
 
+func TestAccAliCloudVPCVSwitchesDataSourceCoverage(t *testing.T) {
+	rand := acctest.RandInt()
+	testAccCheckExist, testAccCheckEmpty := vswitchesCheckInfo.checkDataSourceAttr(rand)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAlicloudVSwitchesDataSourceCoverageConfig(rand, map[string]interface{}{
+					"name_regex":        "${alicloud_vswitch.default.vswitch_name}",
+					"ids":               []string{"${alicloud_vswitch.default.id}"},
+					"cidr_block":        "172.16.0.0/24",
+					"is_default":        false,
+					"vpc_id":            "${alicloud_vpc.default.id}",
+					"zone_id":           "${data.alicloud_zones.default.zones.0.id}",
+					"resource_group_id": "",
+					"route_table_id":    "${alicloud_vpc.default.route_table_id}",
+					"status":            "Available",
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "acceptance test",
+					},
+					"vswitch_name":     "${alicloud_vswitch.default.vswitch_name}",
+					"vswitch_owner_id": 0,
+					"output_file":      "./test_output_file",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExist(nil),
+				),
+			},
+			{
+				Config: testAccCheckAlicloudVSwitchesDataSourceCoverageConfig(rand, map[string]interface{}{
+					"name_regex":        "${alicloud_vswitch.default.vswitch_name}_fake",
+					"ids":               []string{"${alicloud_vswitch.default.id}_fake"},
+					"cidr_block":        "172.16.0.0/23",
+					"is_default":        true,
+					"vpc_id":            "${alicloud_vpc.default.id}_fake",
+					"zone_id":           "${data.alicloud_zones.default.zones.0.id}_fake",
+					"resource_group_id": "rg-fake",
+					"route_table_id":    "",
+					"status":            "Pending",
+					"tags": map[string]string{
+						"Created": "TF-fake",
+						"For":     "acceptance test",
+					},
+					"vswitch_name":     "${alicloud_vswitch.default.vswitch_name}_fake",
+					"vswitch_owner_id": 1,
+					"output_file":      "./test_output_file_fake",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEmpty(nil),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAlicloudVSwitchesDataSourceCoverageConfig(rand int, attrMap map[string]interface{}) string {
+	pairs := make([]string, 0, len(attrMap))
+	for k, v := range attrMap {
+		pairs = append(pairs, fmt.Sprintf("%s = %s", k, hclValue(v)))
+	}
+
+	config := fmt.Sprintf(`
+variable "name" {
+  default = "tf-testAccVSwitchDatasource%d"
+}
+data "alicloud_zones" "default" {}
+
+resource "alicloud_vpc" "default" {
+  cidr_block = "172.16.0.0/16"
+  vpc_name = "${var.name}"
+}
+
+resource "alicloud_vswitch" "default" {
+  vswitch_name = "${var.name}"
+  cidr_block = "172.16.0.0/24"
+  vpc_id = "${alicloud_vpc.default.id}"
+  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  tags 		= {
+		Created = "TF"
+		For 	= "acceptance test"
+  }
+}
+
+data "alicloud_vswitches" "default" {
+	%s
+}`, rand, strings.Join(pairs, "\n  "))
+	return config
+}
+
+func hclValue(v interface{}) string {
+	switch value := v.(type) {
+	case string:
+		return fmt.Sprintf("%q", value)
+	case bool:
+		return fmt.Sprintf("%t", value)
+	case int:
+		return fmt.Sprintf("%d", value)
+	case []string:
+		values := make([]string, 0, len(value))
+		for _, item := range value {
+			values = append(values, fmt.Sprintf("%q", item))
+		}
+		return fmt.Sprintf("[%s]", strings.Join(values, ", "))
+	case map[string]string:
+		values := make([]string, 0, len(value))
+		for k, item := range value {
+			values = append(values, fmt.Sprintf("%s = %q", k, item))
+		}
+		return fmt.Sprintf("{\n%s\n  }", strings.Join(values, "\n"))
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
 func testAccCheckAlicloudVSwitchesDataSourceConfig(rand int, attrMap map[string]string) string {
 	var pairs []string
 	for k, v := range attrMap {
@@ -148,6 +268,7 @@ variable "name" {
   default = "tf-testAccVSwitchDatasource%d"
 }
 data "alicloud_zones" "default" {}
+data "alicloud_account" "current" {}
 
 resource "alicloud_vpc" "default" {
   cidr_block = "172.16.0.0/16"
@@ -185,6 +306,7 @@ var existVSwitchesMapFunc = func(rand int) map[string]string {
 		"vswitches.0.cidr_block":                 "172.16.0.0/24",
 		"vswitches.0.description":                "",
 		"vswitches.0.is_default":                 "false",
+		"vswitches.0.enable_ipv6":                "false",
 		"vswitches.0.creation_time":              CHECKSET,
 		"vswitches.0.tags.%":                     "2",
 		"vswitches.0.tags.Created":               "TF",

--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -46,6 +46,7 @@ func resourceAliCloudVpcVswitch() *schema.Resource {
 			"enable_ipv6": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"ipv6_cidr_block": {
 				Type:     schema.TypeString,
@@ -54,11 +55,12 @@ func resourceAliCloudVpcVswitch() *schema.Resource {
 			"ipv6_cidr_block_mask": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				Computed: true,
 			},
 			"is_default": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"status": {
 				Type:     schema.TypeString,
@@ -76,6 +78,10 @@ func resourceAliCloudVpcVswitch() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
+			},
+			"vpc_ipv6_cidr_block": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"zone_id": {
 				Type:         schema.TypeString,
@@ -182,6 +188,9 @@ func resourceAliCloudVpcVswitchCreate(d *schema.ResourceData, meta interface{}) 
 		if v, ok := d.GetOkExists("ipv6_cidr_block_mask"); ok {
 			request["Ipv6CidrBlock"] = v
 		}
+		if v, ok := d.GetOk("vpc_ipv6_cidr_block"); ok {
+			request["VpcIpv6CidrBlock"] = v
+		}
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 			response, err = client.RpcPost("Vpc", "2016-04-28", action, nil, request, true)
@@ -233,6 +242,7 @@ func resourceAliCloudVpcVswitchRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("create_time", objectRaw["CreationTime"])
 	d.Set("description", objectRaw["Description"])
 	d.Set("ipv6_cidr_block", objectRaw["Ipv6CidrBlock"])
+	d.Set("is_default", objectRaw["IsDefault"])
 	d.Set("status", objectRaw["Status"])
 	d.Set("vswitch_name", objectRaw["VSwitchName"])
 	d.Set("vpc_id", objectRaw["VpcId"])
@@ -243,13 +253,10 @@ func resourceAliCloudVpcVswitchRead(d *schema.ResourceData, meta interface{}) er
 
 	d.Set("name", d.Get("vswitch_name"))
 	d.Set("availability_zone", d.Get("zone_id"))
-	if v, ok := objectRaw["Ipv6CidrBlock"]; ok && fmt.Sprint(v) != "" {
-		_, cidrBlock := GetIPv6SubnetAddr(v.(string))
-		d.Set("ipv6_cidr_block_mask", cidrBlock)
-	}
-
 	if enableIpv6, ok := d.GetOkExists("enable_ipv6"); ok {
 		d.Set("enable_ipv6", enableIpv6)
+	} else {
+		d.Set("enable_ipv6", fmt.Sprint(objectRaw["Ipv6CidrBlock"]) != "")
 	}
 	return nil
 }
@@ -278,6 +285,13 @@ func resourceAliCloudVpcVswitchUpdate(d *schema.ResourceData, meta interface{}) 
 	if !d.IsNewResource() && d.HasChange("description") {
 		update = true
 		request["Description"] = d.Get("description")
+	}
+
+	if v, ok := d.GetOk("vpc_ipv6_cidr_block"); ok {
+		request["VpcIpv6CidrBlock"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("vpc_ipv6_cidr_block") {
+		update = true
 	}
 
 	if !d.IsNewResource() && d.HasChange("ipv6_cidr_block_mask") {

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -389,7 +389,7 @@ func TestAccAliCloudVPCVSwitch_basic3(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enable_ipv6"},
+				ImportStateVerifyIgnore: []string{"enable_ipv6", "ipv6_cidr_block_mask"},
 			},
 		},
 	})
@@ -471,7 +471,7 @@ func TestAccAliCloudVPCVSwitch_basic4(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enable_ipv6"},
+				ImportStateVerifyIgnore: []string{"enable_ipv6", "ipv6_cidr_block_mask"},
 			},
 		},
 	})
@@ -585,7 +585,7 @@ func TestAccAliCloudVPCVSwitch_basic5(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enable_ipv6"},
+				ImportStateVerifyIgnore: []string{"enable_ipv6", "ipv6_cidr_block_mask"},
 			},
 		},
 	})
@@ -623,20 +623,9 @@ func TestAccAliCloudVPCVSwitch_isDefault(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccConfig(map[string]interface{}{
-					"ipv6_cidr_block_mask": "8",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"ipv6_cidr_block_mask": "8",
-					}),
-				),
-			},
-			{
-				ResourceName:            resourceId,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"is_default"},
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -664,22 +653,19 @@ func TestAccAliCloudVPCVSwitch_isDefault_twin(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"is_default":           "true",
-					"zone_id":              "${data.alicloud_zones.default.zones.1.id}",
-					"ipv6_cidr_block_mask": "8",
+					"is_default": "true",
+					"zone_id":    "${data.alicloud_zones.default.zones.1.id}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"zone_id":              CHECKSET,
-						"ipv6_cidr_block_mask": "8",
+						"zone_id": CHECKSET,
 					}),
 				),
 			},
 			{
-				ResourceName:            resourceId,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"is_default"},
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1118,9 +1104,8 @@ func TestUnitAlicloudVPCVSwitch(t *testing.T) {
 	})
 }
 
-// Test Vpc Vswitch. >>> Resource test cases, automatically generated.
 // Case 3078
-func TestAccAliCloudVpcVswitch_basic3078(t *testing.T) {
+func TestAccAliCloudVPCVSwitch_basic3078(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vswitch.default"
 	ra := resourceAttrInit(resourceId, AlicloudVpcVswitchMap3078)
@@ -1195,6 +1180,7 @@ func TestAccAliCloudVpcVswitch_basic3078(t *testing.T) {
 					"cidr_block":           "172.16.0.0/24",
 					"vswitch_name":         name + "_update",
 					"ipv6_cidr_block_mask": "8",
+					"vpc_ipv6_cidr_block":  "${alicloud_vpc.OeB4be.ipv6_cidr_block}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -1204,6 +1190,7 @@ func TestAccAliCloudVpcVswitch_basic3078(t *testing.T) {
 						"cidr_block":           "172.16.0.0/24",
 						"vswitch_name":         name + "_update",
 						"ipv6_cidr_block_mask": "8",
+						"vpc_ipv6_cidr_block":  CHECKSET,
 					}),
 				),
 			},
@@ -1253,7 +1240,7 @@ func TestAccAliCloudVpcVswitch_basic3078(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enable_ipv6", "is_default"},
+				ImportStateVerifyIgnore: []string{"enable_ipv6", "ipv6_cidr_block_mask", "vpc_ipv6_cidr_block"},
 			},
 		},
 	})
@@ -1281,7 +1268,7 @@ data "alicloud_zones" "default" {
 }
 
 // Case 3078  twin
-func TestAccAliCloudVpcVswitch_basic3078_twin(t *testing.T) {
+func TestAccAliCloudVPCVSwitch_basic3078_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vswitch.default"
 	ra := resourceAttrInit(resourceId, AlicloudVpcVswitchMap3078)
@@ -1310,6 +1297,7 @@ func TestAccAliCloudVpcVswitch_basic3078_twin(t *testing.T) {
 					"cidr_block":           "172.16.0.0/24",
 					"vswitch_name":         name,
 					"ipv6_cidr_block_mask": "8",
+					"vpc_ipv6_cidr_block":  "${alicloud_vpc.OeB4be.ipv6_cidr_block}",
 					"tags": map[string]string{
 						"Created": "TF",
 						"For":     "Test",
@@ -1323,6 +1311,7 @@ func TestAccAliCloudVpcVswitch_basic3078_twin(t *testing.T) {
 						"cidr_block":           "172.16.0.0/24",
 						"vswitch_name":         name,
 						"ipv6_cidr_block_mask": "8",
+						"vpc_ipv6_cidr_block":  CHECKSET,
 						"tags.%":               "2",
 						"tags.Created":         "TF",
 						"tags.For":             "Test",
@@ -1333,10 +1322,8 @@ func TestAccAliCloudVpcVswitch_basic3078_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enable_ipv6", "is_default"},
+				ImportStateVerifyIgnore: []string{"enable_ipv6", "ipv6_cidr_block_mask", "vpc_ipv6_cidr_block"},
 			},
 		},
 	})
 }
-
-// Test Vpc Vswitch. <<< Resource test cases, automatically generated.

--- a/website/docs/d/vswitches.html.markdown
+++ b/website/docs/d/vswitches.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 This data source provides a list of VSwitches owned by an Alibaba Cloud account.
 
+-> **NOTE:** Available since v1.7.2.
+
 ## Example Usage
 
 ```terraform
@@ -67,9 +69,9 @@ The following attributes are exported in addition to the arguments listed above:
   * `vpc_id` - ID of the VPC that owns the vSwitch.
   * `name` - Name of the vSwitch.
   * `cidr_block` - CIDR block of the vSwitch.
-  * `instance_ids` - (Deprecated in v1.119.0+) List of ECS instance IDs in the specified vSwitch.
   * `description` - Description of the vSwitch.
   * `is_default` - Whether the vSwitch is the default one in the region.
+  * `enable_ipv6` - Whether the IPv6 function is enabled in the vSwitch.
   * `creation_time` - Time of creation.
   * `available_ip_address_count` - The available ip address count of the vSwitch.
   * `resource_group_id` - The resource group ID of the vSwitch.

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -56,6 +56,8 @@ The following arguments are supported:
   - `true`
   - `false`(default)
 
+-> **NOTE:** When `is_default` is `true`, a region can contain only one default VPC and concurrent default VPC creation in the same region is not supported. After a default VPC is created, its CIDR block cannot be modified, but secondary IPv4 CIDR blocks can be added. A default VPC provides 300,000 private IP addresses for cloud resources and this quota cannot be increased. A router and route table are automatically created with the default VPC. Each default VPC supports up to three user CIDR blocks; if multiple user CIDR blocks overlap, the CIDR block with the shorter mask takes effect.
+
 * `cidr_block` - (Optional, Computed) The CIDR block of the VPC.
 
   - You can specify one of the following CIDR blocks or their subsets as the primary IPv4 CIDR block of the VPC: 192.168.0.0/16, 172.16.0.0/12, and 10.0.0.0/8. These CIDR blocks are standard private CIDR blocks as defined by Request for Comments (RFC) documents. The subnet mask must be 8 to 28 bits in length.
@@ -115,8 +117,8 @@ The following attributes are exported:
 * `id` - The ID of the resource supplied above.
 * `create_time` - The creation time of the VPC.
 * `ipv6_cidr_blocks` - The IPv6 CIDR block information of the VPC.
-  * `ipv6_cidr_block` - The IPv6 CIDR block of the VPC.
-  * `ipv6_isp` - Valid values: **BGP** (default): Alibaba Cloud BGP IPv6.
+    * `ipv6_cidr_block` - The IPv6 CIDR block of the VPC.
+    * `ipv6_isp` - Valid values: **BGP** (default): Alibaba Cloud BGP IPv6.
 * `is_default` - Specifies whether to create the default VPC in the specified region.
 * `region_id` - The ID of the region where the VPC is located.
 * `route_table_id` - The ID of the system route table.

--- a/website/docs/r/vswitch.html.markdown
+++ b/website/docs/r/vswitch.html.markdown
@@ -120,16 +120,19 @@ The following arguments are supported:
 * `cidr_block` - (Optional, ForceNew) The IPv4 CIDR block of the VSwitch. **NOTE:** From version 1.233.0, if you do not set `is_default`, or set `is_default` to `false`, `cidr_block` is required.
 * `description` - (Optional) The description of VSwitch.
 * `zone_id` - (Optional, ForceNew, Available since v1.119.0) The AZ for the VSwitch. **Note:** Required for a VPC VSwitch.
-* `enable_ipv6` - (Optional, Available since v1.201.0) Whether the IPv6 function is enabled in the switch. Value:
+* `enable_ipv6` - (Optional, Computed, Available since v1.201.0) Whether the IPv6 function is enabled in the switch. Value:
   - `true`: enables IPv6.
   - `false` (default): IPv6 is not enabled.
-* `ipv6_cidr_block_mask` - (Optional, Available since v1.201.0) The IPv6 CIDR block of the VSwitch.
+* `ipv6_cidr_block_mask` - (Optional, Available since v1.201.0) The IPv6 CIDR block of the VSwitch. This parameter is used only for create and update operations.
 * `tags` - (Optional, Map, Available since v1.55.3) The tags of VSwitch.
 * `vswitch_name` - (Optional, Available since v1.119.0) The name of the VSwitch.
 * `vpc_id` - (Optional, ForceNew) The VPC ID. **NOTE:** From version 1.233.0, if you do not set `is_default`, or set `is_default` to `false`, `vpc_id` is required.
-* `is_default` - (Optional, Bool, Available since v1.233.0) Specifies whether to create the default VSwitch. Default value: `false`. Valid values:
+* `is_default` - (Optional, Computed, ForceNew, Bool, Available since v1.233.0) Specifies whether to create the default VSwitch. Default value: `false`. Valid values:
   - `true`: Creates a default vSwitch.
   - `false`: Creates a vSwitch.
+
+-> **NOTE:** When `is_default` is `true`, a default VPC must already exist in the region. A zone can contain only one default vSwitch, and creating another one in the same zone fails. After a default vSwitch is created, its CIDR block cannot be modified. The first and last three IP addresses in each default vSwitch CIDR block are reserved by the system, default vSwitches do not support multicast or broadcast, and the number of cloud product instances in a default vSwitch cannot exceed the remaining available instance quota of the VPC.
+* `vpc_ipv6_cidr_block` - (Optional, Available since v1.280.0) The IPv6 CIDR block of the VPC. If the VPC has multiple IPv6 CIDR blocks, you can use this parameter to specify the IPv6 CIDR block range to which the VSwitch belongs. This parameter is used only for create and update operations.
 
 The following arguments will be discarded. Please use new fields as soon as possible:
 * `name` - (Deprecated since v1.119.0) Field `name` has been deprecated from provider version 1.119.0. New field `vswitch_name` instead.


### PR DESCRIPTION
=== RUN TestAccAliCloudVPCVSwitch_basic
--- PASS: TestAccAliCloudVPCVSwitch_basic (44.68s)

=== RUN TestAccAliCloudVPCVSwitch_basic1
--- PASS: TestAccAliCloudVPCVSwitch_basic1 (27.63s)

=== RUN TestAccAliCloudVPCVSwitch_basic2
--- PASS: TestAccAliCloudVPCVSwitch_basic2 (30.54s)

=== RUN TestAccAliCloudVPCVSwitch_basic3
--- PASS: TestAccAliCloudVPCVSwitch_basic3 (26.24s)

=== RUN TestAccAliCloudVPCVSwitch_basic4
--- PASS: TestAccAliCloudVPCVSwitch_basic4 (44.54s)

=== RUN TestAccAliCloudVPCVSwitch_basic5
--- PASS: TestAccAliCloudVPCVSwitch_basic5 (59.25s)

=== RUN TestAccAliCloudVPCVSwitch_basic3078
--- PASS: TestAccAliCloudVPCVSwitch_basic3078 (56.52s)

=== RUN TestAccAliCloudVPCVSwitch_basic3078_twin
--- PASS: TestAccAliCloudVPCVSwitch_basic3078_twin (26.25s)

=== RUN TestAccAliCloudVPCVSwitch_isDefault
--- PASS: TestAccAliCloudVPCVSwitch_isDefault (14.91s)

=== RUN TestAccAliCloudVPCVSwitch_isDefault_twin
--- PASS: TestAccAliCloudVPCVSwitch_isDefault_twin (14.05s)

=== RUN TestAccAliCloudVPCVSwitchesDataSourceBasic
--- PASS: TestAccAliCloudVPCVSwitchesDataSourceBasic (120.28s)

=== RUN TestAccAliCloudVPCVSwitchesDataSourceCoverage
--- PASS: TestAccAliCloudVPCVSwitchesDataSourceCoverage (29.95s)