### PR TITLE
data-source/alicloud_threat_detection_check_structures: refactor data-source/alicloud_threat_detection_check_item_configs: refactor data soruce

### DIFF
--- a/alicloud/data_source_alicloud_threat_detection_check_item_configs.go
+++ b/alicloud/data_source_alicloud_threat_detection_check_item_configs.go
@@ -1,4 +1,3 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
@@ -27,12 +26,14 @@ func dataSourceAliCloudThreatDetectionCheckItemConfigs() *schema.Resource {
 				Optional: true,
 			},
 			"page_number": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntAtLeast(1),
 			},
 			"page_size": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntAtLeast(1),
 			},
 			"task_sources": {
 				Type:     schema.TypeList,
@@ -151,26 +152,34 @@ func dataSourceAliCloudThreatDetectionCheckItemConfigRead(d *schema.ResourceData
 		}
 	}
 
-	var request map[string]interface{}
-	var response map[string]interface{}
-	var query map[string]interface{}
 	action := "ListCheckItem"
+	pageSize := PageSizeLarge
+	if v := d.Get("page_size").(int); v > 0 {
+		pageSize = v
+	}
+	pageNumber := 1
+	singlePage := false
+	if v := d.Get("page_number").(int); v > 0 {
+		pageNumber = v
+		singlePage = true
+	}
+	request := map[string]interface{}{
+		"PageSize":   pageSize,
+		"PageNumber": pageNumber,
+	}
+	query := map[string]interface{}{}
+	var response map[string]interface{}
 	var err error
-	request = make(map[string]interface{})
-	query = make(map[string]interface{})
+
 	if v, ok := d.GetOk("lang"); ok {
 		request["Lang"] = v
 	}
 	if v, ok := d.GetOk("task_sources"); ok {
-		taskSourcesMapsArray := convertToInterfaceArray(v)
-
-		request["TaskSources"] = taskSourcesMapsArray
+		request["TaskSources"] = convertToInterfaceArray(v)
 	}
 
 	runtime := util.RuntimeOptions{}
 	runtime.SetAutoretry(true)
-	request["PageSize"] = PageSizeLarge
-	request["PageNumber"] = 1
 	for {
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
@@ -196,21 +205,20 @@ func dataSourceAliCloudThreatDetectionCheckItemConfigRead(d *schema.ResourceData
 		for _, v := range result {
 			item := v.(map[string]interface{})
 			if len(idsMap) > 0 {
-				if _, ok := idsMap[fmt.Sprint()]; !ok {
+				if _, ok := idsMap[fmt.Sprint(item["CheckId"])]; !ok {
 					continue
 				}
 			}
 			objects = append(objects, item)
 		}
 
-		if len(result) < PageSizeLarge {
+		if singlePage || len(result) < pageSize {
 			break
 		}
 		request["PageNumber"] = request["PageNumber"].(int) + 1
 	}
 
 	ids := make([]string, 0)
-	names := make([]interface{}, 0)
 	s := make([]map[string]interface{}, 0)
 	for _, objectRaw := range objects {
 		mapping := map[string]interface{}{}
@@ -260,8 +268,7 @@ func dataSourceAliCloudThreatDetectionCheckItemConfigRead(d *schema.ResourceData
 		}
 		mapping["description"] = descriptionMaps
 
-		ids = append(ids, fmt.Sprint(mapping["id"]))
-		names = append(names, objectRaw[""])
+		ids = append(ids, fmt.Sprint(objectRaw["CheckId"]))
 		s = append(s, mapping)
 	}
 

--- a/alicloud/data_source_alicloud_threat_detection_check_item_configs_test.go
+++ b/alicloud/data_source_alicloud_threat_detection_check_item_configs_test.go
@@ -1,4 +1,3 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
@@ -10,16 +9,35 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-func TestAccAlicloudThreatDetectionCheckItemConfigDataSource(t *testing.T) {
-	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+// NOTE: Test depends on data source or hardcoded are not stable and may fail at any time
+// Uninitialized resource; assumes the resource already exists.
+
+func TestAccAliCloudThreatDetectionCheckItemConfigsDataSource(t *testing.T) {
 	rand := acctest.RandIntRange(1000000, 9999999)
 
-	ThreatDetectionCheckItemConfigCheckInfo.dataSourceTestCheck(t, rand)
+	pagingConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudThreatDetectionCheckItemConfigSourceConfig(rand, map[string]string{
+			"lang":        `"zh"`,
+			"page_number": `1`,
+			"page_size":   `10`,
+		}),
+		fakeConfig: testAccCheckAlicloudThreatDetectionCheckItemConfigSourceConfig(rand, map[string]string{
+			"lang":        `"zh"`,
+			"page_number": `1`,
+			"page_size":   `10`,
+			"ids":         `["fake-id-not-exist"]`,
+		}),
+	}
+
+	preCheck := func() {
+		testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	}
+	ThreatDetectionCheckItemConfigCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, pagingConf)
 }
 
 var existThreatDetectionCheckItemConfigMapFunc = func(rand int) map[string]string {
 	return map[string]string{
-		"configs.#":                   "1",
+		"configs.#":                   CHECKSET,
 		"configs.0.section_ids.#":     CHECKSET,
 		"configs.0.description.#":     CHECKSET,
 		"configs.0.check_show_name":   CHECKSET,
@@ -53,7 +71,7 @@ func testAccCheckAlicloudThreatDetectionCheckItemConfigSourceConfig(rand int, at
 	}
 	config := fmt.Sprintf(`
 variable "name" {
-	default = "tf-testAccThreatDetectionCheckItemConfig%d"
+  default = "tf-testAccThreatDetectionCheckItemConfig%d"
 }
 
 data "alicloud_threat_detection_check_item_configs" "default" {

--- a/alicloud/data_source_alicloud_threat_detection_check_structures.go
+++ b/alicloud/data_source_alicloud_threat_detection_check_structures.go
@@ -1,16 +1,43 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/PaesslerAG/jsonpath"
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
+
+type checkStructureResponse struct {
+	CheckStructureResponse []checkStructureItem `json:"CheckStructureResponse"`
+}
+
+type checkStructureItem struct {
+	StandardType string              `json:"StandardType"`
+	Standards    []checkStructureStd `json:"Standards"`
+}
+
+type checkStructureStd struct {
+	Id           int                 `json:"Id"`
+	ShowName     string              `json:"ShowName"`
+	Type         string              `json:"Type"`
+	Requirements []checkStructureReq `json:"Requirements"`
+}
+
+type checkStructureReq struct {
+	Id              int                 `json:"Id"`
+	ShowName        string              `json:"ShowName"`
+	TotalCheckCount int                 `json:"TotalCheckCount"`
+	Sections        []checkStructureSec `json:"Sections"`
+}
+
+type checkStructureSec struct {
+	Id       int    `json:"Id"`
+	ShowName string `json:"ShowName"`
+}
 
 func dataSourceAliCloudThreatDetectionCheckStructures() *schema.Resource {
 	return &schema.Resource{
@@ -23,8 +50,14 @@ func dataSourceAliCloudThreatDetectionCheckStructures() *schema.Resource {
 				Computed: true,
 			},
 			"current_page": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntAtLeast(1),
+			},
+			"page_size": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntAtLeast(1),
 			},
 			"lang": {
 				Type:     schema.TypeString,
@@ -114,8 +147,6 @@ func dataSourceAliCloudThreatDetectionCheckStructures() *schema.Resource {
 func dataSourceAliCloudThreatDetectionCheckStructureRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 
-	var objects []map[string]interface{}
-
 	idsMap := make(map[string]string)
 	if v, ok := d.GetOk("ids"); ok {
 		for _, vv := range v.([]interface{}) {
@@ -126,24 +157,25 @@ func dataSourceAliCloudThreatDetectionCheckStructureRead(d *schema.ResourceData,
 		}
 	}
 
-	var request map[string]interface{}
-	var response map[string]interface{}
-	var query map[string]interface{}
 	action := "GetCheckStructure"
+	request := map[string]interface{}{
+		"RegionId": client.RegionId,
+	}
+	query := map[string]interface{}{}
+	var response map[string]interface{}
 	var err error
-	request = make(map[string]interface{})
-	query = make(map[string]interface{})
-	request["RegionId"] = client.RegionId
-	if v, ok := d.GetOkExists("current_page"); ok {
+
+	if v := d.Get("current_page").(int); v > 0 {
 		request["CurrentPage"] = v
+	}
+	if v := d.Get("page_size").(int); v > 0 {
+		request["PageSize"] = v
 	}
 	if v, ok := d.GetOk("lang"); ok {
 		request["Lang"] = v
 	}
 	if v, ok := d.GetOk("task_sources"); ok {
-		taskSourcesMapsArray := convertToInterfaceArray(v)
-
-		request["TaskSources"] = taskSourcesMapsArray
+		request["TaskSources"] = convertToInterfaceArray(v)
 	}
 
 	runtime := util.RuntimeOptions{}
@@ -166,72 +198,69 @@ func dataSourceAliCloudThreatDetectionCheckStructureRead(d *schema.ResourceData,
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 
-	resp, _ := jsonpath.Get("$.CheckStructureResponse[*]", response)
+	respBytes, err := json.Marshal(response)
+	if err != nil {
+		return WrapError(err)
+	}
+	var parsed checkStructureResponse
+	if err := json.Unmarshal(respBytes, &parsed); err != nil {
+		return WrapError(err)
+	}
 
-	result, _ := resp.([]interface{})
-	for _, v := range result {
-		item := v.(map[string]interface{})
-		if len(idsMap) > 0 {
-			if _, ok := idsMap[fmt.Sprint()]; !ok {
-				continue
+	objects := make([]checkStructureItem, 0, len(parsed.CheckStructureResponse))
+	for _, item := range parsed.CheckStructureResponse {
+		matched := make([]checkStructureStd, 0, len(item.Standards))
+		for _, std := range item.Standards {
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(std.Id)]; !ok {
+					continue
+				}
 			}
+			matched = append(matched, std)
 		}
-		objects = append(objects, item)
+		if len(matched) == 0 {
+			continue
+		}
+		objects = append(objects, checkStructureItem{
+			StandardType: item.StandardType,
+			Standards:    matched,
+		})
 	}
 
 	ids := make([]string, 0)
-	names := make([]interface{}, 0)
-	s := make([]map[string]interface{}, 0)
-	for _, objectRaw := range objects {
-		mapping := map[string]interface{}{}
-
-		mapping["standard_type"] = objectRaw["StandardType"]
-
-		standardsRaw := objectRaw["Standards"]
-		standardsMaps := make([]map[string]interface{}, 0)
-		if standardsRaw != nil {
-			for _, standardsChildRaw := range convertToInterfaceArray(standardsRaw) {
-				standardsMap := make(map[string]interface{})
-				standardsChildRaw := standardsChildRaw.(map[string]interface{})
-				standardsMap["id"] = standardsChildRaw["Id"]
-				standardsMap["show_name"] = standardsChildRaw["ShowName"]
-				standardsMap["type"] = standardsChildRaw["Type"]
-
-				requirementsRaw := standardsChildRaw["Requirements"]
-				requirementsMaps := make([]map[string]interface{}, 0)
-				if requirementsRaw != nil {
-					for _, requirementsChildRaw := range convertToInterfaceArray(requirementsRaw) {
-						requirementsMap := make(map[string]interface{})
-						requirementsChildRaw := requirementsChildRaw.(map[string]interface{})
-						requirementsMap["id"] = requirementsChildRaw["Id"]
-						requirementsMap["show_name"] = requirementsChildRaw["ShowName"]
-						requirementsMap["total_check_count"] = requirementsChildRaw["TotalCheckCount"]
-
-						sectionsRaw := requirementsChildRaw["Sections"]
-						sectionsMaps := make([]map[string]interface{}, 0)
-						if sectionsRaw != nil {
-							for _, sectionsChildRaw := range convertToInterfaceArray(sectionsRaw) {
-								sectionsMap := make(map[string]interface{})
-								sectionsChildRaw := sectionsChildRaw.(map[string]interface{})
-								sectionsMap["id"] = sectionsChildRaw["Id"]
-								sectionsMap["show_name"] = sectionsChildRaw["ShowName"]
-
-								sectionsMaps = append(sectionsMaps, sectionsMap)
-							}
-						}
-						requirementsMap["sections"] = sectionsMaps
-						requirementsMaps = append(requirementsMaps, requirementsMap)
-					}
+	s := make([]map[string]interface{}, 0, len(objects))
+	for _, object := range objects {
+		standardsMaps := make([]map[string]interface{}, 0, len(object.Standards))
+		for _, std := range object.Standards {
+			requirementsMaps := make([]map[string]interface{}, 0, len(std.Requirements))
+			for _, req := range std.Requirements {
+				sectionsMaps := make([]map[string]interface{}, 0, len(req.Sections))
+				for _, sec := range req.Sections {
+					sectionsMaps = append(sectionsMaps, map[string]interface{}{
+						"id":        sec.Id,
+						"show_name": sec.ShowName,
+					})
 				}
-				standardsMap["requirements"] = requirementsMaps
-				standardsMaps = append(standardsMaps, standardsMap)
+				requirementsMaps = append(requirementsMaps, map[string]interface{}{
+					"id":                req.Id,
+					"show_name":         req.ShowName,
+					"total_check_count": req.TotalCheckCount,
+					"sections":          sectionsMaps,
+				})
 			}
+			standardsMaps = append(standardsMaps, map[string]interface{}{
+				"id":           std.Id,
+				"show_name":    std.ShowName,
+				"type":         std.Type,
+				"requirements": requirementsMaps,
+			})
+			ids = append(ids, fmt.Sprint(std.Id))
 		}
-		mapping["standards"] = standardsMaps
 
-		ids = append(ids, fmt.Sprint(mapping["id"]))
-		names = append(names, objectRaw[""])
-		s = append(s, mapping)
+		s = append(s, map[string]interface{}{
+			"standard_type": object.StandardType,
+			"standards":     standardsMaps,
+		})
 	}
 
 	d.SetId(dataResourceIdHash(ids))

--- a/alicloud/data_source_alicloud_threat_detection_check_structures_test.go
+++ b/alicloud/data_source_alicloud_threat_detection_check_structures_test.go
@@ -1,4 +1,3 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
@@ -10,16 +9,32 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-func TestAccAlicloudThreatDetectionCheckStructureDataSource(t *testing.T) {
-	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+func TestAccAliCloudThreatDetectionCheckStructuresDataSource(t *testing.T) {
 	rand := acctest.RandIntRange(1000000, 9999999)
 
-	ThreatDetectionCheckStructureCheckInfo.dataSourceTestCheck(t, rand)
+	pagingConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudThreatDetectionCheckStructureSourceConfig(rand, map[string]string{
+			"lang":         `"zh"`,
+			"current_page": `1`,
+			"page_size":    `10`,
+		}),
+		fakeConfig: testAccCheckAlicloudThreatDetectionCheckStructureSourceConfig(rand, map[string]string{
+			"lang":         `"zh"`,
+			"current_page": `1`,
+			"page_size":    `10`,
+			"ids":          `["fake-id-not-exist"]`,
+		}),
+	}
+
+	preCheck := func() {
+		testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	}
+	ThreatDetectionCheckStructureCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, pagingConf)
 }
 
 var existThreatDetectionCheckStructureMapFunc = func(rand int) map[string]string {
 	return map[string]string{
-		"structures.#":               "1",
+		"structures.#":               CHECKSET,
 		"structures.0.standards.#":   CHECKSET,
 		"structures.0.standard_type": CHECKSET,
 	}
@@ -44,7 +59,7 @@ func testAccCheckAlicloudThreatDetectionCheckStructureSourceConfig(rand int, att
 	}
 	config := fmt.Sprintf(`
 variable "name" {
-	default = "tf-testAccThreatDetectionCheckStructure%d"
+  default = "tf-testAccThreatDetectionCheckStructure%d"
 }
 
 data "alicloud_threat_detection_check_structures" "default" {

--- a/website/docs/d/threat_detection_check_item_configs.html.markdown
+++ b/website/docs/d/threat_detection_check_item_configs.html.markdown
@@ -21,6 +21,9 @@ provider "alicloud" {
 }
 
 data "alicloud_threat_detection_check_item_configs" "default" {
+  lang        = "zh"
+  page_number = 1
+  page_size   = 10
 }
 
 output "alicloud_threat_detection_check_item_config_example_check_id" {
@@ -31,12 +34,12 @@ output "alicloud_threat_detection_check_item_config_example_check_id" {
 ## Argument Reference
 
 The following arguments are supported:
-* `lang` - (ForceNew, Optional) The language of the content within the request and response. Default value: **zh**. Valid value:*   **zh**: Chinese*   **en**: English
-* `page_number` - (ForceNew, Optional) Current page number.
-* `page_size` - (ForceNew, Optional) Number of records per page.
-* `task_sources` - (ForceNew, Optional) List of task sources.
-* `ids` - (Optional, ForceNew, Computed) A list of Check Item Config IDs. 
-* `output_file` - (Optional, ForceNew) File name where to save data source results (after running `terraform plan`).
+* `lang` - (Optional) The language of the content within the request and response. Default value: `zh`. Valid values: `zh` (Chinese), `en` (English).
+* `page_number` - (Optional) The page number. Must be greater than 0.
+* `page_size` - (Optional) Number of records per page. Must be greater than 0.
+* `task_sources` - (Optional) List of task sources.
+* `ids` - (Optional, Computed) A list of Check Item Config IDs.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
 
 ## Attributes Reference
@@ -44,21 +47,48 @@ The following arguments are supported:
 The following attributes are exported in addition to the arguments listed above:
 * `ids` - A list of Check Item Config IDs.
 * `configs` - A list of Check Item Config Entries. Each element contains the following attributes:
-  * `check_id` - The ID of the check item
-  * `check_show_name` - The name of the check item.
-  * `check_type` - The source type of the Situation Awareness check item. Value:- **CUSTOM**: user-defined- **SYSTEM**: Predefined by the situational awareness platform
-  * `custom_configs` - The custom configuration items of the check item.
-    * `default_value` - The default value of the custom configuration item. The value is a string.
-    * `name` - The name of the custom configuration item, which is unique in a check item.
-    * `show_name` - The display name of the custom configuration item for internationalization.
-    * `type_define` - The type of the custom configuration item. The value is a JSON string.
-    * `value` - The value of the custom configuration item. The value is a string.
-  * `description` - The description of the check item.
-    * `type` - The type of the description of the check item. Valid value:*   **text**.
-    * `value` - The content of the description for the check item when the Type parameter is text.
-  * `estimated_count` - The estimated quota that will be consumed by this check item.
-  * `instance_sub_type` - The asset subtype of the cloud service. Valid values:*   If **InstanceType** is set to **ECS**, this parameter supports the following valid values:    *   **INSTANCE**    *   **DISK**    *   **SECURITY_GROUP***   If **InstanceType** is set to **ACR**, this parameter supports the following valid values:    *   **REPOSITORY_ENTERPRISE**    *   **REPOSITORY_PERSON***   If **InstanceType** is set to **RAM**, this parameter supports the following valid values:    *   **ALIAS**    *   **USER**    *   **POLICY**    *   **GROUP***   If **InstanceType** is set to **WAF**, this parameter supports the following valid value:    *   **DOMAIN***   If **InstanceType** is set to other values, this parameter supports the following valid values:    *   **INSTANCE**
-  * `instance_type` - The asset type of the cloud service. Valid values:*   **ECS**: Elastic Compute Service (ECS).*   **SLB**: Server Load Balancer (SLB).*   **RDS**: ApsaraDB RDS.*   **MONGODB**: ApsaraDB for MongoDB (MongoDB).*   **KVSTORE**: ApsaraDB for Redis (Redis).*   **ACR**: Container Registry.*   **CSK**: Container Service for Kubernetes (ACK).*   **VPC**: Virtual Private Cloud (VPC).*   **ACTIONTRAIL**: ActionTrail.*   **CDN**: Alibaba Cloud CDN (CDN).*   **CAS**: Certificate Management Service (formerly SSL Certificates Service).*   **RDC**: Apsara Devops.*   **RAM**: Resource Access Management (RAM).*   **DDOS**: Anti-DDoS.*   **WAF**: Web Application Firewall (WAF).*   **OSS**: Object Storage Service (OSS).*   **POLARDB**: PolarDB.*   **POSTGRESQL**: ApsaraDB RDS for PostgreSQL.*   **MSE**: Microservices Engine (MSE).*   **NAS**: File Storage NAS (NAS).*   **SDDP**: Sensitive Data Discovery and Protection (SDDP).*   **EIP**: Elastic IP Address (EIP).
-  * `risk_level` - The risk level of the check item. Valid values:*   **HIGH***   **MEDIUM***   **LOW**
-  * `section_ids` - The IDs of the sections associated with the check items.
-  * `vendor` - The type of the cloud asset. Valid values:*   **0**: an asset provided by Alibaba Cloud.*   **1**: an asset outside Alibaba Cloud.*   **2**: an asset in a data center.*   **3**, **4**, **5**, and **7**: other cloud asset.*   **8**: a simple application server.
+    * `check_id` - The ID of the check item.
+    * `check_show_name` - The name of the check item.
+    * `check_type` - The source type of the Situation Awareness check item. Valid values: `CUSTOM` (user-defined), `SYSTEM` (predefined by the situational awareness platform).
+    * `custom_configs` - The custom configuration items of the check item.
+      * `default_value` - The default value of the custom configuration item. The value is a string.
+      * `name` - The name of the custom configuration item, which is unique in a check item.
+      * `show_name` - The display name of the custom configuration item for internationalization.
+      * `type_define` - The type of the custom configuration item. The value is a JSON string.
+      * `value` - The value of the custom configuration item. The value is a string.
+    * `description` - The description of the check item.
+      * `type` - The type of the description of the check item. Valid value: `text`.
+      * `value` - The content of the description for the check item when the Type parameter is text.
+    * `estimated_count` - The estimated quota that will be consumed by this check item.
+    * `instance_sub_type` - The asset subtype of the cloud service. Valid values depend on `instance_type`:
+      * `ECS`: `INSTANCE`, `DISK`, `SECURITY_GROUP`.
+      * `ACR`: `REPOSITORY_ENTERPRISE`, `REPOSITORY_PERSON`.
+      * `RAM`: `ALIAS`, `USER`, `POLICY`, `GROUP`.
+      * `WAF`: `DOMAIN`.
+      * Other values: `INSTANCE`.
+    * `instance_type` - The asset type of the cloud service. Valid values:
+      * `ECS`: Elastic Compute Service.
+      * `SLB`: Server Load Balancer.
+      * `RDS`: ApsaraDB RDS.
+      * `MONGODB`: ApsaraDB for MongoDB.
+      * `KVSTORE`: ApsaraDB for Redis.
+      * `ACR`: Container Registry.
+      * `CSK`: Container Service for Kubernetes.
+      * `VPC`: Virtual Private Cloud.
+      * `ACTIONTRAIL`: ActionTrail.
+      * `CDN`: Alibaba Cloud CDN.
+      * `CAS`: Certificate Management Service.
+      * `RDC`: Apsara DevOps.
+      * `RAM`: Resource Access Management.
+      * `DDOS`: Anti-DDoS.
+      * `WAF`: Web Application Firewall.
+      * `OSS`: Object Storage Service.
+      * `POLARDB`: PolarDB.
+      * `POSTGRESQL`: ApsaraDB RDS for PostgreSQL.
+      * `MSE`: Microservices Engine.
+      * `NAS`: File Storage NAS.
+      * `SDDP`: Sensitive Data Discovery and Protection.
+      * `EIP`: Elastic IP Address.
+    * `risk_level` - The risk level of the check item. Valid values: `HIGH`, `MEDIUM`, `LOW`.
+    * `section_ids` - The IDs of the sections associated with the check items.
+    * `vendor` - The type of the cloud asset. Valid values: `0` (an asset provided by Alibaba Cloud), `1` (an asset outside Alibaba Cloud), `2` (an asset in a data center), `3`/`4`/`5`/`7` (other cloud asset), `8` (a simple application server).

--- a/website/docs/d/threat_detection_check_structures.html.markdown
+++ b/website/docs/d/threat_detection_check_structures.html.markdown
@@ -21,7 +21,9 @@ provider "alicloud" {
 }
 
 data "alicloud_threat_detection_check_structures" "default" {
-
+  lang         = "zh"
+  current_page = 1
+  page_size    = 10
 }
 
 output "alicloud_threat_detection_check_structure_example_standard_type" {
@@ -32,11 +34,12 @@ output "alicloud_threat_detection_check_structure_example_standard_type" {
 ## Argument Reference
 
 The following arguments are supported:
-* `current_page` - (ForceNew, Optional) The page number.
-* `lang` - (ForceNew, Optional) The language of the content within the request and response. Default value: zh. Valid values:- **zh**: Chinese- **en**: English
-* `task_sources` - (ForceNew, Optional) List of task sources.
-* `ids` - (Optional, ForceNew, Computed) A list of Check Structure IDs.
-* `output_file` - (Optional, ForceNew) File name where to save data source results (after running `terraform plan`).
+* `lang` - (Optional) The language of the content within the request and response. Default value: `zh`. Valid values: `zh` (Chinese), `en` (English).
+* `current_page` - (Optional) The page number. Must be greater than 0.
+* `page_size` - (Optional) Number of records per page. Must be greater than 0.
+* `task_sources` - (Optional) List of task sources.
+* `ids` - (Optional, Computed) A list of standard IDs (matches `structures.*.standards.*.id`). When set, only structures containing at least one matching standard are returned.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
 
 ## Attributes Reference
@@ -44,15 +47,15 @@ The following arguments are supported:
 The following attributes are exported in addition to the arguments listed above:
 * `ids` - A list of Check Structure IDs.
 * `structures` - A list of Check Structure Entries. Each element contains the following attributes:
-  * `standard_type` - The type of the check item.- **RISK**: security risk.- **IDENTITY_PERMISSION**: Cloud Infrastructure Entitlement Management (CIEM).- **COMPLIANCE**: security compliance.
-  * `standards` - The structure information about the check items of the business type.
-    * `id` - The standard ID of the check item.
-    * `requirements` - The standards of the check items.
-      * `id` - The ID of the requirement item for the check item.
-      * `sections` - The information about the sections of check items.
-        * `id` - The ID of the section for the check item.
-        * `show_name` - The display name of the section for the check item.
-      * `show_name` - The display name of the requirement item for the check item.
-      * `total_check_count` - The total number of check items for the requirement.
-    * `show_name` - The display name of the standard for the check item.
-    * `type` - The standard type of the check item. Valid values:- **RISK**: security risk.- **IDENTITY_PERMISSION**: CIEM.- **COMPLIANCE**: security compliance.
+    * `standard_type` - The type of the check item. Valid values: `RISK` (security risk), `IDENTITY_PERMISSION` (Cloud Infrastructure Entitlement Management, CIEM), `COMPLIANCE` (security compliance).
+    * `standards` - The structure information about the check items of the business type.
+      * `id` - The standard ID of the check item.
+      * `show_name` - The display name of the standard for the check item.
+      * `type` - The standard type of the check item. Valid values: `RISK` (security risk), `IDENTITY_PERMISSION` (CIEM), `COMPLIANCE` (security compliance).
+      * `requirements` - The standards of the check items.
+        * `id` - The ID of the requirement item for the check item.
+        * `show_name` - The display name of the requirement item for the check item.
+        * `total_check_count` - The total number of check items for the requirement.
+        * `sections` - The information about the sections of check items.
+          * `id` - The ID of the section for the check item.
+          * `show_name` - The display name of the section for the check item.


### PR DESCRIPTION
Refactor these two completely unusable resources.

threat_detection: fix check_item_configs/check_structures data sources
- check_structures: GetCheckStructure response was decoded with jsonpath
- interface casts that panicked on the Standards array. Parse via typed structs. The ids filter matched against StandardType (a constant like "RISK") instead of standard ids, so no useful filtering was possible. Now filters by Standards[].Id and prunes non-matching standards.

check_item_configs: pagination uses d.Get(...).(int) > 0; request map built as a literal.
- Docs: auto-generated docs marked every argument as ForceNew (data sources have no ForceNew), smushed bullet lists, omitted page_size, and described the ids filter incorrectly. Fixed.

```log
=== RUN   TestAccAliCloudThreatDetectionCheckStructuresDataSource
--- PASS: TestAccAliCloudThreatDetectionCheckStructuresDataSource (4.86s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  9.295s
=== RUN   TestAccAliCloudThreatDetectionCheckItemConfigsDataSource
--- PASS: TestAccAliCloudThreatDetectionCheckItemConfigsDataSource (4.61s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  7.141s

```