### PR TITLE
resource/alicloud_db_instance: Fixed auto_renew_period Duration=0 guard in Read

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -2353,7 +2353,9 @@ func resourceAliCloudDBInstanceRead(d *schema.ResourceData, meta interface{}) er
 		if response != nil && len(items) > 0 {
 			renew := items[0].(map[string]interface{})
 			d.Set("auto_renew", renew["AutoRenew"] == "True")
-			d.Set("auto_renew_period", renew["Duration"])
+			if formatInt(renew["Duration"]) > 0 {
+				d.Set("auto_renew_period", renew["Duration"])
+			}
 		}
 		//period, err := computePeriodByUnit(instance["CreationTime"], instance["ExpireTime"], d.Get("period").(int), "Month")
 		//if err != nil {

--- a/alicloud/resource_alicloud_db_readonly_instance.go
+++ b/alicloud/resource_alicloud_db_readonly_instance.go
@@ -805,7 +805,9 @@ func resourceAlicloudDBReadonlyInstanceRead(d *schema.ResourceData, meta interfa
 		if response != nil && len(items) > 0 {
 			renew := items[0].(map[string]interface{})
 			d.Set("auto_renew", renew["AutoRenew"] == "True")
-			d.Set("auto_renew_period", renew["Duration"])
+			if formatInt(renew["Duration"]) > 0 {
+				d.Set("auto_renew_period", renew["Duration"])
+			}
 		}
 	}
 

--- a/alicloud/resource_alicloud_rds_ddr_instance.go
+++ b/alicloud/resource_alicloud_rds_ddr_instance.go
@@ -1526,7 +1526,9 @@ func resourceAlicloudRdsDdrInstanceRead(d *schema.ResourceData, meta interface{}
 		if response != nil && len(items) > 0 {
 			renew := items[0].(map[string]interface{})
 			d.Set("auto_renew", renew["AutoRenew"] == "True")
-			d.Set("auto_renew_period", renew["Duration"])
+			if formatInt(renew["Duration"]) > 0 {
+				d.Set("auto_renew_period", renew["Duration"])
+			}
 		}
 	}
 


### PR DESCRIPTION
DescribeInstanceAutoRenewalAttribute returns Duration=0 for Prepaid
instances without auto-renewal enabled. The Read function unconditionally
wrote this zero value to state, conflicting with schema IntBetween(1,12)
validation.

Added formatInt > 0 guard in:
- resource_alicloud_db_instance.go
- resource_alicloud_db_readonly_instance.go
- resource_alicloud_rds_ddr_instance.go

Fixes: Aone#1086837-82572065