### PR TITLE
resource/alicloud_vpc: update IPv6 attribute schema

### DIFF
--- a/alicloud/resource_alicloud_vpc.go
+++ b/alicloud/resource_alicloud_vpc.go
@@ -56,6 +56,7 @@ func resourceAliCloudVpcVpc() *schema.Resource {
 			"enable_ipv6": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"force_delete": {
 				Type:     schema.TypeBool,
@@ -70,10 +71,11 @@ func resourceAliCloudVpcVpc() *schema.Resource {
 				Optional: true,
 			},
 			"ipv6_cidr_block": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "Field 'ipv6_cidr_block' has been deprecated from provider version 1.280.0. Please use the new resource 'alicloud_vpc_ipv6_cidr_block'.",
 			},
 			"ipv6_cidr_blocks": {
 				Type:     schema.TypeList,
@@ -92,8 +94,10 @@ func resourceAliCloudVpcVpc() *schema.Resource {
 				},
 			},
 			"ipv6_isp": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "Field 'ipv6_isp' has been deprecated from provider version 1.280.0. Please use the new resource 'alicloud_vpc_ipv6_cidr_block'.",
 			},
 			"region_id": {
 				Type:     schema.TypeString,
@@ -164,6 +168,8 @@ func resourceAliCloudVpcVpc() *schema.Resource {
 			"is_default": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"system_route_table_route_propagation_enable": {
 				Type:     schema.TypeBool,
@@ -201,8 +207,7 @@ func resourceAliCloudVpcVpc() *schema.Resource {
 func resourceAliCloudVpcVpcCreate(d *schema.ResourceData, meta interface{}) error {
 
 	client := meta.(*connectivity.AliyunClient)
-	if v := d.Get("is_default"); !v.(bool) {
-
+	if v, ok := d.GetOkExists("is_default"); !ok || !v.(bool) {
 		action := "CreateVpc"
 		var request map[string]interface{}
 		var response map[string]interface{}
@@ -282,7 +287,7 @@ func resourceAliCloudVpcVpcCreate(d *schema.ResourceData, meta interface{}) erro
 
 	}
 
-	if v, ok := d.GetOk("is_default"); ok && InArray(fmt.Sprint(v), []string{"true"}) {
+	if v, ok := d.GetOkExists("is_default"); ok && v.(bool) {
 		action := "CreateDefaultVpc"
 		var request map[string]interface{}
 		var response map[string]interface{}
@@ -354,6 +359,7 @@ func resourceAliCloudVpcVpcRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("enable_ipv6", objectRaw["EnabledIpv6"])
 	d.Set("ipv6_cidr_block", objectRaw["Ipv6CidrBlock"])
 	d.Set("region_id", objectRaw["RegionId"])
+	d.Set("is_default", objectRaw["IsDefault"])
 	d.Set("resource_group_id", objectRaw["ResourceGroupId"])
 	d.Set("router_id", objectRaw["VRouterId"])
 	d.Set("status", objectRaw["Status"])
@@ -362,7 +368,7 @@ func resourceAliCloudVpcVpcRead(d *schema.ResourceData, meta interface{}) error 
 	ipv6CidrBlockRaw, _ := jsonpath.Get("$.Ipv6CidrBlocks.Ipv6CidrBlock", objectRaw)
 	ipv6CidrBlocksMaps := make([]map[string]interface{}, 0)
 	if ipv6CidrBlockRaw != nil {
-		for _, ipv6CidrBlockChildRaw := range ipv6CidrBlockRaw.([]interface{}) {
+		for _, ipv6CidrBlockChildRaw := range convertToInterfaceArray(ipv6CidrBlockRaw) {
 			ipv6CidrBlocksMap := make(map[string]interface{})
 			ipv6CidrBlockChildRaw := ipv6CidrBlockChildRaw.(map[string]interface{})
 			ipv6CidrBlocksMap["ipv6_cidr_block"] = ipv6CidrBlockChildRaw["Ipv6CidrBlock"]
@@ -373,6 +379,13 @@ func resourceAliCloudVpcVpcRead(d *schema.ResourceData, meta interface{}) error 
 	}
 	if err := d.Set("ipv6_cidr_blocks", ipv6CidrBlocksMaps); err != nil {
 		return err
+	}
+	if v, ok := objectRaw["Ipv6Isp"]; ok && v != nil && fmt.Sprint(v) != "" {
+		d.Set("ipv6_isp", v)
+	} else if len(ipv6CidrBlocksMaps) > 0 {
+		if v, ok := ipv6CidrBlocksMaps[0]["ipv6_isp"]; ok && v != nil && fmt.Sprint(v) != "" {
+			d.Set("ipv6_isp", v)
+		}
 	}
 	secondaryCidrBlockRaw, _ := jsonpath.Get("$.SecondaryCidrBlocks.SecondaryCidrBlock", objectRaw)
 	d.Set("secondary_cidr_blocks", secondaryCidrBlockRaw)
@@ -500,8 +513,9 @@ func resourceAliCloudVpcVpcUpdate(d *schema.ResourceData, meta interface{}) erro
 		request["EnableIPv6"] = d.Get("enable_ipv6")
 	}
 
-	if v, ok := d.GetOk("ipv6_isp"); ok {
-		request["Ipv6Isp"] = v
+	if !d.IsNewResource() && d.HasChange("ipv6_isp") {
+		update = true
+		request["Ipv6Isp"] = d.Get("ipv6_isp")
 	}
 	if !d.IsNewResource() && d.HasChange("dns_hostname_status") {
 		update = true
@@ -530,7 +544,6 @@ func resourceAliCloudVpcVpcUpdate(d *schema.ResourceData, meta interface{}) erro
 		if _, err := stateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
-
 		if d.HasChange("dns_hostname_status") {
 			stateConf := BuildStateConf([]string{}, []string{fmt.Sprint(d.Get("dns_hostname_status"))}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, vpcServiceV2.VpcVpcStateRefreshFunc(d.Id(), "DnsHostnameStatus", []string{}))
 			if _, err := stateConf.WaitForState(); err != nil {

--- a/alicloud/resource_alicloud_vpc_test.go
+++ b/alicloud/resource_alicloud_vpc_test.go
@@ -628,7 +628,7 @@ func TestAccAliCloudVPC_isNotDefault(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "enable_ipv6", "is_default"},
+				ImportStateVerifyIgnore: []string{"dry_run", "enable_ipv6"},
 			},
 		},
 	})
@@ -685,7 +685,7 @@ func TestAccAliCloudVPC_isDefault(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "enable_ipv6", "is_default"},
+				ImportStateVerifyIgnore: []string{"dry_run", "enable_ipv6"},
 			},
 		},
 	})

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -40,8 +40,7 @@ variable "name" {
 
 
 resource "alicloud_vpc" "default" {
-  ipv6_isp    = "BGP"
-  description = "test"
+  description = "example description"
   cidr_block  = "10.0.0.0/8"
   vpc_name    = var.name
   enable_ipv6 = true
@@ -53,7 +52,7 @@ resource "alicloud_vpc" "default" {
 ## Argument Reference
 
 The following arguments are supported:
-* `is_default` - (Optional) Specifies whether to create the default VPC in the specified region. Valid values:
+* `is_default` - (Optional, ForceNew, Computed) Specifies whether to create the default VPC in the specified region. Valid values:
   - `true`
   - `false`(default)
 
@@ -68,7 +67,7 @@ The description must be 1 to 256 characters in length, and cannot start with `ht
 * `dry_run` - (Optional, Available since v1.119.0) Whether to PreCheck only this request. Value:
   - `true`: The check request is sent without creating a VPC. Check items include whether required parameters, request format, and business restrictions are filled in. If the check does not pass, the corresponding error is returned. If the check passes, the error code 'DryRunOperation' is returned '.
   - `false` (default): Sends a normal request, returns an HTTP 2xx status code and directly creates a VPC.
-* `enable_ipv6` - (Optional, Available since v1.119.0) Whether to enable the IPv6 network segment. Value:
+* `enable_ipv6` - (Optional, Computed, Available since v1.119.0) Whether to enable the IPv6 network segment. Value:
   - `false` (default): Not enabled.
   - `true`: enabled.
 * `force_delete` - (Optional, Available since v1.248.0) Force delete vpc or not.
@@ -77,11 +76,11 @@ The description must be 1 to 256 characters in length, and cannot start with `ht
 -> **NOTE:**  when you specify the IPAM address pool to create a VPC, enter at least one of the CidrBlock or Ipv4CidrMask parameters.
 
 * `ipv4_ipam_pool_id` - (Optional) The ID of the IP Address Manager (IPAM) pool that contains IPv4 addresses.
-* `ipv6_cidr_block` - (Optional, ForceNew, Computed) The IPv6 CIDR block of the default VPC.
+* `ipv6_cidr_block` - (Optional, ForceNew, Computed, Deprecated since v1.280.0) The IPv6 CIDR block of the default VPC. Please use the new resource `alicloud_vpc_ipv6_cidr_block`.
 
 -> **NOTE:**  When `EnableIpv6` is set to `true`, this parameter is required.
 
-* `ipv6_isp` - (Optional) The IPv6 address segment type of the VPC. Value:
+* `ipv6_isp` - (Optional, Computed, Deprecated since v1.280.0) The IPv6 address segment type of the VPC. Please use the new resource `alicloud_vpc_ipv6_cidr_block`. Value:
   - `BGP` (default): Alibaba Cloud BGP IPv6.
   - `ChinaMobile`: China Mobile (single line).
   - `ChinaUnicom`: China Unicom (single line).
@@ -93,13 +92,12 @@ The description must be 1 to 256 characters in length, and cannot start with `ht
 
 -> **NOTE:**   You can use resource groups to facilitate resource grouping and permission management for an Alibaba Cloud. For more information, see [What is resource management?](https://www.alibabacloud.com/help/en/doc-detail/94475.html)
 
-* `route_table_id` - (Optional, ForceNew, Computed) The ID of the system route table.
 * `secondary_cidr_blocks` - (Optional, Computed, List, Deprecated since v1.185.0) Field 'secondary_cidr_blocks' has been deprecated from provider version 1.185.0 and it will be removed in the future version. Please use the new resource 'alicloud_vpc_ipv4_cidr_block'. `secondary_cidr_blocks` attributes and `alicloud_vpc_ipv4_cidr_block` resource cannot be used at the same time.
 * `system_route_table_description` - (Optional) The description of the route table.
 The description must be 1 to 256 characters in length, and cannot start with `http://` or `https://`.
 * `system_route_table_name` - (Optional) The name of the route table.
 The name must be 1 to 128 characters in length and cannot start with `http://` or `https://`.
-* `system_route_table_route_propagation_enable` - (Optional, Available since v1.248.0) Whether the system route table receives propagation routes.
+* `system_route_table_route_propagation_enable` - (Optional, Computed, Available since v1.248.0) Whether the system route table receives propagation routes.
 * `tags` - (Optional, Map, Available since v1.55.3) The tags of Vpc.
 * `user_cidrs` - (Optional, ForceNew, Computed, List, Available since v1.119.0) A list of user CIDRs.
 * `vpc_name` - (Optional, Computed, Available since v1.119.0) The new name of the VPC.
@@ -118,8 +116,10 @@ The following attributes are exported:
 * `create_time` - The creation time of the VPC.
 * `ipv6_cidr_blocks` - The IPv6 CIDR block information of the VPC.
   * `ipv6_cidr_block` - The IPv6 CIDR block of the VPC.
-  * `ipv6_isp` - Valid values: `BGP` (default): Alibaba Cloud BGP IPv6.
+  * `ipv6_isp` - Valid values: **BGP** (default): Alibaba Cloud BGP IPv6.
+* `is_default` - Specifies whether to create the default VPC in the specified region.
 * `region_id` - The ID of the region where the VPC is located.
+* `route_table_id` - The ID of the system route table.
 * `router_id` - The region ID of the VPC to which the route table belongs.
 * `status` - The status of the VPC.   `Pending`: The VPC is being configured. `Available`: The VPC is available.
 


### PR DESCRIPTION
=== RUN TestAccAliCloudVPC_basic
--- PASS: TestAccAliCloudVPC_basic (85.89s)

=== RUN TestAccAliCloudVPC_enableIpv6
--- PASS: TestAccAliCloudVPC_enableIpv6 (94.00s)

=== RUN TestAccAliCloudVPC_basic1
--- PASS: TestAccAliCloudVPC_basic1 (23.88s)

=== RUN TestAccAliCloudVPC_basic2
--- PASS: TestAccAliCloudVPC_basic2 (28.84s)

=== RUN TestAccAliCloudVPC_isNotDefault
--- PASS: TestAccAliCloudVPC_isNotDefault (29.62s)

=== RUN TestAccAliCloudVPC_isDefault
--- PASS: TestAccAliCloudVPC_isDefault (28.27s)

=== RUN TestAccAliCloudVpcVpc_basic3113
--- PASS: TestAccAliCloudVpcVpc_basic3113 (111.10s)

=== RUN TestAccAliCloudVpcVpc_basic3113_twin
--- PASS: TestAccAliCloudVpcVpc_basic3113_twin (131.74s)

=== RUN TestAccAliCloudVpcVpc_basic9656
--- PASS: TestAccAliCloudVpcVpc_basic9656 (46.98s)

=== RUN TestAccAlicloudVPCsDataSourceBasic
--- PASS: TestAccAlicloudVPCsDataSourceBasic (219.78s)