### PR TITLE
resource/alicloud_vswitch: require ipv6_cidr_block_mask when enabling enable_ipv6

### DIFF
--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -295,35 +295,35 @@ func resourceAliCloudVpcVswitchUpdate(d *schema.ResourceData, meta interface{}) 
 		update = true
 	}
 
-	if !d.IsNewResource() && d.HasChange("ipv6_cidr_block_mask") {
-		err := CancelIpv6(d, meta)
-		if err != nil {
-			return WrapError(err)
-		}
-		if !d.HasChange("enable_ipv6") || d.Get("enable_ipv6").(bool) {
-			update = true
-			request["EnableIPv6"] = true
-			request["Ipv6CidrBlock"] = d.Get("ipv6_cidr_block_mask")
-		}
-	}
-
-	if !d.IsNewResource() && d.HasChange("enable_ipv6") {
-		update = true
-		enableIpv6 := d.Get("enable_ipv6").(bool)
-		request["EnableIPv6"] = enableIpv6
-		if enableIpv6 {
-			// The ModifyVSwitchAttribute API requires Ipv6CidrBlock whenever EnableIPv6 is
-			// set to true (otherwise the backend returns MissingParam.Ipv6CidrBlock). Require
-			// ipv6_cidr_block_mask here so the user gets a clear, early error instead of the
-			// opaque backend one — and so we never silently fall back to subnet 0. This only
-			// applies to enabling IPv6 on an existing vswitch (the create path is untouched).
+	// enable_ipv6 and ipv6_cidr_block_mask are handled together: the mask only takes effect
+	// when IPv6 is enabled, so the desired enable_ipv6 state drives the whole request.
+	if !d.IsNewResource() && (d.HasChange("enable_ipv6") || d.HasChange("ipv6_cidr_block_mask")) {
+		if d.Get("enable_ipv6").(bool) {
+			// Enabling IPv6 (or re-assigning its subnet) requires ipv6_cidr_block_mask: the
+			// ModifyVSwitchAttribute API rejects EnableIPv6=true without Ipv6CidrBlock. Require it
+			// here so the user gets a clear, early error instead of the opaque backend one, and so
+			// we never silently fall back to subnet 0.
 			if _, ok := d.GetOkExists("ipv6_cidr_block_mask"); !ok {
 				return WrapError(fmt.Errorf("`ipv6_cidr_block_mask` is required when enabling `enable_ipv6` for an existing vswitch"))
 			}
+			// When only the subnet changes while IPv6 is already enabled, the existing block must
+			// be released first (it cannot be re-assigned in place), so disable then re-enable.
+			if !d.HasChange("enable_ipv6") {
+				if err := CancelIpv6(d, meta); err != nil {
+					return WrapError(err)
+				}
+			}
+			update = true
+			request["EnableIPv6"] = true
 			request["Ipv6CidrBlock"] = d.Get("ipv6_cidr_block_mask")
-		} else {
-			delete(request, "Ipv6CidrBlock")
+		} else if d.HasChange("enable_ipv6") {
+			// Disabling IPv6. Ipv6CidrBlock is only written in the branch above, which is mutually
+			// exclusive with this one, so there is nothing to delete here (the API also forbids
+			// sending Ipv6CidrBlock when disabling).
+			update = true
+			request["EnableIPv6"] = false
 		}
+		// enable_ipv6 is false and unchanged (only the mask changed) -> no IPv6 change needed.
 	}
 
 	if update {

--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -300,16 +300,22 @@ func resourceAliCloudVpcVswitchUpdate(d *schema.ResourceData, meta interface{}) 
 		if err != nil {
 			return WrapError(err)
 		}
-		if v, ok := d.GetOkExists("ipv6_cidr_block_mask"); ok {
+		if !d.HasChange("enable_ipv6") || d.Get("enable_ipv6").(bool) {
 			update = true
 			request["EnableIPv6"] = true
-			request["Ipv6CidrBlock"] = v
+			request["Ipv6CidrBlock"] = d.Get("ipv6_cidr_block_mask")
 		}
 	}
 
 	if !d.IsNewResource() && d.HasChange("enable_ipv6") {
 		update = true
-		request["EnableIPv6"] = d.Get("enable_ipv6")
+		enableIpv6 := d.Get("enable_ipv6").(bool)
+		request["EnableIPv6"] = enableIpv6
+		if enableIpv6 {
+			request["Ipv6CidrBlock"] = d.Get("ipv6_cidr_block_mask")
+		} else {
+			delete(request, "Ipv6CidrBlock")
+		}
 	}
 
 	if update {

--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -312,6 +312,14 @@ func resourceAliCloudVpcVswitchUpdate(d *schema.ResourceData, meta interface{}) 
 		enableIpv6 := d.Get("enable_ipv6").(bool)
 		request["EnableIPv6"] = enableIpv6
 		if enableIpv6 {
+			// The ModifyVSwitchAttribute API requires Ipv6CidrBlock whenever EnableIPv6 is
+			// set to true (otherwise the backend returns MissingParam.Ipv6CidrBlock). Require
+			// ipv6_cidr_block_mask here so the user gets a clear, early error instead of the
+			// opaque backend one — and so we never silently fall back to subnet 0. This only
+			// applies to enabling IPv6 on an existing vswitch (the create path is untouched).
+			if _, ok := d.GetOkExists("ipv6_cidr_block_mask"); !ok {
+				return WrapError(fmt.Errorf("`ipv6_cidr_block_mask` is required when enabling `enable_ipv6` for an existing vswitch"))
+			}
 			request["Ipv6CidrBlock"] = d.Get("ipv6_cidr_block_mask")
 		} else {
 			delete(request, "Ipv6CidrBlock")

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -946,6 +946,55 @@ func TestAccAliCloudVPCVSwitch_ipv6EnableWithMask(t *testing.T) {
 	})
 }
 
+// TestAccAliCloudVPCVSwitch_ipv6MaskWhileDisabled: setting/changing ipv6_cidr_block_mask while
+// IPv6 is disabled (enable_ipv6 is not true and not changing) must NOT enable IPv6. The mask
+// only takes effect when enable_ipv6 is true; it must never silently turn IPv6 on by itself.
+func TestAccAliCloudVPCVSwitch_ipv6MaskWhileDisabled(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// Step 0: create without IPv6.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":    "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":     "${alicloud_vpc.default.id}",
+					"cidr_block": "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+				),
+			},
+			// Step 1: set ipv6_cidr_block_mask but DON'T enable IPv6 -> IPv6 must stay disabled
+			// (enable_ipv6 stays false); the mask is recorded but has no effect.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ipv6_cidr_block_mask": 8,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "8"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAliCloudVPCVSwitch_ipv6ReenableSameMaskAfterDisable(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vswitch.default"

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -842,6 +843,102 @@ func TestAccAliCloudVPCVSwitch_ipv6EnableZeroMaskFromDisabled(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "true"),
 					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "0"),
+					resource.TestCheckResourceAttrSet(resourceId, "ipv6_cidr_block"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAliCloudVPCVSwitch_ipv6EnableNoMask: enabling IPv6 on an existing vswitch
+// (enable_ipv6 false -> true) WITHOUT ipv6_cidr_block_mask must fail fast with a clear
+// provider error — instead of silently sending Ipv6CidrBlock=0 (forcing subnet 0) or
+// letting the backend return the opaque MissingParam.Ipv6CidrBlock. The ModifyVSwitchAttribute
+// API requires Ipv6CidrBlock whenever EnableIPv6=true.
+func TestAccAliCloudVPCVSwitch_ipv6EnableNoMask(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// Step 0: create the vswitch without IPv6.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":    "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":     "${alicloud_vpc.default.id}",
+					"cidr_block": "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+				),
+			},
+			// Step 1: enable IPv6 with NO ipv6_cidr_block_mask -> must error (not silently use 0).
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6": true,
+				}),
+				ExpectError: regexp.MustCompile("ipv6_cidr_block_mask.*is required when enabling"),
+			},
+		},
+	})
+}
+
+// TestAccAliCloudVPCVSwitch_ipv6EnableWithMask: enabling IPv6 on an existing vswitch WITH
+// ipv6_cidr_block_mask set works normally — Ipv6CidrBlock is sent with the user's value.
+func TestAccAliCloudVPCVSwitch_ipv6EnableWithMask(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// Step 0: create the vswitch without IPv6.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":    "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":     "${alicloud_vpc.default.id}",
+					"cidr_block": "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+				),
+			},
+			// Step 1: enable IPv6 WITH a mask -> succeeds.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6":          true,
+					"ipv6_cidr_block_mask": 8,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "8"),
 					resource.TestCheckResourceAttrSet(resourceId, "ipv6_cidr_block"),
 				),
 			},

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -748,6 +748,165 @@ func TestAccAliCloudVPCVSwitch_ipv6MaskSetZero(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudVPCVSwitch_enableIpv6FalseAfterComputedTrue(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":              "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":               "${alicloud_vpc.default.id}",
+					"cidr_block":           "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+					"ipv6_cidr_block_mask": "4",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "4"),
+					resource.TestCheckResourceAttrSet(resourceId, "ipv6_cidr_block"),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6":          false,
+					"ipv6_cidr_block_mask": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[resourceId]
+						if !ok {
+							return fmt.Errorf("resource not found: %s", resourceId)
+						}
+						if got := rs.Primary.Attributes["ipv6_cidr_block"]; got != "" {
+							return fmt.Errorf("expected ipv6_cidr_block to be empty after enable_ipv6=false, got %q", got)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccAliCloudVPCVSwitch_ipv6EnableZeroMaskFromDisabled(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":    "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":     "${alicloud_vpc.default.id}",
+					"cidr_block": "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6":          true,
+					"ipv6_cidr_block_mask": 0,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "0"),
+					resource.TestCheckResourceAttrSet(resourceId, "ipv6_cidr_block"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAliCloudVPCVSwitch_ipv6ReenableSameMaskAfterDisable(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":              "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":               "${alicloud_vpc.default.id}",
+					"cidr_block":           "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+					"enable_ipv6":          true,
+					"ipv6_cidr_block_mask": 4,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "4"),
+					resource.TestCheckResourceAttrSet(resourceId, "ipv6_cidr_block"),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6":          false,
+					"ipv6_cidr_block_mask": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6":          true,
+					"ipv6_cidr_block_mask": 4,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "4"),
+					resource.TestCheckResourceAttrSet(resourceId, "ipv6_cidr_block"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAliCloudVPCVSwitch_isDefault(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vswitch.default"

--- a/website/docs/r/vswitch.html.markdown
+++ b/website/docs/r/vswitch.html.markdown
@@ -124,9 +124,11 @@ The following arguments are supported:
   - `true`: enables IPv6.
   - `false` (default): IPv6 is not enabled.
 
--> **NOTE:** When enabling IPv6 on an existing VSwitch (changing `enable_ipv6` from `false` to `true`), `ipv6_cidr_block_mask` is required. The underlying `ModifyVSwitchAttribute` API requires the IPv6 CIDR block to be specified whenever IPv6 is enabled, otherwise it returns `MissingParam.Ipv6CidrBlock`.
+-> **NOTE:** Since v1.281.0, `ipv6_cidr_block_mask` only takes effect when `enable_ipv6` is `true`, and it is required when `enable_ipv6` is `true`.
 
-* `ipv6_cidr_block_mask` - (Optional, Available since v1.201.0) The last 8 bits of the IPv6 CIDR block of the VSwitch, that is, the subnet number. Valid values: `0` to `255`. It is **required** when enabling `enable_ipv6` on an existing VSwitch. This parameter is used only for create and update operations.
+-> **NOTE:** When `enable_ipv6` is `true`, modifying `ipv6_cidr_block_mask` will disable IPv6 and then re-enable it to assign the new subnet. This re-assignment may interrupt the IPv6 service of the VSwitch, so plan such changes with care.
+
+* `ipv6_cidr_block_mask` - (Optional, Available since v1.201.0) The last 8 bits of the IPv6 CIDR block of the VSwitch, that is, the subnet number. Valid values: `0` to `255`. It only takes effect and is required when `enable_ipv6` is `true`. This parameter is used only for create and update operations.
 * `tags` - (Optional, Map, Available since v1.55.3) The tags of VSwitch.
 * `vswitch_name` - (Optional, Available since v1.119.0) The name of the VSwitch.
 * `vpc_id` - (Optional, ForceNew) The VPC ID. **NOTE:** From version 1.233.0, if you do not set `is_default`, or set `is_default` to `false`, `vpc_id` is required.

--- a/website/docs/r/vswitch.html.markdown
+++ b/website/docs/r/vswitch.html.markdown
@@ -123,7 +123,10 @@ The following arguments are supported:
 * `enable_ipv6` - (Optional, Computed, Available since v1.201.0) Whether the IPv6 function is enabled in the switch. Value:
   - `true`: enables IPv6.
   - `false` (default): IPv6 is not enabled.
-* `ipv6_cidr_block_mask` - (Optional, Available since v1.201.0) The IPv6 CIDR block of the VSwitch. This parameter is used only for create and update operations.
+
+-> **NOTE:** When enabling IPv6 on an existing VSwitch (changing `enable_ipv6` from `false` to `true`), `ipv6_cidr_block_mask` is required. The underlying `ModifyVSwitchAttribute` API requires the IPv6 CIDR block to be specified whenever IPv6 is enabled, otherwise it returns `MissingParam.Ipv6CidrBlock`.
+
+* `ipv6_cidr_block_mask` - (Optional, Available since v1.201.0) The last 8 bits of the IPv6 CIDR block of the VSwitch, that is, the subnet number. Valid values: `0` to `255`. It is **required** when enabling `enable_ipv6` on an existing VSwitch. This parameter is used only for create and update operations.
 * `tags` - (Optional, Map, Available since v1.55.3) The tags of VSwitch.
 * `vswitch_name` - (Optional, Available since v1.119.0) The name of the VSwitch.
 * `vpc_id` - (Optional, ForceNew) The VPC ID. **NOTE:** From version 1.233.0, if you do not set `is_default`, or set `is_default` to `false`, `vpc_id` is required.


### PR DESCRIPTION
### Why

On an existing vSwitch, enabling IPv6 (`enable_ipv6 = true`) without `ipv6_cidr_block_mask` made the backend return the opaque `MissingParam.Ipv6CidrBlock`, and changing/setting the mask while IPv6 was disabled could unexpectedly turn IPv6 on.

### What

- `enable_ipv6` and `ipv6_cidr_block_mask` are now handled in a single update path driven by the desired `enable_ipv6` state.
- Enabling IPv6 on an existing vSwitch requires `ipv6_cidr_block_mask` — a clear, early error is returned instead of the backend `MissingParam.Ipv6CidrBlock`, and the provider never silently falls back to subnet `0`. Explicitly setting `ipv6_cidr_block_mask = 0` is still honored.
- `ipv6_cidr_block_mask` only takes effect when `enable_ipv6` is `true`; setting it while IPv6 is disabled no longer force-enables IPv6.
- The create path is unchanged (no new validation), so existing create configs — including default vSwitches — are unaffected.
- Docs updated; acceptance tests added.

### Acceptance tests

```text
=== RUN   TestAccAliCloudVPCVSwitch_basic
--- PASS: TestAccAliCloudVPCVSwitch_basic (42.62s)

=== RUN   TestAccAliCloudVPCVSwitch_basic1
--- PASS: TestAccAliCloudVPCVSwitch_basic1 (25.97s)

=== RUN   TestAccAliCloudVPCVSwitch_basic2
--- PASS: TestAccAliCloudVPCVSwitch_basic2 (29.70s)

=== RUN   TestAccAliCloudVPCVSwitch_basic3
--- PASS: TestAccAliCloudVPCVSwitch_basic3 (25.92s)

=== RUN   TestAccAliCloudVPCVSwitch_basic4
--- PASS: TestAccAliCloudVPCVSwitch_basic4 (41.73s)

=== RUN   TestAccAliCloudVPCVSwitch_basic5
--- PASS: TestAccAliCloudVPCVSwitch_basic5 (51.91s)

=== RUN   TestAccAliCloudVPCVSwitch_basic3078
--- PASS: TestAccAliCloudVPCVSwitch_basic3078 (52.10s)

=== RUN   TestAccAliCloudVPCVSwitch_basic3078_twin
--- PASS: TestAccAliCloudVPCVSwitch_basic3078_twin (26.30s)

=== RUN   TestAccAliCloudVPCVSwitch_isDefault
--- PASS: TestAccAliCloudVPCVSwitch_isDefault (13.52s)

=== RUN   TestAccAliCloudVPCVSwitch_isDefault_twin
--- PASS: TestAccAliCloudVPCVSwitch_isDefault_twin (12.90s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6MaskRemoval
--- PASS: TestAccAliCloudVPCVSwitch_ipv6MaskRemoval (28.91s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6MaskSetZero
--- PASS: TestAccAliCloudVPCVSwitch_ipv6MaskSetZero (33.60s)

=== RUN   TestAccAliCloudVPCVSwitchesDataSourceBasic
--- PASS: TestAccAliCloudVPCVSwitchesDataSourceBasic (114.65s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6EnableNoMask
--- PASS: TestAccAliCloudVPCVSwitch_ipv6EnableNoMask (26.81s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6EnableWithMask
--- PASS: TestAccAliCloudVPCVSwitch_ipv6EnableWithMask (29.40s)

=== RUN   TestAccAliCloudVPCVSwitchesDataSourceCoverage
--- PASS: TestAccAliCloudVPCVSwitchesDataSourceCoverage (29.40s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6MaskWhileDisabled
--- PASS: TestAccAliCloudVPCVSwitch_ipv6MaskWhileDisabled (28.51s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6EnableZeroMaskFromDisabled
--- PASS: TestAccAliCloudVPCVSwitch_ipv6EnableZeroMaskFromDisabled (29.98s)

=== RUN   TestAccAliCloudVPCVSwitch_enableIpv6FalseAfterComputedTrue
--- PASS: TestAccAliCloudVPCVSwitch_enableIpv6FalseAfterComputedTrue (32.69s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6ReenableSameMaskAfterDisable
--- PASS: TestAccAliCloudVPCVSwitch_ipv6ReenableSameMaskAfterDisable (36.15s)

PASS
```
