### PR TITLE
bump alibaba-cloud-sdk-go to v1.63.107

### DIFF
--- a/alicloud/data_source_alicloud_vpn_connections.go
+++ b/alicloud/data_source_alicloud_vpn_connections.go
@@ -404,7 +404,7 @@ func dataSourceAlicloudVpnConnectionsRead(d *schema.ResourceData, meta interface
 	request.RegionId = string(client.Region)
 	request.PageSize = requests.NewInteger(PageSizeLarge)
 	request.PageNumber = requests.NewInteger(1)
-	var allVpnConns []vpc.VpnConnection
+	var allVpnConns []vpc.VpnConnectionInDescribeVpnConnections
 
 	if v, ok := d.GetOk("vpn_gateway_id"); ok && v.(string) != "" {
 		request.VpnGatewayId = v.(string)
@@ -441,7 +441,7 @@ func dataSourceAlicloudVpnConnectionsRead(d *schema.ResourceData, meta interface
 		request.PageNumber = page
 	}
 
-	var filteredVpnConns []vpc.VpnConnection
+	var filteredVpnConns []vpc.VpnConnectionInDescribeVpnConnections
 	var reg *regexp.Regexp
 	var ids []string
 	if v, ok := d.GetOk("ids"); ok && len(v.([]interface{})) > 0 {
@@ -477,10 +477,10 @@ func dataSourceAlicloudVpnConnectionsRead(d *schema.ResourceData, meta interface
 		}
 	}
 
-	return vpnConnectionsDecriptionAttributes(d, filteredVpnConns, meta)
+	return vpnConnectionsDescriptionAttributes(d, filteredVpnConns, meta)
 }
 
-func vpnConnectionsDecriptionAttributes(d *schema.ResourceData, vpnSetTypes []vpc.VpnConnection, meta interface{}) error {
+func vpnConnectionsDescriptionAttributes(d *schema.ResourceData, vpnSetTypes []vpc.VpnConnectionInDescribeVpnConnections, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	vpnGatewayService := VpnGatewayService{client}
 	var ids []string

--- a/alicloud/resource_alicloud_edas_application.go
+++ b/alicloud/resource_alicloud_edas_application.go
@@ -1,11 +1,11 @@
 package alicloud
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/edas"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -87,7 +87,7 @@ func resourceAlicloudEdasApplicationCreate(d *schema.ResourceData, meta interfac
 	request.ClusterId = d.Get("cluster_id").(string)
 
 	if v, ok := d.GetOk("build_pack_id"); ok {
-		request.BuildPackId = fmt.Sprint(v)
+		request.BuildPackId = requests.NewInteger(v.(int))
 	}
 
 	if v, ok := d.GetOk("descriotion"); ok {

--- a/alicloud/resource_alicloud_edas_application_scale.go
+++ b/alicloud/resource_alicloud_edas_application_scale.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/edas"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -149,7 +150,7 @@ func resourceAlicloudEdasApplicationScaleDelete(d *schema.ResourceData, meta int
 	request.AppId = d.Get("app_id").(string)
 	request.EccInfo = d.Get("ecc_info").(string)
 	if v, ok := d.GetOk("force_status"); ok {
-		request.ForceStatus = fmt.Sprint(v)
+		request.ForceStatus = requests.NewBoolean(v.(bool))
 	}
 
 	raw, err := edasService.client.WithEdasClient(func(edasClient *edas.Client) (interface{}, error) {

--- a/alicloud/resource_alicloud_edas_cluster.go
+++ b/alicloud/resource_alicloud_edas_cluster.go
@@ -1,10 +1,10 @@
 package alicloud
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/edas"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -59,8 +59,8 @@ func rresourceAlicloudEdasClusterCreate(d *schema.ResourceData, meta interface{}
 	request := edas.CreateInsertClusterRequest()
 	request.RegionId = client.RegionId
 	request.ClusterName = d.Get("cluster_name").(string)
-	request.ClusterType = fmt.Sprint(d.Get("cluster_type"))
-	request.NetworkMode = fmt.Sprint(d.Get("network_mode"))
+	request.ClusterType = requests.NewInteger(d.Get("cluster_type").(int))
+	request.NetworkMode = requests.NewInteger(d.Get("network_mode").(int))
 	if v, ok := d.GetOk("logical_region_id"); ok {
 		request.LogicalRegionId = v.(string)
 	}

--- a/alicloud/resource_alicloud_edas_k8s_application.go
+++ b/alicloud/resource_alicloud_edas_k8s_application.go
@@ -1,12 +1,12 @@
 package alicloud
 
 import (
-	"fmt"
 	"log"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/edas"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -245,18 +245,18 @@ func resourceAlicloudEdasK8sApplicationCreate(d *schema.ResourceData, meta inter
 		}
 	}
 
-	request.Replicas = fmt.Sprint(d.Get("replicas").(int))
+	request.Replicas = requests.NewInteger(d.Get("replicas").(int))
 
 	if v, ok := d.GetOk("application_descriotion"); ok {
 		request.ApplicationDescription = v.(string)
 	}
 
 	if v, ok := d.GetOk("limit_mem"); ok {
-		request.LimitMem = fmt.Sprint(v.(int))
+		request.LimitMem = requests.NewInteger(v.(int))
 	}
 
 	if v, ok := d.GetOk("requests_mem"); ok {
-		request.RequestsMem = fmt.Sprint(v.(int))
+		request.RequestsMem = requests.NewInteger(v.(int))
 	}
 
 	if v, ok := d.GetOk("command"); ok {
@@ -280,11 +280,11 @@ func resourceAlicloudEdasK8sApplicationCreate(d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("internet_slb_port"); ok {
-		request.InternetSlbPort = fmt.Sprint(v.(int))
+		request.InternetSlbPort = requests.NewInteger(v.(int))
 	}
 
 	if v, ok := d.GetOk("internet_target_port"); ok {
-		request.InternetTargetPort = fmt.Sprint(v.(int))
+		request.InternetTargetPort = requests.NewInteger(v.(int))
 	}
 
 	if v, ok := d.GetOk("envs"); ok {
@@ -332,11 +332,11 @@ func resourceAlicloudEdasK8sApplicationCreate(d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("requests_m_cpu"); ok {
-		request.RequestsmCpu = fmt.Sprint(v.(int))
+		request.RequestsmCpu = requests.NewInteger(v.(int))
 	}
 
 	if v, ok := d.GetOk("limit_m_cpu"); ok {
-		request.LimitmCpu = fmt.Sprint(v.(int))
+		request.LimitmCpu = requests.NewInteger(v.(int))
 	}
 
 	var appId string
@@ -512,16 +512,16 @@ func resourceAlicloudEdasK8sApplicationUpdate(d *schema.ResourceData, meta inter
 	if d.HasChange("replicas") {
 		partialKeys = append(partialKeys, "replicas")
 	}
-	request.Replicas = fmt.Sprint(d.Get("replicas").(int))
+	request.Replicas = requests.NewInteger(d.Get("replicas").(int))
 
 	if d.HasChange("limit_mem") {
 		partialKeys = append(partialKeys, "limit_mem")
-		request.MemoryLimit = fmt.Sprint(d.Get("limit_mem").(int))
+		request.MemoryLimit = requests.NewInteger(d.Get("limit_mem").(int))
 	}
 
 	if d.HasChange("requests_mem") {
 		partialKeys = append(partialKeys, "requests_mem")
-		request.MemoryRequest = fmt.Sprint(d.Get("requests_mem").(int))
+		request.MemoryRequest = requests.NewInteger(d.Get("requests_mem").(int))
 	}
 
 	if d.HasChange("command") {
@@ -592,12 +592,12 @@ func resourceAlicloudEdasK8sApplicationUpdate(d *schema.ResourceData, meta inter
 
 	if d.HasChange("requests_m_cpu") {
 		partialKeys = append(partialKeys, "requests_m_cpu")
-		request.McpuRequest = fmt.Sprint(d.Get("requests_m_cpu").(int))
+		request.McpuRequest = requests.NewInteger(d.Get("requests_m_cpu").(int))
 	}
 
 	if d.HasChange("limit_m_cpu") {
 		partialKeys = append(partialKeys, "limit_m_cpu")
-		request.McpuLimit = fmt.Sprint(d.Get("limit_m_cpu").(int))
+		request.McpuLimit = requests.NewInteger(d.Get("limit_m_cpu").(int))
 	}
 
 	if len(partialKeys) > 0 {

--- a/alicloud/resource_alicloud_edas_slb_attachment.go
+++ b/alicloud/resource_alicloud_edas_slb_attachment.go
@@ -1,8 +1,7 @@
 package alicloud
 
 import (
-	"fmt"
-
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/edas"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -78,7 +77,7 @@ func resourceAlicloudEdasSlbAttachmentCreate(d *schema.ResourceData, meta interf
 	request.SlbId = slbId
 	request.SlbIp = d.Get("slb_ip").(string)
 	if v, ok := d.GetOk("listener_port"); ok {
-		request.ListenerPort = fmt.Sprint(v.(int))
+		request.ListenerPort = requests.NewInteger(v.(int))
 	}
 	if v, ok := d.GetOk("vserver_group_id"); ok {
 		request.VServerGroupId = v.(string)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/alibabacloud-go/tea-roa v1.3.4
 	github.com/alibabacloud-go/tea-rpc v1.2.0
 	github.com/alibabacloud-go/tea-utils v1.4.5
-	github.com/aliyun/alibaba-cloud-sdk-go v1.62.590
+	github.com/aliyun/alibaba-cloud-sdk-go v1.63.107
 	github.com/aliyun/aliyun-datahub-sdk-go v0.1.5
 	github.com/aliyun/aliyun-log-go-sdk v0.1.108
 	github.com/aliyun/aliyun-mns-go-sdk v0.0.0-20210305050620-d1b5875bda58

--- a/go.sum
+++ b/go.sum
@@ -307,8 +307,8 @@ github.com/alibabacloud-go/tea-utils/v2 v2.0.7/go.mod h1:qxn986l+q33J5VkialKMqT/
 github.com/alibabacloud-go/tea-xml v1.1.2/go.mod h1:Rq08vgCcCAjHyRi/M7xlHKUykZCEtyBy9+DPF6GgEu8=
 github.com/alibabacloud-go/tea-xml v1.1.3 h1:7LYnm+JbOq2B+T/B0fHC4Ies4/FofC4zHzYtqw7dgt0=
 github.com/alibabacloud-go/tea-xml v1.1.3/go.mod h1:Rq08vgCcCAjHyRi/M7xlHKUykZCEtyBy9+DPF6GgEu8=
-github.com/aliyun/alibaba-cloud-sdk-go v1.62.590 h1:Cvekl0SVm0+gHPBdhdA3XA/ZghLOThyof4GaPLz7c1I=
-github.com/aliyun/alibaba-cloud-sdk-go v1.62.590/go.mod h1:CJJYa1ZMxjlN/NbXEwmejEnBkhi0DV+Yb3B2lxf+74o=
+github.com/aliyun/alibaba-cloud-sdk-go v1.63.107 h1:qagvUyrgOnBIlVRQWOyCZGVKUIYbMBdGdJ104vBpRFU=
+github.com/aliyun/alibaba-cloud-sdk-go v1.63.107/go.mod h1:SOSDHfe1kX91v3W5QiBsWSLqeLxImobbMX1mxrFHsVQ=
 github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.5.0 h1:3qbrAiouDwR8bh6P25vDiyU9qjIDU6TNefDiFFc+Jt0=
 github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.5.0/go.mod h1:FTzydeQVmR24FI0D6XWUOMKckjXehM/jgMn1xC+DA9M=
 github.com/aliyun/aliyun-datahub-sdk-go v0.1.5 h1:c2TFcJ5PjkqkHr2use7Av2wHB8jVgoKxX1gmLDsysR4=
@@ -688,7 +688,6 @@ github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
-github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -697,7 +696,6 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
-github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -1643,7 +1641,6 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.56.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.66.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=


### PR DESCRIPTION
bump alibaba-cloud-sdk-go to v1.63.107

```log
=== RUN   TestAccAlicloudVPNConnectionsDataSourceBasic
--- PASS: TestAccAlicloudVPNConnectionsDataSourceBasic (287.73s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  290.428s

=== RUN   TestAccAlicloudEdasApplication_basic
--- PASS: TestAccAlicloudEdasApplication_basic (59.74s)
=== RUN   TestAccAlicloudEdasApplication_multi
--- PASS: TestAccAlicloudEdasApplication_multi (26.31s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  89.199s

=== RUN   TestAccAlicloudEdasCluster_basic
--- PASS: TestAccAlicloudEdasCluster_basic (46.55s)
=== RUN   TestAccAlicloudEdasCluster_multi
--- PASS: TestAccAlicloudEdasCluster_multi (26.51s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  76.270s
```