### PR TITLE
resource/alicloud_vswitch: require ipv6_cidr_block_mask when enabling enable_ipv6

### DIFF
--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -295,21 +295,35 @@ func resourceAliCloudVpcVswitchUpdate(d *schema.ResourceData, meta interface{}) 
 		update = true
 	}
 
-	if !d.IsNewResource() && d.HasChange("ipv6_cidr_block_mask") {
-		err := CancelIpv6(d, meta)
-		if err != nil {
-			return WrapError(err)
-		}
-		if v, ok := d.GetOkExists("ipv6_cidr_block_mask"); ok {
+	// enable_ipv6 and ipv6_cidr_block_mask are handled together: the mask only takes effect
+	// when IPv6 is enabled, so the desired enable_ipv6 state drives the whole request.
+	if !d.IsNewResource() && (d.HasChange("enable_ipv6") || d.HasChange("ipv6_cidr_block_mask")) {
+		if d.Get("enable_ipv6").(bool) {
+			// Enabling IPv6 (or re-assigning its subnet) requires ipv6_cidr_block_mask: the
+			// ModifyVSwitchAttribute API rejects EnableIPv6=true without Ipv6CidrBlock. Require it
+			// here so the user gets a clear, early error instead of the opaque backend one, and so
+			// we never silently fall back to subnet 0.
+			if _, ok := d.GetOkExists("ipv6_cidr_block_mask"); !ok {
+				return WrapError(fmt.Errorf("`ipv6_cidr_block_mask` is required when enabling `enable_ipv6` for an existing vswitch"))
+			}
+			// When only the subnet changes while IPv6 is already enabled, the existing block must
+			// be released first (it cannot be re-assigned in place), so disable then re-enable.
+			if !d.HasChange("enable_ipv6") {
+				if err := CancelIpv6(d, meta); err != nil {
+					return WrapError(err)
+				}
+			}
 			update = true
 			request["EnableIPv6"] = true
-			request["Ipv6CidrBlock"] = v
+			request["Ipv6CidrBlock"] = d.Get("ipv6_cidr_block_mask")
+		} else if d.HasChange("enable_ipv6") {
+			// Disabling IPv6. Ipv6CidrBlock is only written in the branch above, which is mutually
+			// exclusive with this one, so there is nothing to delete here (the API also forbids
+			// sending Ipv6CidrBlock when disabling).
+			update = true
+			request["EnableIPv6"] = false
 		}
-	}
-
-	if !d.IsNewResource() && d.HasChange("enable_ipv6") {
-		update = true
-		request["EnableIPv6"] = d.Get("enable_ipv6")
+		// enable_ipv6 is false and unchanged (only the mask changed) -> no IPv6 change needed.
 	}
 
 	if update {

--- a/alicloud/resource_alicloud_vswitch_test.go
+++ b/alicloud/resource_alicloud_vswitch_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -742,6 +743,310 @@ func TestAccAliCloudVPCVSwitch_ipv6MaskSetZero(t *testing.T) {
 						}
 						return nil
 					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccAliCloudVPCVSwitch_enableIpv6FalseAfterComputedTrue(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":              "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":               "${alicloud_vpc.default.id}",
+					"cidr_block":           "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+					"ipv6_cidr_block_mask": "4",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "4"),
+					resource.TestCheckResourceAttrSet(resourceId, "ipv6_cidr_block"),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6":          false,
+					"ipv6_cidr_block_mask": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[resourceId]
+						if !ok {
+							return fmt.Errorf("resource not found: %s", resourceId)
+						}
+						if got := rs.Primary.Attributes["ipv6_cidr_block"]; got != "" {
+							return fmt.Errorf("expected ipv6_cidr_block to be empty after enable_ipv6=false, got %q", got)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccAliCloudVPCVSwitch_ipv6EnableZeroMaskFromDisabled(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":    "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":     "${alicloud_vpc.default.id}",
+					"cidr_block": "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6":          true,
+					"ipv6_cidr_block_mask": 0,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "0"),
+					resource.TestCheckResourceAttrSet(resourceId, "ipv6_cidr_block"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAliCloudVPCVSwitch_ipv6EnableNoMask: enabling IPv6 on an existing vswitch
+// (enable_ipv6 false -> true) WITHOUT ipv6_cidr_block_mask must fail fast with a clear
+// provider error — instead of silently sending Ipv6CidrBlock=0 (forcing subnet 0) or
+// letting the backend return the opaque MissingParam.Ipv6CidrBlock. The ModifyVSwitchAttribute
+// API requires Ipv6CidrBlock whenever EnableIPv6=true.
+func TestAccAliCloudVPCVSwitch_ipv6EnableNoMask(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// Step 0: create the vswitch without IPv6.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":    "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":     "${alicloud_vpc.default.id}",
+					"cidr_block": "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+				),
+			},
+			// Step 1: enable IPv6 with NO ipv6_cidr_block_mask -> must error (not silently use 0).
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6": true,
+				}),
+				ExpectError: regexp.MustCompile("ipv6_cidr_block_mask.*is required when enabling"),
+			},
+		},
+	})
+}
+
+// TestAccAliCloudVPCVSwitch_ipv6EnableWithMask: enabling IPv6 on an existing vswitch WITH
+// ipv6_cidr_block_mask set works normally — Ipv6CidrBlock is sent with the user's value.
+func TestAccAliCloudVPCVSwitch_ipv6EnableWithMask(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// Step 0: create the vswitch without IPv6.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":    "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":     "${alicloud_vpc.default.id}",
+					"cidr_block": "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+				),
+			},
+			// Step 1: enable IPv6 WITH a mask -> succeeds.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6":          true,
+					"ipv6_cidr_block_mask": 8,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "8"),
+					resource.TestCheckResourceAttrSet(resourceId, "ipv6_cidr_block"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAliCloudVPCVSwitch_ipv6MaskWhileDisabled: setting/changing ipv6_cidr_block_mask while
+// IPv6 is disabled (enable_ipv6 is not true and not changing) must NOT enable IPv6. The mask
+// only takes effect when enable_ipv6 is true; it must never silently turn IPv6 on by itself.
+func TestAccAliCloudVPCVSwitch_ipv6MaskWhileDisabled(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// Step 0: create without IPv6.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":    "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":     "${alicloud_vpc.default.id}",
+					"cidr_block": "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+				),
+			},
+			// Step 1: set ipv6_cidr_block_mask but DON'T enable IPv6 -> IPv6 must stay disabled
+			// (enable_ipv6 stays false); the mask is recorded but has no effect.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ipv6_cidr_block_mask": 8,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "8"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAliCloudVPCVSwitch_ipv6ReenableSameMaskAfterDisable(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vswitch.default"
+	ra := resourceAttrInit(resourceId, AlicloudVswitchMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVswitch")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%svswitch%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVswitchBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":              "${data.alicloud_zones.default.zones.0.id}",
+					"vpc_id":               "${alicloud_vpc.default.id}",
+					"cidr_block":           "${cidrsubnet(alicloud_vpc.default.cidr_block, 4, 2)}",
+					"enable_ipv6":          true,
+					"ipv6_cidr_block_mask": 4,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "4"),
+					resource.TestCheckResourceAttrSet(resourceId, "ipv6_cidr_block"),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6":          false,
+					"ipv6_cidr_block_mask": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "false"),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_ipv6":          true,
+					"ipv6_cidr_block_mask": 4,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceId, "enable_ipv6", "true"),
+					resource.TestCheckResourceAttr(resourceId, "ipv6_cidr_block_mask", "4"),
+					resource.TestCheckResourceAttrSet(resourceId, "ipv6_cidr_block"),
 				),
 			},
 		},

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -72,6 +72,9 @@ The description must be 1 to 256 characters in length, and cannot start with `ht
 * `enable_ipv6` - (Optional, Computed, Available since v1.119.0) Whether to enable the IPv6 network segment. Value:
   - `false` (default): Not enabled.
   - `true`: enabled.
+
+-> **NOTE:** If you use the `alicloud_vpc_ipv6_cidr_block` resource to add an IPv6 CIDR block to the VPC, you do not need to set `enable_ipv6`.
+
 * `force_delete` - (Optional, Available since v1.248.0) Force delete vpc or not.
 * `ipv4_cidr_mask` - (Optional, Int, Available since v1.240.0) Allocate VPC from The IPAM address pool by entering a mask.
 

--- a/website/docs/r/vpc_ipv6_cidr_block.html.markdown
+++ b/website/docs/r/vpc_ipv6_cidr_block.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a VPC Ipv6 Cidr Block resource.
 
-VPC IPv6 supplementary CIDR block.
+VPC IPv6 additional CIDR block.
 
 For information about VPC Ipv6 Cidr Block and how to use it, see [What is Ipv6 Cidr Block](https://next.api.alibabacloud.com/document/Vpc/2016-04-28/AssociateVpcCidrBlock).
 
@@ -19,12 +19,6 @@ For information about VPC Ipv6 Cidr Block and how to use it, see [What is Ipv6 C
 ## Example Usage
 
 Basic Usage
-
-<div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
-  <a href="https://api.aliyun.com/terraform?resource=alicloud_vpc_ipv6_cidr_block&exampleId=1ff2fce0-4f79-91fb-b641-a82d9d5f08dbd24940a5&activeTab=example&spm=docs.r.vpc_ipv6_cidr_block.0.1ff2fce04f&intl_lang=EN_US" target="_blank">
-    <img alt="Open in AliCloud" src="https://img.alicdn.com/imgextra/i1/O1CN01hjjqXv1uYUlY56FyX_!!6000000006049-55-tps-254-36.svg" style="max-height: 44px; max-width: 100%;">
-  </a>
-</div></div>
 
 ```terraform
 variable "name" {
@@ -40,14 +34,15 @@ resource "alicloud_vpc_ipam_ipam" "defaultIpam" {
 }
 
 resource "alicloud_vpc_ipam_ipam_pool" "defaultIpv6Pool" {
-  ipam_scope_id  = alicloud_vpc_ipam_ipam.defaultIpam.private_default_scope_id
+  ipam_scope_id  = alicloud_vpc_ipam_ipam.defaultIpam.public_default_scope_id
   pool_region_id = alicloud_vpc_ipam_ipam.defaultIpam.region_id
   ip_version     = "IPv6"
+  ipv6_isp       = "BGP"
 }
 
 resource "alicloud_vpc_ipam_ipam_pool_cidr" "defaultIpv6PoolCidr" {
-  ipam_pool_id = alicloud_vpc_ipam_ipam_pool.defaultIpv6Pool.id
-  cidr         = "fd03:d00:a000::/48"
+  ipam_pool_id   = alicloud_vpc_ipam_ipam_pool.defaultIpv6Pool.id
+  netmask_length = 56
 }
 
 resource "alicloud_vpc" "defaultVpc" {
@@ -55,11 +50,10 @@ resource "alicloud_vpc" "defaultVpc" {
   vpc_name   = "example-ipv6-cidr-block"
 }
 
-
 resource "alicloud_vpc_ipv6_cidr_block" "default" {
   ipv6_ipam_pool_id = alicloud_vpc_ipam_ipam_pool.defaultIpv6Pool.id
   vpc_id            = alicloud_vpc.defaultVpc.id
-  ipv6_cidr_block   = "fd03:d00:a000::/60"
+  ipv6_cidr_mask    = 56
 }
 ```
 
@@ -70,18 +64,18 @@ resource "alicloud_vpc_ipv6_cidr_block" "default" {
 ## Argument Reference
 
 The following arguments are supported:
-* `ipv6_cidr_block` - (Optional, ForceNew, Computed) The additional IPv6 CIDR block to be removed.
+* `ipv6_cidr_block` - (Optional, ForceNew, Computed) The additional IPv6 CIDR block. Both `ipv6_cidr_block` and `ipv6_cidr_mask` are optional and can be left empty. If neither is specified, the system automatically allocates a `/56` IPv6 CIDR block to the VPC from the Alibaba Cloud GUA address pool.
 
--> **NOTE:**  You must specify either the `Ipv6CidrBlock` parameter or the `SecondaryCidrBlock` parameter, but not both.
+-> **NOTE:**  If you specify `ipv6_cidr_block`, the CIDR block must be reserved beforehand by calling the AllocateVpcIpv6Cidr operation, or you can specify `ipv6_ipam_pool_id` instead. If you specify `ipv6_cidr_mask`, you must also specify `ipv6_ipam_pool_id`.
 
-* `ipv6_cidr_mask` - (Optional, Int) Add an IPv6 CIDR block to the VPC from an IPAM pool by specifying a subnet mask.
+* `ipv6_cidr_mask` - (Optional, Int) The IPv6 CIDR mask used to allocate an IPv6 CIDR block from the IPAM address pool to the VPC.
 
--> **NOTE:**  When adding an additional IPv6 CIDR block to a VPC from an IPAM pool, you must specify at least one of the `Ipv6CidrBlock` or `Ipv6CidrMask` parameters.
+-> **NOTE:**  When assigning an additional IPv6 CIDR block from an IPAM address pool to a VPC, you must specify at least one of the `Ipv6CidrBlock` or `Ipv6CidrMask` properties.
 
 
 -> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
 
-* `ipv6_ipam_pool_id` - (Optional) The ID of the IPAM pool instance.
+* `ipv6_ipam_pool_id` - (Optional) The ID of the IPAM IPv6 address pool instance.
 
 -> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
 

--- a/website/docs/r/vswitch.html.markdown
+++ b/website/docs/r/vswitch.html.markdown
@@ -123,7 +123,15 @@ The following arguments are supported:
 * `enable_ipv6` - (Optional, Computed, Available since v1.201.0) Whether the IPv6 function is enabled in the switch. Value:
   - `true`: enables IPv6.
   - `false` (default): IPv6 is not enabled.
-* `ipv6_cidr_block_mask` - (Optional, Available since v1.201.0) The IPv6 CIDR block of the VSwitch. This parameter is used only for create and update operations.
+
+-> **NOTE:** Since v1.281.0, `ipv6_cidr_block_mask` only takes effect when `enable_ipv6` is `true`, and it is required when `enable_ipv6` is `true`.
+
+-> **NOTE:** When `enable_ipv6` is `true`, modifying `ipv6_cidr_block_mask` will disable IPv6 and then re-enable it to assign the new subnet. This re-assignment may interrupt the IPv6 service of the VSwitch, so plan such changes with care.
+
+* `ipv6_cidr_block_mask` - (Optional, Available since v1.201.0) The last 4, 8, or 12 bits of the IPv6 CIDR block of the VSwitch, corresponding to a VPC IPv6 address mask of `60`, `56`, or `52` respectively. It only takes effect and is required when `enable_ipv6` is `true`, and is used only for create and update operations. The valid values are determined by the IPv6 address mask of the VPC:
+  - When the VPC IPv6 address mask is `52`: `0` to `4095`.
+  - When the VPC IPv6 address mask is `56`: `0` to `255`.
+  - When the VPC IPv6 address mask is `60`: `0` to `15`.
 * `tags` - (Optional, Map, Available since v1.55.3) The tags of VSwitch.
 * `vswitch_name` - (Optional, Available since v1.119.0) The name of the VSwitch.
 * `vpc_id` - (Optional, ForceNew) The VPC ID. **NOTE:** From version 1.233.0, if you do not set `is_default`, or set `is_default` to `false`, `vpc_id` is required.


### PR DESCRIPTION
### Why

On an existing vSwitch, enabling IPv6 (`enable_ipv6 = true`) without `ipv6_cidr_block_mask` made the backend return the opaque `MissingParam.Ipv6CidrBlock`, and changing/setting the mask while IPv6 was disabled could unexpectedly turn IPv6 on.

### What

- `enable_ipv6` and `ipv6_cidr_block_mask` are handled in a single update path driven by the desired `enable_ipv6` state.
- Enabling IPv6 on an existing vSwitch requires `ipv6_cidr_block_mask` — a clear, early error is returned instead of the backend `MissingParam.Ipv6CidrBlock`, and the provider never silently falls back to subnet `0`. Explicitly setting `ipv6_cidr_block_mask = 0` is still honored.
- `ipv6_cidr_block_mask` only takes effect when `enable_ipv6` is `true`; setting it while IPv6 is disabled no longer force-enables IPv6.
- The create path is unchanged (no new validation), so existing create configs — including default vSwitches — are unaffected.
- Docs updated; acceptance tests added.

### Acceptance tests

```text
=== RUN   TestAccAliCloudVPCVSwitch_basic
--- PASS: TestAccAliCloudVPCVSwitch_basic (42.62s)

=== RUN   TestAccAliCloudVPCVSwitch_basic1
--- PASS: TestAccAliCloudVPCVSwitch_basic1 (25.97s)

=== RUN   TestAccAliCloudVPCVSwitch_basic2
--- PASS: TestAccAliCloudVPCVSwitch_basic2 (29.70s)

=== RUN   TestAccAliCloudVPCVSwitch_basic3
--- PASS: TestAccAliCloudVPCVSwitch_basic3 (25.92s)

=== RUN   TestAccAliCloudVPCVSwitch_basic4
--- PASS: TestAccAliCloudVPCVSwitch_basic4 (41.73s)

=== RUN   TestAccAliCloudVPCVSwitch_basic5
--- PASS: TestAccAliCloudVPCVSwitch_basic5 (51.91s)

=== RUN   TestAccAliCloudVPCVSwitch_basic3078
--- PASS: TestAccAliCloudVPCVSwitch_basic3078 (52.10s)

=== RUN   TestAccAliCloudVPCVSwitch_basic3078_twin
--- PASS: TestAccAliCloudVPCVSwitch_basic3078_twin (26.30s)

=== RUN   TestAccAliCloudVPCVSwitch_isDefault
--- PASS: TestAccAliCloudVPCVSwitch_isDefault (13.52s)

=== RUN   TestAccAliCloudVPCVSwitch_isDefault_twin
--- PASS: TestAccAliCloudVPCVSwitch_isDefault_twin (12.90s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6MaskRemoval
--- PASS: TestAccAliCloudVPCVSwitch_ipv6MaskRemoval (28.91s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6MaskSetZero
--- PASS: TestAccAliCloudVPCVSwitch_ipv6MaskSetZero (33.60s)

=== RUN   TestAccAliCloudVPCVSwitchesDataSourceBasic
--- PASS: TestAccAliCloudVPCVSwitchesDataSourceBasic (114.65s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6EnableNoMask
--- PASS: TestAccAliCloudVPCVSwitch_ipv6EnableNoMask (26.81s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6EnableWithMask
--- PASS: TestAccAliCloudVPCVSwitch_ipv6EnableWithMask (29.40s)

=== RUN   TestAccAliCloudVPCVSwitchesDataSourceCoverage
--- PASS: TestAccAliCloudVPCVSwitchesDataSourceCoverage (29.40s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6MaskWhileDisabled
--- PASS: TestAccAliCloudVPCVSwitch_ipv6MaskWhileDisabled (28.51s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6EnableZeroMaskFromDisabled
--- PASS: TestAccAliCloudVPCVSwitch_ipv6EnableZeroMaskFromDisabled (29.98s)

=== RUN   TestAccAliCloudVPCVSwitch_enableIpv6FalseAfterComputedTrue
--- PASS: TestAccAliCloudVPCVSwitch_enableIpv6FalseAfterComputedTrue (32.69s)

=== RUN   TestAccAliCloudVPCVSwitch_ipv6ReenableSameMaskAfterDisable
--- PASS: TestAccAliCloudVPCVSwitch_ipv6ReenableSameMaskAfterDisable (36.15s)

PASS
```
