### PR TITLE
New Resource: alicloud_wafv3_address_book; New Data Source: alicloud_wafv3_address_books

### DIFF
--- a/alicloud/data_source_alicloud_wafv3_address_books.go
+++ b/alicloud/data_source_alicloud_wafv3_address_books.go
@@ -1,0 +1,276 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudWafv3AddressBooks() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudWafv3AddressBookRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"books": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"address_book_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"address_book_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"address_book_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"address_list": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudWafv3AddressBookRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	action := "DescribeDefenseRules"
+	queryFilter, _ := json.Marshal(map[string]interface{}{"scene": "address_book"})
+	pageNumber := 1
+	pageSize := PageSizeLarge
+	instanceId := d.Get("instance_id")
+
+	type bookEntry struct {
+		composedId string
+		ruleId     string
+		config     map[string]interface{}
+	}
+	entries := make([]bookEntry, 0)
+
+	for {
+		request := map[string]interface{}{
+			"RegionId":    client.RegionId,
+			"InstanceId":  instanceId,
+			"DefenseType": "global",
+			"Query":       string(queryFilter),
+			"PageNumber":  pageNumber,
+			"PageSize":    pageSize,
+		}
+
+		var response map[string]interface{}
+		var err error
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("waf-openapi", "2021-10-01", action, nil, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_wafv3_address_books", action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.Rules", response)
+		result, _ := resp.([]interface{})
+
+		for _, v := range result {
+			item, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			configRaw := decodeWafv3AddressBookConfig(item["Config"])
+			bookName := ""
+			if configRaw != nil {
+				if n, ok := configRaw["name"].(string); ok {
+					bookName = n
+				}
+			}
+			if nameRegex != nil && !nameRegex.MatchString(bookName) {
+				continue
+			}
+
+			composedId := fmt.Sprintf("%v:%v", instanceId, item["RuleId"])
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[composedId]; !ok {
+					continue
+				}
+			}
+
+			entries = append(entries, bookEntry{
+				composedId: composedId,
+				ruleId:     fmt.Sprint(item["RuleId"]),
+				config:     configRaw,
+			})
+		}
+
+		if len(result) < pageSize {
+			break
+		}
+		pageNumber++
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	enableDetails := d.Get("enable_details").(bool)
+	wafv3ServiceV2 := Wafv3ServiceV2{client}
+
+	for _, entry := range entries {
+		mapping := map[string]interface{}{
+			"id":              entry.composedId,
+			"address_book_id": entry.ruleId,
+		}
+
+		bookName := ""
+		bookDesc := ""
+		bookType := ""
+		if entry.config != nil {
+			if n, ok := entry.config["name"].(string); ok {
+				bookName = n
+			}
+			if dRaw, ok := entry.config["description"].(string); ok {
+				bookDesc = dRaw
+			}
+			if t, ok := entry.config["valueType"].(string); ok {
+				bookType = t
+			}
+		}
+		mapping["address_book_name"] = bookName
+		mapping["address_book_type"] = bookType
+		mapping["description"] = bookDesc
+
+		if enableDetails {
+			addressesRaw, err := wafv3ServiceV2.DescribeWafv3AddressBookAddresses(entry.composedId)
+			if err != nil && !NotFoundError(err) {
+				return WrapError(err)
+			}
+			addressList := make([]interface{}, 0)
+			if addrListRawObj, _ := jsonpath.Get("$.AddressList", addressesRaw); addrListRawObj != nil {
+				if addrItems, ok := addrListRawObj.([]interface{}); ok {
+					for _, addrItem := range addrItems {
+						if addrEntry, ok := addrItem.(map[string]interface{}); ok {
+							if addr, ok := addrEntry["Address"]; ok && addr != nil {
+								addressList = append(addressList, addr)
+							}
+						}
+					}
+				}
+			}
+			mapping["address_list"] = addressList
+		}
+
+		ids = append(ids, entry.composedId)
+		names = append(names, bookName)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("books", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func decodeWafv3AddressBookConfig(raw interface{}) map[string]interface{} {
+	switch v := raw.(type) {
+	case map[string]interface{}:
+		return v
+	case string:
+		if v == "" {
+			return nil
+		}
+		out := make(map[string]interface{})
+		if err := json.Unmarshal([]byte(v), &out); err != nil {
+			return nil
+		}
+		return out
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_wafv3_address_books_test.go
+++ b/alicloud/data_source_alicloud_wafv3_address_books_test.go
@@ -1,0 +1,122 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudWafv3AddressBookDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudWafv3AddressBookSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_wafv3_address_book.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudWafv3AddressBookSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_wafv3_address_book.default.id}_fake"]`,
+		}),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudWafv3AddressBookSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_wafv3_address_book.default.address_book_name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudWafv3AddressBookSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_wafv3_address_book.default.address_book_name}_fake"`,
+		}),
+	}
+
+	enableDetailsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudWafv3AddressBookSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_wafv3_address_book.default.id}"]`,
+			"enable_details": `"true"`,
+		}),
+		existChangMap: map[string]string{
+			"books.0.address_list.#": "3",
+		},
+		fakeConfig: testAccCheckAlicloudWafv3AddressBookSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_wafv3_address_book.default.id}_fake"]`,
+			"enable_details": `"true"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudWafv3AddressBookSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_wafv3_address_book.default.id}"]`,
+			"name_regex":     `"${alicloud_wafv3_address_book.default.address_book_name}"`,
+			"enable_details": `"true"`,
+		}),
+		existChangMap: map[string]string{
+			"books.0.address_list.#": "3",
+		},
+		fakeConfig: testAccCheckAlicloudWafv3AddressBookSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_wafv3_address_book.default.id}_fake"]`,
+			"name_regex":     `"${alicloud_wafv3_address_book.default.address_book_name}_fake"`,
+			"enable_details": `"true"`,
+		}),
+	}
+
+	Wafv3AddressBookCheckInfo.dataSourceTestCheck(t, rand, idsConf, nameRegexConf, enableDetailsConf, allConf)
+}
+
+var existWafv3AddressBookMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"books.#":                   "1",
+		"books.0.description":       CHECKSET,
+		"books.0.address_book_name": CHECKSET,
+		"books.0.address_book_id":   CHECKSET,
+		"books.0.address_book_type": CHECKSET,
+		"books.0.id":                CHECKSET,
+		"ids.#":                     "1",
+		"names.#":                   "1",
+	}
+}
+
+var fakeWafv3AddressBookMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"books.#": "0",
+		"ids.#":   "0",
+		"names.#": "0",
+	}
+}
+
+var Wafv3AddressBookCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_wafv3_address_books.default",
+	existMapFunc: existWafv3AddressBookMapFunc,
+	fakeMapFunc:  fakeWafv3AddressBookMapFunc,
+}
+
+func testAccCheckAlicloudWafv3AddressBookSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccWafv3AddressBook%d"
+}
+
+data "alicloud_wafv3_instances" "default" {
+}
+
+resource "alicloud_wafv3_address_book" "default" {
+  description       = "test"
+  instance_id       = data.alicloud_wafv3_instances.default.ids.0
+  address_book_name = var.name
+  address_list      = ["100.100.100.100/32", "101.101.101.101/32", "102.102.102.102/32"]
+  address_book_type = "ip"
+}
+
+data "alicloud_wafv3_address_books" "default" {
+  instance_id = data.alicloud_wafv3_instances.default.ids.0
+  %s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -171,6 +171,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_wafv3_address_books":                        dataSourceAliCloudWafv3AddressBooks(),
 			"alicloud_amqp_open_source_accounts":                  dataSourceAliCloudAmqpOpenSourceAccounts(),
 			"alicloud_vpc_ipv6_cidr_blocks":                       dataSourceAliCloudVpcIpv6CidrBlocks(),
 			"alicloud_amqp_open_source_permissions":               dataSourceAliCloudAmqpOpenSourcePermissions(),
@@ -925,6 +926,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_wafv3_address_book":                                   resourceAliCloudWafv3AddressBook(),
 			"alicloud_amqp_open_source_account":                             resourceAliCloudAmqpOpenSourceAccount(),
 			"alicloud_vpc_ipv6_cidr_block":                                  resourceAliCloudVpcIpv6CidrBlock(),
 			"alicloud_amqp_open_source_permission":                          resourceAliCloudAmqpOpenSourcePermission(),

--- a/alicloud/resource_alicloud_wafv3_address_book.go
+++ b/alicloud/resource_alicloud_wafv3_address_book.go
@@ -1,0 +1,337 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudWafv3AddressBook() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudWafv3AddressBookCreate,
+		Read:   resourceAliCloudWafv3AddressBookRead,
+		Update: resourceAliCloudWafv3AddressBookUpdate,
+		Delete: resourceAliCloudWafv3AddressBookDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"address_book_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"address_book_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"address_book_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"ip"}, false),
+			},
+			"address_list": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudWafv3AddressBookCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateDefenseRule"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("instance_id"); ok {
+		request["InstanceId"] = v
+	}
+	request["RegionId"] = client.RegionId
+
+	rulesDataList := make(map[string]interface{})
+
+	if v, ok := d.GetOk("address_book_type"); ok {
+		rulesDataList["valueType"] = v
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		rulesDataList["description"] = v
+	}
+
+	if v, ok := d.GetOk("address_book_name"); ok {
+		rulesDataList["name"] = v
+	}
+
+	RulesMap := make([]interface{}, 0)
+	RulesMap = append(RulesMap, rulesDataList)
+	rulesJson, err := json.Marshal(RulesMap)
+	if err != nil {
+		return WrapError(err)
+	}
+	request["Rules"] = string(rulesJson)
+
+	request["DefenseScene"] = "address_book"
+	request["DefenseType"] = "global"
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("waf-openapi", "2021-10-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_wafv3_address_book", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", request["InstanceId"], response["RuleIds"]))
+
+	return resourceAliCloudWafv3AddressBookUpdate(d, meta)
+}
+
+func resourceAliCloudWafv3AddressBookRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	wafv3ServiceV2 := Wafv3ServiceV2{client}
+
+	objectRaw, err := wafv3ServiceV2.DescribeWafv3AddressBook(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_wafv3_address_book DescribeWafv3AddressBook Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("address_book_name", objectRaw["name"])
+	d.Set("address_book_type", objectRaw["valueType"])
+	d.Set("description", objectRaw["description"])
+
+	addressesRaw, err := wafv3ServiceV2.DescribeWafv3AddressBookAddresses(d.Id())
+	if err != nil && !NotFoundError(err) {
+		return WrapError(err)
+	}
+
+	addressListRawObj, _ := jsonpath.Get("$.AddressList", addressesRaw)
+	addressListRaw := make([]interface{}, 0)
+	if addressListRawObj != nil {
+		addressListRaw = convertToInterfaceArray(addressListRawObj)
+	}
+
+	addresses := make([]interface{}, 0)
+	for _, item := range addressListRaw {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if addr, ok := entry["Address"]; ok && addr != nil {
+			addresses = append(addresses, addr)
+		}
+	}
+
+	d.Set("address_list", addresses)
+
+	parts := strings.Split(d.Id(), ":")
+	d.Set("instance_id", parts[0])
+	d.Set("address_book_id", parts[1])
+
+	return nil
+}
+
+func resourceAliCloudWafv3AddressBookUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(d.Id(), ":")
+
+	if d.HasChange("description") || d.HasChange("address_book_name") {
+		action := "ModifyDefenseRule"
+		request = make(map[string]interface{})
+		query = make(map[string]interface{})
+		request["InstanceId"] = parts[0]
+		request["RegionId"] = client.RegionId
+		request["DefenseScene"] = "address_book"
+		request["DefenseType"] = "global"
+
+		rulesDataList := map[string]interface{}{
+			"id":        parts[1],
+			"valueType": d.Get("address_book_type"),
+		}
+		if v, ok := d.GetOk("description"); ok {
+			rulesDataList["description"] = v
+		}
+		if v, ok := d.GetOk("address_book_name"); ok {
+			rulesDataList["name"] = v
+		}
+
+		rulesJson, err := json.Marshal([]interface{}{rulesDataList})
+		if err != nil {
+			return WrapError(err)
+		}
+		request["Rules"] = string(rulesJson)
+
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("waf-openapi", "2021-10-01", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	if d.HasChange("address_list") {
+		var err error
+		oldEntry, newEntry := d.GetChange("address_list")
+		oldEntrySet := oldEntry.(*schema.Set)
+		newEntrySet := newEntry.(*schema.Set)
+		removed := oldEntrySet.Difference(newEntrySet)
+		added := newEntrySet.Difference(oldEntrySet)
+
+		if removed.Len() > 0 {
+			parts := strings.Split(d.Id(), ":")
+			action := "DeleteAddress"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["RuleId"] = parts[1]
+			request["InstanceId"] = parts[0]
+
+			localData := removed.List()
+			addressListMapsArray := localData
+			request["AddressList"] = addressListMapsArray
+
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("waf-openapi", "2021-10-01", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+
+		}
+
+		if added.Len() > 0 {
+			parts := strings.Split(d.Id(), ":")
+			action := "AddAddress"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["RuleId"] = parts[1]
+			request["InstanceId"] = parts[0]
+
+			localData := added.List()
+			addressListMapsArray := localData
+			request["AddressList"] = addressListMapsArray
+
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("waf-openapi", "2021-10-01", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+
+		}
+
+	}
+	return resourceAliCloudWafv3AddressBookRead(d, meta)
+}
+
+func resourceAliCloudWafv3AddressBookDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := "DeleteDefenseRule"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["RuleIds"] = parts[1]
+	request["InstanceId"] = parts[0]
+	request["RegionId"] = client.RegionId
+
+	request["DefenseType"] = "global"
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("waf-openapi", "2021-10-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_wafv3_address_book_test.go
+++ b/alicloud/resource_alicloud_wafv3_address_book_test.go
@@ -1,0 +1,393 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Wafv3 AddressBook. >>> Resource test cases, automatically generated.
+// Case 测试地址簿 12719
+func TestAccAliCloudWafv3AddressBook_basic12719(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_wafv3_address_book.default"
+	ra := resourceAttrInit(resourceId, AlicloudWafv3AddressBookMap12719)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &Wafv3ServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeWafv3AddressBook")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudWafv3AddressBookBasicDependence12719)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "test",
+					"instance_id":       "${data.alicloud_wafv3_instances.default.ids.0}",
+					"address_book_name": name,
+					"address_list": []string{
+						"100.100.100.100/32", "101.101.101.101/32", "102.102.102.102/32"},
+					"address_book_type": "ip",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "test",
+						"instance_id":       CHECKSET,
+						"address_book_name": name,
+						"address_list.#":    "3",
+						"address_book_type": "ip",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "test1",
+					"address_book_type": "ip",
+					"address_list": []string{
+						"101.101.101.101/32"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "test1",
+						"address_book_type": "ip",
+						"address_list.#":    "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"address_list": []string{},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"address_list.#": "0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "test2",
+					"address_list": []string{
+						"102.102.102.102/32"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":    "test2",
+						"address_list.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudWafv3AddressBookMap12719 = map[string]string{
+	"id":              CHECKSET,
+	"address_book_id": CHECKSET,
+}
+
+func AlicloudWafv3AddressBookBasicDependence12719(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_wafv3_instances" "default" {
+}
+
+
+`, name)
+}
+
+// Case 地址库 12702
+func TestAccAliCloudWafv3AddressBook_basic12702(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_wafv3_address_book.default"
+	ra := resourceAttrInit(resourceId, AlicloudWafv3AddressBookMap12702)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &Wafv3ServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeWafv3AddressBook")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccwafv3%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudWafv3AddressBookBasicDependence12702)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "创建",
+					"instance_id":       "${data.alicloud_wafv3_instances.default.ids.0}",
+					"address_book_name": name,
+					"address_list": []string{
+						"100.100.100.100/32", "101.101.101.101/32", "102.102.102.102/32"},
+					"address_book_type": "ip",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "创建",
+						"instance_id":       CHECKSET,
+						"address_book_name": name,
+						"address_list.#":    "3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "更新1",
+					"address_book_name": name + "_update",
+					"address_list": []string{
+						"101.101.101.101/32"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "更新1",
+						"address_book_name": name + "_update",
+						"address_list.#":    "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "更新2",
+					"address_book_name": name + "_update",
+					"address_list":      []string{},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "更新2",
+						"address_book_name": name + "_update",
+						"address_list.#":    "0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "更新3",
+					"address_book_name": name + "_update",
+					"address_list": []string{
+						"102.102.102.102/32"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "更新3",
+						"address_book_name": name + "_update",
+						"address_list.#":    "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "update4",
+					"address_book_name": name + "_update",
+					"address_list": []string{
+						"100.100.100.100/26"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "update4",
+						"address_book_name": name + "_update",
+						"address_list.#":    "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudWafv3AddressBookMap12702 = map[string]string{
+	"id":              CHECKSET,
+	"address_book_id": CHECKSET,
+}
+
+func AlicloudWafv3AddressBookBasicDependence12702(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_wafv3_instances" "default" {
+}
+
+
+`, name)
+}
+
+// Case test 12677
+func TestAccAliCloudWafv3AddressBook_basic12677(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_wafv3_address_book.default"
+	ra := resourceAttrInit(resourceId, AlicloudWafv3AddressBookMap12677)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &Wafv3ServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeWafv3AddressBook")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudWafv3AddressBookBasicDependence12677)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "test",
+					"instance_id":       "${data.alicloud_wafv3_instances.default.ids.0}",
+					"address_book_name": name,
+					"address_list": []string{
+						"100.100.100.100/32", "101.101.101.101/32", "102.102.102.102/32"},
+					"address_book_type": "ip",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "test",
+						"instance_id":       CHECKSET,
+						"address_book_name": name,
+						"address_list.#":    "3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "test1",
+					"address_book_name": name + "_update",
+					"address_list": []string{
+						"101.101.101.101/32"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "test1",
+						"address_book_name": name + "_update",
+						"address_list.#":    "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"address_book_name": name + "_update",
+					"address_list":      []string{},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"address_book_name": name + "_update",
+						"address_list.#":    "0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "test2",
+					"address_book_name": name + "_update",
+					"address_list": []string{
+						"102.102.102.102/32"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "test2",
+						"address_book_name": name + "_update",
+						"address_list.#":    "1",
+					}),
+				),
+			},
+			{
+				// Overlap replace: keep 102, add 103 + 104. Exercises Update where
+				// DeleteAddress + AddAddress fire in the same call.
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "test3",
+					"address_book_name": name + "_update",
+					"address_list": []string{
+						"102.102.102.102/32", "103.103.103.103/32", "104.104.104.104/32"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "test3",
+						"address_book_name": name + "_update",
+						"address_list.#":    "3",
+					}),
+				),
+			},
+			{
+				// No-op re-apply: re-applying the prior config must produce an empty
+				// plan. Guards against perpetual diff in Read.
+				Config: testAccConfig(map[string]interface{}{
+					"description":       "test3",
+					"address_book_name": name + "_update",
+					"address_list": []string{
+						"102.102.102.102/32", "103.103.103.103/32", "104.104.104.104/32"},
+				}),
+				PlanOnly: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":       "test3",
+						"address_book_name": name + "_update",
+						"address_list.#":    "3",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudWafv3AddressBookMap12677 = map[string]string{
+	"id":              CHECKSET,
+	"address_book_id": CHECKSET,
+}
+
+func AlicloudWafv3AddressBookBasicDependence12677(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_wafv3_instances" "default" {
+}
+
+
+`, name)
+}
+
+// Test Wafv3 AddressBook. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_wafv3_v2.go
+++ b/alicloud/service_alicloud_wafv3_v2.go
@@ -1,6 +1,7 @@
 package alicloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -515,3 +516,119 @@ func (s *Wafv3ServiceV2) Wafv3DefenseResourceGroupStateRefreshFuncWithApi(id str
 }
 
 // DescribeWafv3DefenseResourceGroup >>> Encapsulated.
+
+// DescribeWafv3AddressBook <<< Encapsulated get interface for Wafv3 AddressBook.
+
+func (s *Wafv3ServiceV2) DescribeWafv3AddressBook(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RuleId"] = parts[1]
+	request["InstanceId"] = parts[0]
+	request["RegionId"] = client.RegionId
+	request["DefenseType"] = "global"
+	action := "DescribeDefenseRule"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("waf-openapi", "2021-10-01", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"Defense.Control.DefenseRuleNotExist"}) {
+			return object, WrapErrorf(NotFoundErr("AddressBook", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Rule.Config", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Rule.Config", response)
+	}
+
+	if configStr, ok := v.(string); ok {
+		object = make(map[string]interface{})
+		if err := json.Unmarshal([]byte(configStr), &object); err != nil {
+			return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Rule.Config", response)
+		}
+		return object, nil
+	}
+	return v.(map[string]interface{}), nil
+}
+func (s *Wafv3ServiceV2) DescribeWafv3AddressBookAddresses(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+
+	action := "DescribeAddresses"
+	aggregatedAddresses := make([]interface{}, 0)
+	nextToken := ""
+
+	for {
+		request := map[string]interface{}{
+			"RuleId":     parts[1],
+			"InstanceId": parts[0],
+			"RegionId":   client.RegionId,
+			"MaxResults": 100,
+		}
+		if nextToken != "" {
+			request["NextToken"] = nextToken
+		}
+		query := make(map[string]interface{})
+
+		var response map[string]interface{}
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPost("waf-openapi", "2021-10-01", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"Defense.Control.DefenseRuleNotExist"}) {
+				return object, WrapErrorf(NotFoundErr("AddressBook", id), NotFoundMsg, response)
+			}
+			return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+		}
+
+		if pageList, ok := response["AddressList"].([]interface{}); ok {
+			aggregatedAddresses = append(aggregatedAddresses, pageList...)
+		}
+
+		nt, _ := response["NextToken"].(string)
+		if nt == "" || nt == nextToken {
+			break
+		}
+		nextToken = nt
+	}
+
+	return map[string]interface{}{"AddressList": aggregatedAddresses}, nil
+}
+
+// DescribeWafv3AddressBook >>> Encapsulated.

--- a/website/docs/d/wafv3_address_books.html.markdown
+++ b/website/docs/d/wafv3_address_books.html.markdown
@@ -1,0 +1,73 @@
+---
+subcategory: "Web Application Firewall(WAF)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_wafv3_address_books"
+sidebar_current: "docs-alicloud-datasource-wafv3-address-books"
+description: |-
+  Provides a list of Wafv3 Address Book owned by an Alibaba Cloud account.
+---
+
+# alicloud_wafv3_address_books
+
+This data source provides Wafv3 Address Book available to the user.[What is Address Book](https://next.api.alibabacloud.com/document/waf-openapi/2021-10-01/CreateDefenseRule)
+
+-> **NOTE:** Available since v1.283.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+data "alicloud_wafv3_instances" "default" {
+}
+
+resource "alicloud_wafv3_address_book" "default" {
+  description       = "test"
+  instance_id       = data.alicloud_wafv3_instances.default.ids.0
+  address_book_name = var.name
+  address_list      = ["100.100.100.100/32", "101.101.101.101/32", "102.102.102.102/32"]
+  address_book_type = "ip"
+}
+
+data "alicloud_wafv3_address_books" "default" {
+  ids         = ["${alicloud_wafv3_address_book.default.id}"]
+  name_regex  = alicloud_wafv3_address_book.default.address_book_name
+  instance_id = data.alicloud_wafv3_instances.default.ids.0
+}
+
+output "alicloud_wafv3_address_book_example_id" {
+  value = data.alicloud_wafv3_address_books.default.books.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `instance_id` - (Required) The ID of the WAF instance.
+
+-> **NOTE:**  You can call [DescribeInstance](~~ 433756 ~~) to view the ID of the current WAF instance.
+
+* `ids` - (Optional, Computed) A list of Address Book IDs. The value is formulated as `<instance_id>:<address_book_id>`.
+* `name_regex` - (Optional) A regex string to filter results by Address Book name.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` to fetch the `address_list` of each Address Book.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Address Book IDs.
+* `names` - A list of name of Address Books.
+* `books` - A list of Address Book Entries. Each element contains the following attributes:
+    * `address_book_id` - The ID of the Address Book.
+    * `address_book_name` - The name of the Address Book.
+    * `address_book_type` - The type of the Address Book. Valid values: `ip`.
+    * `address_list` - The address list of the Address Book. **NOTE:** This field is only available when `enable_details` is `true`.
+    * `description` - The description of the Address Book.
+    * `id` - The resource ID. It is formatted as `<instance_id>:<address_book_id>`.

--- a/website/docs/r/wafv3_address_book.html.markdown
+++ b/website/docs/r/wafv3_address_book.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "Web Application Firewall(WAF)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_wafv3_address_book"
+description: |-
+  Provides a Alicloud WAFV3 Address Book resource.
+---
+
+# alicloud_wafv3_address_book
+
+Provides a WAFV3 Address Book resource.
+
+An Address Book is a named collection of IP/CIDR entries that can be referenced from WAFV3 protection rules.
+
+For information about WAFV3 Address Book and how to use it, see [What is Address Book](https://next.api.alibabacloud.com/document/waf-openapi/2021-10-01/CreateDefenseRule).
+
+-> **NOTE:** Available since v1.283.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+data "alicloud_wafv3_instances" "default" {
+}
+
+resource "alicloud_wafv3_address_book" "default" {
+  description       = "example"
+  instance_id       = data.alicloud_wafv3_instances.default.ids.0
+  address_book_name = var.name
+  address_list      = ["100.100.100.100/32", "101.101.101.101/32", "102.102.102.102/32"]
+  address_book_type = "ip"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `address_book_name` - (Optional) The name of the Address Book.
+* `address_book_type` - (Required, ForceNew) The type of the Address Book. Valid values: `ip`.
+* `address_list` - (Optional, Set) The address list of the Address Book. Each entry is a single IP address or a CIDR block, IPv4 or IPv6.
+* `description` - (Optional) The description of the Address Book.
+* `instance_id` - (Required, ForceNew) The ID of the WAF instance.
+
+-> **NOTE:**  You can call [DescribeInstance](~~ 433756 ~~) to view the ID of the current WAF instance.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<instance_id>:<address_book_id>`.
+* `address_book_id` - The ID of the Address Book.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Address Book.
+* `delete` - (Defaults to 5 mins) Used when delete the Address Book.
+* `update` - (Defaults to 5 mins) Used when update the Address Book.
+
+## Import
+
+WAFV3 Address Book can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_wafv3_address_book.example <instance_id>:<address_book_id>
+```


### PR DESCRIPTION
## Summary

Add the new `alicloud_wafv3_address_book` resource and `alicloud_wafv3_address_books` data source for WAFV3.

An Address Book is a named collection of IP/CIDR entries that protection rules can reference. The resource wraps the WAFV3 `CreateDefenseRule` / `ModifyDefenseRule` / `DeleteDefenseRule` APIs (with `DefenseScene=address_book`, `DefenseType=global`) plus `AddAddress` / `DeleteAddress` for the per-entry address list.

## Test Plan

```
=== RUN   TestAccAliCloudWafv3AddressBook_basic12719
--- PASS: TestAccAliCloudWafv3AddressBook_basic12719 (20.09s)

=== RUN   TestAccAliCloudWafv3AddressBook_basic12702
--- PASS: TestAccAliCloudWafv3AddressBook_basic12702 (25.15s)

=== RUN   TestAccAliCloudWafv3AddressBook_basic12677
--- PASS: TestAccAliCloudWafv3AddressBook_basic12677 (21.22s)

=== RUN   TestAccAlicloudWafv3AddressBookDataSource
--- PASS: TestAccAlicloudWafv3AddressBookDataSource (26.82s)
```