### PR TITLE
resource/alicloud_vpc_ipam_ipam_pool_cidr: Add retry for delete

### DIFF
--- a/alicloud/resource_alicloud_vpc_ipam_ipam_pool_cidr.go
+++ b/alicloud/resource_alicloud_vpc_ipam_ipam_pool_cidr.go
@@ -141,7 +141,7 @@ func resourceAliCloudVpcIpamIpamPoolCidrDelete(d *schema.ResourceData, meta inte
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		response, err = client.RpcPost("VpcIpam", "2023-02-28", action, query, request, true)
 		if err != nil {
-			if IsExpectedErrors(err, []string{"OperationConflict"}) || NeedRetry(err) {
+			if IsExpectedErrors(err, []string{"OperationConflict", "OperationDenied.IpamPoolAllocationExist"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}


### PR DESCRIPTION
Add retry for deletion for parallel deletion operations of the pool.

```log
=== RUN   TestAccAliCloudVpcIpamIpamPoolCidr_basic10812
--- PASS: TestAccAliCloudVpcIpamIpamPoolCidr_basic10812 (9.88s)
=== RUN   TestAccAliCloudVpcIpamIpamPoolCidr_basic11310
--- PASS: TestAccAliCloudVpcIpamIpamPoolCidr_basic11310 (9.65s)
=== RUN   TestAccAliCloudVpcIpamIpamPoolCidr_basic8028
--- PASS: TestAccAliCloudVpcIpamIpamPoolCidr_basic8028 (7.44s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  30.809s

```