### PR TITLE
resource/alicloud_nlb_load_balancer_security_group_attachment: Add retry for resource updating status

### DIFF
--- a/alicloud/resource_alicloud_nlb_load_balancer_security_group_attachment.go
+++ b/alicloud/resource_alicloud_nlb_load_balancer_security_group_attachment.go
@@ -69,7 +69,7 @@ func resourceAliCloudNlbLoadBalancerSecurityGroupAttachmentCreate(d *schema.Reso
 		request["ClientToken"] = buildClientToken(action)
 
 		if err != nil {
-			if IsExpectedErrors(err, []string{"Conflict.Lock"}) || NeedRetry(err) {
+			if IsExpectedErrors(err, []string{"Conflict.Lock", "OperationFailed.ResourceIsConfiguring"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}


### PR DESCRIPTION
Add retry for resource updating status

```log
=== RUN   TestAccAliCloudNlbLoadBalancerSecurityGroupAttachment_basic
--- PASS: TestAccAliCloudNlbLoadBalancerSecurityGroupAttachment_basic (124.80s)
=== RUN   TestAccAliCloudNlbLoadBalancerSecurityGroupAttachment_basic4781
--- PASS: TestAccAliCloudNlbLoadBalancerSecurityGroupAttachment_basic4781 (146.12s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  273.824s

```