### PR TITLE
resource/alicloud_db_instance: Add UsedTime/Period for UpgradeDBInstanceMajorVersion on Prepaid instances

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -1119,6 +1119,15 @@ func resourceAliCloudDBInstanceUpdate(d *schema.ResourceData, meta interface{}) 
 		if v, ok := d.GetOk("collect_stat_mode"); ok && v.(string) != "" {
 			request["CollectStatMode"] = v
 		}
+		if PayType(request["PayType"].(string)) == Prepaid {
+			period := d.Get("period").(int)
+			request["UsedTime"] = strconv.Itoa(period)
+			request["Period"] = Month
+			if period > 9 {
+				request["UsedTime"] = strconv.Itoa(period / 12)
+				request["Period"] = Year
+			}
+		}
 		wait = incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			response, err = client.RpcPost("Rds", "2014-08-15", action, nil, request, true)

--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -4228,6 +4228,100 @@ func TestAccAliCloudRdsDBInstancePostgreSQL(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudRdsDBInstance_PG_MajorVersionUpgrade_Prepaid(t *testing.T) {
+	var instance map[string]interface{}
+	resourceId := "alicloud_db_instance.default"
+	ra := resourceAttrInit(resourceId, instanceBasicMap7)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &instance, func() interface{} {
+		return &RdsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeDBInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAccDBInstanceConfig%d", rand.Intn(1000))
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceDBInstancePGMajorVersionUpgradePrepaidDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"engine":                   "PostgreSQL",
+					"engine_version":           "17.0",
+					"instance_type":            "pg.n4.2c.2m",
+					"instance_storage":         "30",
+					"instance_charge_type":     "Prepaid",
+					"period":                   "1",
+					"instance_name":            "${var.name}",
+					"vswitch_id":               "${data.alicloud_vswitches.default.ids.0}",
+					"db_instance_storage_type": "general_essd",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"engine":               "PostgreSQL",
+						"engine_version":       "17.0",
+						"instance_charge_type": "Prepaid",
+						"instance_name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"engine_version":    "18.0",
+					"collect_stat_mode": "Before",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"engine_version": "18.0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_charge_type": "Postpaid",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_charge_type": "Postpaid",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_restart", "period", "collect_stat_mode", "auto_renew", "auto_renew_period"},
+			},
+		},
+	})
+}
+
+func resourceDBInstancePGMajorVersionUpgradePrepaidDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "%s"
+}
+
+data "alicloud_db_zones" "default" {
+	engine         = "PostgreSQL"
+	engine_version = "17.0"
+}
+
+data "alicloud_vpcs" "default" {
+	name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+	vpc_id  = data.alicloud_vpcs.default.ids.0
+	zone_id = data.alicloud_db_zones.default.zones.0.id
+}
+`, name)
+}
+
 func resourceDBInstanceConfigGeneralEssdPgSql(name string) string {
 	templateName1 := fmt.Sprintf("tf-test%d", rand.Intn(1000))
 	templateName2 := fmt.Sprintf("tf-test%d", rand.Intn(1000))


### PR DESCRIPTION
- Add prepaid UsedTime/Period block in UpgradeDBInstanceMajorVersion request
- Fixes prepaid PostgreSQL instance upgrade failure due to missing parameters

The UpgradeDBInstanceMajorVersion API supports UsedTime/Period parameters for Prepaid instances (confirmed in rds_api_docs.json), but the current Terraform provider code only sets PayType without the purchase duration parameters. This causes prepaid PostgreSQL instances to fail when changing engine_version for major version upgrades.

This change adds the same prepaid UsedTime/Period block that already exists in ModifyDBInstanceSpec and TransformDBInstancePayType, using the same duration conversion logic (1-9 months, 12/24/36 months → years).