### PR TITLE
resource/alicloud_db_instance: Support force_encryption for MySQL and SQLServer

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -686,7 +686,8 @@ func resourceAliCloudDBInstance() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: IntInSlice([]int{0, 1}),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return d.Get("engine").(string) != "SQLServer"
+					engine := d.Get("engine").(string)
+					return engine != "MySQL" && engine != "SQLServer"
 				},
 			},
 			"ssl_certificate": {
@@ -1590,10 +1591,12 @@ func resourceAliCloudDBInstanceUpdate(d *schema.ResourceData, meta interface{}) 
 			}
 		}
 
-		if d.Get("engine").(string) == "SQLServer" {
+		if engine := d.Get("engine").(string); engine == "MySQL" || engine == "SQLServer" {
 			if v, ok := d.GetOkExists("force_encryption"); ok {
 				request["ForceEncryption"] = v.(int)
 			}
+		}
+		if d.Get("engine").(string) == "SQLServer" {
 			if d.HasChange("ssl_certificate") {
 				if v, ok := d.GetOk("ssl_certificate"); ok && v.(string) != "" {
 					request["Certificate"] = v.(string)

--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -466,6 +466,30 @@ func TestAccAliCloudRdsDBInstance_Mysql_8_0(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"ssl_action":       "Open",
+					"force_encryption": "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ssl_action":       "Open",
+						"force_encryption": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ssl_action":       "Close",
+					"force_encryption": "0",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ssl_action":       "Close",
+						"force_encryption": "0",
+					}),
+				),
+			},
+			{
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -728,7 +728,7 @@ The following arguments are supported:
 
   -> **NOTE:** The default time zone of the instance is China Standard Time. You must specify one of the Collation and Timezone parameters.
 
-* `force_encryption` - (Optional, Available since v1.277.0) Specifies whether to enable the forceful SSL encryption feature. This parameter is supported only for ApsaraDB RDS for SQL Server instances.Valid values:
+* `force_encryption` - (Optional, Available since v1.277.0) Specifies whether to enable the forceful SSL encryption feature. This parameter is supported only for ApsaraDB RDS for MySQL and SQL Server instances. Valid values:
   - 1: enables the feature.
   - 0: disables the feature.
 * `ssl_certificate` -(Optional, Available in 1.277.0) The custom certificate.


### PR DESCRIPTION
…encryption, making it available for all engines

- Removed DiffSuppressFunc that limited force_encryption to SQLServer only
- Moved ForceEncryption API call outside the engine==SQLServer check block
- Added temp test for MySQL 8.0 with force_encryption