### PR TITLE
resource/alicloud_ots_table: Fix tablestore data plane ignoring HTTP(S)_PROXY under cross-border proxy

### DIFF
--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -1530,7 +1531,22 @@ func (client *AliyunClient) WithTableStoreClient(instanceName string, do func(*t
 		externalHeaders["x-ots-sourceip"] = client.config.SourceIp
 	}
 	accessKey, secretKey, token := client.config.GetRefreshCredential()
-	tableStoreClient = tablestore.NewClientWithExternalHeader(endpoint, instanceName, accessKey, secretKey, token, tablestore.NewDefaultTableStoreConfig(), externalHeaders)
+	otsConfig := tablestore.NewDefaultTableStoreConfig()
+	// The TableStore data plane does not honor HTTP(S)_PROXY by default, so configure the proxy
+	// explicitly to keep it consistent with the OTS control plane (e.g. cross-border proxy access).
+	if proxy, err := client.getOtsProxy(endpoint); err != nil {
+		return nil, err
+	} else if proxy != nil {
+		otsConfig.Transport = &http.Transport{
+			MaxIdleConnsPerHost: otsConfig.MaxIdleConnections,
+			IdleConnTimeout:     otsConfig.IdleConnTimeout,
+			Proxy:               http.ProxyURL(proxy),
+			Dial: (&net.Dialer{
+				Timeout: otsConfig.HTTPTimeout.ConnectionTimeout,
+			}).Dial,
+		}
+	}
+	tableStoreClient = tablestore.NewClientWithExternalHeader(endpoint, instanceName, accessKey, secretKey, token, otsConfig, externalHeaders)
 	client.tablestoreconnByInstanceName[instanceName] = tableStoreClient
 
 	return do(tableStoreClient)
@@ -1564,7 +1580,17 @@ func (client *AliyunClient) WithTableStoreTunnelClient(instanceName string, do f
 		externalHeaders["x-ots-sourceip"] = client.config.SourceIp
 	}
 	accessKey, secretKey, token := client.config.GetRefreshCredential()
-	tunnelClient = otsTunnel.NewTunnelClientWithConfigAndExternalHeader(endpoint, instanceName, accessKey, secretKey, token, otsTunnel.DefaultTunnelConfig, externalHeaders)
+	tunnelConfig := otsTunnel.DefaultTunnelConfig
+	// Keep the OTS tunnel data plane consistent with the control plane by honoring the proxy,
+	// otherwise it ignores the provider proxy/HTTP(S)_PROXY and forces a direct connection.
+	if proxy, err := client.getOtsProxy(endpoint); err != nil {
+		return nil, err
+	} else if proxy != nil {
+		cfg := *otsTunnel.DefaultTunnelConfig
+		cfg.Transport = &http.Transport{Proxy: http.ProxyURL(proxy)}
+		tunnelConfig = &cfg
+	}
+	tunnelClient = otsTunnel.NewTunnelClientWithConfigAndExternalHeader(endpoint, instanceName, accessKey, secretKey, token, tunnelConfig, externalHeaders)
 	client.otsTunnelConnByInstanceName[instanceName] = tunnelClient
 
 	return do(tunnelClient)
@@ -1735,6 +1761,23 @@ func (client *AliyunClient) getTransport() *http.Transport {
 	transport.TLSHandshakeTimeout = time.Duration(handshakeTimeout) * time.Second
 
 	return transport
+}
+
+// getOtsProxy returns the proxy URL to use for an OTS data-plane endpoint, honoring the
+// HTTP(S)_PROXY env vars and NO_PROXY. It returns nil when the request should be sent direct.
+func (client *AliyunClient) getOtsProxy(endpoint string) (*url.URL, error) {
+	proxy, err := client.getHttpProxy()
+	if err != nil || proxy == nil {
+		return nil, err
+	}
+	skip, err := client.skipProxy(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if skip {
+		return nil, nil
+	}
+	return proxy, nil
 }
 
 func (client *AliyunClient) getHttpProxy() (proxy *url.URL, err error) {

--- a/alicloud/connectivity/client_test.go
+++ b/alicloud/connectivity/client_test.go
@@ -1,6 +1,7 @@
 package connectivity
 
 import (
+	"net/http"
 	"os"
 	"sync"
 	"testing"
@@ -9,6 +10,8 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ram"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
+	otsTunnel "github.com/aliyun/aliyun-tablestore-go-sdk/tunnel"
 	"github.com/aliyun/credentials-go/credentials"
 	"github.com/stretchr/testify/assert"
 )
@@ -224,4 +227,93 @@ func TestUnitCommonWithRamClient_Proxy(t *testing.T) {
 			}
 		})
 	}
+}
+
+// otsProxyTestEndpoint mimics a cn-hangzhou TableStore data-plane endpoint.
+const otsProxyTestEndpoint = "https://my-inst.cn-hangzhou.ots.aliyuncs.com"
+
+// TestUnitGetOtsProxy verifies the OTS data-plane proxy resolution: honor HTTP(S)_PROXY,
+// skip when NO_PROXY matches, and stay direct when no proxy is configured.
+func TestUnitGetOtsProxy(t *testing.T) {
+	client := &AliyunClient{config: &Config{Protocol: "HTTPS"}}
+	cases := []struct {
+		name       string
+		httpsProxy string
+		noProxy    string
+		wantProxy  string // "" means direct (nil)
+	}{
+		{"no proxy -> direct", "", "", ""},
+		{"proxy set -> via proxy", "https://de.coia.siemens.net:9400", "", "https://de.coia.siemens.net:9400"},
+		{"no_proxy matches -> direct", "https://de.coia.siemens.net:9400", "ots.aliyuncs.com", ""},
+		{"no_proxy non-match -> via proxy", "https://de.coia.siemens.net:9400", "example.com", "https://de.coia.siemens.net:9400"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HTTPS_PROXY", tc.httpsProxy)
+			t.Setenv("NO_PROXY", tc.noProxy)
+			proxy, err := client.getOtsProxy(otsProxyTestEndpoint)
+			assert.NoError(t, err)
+			if tc.wantProxy == "" {
+				assert.Nil(t, proxy)
+			} else {
+				assert.NotNil(t, proxy)
+				assert.Equal(t, tc.wantProxy, proxy.String())
+			}
+		})
+	}
+}
+
+// TestUnitWithTableStoreClient_Proxy verifies the table-store data-plane transport routes
+// through the proxy when set and stays direct otherwise.
+func TestUnitWithTableStoreClient_Proxy(t *testing.T) {
+	client := &AliyunClient{config: &Config{Protocol: "HTTPS"}}
+	req, _ := http.NewRequest("POST", otsProxyTestEndpoint, nil)
+
+	t.Run("with proxy", func(t *testing.T) {
+		t.Setenv("HTTPS_PROXY", "https://de.coia.siemens.net:9400")
+		t.Setenv("NO_PROXY", "")
+		cfg := tablestore.NewDefaultTableStoreConfig()
+		proxy, err := client.getOtsProxy(otsProxyTestEndpoint)
+		assert.NoError(t, err)
+		assert.NotNil(t, proxy)
+		cfg.Transport = &http.Transport{Proxy: http.ProxyURL(proxy)}
+		used, err := cfg.Transport.(*http.Transport).Proxy(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://de.coia.siemens.net:9400", used.String())
+	})
+
+	t.Run("without proxy -> direct", func(t *testing.T) {
+		t.Setenv("HTTPS_PROXY", "")
+		t.Setenv("NO_PROXY", "")
+		proxy, err := client.getOtsProxy(otsProxyTestEndpoint)
+		assert.NoError(t, err)
+		assert.Nil(t, proxy) // transport untouched -> SDK default direct connection
+	})
+}
+
+// TestUnitWithTableStoreTunnelClient_Proxy verifies the tunnel data-plane transport routes
+// through the proxy when set and stays on the SDK default otherwise.
+func TestUnitWithTableStoreTunnelClient_Proxy(t *testing.T) {
+	client := &AliyunClient{config: &Config{Protocol: "HTTPS"}}
+	req, _ := http.NewRequest("POST", otsProxyTestEndpoint, nil)
+
+	t.Run("with proxy", func(t *testing.T) {
+		t.Setenv("HTTPS_PROXY", "https://de.coia.siemens.net:9400")
+		t.Setenv("NO_PROXY", "")
+		proxy, err := client.getOtsProxy(otsProxyTestEndpoint)
+		assert.NoError(t, err)
+		cfg := *otsTunnel.DefaultTunnelConfig
+		cfg.Transport = &http.Transport{Proxy: http.ProxyURL(proxy)}
+		used, err := cfg.Transport.(*http.Transport).Proxy(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://de.coia.siemens.net:9400", used.String())
+	})
+
+	t.Run("without proxy -> direct", func(t *testing.T) {
+		t.Setenv("HTTPS_PROXY", "")
+		t.Setenv("NO_PROXY", "")
+		proxy, err := client.getOtsProxy(otsProxyTestEndpoint)
+		assert.NoError(t, err)
+		assert.Nil(t, proxy) // tunnel keeps DefaultTunnelConfig (no forced proxy)
+	})
 }


### PR DESCRIPTION
## Problem
OTS data-plane operations (table/secondary index/search index/tunnel) ignore the proxy and force a direct connection. Where the region is reachable only via a proxy (e.g. cross-border CI runner), control-plane and OSS state work but any OTS data-plane call fails with `net.OpError` on Post. Refs Aone Req 82959751, bug 82899631.

## Root cause
`WithOtsClient` (control plane) sets the proxy via `SetHttpProxy/SetHttpsProxy`, but `WithTableStoreClient`/`WithTableStoreTunnelClient` build the SDK client with `NewDefaultTableStoreConfig()`/`DefaultTunnelConfig`, whose transport has no Proxy, so the proxy is ignored.

## Fix
Add `getOtsProxy()` (HTTP(S)_PROXY + NO_PROXY, same logic as the control plane) and set the proxy on the TableStore/tunnel transport. Direct-connect path is untouched (proxy nil -> SDK default).

## Test
- New unit tests: getOtsProxy + table/tunnel transport, proxy vs direct vs NO_PROXY (all pass)
- Remote ACC: TestAccAliCloudOtsTable_basic PASS (direct path not broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)