### PR TITLE
resource/alicloud_ecs_launch_template: Add customizeDiff to propagate the update event of latest_version_number and fix template_tags update bug

### DIFF
--- a/alicloud/resource_alicloud_ecs_launch_template.go
+++ b/alicloud/resource_alicloud_ecs_launch_template.go
@@ -451,6 +451,32 @@ func resourceAliCloudEcsLaunchTemplate() *schema.Resource {
 				ConflictsWith: []string{"system_disk"},
 			},
 		},
+		CustomizeDiff: func(diff *schema.ResourceDiff, i interface{}) error {
+			if diff.Id() == "" {
+				return nil
+			}
+			versionTriggers := []string{
+				"auto_release_time", "data_disks", "deployment_set_id", "description",
+				"enable_vm_os_config", "host_name", "image_id", "image_owner_alias",
+				"instance_charge_type", "instance_name", "instance_type", "internet_charge_type",
+				"internet_max_bandwidth_in", "internet_max_bandwidth_out", "io_optimized",
+				"key_pair_name", "launch_template_name", "name", "network_interfaces",
+				"network_type", "password_inherit", "period", "private_ip_address",
+				"ram_role_name", "resource_group_id", "security_enhancement_strategy",
+				"security_group_id", "security_group_ids", "spot_duration", "spot_price_limit",
+				"spot_strategy", "system_disk", "system_disk_category", "system_disk_description",
+				"system_disk_name", "system_disk_size", "tags", "user_data", "userdata",
+				"vswitch_id", "version_description", "vpc_id", "zone_id",
+				"http_endpoint", "http_tokens", "http_put_response_hop_limit", "image_options",
+			}
+			for _, key := range versionTriggers {
+				if diff.HasChange(key) {
+					diff.SetNewComputed("latest_version_number")
+					break
+				}
+			}
+			return nil
+		},
 	}
 }
 

--- a/alicloud/resource_alicloud_ecs_launch_template_test.go
+++ b/alicloud/resource_alicloud_ecs_launch_template_test.go
@@ -563,6 +563,21 @@ func TestAccAliCloudECSLaunchTemplateBasic(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"template_tags": map[string]string{
+						"tag1": "updated",
+						"tag2": "updated",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"template_tags.tag1":    "updated",
+						"template_tags.tag2":    "updated",
+						"latest_version_number": "27",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"name":                          name,
 					"description":                   name,
 					"host_name":                     name,
@@ -717,13 +732,13 @@ func TestAccAliCloudECSLaunchTemplateBasic1(t *testing.T) {
 					"password_inherit":              "false",
 					"period":                        "1",
 					"private_ip_address":            "172.16.0.10",
-					"template_resource_group_id":    "rg-zkdfjahg9zxncv0",
+					"template_resource_group_id":    "${alicloud_resource_manager_resource_group.test.id}",
 					"version_description":           name,
 					"system_disk_category":          "cloud_ssd",
 					"system_disk_description":       name,
 					"system_disk_name":              name,
 					"system_disk_size":              "40",
-					"resource_group_id":             "rg-zkdfjahg9zxncv0",
+					"resource_group_id":             "${alicloud_resource_manager_resource_group.test.id}",
 					"userdata":                      "xxxxxxx",
 					"vswitch_id":                    "${alicloud_vswitch.shareVswitch1.id}",
 					"tags": map[string]string{
@@ -944,13 +959,13 @@ func TestAccAliCloudECSLaunchTemplateBasic2(t *testing.T) {
 					"period":                        "1",
 					"period_unit":                   "Month",
 					"private_ip_address":            "172.16.0.10",
-					"template_resource_group_id":    "rg-zkdfjahg9zxncv0",
+					"template_resource_group_id":    "${alicloud_resource_manager_resource_group.test.id}",
 					"version_description":           name,
 					"system_disk_category":          "cloud_ssd",
 					"system_disk_description":       name,
 					"system_disk_name":              name,
 					"system_disk_size":              "40",
-					"resource_group_id":             "rg-zkdfjahg9zxncv0",
+					"resource_group_id":             "${alicloud_resource_manager_resource_group.test.id}",
 					"userdata":                      "xxxxxxx",
 					"http_endpoint":                 "enabled",
 					"http_tokens":                   "optional",
@@ -1098,11 +1113,11 @@ func TestAccAliCloudECSLaunchTemplateMulti(t *testing.T) {
 							"kms_key_id":           "${alicloud_kms_key.default.id}",
 						},
 					},
-					"resource_group_id": "rg-zkdfjahg9zxncv0",
+					"resource_group_id": "alicloud_resource_manager_resource_group.test.id",
 					"user_data":         "xxxxxxxxxxxxxx",
 					"vswitch_id":        "${alicloud_vswitch.shareVswitch1.id}",
-					"vpc_id":            "vpc-asdfnbg0as8dfk1nb2",
-					"zone_id":           "cn-beijing-a",
+					"vpc_id":            "${alicloud_vpc.shareVPC.id}",
+					"zone_id":           "cn-hangzhou-i",
 					"tags": map[string]string{
 						"tag1": "hello",
 						"tag2": "world",
@@ -1209,10 +1224,7 @@ data "alicloud_images" "default" {
   owners      = "system"
 }
 data "alicloud_vpcs" "default" {
-    name_regex = "^default-NODELETING$"
-}
-data "alicloud_vswitches" "default" {
- vpc_id = "${data.alicloud_vpcs.default.ids.0}"
+  name_regex = "^default-NODELETING$"
 }
 
 resource "alicloud_vpc" "shareVPC" {
@@ -1233,17 +1245,23 @@ resource "alicloud_vswitch" "shareVswitch2" {
 }
 
 resource "alicloud_security_group" "default" {
-  name   = "${var.name}"
-  vpc_id  = "${data.alicloud_vpcs.default.ids.0}"
+  security_group_name = "${var.name}"
+  vpc_id              = "${data.alicloud_vpcs.default.ids.0}"
 }
 resource "alicloud_security_group" "update" {
-  name   = "${var.name}1"
-  vpc_id = "${data.alicloud_vpcs.default.ids.0}"
+  security_group_name = "${var.name}1"
+  vpc_id              = "${data.alicloud_vpcs.default.ids.0}"
 }
+
 resource "alicloud_kms_key" "default" {
-	description             = var.name
-	pending_window_in_days  = "7"
-	status               = "Enabled"
+  description            = var.name
+  pending_window_in_days = "7"
+  status                 = "Enabled"
+}
+
+resource "alicloud_resource_manager_resource_group" "test" {
+  resource_group_name = var.name
+  display_name        = var.name
 }
 `, name)
 }
@@ -1258,20 +1276,21 @@ data "alicloud_zones" "default" {
   available_disk_category     = "cloud_efficiency"
   available_resource_creation = "VSwitch"
 }
+
 data "alicloud_instance_types" "default" {
   availability_zone = "${data.alicloud_zones.default.zones.0.id}"
 }
+
 data "alicloud_images" "default" {
   name_regex  = "^ubuntu"
   most_recent = true
   owners      = "system"
 }
+
 data "alicloud_vpcs" "default" {
-    name_regex = "^default-NODELETING$"
+  name_regex = "^default-NODELETING$"
 }
-data "alicloud_vswitches" "default" {
- vpc_id = "${data.alicloud_vpcs.default.ids.0}"
-}
+
 resource "alicloud_vpc" "shareVPC" {
   cidr_block = "172.16.0.0/12"
   vpc_name   = var.name
@@ -1288,14 +1307,22 @@ resource "alicloud_vswitch" "shareVswitch2" {
   zone_id    = data.alicloud_zones.default.zones.1.id
   cidr_block = "172.16.2.0/24"
 }
-resource "alicloud_security_group" "default" {
-  name   = "${var.name}"
-  vpc_id  = "${data.alicloud_vpcs.default.ids.0}"
+
+resource "alicloud_resource_manager_resource_group" "test" {
+  resource_group_name = var.name
+  display_name        = var.name
 }
+
+resource "alicloud_security_group" "default" {
+  name   = var.name
+  vpc_id = "${data.alicloud_vpcs.default.ids.0}"
+}
+
 resource "alicloud_security_group" "update" {
   name   = "${var.name}1"
   vpc_id = "${data.alicloud_vpcs.default.ids.0}"
 }
+
 resource "alicloud_ecs_deployment_set" "default" {
   strategy            = "Availability"
   domain              = "Default"

--- a/alicloud/service_alicloud_ecs.go
+++ b/alicloud/service_alicloud_ecs.go
@@ -1937,7 +1937,7 @@ func (s *EcsService) DescribeLaunchTemplateVersions(id string, version interface
 func (s *EcsService) SetResourceTemplateTags(d *schema.ResourceData, resourceType string) error {
 
 	if d.HasChange("template_tags") {
-		added, removed := parsingTags(d)
+		added, removed := parsingTemplateTags(d)
 		client := s.client
 
 		removedTagKeys := make([]string, 0)

--- a/alicloud/tags.go
+++ b/alicloud/tags.go
@@ -61,6 +61,22 @@ func tagsSchemaWithIgnore() *schema.Schema {
 	}
 }
 
+// parse template_tags
+func parsingTemplateTags(d *schema.ResourceData) (map[string]interface{}, []string) {
+	oraw, nraw := d.GetChange("template_tags")
+	removedTags := oraw.(map[string]interface{})
+	addedTags := nraw.(map[string]interface{})
+	removed := make([]string, 0)
+	for key, value := range removedTags {
+		old, ok := addedTags[key]
+		if !ok || old != value {
+			removed = append(removed, key)
+		}
+	}
+
+	return addedTags, removed
+}
+
 func parsingTags(d *schema.ResourceData) (map[string]interface{}, []string) {
 	oraw, nraw := d.GetChange("tags")
 	removedTags := oraw.(map[string]interface{})


### PR DESCRIPTION
- Add scoped CustomizeDiff to mark `latest_version_number` as computed only when version-triggering properties change, enabling downstream resources to detect and apply updates in a single apply cycle. The `latest_version_number` update event can now be propagate to downstream resource.
- Fix `template_tags` update bug by adding **parsingTemplateTags** to read from `template_tags` instead of tags
- Update test case

```log
=== RUN   TestAccAliCloudECSLaunchTemplateBasic
--- PASS: TestAccAliCloudECSLaunchTemplateBasic (269.03s)
=== RUN   TestAccAliCloudECSLaunchTemplateBasic1
--- PASS: TestAccAliCloudECSLaunchTemplateBasic1 (66.47s)
=== RUN   TestAccAliCloudECSLaunchTemplateBasic2
--- PASS: TestAccAliCloudECSLaunchTemplateBasic2 (35.83s)
=== RUN   TestAccAliCloudECSLaunchTemplateMulti
--- PASS: TestAccAliCloudECSLaunchTemplateMulti (37.87s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  413.083s
```