### PR TITLE
resource/alicloud_vswitch: fix ipv6_cidr_block_mask sending Ipv6CidrBlock=0 on removal

### DIFF
--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -55,6 +55,7 @@ func resourceAliCloudVpcVswitch() *schema.Resource {
 			"ipv6_cidr_block_mask": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"is_default": {
 				Type:     schema.TypeBool,

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -591,6 +591,163 @@ func TestAccAliCloudVPCVSwitch_basic5(t *testing.T) {
 	})
 }
 
+// TestAccAliCloudVPCVSwitch_ipv6MaskRemoval — scenario ① (mask removal).
+// With ipv6_cidr_block_mask as Optional-only, removing it from config drove the int
+// to 0 with HasChange=true, so the Update sent "Ipv6CidrBlock":0 to
+// ModifyVSwitchAttribute and the backend re-assigned subnet 0 (reproduced bug).
+// After making the attribute Optional+Computed, removing it from config produces NO
+// diff (Terraform keeps the prior value), HasChange is false, the block is skipped,
+// and no Ipv6CidrBlock is sent — so the already-assigned IPv6 CIDR must stay
+// unchanged. We capture the assigned CIDR after step 0 and assert it does not change
+// after the mask is removed: fails on the old (Optional-only) code, passes with the
+// Computed fix.
+func TestAccAliCloudVPCVSwitch_ipv6MaskRemoval(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	var ipv6Before string
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// Step 0: create the vswitch with IPv6 enabled and an explicit mask = 1 (user scenario).
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":              "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":               "${alicloud_vpc.default.id}",
+					"cidr_block":           "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+					"enable_ipv6":          "true",
+					"ipv6_cidr_block_mask": "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_id":              CHECKSET,
+						"vpc_id":               CHECKSET,
+						"cidr_block":           CHECKSET,
+						"enable_ipv6":          "true",
+						"ipv6_cidr_block_mask": "1",
+						"ipv6_cidr_block":      CHECKSET,
+					}),
+					// Capture the IPv6 CIDR the backend assigned, so we can assert it is not changed below.
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[resourceId]
+						if !ok {
+							return fmt.Errorf("resource not found: %s", resourceId)
+						}
+						ipv6Before = rs.Primary.Attributes["ipv6_cidr_block"]
+						return nil
+					},
+				),
+			},
+			// Step 1: remove ONLY ipv6_cidr_block_mask from the config (enable_ipv6 stays true).
+			// Per the report, the Modify API must not carry Ipv6CidrBlock, so the assigned
+			// IPv6 CIDR must stay identical. If the bug exists, the provider sends
+			// Ipv6CidrBlock=0 and the CIDR flips to subnet 0, failing this assertion.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ipv6_cidr_block_mask": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPtr(resourceId, "ipv6_cidr_block", &ipv6Before),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAliCloudVPCVSwitch_ipv6MaskSetZero — scenario ② (explicit mask = 0).
+// After making ipv6_cidr_block_mask Optional+Computed, this checks whether a user can
+// still EXPLICITLY set the mask to 0. On SDK v1.17.2 (no GetRawConfig) the zero value
+// of an Optional+Computed int is the ambiguous case, so this is exactly what might
+// regress. We create with mask=1, then set mask=0, and expect it to take effect:
+// ipv6_cidr_block_mask=0 in state AND the backend re-assigns subnet 0 (ipv6_cidr_block
+// changes from the captured value). The tf-debug.log confirms whether
+// ModifyVSwitchAttribute actually received Ipv6CidrBlock:0. If v1 swallows the explicit
+// 0, this test fails and tells us Computed alone is not enough to keep 0 settable.
+func TestAccAliCloudVPCVSwitch_ipv6MaskSetZero(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	var ipv6Before string
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// Step 0: create with IPv6 enabled and an explicit mask = 1.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":              "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":               "${alicloud_vpc.default.id}",
+					"cidr_block":           "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+					"enable_ipv6":          "true",
+					"ipv6_cidr_block_mask": "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable_ipv6":          "true",
+						"ipv6_cidr_block_mask": "1",
+						"ipv6_cidr_block":      CHECKSET,
+					}),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[resourceId]
+						if !ok {
+							return fmt.Errorf("resource not found: %s", resourceId)
+						}
+						ipv6Before = rs.Primary.Attributes["ipv6_cidr_block"]
+						return nil
+					},
+				),
+			},
+			// Step 1: explicitly set mask = 0 (enable_ipv6 stays true). Desired behaviour:
+			// the 0 is applied (ipv6_cidr_block_mask=0) and the backend re-assigns subnet 0,
+			// so ipv6_cidr_block changes. If the explicit 0 is swallowed, both checks fail.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ipv6_cidr_block_mask": "0",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ipv6_cidr_block_mask": "0",
+					}),
+					func(s *terraform.State) error {
+						got := s.RootModule().Resources[resourceId].Primary.Attributes["ipv6_cidr_block"]
+						if got == ipv6Before {
+							return fmt.Errorf("ipv6_cidr_block did not change after setting mask=0 (still %q): the explicit 0 was not pushed to the backend", got)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func TestAccAliCloudVPCVSwitch_isDefault(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vswitch.default"


### PR DESCRIPTION
=== RUN   TestAccAliCloudVPCVSwitch_basic
--- PASS: TestAccAliCloudVPCVSwitch_basic (47.07s)

=== RUN   TestAccAliCloudVPCVSwitch_basic1
--- PASS: TestAccAliCloudVPCVSwitch_basic1 (26.58s)

=== RUN   TestAccAliCloudVPCVSwitch_basic2
--- PASS: TestAccAliCloudVPCVSwitch_basic2 (31.18s)

=== RUN   TestAccAliCloudVPCVSwitch_basic3
--- PASS: TestAccAliCloudVPCVSwitch_basic3 (27.35s)

=== RUN   TestAccAliCloudVPCVSwitch_basic4
--- PASS: TestAccAliCloudVPCVSwitch_basic4 (44.01s)

=== RUN   TestAccAliCloudVPCVSwitch_basic5
--- PASS: TestAccAliCloudVPCVSwitch_basic5 (57.00s)

=== RUN   TestAccAliCloudVPCVSwitch_basic3078
--- PASS: TestAccAliCloudVPCVSwitch_basic3078 (56.95s)

=== RUN   TestAccAliCloudVPCVSwitch_basic3078_twin
--- PASS: TestAccAliCloudVPCVSwitch_basic3078_twin (27.00s)

=== RUN   TestAccAliCloudVPCVSwitch_isDefault
--- PASS: TestAccAliCloudVPCVSwitch_isDefault (15.19s)

=== RUN   TestAccAliCloudVPCVSwitch_isDefault_twin
--- PASS: TestAccAliCloudVPCVSwitch_isDefault_twin (14.64s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6MaskRemoval
--- PASS: TestAccAliCloudVPCVSwitch_ipv6MaskRemoval (30.64s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6MaskSetZero
--- PASS: TestAccAliCloudVPCVSwitch_ipv6MaskSetZero (34.71s)

=== RUN   TestAccAliCloudVPCVSwitchesDataSourceBasic
--- PASS: TestAccAliCloudVPCVSwitchesDataSourceBasic (122.11s)

=== RUN   TestAccAliCloudVPCVSwitchesDataSourceCoverage
--- PASS: TestAccAliCloudVPCVSwitchesDataSourceCoverage (30.54s)

PASS