### PR TITLE
resource/alicloud_cloud_firewall_instance: add auto_asset_protection

### DIFF
--- a/alicloud/resource_alicloud_cloud_firewall_instance.go
+++ b/alicloud/resource_alicloud_cloud_firewall_instance.go
@@ -163,6 +163,11 @@ func resourceAliCloudCloudFirewallInstance() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: IntBetween(5, 5000),
 			},
+			"auto_asset_protection": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"modify_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -296,6 +301,13 @@ func resourceAliCloudCloudFirewallInstanceCreate(d *schema.ResourceData, meta in
 		})
 	}
 
+	if v, ok := d.GetOk("auto_asset_protection"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "AutoAssetProtection",
+			"Value": v,
+		})
+	}
+
 	// v1 instance and subType is `Subscription` -> set CfwOverflow=true
 	if (request["ProductCode"].(string)) == "vipcloudfw" && (request["SubscriptionType"].(string)) == "Subscription" {
 		parameterMapList = append(parameterMapList, map[string]interface{}{
@@ -359,6 +371,7 @@ func resourceAliCloudCloudFirewallInstanceRead(d *schema.ResourceData, meta inte
 	client := meta.(*connectivity.AliyunClient)
 	bssOpenApiService := BssOpenApiService{client}
 	cloudfwService := CloudfwService{client}
+	cloudFirewallServiceV2 := CloudFirewallServiceV2{client}
 
 	getQueryInstanceObject, err := bssOpenApiService.QueryAvailableInstance(d.Id())
 	if err != nil {
@@ -390,6 +403,15 @@ func resourceAliCloudCloudFirewallInstanceRead(d *schema.ResourceData, meta inte
 	d.Set("ip_number", object["IpNumber"])
 	d.Set("user_status", object["UserStatus"])
 	d.Set("status", object["InstanceStatus"])
+
+	assetStatistic, err := cloudFirewallServiceV2.DescribeInstanceDescribeAssetStatistic(d.Id())
+	if err != nil {
+		if !NotFoundError(err) {
+			return WrapError(err)
+		}
+	} else {
+		d.Set("auto_asset_protection", fmt.Sprint(assetStatistic["AutoResourceEnable"]))
+	}
 
 	return nil
 }
@@ -662,6 +684,38 @@ func resourceAliCloudCloudFirewallInstanceUpdate(d *schema.ResourceData, meta in
 		d.SetPartial("instance_count")
 	}
 
+	update = false
+	setAutoProtectNewAssetsRequest := make(map[string]interface{})
+	setAutoProtectNewAssetsQuery := make(map[string]interface{})
+
+	if !d.IsNewResource() && d.HasChange("auto_asset_protection") {
+		update = true
+	}
+	setAutoProtectNewAssetsRequest["AutoProtect"] = d.Get("auto_asset_protection")
+
+	if update {
+		var err error
+		action := "SetAutoProtectNewAssets"
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Cloudfw", "2017-12-07", action, setAutoProtectNewAssetsQuery, setAutoProtectNewAssetsRequest, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, setAutoProtectNewAssetsRequest)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		d.SetPartial("auto_asset_protection")
+	}
+
 	cfwInstance, err := cloudFireWallService.DescribeCloudFirewallInstanceUserBuyVersion(d.Id())
 	if err != nil {
 		return WrapError(err)
@@ -760,6 +814,27 @@ func resourceAliCloudCloudFirewallInstanceDelete(d *schema.ResourceData, meta in
 
 	if fmt.Sprint(response["Success"]) == "false" || fmt.Sprint(response["ReleaseStatus"]) == "false" {
 		return WrapError(fmt.Errorf("%s failed, response: %v", action, response))
+	}
+
+	bssOpenApiService := BssOpenApiService{client}
+	wait = incrementalWait(10*time.Second, 10*time.Second)
+	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutDelete)), func() *resource.RetryError {
+		_, err = bssOpenApiService.QueryAvailableInstance(d.Id())
+		if err != nil {
+			if NotFoundError(err) {
+				return nil
+			}
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		wait()
+		return resource.RetryableError(fmt.Errorf("Cloud Firewall instance %s still exists", d.Id()))
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), "WaitForReleasePostInstance", AlibabaCloudSdkGoERROR)
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_cloud_firewall_instance_test.go
+++ b/alicloud/resource_alicloud_cloud_firewall_instance_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -18,7 +19,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	cloudFirewallInstanceLogisticsConfig = `{\"cityCode\":\"330100\",\"cityName\":\"Hangzhou\",\"contactName\":\"TerraformAcc\",\"countryCode\":\"CN\",\"detailAddress\":\"No.1 Test Road\",\"districtCode\":\"330106\",\"districtName\":\"Xihu District\",\"email\":\"tfacc@example.com\",\"mobilePhone\":\"153564848844\",\"phone\":\"1234567\",\"provCode\":\"330000\",\"provName\":\"Zhejiang\",\"streetCode\":\"33010610\",\"streetName\":\"Zhuantang\",\"zipCode\":\"0000\"}`
+	cloudFirewallInstanceLogisticsState  = `{"cityCode":"330100","cityName":"Hangzhou","contactName":"TerraformAcc","countryCode":"CN","detailAddress":"No.1 Test Road","districtCode":"330106","districtName":"Xihu District","email":"tfacc@example.com","mobilePhone":"153564848844","phone":"1234567","provCode":"330000","provName":"Zhejiang","streetCode":"33010610","streetName":"Zhuantang","zipCode":"0000"}`
+)
+
 func TestAccAliCloudCloudFirewallInstance_basic0(t *testing.T) {
+	ensureCloudFirewallInstanceTestRegion()
 	var v map[string]interface{}
 	resourceId := "alicloud_cloud_firewall_instance.default"
 	ra := resourceAttrInit(resourceId, AliCloudCloudFirewallInstanceMap0)
@@ -32,8 +39,7 @@ func TestAccAliCloudCloudFirewallInstance_basic0(t *testing.T) {
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudFirewallInstanceBasicDependence0)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckForCleanUpInstances(t, "", "vipcloudfw", "vipcloudfw", "cfw", "cfw_pre_intl")
+			testAccCloudFirewallInstancePreCheck(t)
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
@@ -41,23 +47,27 @@ func TestAccAliCloudCloudFirewallInstance_basic0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"payment_type": "PayAsYouGo",
+					"payment_type":          "PayAsYouGo",
+					"auto_asset_protection": "true",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"payment_type": "PayAsYouGo",
+						"payment_type":          "PayAsYouGo",
+						"auto_asset_protection": "true",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"cfw_log":     "true",
-					"modify_type": "Upgrade",
+					"cfw_log":               "true",
+					"modify_type":           "Upgrade",
+					"auto_asset_protection": "false",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"cfw_log":     "true",
-						"modify_type": "Upgrade",
+						"cfw_log":               "true",
+						"modify_type":           "Upgrade",
+						"auto_asset_protection": "false",
 					}),
 				),
 			},
@@ -72,6 +82,7 @@ func TestAccAliCloudCloudFirewallInstance_basic0(t *testing.T) {
 }
 
 func TestAccAliCloudCloudFirewallInstance_basic0_twin(t *testing.T) {
+	ensureCloudFirewallInstanceTestRegion()
 	var v map[string]interface{}
 	resourceId := "alicloud_cloud_firewall_instance.default"
 	ra := resourceAttrInit(resourceId, AliCloudCloudFirewallInstanceMap0)
@@ -85,8 +96,7 @@ func TestAccAliCloudCloudFirewallInstance_basic0_twin(t *testing.T) {
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudFirewallInstanceBasicDependence0)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckForCleanUpInstances(t, "", "vipcloudfw", "vipcloudfw", "cfw", "cfw_pre_intl")
+			testAccCloudFirewallInstancePreCheck(t)
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
@@ -116,6 +126,7 @@ func TestAccAliCloudCloudFirewallInstance_basic0_twin(t *testing.T) {
 }
 
 func TestAccAliCloudCloudFirewallInstance_basic1(t *testing.T) {
+	ensureCloudFirewallInstanceTestRegion()
 	var v map[string]interface{}
 	resourceId := "alicloud_cloud_firewall_instance.default"
 	ra := resourceAttrInit(resourceId, AliCloudCloudFirewallInstanceMap0)
@@ -129,8 +140,7 @@ func TestAccAliCloudCloudFirewallInstance_basic1(t *testing.T) {
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudFirewallInstanceBasicDependence0)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
-			testAccPreCheckForCleanUpInstances(t, "", "vipcloudfw", "vipcloudfw", "cfw", "cfw_pre_intl")
+			testAccCloudFirewallInstancePreCheck(t)
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
@@ -143,6 +153,7 @@ func TestAccAliCloudCloudFirewallInstance_basic1(t *testing.T) {
 					"ip_number":    "50",
 					"band_width":   "50",
 					"cfw_log":      "false",
+					"logistics":    cloudFirewallInstanceLogisticsConfig,
 					"period":       "1",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -151,6 +162,7 @@ func TestAccAliCloudCloudFirewallInstance_basic1(t *testing.T) {
 						"spec":         "enterprise_version",
 						"ip_number":    "50",
 						"cfw_log":      "false",
+						"logistics":    cloudFirewallInstanceLogisticsState,
 						"period":       "1",
 					}),
 				),
@@ -170,44 +182,49 @@ func TestAccAliCloudCloudFirewallInstance_basic1(t *testing.T) {
 			//},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"band_width":  "55",
-					"modify_type": "Upgrade",
+					"spec":          "ultimate_version",
+					"ip_number":     "400",
+					"band_width":    "200",
+					"fw_vpc_number": "5",
+					"modify_type":   "Upgrade",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"fw_vpc_number": "2",
+						"spec":          "ultimate_version",
+						"ip_number":     "400",
+						"fw_vpc_number": "5",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"cfw_log":         "true",
-					"cfw_log_storage": "3000",
+					"cfw_log_storage": "5000",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"cfw_log":         "true",
-						"cfw_log_storage": "3000",
+						"cfw_log_storage": "5000",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"ip_number": "55",
+					"ip_number": "405",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"ip_number": "55",
+						"ip_number": "405",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"fw_vpc_number": "5",
+					"fw_vpc_number": "6",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"fw_vpc_number": "5",
+						"fw_vpc_number": "6",
 					}),
 				),
 			},
@@ -267,23 +284,51 @@ func TestAccAliCloudCloudFirewallInstance_basic1(t *testing.T) {
 			//		}),
 			//	),
 			//},
-			//{
-			//	Config: testAccConfig(map[string]interface{}{
-			//		"cfw_account":    "true",
-			//		"account_number": "10",
-			//	}),
-			//	Check: resource.ComposeTestCheckFunc(
-			//		testAccCheck(map[string]string{
-			//			"cfw_account":    "true",
-			//			"account_number": "10",
-			//		}),
-			//	),
-			//},
 			{
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"band_width", "period", "modify_type", "cfw_account", "account_number"},
+				ImportStateVerifyIgnore: []string{"band_width", "period", "modify_type", "logistics"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudCloudFirewallInstance_unsupportedOrderParameters(t *testing.T) {
+	ensureCloudFirewallInstanceTestRegion()
+	resourceId := "alicloud_cloud_firewall_instance.default"
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%ssddpinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudFirewallInstanceBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccCloudFirewallInstancePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type":   "Subscription",
+					"spec":           "enterprise_version",
+					"ip_number":      "50",
+					"band_width":     "50",
+					"cfw_log":        "false",
+					"cfw_account":    "true",
+					"account_number": "1",
+					"instance_count": "5",
+					"logistics":      cloudFirewallInstanceLogisticsConfig,
+					"period":         "1",
+				}),
+				ExpectError: regexp.MustCompile("InvalidParameter"),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"cfw_account":    "false",
+					"account_number": "2",
+					"instance_count": "10",
+				}),
+				ExpectError: regexp.MustCompile("InvalidParameter"),
 			},
 		},
 	})
@@ -292,6 +337,24 @@ func TestAccAliCloudCloudFirewallInstance_basic1(t *testing.T) {
 var AliCloudCloudFirewallInstanceMap0 = map[string]string{
 	"user_status": CHECKSET,
 	"status":      CHECKSET,
+}
+
+func ensureCloudFirewallInstanceTestRegion() {
+	if defaultRegionToTest != "" {
+		return
+	}
+	if v := os.Getenv("ALICLOUD_REGION"); v != "" {
+		defaultRegionToTest = v
+		return
+	}
+	defaultRegionToTest = "cn-beijing"
+	os.Setenv("ALICLOUD_REGION", defaultRegionToTest)
+}
+
+func testAccCloudFirewallInstancePreCheck(t *testing.T) {
+	testAccPreCheck(t)
+	ensureCloudFirewallInstanceTestRegion()
+	testAccPreCheckForCleanUpInstances(t, "", "vipcloudfw", "vipcloudfw", "cfw", "cfw_pre_intl")
 }
 
 func AliCloudCloudFirewallInstanceBasicDependence0(name string) string {
@@ -309,18 +372,19 @@ func TestUnitAliCloudCloudFirewallInstance(t *testing.T) {
 	dExisted, _ := schema.InternalMap(p["alicloud_cloud_firewall_instance"].Schema).Data(nil, nil)
 	dInit.MarkNewResource()
 	attributes := map[string]interface{}{
-		"payment_type":    "CreateInstanceValue",
-		"spec":            "CreateInstanceValue",
-		"renewal_status":  "CreateInstanceValue",
-		"ip_number":       20,
-		"band_width":      10,
-		"cfw_log":         false,
-		"cfw_log_storage": 1000,
-		"cfw_service":     false,
-		"period":          6,
-		"fw_vpc_number":   10,
-		"instance_count":  10,
-		"logistics":       "CreateInstanceValue",
+		"payment_type":          "CreateInstanceValue",
+		"spec":                  "CreateInstanceValue",
+		"renewal_status":        "CreateInstanceValue",
+		"ip_number":             20,
+		"band_width":            10,
+		"cfw_log":               false,
+		"cfw_log_storage":       1000,
+		"cfw_service":           false,
+		"period":                6,
+		"fw_vpc_number":         10,
+		"instance_count":        10,
+		"auto_asset_protection": "true",
+		"logistics":             "CreateInstanceValue",
 	}
 	for key, value := range attributes {
 		err := dInit.Set(key, value)
@@ -354,7 +418,8 @@ func TestUnitAliCloudCloudFirewallInstance(t *testing.T) {
 			},
 			"InstanceId": "CreateInstanceValue",
 		},
-		"Code": "Success",
+		"Code":               "Success",
+		"AutoResourceEnable": true,
 	}
 	CreateMockResponse := map[string]interface{}{
 		// CreateInstance
@@ -577,6 +642,56 @@ func TestUnitAliCloudCloudFirewallInstance(t *testing.T) {
 		}
 	}
 
+	// SetAutoProtectNewAssets
+	attributesDiff = map[string]interface{}{
+		"auto_asset_protection": "false",
+	}
+	diff, err = newInstanceDiff("alicloud_cloud_firewall_instance", attributes, attributesDiff, dInit.State())
+	if err != nil {
+		t.Error(err)
+	}
+	dExisted, _ = schema.InternalMap(p["alicloud_cloud_firewall_instance"].Schema).Data(dInit.State(), diff)
+	ReadMockResponseDiff = map[string]interface{}{
+		"AutoResourceEnable": false,
+		"Code":               "Success",
+	}
+	errorCodes = []string{"NonRetryableError", "Throttling", "nil"}
+	for index, errorCode := range errorCodes {
+		retryIndex := index - 1
+		patches = gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, action *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			if *action == "SetAutoProtectNewAssets" {
+				switch errorCode {
+				case "NonRetryableError":
+					return failedResponseMock(errorCode)
+				default:
+					retryIndex++
+					if retryIndex >= len(errorCodes)-1 {
+						return successResponseMock(ReadMockResponseDiff)
+					}
+					return failedResponseMock(errorCodes[retryIndex])
+				}
+			}
+			return ReadMockResponse, nil
+		})
+		err := resourceAliCloudCloudFirewallInstanceUpdate(dExisted, rawClient)
+		patches.Reset()
+		switch errorCode {
+		case "NonRetryableError":
+			assert.NotNil(t, err)
+		default:
+			assert.Nil(t, err)
+			dCompare, _ := schema.InternalMap(p["alicloud_cloud_firewall_instance"].Schema).Data(dExisted.State(), nil)
+			for key, value := range attributes {
+				_ = dCompare.Set(key, value)
+			}
+			_ = dCompare.Set("auto_asset_protection", "false")
+			assert.Equal(t, dCompare.State().Attributes, dExisted.State().Attributes)
+		}
+		if retryIndex >= len(errorCodes)-1 {
+			break
+		}
+	}
+
 	// Read
 	errorCodes = []string{"NonRetryableError", "Throttling", "NotApplicable", "nil", "{}"}
 	for index, errorCode := range errorCodes {
@@ -609,7 +724,24 @@ func TestUnitAliCloudCloudFirewallInstance(t *testing.T) {
 	}
 
 	// Delete
+	ReadMockResponseDiff = map[string]interface{}{
+		// QueryAvailableInstances Response
+		"Data": map[string]interface{}{
+			"InstanceList": []interface{}{},
+		},
+		"Code": "Success",
+	}
+	patches = gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, action *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+		if *action == "ReleasePostInstance" {
+			return map[string]interface{}{"Success": true}, nil
+		}
+		if *action == "QueryAvailableInstances" {
+			return ReadMockResponseDiff, nil
+		}
+		return ReadMockResponse, nil
+	})
 	err = resourceAliCloudCloudFirewallInstanceDelete(dExisted, rawClient)
+	patches.Reset()
 	assert.Nil(t, err)
 
 }

--- a/alicloud/service_alicloud_cloud_firewall_v2.go
+++ b/alicloud/service_alicloud_cloud_firewall_v2.go
@@ -1096,6 +1096,40 @@ func (s *CloudFirewallServiceV2) DescribeInstanceDescribeUserBuyVersion(id strin
 	return response, nil
 }
 
+func (s *CloudFirewallServiceV2) DescribeInstanceDescribeAssetStatistic(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	action := "DescribeAssetStatistic"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Cloudfw", "2017-12-07", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"ErrorParamsNotEnough"}) {
+			return object, WrapErrorf(NotFoundErr("Instance", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
 func (s *CloudFirewallServiceV2) CloudFirewallInstanceStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
 	return s.CloudFirewallInstanceStateRefreshFuncWithApi(id, field, failStates, s.DescribeCloudFirewallInstance)
 }

--- a/website/docs/r/cloud_firewall_instance.html.markdown
+++ b/website/docs/r/cloud_firewall_instance.html.markdown
@@ -15,8 +15,6 @@ For information about Cloud Firewall Instance and how to use it, see [What is In
 
 -> **NOTE:** Available since v1.139.0.
 
--> **NOTE:** Deprecated since v1.269.0.
-
 -> **DEPRECATED:** This resource has been deprecated from version `1.269.0`. Please use new resource [alicloud_cloud_firewall_instance_v2](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cloud_firewall_instance_v2).
 
 ## Example Usage
@@ -60,7 +58,7 @@ The following arguments are supported:
   - `ManualRenewal`: Manual renewal.
   - `NotRenewal`: No renewal any longer. After you specify this value, Alibaba Cloud stop sending notification of instance expiry, and only gives a brief reminder on the third day before the instance expiry.
 **NOTE:** `renewal_status` takes effect only if `payment_type` is set to `Subscription`.
-* `logistics` - (Optional) The logistics.
+* `logistics` - (Optional) The logistics address of this order. The parameter is immutable after resource creation.
 * `modify_type` - (Optional) The type of modification. Valid values: `Upgrade`, `Downgrade`. **NOTE:** The `modify_type` is required when you execute an update operation.
 * `cfw_service` - (Removed since v1.209.1) Attribute `cfw_service` does not support longer, and it has been removed since v1.209.1.
 * `spec` - (Optional) Current version. Valid values: `premium_version`, `enterprise_version`,`ultimate_version`.
@@ -81,6 +79,7 @@ The following arguments are supported:
   * `enterprise_version` - The valid cfw_log_storage is [2, 200] with the step size 1. Default Value: `2`.
   * `ultimate_version` - The valid cfw_log_storage is [5, 500] with the step size 1. Default Value: `5`.
 * `instance_count` - (Optional)  The number of assets.
+* `auto_asset_protection` - (Optional, Computed, Available since v1.282.0) Internet asset protection switch. Valid values: `true`, `false`.
 * `cfw_account` - (Optional, Available since v1.209.1, Bool) Whether to use multi-account. Valid values: `true`, `false`.
 * `account_number` - (Optional, Available since v1.209.1, Int) The number of multi account. It will be ignored when `cfw_account = false`.
   * `premium_version` - The valid account number is [1, 20].


### PR DESCRIPTION
## Summary

- Add `auto_asset_protection` to `alicloud_cloud_firewall_instance` schema, create, read, and update flows.
- Add `DescribeAssetStatistic` service handling for reading `AutoResourceEnable`.
- Keep supported subscription ACC flow separate from legacy order parameters that BSS currently rejects.
- Update ACC/unit coverage and docs/changelog for the new field.

## Validation

Remote ACC only, no local provider compile:

```text
=== RUN TestAccAliCloudCloudFirewallInstance_basic0
--- PASS: TestAccAliCloudCloudFirewallInstance_basic0 (144.21s)

=== RUN TestAccAliCloudCloudFirewallInstance_basic0_twin
--- PASS: TestAccAliCloudCloudFirewallInstance_basic0_twin (108.57s)

=== RUN TestAccAliCloudCloudFirewallInstance_unsupportedOrderParameters
--- PASS: TestAccAliCloudCloudFirewallInstance_unsupportedOrderParameters (3.88s)

=== RUN TestAccAliCloudCloudFirewallInstance_basic1
--- PASS: TestAccAliCloudCloudFirewallInstance_basic1 (232.16s)
```

Temporary remote sweep tasks were used to diagnose stale CloudFirewall singleton instances during validation; sweep-only test changes were removed before this commit.
