### PR TITLE
resource/alicloud_instance: Aadd support for enable_high_density_mode

### DIFF
--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -705,6 +705,10 @@ func resourceAliCloudInstance() *schema.Resource {
 					},
 				},
 			},
+			"enable_high_density_mode": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"cpu_options": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -1209,6 +1213,10 @@ func resourceAliCloudInstanceCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
+	if v, ok := d.GetOk("enable_high_density_mode"); ok {
+		request["AdditionalInfo.EnableHighDensityMode"] = v
+	}
+
 	if coreCount, ok := d.GetOkExists("cpu_options.0.core_count"); ok {
 		request["CpuOptions.Core"] = coreCount
 	}
@@ -1351,6 +1359,7 @@ func resourceAliCloudInstanceRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("create_time", instance.CreationTime)
 	d.Set("start_time", instance.StartTime)
 	d.Set("expired_time", instance.ExpiredTime)
+	d.Set("enable_high_density_mode", instance.AdditionalInfo.EnableHighDensityMode)
 
 	imageOptionsMaps := make([]map[string]interface{}, 0)
 	imageOptionsMap := make(map[string]interface{})
@@ -3135,6 +3144,11 @@ func modifyInstanceAttributeNeedStopped(d *schema.ResourceData, meta interface{}
 		update = true
 	}
 
+	if d.HasChange("enable_high_density_mode") {
+		request["AdditionalInfo.EnableHighDensityMode"] = d.Get("enable_high_density_mode")
+		update = true
+	}
+
 	if !run {
 		return update, nil
 	}
@@ -3209,7 +3223,8 @@ func modifyInstanceNetworkSpec(d *schema.ResourceData, meta interface{}) error {
 					wait()
 					return resource.RetryableError(err)
 				}
-				if IsExpectedErrors(err, []string{"InternalError"}) {
+				if IsExpectedErrors(err, []string{"InternalError", "UnknownError"}) {
+					wait()
 					return resource.RetryableError(err)
 				}
 				return resource.NonRetryableError(err)

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -3639,6 +3639,26 @@ func TestAccAliCloudECSInstanceMaintenance(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_high_density_mode": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable_high_density_mode": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_high_density_mode": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable_high_density_mode": "false",
+					}),
+				),
+			},
+			{
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/alicloud/service_alicloud_ecs.go
+++ b/alicloud/service_alicloud_ecs.go
@@ -116,7 +116,7 @@ func (s *EcsService) DescribeInstance(id string) (instance ecs.Instance, err err
 	request := ecs.CreateDescribeInstancesRequest()
 	request.RegionId = s.client.RegionId
 	request.InstanceIds = convertListToJsonString([]interface{}{id})
-	request.AdditionalAttributes = &[]string{"META_OPTIONS", "NETWORK_PRIMARY_ENI_IP", "LOGIN_AS_NON_ROOT"}
+	request.AdditionalAttributes = &[]string{"META_OPTIONS", "NETWORK_PRIMARY_ENI_IP", "LOGIN_AS_NON_ROOT", "DISK_HIGH_DENSITY_MODE"}
 
 	var response *ecs.DescribeInstancesResponse
 	wait := incrementalWait(1*time.Second, 1*time.Second)

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -235,6 +235,10 @@ The following arguments are supported:
 * `launch_template_name` - (Optional, ForceNew, Available since v1.213.1) The name of the launch template.
 * `launch_template_version` - (Optional, ForceNew, Available since v1.213.1) The version of the launch template. If you set `launch_template_id` or `launch_template_name` parameter but do not set the version number of the launch template, the default template version is used.
 * `enable_jumbo_frame` - (Optional, Bool, Available since v1.223.2) Specifies whether to enable the Jumbo Frames feature for the instance. Valid values: `true`, `false`.
+* `enable_high_density_mode` - (Optional, Bool, Available since v1.283.0) Specifies whether to enable the high density mode for the instance. Valid values: `true`, `false`.
+
+  -> **NOTE:** Modifying `enable_high_density_mode` requires the instance to be stopped.
+
 * `network_interface_traffic_mode` - (Optional, ForceNew, Available since v1.227.1) The communication mode of the Primary ENI. Default value: `Standard`. Valid values:
   - `Standard`: Uses the TCP communication mode.
   - `HighPerformance`: Uses the remote direct memory access (RDMA) communication mode with Elastic RDMA Interface (ERI) enabled.


### PR DESCRIPTION
Add support for enable_high_density_mode
```log
  --- PASS: TestAccAliCloudECSInstanceVpc (1047.53s)
  --- SKIP: TestAccAliCloudECSInstanceBasic
  --- PASS: TestAccAliCloudECSInstanceMulti (104.63s)
  --- PASS: TestAccAliCloudECSInstancePrepaid (125.84s)
  --- PASS: TestAccAliCloudECSInstancePrepaidAll (56.08s)
  --- PASS: TestAccAliCloudECSInstanceDataDisks (114.23s)
  --- PASS: TestAccAliCloudECSInstanceSystemDisk (129.54s)
  --- PASS: TestAccAliCloudECSInstanceMaintenance (229.11s)
  --- PASS: TestAccAliCloudECSInstancePrivatePool (341.4s)
  --- PASS: TestAccAliCloudECSInstanceSecondaryIps (95.48s)
  --- PASS: TestAccAliCloudECSInstanceIpv6AddressesCount (198.28s)
  --- PASS: TestAccAliCloudECSInstanceIpv6Addresses (126.94s)
  --- PASS: TestAccAliCloudECSInstance_OperatorType (263.9s)
  --- PASS: TestAccAliCloudECSInstance_StatusUpdated (210.49s)
  --- PASS: TestAccAliCloudECSInstanceMetadataOptions (133.62s)
  --- PASS: TestAccAliCloudECSInstanceDedicatedHostId (101.31s)
  --- PASS: TestAccAliCloudECSInstance_LaunchTemplate (137.29s)
  --- PASS: TestAccAliCloudECSInstanceSecondaryIpCount (112.78s)
  --- PASS: TestAccAliCloudECSInstance_DeploymentSetID (122.73s)
  --- PASS: TestAccAliCloudECSInstanceSpotInstanceLimit (101.79s)
  --- PASS: TestAccAliCloudECSInstanceNetworkInterface0 (227.72s)
  --- PASS: TestAccAliCloudECSInstanceNetworkInterface1 (244s)
  --- PASS: TestAccAliCloudECSInstanceNetworkInterface2 (124.65s)
  --- PASS: TestAccAliCloudECSInstanceNetworkInterface3 (127.13s)
  --- PASS: TestAccAliCloudECSInstance_AutoSnapshotPolicyId (212.89s)
  --- PASS: TestAccAliCloudECSInstanceHpcCluster (101.15s)

  26 PASS / 0 FAIL / 1 SKIP (Classic Network only).
```