### PR TITLE
resource/alicloud_privatelink_vpc_endpoint: support PVL cross-region; resource/alicloud_privatelink_vpc_endpoint_service: support PVL cross-region

### DIFF
--- a/alicloud/resource_alicloud_privatelink_vpc_endpoint.go
+++ b/alicloud/resource_alicloud_privatelink_vpc_endpoint.go
@@ -39,6 +39,11 @@ func resourceAliCloudPrivateLinkVpcEndpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"cross_region_bandwidth": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 			"create_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -90,6 +95,12 @@ func resourceAliCloudPrivateLinkVpcEndpoint() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"service_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"service_region_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -156,6 +167,12 @@ func resourceAliCloudPrivateLinkVpcEndpointCreate(d *schema.ResourceData, meta i
 	if v, ok := d.GetOkExists("zone_private_ip_address_count"); ok {
 		request["ZonePrivateIpAddressCount"] = v
 	}
+	if v, ok := d.GetOk("address_ip_version"); ok {
+		request["AddressIpVersion"] = v
+	}
+	if v, ok := d.GetOk("cross_region_bandwidth"); ok {
+		request["CrossRegionBandwidth"] = v
+	}
 	if v, ok := d.GetOk("security_group_ids"); ok {
 		securityGroupIdMapsArray := v.(*schema.Set).List()
 		request["SecurityGroupId"] = securityGroupIdMapsArray
@@ -170,6 +187,9 @@ func resourceAliCloudPrivateLinkVpcEndpointCreate(d *schema.ResourceData, meta i
 	request["VpcId"] = d.Get("vpc_id")
 	if v, ok := d.GetOk("service_name"); ok {
 		request["ServiceName"] = v
+	}
+	if v, ok := d.GetOk("service_region_id"); ok {
+		request["ServiceRegionId"] = v
 	}
 	if v, ok := d.GetOk("endpoint_description"); ok {
 		request["EndpointDescription"] = v
@@ -232,6 +252,9 @@ func resourceAliCloudPrivateLinkVpcEndpointRead(d *schema.ResourceData, meta int
 	if objectRaw["ConnectionStatus"] != nil {
 		d.Set("connection_status", objectRaw["ConnectionStatus"])
 	}
+	if objectRaw["CrossRegionBandwidth"] != nil {
+		d.Set("cross_region_bandwidth", objectRaw["CrossRegionBandwidth"])
+	}
 	if objectRaw["CreateTime"] != nil {
 		d.Set("create_time", objectRaw["CreateTime"])
 	}
@@ -258,6 +281,9 @@ func resourceAliCloudPrivateLinkVpcEndpointRead(d *schema.ResourceData, meta int
 	}
 	if objectRaw["ServiceId"] != nil {
 		d.Set("service_id", objectRaw["ServiceId"])
+	}
+	if objectRaw["ServiceRegionId"] != nil {
+		d.Set("service_region_id", objectRaw["ServiceRegionId"])
 	}
 	if objectRaw["ServiceName"] != nil {
 		d.Set("service_name", objectRaw["ServiceName"])
@@ -299,7 +325,6 @@ func resourceAliCloudPrivateLinkVpcEndpointUpdate(d *schema.ResourceData, meta i
 	var response map[string]interface{}
 	var query map[string]interface{}
 	update := false
-	d.Partial(true)
 
 	action := "UpdateVpcEndpointAttribute"
 	var err error
@@ -326,13 +351,17 @@ func resourceAliCloudPrivateLinkVpcEndpointUpdate(d *schema.ResourceData, meta i
 	if v, ok := d.GetOkExists("dry_run"); ok {
 		request["DryRun"] = v
 	}
-	if d.HasChange("address_ip_version") {
+	if !d.IsNewResource() && d.HasChange("address_ip_version") {
 		update = true
 		request["AddressIpVersion"] = d.Get("address_ip_version")
 	}
+	if !d.IsNewResource() && d.HasChange("cross_region_bandwidth") {
+		update = true
+		request["CrossRegionBandwidth"] = d.Get("cross_region_bandwidth")
+	}
 
 	if update {
-		wait := incrementalWait(3*time.Second, 5*time.Second)
+		wait := incrementalWait(5*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			response, err = client.RpcPost("Privatelink", "2020-04-15", action, query, request, true)
 			if err != nil {
@@ -368,7 +397,7 @@ func resourceAliCloudPrivateLinkVpcEndpointUpdate(d *schema.ResourceData, meta i
 	if update {
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
-			response, err = client.RpcPost("Privatelink", "2020-04-15", action, query, request, false)
+			response, err = client.RpcPost("Privatelink", "2020-04-15", action, query, request, true)
 			if err != nil {
 				if NeedRetry(err) {
 					wait()
@@ -477,7 +506,6 @@ func resourceAliCloudPrivateLinkVpcEndpointUpdate(d *schema.ResourceData, meta i
 		}
 
 	}
-	d.Partial(false)
 	return resourceAliCloudPrivateLinkVpcEndpointRead(d, meta)
 }
 

--- a/alicloud/resource_alicloud_privatelink_vpc_endpoint_service.go
+++ b/alicloud/resource_alicloud_privatelink_vpc_endpoint_service.go
@@ -1,4 +1,3 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
@@ -90,6 +89,12 @@ func resourceAliCloudPrivateLinkVpcEndpointService() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"supported_region_list": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -147,6 +152,9 @@ func resourceAliCloudPrivateLinkVpcEndpointServiceCreate(d *schema.ResourceData,
 	if v, ok := d.GetOkExists("auto_accept_connection"); ok {
 		request["AutoAcceptEnabled"] = v
 	}
+	if v, ok := d.GetOk("supported_region_list"); ok {
+		request["SupportedRegionList"] = v.(*schema.Set).List()
+	}
 	if v, ok := d.GetOkExists("dry_run"); ok {
 		request["DryRun"] = v
 	}
@@ -198,7 +206,7 @@ func resourceAliCloudPrivateLinkVpcEndpointServiceRead(d *schema.ResourceData, m
 
 	d.Set("address_ip_version", objectRaw["AddressIpVersion"])
 	d.Set("auto_accept_connection", objectRaw["AutoAcceptEnabled"])
-	d.Set("connect_bandwidth", objectRaw["ConnectBandwidth"])
+	setVpcEndpointServiceConnectBandwidth(d, objectRaw)
 	d.Set("create_time", objectRaw["CreateTime"])
 	d.Set("payer", objectRaw["Payer"])
 	d.Set("region_id", objectRaw["RegionId"])
@@ -208,6 +216,7 @@ func resourceAliCloudPrivateLinkVpcEndpointServiceRead(d *schema.ResourceData, m
 	d.Set("service_domain", objectRaw["ServiceDomain"])
 	d.Set("service_resource_type", objectRaw["ServiceResourceType"])
 	d.Set("service_support_ipv6", objectRaw["ServiceSupportIPv6"])
+	d.Set("supported_region_list", convertSupportedRegionSetToStringList(objectRaw["SupportedRegionSet"]))
 	d.Set("status", objectRaw["ServiceStatus"])
 	d.Set("vpc_endpoint_service_name", objectRaw["ServiceName"])
 	d.Set("zone_affinity_enabled", objectRaw["ZoneAffinityEnabled"])
@@ -221,6 +230,41 @@ func resourceAliCloudPrivateLinkVpcEndpointServiceRead(d *schema.ResourceData, m
 	d.Set("tags", tagsToMap(tagsMaps))
 
 	return nil
+}
+
+func setVpcEndpointServiceConnectBandwidth(d *schema.ResourceData, objectRaw map[string]interface{}) {
+	connectBandwidth, ok := objectRaw["ConnectBandwidth"]
+	serviceResourceType := fmt.Sprint(objectRaw["ServiceResourceType"])
+	if serviceResourceType == "" || serviceResourceType == "<nil>" {
+		if v, ok := d.GetOk("service_resource_type"); ok {
+			serviceResourceType = v.(string)
+		}
+	}
+
+	if serviceResourceType == "slb" {
+		d.Set("connect_bandwidth", connectBandwidth)
+		return
+	}
+	if ok && !isEmptyVpcEndpointServiceConnectBandwidth(connectBandwidth) {
+		d.Set("connect_bandwidth", connectBandwidth)
+	}
+}
+
+func isEmptyVpcEndpointServiceConnectBandwidth(v interface{}) bool {
+	switch vv := v.(type) {
+	case nil:
+		return true
+	case int:
+		return vv == 0
+	case int64:
+		return vv == 0
+	case float64:
+		return vv == 0
+	case string:
+		return vv == "" || vv == "0"
+	default:
+		return fmt.Sprint(vv) == "" || fmt.Sprint(vv) == "0"
+	}
 }
 
 func resourceAliCloudPrivateLinkVpcEndpointServiceUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -287,6 +331,77 @@ func resourceAliCloudPrivateLinkVpcEndpointServiceUpdate(d *schema.ResourceData,
 		addDebug(action, response, request)
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	if !d.IsNewResource() && d.HasChange("supported_region_list") {
+		oldEntry, newEntry := d.GetChange("supported_region_list")
+		oldEntrySet := oldEntry.(*schema.Set)
+		newEntrySet := newEntry.(*schema.Set)
+		removed := oldEntrySet.Difference(newEntrySet)
+		added := newEntrySet.Difference(oldEntrySet)
+
+		if added.Len() > 0 {
+			action = "UpdateVpcEndpointServiceAttribute"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["ServiceId"] = d.Id()
+			request["RegionId"] = client.RegionId
+			request["ClientToken"] = buildClientToken(action)
+			request["AddSupportedRegionSet"] = added.List()
+			if v, ok := d.GetOkExists("dry_run"); ok {
+				request["DryRun"] = v
+			}
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Privatelink", "2020-04-15", action, query, request, true)
+				if err != nil {
+					if IsExpectedErrors(err, []string{"EndpointServiceOperationDenied", "ConcurrentCallNotSupported", "EndpointServiceLocked"}) || NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+		}
+
+		if removed.Len() > 0 {
+			action = "UpdateVpcEndpointServiceAttribute"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["ServiceId"] = d.Id()
+			request["RegionId"] = client.RegionId
+			request["ClientToken"] = buildClientToken(action)
+			request["DeleteSupportedRegionSet"] = removed.List()
+			if v, ok := d.GetOkExists("dry_run"); ok {
+				request["DryRun"] = v
+			}
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Privatelink", "2020-04-15", action, query, request, true)
+				if err != nil {
+					if IsExpectedErrors(err, []string{"EndpointServiceOperationDenied", "ConcurrentCallNotSupported", "EndpointServiceLocked"}) || NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+		}
+
+		privateLinkServiceV2 := PrivateLinkServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{"Active"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, privateLinkServiceV2.PrivateLinkVpcEndpointServiceStateRefreshFunc(d.Id(), "ServiceStatus", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
 		}
 	}
 	update = false
@@ -385,4 +500,23 @@ func resourceAliCloudPrivateLinkVpcEndpointServiceDelete(d *schema.ResourceData,
 	}
 
 	return nil
+}
+
+func convertSupportedRegionSetToStringList(src interface{}) (result []interface{}) {
+	if src == nil {
+		return
+	}
+	for _, v := range convertToInterfaceArray(src) {
+		vv, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if fmt.Sprint(vv["RegionServiceStatus"]) == "Closed" {
+			continue
+		}
+		if regionId, ok := vv["SupportedRegionId"]; ok {
+			result = append(result, fmt.Sprint(regionId))
+		}
+	}
+	return
 }

--- a/alicloud/resource_alicloud_privatelink_vpc_endpoint_service_test.go
+++ b/alicloud/resource_alicloud_privatelink_vpc_endpoint_service_test.go
@@ -18,7 +18,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testAccPrivateLinkCrossRegionServiceRegion  = "cn-hangzhou"
+	testAccPrivateLinkCrossRegionEndpointRegion = "cn-beijing"
 )
 
 func init() {
@@ -99,7 +105,7 @@ func testSweepPrivatelinkVpcEndpointService(region string) error {
 	return nil
 }
 
-func TestAccAliCloudPrivatelinkVpcEndpointService_basic(t *testing.T) {
+func TestAccAliCloudPrivatelinkVpcEndpointService_base(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_privatelink_vpc_endpoint_service.default"
 	ra := resourceAttrInit(resourceId, AlicloudPrivatelinkVpcEndpointServiceMap)
@@ -189,6 +195,263 @@ func TestAccAliCloudPrivatelinkVpcEndpointService_basic(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudPrivatelinkVpcEndpointService_supportedRegionList(t *testing.T) {
+	resourceId := "alicloud_privatelink_vpc_endpoint_service.default"
+	ra := resourceAttrInit(resourceId, AlicloudPrivatelinkVpcEndpointServiceMap)
+	testAccCheck := ra.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccPrivateLinkCrossRegion%d", rand)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckPrivateLinkCrossRegion(t)
+		},
+		IDRefreshName:     resourceId,
+		ProviderFactories: testAccPrivateLinkProviderFactories(),
+		CheckDestroy:      testAccCheckPrivateLinkVpcEndpointServiceDestroyInRegion(testAccPrivateLinkCrossRegionServiceRegion),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateLinkVpcEndpointServiceSupportedRegionConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"service_description":     name,
+						"service_resource_type":   "nlb",
+						"auto_accept_connection":  "true",
+						"supported_region_list.#": "1",
+					}),
+					testAccCheckPrivateLinkVpcEndpointServiceSupportedRegions(resourceId, testAccPrivateLinkCrossRegionServiceRegion),
+					testAccAttachPrivateLinkVpcEndpointServiceResources(
+						resourceId,
+						"alicloud_nlb_load_balancer.service",
+						"data.alicloud_nlb_zones.default",
+					),
+				),
+			},
+			{
+				Config: testAccPrivateLinkVpcEndpointServiceSupportedAllRegionsConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"supported_region_list.#": "2",
+						"service_support_ipv6":    "false",
+					}),
+					testAccCheckPrivateLinkVpcEndpointServiceSupportedRegions(resourceId, testAccPrivateLinkCrossRegionServiceRegion, testAccPrivateLinkCrossRegionEndpointRegion),
+				),
+			},
+			{
+				Config: testAccPrivateLinkVpcEndpointServiceSupportedRegionConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"supported_region_list.#": "1",
+					}),
+					testAccCheckPrivateLinkVpcEndpointServiceSupportedRegions(resourceId, testAccPrivateLinkCrossRegionServiceRegion),
+				),
+			},
+			// ImportState is intentionally omitted because this test uses
+			// ProviderFactories with an inline provider region; Terraform SDK v1
+			// import steps can fail with "unknown provider \"alicloud\"" in this shape.
+		},
+	})
+}
+
+func testAccPrivateLinkVpcEndpointServiceSupportedRegionConfig(name string) string {
+	return testAccPrivateLinkVpcEndpointServiceSupportedRegionListConfig(name, []string{
+		testAccPrivateLinkCrossRegionServiceRegion,
+	})
+}
+
+func testAccPrivateLinkVpcEndpointServiceSupportedAllRegionsConfig(name string) string {
+	return testAccPrivateLinkVpcEndpointServiceSupportedRegionListConfig(name, []string{
+		testAccPrivateLinkCrossRegionServiceRegion,
+		testAccPrivateLinkCrossRegionEndpointRegion,
+	})
+}
+
+func testAccPrivateLinkProviderFactories() map[string]terraform.ResourceProviderFactory {
+	return map[string]terraform.ResourceProviderFactory{
+		"alicloud": func() (terraform.ResourceProvider, error) {
+			return Provider(), nil
+		},
+	}
+}
+
+func testAccPreCheckPrivateLinkCrossRegion(t *testing.T) {
+	testAccPreCheck(t)
+	if !testAccPrivateLinkRegionInList(connectivity.Hangzhou, connectivity.NLBSupportRegions) {
+		t.Skipf("Skipping unsupported service region %s. NLB supported regions: %v.", connectivity.Hangzhou, connectivity.NLBSupportRegions)
+		t.Skipped()
+	}
+}
+
+func testAccPrivateLinkRegionInList(region connectivity.Region, regions []connectivity.Region) bool {
+	for _, r := range regions {
+		if region == r {
+			return true
+		}
+	}
+	return false
+}
+
+func testAccCheckPrivateLinkVpcEndpointServiceDestroyInRegion(region string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rawClient, err := sharedClientForRegion(region)
+		if err != nil {
+			return WrapErrorf(err, "Error getting Alicloud client.")
+		}
+		client := rawClient.(*connectivity.AliyunClient)
+		service := PrivateLinkServiceV2{client}
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "alicloud_privatelink_vpc_endpoint_service" {
+				continue
+			}
+			_, err := service.DescribePrivateLinkVpcEndpointService(rs.Primary.ID)
+			if err != nil {
+				if NotFoundError(err) {
+					continue
+				}
+				return err
+			}
+			return fmt.Errorf("PrivateLink VpcEndpointService %s still exists", rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
+func testAccAttachPrivateLinkVpcEndpointServiceResources(serviceResourceName, resourceResourceName, zonesDataSourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		serviceId, err := testAccPrivateLinkStateResourceID(s, serviceResourceName)
+		if err != nil {
+			return err
+		}
+		resourceId, err := testAccPrivateLinkStateResourceID(s, resourceResourceName)
+		if err != nil {
+			return err
+		}
+		zoneIds, err := testAccPrivateLinkNlbZoneIdsFromState(s, zonesDataSourceName)
+		if err != nil {
+			return err
+		}
+
+		rawClient, err := sharedClientForRegion(testAccPrivateLinkCrossRegionServiceRegion)
+		if err != nil {
+			return WrapErrorf(err, "Error getting Alicloud client.")
+		}
+		client := rawClient.(*connectivity.AliyunClient)
+		for _, zoneId := range zoneIds {
+			if err := testAccAttachPrivateLinkVpcEndpointServiceResource(client, serviceId, resourceId, zoneId); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func testAccPrivateLinkStateResourceID(s *terraform.State, resourceName string) (string, error) {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return "", fmt.Errorf("resource %s not found", resourceName)
+	}
+	if rs.Primary == nil || rs.Primary.ID == "" {
+		return "", fmt.Errorf("resource %s has empty ID", resourceName)
+	}
+	return rs.Primary.ID, nil
+}
+
+func testAccPrivateLinkNlbZoneIdsFromState(s *terraform.State, resourceName string) ([]string, error) {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("resource %s not found", resourceName)
+	}
+	if rs.Primary == nil {
+		return nil, fmt.Errorf("resource %s has empty state", resourceName)
+	}
+
+	zoneIds := make([]string, 0, 2)
+	for i := 0; i < 2; i++ {
+		zoneId := rs.Primary.Attributes[fmt.Sprintf("zones.%d.id", i)]
+		if zoneId == "" {
+			zoneId = rs.Primary.Attributes[fmt.Sprintf("ids.%d", i)]
+		}
+		if zoneId == "" {
+			return nil, fmt.Errorf("resource %s has empty NLB zone at index %d", resourceName, i)
+		}
+		zoneIds = append(zoneIds, zoneId)
+	}
+	return zoneIds, nil
+}
+
+func testAccAttachPrivateLinkVpcEndpointServiceResource(client *connectivity.AliyunClient, serviceId, resourceId, zoneId string) error {
+	privateLinkServiceV2 := PrivateLinkServiceV2{client}
+	id := fmt.Sprintf("%s:%s:%s", serviceId, resourceId, zoneId)
+	if _, err := privateLinkServiceV2.DescribePrivateLinkVpcEndpointServiceResource(id); err == nil {
+		return nil
+	} else if !NotFoundError(err) {
+		return WrapError(err)
+	}
+
+	action := "AttachResourceToVpcEndpointService"
+	query := make(map[string]interface{})
+	request := map[string]interface{}{
+		"ResourceId":   resourceId,
+		"ServiceId":    serviceId,
+		"ZoneId":       zoneId,
+		"RegionId":     client.RegionId,
+		"ResourceType": "nlb",
+	}
+	var response map[string]interface{}
+	var err error
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		request["ClientToken"] = buildClientToken(action)
+		response, err = client.RpcPost("Privatelink", "2020-04-15", action, query, request, true)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"EndpointServiceOperationDenied", "ConcurrentCallNotSupported", "EndpointServiceLocked"}) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if _, describeErr := privateLinkServiceV2.DescribePrivateLinkVpcEndpointServiceResource(id); describeErr == nil {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_privatelink_vpc_endpoint_service_resource", action, AlibabaCloudSdkGoERROR)
+	}
+
+	stateConf := BuildStateConf([]string{}, []string{resourceId}, 5*time.Minute, 5*time.Second, privateLinkServiceV2.PrivateLinkVpcEndpointServiceResourceStateRefreshFunc(id, "ResourceId", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, id)
+	}
+	return nil
+}
+
+func testAccCheckPrivateLinkVpcEndpointServiceSupportedRegions(resourceName string, expected ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found", resourceName)
+		}
+		actual := make(map[string]bool)
+		for key, value := range rs.Primary.Attributes {
+			if strings.HasPrefix(key, "supported_region_list.") && key != "supported_region_list.#" {
+				actual[value] = true
+			}
+		}
+		if len(actual) != len(expected) {
+			return fmt.Errorf("expected supported_region_list %#v, got %#v", expected, actual)
+		}
+		for _, region := range expected {
+			if !actual[region] {
+				return fmt.Errorf("expected supported_region_list to contain %s, got %#v", region, actual)
+			}
+		}
+		return nil
+	}
+}
+
 var AlicloudPrivatelinkVpcEndpointServiceMap = map[string]string{
 	"service_business_status": "Normal",
 	"service_domain":          CHECKSET,
@@ -205,6 +468,135 @@ func AlicloudPrivatelinkVpcEndpointServiceBasicDependence(name string) string {
 	  enable = "On"
 	}
 `, name)
+}
+
+func testAccPrivateLinkVpcEndpointServiceSupportedRegionListConfig(name string, supportedRegions []string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+provider "alicloud" {
+  region = "%s"
+}
+
+data "alicloud_nlb_zones" "default" {}
+
+resource "alicloud_vpc" "service" {
+  vpc_name   = var.name
+  cidr_block = "10.0.0.0/8"
+}
+
+resource "alicloud_vswitch" "service_a" {
+  vpc_id     = alicloud_vpc.service.id
+  zone_id    = data.alicloud_nlb_zones.default.zones.0.id
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "alicloud_vswitch" "service_b" {
+  vpc_id     = alicloud_vpc.service.id
+  zone_id    = data.alicloud_nlb_zones.default.zones.1.id
+  cidr_block = "10.2.0.0/16"
+}
+
+resource "alicloud_nlb_load_balancer" "service" {
+  load_balancer_name = var.name
+  vpc_id             = alicloud_vpc.service.id
+  address_type       = "Intranet"
+
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.service_a.id
+    zone_id    = data.alicloud_nlb_zones.default.zones.0.id
+  }
+
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.service_b.id
+    zone_id    = data.alicloud_nlb_zones.default.zones.1.id
+  }
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service" "default" {
+  service_description    = var.name
+  service_resource_type  = "nlb"
+  auto_accept_connection = true
+  supported_region_list  = [
+%s
+  ]
+
+  depends_on = [alicloud_nlb_load_balancer.service]
+}
+`, name, testAccPrivateLinkCrossRegionServiceRegion, testAccPrivateLinkQuotedList(supportedRegions))
+}
+
+func testAccPrivateLinkQuotedList(values []string) string {
+	list := make([]string, 0, len(values))
+	for _, value := range values {
+		list = append(list, fmt.Sprintf("    %q,", value))
+	}
+	return strings.Join(list, "\n")
+}
+
+func TestUnitVpcEndpointServiceConnectBandwidthReadByResourceType(t *testing.T) {
+	p := Provider().(*schema.Provider).ResourcesMap
+
+	cases := []struct {
+		name                string
+		serviceResourceType string
+		response            map[string]interface{}
+		expected            int
+	}{
+		{
+			name:                "slb missing connect bandwidth is authoritative",
+			serviceResourceType: "slb",
+			response: map[string]interface{}{
+				"ServiceResourceType": "slb",
+			},
+			expected: 0,
+		},
+		{
+			name:                "slb returned connect bandwidth is authoritative",
+			serviceResourceType: "slb",
+			response: map[string]interface{}{
+				"ServiceResourceType": "slb",
+				"ConnectBandwidth":    100,
+			},
+			expected: 100,
+		},
+		{
+			name:                "nlb missing connect bandwidth preserves config",
+			serviceResourceType: "nlb",
+			response: map[string]interface{}{
+				"ServiceResourceType": "nlb",
+			},
+			expected: 3072,
+		},
+		{
+			name:                "alb zero connect bandwidth preserves config",
+			serviceResourceType: "alb",
+			response: map[string]interface{}{
+				"ServiceResourceType": "alb",
+				"ConnectBandwidth":    0,
+			},
+			expected: 3072,
+		},
+		{
+			name:                "gwlb empty connect bandwidth preserves config",
+			serviceResourceType: "gwlb",
+			response: map[string]interface{}{
+				"ServiceResourceType": "gwlb",
+				"ConnectBandwidth":    "",
+			},
+			expected: 3072,
+		},
+	}
+
+	for _, tc := range cases {
+		d, _ := schema.InternalMap(p["alicloud_privatelink_vpc_endpoint_service"].Schema).Data(nil, nil)
+		assert.Nil(t, d.Set("service_resource_type", tc.serviceResourceType))
+		assert.Nil(t, d.Set("connect_bandwidth", 3072))
+		setVpcEndpointServiceConnectBandwidth(d, tc.response)
+		assert.Equal(t, tc.expected, d.Get("connect_bandwidth"), tc.name)
+	}
 }
 
 // lintignore: R001
@@ -462,7 +854,7 @@ func TestUnitAlicloudPrivatelinkVpcEndpointService(t *testing.T) {
 
 // Test PrivateLink VpcEndpointService. >>> Resource test cases, automatically generated.
 // Case 生命周期测试-克隆-nlb 4837
-func TestAccAliCloudPrivateLinkVpcEndpointService_basic4837(t *testing.T) {
+func TestAccAliCloudPrivatelinkVpcEndpointService_case4837(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_privatelink_vpc_endpoint_service.default"
 	ra := resourceAttrInit(resourceId, AlicloudPrivateLinkVpcEndpointServiceMap4837)
@@ -589,7 +981,7 @@ func TestAccAliCloudPrivateLinkVpcEndpointService_basic4837(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run"},
+				ImportStateVerifyIgnore: []string{"connect_bandwidth", "dry_run"},
 			},
 		},
 	})
@@ -617,7 +1009,7 @@ data "alicloud_resource_manager_resource_groups" "default" {}
 }
 
 // Case pvl+gwlb生命周期测试 9628
-func TestAccAliCloudPrivateLinkVpcEndpointService_basic9628(t *testing.T) {
+func TestAccAliCloudPrivatelinkVpcEndpointService_case9628(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_privatelink_vpc_endpoint_service.default"
 	ra := resourceAttrInit(resourceId, AlicloudPrivateLinkVpcEndpointServiceMap9628)

--- a/alicloud/resource_alicloud_privatelink_vpc_endpoint_test.go
+++ b/alicloud/resource_alicloud_privatelink_vpc_endpoint_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -102,7 +103,7 @@ func testSweepPrivatelinkVpcEndpoint(region string) error {
 	return nil
 }
 
-func TestAccAliCloudPrivatelinkVpcEndpoint_basic(t *testing.T) {
+func TestAccAliCloudPrivatelinkVpcEndpoint_base(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_privatelink_vpc_endpoint.default"
 	ra := resourceAttrInit(resourceId, AlicloudPrivatelinkVpcEndpointMap)
@@ -219,6 +220,130 @@ func TestAccAliCloudPrivatelinkVpcEndpoint_basic(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudPrivatelinkVpcEndpoint_crossRegion(t *testing.T) {
+	resourceId := "alicloud_privatelink_vpc_endpoint.default"
+	ra := resourceAttrInit(resourceId, AlicloudPrivatelinkVpcEndpointMap)
+	testAccCheck := ra.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccPrivateLinkCrossRegion%d", rand)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckPrivateLinkCrossRegion(t)
+		},
+		ProviderFactories: testAccPrivateLinkProviderFactories(),
+		CheckDestroy:      testAccCheckPrivateLinkVpcEndpointDestroyInRegion(testAccPrivateLinkCrossRegionEndpointRegion),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateLinkVpcEndpointCrossRegionServiceRegionConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPrivateLinkVpcEndpointServiceSupportedRegions(
+						"alicloud_privatelink_vpc_endpoint_service.service",
+						testAccPrivateLinkCrossRegionServiceRegion,
+					),
+					testAccAttachPrivateLinkVpcEndpointServiceResources(
+						"alicloud_privatelink_vpc_endpoint_service.service",
+						"alicloud_nlb_load_balancer.service",
+						"data.alicloud_nlb_zones.service",
+					),
+				),
+			},
+			{
+				Config: testAccPrivateLinkVpcEndpointCrossRegionServiceAllRegionsConfig(name),
+				Check: testAccCheckPrivateLinkVpcEndpointServiceSupportedRegions(
+					"alicloud_privatelink_vpc_endpoint_service.service",
+					testAccPrivateLinkCrossRegionServiceRegion,
+					testAccPrivateLinkCrossRegionEndpointRegion,
+				),
+			},
+			{
+				Config: testAccPrivateLinkVpcEndpointCrossRegionConfig(name, 512),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"service_region_id":      testAccPrivateLinkCrossRegionServiceRegion,
+						"address_ip_version":     "IPv4",
+						"cross_region_bandwidth": "512",
+					}),
+					resource.TestCheckResourceAttrSet(resourceId, "service_id"),
+					resource.TestCheckResourceAttr(resourceId, "service_region_id", testAccPrivateLinkCrossRegionServiceRegion),
+					resource.TestCheckResourceAttrSet(resourceId, "vpc_id"),
+					resource.TestCheckResourceAttr(resourceId, "security_group_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceId, "vpc_endpoint_name", name),
+					resource.TestCheckResourceAttr(resourceId, "endpoint_description", name),
+					resource.TestCheckResourceAttr(resourceId, "address_ip_version", "IPv4"),
+					resource.TestCheckResourceAttr(resourceId, "cross_region_bandwidth", "512"),
+				),
+			},
+			{
+				Config: testAccPrivateLinkVpcEndpointCrossRegionConfig(name, 1000),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cross_region_bandwidth": "1000",
+					}),
+					resource.TestCheckResourceAttr(resourceId, "cross_region_bandwidth", "1000"),
+				),
+			},
+			{
+				Config: testAccPrivateLinkVpcEndpointCrossRegionServiceAllRegionsConfig(name),
+				Check: testAccCheckPrivateLinkVpcEndpointServiceSupportedRegions(
+					"alicloud_privatelink_vpc_endpoint_service.service",
+					testAccPrivateLinkCrossRegionServiceRegion,
+					testAccPrivateLinkCrossRegionEndpointRegion,
+				),
+			},
+			{
+				Config: testAccPrivateLinkVpcEndpointCrossRegionServiceRegionConfig(name),
+				Check: testAccCheckPrivateLinkVpcEndpointServiceSupportedRegions(
+					"alicloud_privatelink_vpc_endpoint_service.service",
+					testAccPrivateLinkCrossRegionServiceRegion,
+				),
+			},
+			// ImportState is intentionally omitted because the resource uses an
+			// aliased provider in a different region, and Terraform SDK v1 import
+			// steps do not reliably thread ProviderFactories through aliases.
+		},
+	})
+}
+
+func testAccPrivateLinkVpcEndpointCrossRegionServiceRegionConfig(name string) string {
+	return testAccPrivateLinkVpcEndpointCrossRegionServiceConfig(name, []string{
+		testAccPrivateLinkCrossRegionServiceRegion,
+	})
+}
+
+func testAccPrivateLinkVpcEndpointCrossRegionServiceAllRegionsConfig(name string) string {
+	return testAccPrivateLinkVpcEndpointCrossRegionServiceConfig(name, []string{
+		testAccPrivateLinkCrossRegionServiceRegion,
+		testAccPrivateLinkCrossRegionEndpointRegion,
+	})
+}
+
+func testAccCheckPrivateLinkVpcEndpointDestroyInRegion(region string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rawClient, err := sharedClientForRegion(region)
+		if err != nil {
+			return WrapErrorf(err, "Error getting Alicloud client.")
+		}
+		client := rawClient.(*connectivity.AliyunClient)
+		service := PrivateLinkServiceV2{client}
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "alicloud_privatelink_vpc_endpoint" {
+				continue
+			}
+			_, err := service.DescribePrivateLinkVpcEndpoint(rs.Primary.ID)
+			if err != nil {
+				if NotFoundError(err) {
+					continue
+				}
+				return err
+			}
+			return fmt.Errorf("PrivateLink VpcEndpoint %s still exists", rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
 var AlicloudPrivatelinkVpcEndpointMap = map[string]string{
 	"bandwidth":                CHECKSET,
 	"connection_status":        CHECKSET,
@@ -249,6 +374,102 @@ func AlicloudPrivatelinkVpcEndpointBasicDependence(name string) string {
      auto_accept_connection = false
 	}
 `, name)
+}
+
+func testAccPrivateLinkVpcEndpointCrossRegionConfig(name string, crossRegionBandwidth int) string {
+	return testAccPrivateLinkVpcEndpointCrossRegionServiceConfig(name, []string{
+		testAccPrivateLinkCrossRegionServiceRegion,
+		testAccPrivateLinkCrossRegionEndpointRegion,
+	}) + fmt.Sprintf(`
+resource "alicloud_vpc" "endpoint" {
+  provider   = alicloud.endpoint
+  vpc_name   = var.name
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_security_group" "endpoint" {
+  provider = alicloud.endpoint
+  name     = var.name
+  vpc_id   = alicloud_vpc.endpoint.id
+}
+
+resource "alicloud_privatelink_vpc_endpoint" "default" {
+  provider               = alicloud.endpoint
+  service_id             = alicloud_privatelink_vpc_endpoint_service.service.id
+  service_region_id      = "%s"
+  vpc_id                 = alicloud_vpc.endpoint.id
+  security_group_ids     = [alicloud_security_group.endpoint.id]
+  vpc_endpoint_name      = var.name
+  endpoint_description   = var.name
+  address_ip_version     = "IPv4"
+  cross_region_bandwidth = %d
+
+  depends_on = [alicloud_privatelink_vpc_endpoint_service.service]
+}
+`, testAccPrivateLinkCrossRegionServiceRegion, crossRegionBandwidth)
+}
+
+func testAccPrivateLinkVpcEndpointCrossRegionServiceConfig(name string, supportedRegions []string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+provider "alicloud" {
+  region = "%s"
+}
+
+provider "alicloud" {
+  alias  = "endpoint"
+  region = "%s"
+}
+
+data "alicloud_nlb_zones" "service" {}
+
+resource "alicloud_vpc" "service" {
+  vpc_name   = var.name
+  cidr_block = "10.0.0.0/8"
+}
+
+resource "alicloud_vswitch" "service_a" {
+  vpc_id     = alicloud_vpc.service.id
+  zone_id    = data.alicloud_nlb_zones.service.zones.0.id
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "alicloud_vswitch" "service_b" {
+  vpc_id     = alicloud_vpc.service.id
+  zone_id    = data.alicloud_nlb_zones.service.zones.1.id
+  cidr_block = "10.2.0.0/16"
+}
+
+resource "alicloud_nlb_load_balancer" "service" {
+  load_balancer_name = var.name
+  vpc_id             = alicloud_vpc.service.id
+  address_type       = "Intranet"
+
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.service_a.id
+    zone_id    = data.alicloud_nlb_zones.service.zones.0.id
+  }
+
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.service_b.id
+    zone_id    = data.alicloud_nlb_zones.service.zones.1.id
+  }
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service" "service" {
+  service_description    = var.name
+  service_resource_type  = "nlb"
+  auto_accept_connection = true
+  supported_region_list  = [
+%s
+  ]
+
+  depends_on = [alicloud_nlb_load_balancer.service]
+}
+`, name, testAccPrivateLinkCrossRegionServiceRegion, testAccPrivateLinkCrossRegionEndpointRegion, testAccPrivateLinkQuotedList(supportedRegions))
 }
 
 // lintignore: R001
@@ -623,7 +844,7 @@ func TestUnitAlicloudPrivatelinkVpcEndpoint(t *testing.T) {
 
 }
 
-func TestAccAliCloudPrivateLinkVpcEndpoint_basic4793(t *testing.T) {
+func TestAccAliCloudPrivatelinkVpcEndpoint_case4793Main(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_privatelink_vpc_endpoint.default"
 	ra := resourceAttrInit(resourceId, AlicloudPrivateLinkVpcEndpointMap4793)
@@ -937,7 +1158,6 @@ resource "alicloud_security_group" "default97JOJ3" {
 
 resource "alicloud_privatelink_vpc_endpoint_service" "defaultr0WBYX" {
   service_description   = "test-zejun-service"
-  connect_bandwidth     = "3072"
   service_resource_type = "nlb"
 }
 
@@ -946,7 +1166,7 @@ resource "alicloud_privatelink_vpc_endpoint_service" "defaultr0WBYX" {
 }
 
 // Case 4793  twin
-func TestAccAliCloudPrivateLinkVpcEndpoint_basic4793_twin(t *testing.T) {
+func TestAccAliCloudPrivatelinkVpcEndpoint_case4793Twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_privatelink_vpc_endpoint.default"
 	ra := resourceAttrInit(resourceId, AlicloudPrivateLinkVpcEndpointMap4793)
@@ -1012,7 +1232,7 @@ func TestAccAliCloudPrivateLinkVpcEndpoint_basic4793_twin(t *testing.T) {
 
 // Test PrivateLink VpcEndpoint. >>> Resource test cases, automatically generated.
 // Case 生命周期测试（PolicyDocument发布terraform） 6705
-func TestAccAliCloudPrivateLinkVpcEndpoint_basic6705(t *testing.T) {
+func TestAccAliCloudPrivatelinkVpcEndpoint_case6705Main(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_privatelink_vpc_endpoint.default"
 	ra := resourceAttrInit(resourceId, AlicloudPrivateLinkVpcEndpointMap6705)
@@ -1035,7 +1255,7 @@ func TestAccAliCloudPrivateLinkVpcEndpoint_basic6705(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"vpc_id":            "${alicloud_vpc.defaultbFzA4a.id}",
+					"vpc_id":            "${data.alicloud_vpcs.defaultbFzA4a.ids.0}",
 					"vpc_endpoint_name": name,
 					"service_id":        "epsrv-k1apjysze8u1l9t6uyg9",
 					"service_name":      "com.aliyuncs.privatelink.ap-southeast-5.oss",
@@ -1103,7 +1323,7 @@ func TestAccAliCloudPrivateLinkVpcEndpoint_basic6705(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"vpc_endpoint_name":             name + "_update",
-					"vpc_id":                        "${alicloud_vpc.defaultbFzA4a.id}",
+					"vpc_id":                        "${data.alicloud_vpcs.defaultbFzA4a.ids.0}",
 					"endpoint_description":          "test-endpoint-zejun",
 					"service_id":                    "epsrv-k1apjysze8u1l9t6uyg9",
 					"service_name":                  "com.aliyuncs.privatelink.ap-southeast-5.oss",
@@ -1186,8 +1406,9 @@ func TestAccAliCloudPrivateLinkVpcEndpoint_basic6705(t *testing.T) {
 }
 
 var AlicloudPrivateLinkVpcEndpointMap6705 = map[string]string{
-	"endpoint_domain":               CHECKSET,
-	"bandwidth":                     CHECKSET,
+	"endpoint_domain": CHECKSET,
+	// In some scenarios, bandwidth does not return.
+	//"bandwidth":                     CHECKSET,
 	"endpoint_type":                 CHECKSET,
 	"connection_status":             CHECKSET,
 	"status":                        CHECKSET,
@@ -1205,20 +1426,18 @@ variable "name" {
 
 data "alicloud_resource_manager_resource_groups" "default" {}
 
-resource "alicloud_vpc" "defaultbFzA4a" {
-  description = "test-terraform"
-  cidr_block  = "172.16.0.0/12"
-  vpc_name    = var.name
+data "alicloud_vpcs" "defaultbFzA4a" {
+  status = "Available"
 }
 
 resource "alicloud_security_group" "default1FTFrP" {
   name = var.name
-  vpc_id              = alicloud_vpc.defaultbFzA4a.id
+  vpc_id              = data.alicloud_vpcs.defaultbFzA4a.ids.0
 }
 
 resource "alicloud_security_group" "defaultjljY5S" {
   name = var.name
-  vpc_id              = alicloud_vpc.defaultbFzA4a.id
+  vpc_id              = data.alicloud_vpcs.defaultbFzA4a.ids.0
 }
 
 
@@ -1226,7 +1445,7 @@ resource "alicloud_security_group" "defaultjljY5S" {
 }
 
 // Case 生命周期测试（PolicyDocument发布terraform） 6705  twin
-func TestAccAliCloudPrivateLinkVpcEndpoint_basic6705_twin(t *testing.T) {
+func TestAccAliCloudPrivatelinkVpcEndpoint_case6705Twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_privatelink_vpc_endpoint.default"
 	ra := resourceAttrInit(resourceId, AlicloudPrivateLinkVpcEndpointMap6705)
@@ -1250,7 +1469,7 @@ func TestAccAliCloudPrivateLinkVpcEndpoint_basic6705_twin(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"vpc_endpoint_name":             name,
-					"vpc_id":                        "${alicloud_vpc.defaultbFzA4a.id}",
+					"vpc_id":                        "${data.alicloud_vpcs.defaultbFzA4a.ids.0}",
 					"endpoint_description":          "test-endpoint-zejun",
 					"service_id":                    "epsrv-k1apjysze8u1l9t6uyg9",
 					"service_name":                  "com.aliyuncs.privatelink.ap-southeast-5.oss",
@@ -1298,7 +1517,7 @@ func TestAccAliCloudPrivateLinkVpcEndpoint_basic6705_twin(t *testing.T) {
 }
 
 // Case 生命周期测试（PolicyDocument发布terraform） 6705  raw
-func TestAccAliCloudPrivateLinkVpcEndpoint_basic6705_raw(t *testing.T) {
+func TestAccAliCloudPrivatelinkVpcEndpoint_case6705Raw(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_privatelink_vpc_endpoint.default"
 	ra := resourceAttrInit(resourceId, AlicloudPrivateLinkVpcEndpointMap6705)
@@ -1322,7 +1541,7 @@ func TestAccAliCloudPrivateLinkVpcEndpoint_basic6705_raw(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"vpc_endpoint_name":             name,
-					"vpc_id":                        "${alicloud_vpc.defaultbFzA4a.id}",
+					"vpc_id":                        "${data.alicloud_vpcs.defaultbFzA4a.ids.0}",
 					"endpoint_description":          "test-endpoint-zejun",
 					"service_id":                    "epsrv-k1apjysze8u1l9t6uyg9",
 					"service_name":                  "com.aliyuncs.privatelink.ap-southeast-5.oss",

--- a/website/docs/r/privatelink_vpc_endpoint.html.markdown
+++ b/website/docs/r/privatelink_vpc_endpoint.html.markdown
@@ -79,6 +79,7 @@ The following arguments are supported:
 * `address_ip_version` - (Optional, Computed, Available since v1.239.0) The IP address version. Valid values:
   - `IPv4` (default): IPv4.
   - `DualStack`: dual-stack.
+* `cross_region_bandwidth` - (Optional, Computed, Int, Available since v1.282.0) The cross-region bandwidth that is supported by the cross-region endpoint.
 * `dry_run` - (Optional) Specifies whether to perform only a dry run, without performing the actual request. Valid values:
   - `true`: performs only a dry run. The system checks the request for potential issues, including missing parameter values, incorrect request syntax, and service limits. If the request fails the dry run, an error message is returned. If the request passes the dry run, the DryRunOperation error code is returned.
   - **false (default)**: performs a dry run and performs the actual request. If the request passes the dry run, a 2xx HTTP status code is returned and the operation is performed.
@@ -95,6 +96,7 @@ The following arguments are supported:
 
   The endpoint can be associated with up to 10 security groups.
 * `service_id` - (Optional, ForceNew, Computed) The ID of the endpoint service with which the endpoint is associated.
+* `service_region_id` - (Optional, Computed, ForceNew, Available since v1.282.0) The region ID of the endpoint service.
 * `service_name` - (Optional, ForceNew, Computed) The name of the endpoint service with which the endpoint is associated.
 * `tags` - (Optional, Map, Available since v1.212.0) The list of tags.
 * `vpc_endpoint_name` - (Optional) The name of the endpoint.

--- a/website/docs/r/privatelink_vpc_endpoint_service.html.markdown
+++ b/website/docs/r/privatelink_vpc_endpoint_service.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `auto_accept_connection` - (Optional) Indicates whether the endpoint service automatically accepts endpoint connection requests. Valid values:
   - `true`
   - `false`
-* `connect_bandwidth` - (Optional, Computed, Int) The default bandwidth of the endpoint connection. Valid values: 100 to 10240. Unit: Mbit/s.
+* `connect_bandwidth` - (Optional, Computed, Int) The default bandwidth of the endpoint connection. Valid values: 100 to 10240. Unit: Mbit/s. When `service_resource_type` is `slb`, this field can be read from the remote API. When `service_resource_type` is `nlb`, `alb`, or `gwlb`, this field can be configured but is not returned by the remote API.
 * `dry_run` - (Optional) Specifies whether to perform only a dry run, without performing the actual request.
   - `true`: performs only a dry run. The system checks the request for potential issues, including missing parameter values, incorrect request syntax, and service limits. If the request fails the dry run, an error message is returned. If the request passes the dry run, the DryRunOperation error code is returned.
   - **false (default)**: performs a dry run and performs the actual request. If the request passes the dry run, a 2xx HTTP status code is returned and the operation is performed.
@@ -64,6 +64,7 @@ The following arguments are supported:
 * `service_support_ipv6` - (Optional, Computed) Specifies whether to enable IPv6 for the endpoint service. Valid values:
   - `true`
   - **false (default)**
+* `supported_region_list` - (Optional, Computed, Set, Available since v1.282.0) The list of remote region IDs that are supported by the endpoint service.
 * `tags` - (Optional, Map) The list of tags.
 * `zone_affinity_enabled` - (Optional, Computed) Specifies whether to first resolve the domain name of the nearest endpoint that is associated with the endpoint service. Valid values:
   - `true`


### PR DESCRIPTION
## Summary

- Update PrivateLink `VpcEndpoint` and `VpcEndpointService` for PVL cross-region Terraform support.
- Add handwritten ACC coverage for `SupportedRegionList`, `ServiceRegionId`, and `CrossRegionBandwidth` cross-region scenarios.
- Preserve `VpcEndpointService.connect_bandwidth` state for non-`slb` service resource types when Get returns an empty value, while still reading it from the service side for `slb`.
- Refresh related resource documentation.

## Validation

- Rebased onto latest `upstream/master` before commit.
- `git diff --check`

Remote ACC task `6010`, `TestAccAliCloudPrivatelinkVpcEndpointService_` full resource set:

```text
=== RUN TestAccAliCloudPrivatelinkVpcEndpointService_base
--- PASS: TestAccAliCloudPrivatelinkVpcEndpointService_base (43.36s)

=== RUN TestAccAliCloudPrivatelinkVpcEndpointService_case4837
--- PASS: TestAccAliCloudPrivatelinkVpcEndpointService_case4837 (62.37s)

=== RUN TestAccAliCloudPrivatelinkVpcEndpointService_case9628
--- PASS: TestAccAliCloudPrivatelinkVpcEndpointService_case9628 (32.92s)

=== RUN TestAccAliCloudPrivatelinkVpcEndpointService_supportedRegionList
--- PASS: TestAccAliCloudPrivatelinkVpcEndpointService_supportedRegionList (228.07s)
```

Remote ACC task `6011`, `TestAccAliCloudPrivatelinkVpcEndpoint_` full resource set:

```text
=== RUN TestAccAliCloudPrivatelinkVpcEndpoint_base
--- PASS: TestAccAliCloudPrivatelinkVpcEndpoint_base (362.75s)

=== RUN TestAccAliCloudPrivatelinkVpcEndpoint_crossRegion
--- PASS: TestAccAliCloudPrivatelinkVpcEndpoint_crossRegion (337.62s)

=== RUN TestAccAliCloudPrivatelinkVpcEndpoint_case6705Raw
--- PASS: TestAccAliCloudPrivatelinkVpcEndpoint_case6705Raw (129.17s)

=== RUN TestAccAliCloudPrivatelinkVpcEndpoint_case4793Main
--- PASS: TestAccAliCloudPrivatelinkVpcEndpoint_case4793Main (798.36s)

=== RUN TestAccAliCloudPrivatelinkVpcEndpoint_case4793Twin
--- PASS: TestAccAliCloudPrivatelinkVpcEndpoint_case4793Twin (88.60s)

=== RUN TestAccAliCloudPrivatelinkVpcEndpoint_case6705Main
--- PASS: TestAccAliCloudPrivatelinkVpcEndpoint_case6705Main (349.77s)

=== RUN TestAccAliCloudPrivatelinkVpcEndpoint_case6705Twin
--- PASS: TestAccAliCloudPrivatelinkVpcEndpoint_case6705Twin (101.09s)
```

Local Go compile/test was not run because this provider build can overload the local machine.
