### PR TITLE
resource/alicloud_ros_stack: read template_body from stack and improve state polling

### DIFF
--- a/alicloud/resource_alicloud_ros_stack.go
+++ b/alicloud/resource_alicloud_ros_stack.go
@@ -230,7 +230,7 @@ func resourceAlicloudRosStackCreate(d *schema.ResourceData, meta interface{}) er
 	addDebug(action, response, request)
 
 	d.SetId(fmt.Sprint(response["StackId"]))
-	stateConf := BuildStateConf([]string{}, []string{"CREATE_COMPLETE"}, d.Timeout(schema.TimeoutCreate), 100*time.Second, rosService.RosStackStateRefreshFunc(d.Id(), []string{"CREATE_FAILED", "CREATE_ROLLBACK_COMPLETE", "CREATE_ROLLBACK_FAILED"}))
+	stateConf := BuildStateConf([]string{}, []string{"CREATE_COMPLETE"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, rosService.RosStackStateRefreshFunc(d.Id(), []string{"CREATE_FAILED", "CREATE_ROLLBACK_COMPLETE", "CREATE_ROLLBACK_FAILED"}))
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
@@ -240,7 +240,8 @@ func resourceAlicloudRosStackCreate(d *schema.ResourceData, meta interface{}) er
 func resourceAlicloudRosStackRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	rosService := RosService{client}
-	object, err := rosService.DescribeRosStack(d.Id())
+	stackId := d.Id()
+	object, err := rosService.DescribeRosStack(stackId)
 	if err != nil {
 		if !d.IsNewResource() && NotFoundError(err) {
 			log.Printf("[DEBUG] Resource alicloud_ros_stack rosService.DescribeRosStack Failed!!! %s", err)
@@ -274,13 +275,19 @@ func resourceAlicloudRosStackRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("status", object["Status"])
 	d.Set("timeout_in_minutes", formatInt(object["TimeoutInMinutes"]))
 
-	listTagResourcesObject, err := rosService.ListTagResources(d.Id(), "stack")
+	template, err := rosService.DescribeRosTemplateByStackId(stackId)
+	if err != nil {
+		return WrapError(err)
+	}
+	d.Set("template_body", template["TemplateBody"])
+
+	listTagResourcesObject, err := rosService.ListTagResources(stackId, "stack")
 	if err != nil {
 		return WrapError(err)
 	}
 	d.Set("tags", tagsToMap(listTagResourcesObject))
 
-	getStackPolicyObject, err := rosService.GetStackPolicy(d.Id())
+	getStackPolicyObject, err := rosService.GetStackPolicy(stackId)
 	if err != nil {
 		return WrapError(err)
 	}
@@ -375,7 +382,7 @@ func resourceAlicloudRosStackUpdate(d *schema.ResourceData, meta interface{}) er
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
-		stateConf := BuildStateConf([]string{}, []string{"UPDATE_COMPLETE"}, d.Timeout(schema.TimeoutUpdate), 100*time.Second, rosService.RosStackStateRefreshFunc(d.Id(), []string{"UPDATE_FAILED", "ROLLBACK_FAILED"}))
+		stateConf := BuildStateConf([]string{}, []string{"UPDATE_COMPLETE"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, rosService.RosStackStateRefreshFunc(d.Id(), []string{"UPDATE_FAILED", "ROLLBACK_FAILED"}))
 		if _, err := stateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
@@ -427,7 +434,7 @@ func resourceAlicloudRosStackDelete(d *schema.ResourceData, meta interface{}) er
 		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
-	stateConf := BuildStateConf([]string{}, []string{"DELETE_COMPLETE"}, d.Timeout(schema.TimeoutDelete), 100*time.Second, rosService.RosStackStateRefreshFunc(d.Id(), []string{"DELETE_FAILED"}))
+	stateConf := BuildStateConf([]string{}, []string{"DELETE_COMPLETE"}, d.Timeout(schema.TimeoutDelete), 5*time.Second, rosService.RosStackStateRefreshFunc(d.Id(), []string{"DELETE_FAILED"}))
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}

--- a/alicloud/resource_alicloud_ros_stack_test.go
+++ b/alicloud/resource_alicloud_ros_stack_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -110,14 +111,35 @@ func TestAccAlicloudROSStack_basic(t *testing.T) {
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tf-testAcc%sAlicloudRosStack%d", defaultRegionToTest, rand)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRosStackBasicDependence)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 		},
 
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
-		CheckDestroy:  rac.checkResourceDestroy(),
+		CheckDestroy: func(state *terraform.State) error {
+			rosServiceClient := RosService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+			for _, rs := range state.RootModule().Resources {
+				if "alicloud_ros_stack" != rs.Type {
+					continue
+				}
+				stackId := rs.Primary.ID
+				stack, err := rosServiceClient.DescribeRosStack(stackId)
+				if err != nil {
+					if NotFoundError(err) {
+						continue
+					}
+					return WrapError(err)
+				}
+				if stack != nil {
+					if v, ok := stack["Status"]; ok && v == "DELETE_COMPLETE" { // check delete status
+						return nil
+					}
+				}
+			}
+			return nil
+		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -154,7 +176,7 @@ func TestAccAlicloudROSStack_basic(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"create_option", "notification_urls", "replacement_option", "retain_all_resources", "retain_resources", "stack_policy_during_update_body", "stack_policy_body", "stack_policy_during_update_url", "stack_policy_url", "template_body", "tags", "template_url", "use_previous_parameters"},
+				ImportStateVerifyIgnore: []string{"create_option", "notification_urls", "replacement_option", "retain_all_resources", "retain_resources", "stack_policy_during_update_body", "stack_policy_body", "stack_policy_during_update_url", "stack_policy_url", "tags", "template_url", "use_previous_parameters"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{

--- a/alicloud/service_alicloud_ros.go
+++ b/alicloud/service_alicloud_ros.go
@@ -337,6 +337,43 @@ func (s *RosService) DescribeRosTemplate(id string) (object map[string]interface
 	return object, nil
 }
 
+func (s *RosService) DescribeRosTemplateByStackId(stackId string) (object map[string]interface{}, err error) {
+	var response map[string]interface{}
+	client := s.client
+	action := "GetTemplate"
+	request := map[string]interface{}{
+		"RegionId": s.client.RegionId,
+		"StackId":  stackId,
+	}
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("ROS", "2019-09-10", action, nil, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		if IsExpectedErrors(err, []string{"StackNotFound"}) {
+			err = WrapErrorf(NotFoundErr("RosTemplate", stackId), NotFoundMsg, ProviderERROR)
+			return object, err
+		}
+		err = WrapErrorf(err, DefaultErrorMsg, stackId, action, AlibabaCloudSdkGoERROR)
+		return object, err
+	}
+	addDebug(action, response, request)
+	v, err := jsonpath.Get("$", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, stackId, "$", response)
+	}
+	object = v.(map[string]interface{})
+	return object, nil
+}
+
 func (s *RosService) DescribeRosStackInstance(id string) (object map[string]interface{}, err error) {
 	var response map[string]interface{}
 	client := s.client


### PR DESCRIPTION
Fix the issue that `template_body` cannot be imporeted.

- Add `DescribeRosTemplateByStackId` to fetch template via GetTemplate API using StackId
- Read template_body in resourceRead so it is tracked in state and verified on import
- Reduce state refresh poll interval from 100s to 5s for create/update/delete
- Update test to use custom CheckDestroy that accepts `DELETE_COMPLETE` status
- 
- Remove template_body from ImportStateVerifyIgnore
```log
=== RUN   TestAccAlicloudROSStack_basic
=== PAUSE TestAccAlicloudROSStack_basic
=== CONT  TestAccAlicloudROSStack_basic
--- PASS: TestAccAlicloudROSStack_basic (54.73s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  57.699s

```