### PR TITLE
resource/alicloud_cr_ee_repo: support tag_immutability attribute

### DIFF
--- a/alicloud/resource_alicloud_cr_ee_repo.go
+++ b/alicloud/resource_alicloud_cr_ee_repo.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aliyun/alibaba-cloud-sdk-go/services/cr_ee"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -48,6 +47,11 @@ func resourceAliCloudCrEERepo() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"tag_immutability": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"repo_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -58,28 +62,30 @@ func resourceAliCloudCrEERepo() *schema.Resource {
 
 func resourceAliCloudCrEERepoCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
-	crService := &CrService{client}
-	response := &cr_ee.CreateRepositoryResponse{}
-	request := cr_ee.CreateCreateRepositoryRequest()
-	request.RegionId = crService.client.RegionId
 
-	request.InstanceId = d.Get("instance_id").(string)
-	request.RepoNamespaceName = d.Get("namespace").(string)
-	request.RepoName = d.Get("name").(string)
-	request.RepoType = d.Get("repo_type").(string)
-	request.Summary = d.Get("summary").(string)
+	action := "CreateRepository"
+	query := make(map[string]interface{})
+	request := make(map[string]interface{})
+
+	request["RegionId"] = client.RegionId
+	request["InstanceId"] = d.Get("instance_id")
+	request["RepoNamespaceName"] = d.Get("namespace")
+	request["RepoName"] = d.Get("name")
+	request["RepoType"] = d.Get("repo_type")
+	request["Summary"] = d.Get("summary")
 
 	if v, ok := d.GetOk("detail"); ok {
-		request.Detail = v.(string)
+		request["Detail"] = v
+	}
+	if v, ok := d.GetOkExists("tag_immutability"); ok {
+		request["TagImmutability"] = v
 	}
 
-	var raw interface{}
+	var response map[string]interface{}
 	var err error
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
-		raw, err = crService.client.WithCrEEClient(func(creeClient *cr_ee.Client) (interface{}, error) {
-			return creeClient.CreateRepository(request)
-		})
+		response, err = client.RpcPost("cr", "2018-12-01", action, query, request, false)
 		if err != nil {
 			if NeedRetry(err) {
 				wait()
@@ -89,27 +95,25 @@ func resourceAliCloudCrEERepoCreate(d *schema.ResourceData, meta interface{}) er
 		}
 		return nil
 	})
-	addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+	addDebug(action, response, request)
 
 	if err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cr_ee_repo", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cr_ee_repo", action, AlibabaCloudSdkGoERROR)
+	}
+	if isSuccess, ok := response["IsSuccess"].(bool); ok && !isSuccess {
+		return WrapErrorf(fmt.Errorf("%v", response), DefaultErrorMsg, "alicloud_cr_ee_repo", action, AlibabaCloudSdkGoERROR)
 	}
 
-	response, _ = raw.(*cr_ee.CreateRepositoryResponse)
-	if !response.CreateRepositoryIsSuccess {
-		return WrapErrorf(fmt.Errorf("%v", response), DefaultErrorMsg, "alicloud_cr_ee_repo", request.GetActionName(), AlibabaCloudSdkGoERROR)
-	}
-
-	d.SetId(fmt.Sprintf("%s:%s:%s", request.InstanceId, request.RepoNamespaceName, request.RepoName))
+	d.SetId(fmt.Sprintf("%s:%s:%s", request["InstanceId"], request["RepoNamespaceName"], request["RepoName"]))
 
 	return resourceAliCloudCrEERepoRead(d, meta)
 }
 
 func resourceAliCloudCrEERepoRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
-	crService := &CrService{client}
+	crServiceV2 := CrServiceV2{client}
 
-	resp, err := crService.DescribeCrEERepo(d.Id())
+	object, err := crServiceV2.DescribeCrEERepo(d.Id())
 	if err != nil {
 		if !d.IsNewResource() && NotFoundError(err) {
 			d.SetId("")
@@ -118,58 +122,61 @@ func resourceAliCloudCrEERepoRead(d *schema.ResourceData, meta interface{}) erro
 		return WrapError(err)
 	}
 
-	d.Set("instance_id", resp.InstanceId)
-	d.Set("namespace", resp.RepoNamespaceName)
-	d.Set("name", resp.RepoName)
-	d.Set("repo_type", resp.RepoType)
-	d.Set("summary", resp.Summary)
-	d.Set("detail", resp.Detail)
-	d.Set("repo_id", resp.RepoId)
+	d.Set("instance_id", object["InstanceId"])
+	d.Set("namespace", object["RepoNamespaceName"])
+	d.Set("name", object["RepoName"])
+	d.Set("repo_type", object["RepoType"])
+	d.Set("summary", object["Summary"])
+	d.Set("detail", object["Detail"])
+	d.Set("tag_immutability", object["TagImmutability"])
+	d.Set("repo_id", object["RepoId"])
 
 	return nil
 }
 
 func resourceAliCloudCrEERepoUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
-	crService := &CrService{client}
-	response := &cr_ee.UpdateRepositoryResponse{}
+
+	action := "UpdateRepository"
+	query := make(map[string]interface{})
+	request := make(map[string]interface{})
 
 	parts, err := ParseResourceId(d.Id(), 3)
 	if err != nil {
 		return WrapError(err)
 	}
 
-	update := false
-	request := cr_ee.CreateUpdateRepositoryRequest()
-	request.RegionId = crService.client.RegionId
-	request.InstanceId = parts[0]
-	request.RepoId = d.Get("repo_id").(string)
+	request["RegionId"] = client.RegionId
+	request["InstanceId"] = parts[0]
+	request["RepoId"] = d.Get("repo_id")
+	request["RepoType"] = d.Get("repo_type")
+	request["Summary"] = d.Get("summary")
 
+	update := false
 	if d.HasChange("repo_type") {
 		update = true
 	}
-	request.RepoType = d.Get("repo_type").(string)
-
 	if d.HasChange("summary") {
 		update = true
 	}
-	request.Summary = d.Get("summary").(string)
-
 	if d.HasChange("detail") {
 		update = true
 	}
 	if v, ok := d.GetOk("detail"); ok {
-		request.Detail = v.(string)
+		request["Detail"] = v
+	}
+	if d.HasChange("tag_immutability") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("tag_immutability"); ok {
+		request["TagImmutability"] = v
 	}
 
 	if update {
-		var raw interface{}
-		var err error
+		var response map[string]interface{}
 		wait := incrementalWait(3*time.Second, 3*time.Second)
 		err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
-			raw, err = crService.client.WithCrEEClient(func(creeClient *cr_ee.Client) (interface{}, error) {
-				return creeClient.UpdateRepository(request)
-			})
+			response, err = client.RpcPost("cr", "2018-12-01", action, query, request, false)
 			if err != nil {
 				if NeedRetry(err) {
 					wait()
@@ -179,15 +186,13 @@ func resourceAliCloudCrEERepoUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 			return nil
 		})
-		addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+		addDebug(action, response, request)
 
 		if err != nil {
-			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
-
-		response, _ = raw.(*cr_ee.UpdateRepositoryResponse)
-		if !response.UpdateRepositoryIsSuccess {
-			return WrapErrorf(fmt.Errorf("%v", response), DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+		if isSuccess, ok := response["IsSuccess"].(bool); ok && !isSuccess {
+			return WrapErrorf(fmt.Errorf("%v", response), DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
 	}
 

--- a/alicloud/resource_alicloud_cr_ee_repo_test.go
+++ b/alicloud/resource_alicloud_cr_ee_repo_test.go
@@ -31,7 +31,7 @@ func TestAccAliCloudCREERepo_basic0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"instance_id": "${data.alicloud_cr_ee_instances.default.ids.0}",
+					"instance_id": "${alicloud_cr_ee_instance.default.id}",
 					"namespace":   "${alicloud_cr_ee_namespace.default.name}",
 					"name":        name,
 					"repo_type":   "PUBLIC",
@@ -78,6 +78,26 @@ func TestAccAliCloudCREERepo_basic0(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"tag_immutability": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tag_immutability": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tag_immutability": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tag_immutability": "false",
+					}),
+				),
+			},
+			{
 				ResourceName:      resourceId,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -108,21 +128,23 @@ func TestAccAliCloudCREERepo_basic0_twin(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"instance_id": "${data.alicloud_cr_ee_instances.default.ids.0}",
-					"namespace":   "${alicloud_cr_ee_namespace.default.name}",
-					"name":        name,
-					"repo_type":   "PUBLIC",
-					"summary":     name,
-					"detail":      name,
+					"instance_id":      "${alicloud_cr_ee_instance.default.id}",
+					"namespace":        "${alicloud_cr_ee_namespace.default.name}",
+					"name":             name,
+					"repo_type":        "PUBLIC",
+					"summary":          name,
+					"detail":           name,
+					"tag_immutability": "true",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"instance_id": CHECKSET,
-						"namespace":   CHECKSET,
-						"name":        name,
-						"repo_type":   "PUBLIC",
-						"summary":     name,
-						"detail":      name,
+						"instance_id":      CHECKSET,
+						"namespace":        CHECKSET,
+						"name":             name,
+						"repo_type":        "PUBLIC",
+						"summary":          name,
+						"detail":           name,
+						"tag_immutability": "true",
 					}),
 				),
 			},
@@ -158,7 +180,7 @@ func TestAccAliCloudCREERepo_Multi(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"count":       "6",
-					"instance_id": "${data.alicloud_cr_ee_instances.default.ids.0}",
+					"instance_id": "${alicloud_cr_ee_instance.default.id}",
 					"namespace":   "${alicloud_cr_ee_namespace.default.name}",
 					"name":        name + "-${count.index}",
 					"repo_type":   "PUBLIC",
@@ -190,11 +212,16 @@ func AliCloudCREERepoBasicDependence0(name string) string {
   		default = "%s"
 	}
 
-	data "alicloud_cr_ee_instances" "default" {
+	resource "alicloud_cr_ee_instance" "default" {
+		payment_type   = "Subscription"
+		period         = 1
+		renewal_status = "ManualRenewal"
+		instance_type  = "Basic"
+		instance_name  = var.name
 	}
 
 	resource "alicloud_cr_ee_namespace" "default" {
-  		instance_id        = data.alicloud_cr_ee_instances.default.ids.0
+  		instance_id        = alicloud_cr_ee_instance.default.id
   		name               = var.name
   		auto_create        = false
   		default_visibility = "PRIVATE"

--- a/alicloud/service_alicloud_cr_v2.go
+++ b/alicloud/service_alicloud_cr_v2.go
@@ -473,3 +473,56 @@ func (s *CrServiceV2) CrStorageDomainRoutingRuleStateRefreshFuncWithApi(id strin
 }
 
 // DescribeCrStorageDomainRoutingRule >>> Encapsulated.
+
+// DescribeCrEERepo <<< Encapsulated get interface for Cr EE Repo.
+
+func (s *CrServiceV2) DescribeCrEERepo(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	parts, err := ParseResourceId(id, 3)
+	if err != nil {
+		return object, WrapError(err)
+	}
+
+	request := map[string]interface{}{
+		"RegionId":          client.RegionId,
+		"InstanceId":        parts[0],
+		"RepoNamespaceName": parts[1],
+		"RepoName":          parts[2],
+	}
+	query := make(map[string]interface{})
+	action := "GetRepository"
+	var response map[string]interface{}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("cr", "2018-12-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"REPO_NOT_EXIST"}) {
+			return object, WrapErrorf(NotFoundErr("CrEE:Repo", id), NotFoundMsg, ProviderERROR)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	code, _ := jsonpath.Get("$.Code", response)
+	if fmt.Sprint(code) == "REPO_NOT_EXIST" {
+		return object, WrapErrorf(NotFoundErr("CrEE:Repo", id), NotFoundMsg, ProviderERROR)
+	}
+	if isSuccess, ok := response["IsSuccess"].(bool); ok && !isSuccess {
+		return object, WrapErrorf(fmt.Errorf("%v", response), DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+// DescribeCrEERepo >>> Encapsulated.

--- a/website/docs/r/cr_ee_repo.html.markdown
+++ b/website/docs/r/cr_ee_repo.html.markdown
@@ -77,6 +77,9 @@ The following arguments are supported:
   - `PRIVATE`: The repository is a private repository.
 * `summary` - (Required) The summary about the repository.
 * `detail` - (Optional) The description of the repository.
+* `tag_immutability` - (Optional, Available since v1.283.0) Whether to enable image tag immutability. Valid values:
+  - `true`: Image tag immutability is enabled. Existing image tags in the repository cannot be overwritten.
+  - `false`: Image tag immutability is disabled. Existing image tags can be overwritten.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary

- Add the `tag_immutability` (Bool, Optional, Computed) attribute to `alicloud_cr_ee_repo`, wired into `CreateRepository` / `UpdateRepository` / `GetRepository`.
- Refactor `alicloud_cr_ee_repo` Create/Read/Update to the `client.RpcPost("cr", "2018-12-01", ...)` style consistent with `alicloud_cr_ee_instance`; Delete still uses the typed SDK (no behavior change there).
- Add a new `CrServiceV2.DescribeCrEERepo` helper that returns `map[string]interface{}` so the Read path can surface fields not present in the vendored typed SDK.
- Update the basic / twin / multi acceptance tests to cover `tag_immutability` switching and to create their own `alicloud_cr_ee_instance` fixture (Subscription / Basic / period=1), removing the dependence on a long-lived shared instance.

## Test Plan

Remote ACC (cn-beijing) — all PASS:

```
=== RUN TestAccAliCloudCREERepo_basic0
--- PASS: TestAccAliCloudCREERepo_basic0 (183.85s)

=== RUN TestAccAliCloudCREERepo_basic0_twin
--- PASS: TestAccAliCloudCREERepo_basic0_twin (158.09s)

=== RUN TestAccAliCloudCREERepo_Multi
--- PASS: TestAccAliCloudCREERepo_Multi (177.93s)
```