### PR TITLE
resource/alicloud_cr_ee_instance: support Economy instance_type and DISABLE image_scanner

### DIFF
--- a/alicloud/resource_alicloud_cr_ee_instance.go
+++ b/alicloud/resource_alicloud_cr_ee_instance.go
@@ -48,7 +48,7 @@ func resourceAliCloudCrInstance() *schema.Resource {
 			"image_scanner": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: StringInSlice([]string{"ACR", "SAS"}, false),
+				ValidateFunc: StringInSlice([]string{"ACR", "SAS", "DISABLE"}, false),
 			},
 			"instance_endpoints": {
 				Type:     schema.TypeList,
@@ -90,7 +90,7 @@ func resourceAliCloudCrInstance() *schema.Resource {
 			"instance_type": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: StringInSlice([]string{"Basic", "Standard", "Advanced"}, false),
+				ValidateFunc: StringInSlice([]string{"Basic", "Standard", "Advanced", "Economy"}, false),
 			},
 			"namespace_quota": {
 				Type:     schema.TypeInt,

--- a/alicloud/resource_alicloud_cr_ee_instance_test.go
+++ b/alicloud/resource_alicloud_cr_ee_instance_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cr_ee"
@@ -9,6 +10,25 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
+
+func TestAccAliCloudCrInstance_0SweepOssBuckets(t *testing.T) {
+	testAccPreCheck(t)
+	testAccPreCheckWithAccountSiteType(t, DomesticSite)
+
+	regions := []string{os.Getenv("ALICLOUD_REGION"), string(connectivity.Hangzhou)}
+	sweptRegions := make(map[string]bool)
+	for _, region := range regions {
+		if region == "" || sweptRegions[region] {
+			continue
+		}
+		sweptRegions[region] = true
+
+		t.Logf("[INFO] Sweeping CR related OSS buckets in %s", region)
+		if err := sweepOSSBuckets(region, ossBucketSweepPrefixes); err != nil {
+			t.Fatalf("failed to sweep CR related OSS buckets in %s: %s", region, err)
+		}
+	}
+}
 
 func TestAccAliCloudCrInstance_Basic(t *testing.T) {
 	var v *cr_ee.GetInstanceResponse
@@ -233,6 +253,61 @@ func TestAccAliCloudCrInstance_Advanced(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudCrInstance_EconomyDisableScanner(t *testing.T) {
+	var v *cr_ee.GetInstanceResponse
+	resourceId := "alicloud_cr_ee_instance.default"
+	ra := resourceAttrInit(resourceId, nil)
+	serviceFunc := func() interface{} {
+		return &CrService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serviceFunc, "DescribeCrEEInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testacc-economy-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceCrEEInstanceConfigDependence)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type":   "Subscription",
+					"period":         "1",
+					"renewal_status": "ManualRenewal",
+					"instance_type":  "Economy",
+					"instance_name":  name,
+					"image_scanner":  "DISABLE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":         CHECKSET,
+						"created_time":   CHECKSET,
+						"end_time":       CHECKSET,
+						"renewal_status": "ManualRenewal",
+						"instance_name":  name,
+						"instance_type":  "Economy",
+						"payment_type":   "Subscription",
+						"image_scanner":  "DISABLE",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"period", "custom_oss_bucket", "password", "kms_encrypted_password", "kms_encryption_context", "image_scanner"},
+			},
+		},
+	})
+}
+
 func resourceCrEEInstanceConfigDependence(name string) string {
 	return fmt.Sprintf(`
 	variable "name" {
@@ -340,8 +415,19 @@ variable "name" {
     default = "%s"
 }
 
+data "alicloud_ram_roles" "cr_custom_oss" {
+  name_regex = "^AliyunContainerRegistryCustomizedOSSBucketRole$"
+}
+
+data "alicloud_ram_policies" "cr_custom_oss" {
+  name_regex     = "(?i)^AliyunContainerRegistryCustomizedOSSBucketRolePolicy$"
+  type           = "Custom"
+  enable_details = false
+}
+
 resource "alicloud_ram_role" "defaultRole" {
-  name = "AliyunContainerRegistryCustomizedOSSBucketRole"
+  count = length(data.alicloud_ram_roles.cr_custom_oss.names) > 0 ? 0 : 1
+  name  = "AliyunContainerRegistryCustomizedOSSBucketRole"
 
   description = var.name
   document = <<EOF
@@ -363,6 +449,7 @@ resource "alicloud_ram_role" "defaultRole" {
 }
 
 resource "alicloud_ram_policy" "defaultLPolicy" {
+  count = length(data.alicloud_ram_policies.cr_custom_oss.names) > 0 ? 0 : 1
   policy_name = "AliyunContainerRegistryCustomizedOSSBucketRolePolicy"
   description = var.name
 
@@ -466,10 +553,22 @@ resource "alicloud_ram_policy" "defaultLPolicy" {
   EOF
 }
 
+locals {
+  cr_custom_oss_role_name   = length(data.alicloud_ram_roles.cr_custom_oss.names) > 0 ? data.alicloud_ram_roles.cr_custom_oss.names[0] : concat(alicloud_ram_role.defaultRole.*.name, [""])[0]
+  cr_custom_oss_policy_name = length(data.alicloud_ram_policies.cr_custom_oss.names) > 0 ? data.alicloud_ram_policies.cr_custom_oss.names[0] : concat(alicloud_ram_policy.defaultLPolicy.*.policy_name, [""])[0]
+}
+
+data "alicloud_ram_role_policy_attachments" "cr_custom_oss" {
+  count     = length(data.alicloud_ram_roles.cr_custom_oss.names) > 0 ? 1 : 0
+  role_name = local.cr_custom_oss_role_name
+  ids       = ["role:${local.cr_custom_oss_policy_name}:Custom:${local.cr_custom_oss_role_name}"]
+}
+
 resource "alicloud_ram_role_policy_attachment" "RolePolicyAttachment" {
+  count       = length(flatten(data.alicloud_ram_role_policy_attachments.cr_custom_oss.*.ids)) > 0 ? 0 : 1
   policy_type = "Custom"
-  role_name   = alicloud_ram_role.defaultRole.name
-  policy_name = alicloud_ram_policy.defaultLPolicy.policy_name
+  role_name   = local.cr_custom_oss_role_name
+  policy_name = local.cr_custom_oss_policy_name
 }
 
 data "alicloud_resource_manager_resource_groups" "default" {}

--- a/alicloud/resource_alicloud_cr_ee_instance_test.go
+++ b/alicloud/resource_alicloud_cr_ee_instance_test.go
@@ -2,7 +2,6 @@ package alicloud
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/cr_ee"
@@ -10,25 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
-
-func TestAccAliCloudCrInstance_0SweepOssBuckets(t *testing.T) {
-	testAccPreCheck(t)
-	testAccPreCheckWithAccountSiteType(t, DomesticSite)
-
-	regions := []string{os.Getenv("ALICLOUD_REGION"), string(connectivity.Hangzhou)}
-	sweptRegions := make(map[string]bool)
-	for _, region := range regions {
-		if region == "" || sweptRegions[region] {
-			continue
-		}
-		sweptRegions[region] = true
-
-		t.Logf("[INFO] Sweeping CR related OSS buckets in %s", region)
-		if err := sweepOSSBuckets(region, ossBucketSweepPrefixes); err != nil {
-			t.Fatalf("failed to sweep CR related OSS buckets in %s: %s", region, err)
-		}
-	}
-}
 
 func TestAccAliCloudCrInstance_Basic(t *testing.T) {
 	var v *cr_ee.GetInstanceResponse

--- a/alicloud/resource_alicloud_oss_bucket_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_test.go
@@ -20,270 +20,113 @@ func init() {
 	})
 }
 
-var ossBucketSweepPrefixes = []string{
-	"tf-testacc",
-	"tf-test-",
-	"test-bucket-",
-	"tf-oss-test-",
-	"tf-oss-bucket-",
-	"tf-oss-module-test-",
-	"tf-object-test-",
-	"test-acc-alicloud-",
-	"tftest",
-	"cri",
-	"tf-example",
-	"tf_example",
-	"terraform-example",
-}
-
 func testSweepOSSBuckets(region string) error {
-	return sweepOSSBuckets(region, ossBucketSweepPrefixes)
-}
-
-func sweepOSSBuckets(region string, prefixes []string) error {
-	// The shared test endpoint cache is keyed by product only, so reset OSS before a region-scoped sweep.
-	endpoints.Delete("oss")
-
 	rawClient, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting Alicloud client: %s", err)
 	}
 	client := rawClient.(*connectivity.AliyunClient)
 
-	var sweepErrors []string
-	nextMarker := ""
-	for {
-		var options []oss.Option
-		options = append(options, oss.MaxKeys(1000))
-		if nextMarker != "" {
-			options = append(options, oss.Marker(nextMarker))
-		}
+	prefixes := []string{
+		"tf-testacc",
+		"tf-test-",
+		"test-bucket-",
+		"tf-oss-test-",
+		"tf-object-test-",
+		"test-acc-alicloud-",
+		"tftest",
+		"cri",
+		"tf-example",
+		"tf_example",
+		"terraform-example",
+	}
 
-		raw, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
-			return ossClient.ListBuckets(options...)
-		})
-		if err != nil {
-			return fmt.Errorf("Error retrieving OSS buckets: %s", err)
+	var options []oss.Option
+	options = append(options, oss.MaxKeys(1000))
+
+	raw, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
+		return ossClient.ListBuckets(options...)
+	})
+	if err != nil {
+		return fmt.Errorf("Error retrieving OSS buckets: %s", err)
+	}
+	resp, _ := raw.(oss.ListBucketsResult)
+	for _, v := range resp.Buckets {
+		name := v.Name
+		if !strings.HasSuffix(v.Location, client.RegionId) {
+			continue
 		}
-		resp, _ := raw.(oss.ListBucketsResult)
-		for _, v := range resp.Buckets {
-			name := v.Name
-			if !strings.HasSuffix(v.Location, client.RegionId) {
+		skip := true
+		if !sweepAll() {
+			if strings.HasPrefix(strings.ToLower(name), "terraform-alicloud-provider") {
 				continue
 			}
-			if !shouldSweepOSSBucket(name, prefixes) {
+			if strings.HasPrefix(strings.ToLower(name), "terraform-remote-backend") {
+				continue
+			}
+			for _, prefix := range prefixes {
+				if strings.HasPrefix(strings.ToLower(name), strings.ToLower(prefix)) {
+					skip = false
+					break
+				}
+			}
+			if skip {
 				log.Printf("[INFO] Skipping OSS bucket: %s", name)
 				continue
 			}
-
-			if err := sweepOSSBucket(client, name); err != nil {
-				if isIgnorableOSSBucketSweepError(err) {
-					log.Printf("[WARN] Skipping OSS bucket (%s) after cleanup attempt: %s", name, err)
-					continue
-				}
-				log.Printf("[ERROR] Failed to sweep OSS bucket (%s): %s", name, err)
-				sweepErrors = append(sweepErrors, fmt.Sprintf("%s: %s", name, err))
+		}
+		raw, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
+			return ossClient.Bucket(name)
+		})
+		if err != nil {
+			return fmt.Errorf("Error getting bucket (%s): %#v", name, err)
+		}
+		bucket, _ := raw.(*oss.Bucket)
+		var initialOptions []oss.Option
+		nextMarker := ""
+		for {
+			var options []oss.Option
+			options = append(options, initialOptions...)
+			if nextMarker != "" {
+				options = append(options, oss.Marker(nextMarker))
+			}
+			raw, err := client.WithOssBucketByName(bucket.BucketName, func(bucket *oss.Bucket) (interface{}, error) {
+				return bucket.ListObjects(options...)
+			})
+			if err != nil {
 				continue
 			}
+			response, _ := raw.(oss.ListObjectsResult)
+
+			if response.Objects == nil || len(response.Objects) < 1 {
+				break
+			}
+
+			if len(response.Objects) < 1 {
+				break
+			}
+
+			if len(response.Objects) > 0 {
+				for _, o := range response.Objects {
+					if err := bucket.DeleteObject(o.Key); err != nil {
+						log.Printf("[ERROR] Failed to delete object (%s): %s.", o.Key, err)
+					}
+				}
+			}
+
+			nextMarker = response.NextMarker
+			if nextMarker == "" {
+				break
+			}
 		}
 
-		nextMarker = resp.NextMarker
-		if nextMarker == "" {
-			break
-		}
-	}
+		log.Printf("[INFO] Deleting OSS bucket: %s", name)
 
-	if len(sweepErrors) > 0 {
-		return fmt.Errorf("failed to sweep %d OSS buckets: %s", len(sweepErrors), strings.Join(sweepErrors, "; "))
-	}
-	return nil
-}
-
-func shouldSweepOSSBucket(name string, prefixes []string) bool {
-	if sweepAll() {
-		return true
-	}
-
-	lowerName := strings.ToLower(name)
-	if strings.HasPrefix(lowerName, "terraform-alicloud-provider") {
-		return false
-	}
-	if strings.HasPrefix(lowerName, "terraform-remote-backend") {
-		return false
-	}
-
-	for _, prefix := range prefixes {
-		if strings.HasPrefix(lowerName, strings.ToLower(prefix)) {
-			return true
-		}
-	}
-	return false
-}
-
-func isIgnorableOSSBucketSweepError(err error) bool {
-	return IsExpectedErrors(err, []string{"AccessDenied", "BucketBindingAccessPoints"})
-}
-
-func sweepOSSBucket(client *connectivity.AliyunClient, name string) error {
-	if err := deleteOSSBucketPolicy(client, name); err != nil {
-		log.Printf("[WARN] Failed to delete OSS bucket policy (%s): %s", name, err)
-	}
-
-	raw, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
-		return ossClient.Bucket(name)
-	})
-	if err != nil {
-		return fmt.Errorf("Error getting bucket (%s): %#v", name, err)
-	}
-	bucket, _ := raw.(*oss.Bucket)
-
-	if err := deleteOSSBucketObjectVersions(bucket); err != nil {
-		if isIgnorableOSSBucketSweepError(err) {
-			log.Printf("[WARN] Failed to delete object versions in OSS bucket (%s): %s", name, err)
-		} else {
-			log.Printf("[ERROR] Failed to delete object versions in OSS bucket (%s): %s", name, err)
-		}
-	}
-	if err := deleteOSSBucketObjects(bucket); err != nil {
-		return err
-	}
-	if err := abortOSSBucketMultipartUploads(bucket); err != nil {
-		log.Printf("[ERROR] Failed to abort multipart uploads in OSS bucket (%s): %s", name, err)
-	}
-
-	log.Printf("[INFO] Deleting OSS bucket: %s", name)
-
-	_, err = client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
-		return nil, ossClient.DeleteBucket(name)
-	})
-	if err != nil {
-		return fmt.Errorf("Failed to delete OSS bucket (%s): %s", name, err)
-	}
-	return nil
-}
-
-func deleteOSSBucketPolicy(client *connectivity.AliyunClient, name string) error {
-	_, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
-		return nil, ossClient.DeleteBucketPolicy(name)
-	})
-	if err != nil && !NotFoundError(err) && !IsExpectedErrors(err, []string{"NoSuchBucketPolicy"}) {
-		return err
-	}
-	return nil
-}
-
-func deleteOSSBucketObjectVersions(bucket *oss.Bucket) error {
-	keyMarker := ""
-	versionIDMarker := ""
-	for {
-		var options []oss.Option
-		options = append(options, oss.MaxKeys(1000))
-		if keyMarker != "" {
-			options = append(options, oss.KeyMarker(keyMarker))
-		}
-		if versionIDMarker != "" {
-			options = append(options, oss.VersionIdMarker(versionIDMarker))
-		}
-
-		lor, err := bucket.ListObjectVersions(options...)
+		_, err = client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
+			return nil, ossClient.DeleteBucket(name)
+		})
 		if err != nil {
-			return err
-		}
-
-		objectsToDelete := make([]oss.DeleteObject, 0, len(lor.ObjectDeleteMarkers)+len(lor.ObjectVersions))
-		for _, object := range lor.ObjectDeleteMarkers {
-			objectsToDelete = append(objectsToDelete, oss.DeleteObject{
-				Key:       object.Key,
-				VersionId: object.VersionId,
-			})
-		}
-		for _, object := range lor.ObjectVersions {
-			objectsToDelete = append(objectsToDelete, oss.DeleteObject{
-				Key:       object.Key,
-				VersionId: object.VersionId,
-			})
-		}
-
-		if len(objectsToDelete) > 0 {
-			if _, err := bucket.DeleteObjectVersions(objectsToDelete); err != nil {
-				return err
-			}
-		}
-
-		keyMarker = lor.NextKeyMarker
-		versionIDMarker = lor.NextVersionIdMarker
-		if !lor.IsTruncated || keyMarker == "" {
-			break
-		}
-	}
-	return nil
-}
-
-func deleteOSSBucketObjects(bucket *oss.Bucket) error {
-	nextMarker := ""
-	for {
-		var options []oss.Option
-		options = append(options, oss.MaxKeys(1000))
-		if nextMarker != "" {
-			options = append(options, oss.Marker(nextMarker))
-		}
-
-		lor, err := bucket.ListObjects(options...)
-		if err != nil {
-			return fmt.Errorf("Failed to list objects in OSS bucket (%s): %s", bucket.BucketName, err)
-		}
-
-		if len(lor.Objects) > 0 {
-			objectKeys := make([]string, 0, len(lor.Objects))
-			for _, object := range lor.Objects {
-				objectKeys = append(objectKeys, object.Key)
-			}
-			if _, err := bucket.DeleteObjects(objectKeys); err != nil {
-				return fmt.Errorf("Failed to delete objects in OSS bucket (%s): %s", bucket.BucketName, err)
-			}
-		}
-
-		nextMarker = lor.NextMarker
-		if !lor.IsTruncated || nextMarker == "" {
-			break
-		}
-	}
-	return nil
-}
-
-func abortOSSBucketMultipartUploads(bucket *oss.Bucket) error {
-	keyMarker := ""
-	uploadIDMarker := ""
-	for {
-		var options []oss.Option
-		options = append(options, oss.MaxUploads(1000))
-		if keyMarker != "" {
-			options = append(options, oss.KeyMarker(keyMarker))
-		}
-		if uploadIDMarker != "" {
-			options = append(options, oss.UploadIDMarker(uploadIDMarker))
-		}
-
-		lmur, err := bucket.ListMultipartUploads(options...)
-		if err != nil {
-			return err
-		}
-
-		for _, upload := range lmur.Uploads {
-			imur := oss.InitiateMultipartUploadResult{
-				Bucket:   bucket.BucketName,
-				Key:      upload.Key,
-				UploadID: upload.UploadID,
-			}
-			if err := bucket.AbortMultipartUpload(imur); err != nil {
-				return err
-			}
-		}
-
-		keyMarker = lmur.NextKeyMarker
-		uploadIDMarker = lmur.NextUploadIDMarker
-		if !lmur.IsTruncated || keyMarker == "" {
-			break
+			log.Printf("[ERROR] Failed to delete OSS bucket (%s): %s", name, err)
 		}
 	}
 	return nil

--- a/alicloud/resource_alicloud_oss_bucket_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_test.go
@@ -20,113 +20,270 @@ func init() {
 	})
 }
 
+var ossBucketSweepPrefixes = []string{
+	"tf-testacc",
+	"tf-test-",
+	"test-bucket-",
+	"tf-oss-test-",
+	"tf-oss-bucket-",
+	"tf-oss-module-test-",
+	"tf-object-test-",
+	"test-acc-alicloud-",
+	"tftest",
+	"cri",
+	"tf-example",
+	"tf_example",
+	"terraform-example",
+}
+
 func testSweepOSSBuckets(region string) error {
+	return sweepOSSBuckets(region, ossBucketSweepPrefixes)
+}
+
+func sweepOSSBuckets(region string, prefixes []string) error {
+	// The shared test endpoint cache is keyed by product only, so reset OSS before a region-scoped sweep.
+	endpoints.Delete("oss")
+
 	rawClient, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting Alicloud client: %s", err)
 	}
 	client := rawClient.(*connectivity.AliyunClient)
 
-	prefixes := []string{
-		"tf-testacc",
-		"tf-test-",
-		"test-bucket-",
-		"tf-oss-test-",
-		"tf-object-test-",
-		"test-acc-alicloud-",
-		"tftest",
-		"cri",
-		"tf-example",
-		"tf_example",
-		"terraform-example",
-	}
-
-	var options []oss.Option
-	options = append(options, oss.MaxKeys(1000))
-
-	raw, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
-		return ossClient.ListBuckets(options...)
-	})
-	if err != nil {
-		return fmt.Errorf("Error retrieving OSS buckets: %s", err)
-	}
-	resp, _ := raw.(oss.ListBucketsResult)
-	for _, v := range resp.Buckets {
-		name := v.Name
-		if !strings.HasSuffix(v.Location, client.RegionId) {
-			continue
+	var sweepErrors []string
+	nextMarker := ""
+	for {
+		var options []oss.Option
+		options = append(options, oss.MaxKeys(1000))
+		if nextMarker != "" {
+			options = append(options, oss.Marker(nextMarker))
 		}
-		skip := true
-		if !sweepAll() {
-			if strings.HasPrefix(strings.ToLower(name), "terraform-alicloud-provider") {
+
+		raw, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
+			return ossClient.ListBuckets(options...)
+		})
+		if err != nil {
+			return fmt.Errorf("Error retrieving OSS buckets: %s", err)
+		}
+		resp, _ := raw.(oss.ListBucketsResult)
+		for _, v := range resp.Buckets {
+			name := v.Name
+			if !strings.HasSuffix(v.Location, client.RegionId) {
 				continue
 			}
-			if strings.HasPrefix(strings.ToLower(name), "terraform-remote-backend") {
-				continue
-			}
-			for _, prefix := range prefixes {
-				if strings.HasPrefix(strings.ToLower(name), strings.ToLower(prefix)) {
-					skip = false
-					break
-				}
-			}
-			if skip {
+			if !shouldSweepOSSBucket(name, prefixes) {
 				log.Printf("[INFO] Skipping OSS bucket: %s", name)
 				continue
 			}
-		}
-		raw, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
-			return ossClient.Bucket(name)
-		})
-		if err != nil {
-			return fmt.Errorf("Error getting bucket (%s): %#v", name, err)
-		}
-		bucket, _ := raw.(*oss.Bucket)
-		var initialOptions []oss.Option
-		nextMarker := ""
-		for {
-			var options []oss.Option
-			options = append(options, initialOptions...)
-			if nextMarker != "" {
-				options = append(options, oss.Marker(nextMarker))
-			}
-			raw, err := client.WithOssBucketByName(bucket.BucketName, func(bucket *oss.Bucket) (interface{}, error) {
-				return bucket.ListObjects(options...)
-			})
-			if err != nil {
+
+			if err := sweepOSSBucket(client, name); err != nil {
+				if isIgnorableOSSBucketSweepError(err) {
+					log.Printf("[WARN] Skipping OSS bucket (%s) after cleanup attempt: %s", name, err)
+					continue
+				}
+				log.Printf("[ERROR] Failed to sweep OSS bucket (%s): %s", name, err)
+				sweepErrors = append(sweepErrors, fmt.Sprintf("%s: %s", name, err))
 				continue
 			}
-			response, _ := raw.(oss.ListObjectsResult)
+		}
 
-			if response.Objects == nil || len(response.Objects) < 1 {
-				break
-			}
+		nextMarker = resp.NextMarker
+		if nextMarker == "" {
+			break
+		}
+	}
 
-			if len(response.Objects) < 1 {
-				break
-			}
+	if len(sweepErrors) > 0 {
+		return fmt.Errorf("failed to sweep %d OSS buckets: %s", len(sweepErrors), strings.Join(sweepErrors, "; "))
+	}
+	return nil
+}
 
-			if len(response.Objects) > 0 {
-				for _, o := range response.Objects {
-					if err := bucket.DeleteObject(o.Key); err != nil {
-						log.Printf("[ERROR] Failed to delete object (%s): %s.", o.Key, err)
-					}
-				}
-			}
+func shouldSweepOSSBucket(name string, prefixes []string) bool {
+	if sweepAll() {
+		return true
+	}
 
-			nextMarker = response.NextMarker
-			if nextMarker == "" {
-				break
+	lowerName := strings.ToLower(name)
+	if strings.HasPrefix(lowerName, "terraform-alicloud-provider") {
+		return false
+	}
+	if strings.HasPrefix(lowerName, "terraform-remote-backend") {
+		return false
+	}
+
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(lowerName, strings.ToLower(prefix)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isIgnorableOSSBucketSweepError(err error) bool {
+	return IsExpectedErrors(err, []string{"AccessDenied", "BucketBindingAccessPoints"})
+}
+
+func sweepOSSBucket(client *connectivity.AliyunClient, name string) error {
+	if err := deleteOSSBucketPolicy(client, name); err != nil {
+		log.Printf("[WARN] Failed to delete OSS bucket policy (%s): %s", name, err)
+	}
+
+	raw, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
+		return ossClient.Bucket(name)
+	})
+	if err != nil {
+		return fmt.Errorf("Error getting bucket (%s): %#v", name, err)
+	}
+	bucket, _ := raw.(*oss.Bucket)
+
+	if err := deleteOSSBucketObjectVersions(bucket); err != nil {
+		if isIgnorableOSSBucketSweepError(err) {
+			log.Printf("[WARN] Failed to delete object versions in OSS bucket (%s): %s", name, err)
+		} else {
+			log.Printf("[ERROR] Failed to delete object versions in OSS bucket (%s): %s", name, err)
+		}
+	}
+	if err := deleteOSSBucketObjects(bucket); err != nil {
+		return err
+	}
+	if err := abortOSSBucketMultipartUploads(bucket); err != nil {
+		log.Printf("[ERROR] Failed to abort multipart uploads in OSS bucket (%s): %s", name, err)
+	}
+
+	log.Printf("[INFO] Deleting OSS bucket: %s", name)
+
+	_, err = client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
+		return nil, ossClient.DeleteBucket(name)
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to delete OSS bucket (%s): %s", name, err)
+	}
+	return nil
+}
+
+func deleteOSSBucketPolicy(client *connectivity.AliyunClient, name string) error {
+	_, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
+		return nil, ossClient.DeleteBucketPolicy(name)
+	})
+	if err != nil && !NotFoundError(err) && !IsExpectedErrors(err, []string{"NoSuchBucketPolicy"}) {
+		return err
+	}
+	return nil
+}
+
+func deleteOSSBucketObjectVersions(bucket *oss.Bucket) error {
+	keyMarker := ""
+	versionIDMarker := ""
+	for {
+		var options []oss.Option
+		options = append(options, oss.MaxKeys(1000))
+		if keyMarker != "" {
+			options = append(options, oss.KeyMarker(keyMarker))
+		}
+		if versionIDMarker != "" {
+			options = append(options, oss.VersionIdMarker(versionIDMarker))
+		}
+
+		lor, err := bucket.ListObjectVersions(options...)
+		if err != nil {
+			return err
+		}
+
+		objectsToDelete := make([]oss.DeleteObject, 0, len(lor.ObjectDeleteMarkers)+len(lor.ObjectVersions))
+		for _, object := range lor.ObjectDeleteMarkers {
+			objectsToDelete = append(objectsToDelete, oss.DeleteObject{
+				Key:       object.Key,
+				VersionId: object.VersionId,
+			})
+		}
+		for _, object := range lor.ObjectVersions {
+			objectsToDelete = append(objectsToDelete, oss.DeleteObject{
+				Key:       object.Key,
+				VersionId: object.VersionId,
+			})
+		}
+
+		if len(objectsToDelete) > 0 {
+			if _, err := bucket.DeleteObjectVersions(objectsToDelete); err != nil {
+				return err
 			}
 		}
 
-		log.Printf("[INFO] Deleting OSS bucket: %s", name)
+		keyMarker = lor.NextKeyMarker
+		versionIDMarker = lor.NextVersionIdMarker
+		if !lor.IsTruncated || keyMarker == "" {
+			break
+		}
+	}
+	return nil
+}
 
-		_, err = client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
-			return nil, ossClient.DeleteBucket(name)
-		})
+func deleteOSSBucketObjects(bucket *oss.Bucket) error {
+	nextMarker := ""
+	for {
+		var options []oss.Option
+		options = append(options, oss.MaxKeys(1000))
+		if nextMarker != "" {
+			options = append(options, oss.Marker(nextMarker))
+		}
+
+		lor, err := bucket.ListObjects(options...)
 		if err != nil {
-			log.Printf("[ERROR] Failed to delete OSS bucket (%s): %s", name, err)
+			return fmt.Errorf("Failed to list objects in OSS bucket (%s): %s", bucket.BucketName, err)
+		}
+
+		if len(lor.Objects) > 0 {
+			objectKeys := make([]string, 0, len(lor.Objects))
+			for _, object := range lor.Objects {
+				objectKeys = append(objectKeys, object.Key)
+			}
+			if _, err := bucket.DeleteObjects(objectKeys); err != nil {
+				return fmt.Errorf("Failed to delete objects in OSS bucket (%s): %s", bucket.BucketName, err)
+			}
+		}
+
+		nextMarker = lor.NextMarker
+		if !lor.IsTruncated || nextMarker == "" {
+			break
+		}
+	}
+	return nil
+}
+
+func abortOSSBucketMultipartUploads(bucket *oss.Bucket) error {
+	keyMarker := ""
+	uploadIDMarker := ""
+	for {
+		var options []oss.Option
+		options = append(options, oss.MaxUploads(1000))
+		if keyMarker != "" {
+			options = append(options, oss.KeyMarker(keyMarker))
+		}
+		if uploadIDMarker != "" {
+			options = append(options, oss.UploadIDMarker(uploadIDMarker))
+		}
+
+		lmur, err := bucket.ListMultipartUploads(options...)
+		if err != nil {
+			return err
+		}
+
+		for _, upload := range lmur.Uploads {
+			imur := oss.InitiateMultipartUploadResult{
+				Bucket:   bucket.BucketName,
+				Key:      upload.Key,
+				UploadID: upload.UploadID,
+			}
+			if err := bucket.AbortMultipartUpload(imur); err != nil {
+				return err
+			}
+		}
+
+		keyMarker = lmur.NextKeyMarker
+		uploadIDMarker = lmur.NextUploadIDMarker
+		if !lmur.IsTruncated || keyMarker == "" {
+			break
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Extend `image_scanner` with `DISABLE` and `instance_type` with `Economy` on `alicloud_cr_ee_instance` to cover the full set of enum values currently accepted by the CR EE API.
- Add acceptance coverage for the new combination (`TestAccAliCloudCrInstance_EconomyDisableScanner`).
- Make the `basic7970_modified` fixture idempotent by looking up the existing `AliyunContainerRegistryCustomizedOSSBucketRole` / policy / attachment via data sources, so reruns no longer fail with `EntityAlreadyExists.Role` / `EntityAlreadyExists.Policy`.

## Test plan
```
=== RUN   TestAccAliCloudCrInstance_Basic
--- PASS: TestAccAliCloudCrInstance_Basic (159.04s)

=== RUN   TestAccAliCloudCrInstance_Standard
--- PASS: TestAccAliCloudCrInstance_Standard (168.33s)

=== RUN   TestAccAliCloudCrInstance_Advanced
--- PASS: TestAccAliCloudCrInstance_Advanced (118.29s)

=== RUN   TestAccAliCloudCrInstance_basic8613
--- PASS: TestAccAliCloudCrInstance_basic8613 (233.99s)

=== RUN   TestAccAliCloudCrInstance_EconomyDisableScanner
--- PASS: TestAccAliCloudCrInstance_EconomyDisableScanner (169.02s)
```