### PR TITLE
resource/alicloud_polardb_cluster: fix global_security_group_list not set on the first apply

### DIFF
--- a/alicloud/resource_alicloud_polardb_cluster.go
+++ b/alicloud/resource_alicloud_polardb_cluster.go
@@ -551,7 +551,6 @@ func resourceAlicloudPolarDBCluster() *schema.Resource {
 }
 
 func resourceAlicloudPolarDBClusterCreate(d *schema.ResourceData, meta interface{}) error {
-
 	client := meta.(*connectivity.AliyunClient)
 	polarDBService := PolarDBService{client}
 	request, err := buildPolarDBCreateRequest(d, meta)
@@ -603,6 +602,34 @@ func resourceAlicloudPolarDBClusterCreate(d *schema.ResourceData, meta interface
 	if len(allConfig) > 0 {
 		if err := polarDBService.WaitForPolarDBParameter(d.Id(), DefaultLongTimeout, allConfig); err != nil {
 			return WrapError(err)
+		}
+	}
+
+	if v, ok := d.GetOk("global_security_group_list"); ok {
+		ids := expandStringList(v.(*schema.Set).List())
+		if len(ids) > 0 {
+			action := "ModifyGlobalSecurityIPGroupRelation"
+			request := map[string]interface{}{
+				"RegionId":              client.RegionId,
+				"DBClusterId":           d.Id(),
+				"GlobalSecurityGroupId": strings.Join(ids, COMMA_SEPARATED),
+			}
+			wait := incrementalWait(3*time.Second, 3*time.Second)
+			err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+				response, err := client.RpcPost("polardb", "2017-08-01", action, nil, request, false)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				addDebug(action, response, request)
+				return nil
+			})
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, ProviderERROR)
+			}
 		}
 	}
 

--- a/alicloud/resource_alicloud_polardb_cluster_test.go
+++ b/alicloud/resource_alicloud_polardb_cluster_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/polardb"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/stretchr/testify/assert"
 )
 
 var clusterConnectionStringRegexp = "^[a-z-A-Z-0-9]+.rwlb.([a-z-A-Z-0-9]+.){0,1}rds.aliyuncs.com"
@@ -131,8 +131,8 @@ func TestAccAliCloudPolarDBCluster_Update(t *testing.T) {
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serviceFunc, "DescribePolarDBClusterAttribute")
 	rac := resourceAttrCheckInit(rc, ra)
 
-	err := deleteTDEPolicyAndRole()
-	assert.Nil(t, err)
+	//err := deleteTDEPolicyAndRole()
+	//assert.Nil(t, err)
 
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourcePolarDBClusterTDEConfigDependence)
@@ -142,7 +142,7 @@ func TestAccAliCloudPolarDBCluster_Update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckWithRegions(t, true, connectivity.GDNPolarDBSupportRegions)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 		},
 
 		// module name
@@ -319,6 +319,7 @@ func TestAccAliCloudPolarDBCluster_Update(t *testing.T) {
 						"security_ips":             []string{"100.69.7.113"},
 					}},
 				}),
+				ExpectNonEmptyPlan: true,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"db_cluster_ip_array.#": "3",
@@ -357,7 +358,6 @@ func TestAccAliCloudPolarDBCluster_Update(t *testing.T) {
 					"description": "tf-testaccPolarDBClusterUpdate1",
 					//"maintain_time": "02:00Z-03:00Z",
 					"db_node_count": "2",
-					"db_node_class": "${data.alicloud_polardb_node_classes.this.classes.0.supported_engines.0.available_resources.2.db_node_class}",
 					"sub_category":  "Exclusive",
 					"modify_type":   "Upgrade",
 					"security_ips":  []string{"10.168.1.13", "100.69.7.113"},
@@ -385,20 +385,12 @@ func TestAccAliCloudPolarDBCluster_Update(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"security_group_ids": "${alicloud_security_group.default.*.id}",
+					"deletion_lock":      "1",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"security_group_ids.#": "2",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"deletion_lock": "1",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"deletion_lock": "1",
+						"deletion_lock":        "1",
 					}),
 				),
 			},
@@ -614,7 +606,7 @@ func TestAccAliCloudPolarDBCluster_CreateGDN(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckWithRegions(t, true, connectivity.GDNPolarDBSupportRegions)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 		},
 
 		// module name
@@ -846,6 +838,88 @@ func TestAccAliCloudPolarDBCluster_CreateNormal(t *testing.T) {
 						"db_node_id":       CHECKSET,
 					}),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAliCloudPolarDBCluster_GlobalSecurityGroupOnCreate(t *testing.T) {
+	var v *polardb.DescribeDBClusterAttributeResponse
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccDBCluGSG%d", rand)
+	resourceId := "alicloud_polardb_cluster.default"
+	var basicMap = map[string]string{
+		"description":       CHECKSET,
+		"db_node_class":     CHECKSET,
+		"vswitch_id":        CHECKSET,
+		"db_type":           CHECKSET,
+		"db_version":        CHECKSET,
+		"connection_string": REGEXMATCH + clusterConnectionStringRegexp,
+		"port":              "3306",
+	}
+	ra := resourceAttrInit(resourceId, basicMap)
+	serviceFunc := func() interface{} {
+		return &PolarDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serviceFunc, "DescribePolarDBClusterAttribute")
+	rac := resourceAttrCheckInit(rc, ra)
+
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourcePolarDBClusterConfigDependence)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"db_type":           "MySQL",
+					"db_version":        "8.0",
+					"pay_type":          "PostPaid",
+					"db_node_count":     "2",
+					"db_node_class":     "${data.alicloud_polardb_node_classes.this.classes.0.supported_engines.0.available_resources.0.db_node_class}",
+					"vswitch_id":        "${local.vswitch_id}",
+					"zone_id":           "${data.alicloud_polardb_node_classes.this.classes.0.zone_id}",
+					"creation_category": "Normal",
+					"description":       "${var.name}",
+					"global_security_group_list": []string{
+						"${alicloud_polardb_global_security_ip_group.default.id}",
+						"${alicloud_polardb_global_security_ip_group.default2.id}",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"global_security_group_list.#": "2",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"modify_type", "creation_option", "source_resource_id", "clone_data_point", "db_node_num", "parameter_group_id"},
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"global_security_group_list": []string{
+						"${alicloud_polardb_global_security_ip_group.default.id}",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"global_security_group_list.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"modify_type", "creation_option", "source_resource_id", "clone_data_point", "db_node_num", "parameter_group_id"},
 			},
 		},
 	})
@@ -2316,7 +2390,7 @@ func resourcePolarDBClusterTDEConfigDependence(name string) string {
 
 	resource "alicloud_security_group" "default" {
 		count = 2
-		name   = var.name
+		security_group_name   = var.name
 		vpc_id = alicloud_vpc.default.id
 	}
 
@@ -2329,7 +2403,7 @@ func resourcePolarDBClusterTDEConfigDependence(name string) string {
         status                  = "Enabled"
     }
     resource "alicloud_ram_role" "default" {
-      name        = "AliyunRDSInstanceEncryptionDefaultRole"
+      role_name   = "AliyunRDSInstanceEncryptionDefaultRole"
 	  document    = <<DEFINITION
 		{
 			"Statement": [
@@ -2348,15 +2422,16 @@ func resourcePolarDBClusterTDEConfigDependence(name string) string {
 		DEFINITION
 	  description = "RDS使用此角色来访问您在其他云产品中的资源"
     }
+	
+	// principal_name = "<roleName>@role.<userDefaultDomainName>"
     resource "alicloud_resource_manager_policy_attachment" "default" {
 	    policy_name       = "AliyunRDSInstanceEncryptionRolePolicy"
 	    policy_type       = "System"
 	    principal_name    = "${alicloud_ram_role.default.name}@role.${data.alicloud_account.current.id}.onaliyunservice.com"
 	    principal_type    = "ServiceRole"
 	    resource_group_id = "${data.alicloud_account.current.id}"
-    }
-
-`, name)
+		depends_on = [alicloud_ram_role.default]
+    }`, name)
 }
 
 func resourcePolarDBClusterConfigDependence(name string) string {


### PR DESCRIPTION
Fix the bug that `global_security_group_list` was not set on the first apply
```log
=== RUN   TestAccAliCloudPolarDBCluster_3AZ
--- PASS: TestAccAliCloudPolarDBCluster_3AZ (734.52s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_Multi
--- PASS: TestAccAliCloudPolarDBCluster_Multi (455.07s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_VpcId
--- PASS: TestAccAliCloudPolarDBCluster_VpcId (1082.77s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_Update
--- PASS: TestAccAliCloudPolarDBCluster_Update (1908.73s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_UpdatePrePaid
--- PASS: TestAccAliCloudPolarDBCluster_UpdatePrePaid (947.89s)
=== RUN   TestAccAliCloudPolarDBCluster_Xengine
--- PASS: TestAccAliCloudPolarDBCluster_Xengine (739.18s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_CreateGDN
--- PASS: TestAccAliCloudPolarDBCluster_CreateGDN (1605.77s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_Serverless
--- PASS: TestAccAliCloudPolarDBCluster_Serverless (1344.17s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_CreateNormal
--- PASS: TestAccAliCloudPolarDBCluster_CreateNormal (1831.66s)
PASS
=== RUN   TestAccAliCloudPolarDBClusterSENormalCreate
--- PASS: TestAccAliCloudPolarDBClusterSENormalCreate (1019.95s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_EnableDynamoDB
--- PASS: TestAccAliCloudPolarDBCluster_EnableDynamoDB (1008.41s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_CreateDBCluster
--- PASS: TestAccAliCloudPolarDBCluster_CreateDBCluster (887.30s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_SteadyServerless
--- PASS: TestAccAliCloudPolarDBCluster_SteadyServerless (3540.23s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_NormalMultimaster
--- PASS: TestAccAliCloudPolarDBCluster_NormalMultimaster (823.02s)
PASS
=== RUN   TestAccAliCloudPolarDBClusterDatabasesDataSource
--- PASS: TestAccAliCloudPolarDBClusterDatabasesDataSource (497.47s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_CreateCloneFromRDS
--- PASS: TestAccAliCloudPolarDBCluster_CreateCloneFromRDS (1736.75s)
PASS
=== RUN   TestAccAliCloudPolarDBClusterSENormalEqualCreateWithStandbyAz
--- PASS: TestAccAliCloudPolarDBClusterSENormalEqualCreateWithStandbyAz (398.08s)
=== RUN   TestAccAliCloudPolarDBClusterSENormalEqualCreate
--- PASS: TestAccAliCloudPolarDBClusterSENormalEqualCreate (924.45s)
PASS
=== RUN   TestAccAliCloudPolarDBClusterEndpointConfigUpdate
--- PASS: TestAccAliCloudPolarDBClusterEndpointConfigUpdate (1250.02s)
=== RUN   TestAccAliCloudPolarDBClusterEndpointConfigUpdate_SslConnectionStringAndConne
ctionPrefix
--- PASS: TestAccAliCloudPolarDBClusterEndpointConfigUpdate_SslConnectionStringAndConne
ctionPrefix (1140.66s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_CreateCloneFromPolarDB
--- PASS: TestAccAliCloudPolarDBCluster_CreateCloneFromPolarDB (916.54s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_CreateMigrationFromRDS
--- PASS: TestAccAliCloudPolarDBCluster_CreateMigrationFromRDS (2399.87s)
PASS
=== RUN   TestAccAliCloudPolarDBCluster_GlobalSecurityGroupOnCreate
--- PASS: TestAccAliCloudPolarDBCluster_GlobalSecurityGroupOnCreate (766.03s)
PASS
```