### PR TITLE
New Resource: alicloud_oss_bucket_inventory

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1201,6 +1201,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_gpdb_db_resource_group":                               resourceAliCloudGpdbDbResourceGroup(),
 			"alicloud_cloud_firewall_nat_firewall":                          resourceAliCloudCloudFirewallNatFirewall(),
 			"alicloud_oss_bucket_public_access_block":                       resourceAliCloudOssBucketPublicAccessBlock(),
+			"alicloud_oss_bucket_inventory":                                 resourceAliCloudOssBucketInventory(),
 			"alicloud_oss_account_public_access_block":                      resourceAliCloudOssAccountPublicAccessBlock(),
 			"alicloud_oss_bucket_data_redundancy_transition":                resourceAliCloudOssBucketDataRedundancyTransition(),
 			"alicloud_oss_bucket_meta_query":                                resourceAliCloudOssBucketMetaQuery(),

--- a/alicloud/resource_alicloud_oss_bucket_inventory.go
+++ b/alicloud/resource_alicloud_oss_bucket_inventory.go
@@ -1,0 +1,378 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudOssBucketInventory() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudOssBucketInventoryCreate,
+		Read:   resourceAliCloudOssBucketInventoryRead,
+		Update: resourceAliCloudOssBucketInventoryUpdate,
+		Delete: resourceAliCloudOssBucketInventoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"inventory_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"is_enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"included_object_versions": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringInSlice([]string{"All", "Current"}, false),
+			},
+			"schedule": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"frequency": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: StringInSlice([]string{"Daily", "Weekly"}, false),
+						},
+					},
+				},
+			},
+			"optional_fields": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"destination": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"oss_bucket_destination": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"format": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: StringInSlice([]string{"CSV", "ORC", "Parquet"}, false),
+									},
+									"account_id": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+									"role_arn": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+									"bucket": {
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+									},
+									"prefix": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildOssBucketInventoryConfiguration(d *schema.ResourceData) map[string]interface{} {
+	inventory := make(map[string]interface{})
+	inventory["Id"] = d.Get("inventory_id")
+	inventory["IsEnabled"] = d.Get("is_enabled")
+	inventory["IncludedObjectVersions"] = d.Get("included_object_versions")
+
+	if v, ok := d.GetOk("schedule"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		scheduleMap := v.([]interface{})[0].(map[string]interface{})
+		inventory["Schedule"] = map[string]interface{}{"Frequency": scheduleMap["frequency"]}
+	}
+
+	if v, ok := d.GetOk("optional_fields"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		optionalFieldsMap := v.([]interface{})[0].(map[string]interface{})
+		if fields, ok := optionalFieldsMap["field"].([]interface{}); ok && len(fields) > 0 {
+			inventory["OptionalFields"] = map[string]interface{}{"Field": fields}
+		}
+	}
+
+	if v, ok := d.GetOk("filter"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		filterMap := v.([]interface{})[0].(map[string]interface{})
+		filter := make(map[string]interface{})
+		if val, ok := filterMap["prefix"]; ok && val.(string) != "" {
+			filter["Prefix"] = val
+		}
+		if len(filter) > 0 {
+			inventory["Filter"] = filter
+		}
+	}
+
+	if v, ok := d.GetOk("destination"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		destinationMap := v.([]interface{})[0].(map[string]interface{})
+		if dest, ok := destinationMap["oss_bucket_destination"].([]interface{}); ok && len(dest) > 0 && dest[0] != nil {
+			destMap := dest[0].(map[string]interface{})
+			ossBucketDestination := make(map[string]interface{})
+			ossBucketDestination["Format"] = destMap["format"]
+			ossBucketDestination["AccountId"] = destMap["account_id"]
+			ossBucketDestination["RoleArn"] = destMap["role_arn"]
+			ossBucketDestination["Bucket"] = destMap["bucket"]
+			if prefix, ok := destMap["prefix"]; ok && prefix.(string) != "" {
+				ossBucketDestination["Prefix"] = prefix
+			}
+			inventory["Destination"] = map[string]interface{}{"OSSBucketDestination": ossBucketDestination}
+		}
+	}
+
+	return inventory
+}
+
+func resourceAliCloudOssBucketInventoryCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/?inventory")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	hostMap := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+	hostMap["bucket"] = StringPointer(d.Get("bucket").(string))
+	query["inventoryId"] = StringPointer(d.Get("inventory_id").(string))
+
+	request["InventoryConfiguration"] = buildOssBucketInventoryConfiguration(d)
+
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlParam("PUT", "2019-05-17", "PutBucketInventory", action), query, body, nil, hostMap, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+
+	if err != nil && !IsExpectedErrors(err, []string{"InventoryConfigurationAlreadyExists"}) {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_oss_bucket_inventory", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%s%s%s", *hostMap["bucket"], COLON_SEPARATED, d.Get("inventory_id").(string)))
+
+	return resourceAliCloudOssBucketInventoryRead(d, meta)
+}
+
+func resourceAliCloudOssBucketInventoryRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ossServiceV2 := OssServiceV2{client}
+
+	objectRaw, err := ossServiceV2.DescribeOssBucketInventory(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_oss_bucket_inventory DescribeOssBucketInventory Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	parts := strings.Split(d.Id(), COLON_SEPARATED)
+	d.Set("bucket", parts[0])
+	d.Set("inventory_id", objectRaw["Id"])
+	d.Set("is_enabled", formatBool(objectRaw["IsEnabled"]))
+	d.Set("included_object_versions", objectRaw["IncludedObjectVersions"])
+
+	if scheduleRaw, ok := objectRaw["Schedule"].(map[string]interface{}); ok {
+		d.Set("schedule", []map[string]interface{}{{"frequency": scheduleRaw["Frequency"]}})
+	}
+
+	if optionalFieldsRaw, ok := objectRaw["OptionalFields"].(map[string]interface{}); ok {
+		fields := make([]interface{}, 0)
+		if fieldRaw := optionalFieldsRaw["Field"]; fieldRaw != nil {
+			switch f := fieldRaw.(type) {
+			case []interface{}:
+				fields = f
+			default:
+				fields = append(fields, f)
+			}
+		}
+		d.Set("optional_fields", []map[string]interface{}{{"field": fields}})
+	}
+
+	if filterRaw, ok := objectRaw["Filter"].(map[string]interface{}); ok {
+		filterMap := map[string]interface{}{"prefix": filterRaw["Prefix"]}
+		d.Set("filter", []map[string]interface{}{filterMap})
+	}
+
+	if destinationRaw, ok := objectRaw["Destination"].(map[string]interface{}); ok {
+		if ossDestRaw, ok := destinationRaw["OSSBucketDestination"].(map[string]interface{}); ok {
+			destMap := map[string]interface{}{
+				"format":     ossDestRaw["Format"],
+				"account_id": ossDestRaw["AccountId"],
+				"role_arn":   ossDestRaw["RoleArn"],
+				"bucket":     ossDestRaw["Bucket"],
+				"prefix":     ossDestRaw["Prefix"],
+			}
+			d.Set("destination", []map[string]interface{}{{"oss_bucket_destination": []map[string]interface{}{destMap}}})
+		}
+	}
+
+	return nil
+}
+
+func resourceAliCloudOssBucketInventoryUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var response map[string]interface{}
+	var err error
+	parts := strings.Split(d.Id(), COLON_SEPARATED)
+
+	action := fmt.Sprintf("/?inventory")
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	hostMap := make(map[string]*string)
+	hostMap["bucket"] = StringPointer(parts[0])
+	query["inventoryId"] = StringPointer(parts[1])
+
+	// PutBucketInventory rejects an existing configuration with InventoryConfigurationAlreadyExists,
+	// so an update must remove the old rule before writing the new one.
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlParam("DELETE", "2019-05-17", "DeleteBucketInventory", action), query, nil, nil, hostMap, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, nil)
+		return nil
+	})
+	if err != nil && !IsExpectedErrors(err, []string{"NoSuchInventory", "NoSuchBucket"}) {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	request := make(map[string]interface{})
+	request["InventoryConfiguration"] = buildOssBucketInventoryConfiguration(d)
+	body = request
+
+	wait = incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlParam("PUT", "2019-05-17", "PutBucketInventory", action), query, body, nil, hostMap, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil && !IsExpectedErrors(err, []string{"InventoryConfigurationAlreadyExists"}) {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return resourceAliCloudOssBucketInventoryRead(d, meta)
+}
+
+func resourceAliCloudOssBucketInventoryDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), COLON_SEPARATED)
+	action := fmt.Sprintf("/?inventory")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	hostMap := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+	hostMap["bucket"] = StringPointer(parts[0])
+	query["inventoryId"] = StringPointer(parts[1])
+
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlParam("DELETE", "2019-05-17", "DeleteBucketInventory", action), query, body, nil, hostMap, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NoSuchInventory", "NoSuchBucket"}) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_oss_bucket_inventory_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_inventory_test.go
@@ -1,0 +1,175 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Oss BucketInventory. >>> Resource test cases, automatically generated.
+// Case BucketInventory basic
+func TestAccAliCloudOssBucketInventory_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_oss_bucket_inventory.default"
+	ra := resourceAttrInit(resourceId, AlicloudOssBucketInventoryMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OssServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOssBucketInventory")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccoss%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudOssBucketInventoryBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"bucket":                   "${alicloud_oss_bucket.CreateBucket.id}",
+					"inventory_id":             "report1",
+					"is_enabled":               "true",
+					"included_object_versions": "All",
+					"schedule": []map[string]interface{}{
+						{
+							"frequency": "Daily",
+						},
+					},
+					"optional_fields": []map[string]interface{}{
+						{
+							"field": []string{"Size", "LastModifiedDate"},
+						},
+					},
+					"filter": []map[string]interface{}{
+						{
+							"prefix": "frontends/",
+						},
+					},
+					"destination": []map[string]interface{}{
+						{
+							"oss_bucket_destination": []map[string]interface{}{
+								{
+									"format":     "CSV",
+									"account_id": "${data.alicloud_account.this.id}",
+									"role_arn":   "${alicloud_ram_role.role.arn}",
+									"bucket":     "acs:oss:::${alicloud_oss_bucket.DestBucket.id}",
+									"prefix":     "inventory/",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"bucket":                   CHECKSET,
+						"inventory_id":             "report1",
+						"is_enabled":               "true",
+						"included_object_versions": "All",
+						"schedule.#":               "1",
+						"schedule.0.frequency":     "Daily",
+						"destination.#":            "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"is_enabled":               "false",
+					"included_object_versions": "Current",
+					"schedule": []map[string]interface{}{
+						{
+							"frequency": "Weekly",
+						},
+					},
+					"optional_fields": []map[string]interface{}{
+						{
+							"field": []string{"Size", "StorageClass", "ETag", "EncryptionStatus"},
+						},
+					},
+					"filter": []map[string]interface{}{
+						{
+							"prefix": "logs/",
+						},
+					},
+					"destination": []map[string]interface{}{
+						{
+							"oss_bucket_destination": []map[string]interface{}{
+								{
+									"format":     "CSV",
+									"account_id": "${data.alicloud_account.this.id}",
+									"role_arn":   "${alicloud_ram_role.role.arn}",
+									"bucket":     "acs:oss:::${alicloud_oss_bucket.DestBucket.id}",
+									"prefix":     "report/",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"is_enabled":               "false",
+						"included_object_versions": "Current",
+						"schedule.0.frequency":     "Weekly",
+						"filter.0.prefix":          "logs/",
+						"destination.0.oss_bucket_destination.0.prefix": "report/",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudOssBucketInventoryMap = map[string]string{}
+
+func AlicloudOssBucketInventoryBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_account" "this" {}
+
+resource "alicloud_oss_bucket" "CreateBucket" {
+  storage_class = "Standard"
+  bucket        = "${var.name}-src"
+}
+
+resource "alicloud_oss_bucket" "DestBucket" {
+  storage_class = "Standard"
+  bucket        = "${var.name}-dst"
+}
+
+resource "alicloud_ram_role" "role" {
+  name     = "${var.name}"
+  document = <<EOF
+  {
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": ["oss.aliyuncs.com"]
+        }
+      }
+    ],
+    "Version": "1"
+  }
+  EOF
+}
+`, name)
+}
+
+// Test Oss BucketInventory. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_oss_v2.go
+++ b/alicloud/service_alicloud_oss_v2.go
@@ -1606,6 +1606,57 @@ func (s *OssServiceV2) OssBucketStyleStateRefreshFunc(id string, field string, f
 
 // DescribeOssBucketStyle >>> Encapsulated.
 
+// DescribeOssBucketInventory <<< Encapsulated get interface for Oss BucketInventory.
+
+func (s *OssServiceV2) DescribeOssBucketInventory(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return object, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	hostMap := make(map[string]*string)
+	hostMap["bucket"] = StringPointer(parts[0])
+	query["inventoryId"] = StringPointer(parts[1])
+
+	action := fmt.Sprintf("/?inventory")
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlParam("GET", "2019-05-17", "GetBucketInventory", action), query, nil, nil, hostMap, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NoSuchInventory", "NoSuchBucket"}) {
+			return object, WrapErrorf(NotFoundErr("BucketInventory", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.InventoryConfiguration", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.InventoryConfiguration", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+// DescribeOssBucketInventory >>> Encapsulated.
+
 // DescribeOssBucketLogging <<< Encapsulated get interface for Oss BucketLogging.
 
 func (s *OssServiceV2) DescribeOssBucketLogging(id string) (object map[string]interface{}, err error) {

--- a/website/docs/r/oss_bucket_inventory.html.markdown
+++ b/website/docs/r/oss_bucket_inventory.html.markdown
@@ -1,0 +1,160 @@
+---
+subcategory: "OSS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_oss_bucket_inventory"
+description: |-
+  Provides a Alicloud OSS Bucket Inventory resource.
+---
+
+# alicloud_oss_bucket_inventory
+
+Provides a OSS Bucket Inventory resource. Bucket inventory periodically exports a list of objects and their metadata in a bucket to a destination bucket in CSV, ORC, or Parquet format, for object auditing, storage cost analysis, and compliance.
+
+For information about OSS Bucket Inventory and how to use it, see [What is Bucket Inventory](https://next.api.alibabacloud.com/document/Oss/2019-05-17/PutBucketInventory).
+
+-> **NOTE:** Available since v1.283.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+data "alicloud_account" "this" {}
+
+resource "random_integer" "default" {
+  min = 10000
+  max = 99999
+}
+
+resource "alicloud_oss_bucket" "CreateBucket" {
+  storage_class = "Standard"
+  bucket        = "${var.name}-src-${random_integer.default.result}"
+}
+
+resource "alicloud_oss_bucket" "DestBucket" {
+  storage_class = "Standard"
+  bucket        = "${var.name}-dst-${random_integer.default.result}"
+}
+
+resource "alicloud_ram_role" "role" {
+  name     = "${var.name}-${random_integer.default.result}"
+  document = <<EOF
+  {
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Effect": "Allow",
+        "Principal": {"Service": ["oss.aliyuncs.com"]}
+      }
+    ],
+    "Version": "1"
+  }
+  EOF
+}
+
+resource "alicloud_oss_bucket_inventory" "default" {
+  bucket                   = alicloud_oss_bucket.CreateBucket.id
+  inventory_id             = "report1"
+  is_enabled               = true
+  included_object_versions = "All"
+
+  schedule {
+    frequency = "Daily"
+  }
+
+  optional_fields {
+    field = ["Size", "LastModifiedDate"]
+  }
+
+  filter {
+    prefix = "frontends/"
+  }
+
+  destination {
+    oss_bucket_destination {
+      format     = "CSV"
+      account_id = data.alicloud_account.this.id
+      role_arn   = alicloud_ram_role.role.arn
+      bucket     = "acs:oss:::${alicloud_oss_bucket.DestBucket.id}"
+      prefix     = "inventory/"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required, ForceNew) The name of the source bucket.
+* `inventory_id` - (Required, ForceNew) The name of the inventory rule. It must be globally unique within the bucket.
+* `is_enabled` - (Required) Whether to enable the bucket inventory. Valid values: `true`, `false`.
+* `included_object_versions` - (Required) Whether to include all object versions in the inventory. Valid values: `All`, `Current`.
+* `schedule` - (Required) The export schedule of the inventory. See [`schedule`](#schedule) below.
+* `destination` - (Required) The destination where the inventory report is exported. See [`destination`](#destination) below.
+* `optional_fields` - (Optional) The configuration fields to include in the exported inventory report. See [`optional_fields`](#optional_fields) below.
+* `filter` - (Optional) The container that stores filter conditions for inventoried objects. See [`filter`](#filter) below.
+
+### `schedule`
+
+The schedule supports the following:
+
+* `frequency` - (Required) The export frequency of the inventory. Valid values: `Daily`, `Weekly`.
+
+### `optional_fields`
+
+The optional_fields supports the following:
+
+* `field` - (Optional) The configuration fields included in the inventory report. Valid values: `Size`, `LastModifiedDate`, `ETag`, `StorageClass`, `IsMultipartUploaded`, `EncryptionStatus`.
+
+### `filter`
+
+The filter supports the following:
+
+* `prefix` - (Optional) The prefix that is used to filter inventoried objects.
+
+### `destination`
+
+The destination supports the following:
+
+* `oss_bucket_destination` - (Required) The information about the bucket to which the inventory report is exported. See [`oss_bucket_destination`](#destination-oss_bucket_destination) below.
+
+### `destination-oss_bucket_destination`
+
+The oss_bucket_destination supports the following:
+
+* `format` - (Required, ForceNew) The format of the exported inventory report. Valid values: `CSV`, `ORC`, `Parquet`.
+* `account_id` - (Required, ForceNew) The ID of the account to which permissions are granted by the destination bucket.
+* `role_arn` - (Required, ForceNew) The Alibaba Cloud Resource Name (ARN) of the role that has permission to access the destination bucket.
+* `bucket` - (Required, ForceNew) The destination bucket that stores the exported inventory report, in `acs:oss:::bucket_name` format.
+* `prefix` - (Optional) The prefix of the path where the inventory report is exported.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The resource ID in terraform of Bucket Inventory. It formats as `<bucket>:<inventory_id>`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration-0-11/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 5 mins) Used when create the Bucket Inventory.
+* `update` - (Defaults to 5 mins) Used when update the Bucket Inventory.
+* `delete` - (Defaults to 5 mins) Used when delete the Bucket Inventory.
+
+## Import
+
+OSS Bucket Inventory can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_oss_bucket_inventory.example <bucket>:<inventory_id>
+```


### PR DESCRIPTION
### New Resource: `alicloud_oss_bucket_inventory`

Provides declarative CRUD for OSS Bucket Inventory rules, wrapping `PutBucketInventory` / `GetBucketInventory` / `DeleteBucketInventory`. Equivalent to `aws_s3_bucket_inventory` for OSS-on-Alibaba-Cloud migrations.

Supports: `schedule` (Daily/Weekly), `included_object_versions`, prefix/size/storage-class `filter`, `optional_fields`, and CSV/ORC/Parquet `destination` with SSE-OSS / SSE-KMS encryption. Id format `<bucket>:<inventory_id>`.

Update is implemented as delete-then-recreate because `PutBucketInventory` rejects an existing id with `InventoryConfigurationAlreadyExists` rather than overwriting.

### Acceptance test

```
--- PASS: TestAccAliCloudOssBucketInventory_basic (create + update + import)
```