### PR TITLE
docs: alicloud_cr_ee_instance document Economy instance_type and DISABLE image_scanner

### DIFF
--- a/website/docs/r/cr_ee_instance.html.markdown
+++ b/website/docs/r/cr_ee_instance.html.markdown
@@ -67,6 +67,7 @@ The following arguments are supported:
 * `image_scanner` - (Optional, Available since v1.235.0) The security scan engine used by the Enterprise Edition of Container Image Service. Value:
   - `ACR`: Uses the Trivy scan engine provided by default.
   - `SAS`: uses the enhanced cloud security scan engine.
+  - `DISABLE`: Disables the image security scan engine.
 
 -> **NOTE:** The parameter is immutable after resource creation. It only applies during resource creation and has no effect when modified post-creation.
 
@@ -75,6 +76,7 @@ The following arguments are supported:
   - `Basic`: Basic instance
   - `Standard`: Standard instance
   - `Advanced`: Advanced Edition Instance
+  - `Economy`: Economy instance
 
 -> **NOTE:** The parameter is immutable after resource creation. It only applies during resource creation and has no effect when modified post-creation.
 


### PR DESCRIPTION
## Summary
- Follow-up doc fix for [#9852](https://github.com/aliyun/terraform-provider-alicloud/pull/9852), which extended the `image_scanner` and `instance_type` enums on `alicloud_cr_ee_instance` but did not update the resource documentation.
- Add `DISABLE` to the `image_scanner` value list.
- Add `Economy` to the `instance_type` value list.

## Test plan
- [x] Doc-only change; no acceptance test impact.