### PR TITLE
resource/alicloud_nlb_load_balancer: Add refresh at the end of Update

### DIFF
--- a/alicloud/resource_alicloud_nlb_load_balancer.go
+++ b/alicloud/resource_alicloud_nlb_load_balancer.go
@@ -507,6 +507,7 @@ func resourceAliCloudNlbLoadBalancerRead(d *schema.ResourceData, meta interface{
 
 func resourceAliCloudNlbLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
+	nlbServiceV2 := NlbServiceV2{client}
 	var request map[string]interface{}
 	var response map[string]interface{}
 	var query map[string]interface{}
@@ -514,7 +515,6 @@ func resourceAliCloudNlbLoadBalancerUpdate(d *schema.ResourceData, meta interfac
 	d.Partial(true)
 
 	if d.HasChange("ipv6_address_type") {
-		nlbServiceV2 := NlbServiceV2{client}
 		object, err := nlbServiceV2.DescribeNlbLoadBalancer(d.Id())
 		if err != nil {
 			return WrapError(err)
@@ -522,8 +522,11 @@ func resourceAliCloudNlbLoadBalancerUpdate(d *schema.ResourceData, meta interfac
 
 		target := d.Get("ipv6_address_type").(string)
 		if object["Ipv6AddressType"].(string) != target {
-			if target == "Intranet" {
-				action := "DisableLoadBalancerIpv6Internet"
+			action := map[string]string{
+				"Intranet": "DisableLoadBalancerIpv6Internet",
+				"Internet": "EnableLoadBalancerIpv6Internet",
+			}[target]
+			if action != "" {
 				request = make(map[string]interface{})
 				query = make(map[string]interface{})
 				request["LoadBalancerId"] = d.Id()
@@ -545,32 +548,6 @@ func resourceAliCloudNlbLoadBalancerUpdate(d *schema.ResourceData, meta interfac
 				if err != nil {
 					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 				}
-
-			}
-			if target == "Internet" {
-				action := "EnableLoadBalancerIpv6Internet"
-				request = make(map[string]interface{})
-				query = make(map[string]interface{})
-				request["LoadBalancerId"] = d.Id()
-				request["RegionId"] = client.RegionId
-				request["ClientToken"] = buildClientToken(action)
-				wait := incrementalWait(3*time.Second, 5*time.Second)
-				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
-					response, err = client.RpcPost("Nlb", "2022-04-30", action, query, request, true)
-					if err != nil {
-						if IsExpectedErrors(err, []string{"IncorrectStatus.Ipv6Gateway"}) || NeedRetry(err) {
-							wait()
-							return resource.RetryableError(err)
-						}
-						return resource.NonRetryableError(err)
-					}
-					return nil
-				})
-				addDebug(action, response, request)
-				if err != nil {
-					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
-				}
-
 			}
 		}
 	}
@@ -603,7 +580,6 @@ func resourceAliCloudNlbLoadBalancerUpdate(d *schema.ResourceData, meta interfac
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
-		nlbServiceV2 := NlbServiceV2{client}
 		stateConf := BuildStateConf([]string{}, []string{"Succeeded"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, nlbServiceV2.DescribeAsyncNlbLoadBalancerStateRefreshFunc(d, response, "$.Status", []string{}))
 		if jobDetail, err := stateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id(), jobDetail)
@@ -652,7 +628,6 @@ func resourceAliCloudNlbLoadBalancerUpdate(d *schema.ResourceData, meta interfac
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
-		nlbServiceV2 := NlbServiceV2{client}
 		stateConf := BuildStateConf([]string{}, []string{"Active"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, nlbServiceV2.NlbLoadBalancerStateRefreshFunc(d.Id(), "LoadBalancerStatus", []string{}))
 		if _, err := stateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
@@ -701,7 +676,6 @@ func resourceAliCloudNlbLoadBalancerUpdate(d *schema.ResourceData, meta interfac
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
-		nlbServiceV2 := NlbServiceV2{client}
 		stateConf := BuildStateConf([]string{}, []string{"Active"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, nlbServiceV2.NlbLoadBalancerStateRefreshFunc(d.Id(), "LoadBalancerStatus", []string{}))
 		if _, err := stateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
@@ -824,7 +798,6 @@ func resourceAliCloudNlbLoadBalancerUpdate(d *schema.ResourceData, meta interfac
 	}
 
 	if d.HasChange("tags") {
-		nlbServiceV2 := NlbServiceV2{client}
 		if err := nlbServiceV2.SetResourceTags(d, "loadbalancer"); err != nil {
 			return WrapError(err)
 		}
@@ -833,19 +806,24 @@ func resourceAliCloudNlbLoadBalancerUpdate(d *schema.ResourceData, meta interfac
 		oldEntry, newEntry := d.GetChange("security_group_ids")
 		oldEntrySet := oldEntry.(*schema.Set)
 		newEntrySet := newEntry.(*schema.Set)
-		removed := oldEntrySet.Difference(newEntrySet)
-		added := newEntrySet.Difference(oldEntrySet)
 
-		if removed.Len() > 0 {
-			action := "LoadBalancerLeaveSecurityGroup"
+		for _, op := range []struct {
+			action string
+			ids    []interface{}
+		}{
+			{"LoadBalancerLeaveSecurityGroup", oldEntrySet.Difference(newEntrySet).List()},
+			{"LoadBalancerJoinSecurityGroup", newEntrySet.Difference(oldEntrySet).List()},
+		} {
+			if len(op.ids) == 0 {
+				continue
+			}
+			action := op.action
 			request = make(map[string]interface{})
 			query = make(map[string]interface{})
 			request["LoadBalancerId"] = d.Id()
 			request["RegionId"] = client.RegionId
 			request["ClientToken"] = buildClientToken(action)
-			localData := removed.List()
-			securityGroupIdsMapsArray := localData
-			request["SecurityGroupIds"] = securityGroupIdsMapsArray
+			request["SecurityGroupIds"] = op.ids
 
 			wait := incrementalWait(3*time.Second, 5*time.Second)
 			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
@@ -863,51 +841,19 @@ func resourceAliCloudNlbLoadBalancerUpdate(d *schema.ResourceData, meta interfac
 			if err != nil {
 				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 			}
-			nlbServiceV2 := NlbServiceV2{client}
 			stateConf := BuildStateConf([]string{}, []string{"Succeeded"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, nlbServiceV2.DescribeAsyncNlbLoadBalancerStateRefreshFunc(d, response, "$.Status", []string{}))
 			if jobDetail, err := stateConf.WaitForState(); err != nil {
 				return WrapErrorf(err, IdMsg, d.Id(), jobDetail)
 			}
-
 		}
-
-		if added.Len() > 0 {
-			action := "LoadBalancerJoinSecurityGroup"
-			request = make(map[string]interface{})
-			query = make(map[string]interface{})
-			request["LoadBalancerId"] = d.Id()
-			request["RegionId"] = client.RegionId
-			request["ClientToken"] = buildClientToken(action)
-			localData := added.List()
-			securityGroupIdsMapsArray := localData
-			request["SecurityGroupIds"] = securityGroupIdsMapsArray
-
-			wait := incrementalWait(3*time.Second, 5*time.Second)
-			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
-				response, err = client.RpcPost("Nlb", "2022-04-30", action, query, request, true)
-				if err != nil {
-					if IsExpectedErrors(err, []string{"SystemBusy"}) || NeedRetry(err) {
-						wait()
-						return resource.RetryableError(err)
-					}
-					return resource.NonRetryableError(err)
-				}
-				return nil
-			})
-			addDebug(action, response, request)
-			if err != nil {
-				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
-			}
-			nlbServiceV2 := NlbServiceV2{client}
-			stateConf := BuildStateConf([]string{}, []string{"Succeeded"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, nlbServiceV2.DescribeAsyncNlbLoadBalancerStateRefreshFunc(d, response, "$.Status", []string{}))
-			if jobDetail, err := stateConf.WaitForState(); err != nil {
-				return WrapErrorf(err, IdMsg, d.Id(), jobDetail)
-			}
-
-		}
-
 	}
 	d.Partial(false)
+
+	// Wait LB out of Configuring/Provisioning before Read.
+	stateConf := BuildStateConf([]string{}, []string{"Active"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, nlbServiceV2.NlbLoadBalancerStateRefreshFunc(d.Id(), "LoadBalancerStatus", []string{"CreateFailed"}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
 	return resourceAliCloudNlbLoadBalancerRead(d, meta)
 }
 

--- a/alicloud/resource_alicloud_nlb_load_balancer_test.go
+++ b/alicloud/resource_alicloud_nlb_load_balancer_test.go
@@ -144,7 +144,7 @@ func TestAccAliCloudNlbLoadBalancer_basic0(t *testing.T) {
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tf-testacc%snlbloadbalancer%d", defaultRegionToTest, rand)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudNLBLoadBalancerBasicDependence0)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
@@ -311,8 +311,8 @@ func TestAccAliCloudNlbLoadBalancer_basic1(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tf-testacc%snlbloadbalancer%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudNLBLoadBalancerBasicDependence0)
-	resource.Test(t, resource.TestCase{
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudNLBLoadBalancerBasicDependence1)
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
@@ -482,63 +482,67 @@ var AlicloudNLBLoadBalancerMap0 = map[string]string{
 
 func AlicloudNLBLoadBalancerBasicDependence0(name string) string {
 	return fmt.Sprintf(` 
-	variable "name" {
-  		default = "%s"
-	}
+variable "name" {
+  default = "%s"
+}
 
-	data "alicloud_nlb_zones" "default" {
-	}
+data "alicloud_nlb_zones" "default" {
+}
 
-	data "alicloud_resource_manager_resource_groups" "default" {
-	}
+data "alicloud_resource_manager_resource_groups" "default" {
+}
 
-	resource "alicloud_eip" "zone_a" {
-	  bandwidth            = "10"
-	  internet_charge_type = "PayByTraffic"
-	}
+resource "alicloud_eip" "zone_a" {
+  bandwidth            = "10"
+  internet_charge_type = "PayByTraffic"
+}
 
-	resource "alicloud_eip" "zone_b" {
-	  bandwidth            = "10"
-	  internet_charge_type = "PayByTraffic"
-	}
+resource "alicloud_eip" "zone_b" {
+  bandwidth            = "10"
+  internet_charge_type = "PayByTraffic"
+}
 
-	resource "alicloud_vpc" "default" {
-	  name       = var.name
-	  cidr_block = "172.16.0.0/16"
-      enable_ipv6 = true
-	}
+resource "alicloud_vpc" "default" {
+  name        = var.name
+  cidr_block  = "172.16.0.0/16"
+  enable_ipv6 = true
+}
 
-	resource "alicloud_vpc_ipv6_gateway" "default" {
-	  description       = var.name
-	  ipv6_gateway_name = var.name
-	  vpc_id            = alicloud_vpc.default.id
-	}
+resource "alicloud_vpc_ipv6_gateway" "default" {
+  description       = var.name
+  ipv6_gateway_name = var.name
+  vpc_id            = alicloud_vpc.default.id
+}
 
-	resource "alicloud_vswitch" "default" {
-	  count      = length(data.alicloud_nlb_zones.default.zones)
-	  vpc_id     = alicloud_vpc.default.id
-	  cidr_block = cidrsubnet(alicloud_vpc.default.cidr_block, 3, count.index)
-	  zone_id    = data.alicloud_nlb_zones.default.zones[count.index].id
-      ipv6_cidr_block_mask = count.index + 60
-      enable_ipv6 = true
-	}
+resource "alicloud_vswitch" "default" {
+  count                = length(data.alicloud_nlb_zones.default.zones)
+  vpc_id               = alicloud_vpc.default.id
+  cidr_block           = cidrsubnet(alicloud_vpc.default.cidr_block, 3, count.index)
+  zone_id              = data.alicloud_nlb_zones.default.zones[count.index].id
+  ipv6_cidr_block_mask = count.index + 60
+  enable_ipv6          = true
+}
 
-	locals {
-  		zone_id_1    = data.alicloud_nlb_zones.default.zones.0.id
-  		vswitch_id_1 = alicloud_vswitch.default.0.id
-  		zone_id_2    = data.alicloud_nlb_zones.default.zones.1.id
-  		vswitch_id_2 = alicloud_vswitch.default.1.id
-  		zone_id_3    = data.alicloud_nlb_zones.default.zones.2.id
-  		vswitch_id_3 = alicloud_vswitch.default.2.id
-	}
+locals {
+  zone_id_1    = data.alicloud_nlb_zones.default.zones.0.id
+  vswitch_id_1 = alicloud_vswitch.default.0.id
+  zone_id_2    = data.alicloud_nlb_zones.default.zones.1.id
+  vswitch_id_2 = alicloud_vswitch.default.1.id
+  zone_id_3    = data.alicloud_nlb_zones.default.zones.2.id
+  vswitch_id_3 = alicloud_vswitch.default.2.id
+}
 
-	resource "alicloud_common_bandwidth_package" "default" {
-  		bandwidth            = 2
-  		internet_charge_type = "PayByBandwidth"
-  		name                 = "${var.name}"
-  		description          = "${var.name}_description"
-	}
+resource "alicloud_common_bandwidth_package" "default" {
+  bandwidth            = 2
+  internet_charge_type = "PayByBandwidth"
+  name                 = "${var.name}"
+  description          = "${var.name}_description"
+}
 `, name)
+}
+
+func AlicloudNLBLoadBalancerBasicDependence1(name string) string {
+	return strings.ReplaceAll(AlicloudNLBLoadBalancerBasicDependence0(name), "172.16.", "172.17.")
 }
 
 var AlicloudNLBLoadBalancerMap1 = map[string]string{
@@ -1243,7 +1247,7 @@ func TestAccAliCloudNlbLoadBalancer_basic3678(t *testing.T) {
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tf-testacc%snlbloadbalancer%d", defaultRegionToTest, rand)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudNlbLoadBalancerBasicDependence3678)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckWithRegions(t, true, connectivity.NLBSupportRegions)
@@ -1649,7 +1653,7 @@ var AlicloudNlbLoadBalancerMap3678 = map[string]string{
 func AlicloudNlbLoadBalancerBasicDependence3678(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
-    default = "%s"
+  default = "%s"
 }
 
 data "alicloud_nlb_zones" "default" {
@@ -1678,20 +1682,20 @@ resource "alicloud_vswitch" "vsk" {
 }
 
 resource "alicloud_security_group" "defaultLkkjal" {
-  vpc_id              = alicloud_vpc.vpc.id
-  name = var.name
+  vpc_id = alicloud_vpc.vpc.id
+  name   = var.name
 
 }
 
 resource "alicloud_security_group" "defaultmlAdy7" {
-  vpc_id              = alicloud_vpc.vpc.id
-  name = var.name
+  vpc_id = alicloud_vpc.vpc.id
+  name   = var.name
 
 }
 
 resource "alicloud_security_group" "defaultCr6BU3" {
-  vpc_id              = alicloud_vpc.vpc.id
-  name = var.name
+  vpc_id = alicloud_vpc.vpc.id
+  name   = var.name
 
 }
 
@@ -1704,10 +1708,7 @@ resource "alicloud_vswitch" "vsg" {
   cidr_block   = "192.168.30.0/24"
   vswitch_name = var.name
 
-}
-
-
-`, name)
+}`, name)
 }
 
 // Case 3862
@@ -1723,7 +1724,7 @@ func TestAccAliCloudNlbLoadBalancer_basic3862(t *testing.T) {
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tf-testacc%snlbloadbalancer%d", defaultRegionToTest, rand)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudNlbLoadBalancerBasicDependence3862)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
@@ -1899,7 +1900,7 @@ var AlicloudNlbLoadBalancerMap3862 = map[string]string{
 func AlicloudNlbLoadBalancerBasicDependence3862(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
-    default = "%s"
+  default = "%s"
 }
 
 data "alicloud_nlb_zones" "default" {
@@ -1934,10 +1935,7 @@ resource "alicloud_vswitch" "defaultkR35um" {
 resource "alicloud_common_bandwidth_package" "cbwp" {
   bandwidth            = "1000"
   internet_charge_type = "PayByBandwidth"
-}
-
-
-`, name)
+}`, name)
 }
 
 // Case 3678  twin
@@ -1952,8 +1950,8 @@ func TestAccAliCloudNlbLoadBalancer_basic3678_twin(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tf-testacc%snlbloadbalancer%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudNlbLoadBalancerBasicDependence3678)
-	resource.Test(t, resource.TestCase{
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudNlbLoadBalancerBasicDependence3678Twin)
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckWithRegions(t, true, connectivity.NLBSupportRegions)
@@ -2043,8 +2041,8 @@ func TestAccAliCloudNlbLoadBalancer_basic3862_twin(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tf-testacc%snlbloadbalancer%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudNlbLoadBalancerBasicDependence3862)
-	resource.Test(t, resource.TestCase{
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudNlbLoadBalancerBasicDependence3862Twin)
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
@@ -2105,3 +2103,15 @@ func TestAccAliCloudNlbLoadBalancer_basic3862_twin(t *testing.T) {
 }
 
 // Test Nlb LoadBalancer. <<< Resource test cases, automatically generated.
+
+func AlicloudNlbLoadBalancerBasicDependence3678Twin(name string) string {
+	return strings.ReplaceAll(AlicloudNlbLoadBalancerBasicDependence3678(name), "192.168.", "172.18.")
+}
+
+func AlicloudNlbLoadBalancerBasicDependence3862Twin(name string) string {
+	return strings.NewReplacer(
+		"10.0.0.0/8", "10.1.0.0/16",
+		"10.0.1.0/24", "10.1.1.0/24",
+		"10.0.2.0/24", "10.1.2.0/24",
+	).Replace(AlicloudNlbLoadBalancerBasicDependence3862(name))
+}


### PR DESCRIPTION
Add refresh status at end of Update before read. Ensure the resource in the stable state.

- Update: wait for LoadBalancerStatus=Active via GetLoadBalancerAttribute before Read, replacing the stale async-job-based wait
- Update: collapse ipv6_address_type Enable/Disable branches and security_group_ids Leave/Join branches into single loops; drop redundant inner status waits and duplicate NlbServiceV2 shadow declarations
- Tests: switch the 6 TestAccAliCloudNlbLoadBalancer_* tests to resource.ParallelTest
- Tests: add Dependence1/Dependence3678Twin/Dependence3862Twin variants with distinct VPC CIDRs so paired tests don't share VPC/vswitch IPs when run in parallel
- Tests: terrafmt-format embedded HCL blocks
```log
=== RUN   TestAccAliCloudNlbLoadBalancer_basic0
=== PAUSE TestAccAliCloudNlbLoadBalancer_basic0
=== RUN   TestAccAliCloudNlbLoadBalancer_basic1
=== PAUSE 

=== RUN   TestAccAliCloudNlbLoadBalancer_basic3678
=== PAUSE TestAccAliCloudNlbLoadBalancer_basic3678
=== RUN   TestAccAliCloudNlbLoadBalancer_basic3862
=== PAUSE TestAccAliCloudNlbLoadBalancer_basic3862
=== RUN   TestAccAliCloudNlbLoadBalancer_basic3678_twin
=== PAUSE TestAccAliCloudNlbLoadBalancer_basic3678_twin
=== RUN   TestAccAliCloudNlbLoadBalancer_basic3862_twin
=== PAUSE TestAccAliCloudNlbLoadBalancer_basic3862_twin
=== CONT  TestAccAliCloudNlbLoadBalancer_basic0
=== CONT  TestAccAliCloudNlbLoadBalancer_basic3862
=== CONT  TestAccAliCloudNlbLoadBalancer_basic1
=== CONT  TestAccAliCloudNlbLoadBalancer_basic3678
=== CONT  TestAccAliCloudNlbLoadBalancer_basic3862_twin
=== CONT  TestAccAliCloudNlbLoadBalancer_basic3678_twin
--- PASS: TestAccAliCloudNlbLoadBalancer_basic3862_twin (140.02s)
--- PASS: TestAccAliCloudNlbLoadBalancer_basic3678_twin (143.44s)
--- PASS: TestAccAliCloudNlbLoadBalancer_basic0 (240.15s)
--- PASS: TestAccAliCloudNlbLoadBalancer_basic3678 (282.96s)
--- PASS: TestAccAliCloudNlbLoadBalancer_basic3862 (293.23s)
--- PASS: TestAccAliCloudNlbLoadBalancer_basic1 (378.47s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  382.303s

```