### PR TITLE
New Resource: alicloud_cloud_monitor_service_metric_alarm_rule; data-source/alicloud_cloud_monitor_service_metric_alarm_rules: regenerate from CMS IDL

### DIFF
--- a/alicloud/data_source_alicloud_cloud_monitor_service_metric_alarm_rules.go
+++ b/alicloud/data_source_alicloud_cloud_monitor_service_metric_alarm_rules.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -22,6 +23,10 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRules() *schema.Resource {
 				Computed: true,
 			},
 			"dimensions": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"metric_alarm_rule_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -222,6 +227,10 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRules() *schema.Resource {
 								},
 							},
 						},
+						"metric_alarm_rule_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"metric_name": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -286,6 +295,10 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRules() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"send_ok": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 						"silence_time": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -313,6 +326,11 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRules() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -339,31 +357,32 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d *schema.Resource
 	var err error
 	request = make(map[string]interface{})
 	query = make(map[string]interface{})
+
+	if v, ok := d.GetOk("metric_alarm_rule_id"); ok {
+		request["RuleIds"] = v
+	}
 	if v, ok := d.GetOk("dimensions"); ok {
 		request["Dimensions"] = v
 	}
-
 	if v, ok := d.GetOk("metric_name"); ok {
 		request["MetricName"] = v
 	}
-
 	if v, ok := d.GetOk("namespace"); ok {
 		request["Namespace"] = v
 	}
-
 	if v, ok := d.GetOk("rule_name"); ok {
 		request["RuleName"] = v
 	}
-
 	if v, ok := d.GetOkExists("status"); ok {
 		request["EnableState"] = v
 	}
-
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
 	request["PageSize"] = PageSizeLarge
 	request["Page"] = 1
 	for {
 		wait := incrementalWait(3*time.Second, 5*time.Second)
-		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
 			response, err = client.RpcPost("Cms", "2019-01-01", action, query, request, true)
 
 			if err != nil {
@@ -373,18 +392,14 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d *schema.Resource
 				}
 				return resource.NonRetryableError(err)
 			}
+			addDebug(action, response, request)
 			return nil
 		})
-		addDebug(action, response, request)
-
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
 
-		resp, err := jsonpath.Get("$.Alarms.Alarm", response)
-		if err != nil {
-			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.Alarms.Alarm", response)
-		}
+		resp, _ := jsonpath.Get("$.Alarms.Alarm[*]", response)
 
 		result, _ := resp.([]interface{})
 		for _, v := range result {
@@ -397,10 +412,10 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d *schema.Resource
 			objects = append(objects, item)
 		}
 
-		if len(result) < request["PageSize"].(int) {
+		if len(result) < PageSizeLarge {
 			break
 		}
-		request["PageNumber"] = request["PageNumber"].(int) + 1
+		request["Page"] = request["Page"].(int) + 1
 	}
 
 	ids := make([]string, 0)
@@ -421,10 +436,12 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d *schema.Resource
 		mapping["period"] = objectRaw["Period"]
 		mapping["resources"] = objectRaw["Resources"]
 		mapping["rule_name"] = objectRaw["RuleName"]
+		mapping["send_ok"] = objectRaw["SendOK"]
 		mapping["silence_time"] = objectRaw["SilenceTime"]
 		mapping["source_type"] = objectRaw["SourceType"]
 		mapping["status"] = objectRaw["EnableState"]
 		mapping["webhook"] = objectRaw["Webhook"]
+		mapping["metric_alarm_rule_id"] = objectRaw["RuleId"]
 
 		compositeExpressionMaps := make([]map[string]interface{}, 0)
 		compositeExpressionMap := make(map[string]interface{})
@@ -441,7 +458,7 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d *schema.Resource
 			expressionListRaw, _ := jsonpath.Get("$.CompositeExpression.ExpressionList.ExpressionList", objectRaw)
 			expressionListMaps := make([]map[string]interface{}, 0)
 			if expressionListRaw != nil {
-				for _, expressionListChildRaw := range expressionListRaw.([]interface{}) {
+				for _, expressionListChildRaw := range convertToInterfaceArray(expressionListRaw) {
 					expressionListMap := make(map[string]interface{})
 					expressionListChildRaw := expressionListChildRaw.(map[string]interface{})
 					expressionListMap["comparison_operator"] = expressionListChildRaw["ComparisonOperator"]
@@ -519,7 +536,7 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d *schema.Resource
 		labelsRaw, _ := jsonpath.Get("$.Labels.Labels", objectRaw)
 		labelsMaps := make([]map[string]interface{}, 0)
 		if labelsRaw != nil {
-			for _, labelsChildRaw := range labelsRaw.([]interface{}) {
+			for _, labelsChildRaw := range convertToInterfaceArray(labelsRaw) {
 				labelsMap := make(map[string]interface{})
 				labelsChildRaw := labelsChildRaw.(map[string]interface{})
 				labelsMap["key"] = labelsChildRaw["Key"]
@@ -543,7 +560,7 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d *schema.Resource
 			annotationsRaw, _ := jsonpath.Get("$.Prometheus.Annotations.Annotations", objectRaw)
 			annotationsMaps := make([]map[string]interface{}, 0)
 			if annotationsRaw != nil {
-				for _, annotationsChildRaw := range annotationsRaw.([]interface{}) {
+				for _, annotationsChildRaw := range convertToInterfaceArray(annotationsRaw) {
 					annotationsMap := make(map[string]interface{})
 					annotationsChildRaw := annotationsChildRaw.(map[string]interface{})
 					annotationsMap["key"] = annotationsChildRaw["Key"]
@@ -556,6 +573,18 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d *schema.Resource
 			prometheusMaps = append(prometheusMaps, prometheusMap)
 		}
 		mapping["prometheus"] = prometheusMaps
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["RuleId"])
+		mapping, err = dataSourceAliCloudCloudMonitorServiceMetricAlarmRuleReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
 
 		ids = append(ids, fmt.Sprint(mapping["id"]))
 		s = append(s, mapping)
@@ -574,4 +603,170 @@ func dataSourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d *schema.Resource
 		writeToFile(output.(string), s)
 	}
 	return nil
+}
+
+func dataSourceAliCloudCloudMonitorServiceMetricAlarmRuleReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	cloudMonitorServiceServiceV2 := CloudMonitorServiceServiceV2{client}
+	getResp, err := cloudMonitorServiceServiceV2.DescribeCloudMonitorServiceMetricAlarmRule(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["contact_groups"] = objectRaw["ContactGroups"]
+	mapping["dimensions"] = objectRaw["Dimensions"]
+	mapping["effective_interval"] = objectRaw["EffectiveInterval"]
+	mapping["email_subject"] = objectRaw["MailSubject"]
+	mapping["metric_name"] = objectRaw["MetricName"]
+	mapping["namespace"] = objectRaw["Namespace"]
+	mapping["no_data_policy"] = objectRaw["NoDataPolicy"]
+	mapping["no_effective_interval"] = objectRaw["NoEffectiveInterval"]
+	mapping["period"] = objectRaw["Period"]
+	mapping["resources"] = objectRaw["Resources"]
+	mapping["rule_name"] = objectRaw["RuleName"]
+	mapping["send_ok"] = objectRaw["SendOK"]
+	mapping["silence_time"] = objectRaw["SilenceTime"]
+	mapping["source_type"] = objectRaw["SourceType"]
+	mapping["status"] = objectRaw["EnableState"]
+	mapping["webhook"] = objectRaw["Webhook"]
+	mapping["metric_alarm_rule_id"] = objectRaw["RuleId"]
+
+	compositeExpressionMaps := make([]map[string]interface{}, 0)
+	compositeExpressionMap := make(map[string]interface{})
+	compositeExpressionRaw := make(map[string]interface{})
+	if objectRaw["CompositeExpression"] != nil {
+		compositeExpressionRaw = objectRaw["CompositeExpression"].(map[string]interface{})
+	}
+	if len(compositeExpressionRaw) > 0 {
+		compositeExpressionMap["expression_list_join"] = compositeExpressionRaw["ExpressionListJoin"]
+		compositeExpressionMap["expression_raw"] = compositeExpressionRaw["ExpressionRaw"]
+		compositeExpressionMap["level"] = compositeExpressionRaw["Level"]
+		compositeExpressionMap["times"] = compositeExpressionRaw["Times"]
+
+		expressionListRaw, _ := jsonpath.Get("$.CompositeExpression.ExpressionList.ExpressionList", objectRaw)
+		expressionListMaps := make([]map[string]interface{}, 0)
+		if expressionListRaw != nil {
+			for _, expressionListChildRaw := range convertToInterfaceArray(expressionListRaw) {
+				expressionListMap := make(map[string]interface{})
+				expressionListChildRaw := expressionListChildRaw.(map[string]interface{})
+				expressionListMap["comparison_operator"] = expressionListChildRaw["ComparisonOperator"]
+				expressionListMap["metric_name"] = expressionListChildRaw["MetricName"]
+				expressionListMap["period"] = expressionListChildRaw["Period"]
+				expressionListMap["statistics"] = expressionListChildRaw["Statistics"]
+				expressionListMap["threshold"] = expressionListChildRaw["Threshold"]
+
+				expressionListMaps = append(expressionListMaps, expressionListMap)
+			}
+		}
+		compositeExpressionMap["expression_list"] = expressionListMaps
+		compositeExpressionMaps = append(compositeExpressionMaps, compositeExpressionMap)
+	}
+	mapping["composite_expression"] = compositeExpressionMaps
+	escalationsMaps := make([]map[string]interface{}, 0)
+	escalationsMap := make(map[string]interface{})
+	escalationsRaw := make(map[string]interface{})
+	if objectRaw["Escalations"] != nil {
+		escalationsRaw = objectRaw["Escalations"].(map[string]interface{})
+	}
+	if len(escalationsRaw) > 0 {
+
+		criticalMaps := make([]map[string]interface{}, 0)
+		criticalMap := make(map[string]interface{})
+		criticalRaw := make(map[string]interface{})
+		if escalationsRaw["Critical"] != nil {
+			criticalRaw = escalationsRaw["Critical"].(map[string]interface{})
+		}
+		if len(criticalRaw) > 0 {
+			criticalMap["comparison_operator"] = criticalRaw["ComparisonOperator"]
+			criticalMap["pre_condition"] = criticalRaw["PreCondition"]
+			criticalMap["statistics"] = criticalRaw["Statistics"]
+			criticalMap["threshold"] = criticalRaw["Threshold"]
+			criticalMap["times"] = criticalRaw["Times"]
+
+			criticalMaps = append(criticalMaps, criticalMap)
+		}
+		escalationsMap["critical"] = criticalMaps
+		infoMaps := make([]map[string]interface{}, 0)
+		infoMap := make(map[string]interface{})
+		infoRaw := make(map[string]interface{})
+		if escalationsRaw["Info"] != nil {
+			infoRaw = escalationsRaw["Info"].(map[string]interface{})
+		}
+		if len(infoRaw) > 0 {
+			infoMap["comparison_operator"] = infoRaw["ComparisonOperator"]
+			infoMap["pre_condition"] = infoRaw["PreCondition"]
+			infoMap["statistics"] = infoRaw["Statistics"]
+			infoMap["threshold"] = infoRaw["Threshold"]
+			infoMap["times"] = infoRaw["Times"]
+
+			infoMaps = append(infoMaps, infoMap)
+		}
+		escalationsMap["info"] = infoMaps
+		warnMaps := make([]map[string]interface{}, 0)
+		warnMap := make(map[string]interface{})
+		warnRaw := make(map[string]interface{})
+		if escalationsRaw["Warn"] != nil {
+			warnRaw = escalationsRaw["Warn"].(map[string]interface{})
+		}
+		if len(warnRaw) > 0 {
+			warnMap["comparison_operator"] = warnRaw["ComparisonOperator"]
+			warnMap["pre_condition"] = warnRaw["PreCondition"]
+			warnMap["statistics"] = warnRaw["Statistics"]
+			warnMap["threshold"] = warnRaw["Threshold"]
+			warnMap["times"] = warnRaw["Times"]
+
+			warnMaps = append(warnMaps, warnMap)
+		}
+		escalationsMap["warn"] = warnMaps
+		escalationsMaps = append(escalationsMaps, escalationsMap)
+	}
+	mapping["escalations"] = escalationsMaps
+	labelsRaw, _ := jsonpath.Get("$.Labels.Labels", objectRaw)
+	labelsMaps := make([]map[string]interface{}, 0)
+	if labelsRaw != nil {
+		for _, labelsChildRaw := range convertToInterfaceArray(labelsRaw) {
+			labelsMap := make(map[string]interface{})
+			labelsChildRaw := labelsChildRaw.(map[string]interface{})
+			labelsMap["key"] = labelsChildRaw["Key"]
+			labelsMap["value"] = labelsChildRaw["Value"]
+
+			labelsMaps = append(labelsMaps, labelsMap)
+		}
+	}
+	mapping["labels"] = labelsMaps
+	prometheusMaps := make([]map[string]interface{}, 0)
+	prometheusMap := make(map[string]interface{})
+	prometheusRaw := make(map[string]interface{})
+	if objectRaw["Prometheus"] != nil {
+		prometheusRaw = objectRaw["Prometheus"].(map[string]interface{})
+	}
+	if len(prometheusRaw) > 0 {
+		prometheusMap["level"] = prometheusRaw["Level"]
+		prometheusMap["prom_ql"] = prometheusRaw["PromQL"]
+		prometheusMap["times"] = prometheusRaw["Times"]
+
+		annotationsRaw, _ := jsonpath.Get("$.Prometheus.Annotations.Annotations", objectRaw)
+		annotationsMaps := make([]map[string]interface{}, 0)
+		if annotationsRaw != nil {
+			for _, annotationsChildRaw := range convertToInterfaceArray(annotationsRaw) {
+				annotationsMap := make(map[string]interface{})
+				annotationsChildRaw := annotationsChildRaw.(map[string]interface{})
+				annotationsMap["key"] = annotationsChildRaw["Key"]
+				annotationsMap["value"] = annotationsChildRaw["Value"]
+
+				annotationsMaps = append(annotationsMaps, annotationsMap)
+			}
+		}
+		prometheusMap["annotations"] = annotationsMaps
+		prometheusMaps = append(prometheusMaps, prometheusMap)
+	}
+	mapping["prometheus"] = prometheusMaps
+
+	return mapping, nil
 }

--- a/alicloud/data_source_alicloud_cloud_monitor_service_metric_alarm_rules_test.go
+++ b/alicloud/data_source_alicloud_cloud_monitor_service_metric_alarm_rules_test.go
@@ -1,525 +1,182 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-func TestAccAliCloudCloudMonitorServiceMetricAlarmRulesDataSource_basic0(t *testing.T) {
-	rand := acctest.RandIntRange(100, 999)
-	resourceId := "data.alicloud_cloud_monitor_service_metric_alarm_rules.default"
-	name := fmt.Sprintf("tf-testscc-cmsalarm%d", rand)
-	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceCloudMonitorServiceMetricAlarmRulesConfig0)
+func TestAccAlicloudCloudMonitorServiceMetricAlarmRuleDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
 
 	idsConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids": []string{"${alicloud_cms_alarm.default.id}"},
+		existConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}"]`,
 		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"ids": []string{"${alicloud_cms_alarm.default.id}_fake"},
-		}),
-	}
-	dimensionsConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"dimensions": `{\"instanceId\":\"` + "${data.alicloud_instances.default.ids.0}" + `\"}`,
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"dimensions": `{\"instanceId\":\"i-1688\"}`,
+		fakeConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}_fake"]`,
 		}),
 	}
-	metricNameConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":         []string{"${alicloud_cms_alarm.default.id}"},
-			"metric_name": "${alicloud_cms_alarm.default.metric}",
+
+	NamespaceConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}"]`,
+			"namespace": `"acs_drds"`,
 		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"metric_name": "${alicloud_cms_alarm.default.metric}_fake",
-		}),
-	}
-	namespaceConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":       []string{"${alicloud_cms_alarm.default.id}"},
-			"namespace": "${alicloud_cms_alarm.default.project}",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"namespace": "${alicloud_cms_alarm.default.project}_fake",
+		fakeConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}_fake"]`,
+			"namespace": `"acs_drds_fake"`,
 		}),
 	}
-	ruleNameConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"rule_name": "${alicloud_cms_alarm.default.name}",
+	MetricAlarmRuleIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":                  `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}"]`,
+			"metric_alarm_rule_id": `"SystemDefault_acs_drds_IOPSUsageOfDo"`,
 		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"rule_name": "${alicloud_cms_alarm.default.name}_fake",
-		}),
-	}
-	statusConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":    []string{"${alicloud_cms_alarm.default.id}"},
-			"status": "true",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"ids":    []string{"${alicloud_cms_alarm.default.id}_fake"},
-			"status": "false",
+		fakeConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":                  `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}_fake"]`,
+			"metric_alarm_rule_id": `"SystemDefault_acs_drds_IOPSUsageOfDo_fake"`,
 		}),
 	}
+	StatusConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":    `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}"]`,
+			"status": `true`,
+		}),
+		fakeConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":    `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}_fake"]`,
+			"status": `false`,
+		}),
+	}
+	MetricNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}"]`,
+			"metric_name": `"IOPSUsageOfDN"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}_fake"]`,
+			"metric_name": `"IOPSUsageOfDN_fake"`,
+		}),
+	}
+	RuleNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}"]`,
+			"rule_name": `"SystemDefault_acs_drds_IOPSUsageOfDN"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}_fake"]`,
+			"rule_name": `"SystemDefault_acs_drds_IOPSUsageOfDN_fake"`,
+		}),
+	}
+
 	allConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":         []string{"${alicloud_cms_alarm.default.id}"},
-			"dimensions":  `{\"instanceId\":\"` + "${data.alicloud_instances.default.ids.0}" + `\"}`,
-			"metric_name": "${alicloud_cms_alarm.default.metric}",
-			"namespace":   "${alicloud_cms_alarm.default.project}",
-			"rule_name":   "${alicloud_cms_alarm.default.name}",
-			"status":      "true",
+		existConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}"]`,
+			"namespace": `"acs_drds"`,
+
+			"metric_alarm_rule_id": `"SystemDefault_acs_drds_IOPSUsageOfDo"`,
+
+			"status": `true`,
+
+			"metric_name": `"IOPSUsageOfDN"`,
+
+			"rule_name": `"SystemDefault_acs_drds_IOPSUsageOfDN"`,
 		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"ids":         []string{"${alicloud_cms_alarm.default.id}_fake"},
-			"dimensions":  `{\"instanceId\":\"i-1688\"}`,
-			"metric_name": "${alicloud_cms_alarm.default.metric}_fake",
-			"namespace":   "${alicloud_cms_alarm.default.project}_fake",
-			"rule_name":   "${alicloud_cms_alarm.default.name}_fake",
-			"status":      "false",
+		fakeConfig: testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cloud_monitor_service_metric_alarm_rule.default.id}_fake"]`,
+			"namespace": `"acs_drds_fake"`,
+
+			"metric_alarm_rule_id": `"SystemDefault_acs_drds_IOPSUsageOfDo_fake"`,
+
+			"status": `false`,
+
+			"metric_name": `"IOPSUsageOfDN_fake"`,
+
+			"rule_name": `"SystemDefault_acs_drds_IOPSUsageOfDN_fake"`,
 		}),
 	}
-	var existAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc = func(rand int) map[string]string {
-		return map[string]string{
-			"ids.#":                            "1",
-			"rules.#":                          "1",
-			"rules.0.id":                       CHECKSET,
-			"rules.0.contact_groups":           CHECKSET,
-			"rules.0.effective_interval":       CHECKSET,
-			"rules.0.email_subject":            CHECKSET,
-			"rules.0.metric_name":              CHECKSET,
-			"rules.0.namespace":                CHECKSET,
-			"rules.0.period":                   CHECKSET,
-			"rules.0.resources":                CHECKSET,
-			"rules.0.rule_name":                CHECKSET,
-			"rules.0.silence_time":             CHECKSET,
-			"rules.0.source_type":              CHECKSET,
-			"rules.0.status":                   CHECKSET,
-			"rules.0.webhook":                  CHECKSET,
-			"rules.0.escalations.#":            "1",
-			"rules.0.escalations.0.critical.#": "1",
-			"rules.0.escalations.0.critical.0.comparison_operator": CHECKSET,
-			"rules.0.escalations.0.critical.0.times":               CHECKSET,
-			"rules.0.escalations.0.critical.0.statistics":          CHECKSET,
-			"rules.0.escalations.0.critical.0.threshold":           CHECKSET,
-			"rules.0.escalations.0.info.#":                         "1",
-			"rules.0.escalations.0.info.0.comparison_operator":     CHECKSET,
-			"rules.0.escalations.0.info.0.times":                   CHECKSET,
-			"rules.0.escalations.0.info.0.statistics":              CHECKSET,
-			"rules.0.escalations.0.info.0.threshold":               CHECKSET,
-			"rules.0.escalations.0.warn.#":                         "1",
-			"rules.0.escalations.0.warn.0.comparison_operator":     CHECKSET,
-			"rules.0.escalations.0.warn.0.times":                   CHECKSET,
-			"rules.0.escalations.0.warn.0.statistics":              CHECKSET,
-			"rules.0.escalations.0.warn.0.threshold":               CHECKSET,
-			"rules.0.labels.#":                                     "1",
-			"rules.0.labels.0.value":                               CHECKSET,
-			"rules.0.labels.0.key":                                 CHECKSET,
-		}
-	}
-	var fakeAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc = func(rand int) map[string]string {
-		return map[string]string{
-			"ids.#":   "0",
-			"rules.#": "0",
-		}
-	}
-	var alicloudCloudMonitorServiceMetricAlarmRulesCheckInfo = dataSourceAttr{
-		resourceId:   "data.alicloud_cloud_monitor_service_metric_alarm_rules.default",
-		existMapFunc: existAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc,
-		fakeMapFunc:  fakeAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc,
-	}
-	preCheck := func() {
-		testAccPreCheck(t)
-	}
-	alicloudCloudMonitorServiceMetricAlarmRulesCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, idsConf, dimensionsConf, metricNameConf, namespaceConf, ruleNameConf, statusConf, allConf)
+
+	CloudMonitorServiceMetricAlarmRuleCheckInfo.dataSourceTestCheck(t, rand, idsConf, NamespaceConf, MetricAlarmRuleIdConf, StatusConf, MetricNameConf, RuleNameConf, allConf)
 }
 
-func dataSourceCloudMonitorServiceMetricAlarmRulesConfig0(name string) string {
-	return fmt.Sprintf(`
-	variable "name" {
-  		default = "%s"
+var existCloudMonitorServiceMetricAlarmRuleMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"rules.#":                        "1",
+		"rules.0.source_type":            CHECKSET,
+		"rules.0.prometheus.#":           CHECKSET,
+		"rules.0.metric_name":            CHECKSET,
+		"rules.0.email_subject":          CHECKSET,
+		"rules.0.composite_expression.#": CHECKSET,
+		"rules.0.rule_name":              CHECKSET,
+		"rules.0.status":                 CHECKSET,
+		"rules.0.silence_time":           CHECKSET,
+		"rules.0.contact_groups":         CHECKSET,
+		"rules.0.send_ok":                "true",
+		"rules.0.metric_alarm_rule_id":   CHECKSET,
+		"rules.0.period":                 CHECKSET,
+		"rules.0.labels.#":               CHECKSET,
+		"rules.0.effective_interval":     CHECKSET,
+		"rules.0.no_data_policy":         "KEEP_LAST_STATE",
+		"rules.0.namespace":              CHECKSET,
+		"rules.0.escalations.#":          CHECKSET,
+		"rules.0.resources":              CHECKSET,
 	}
+}
 
-	data "alicloud_instances" "default" {
-  		status = "Running"
+var fakeCloudMonitorServiceMetricAlarmRuleMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"rules.#": "0",
 	}
+}
 
-	resource "alicloud_cms_alarm_contact_group" "default" {
-  		alarm_contact_group_name = var.name
+var CloudMonitorServiceMetricAlarmRuleCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_cloud_monitor_service_metric_alarm_rules.default",
+	existMapFunc: existCloudMonitorServiceMetricAlarmRuleMapFunc,
+	fakeMapFunc:  fakeCloudMonitorServiceMetricAlarmRuleMapFunc,
+}
+
+func testAccCheckAlicloudCloudMonitorServiceMetricAlarmRuleSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
 	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccCloudMonitorServiceMetricAlarmRule%d"
+}
 
-	resource "alicloud_cms_alarm" "default" {
-  		name               = var.name
-  		project            = "acs_ecs_dashboard"
-  		metric             = "disk_writebytes"
-  		period             = 900
-  		silence_time       = 300
-  		webhook            = "https://www.aliyun.com"
-  		enabled            = true
-  		contact_groups     = [alicloud_cms_alarm_contact_group.default.alarm_contact_group_name]
-  		effective_interval = "06:00-20:00"
-  		metric_dimensions  = <<EOF
-  [
-    {
-      "instanceId": "${data.alicloud_instances.default.ids.0}",
-      "device": "/dev/vda1"
+
+resource "alicloud_cloud_monitor_service_metric_alarm_rule" "default" {
+  status               = true
+  send_ok              = true
+  contact_groups       = "云账号报警联系人"
+  silence_time         = "86400"
+  metric_alarm_rule_id = "SystemDefault_acs_drds_IOPSUsageOfDo"
+  period               = "60"
+  effective_interval   = "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7"
+  no_data_policy       = "KEEP_LAST_STATE"
+  namespace            = "acs_drds"
+  metric_name          = "IOPSUsageOfDN"
+  escalations {
+    critical {
+      comparison_operator = "GreaterThanThreshold"
+      times               = "5"
+      statistics          = "Average"
+      threshold           = "80"
     }
-  ]
-  EOF
-  		escalations_critical {
-    		statistics          = "Average"
-    		comparison_operator = "<="
-    		threshold           = 90
-    		times               = 1
-  		}
-  		escalations_info {
-			statistics          = "Minimum"
-			comparison_operator = "!="
-			threshold           = 20
-   		 	times               = 3
-  		}
-  		escalations_warn {
-    		statistics          = "Average"
-    		comparison_operator = "=="
-    		threshold           = 30
-    		times               = 5
-  		}
-  		tags = {
-    		Created = "TF"
-  		}
-	}
-`, name)
+  }
+  resources = "[{\"resource\":\"_ALL\"}]"
+  rule_name = "SystemDefault_acs_drds_IOPSUsageOfDN"
 }
 
-func TestAccAliCloudCloudMonitorServiceMetricAlarmRulesDataSource_basic1(t *testing.T) {
-	rand := acctest.RandIntRange(100, 999)
-	resourceId := "data.alicloud_cloud_monitor_service_metric_alarm_rules.default"
-	name := fmt.Sprintf("tf-testscc-cmsalarm%d", rand)
-	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceCloudMonitorServiceMetricAlarmRulesConfig1)
-
-	idsConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids": []string{"${alicloud_cms_alarm.default.id}"},
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"ids": []string{"${alicloud_cms_alarm.default.id}_fake"},
-		}),
-	}
-	dimensionsConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"dimensions": `{\"instanceId\":\"` + "${data.alicloud_instances.default.ids.0}" + `\"}`,
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"dimensions": `{\"instanceId\":\"i-1688\"}`,
-		}),
-	}
-	metricNameConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":         []string{"${alicloud_cms_alarm.default.id}"},
-			"metric_name": "${alicloud_cms_alarm.default.metric}",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"metric_name": "${alicloud_cms_alarm.default.metric}_fake",
-		}),
-	}
-	namespaceConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":       []string{"${alicloud_cms_alarm.default.id}"},
-			"namespace": "${alicloud_cms_alarm.default.project}",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"namespace": "${alicloud_cms_alarm.default.project}_fake",
-		}),
-	}
-	ruleNameConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"rule_name": "${alicloud_cms_alarm.default.name}",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"rule_name": "${alicloud_cms_alarm.default.name}_fake",
-		}),
-	}
-	statusConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":    []string{"${alicloud_cms_alarm.default.id}"},
-			"status": "true",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"ids":    []string{"${alicloud_cms_alarm.default.id}_fake"},
-			"status": "false",
-		}),
-	}
-	allConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":         []string{"${alicloud_cms_alarm.default.id}"},
-			"dimensions":  `{\"instanceId\":\"` + "${data.alicloud_instances.default.ids.0}" + `\"}`,
-			"metric_name": "${alicloud_cms_alarm.default.metric}",
-			"namespace":   "${alicloud_cms_alarm.default.project}",
-			"rule_name":   "${alicloud_cms_alarm.default.name}",
-			"status":      "true",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"ids":         []string{"${alicloud_cms_alarm.default.id}_fake"},
-			"dimensions":  `{\"instanceId\":\"i-1688\"}`,
-			"metric_name": "${alicloud_cms_alarm.default.metric}_fake",
-			"namespace":   "${alicloud_cms_alarm.default.project}_fake",
-			"rule_name":   "${alicloud_cms_alarm.default.name}_fake",
-			"status":      "false",
-		}),
-	}
-	var existAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc = func(rand int) map[string]string {
-		return map[string]string{
-			"ids.#":                                "1",
-			"rules.#":                              "1",
-			"rules.0.id":                           CHECKSET,
-			"rules.0.contact_groups":               CHECKSET,
-			"rules.0.effective_interval":           CHECKSET,
-			"rules.0.email_subject":                CHECKSET,
-			"rules.0.metric_name":                  CHECKSET,
-			"rules.0.namespace":                    CHECKSET,
-			"rules.0.period":                       CHECKSET,
-			"rules.0.resources":                    CHECKSET,
-			"rules.0.rule_name":                    CHECKSET,
-			"rules.0.silence_time":                 CHECKSET,
-			"rules.0.source_type":                  CHECKSET,
-			"rules.0.status":                       CHECKSET,
-			"rules.0.webhook":                      CHECKSET,
-			"rules.0.composite_expression.#":       "1",
-			"rules.0.composite_expression.0.times": CHECKSET,
-			"rules.0.composite_expression.0.expression_raw":                        CHECKSET,
-			"rules.0.composite_expression.0.expression_list_join":                  CHECKSET,
-			"rules.0.composite_expression.0.level":                                 CHECKSET,
-			"rules.0.composite_expression.0.expression_list.#":                     "1",
-			"rules.0.composite_expression.0.expression_list.0.metric_name":         CHECKSET,
-			"rules.0.composite_expression.0.expression_list.0.comparison_operator": CHECKSET,
-			"rules.0.composite_expression.0.expression_list.0.period":              CHECKSET,
-			"rules.0.composite_expression.0.expression_list.0.statistics":          CHECKSET,
-			"rules.0.composite_expression.0.expression_list.0.threshold":           CHECKSET,
-			"rules.0.labels.#":       "1",
-			"rules.0.labels.0.value": CHECKSET,
-			"rules.0.labels.0.key":   CHECKSET,
-		}
-	}
-	var fakeAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc = func(rand int) map[string]string {
-		return map[string]string{
-			"ids.#":   "0",
-			"rules.#": "0",
-		}
-	}
-	var alicloudCloudMonitorServiceMetricAlarmRulesCheckInfo = dataSourceAttr{
-		resourceId:   "data.alicloud_cloud_monitor_service_metric_alarm_rules.default",
-		existMapFunc: existAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc,
-		fakeMapFunc:  fakeAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc,
-	}
-	preCheck := func() {
-		testAccPreCheck(t)
-	}
-	alicloudCloudMonitorServiceMetricAlarmRulesCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, idsConf, dimensionsConf, metricNameConf, namespaceConf, ruleNameConf, statusConf, allConf)
+data "alicloud_cloud_monitor_service_metric_alarm_rules" "default" {
+%s
 }
-
-func dataSourceCloudMonitorServiceMetricAlarmRulesConfig1(name string) string {
-	return fmt.Sprintf(`
-	variable "name" {
-  		default = "%s"
-	}
-
-	data "alicloud_instances" "default" {
-  		status = "Running"
-	}
-
-	resource "alicloud_cms_alarm_contact_group" "default" {
-  		alarm_contact_group_name = var.name
-	}
-
-	resource "alicloud_cms_alarm" "default" {
-  		name               = var.name
-  		project            = "acs_ecs_dashboard"
-  		metric             = "disk_writebytes"
-  		period             = 900
-  		silence_time       = 300
-  		webhook            = "https://www.aliyun.com"
-  		enabled            = true
-  		contact_groups     = [alicloud_cms_alarm_contact_group.default.alarm_contact_group_name]
-  		effective_interval = "06:00-20:00"
-  		metric_dimensions  = <<EOF
-  [
-    {
-      "instanceId": "${data.alicloud_instances.default.ids.0}",
-      "device": "/dev/vda1"
-    }
-  ]
-  EOF
-  		composite_expression {
-    		level                = "CRITICAL"
-    		times                = 1
-    		expression_raw       = "$Average > 60"
-    		expression_list_join = "&&"
-    		expression_list {
-      			metric_name         = "cpu_total"
-      			comparison_operator = "=="
-      			statistics          = "Maximum"
-      			threshold           = 50
-      			period              = 2
-    		}
-  		}
-  		tags = {
-    		Created = "TF"
-  		}
-	}
-`, name)
-}
-
-func TestAccAliCloudCloudMonitorServiceMetricAlarmRulesDataSource_basic2(t *testing.T) {
-	rand := acctest.RandIntRange(100, 999)
-	resourceId := "data.alicloud_cloud_monitor_service_metric_alarm_rules.default"
-	name := fmt.Sprintf("tf-testscc-cmsalarm%d", rand)
-	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceCloudMonitorServiceMetricAlarmRulesConfig2)
-
-	idsConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids": []string{"${alicloud_cms_alarm.default.id}"},
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"ids": []string{"${alicloud_cms_alarm.default.id}_fake"},
-		}),
-	}
-	metricNameConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":         []string{"${alicloud_cms_alarm.default.id}"},
-			"metric_name": "${alicloud_cms_alarm.default.metric}",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"metric_name": "${alicloud_cms_alarm.default.metric}_fake",
-		}),
-	}
-	namespaceConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":       []string{"${alicloud_cms_alarm.default.id}"},
-			"namespace": "${alicloud_cms_alarm.default.project}",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"namespace": "${alicloud_cms_alarm.default.project}_fake",
-		}),
-	}
-	ruleNameConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"rule_name": "${alicloud_cms_alarm.default.name}",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"rule_name": "${alicloud_cms_alarm.default.name}_fake",
-		}),
-	}
-	statusConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":    []string{"${alicloud_cms_alarm.default.id}"},
-			"status": "true",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"ids":    []string{"${alicloud_cms_alarm.default.id}_fake"},
-			"status": "false",
-		}),
-	}
-	allConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids":         []string{"${alicloud_cms_alarm.default.id}"},
-			"metric_name": "${alicloud_cms_alarm.default.metric}",
-			"namespace":   "${alicloud_cms_alarm.default.project}",
-			"rule_name":   "${alicloud_cms_alarm.default.name}",
-			"status":      "true",
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"ids":         []string{"${alicloud_cms_alarm.default.id}_fake"},
-			"metric_name": "${alicloud_cms_alarm.default.metric}_fake",
-			"namespace":   "${alicloud_cms_alarm.default.project}_fake",
-			"rule_name":   "${alicloud_cms_alarm.default.name}_fake",
-			"status":      "false",
-		}),
-	}
-	var existAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc = func(rand int) map[string]string {
-		return map[string]string{
-			"ids.#":                                    "1",
-			"rules.#":                                  "1",
-			"rules.0.id":                               CHECKSET,
-			"rules.0.contact_groups":                   CHECKSET,
-			"rules.0.dimensions":                       CHECKSET,
-			"rules.0.effective_interval":               CHECKSET,
-			"rules.0.email_subject":                    CHECKSET,
-			"rules.0.metric_name":                      CHECKSET,
-			"rules.0.namespace":                        CHECKSET,
-			"rules.0.period":                           CHECKSET,
-			"rules.0.rule_name":                        CHECKSET,
-			"rules.0.silence_time":                     CHECKSET,
-			"rules.0.source_type":                      CHECKSET,
-			"rules.0.status":                           CHECKSET,
-			"rules.0.webhook":                          CHECKSET,
-			"rules.0.prometheus.#":                     "1",
-			"rules.0.prometheus.0.prom_ql":             CHECKSET,
-			"rules.0.prometheus.0.times":               CHECKSET,
-			"rules.0.prometheus.0.level":               CHECKSET,
-			"rules.0.prometheus.0.annotations.#":       "1",
-			"rules.0.prometheus.0.annotations.0.value": CHECKSET,
-			"rules.0.prometheus.0.annotations.0.key":   CHECKSET,
-			"rules.0.labels.#":                         "1",
-			"rules.0.labels.0.value":                   CHECKSET,
-			"rules.0.labels.0.key":                     CHECKSET,
-		}
-	}
-	var fakeAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc = func(rand int) map[string]string {
-		return map[string]string{
-			"ids.#":   "0",
-			"rules.#": "0",
-		}
-	}
-	var alicloudCloudMonitorServiceMetricAlarmRulesCheckInfo = dataSourceAttr{
-		resourceId:   "data.alicloud_cloud_monitor_service_metric_alarm_rules.default",
-		existMapFunc: existAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc,
-		fakeMapFunc:  fakeAliCloudCloudMonitorServiceMetricAlarmRulesDataSourceNameMapFunc,
-	}
-	preCheck := func() {
-		testAccPreCheck(t)
-	}
-	alicloudCloudMonitorServiceMetricAlarmRulesCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, idsConf, metricNameConf, namespaceConf, ruleNameConf, statusConf, allConf)
-}
-
-func dataSourceCloudMonitorServiceMetricAlarmRulesConfig2(name string) string {
-	return fmt.Sprintf(`
-	variable "name" {
-  		default = "%s"
-	}
-
-	data "alicloud_instances" "default" {
-  		status = "Running"
-	}
-
-	resource "alicloud_cms_alarm_contact_group" "default" {
-  		alarm_contact_group_name = var.name
-	}
-
-	resource "alicloud_cms_alarm" "default" {
-  		name               = var.name
-  		project            = "acs_prometheus"
-  		metric             = "AliyunEcs_cpu_total"
-  		period             = 900
-  		silence_time       = 300
-  		webhook            = "https://www.aliyun.com"
-  		enabled            = true
-  		contact_groups     = [alicloud_cms_alarm_contact_group.default.alarm_contact_group_name]
-  		effective_interval = "06:00-20:00"
-  		prometheus {
-    		prom_ql = var.name
-    		times   = 1
-    		level   = "Critical"
-    		annotations = {
-      			Created = "TF"
-    		}
-  		}
-  		tags = {
-    		Created = "TF"
-  		}
-	}
-`, name)
+`, rand, strings.Join(pairs, "\n   "))
+	return config
 }

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -939,6 +939,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_resource_manager_resource_directory_sharing":          resourceAliCloudResourceManagerResourceDirectorySharing(),
 			"alicloud_wafv3_address_book":                                   resourceAliCloudWafv3AddressBook(),
 			"alicloud_threat_detection_service_linked_role":                 resourceAliCloudThreatDetectionServiceLinkedRole(),
+			"alicloud_cloud_monitor_service_metric_alarm_rule":              resourceAliCloudCloudMonitorServiceMetricAlarmRule(),
 			"alicloud_amqp_open_source_account":                             resourceAliCloudAmqpOpenSourceAccount(),
 			"alicloud_vpc_ipv6_cidr_block":                                  resourceAliCloudVpcIpv6CidrBlock(),
 			"alicloud_amqp_open_source_permission":                          resourceAliCloudAmqpOpenSourcePermission(),

--- a/alicloud/resource_alicloud_cloud_monitor_service_metric_alarm_rule.go
+++ b/alicloud/resource_alicloud_cloud_monitor_service_metric_alarm_rule.go
@@ -1,0 +1,1085 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudCloudMonitorServiceMetricAlarmRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCloudMonitorServiceMetricAlarmRuleCreate,
+		Read:   resourceAliCloudCloudMonitorServiceMetricAlarmRuleRead,
+		Update: resourceAliCloudCloudMonitorServiceMetricAlarmRuleUpdate,
+		Delete: resourceAliCloudCloudMonitorServiceMetricAlarmRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"composite_expression": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"times": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"expression_raw": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"expression_list_join": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"level": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"expression_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"metric_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"comparison_operator": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"period": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"statistics": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"threshold": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"contact_groups": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"dimensions": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"effective_interval": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"email_subject": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"escalations": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"critical": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"comparison_operator": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"times": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"pre_condition": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"statistics": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"threshold": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"info": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"comparison_operator": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"times": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"pre_condition": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"statistics": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"threshold": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"warn": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"comparison_operator": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"times": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"pre_condition": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"statistics": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"threshold": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"interval": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"labels": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"metric_alarm_rule_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"metric_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"no_data_policy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"KEEP_LAST_STATE", "INSUFFICIENT_DATA", "OK"}, false),
+			},
+			"no_effective_interval": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"period": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"prometheus": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"annotations": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"value": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"key": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"prom_ql": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"times": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"level": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"resources": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rule_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"send_ok": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"silence_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"source_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"webhook": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCloudMonitorServiceMetricAlarmRuleCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "PutResourceMetricRule"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("metric_alarm_rule_id"); ok {
+		request["RuleId"] = v
+	}
+
+	request["Namespace"] = d.Get("namespace")
+	if v, ok := d.GetOk("silence_time"); ok {
+		request["SilenceTime"] = v
+	}
+	prometheus := make(map[string]interface{})
+
+	if v := d.Get("prometheus"); !IsNil(v) {
+		level1, _ := jsonpath.Get("$[0].level", v)
+		if level1 != nil && level1 != "" {
+			prometheus["Level"] = level1
+		}
+		localData, err := jsonpath.Get("$[0].annotations", v)
+		if err != nil {
+			localData = make([]interface{}, 0)
+		}
+		localMaps := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(localData) {
+			dataLoopTmp := make(map[string]interface{})
+			if dataLoop != nil {
+				dataLoopTmp = dataLoop.(map[string]interface{})
+			}
+			dataLoopMap := make(map[string]interface{})
+			dataLoopMap["Value"] = dataLoopTmp["value"]
+			dataLoopMap["Key"] = dataLoopTmp["key"]
+			localMaps = append(localMaps, dataLoopMap)
+		}
+		prometheus["Annotations"] = localMaps
+
+		promQl, _ := jsonpath.Get("$[0].prom_ql", v)
+		if promQl != nil && promQl != "" {
+			prometheus["PromQL"] = promQl
+		}
+		times1, _ := jsonpath.Get("$[0].times", v)
+		if times1 != nil && times1 != "" {
+			prometheus["Times"] = times1
+		}
+
+		prometheusJson, err := json.Marshal(prometheus)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["Prometheus"] = string(prometheusJson)
+	}
+
+	escalations := make(map[string]interface{})
+
+	if v := d.Get("escalations"); !IsNil(v) {
+		info := make(map[string]interface{})
+		comparisonOperator1, _ := jsonpath.Get("$[0].info[0].comparison_operator", d.Get("escalations"))
+		if comparisonOperator1 != nil && comparisonOperator1 != "" {
+			info["ComparisonOperator"] = comparisonOperator1
+		}
+		statistics1, _ := jsonpath.Get("$[0].info[0].statistics", d.Get("escalations"))
+		if statistics1 != nil && statistics1 != "" {
+			info["Statistics"] = statistics1
+		}
+		threshold1, _ := jsonpath.Get("$[0].info[0].threshold", d.Get("escalations"))
+		if threshold1 != nil && threshold1 != "" {
+			info["Threshold"] = threshold1
+		}
+		times3, _ := jsonpath.Get("$[0].info[0].times", d.Get("escalations"))
+		if times3 != nil && times3 != "" {
+			info["Times"] = times3
+		}
+
+		if len(info) > 0 {
+			escalations["Info"] = info
+		}
+		warn := make(map[string]interface{})
+		statistics3, _ := jsonpath.Get("$[0].warn[0].statistics", d.Get("escalations"))
+		if statistics3 != nil && statistics3 != "" {
+			warn["Statistics"] = statistics3
+		}
+		threshold3, _ := jsonpath.Get("$[0].warn[0].threshold", d.Get("escalations"))
+		if threshold3 != nil && threshold3 != "" {
+			warn["Threshold"] = threshold3
+		}
+		comparisonOperator3, _ := jsonpath.Get("$[0].warn[0].comparison_operator", d.Get("escalations"))
+		if comparisonOperator3 != nil && comparisonOperator3 != "" {
+			warn["ComparisonOperator"] = comparisonOperator3
+		}
+		times5, _ := jsonpath.Get("$[0].warn[0].times", d.Get("escalations"))
+		if times5 != nil && times5 != "" {
+			warn["Times"] = times5
+		}
+
+		if len(warn) > 0 {
+			escalations["Warn"] = warn
+		}
+		critical := make(map[string]interface{})
+		statistics5, _ := jsonpath.Get("$[0].critical[0].statistics", d.Get("escalations"))
+		if statistics5 != nil && statistics5 != "" {
+			critical["Statistics"] = statistics5
+		}
+		threshold5, _ := jsonpath.Get("$[0].critical[0].threshold", d.Get("escalations"))
+		if threshold5 != nil && threshold5 != "" {
+			critical["Threshold"] = threshold5
+		}
+		comparisonOperator5, _ := jsonpath.Get("$[0].critical[0].comparison_operator", d.Get("escalations"))
+		if comparisonOperator5 != nil && comparisonOperator5 != "" {
+			critical["ComparisonOperator"] = comparisonOperator5
+		}
+		times7, _ := jsonpath.Get("$[0].critical[0].times", d.Get("escalations"))
+		if times7 != nil && times7 != "" {
+			critical["Times"] = times7
+		}
+
+		if len(critical) > 0 {
+			escalations["Critical"] = critical
+		}
+
+		request["Escalations"] = escalations
+	}
+
+	compositeExpression := make(map[string]interface{})
+
+	if v := d.Get("composite_expression"); !IsNil(v) {
+		expressionListJoin1, _ := jsonpath.Get("$[0].expression_list_join", v)
+		if expressionListJoin1 != nil && expressionListJoin1 != "" {
+			compositeExpression["ExpressionListJoin"] = expressionListJoin1
+		}
+		localData1, err := jsonpath.Get("$[0].expression_list", v)
+		if err != nil {
+			localData1 = make([]interface{}, 0)
+		}
+		localMaps1 := make([]interface{}, 0)
+		for _, dataLoop1 := range convertToInterfaceArray(localData1) {
+			dataLoop1Tmp := make(map[string]interface{})
+			if dataLoop1 != nil {
+				dataLoop1Tmp = dataLoop1.(map[string]interface{})
+			}
+			dataLoop1Map := make(map[string]interface{})
+			dataLoop1Map["Statistics"] = dataLoop1Tmp["statistics"]
+			dataLoop1Map["ComparisonOperator"] = dataLoop1Tmp["comparison_operator"]
+			dataLoop1Map["MetricName"] = dataLoop1Tmp["metric_name"]
+			dataLoop1Map["Period"] = dataLoop1Tmp["period"]
+			dataLoop1Map["Threshold"] = dataLoop1Tmp["threshold"]
+			localMaps1 = append(localMaps1, dataLoop1Map)
+		}
+		compositeExpression["ExpressionList"] = localMaps1
+
+		level3, _ := jsonpath.Get("$[0].level", v)
+		if level3 != nil && level3 != "" {
+			compositeExpression["Level"] = level3
+		}
+		expressionRaw1, _ := jsonpath.Get("$[0].expression_raw", v)
+		if expressionRaw1 != nil && expressionRaw1 != "" {
+			compositeExpression["ExpressionRaw"] = expressionRaw1
+		}
+		times9, _ := jsonpath.Get("$[0].times", v)
+		if times9 != nil && times9 != "" {
+			compositeExpression["Times"] = times9
+		}
+
+		compositeExpressionJson, err := json.Marshal(compositeExpression)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["CompositeExpression"] = string(compositeExpressionJson)
+	}
+
+	if v, ok := d.GetOk("no_data_policy"); ok {
+		request["NoDataPolicy"] = v
+	}
+	if v, ok := d.GetOk("effective_interval"); ok {
+		request["EffectiveInterval"] = v
+	}
+	if v, ok := d.GetOk("webhook"); ok {
+		request["Webhook"] = v
+	}
+	if v, ok := d.GetOk("interval"); ok {
+		request["Interval"] = v
+	}
+	if v, ok := d.GetOk("email_subject"); ok {
+		request["EmailSubject"] = v
+	}
+	if v, ok := d.GetOk("no_effective_interval"); ok {
+		request["NoEffectiveInterval"] = v
+	}
+	request["ContactGroups"] = d.Get("contact_groups")
+	request["Resources"] = d.Get("resources")
+	if v, ok := d.GetOkExists("send_ok"); ok {
+		request["SendOK"] = v
+	}
+	if v, ok := d.GetOk("labels"); ok {
+		labelsMapsArray := make([]interface{}, 0)
+		for _, dataLoop2 := range convertToInterfaceArray(v) {
+			dataLoop2Tmp := dataLoop2.(map[string]interface{})
+			dataLoop2Map := make(map[string]interface{})
+			dataLoop2Map["Value"] = dataLoop2Tmp["value"]
+			dataLoop2Map["Key"] = dataLoop2Tmp["key"]
+			labelsMapsArray = append(labelsMapsArray, dataLoop2Map)
+		}
+		request["Labels"] = labelsMapsArray
+	}
+
+	request["RuleName"] = d.Get("rule_name")
+	request["MetricName"] = d.Get("metric_name")
+	if v, ok := d.GetOk("period"); ok {
+		request["Period"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Cms", "2019-01-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cloud_monitor_service_metric_alarm_rule", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(request["RuleId"]))
+
+	return resourceAliCloudCloudMonitorServiceMetricAlarmRuleUpdate(d, meta)
+}
+
+func resourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cloudMonitorServiceServiceV2 := CloudMonitorServiceServiceV2{client}
+
+	objectRaw, err := cloudMonitorServiceServiceV2.DescribeCloudMonitorServiceMetricAlarmRule(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cloud_monitor_service_metric_alarm_rule DescribeCloudMonitorServiceMetricAlarmRule Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("contact_groups", objectRaw["ContactGroups"])
+	d.Set("dimensions", objectRaw["Dimensions"])
+	d.Set("effective_interval", objectRaw["EffectiveInterval"])
+	d.Set("email_subject", objectRaw["MailSubject"])
+	d.Set("metric_name", objectRaw["MetricName"])
+	d.Set("namespace", objectRaw["Namespace"])
+	d.Set("no_data_policy", objectRaw["NoDataPolicy"])
+	d.Set("no_effective_interval", objectRaw["NoEffectiveInterval"])
+	d.Set("period", objectRaw["Period"])
+	d.Set("resources", objectRaw["Resources"])
+	d.Set("rule_name", objectRaw["RuleName"])
+	d.Set("send_ok", objectRaw["SendOK"])
+	d.Set("silence_time", objectRaw["SilenceTime"])
+	d.Set("source_type", objectRaw["SourceType"])
+	d.Set("status", objectRaw["EnableState"])
+	d.Set("webhook", objectRaw["Webhook"])
+	d.Set("interval", objectRaw["Interval"])
+	d.Set("metric_alarm_rule_id", objectRaw["RuleId"])
+
+	compositeExpressionMaps := make([]map[string]interface{}, 0)
+	compositeExpressionMap := make(map[string]interface{})
+	compositeExpressionRaw := make(map[string]interface{})
+	if objectRaw["CompositeExpression"] != nil {
+		compositeExpressionRaw = objectRaw["CompositeExpression"].(map[string]interface{})
+	}
+	if len(compositeExpressionRaw) > 0 {
+		compositeExpressionMap["expression_list_join"] = compositeExpressionRaw["ExpressionListJoin"]
+		compositeExpressionMap["expression_raw"] = compositeExpressionRaw["ExpressionRaw"]
+		compositeExpressionMap["level"] = compositeExpressionRaw["Level"]
+		compositeExpressionMap["times"] = compositeExpressionRaw["Times"]
+
+		expressionListRaw, _ := jsonpath.Get("$.CompositeExpression.ExpressionList.ExpressionList", objectRaw)
+		expressionListMaps := make([]map[string]interface{}, 0)
+		if expressionListRaw != nil {
+			for _, expressionListChildRaw := range convertToInterfaceArray(expressionListRaw) {
+				expressionListMap := make(map[string]interface{})
+				expressionListChildRaw := expressionListChildRaw.(map[string]interface{})
+				expressionListMap["comparison_operator"] = expressionListChildRaw["ComparisonOperator"]
+				expressionListMap["metric_name"] = expressionListChildRaw["MetricName"]
+				expressionListMap["period"] = expressionListChildRaw["Period"]
+				expressionListMap["statistics"] = expressionListChildRaw["Statistics"]
+				expressionListMap["threshold"] = expressionListChildRaw["Threshold"]
+
+				expressionListMaps = append(expressionListMaps, expressionListMap)
+			}
+		}
+		compositeExpressionMap["expression_list"] = expressionListMaps
+		compositeExpressionMaps = append(compositeExpressionMaps, compositeExpressionMap)
+	}
+	if err := d.Set("composite_expression", compositeExpressionMaps); err != nil {
+		return err
+	}
+	escalationsMaps := make([]map[string]interface{}, 0)
+	escalationsMap := make(map[string]interface{})
+	escalationsRaw := make(map[string]interface{})
+	if objectRaw["Escalations"] != nil {
+		escalationsRaw = objectRaw["Escalations"].(map[string]interface{})
+	}
+	if len(escalationsRaw) > 0 {
+
+		criticalMaps := make([]map[string]interface{}, 0)
+		criticalMap := make(map[string]interface{})
+		criticalRaw := make(map[string]interface{})
+		if escalationsRaw["Critical"] != nil {
+			criticalRaw = escalationsRaw["Critical"].(map[string]interface{})
+		}
+		// PROMETHEUS-style rules cause the server to inject synthetic Critical
+		// entries (Statistics="value", Times=prometheus.times) with empty
+		// ComparisonOperator/Threshold. Treat those as "not user-configured" so
+		// Read does not surface them as escalations on resources that never set
+		// the block.
+		hasRealEscalation := func(raw map[string]interface{}) bool {
+			return fmt.Sprint(raw["ComparisonOperator"]) != "" || fmt.Sprint(raw["Threshold"]) != ""
+		}
+		if len(criticalRaw) > 0 && hasRealEscalation(criticalRaw) {
+			criticalMap["comparison_operator"] = criticalRaw["ComparisonOperator"]
+			criticalMap["pre_condition"] = criticalRaw["PreCondition"]
+			criticalMap["statistics"] = criticalRaw["Statistics"]
+			criticalMap["threshold"] = criticalRaw["Threshold"]
+			criticalMap["times"] = criticalRaw["Times"]
+
+			criticalMaps = append(criticalMaps, criticalMap)
+		}
+		escalationsMap["critical"] = criticalMaps
+		infoMaps := make([]map[string]interface{}, 0)
+		infoMap := make(map[string]interface{})
+		infoRaw := make(map[string]interface{})
+		if escalationsRaw["Info"] != nil {
+			infoRaw = escalationsRaw["Info"].(map[string]interface{})
+		}
+		if len(infoRaw) > 0 && hasRealEscalation(infoRaw) {
+			infoMap["comparison_operator"] = infoRaw["ComparisonOperator"]
+			infoMap["pre_condition"] = infoRaw["PreCondition"]
+			infoMap["statistics"] = infoRaw["Statistics"]
+			infoMap["threshold"] = infoRaw["Threshold"]
+			infoMap["times"] = infoRaw["Times"]
+
+			infoMaps = append(infoMaps, infoMap)
+		}
+		escalationsMap["info"] = infoMaps
+		warnMaps := make([]map[string]interface{}, 0)
+		warnMap := make(map[string]interface{})
+		warnRaw := make(map[string]interface{})
+		if escalationsRaw["Warn"] != nil {
+			warnRaw = escalationsRaw["Warn"].(map[string]interface{})
+		}
+		if len(warnRaw) > 0 && hasRealEscalation(warnRaw) {
+			warnMap["comparison_operator"] = warnRaw["ComparisonOperator"]
+			warnMap["pre_condition"] = warnRaw["PreCondition"]
+			warnMap["statistics"] = warnRaw["Statistics"]
+			warnMap["threshold"] = warnRaw["Threshold"]
+			warnMap["times"] = warnRaw["Times"]
+
+			warnMaps = append(warnMaps, warnMap)
+		}
+		escalationsMap["warn"] = warnMaps
+		if len(criticalMaps) > 0 || len(infoMaps) > 0 || len(warnMaps) > 0 {
+			escalationsMaps = append(escalationsMaps, escalationsMap)
+		}
+	}
+	if err := d.Set("escalations", escalationsMaps); err != nil {
+		return err
+	}
+	labelsRaw, _ := jsonpath.Get("$.Labels.Labels", objectRaw)
+	labelsMaps := make([]map[string]interface{}, 0)
+	if labelsRaw != nil {
+		for _, labelsChildRaw := range convertToInterfaceArray(labelsRaw) {
+			labelsMap := make(map[string]interface{})
+			labelsChildRaw := labelsChildRaw.(map[string]interface{})
+			labelsMap["key"] = labelsChildRaw["Key"]
+			labelsMap["value"] = labelsChildRaw["Value"]
+
+			labelsMaps = append(labelsMaps, labelsMap)
+		}
+	}
+	if err := d.Set("labels", labelsMaps); err != nil {
+		return err
+	}
+	prometheusMaps := make([]map[string]interface{}, 0)
+	prometheusMap := make(map[string]interface{})
+	prometheusRaw := make(map[string]interface{})
+	if objectRaw["Prometheus"] != nil {
+		prometheusRaw = objectRaw["Prometheus"].(map[string]interface{})
+	}
+	if len(prometheusRaw) > 0 {
+		prometheusMap["level"] = prometheusRaw["Level"]
+		prometheusMap["prom_ql"] = prometheusRaw["PromQL"]
+		prometheusMap["times"] = prometheusRaw["Times"]
+
+		annotationsRaw, _ := jsonpath.Get("$.Prometheus.Annotations.Annotations", objectRaw)
+		annotationsMaps := make([]map[string]interface{}, 0)
+		if annotationsRaw != nil {
+			for _, annotationsChildRaw := range convertToInterfaceArray(annotationsRaw) {
+				annotationsMap := make(map[string]interface{})
+				annotationsChildRaw := annotationsChildRaw.(map[string]interface{})
+				annotationsMap["key"] = annotationsChildRaw["Key"]
+				annotationsMap["value"] = annotationsChildRaw["Value"]
+
+				annotationsMaps = append(annotationsMaps, annotationsMap)
+			}
+		}
+		prometheusMap["annotations"] = annotationsMaps
+		prometheusMaps = append(prometheusMaps, prometheusMap)
+	}
+	if err := d.Set("prometheus", prometheusMaps); err != nil {
+		return err
+	}
+
+	d.Set("metric_alarm_rule_id", d.Id())
+
+	return nil
+}
+
+func resourceAliCloudCloudMonitorServiceMetricAlarmRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	cloudMonitorServiceServiceV2 := CloudMonitorServiceServiceV2{client}
+	objectRaw, _ := cloudMonitorServiceServiceV2.DescribeCloudMonitorServiceMetricAlarmRule(d.Id())
+
+	initedStatus := false
+	if _, ok := d.GetOkExists("status"); ok && d.IsNewResource() {
+		initedStatus = true
+	}
+	if initedStatus || d.HasChange("status") {
+		var err error
+		target := d.Get("status").(bool)
+
+		currentStatus, err := jsonpath.Get("EnableState", objectRaw)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, d.Id(), "EnableState", objectRaw)
+		}
+		if formatBool(currentStatus) != target {
+			if target == true {
+				action := "EnableMetricRules"
+				request = make(map[string]interface{})
+				query = make(map[string]interface{})
+				request["RuleId.1"] = d.Id()
+
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = client.RpcPost("Cms", "2019-01-01", action, query, request, true)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+
+			}
+			if target == false {
+				action := "DisableMetricRules"
+				request = make(map[string]interface{})
+				query = make(map[string]interface{})
+				request["RuleId.1"] = d.Id()
+
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = client.RpcPost("Cms", "2019-01-01", action, query, request, true)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+
+			}
+		}
+	}
+
+	var err error
+	update = false
+	action := "PutResourceMetricRule"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RuleId"] = d.Id()
+
+	// PutResourceMetricRule is a full-replace PUT: any field omitted in the
+	// request body is reset to the server's default value (confirmed by CMS team
+	// on Aone 83358430). Send the complete resource definition on every
+	// invocation — including the Create→Update follow-up call — so that fields
+	// already written by Create aren't blanked out by the second PUT.
+	request["Namespace"] = d.Get("namespace")
+	request["SilenceTime"] = d.Get("silence_time")
+	request["NoDataPolicy"] = d.Get("no_data_policy")
+	request["EffectiveInterval"] = d.Get("effective_interval")
+	request["Webhook"] = d.Get("webhook")
+	request["EmailSubject"] = d.Get("email_subject")
+	request["NoEffectiveInterval"] = d.Get("no_effective_interval")
+	request["ContactGroups"] = d.Get("contact_groups")
+	request["Resources"] = d.Get("resources")
+	request["SendOK"] = d.Get("send_ok")
+	if v, ok := d.GetOk("interval"); ok {
+		request["Interval"] = v
+	}
+	request["RuleName"] = d.Get("rule_name")
+	request["MetricName"] = d.Get("metric_name")
+	request["Period"] = d.Get("period")
+
+	if v := d.Get("prometheus"); v != nil {
+		prometheus := make(map[string]interface{})
+
+		level1, _ := jsonpath.Get("$[0].level", v)
+		if level1 != nil && level1 != "" {
+			prometheus["Level"] = level1
+		}
+		localData, err := jsonpath.Get("$[0].annotations", v)
+		if err != nil {
+			localData = make([]interface{}, 0)
+		}
+		localMaps := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(localData) {
+			dataLoopTmp := make(map[string]interface{})
+			if dataLoop != nil {
+				dataLoopTmp = dataLoop.(map[string]interface{})
+			}
+			dataLoopMap := make(map[string]interface{})
+			dataLoopMap["Value"] = dataLoopTmp["value"]
+			dataLoopMap["Key"] = dataLoopTmp["key"]
+			localMaps = append(localMaps, dataLoopMap)
+		}
+		prometheus["Annotations"] = localMaps
+
+		promQl, _ := jsonpath.Get("$[0].prom_ql", v)
+		if promQl != nil && promQl != "" {
+			prometheus["PromQL"] = promQl
+		}
+		times1, _ := jsonpath.Get("$[0].times", v)
+		if times1 != nil && times1 != "" {
+			prometheus["Times"] = times1
+		}
+
+		if len(prometheus) > 0 {
+			prometheusJson, err := json.Marshal(prometheus)
+			if err != nil {
+				return WrapError(err)
+			}
+			request["Prometheus"] = string(prometheusJson)
+		}
+	}
+
+	if v := d.Get("escalations"); v != nil {
+		escalations := make(map[string]interface{})
+
+		info := make(map[string]interface{})
+		comparisonOperator1, _ := jsonpath.Get("$[0].info[0].comparison_operator", v)
+		if comparisonOperator1 != nil && comparisonOperator1 != "" {
+			info["ComparisonOperator"] = comparisonOperator1
+		}
+		statistics1, _ := jsonpath.Get("$[0].info[0].statistics", v)
+		if statistics1 != nil && statistics1 != "" {
+			info["Statistics"] = statistics1
+		}
+		threshold1, _ := jsonpath.Get("$[0].info[0].threshold", v)
+		if threshold1 != nil && threshold1 != "" {
+			info["Threshold"] = threshold1
+		}
+		times3, _ := jsonpath.Get("$[0].info[0].times", v)
+		if times3 != nil && times3 != "" {
+			info["Times"] = times3
+		}
+		if len(info) > 0 {
+			escalations["Info"] = info
+		}
+
+		warn := make(map[string]interface{})
+		statistics3, _ := jsonpath.Get("$[0].warn[0].statistics", v)
+		if statistics3 != nil && statistics3 != "" {
+			warn["Statistics"] = statistics3
+		}
+		threshold3, _ := jsonpath.Get("$[0].warn[0].threshold", v)
+		if threshold3 != nil && threshold3 != "" {
+			warn["Threshold"] = threshold3
+		}
+		comparisonOperator3, _ := jsonpath.Get("$[0].warn[0].comparison_operator", v)
+		if comparisonOperator3 != nil && comparisonOperator3 != "" {
+			warn["ComparisonOperator"] = comparisonOperator3
+		}
+		times5, _ := jsonpath.Get("$[0].warn[0].times", v)
+		if times5 != nil && times5 != "" {
+			warn["Times"] = times5
+		}
+		if len(warn) > 0 {
+			escalations["Warn"] = warn
+		}
+
+		critical := make(map[string]interface{})
+		statistics5, _ := jsonpath.Get("$[0].critical[0].statistics", v)
+		if statistics5 != nil && statistics5 != "" {
+			critical["Statistics"] = statistics5
+		}
+		threshold5, _ := jsonpath.Get("$[0].critical[0].threshold", v)
+		if threshold5 != nil && threshold5 != "" {
+			critical["Threshold"] = threshold5
+		}
+		comparisonOperator5, _ := jsonpath.Get("$[0].critical[0].comparison_operator", v)
+		if comparisonOperator5 != nil && comparisonOperator5 != "" {
+			critical["ComparisonOperator"] = comparisonOperator5
+		}
+		times7, _ := jsonpath.Get("$[0].critical[0].times", v)
+		if times7 != nil && times7 != "" {
+			critical["Times"] = times7
+		}
+		if len(critical) > 0 {
+			escalations["Critical"] = critical
+		}
+
+		if len(escalations) > 0 {
+			request["Escalations"] = escalations
+		}
+	}
+
+	if v := d.Get("composite_expression"); !IsNil(v) {
+		compositeExpression := make(map[string]interface{})
+
+		expressionListJoin1, _ := jsonpath.Get("$[0].expression_list_join", v)
+		if expressionListJoin1 != nil && expressionListJoin1 != "" {
+			compositeExpression["ExpressionListJoin"] = expressionListJoin1
+		}
+		localData1, err := jsonpath.Get("$[0].expression_list", v)
+		if err != nil {
+			localData1 = make([]interface{}, 0)
+		}
+		localMaps1 := make([]interface{}, 0)
+		for _, dataLoop1 := range convertToInterfaceArray(localData1) {
+			dataLoop1Tmp := make(map[string]interface{})
+			if dataLoop1 != nil {
+				dataLoop1Tmp = dataLoop1.(map[string]interface{})
+			}
+			dataLoop1Map := make(map[string]interface{})
+			dataLoop1Map["Statistics"] = dataLoop1Tmp["statistics"]
+			dataLoop1Map["ComparisonOperator"] = dataLoop1Tmp["comparison_operator"]
+			dataLoop1Map["MetricName"] = dataLoop1Tmp["metric_name"]
+			dataLoop1Map["Period"] = dataLoop1Tmp["period"]
+			dataLoop1Map["Threshold"] = dataLoop1Tmp["threshold"]
+			localMaps1 = append(localMaps1, dataLoop1Map)
+		}
+		if len(localMaps1) > 0 {
+			compositeExpression["ExpressionList"] = localMaps1
+		}
+
+		level3, _ := jsonpath.Get("$[0].level", v)
+		if level3 != nil && level3 != "" {
+			compositeExpression["Level"] = level3
+		}
+		expressionRaw1, _ := jsonpath.Get("$[0].expression_raw", v)
+		if expressionRaw1 != nil && expressionRaw1 != "" {
+			compositeExpression["ExpressionRaw"] = expressionRaw1
+		}
+		times9, _ := jsonpath.Get("$[0].times", v)
+		if times9 != nil && times9 != "" {
+			compositeExpression["Times"] = times9
+		}
+
+		if len(compositeExpression) > 0 {
+			compositeExpressionJson, err := json.Marshal(compositeExpression)
+			if err != nil {
+				return WrapError(err)
+			}
+			request["CompositeExpression"] = string(compositeExpressionJson)
+		}
+	}
+
+	if v, ok := d.GetOk("labels"); ok {
+		labelsMapsArray := make([]interface{}, 0)
+		for _, dataLoop2 := range convertToInterfaceArray(v) {
+			dataLoop2Tmp := dataLoop2.(map[string]interface{})
+			dataLoop2Map := make(map[string]interface{})
+			dataLoop2Map["Value"] = dataLoop2Tmp["value"]
+			dataLoop2Map["Key"] = dataLoop2Tmp["key"]
+			labelsMapsArray = append(labelsMapsArray, dataLoop2Map)
+		}
+		request["Labels"] = labelsMapsArray
+	}
+
+	update = true
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Cms", "2019-01-01", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d, meta)
+}
+
+func resourceAliCloudCloudMonitorServiceMetricAlarmRuleDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteMetricRules"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["Id.1"] = d.Id()
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Cms", "2019-01-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_cloud_monitor_service_metric_alarm_rule_test.go
+++ b/alicloud/resource_alicloud_cloud_monitor_service_metric_alarm_rule_test.go
@@ -1,0 +1,3432 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test CloudMonitorService MetricAlarmRule. >>> Resource test cases, automatically generated.
+// Case resourceCase_info_labels 12863
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12863(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12863)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12863)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"contact_groups":       "云账号报警联系人",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"contact_groups":       "云账号报警联系人",
+						"metric_alarm_rule_id": CHECKSET,
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"silence_time": "86400",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"silence_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"period": "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"period": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"no_data_policy": "KEEP_LAST_STATE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"no_data_policy": "KEEP_LAST_STATE",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"no_effective_interval": "00:00-23:59",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"no_effective_interval": "00:00-23:59",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"labels": []map[string]interface{}{
+						{
+							"value": "testValue",
+							"key":   "testKey",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"labels.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"email_subject": "test alarm",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"email_subject": "test alarm",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"webhook": "https://www.aliyun.com/webhook",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"webhook": "https://www.aliyun.com/webhook",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"resources": "[{\\\"resource\\\":\\\"acs:ecs:cn-hangzhou:*:instance/*\\\"}]",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resources": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudCloudMonitorServiceMetricAlarmRuleMap12863 = map[string]string{
+	"source_type": CHECKSET,
+}
+
+func AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12863(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_composite 12864
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12864(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12864)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12864)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"contact_groups":       "云账号报警联系人",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"composite_expression": []map[string]interface{}{
+						{
+							"times":                "3",
+							"level":                "CRITICAL",
+							"expression_list_join": "&&",
+							"expression_list": []map[string]interface{}{
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"statistics":          "Average",
+									"threshold":           "85",
+								},
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"statistics":          "Average",
+									"threshold":           "90",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"contact_groups":       "云账号报警联系人",
+						"metric_alarm_rule_id": CHECKSET,
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"silence_time": "86400",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"silence_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"period": "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"period": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"no_data_policy": "KEEP_LAST_STATE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"no_data_policy": "KEEP_LAST_STATE",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					// CMS derives the rule-level MetricName from the first
+					// composite expression, so keep the top-level field in
+					// sync when the expression list switches metric.
+					"metric_name": "CPUUtilization",
+					"composite_expression": []map[string]interface{}{
+						{
+							"times":                "3",
+							"level":                "CRITICAL",
+							"expression_list_join": "&&",
+							"expression_list": []map[string]interface{}{
+								{
+									"metric_name":         "CPUUtilization",
+									"comparison_operator": "GreaterThanOrEqualToThreshold",
+									"period":              "60",
+									"statistics":          "Maximum",
+									"threshold":           "95",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"metric_name": "CPUUtilization",
+						"composite_expression.0.expression_list.#":                     "1",
+						"composite_expression.0.expression_list.0.metric_name":         "CPUUtilization",
+						"composite_expression.0.expression_list.0.comparison_operator": "GreaterThanOrEqualToThreshold",
+						"composite_expression.0.expression_list.0.statistics":          "Maximum",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"composite_expression": []map[string]interface{}{
+						{
+							"times":                "3",
+							"level":                "CRITICAL",
+							"expression_list_join": "&&",
+							"expression_list": []map[string]interface{}{
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"period":              "60",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"period":              "60",
+									"statistics":          "Average",
+									"threshold":           "85",
+								},
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"period":              "60",
+									"statistics":          "Average",
+									"threshold":           "90",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"composite_expression.0.expression_list.#":                     "3",
+						"composite_expression.0.expression_list.0.metric_name":         "IOPSUsageOfDN",
+						"composite_expression.0.expression_list.0.comparison_operator": "GreaterThanThreshold",
+						"composite_expression.0.expression_list.0.statistics":          "Average",
+						"resources": CHECKSET,
+						"rule_name": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudCloudMonitorServiceMetricAlarmRuleMap12864 = map[string]string{
+	"source_type": CHECKSET,
+}
+
+func AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12864(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_expression 12865
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12865(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12865)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12865)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"contact_groups":       "云账号报警联系人",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"composite_expression": []map[string]interface{}{
+						{
+							"times":          "3",
+							"expression_raw": "$Average > 80",
+							"level":          "CRITICAL",
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"contact_groups":       "云账号报警联系人",
+						"metric_alarm_rule_id": CHECKSET,
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"silence_time": "86400",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"silence_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"period": "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"period": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"no_data_policy": "KEEP_LAST_STATE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"no_data_policy": "KEEP_LAST_STATE",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"composite_expression": []map[string]interface{}{
+						{
+							"times":          "3",
+							"expression_raw": "$Average > 80",
+							"level":          "CRITICAL",
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudCloudMonitorServiceMetricAlarmRuleMap12865 = map[string]string{
+	"source_type": CHECKSET,
+}
+
+func AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12865(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_targets 12866
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12866(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12866)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12866)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"contact_groups":       "云账号报警联系人",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"contact_groups":       "云账号报警联系人",
+						"metric_alarm_rule_id": CHECKSET,
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"silence_time": "86400",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"silence_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"period": "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"period": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"no_data_policy": "KEEP_LAST_STATE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"no_data_policy": "KEEP_LAST_STATE",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"silence_time": "43200",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"silence_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudCloudMonitorServiceMetricAlarmRuleMap12866 = map[string]string{
+	"source_type": CHECKSET,
+}
+
+func AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12866(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_preconditions 12867
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12867(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12867)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12867)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"contact_groups":       "云账号报警联系人",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"contact_groups":       "云账号报警联系人",
+						"metric_alarm_rule_id": CHECKSET,
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"silence_time": "86400",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"silence_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"period": "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"period": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"no_data_policy": "KEEP_LAST_STATE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"no_data_policy": "KEEP_LAST_STATE",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudCloudMonitorServiceMetricAlarmRuleMap12867 = map[string]string{
+	"source_type": CHECKSET,
+}
+
+func AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12867(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_prometheus 12868
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12868(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12868)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12868)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"contact_groups":       "云账号报警联系人",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"prometheus": []map[string]interface{}{
+						{
+							"annotations": []map[string]interface{}{
+								{
+									"value": "High request rate on {{ $labels.instance }}",
+									"key":   "summary",
+								},
+								{
+									"value": "Request rate is elevated",
+									"key":   "description",
+								},
+								{
+									"value": "critical",
+									"key":   "severity",
+								},
+							},
+							"prom_ql": "avg(rate(http_requests_total[5m])) by (instance) > 100",
+							"times":   "3",
+							"level":   "2",
+						},
+					},
+					"namespace":   "acs_prometheus",
+					"metric_name": "IOPSUsageOfDN",
+					"resources":   "",
+					"rule_name":   "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"contact_groups":       "云账号报警联系人",
+						"metric_alarm_rule_id": CHECKSET,
+						"namespace":            "acs_prometheus",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            "",
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"silence_time": "86400",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"silence_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"period": "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"period": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"prometheus": []map[string]interface{}{
+						{
+							"annotations": []map[string]interface{}{
+								{
+									"value": "High request rate on {{ $labels.instance }}",
+									"key":   "summary",
+								},
+								{
+									"value": "Request rate is elevated",
+									"key":   "description",
+								},
+								{
+									"value": "critical",
+									"key":   "severity",
+								},
+							},
+							"prom_ql": "avg(rate(http_requests_total[5m])) by (instance) > 100",
+							"times":   "3",
+							"level":   "2",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"no_data_policy": "KEEP_LAST_STATE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"no_data_policy": "KEEP_LAST_STATE",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"prometheus": []map[string]interface{}{
+						{
+							"annotations": []map[string]interface{}{
+								{
+									"value": "Request rate is elevated on {{ $labels.instance }}",
+									"key":   "description",
+								},
+								{
+									"value": "warning",
+									"key":   "severity",
+								},
+							},
+							"prom_ql": "avg(rate(http_requests_total[5m])) by (instance) > 50",
+							"times":   "5",
+							"level":   "3",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"prometheus": []map[string]interface{}{
+						{
+							"annotations": []map[string]interface{}{
+								{
+									"value": "High request rate on {{ $labels.instance }}",
+									"key":   "summary",
+								},
+								{
+									"value": "Request rate is elevated",
+									"key":   "description",
+								},
+								{
+									"value": "critical",
+									"key":   "severity",
+								},
+							},
+							"prom_ql": "avg(rate(http_requests_total[5m])) by (instance) > 100",
+							"times":   "3",
+							"level":   "2",
+						},
+					},
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":     "KEEP_LAST_STATE",
+					"namespace":          "acs_prometheus",
+					"metric_name":        "IOPSUsageOfDN",
+					"resources":          "",
+					"rule_name":          "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_prometheus",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            "",
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudCloudMonitorServiceMetricAlarmRuleMap12868 = map[string]string{
+	"source_type": CHECKSET,
+}
+
+func AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12868(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_info_init 12869
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12869(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12869)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12869)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"contact_groups":        "云账号报警联系人",
+					"no_effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"metric_alarm_rule_id":  "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"labels": []map[string]interface{}{
+						{
+							"value": "prod",
+							"key":   "env",
+						},
+						{
+							"value": "platform",
+							"key":   "team",
+						},
+						{
+							"value": "hangzhou",
+							"key":   "region",
+						},
+					},
+					"namespace":     "acs_drds",
+					"metric_name":   "IOPSUsageOfDN",
+					"email_subject": "test-email-subject",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+							"info": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "3",
+									"statistics":          "Average",
+									"threshold":           "50",
+								},
+							},
+						},
+					},
+					"webhook":   "https://www.aliyun.com/webhook",
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+					"interval":  "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"contact_groups":        "云账号报警联系人",
+						"no_effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"metric_alarm_rule_id":  CHECKSET,
+						"labels.#":              "3",
+						"namespace":             "acs_drds",
+						"metric_name":           "IOPSUsageOfDN",
+						"email_subject":         "test-email-subject",
+						"webhook":               "https://www.aliyun.com/webhook",
+						"resources":             CHECKSET,
+						"rule_name":             CHECKSET,
+						"interval":              CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"silence_time": "86400",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"silence_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"no_effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"no_effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"period": "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"period": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"labels": []map[string]interface{}{
+						{
+							"value": "prod",
+							"key":   "env",
+						},
+						{
+							"value": "platform",
+							"key":   "team",
+						},
+						{
+							"value": "hangzhou",
+							"key":   "region",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"labels.#": "3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"no_data_policy": "KEEP_LAST_STATE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"no_data_policy": "KEEP_LAST_STATE",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"email_subject": "test-email-subject",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"email_subject": "test-email-subject",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"webhook": "https://www.aliyun.com/webhook",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"webhook": "https://www.aliyun.com/webhook",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"labels": []map[string]interface{}{
+						{
+							"value": "prod",
+							"key":   "env",
+						},
+						{
+							"value": "platform",
+							"key":   "team",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"labels.#": "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"email_subject": "updated-email-subject",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"email_subject": "updated-email-subject",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"webhook": "https://www.aliyun.com/webhook2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"webhook": "https://www.aliyun.com/webhook2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"interval": "120",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"interval": "120",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":                "true",
+					"send_ok":               "true",
+					"contact_groups":        "云账号报警联系人",
+					"silence_time":          "86400",
+					"no_effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"metric_alarm_rule_id":  "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":                "60",
+					"labels": []map[string]interface{}{
+						{
+							"value": "prod",
+							"key":   "env",
+						},
+						{
+							"value": "platform",
+							"key":   "team",
+						},
+						{
+							"value": "hangzhou",
+							"key":   "region",
+						},
+					},
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":     "KEEP_LAST_STATE",
+					"namespace":          "acs_drds",
+					"metric_name":        "IOPSUsageOfDN",
+					"email_subject":      "test-email-subject",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+							"info": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "3",
+									"statistics":          "Average",
+									"threshold":           "50",
+								},
+							},
+						},
+					},
+					"webhook":   "https://www.aliyun.com/webhook",
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+					"interval":  "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":                "true",
+						"send_ok":               "true",
+						"contact_groups":        "云账号报警联系人",
+						"silence_time":          CHECKSET,
+						"no_effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"metric_alarm_rule_id":  CHECKSET,
+						"period":                CHECKSET,
+						"labels.#":              "3",
+						"effective_interval":    "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":        "KEEP_LAST_STATE",
+						"namespace":             "acs_drds",
+						"metric_name":           "IOPSUsageOfDN",
+						"email_subject":         "test-email-subject",
+						"webhook":               "https://www.aliyun.com/webhook",
+						"resources":             CHECKSET,
+						"rule_name":             CHECKSET,
+						"interval":              CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudCloudMonitorServiceMetricAlarmRuleMap12869 = map[string]string{
+	"source_type": CHECKSET,
+}
+
+func AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12869(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_warn_init 12870
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12870(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12870)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12870)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"contact_groups":       "云账号报警联系人",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"warn": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"contact_groups":       "云账号报警联系人",
+						"metric_alarm_rule_id": CHECKSET,
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"silence_time": "86400",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"silence_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"period": "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"period": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"no_data_policy": "KEEP_LAST_STATE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"no_data_policy": "KEEP_LAST_STATE",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"warn": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudCloudMonitorServiceMetricAlarmRuleMap12870 = map[string]string{
+	"source_type": CHECKSET,
+}
+
+func AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12870(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resourceCase_info_labels 12863  twin
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12863_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12863)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12863)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_composite 12864  twin
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12864_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12864)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12864)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"composite_expression": []map[string]interface{}{
+						{
+							"times":                "3",
+							"level":                "CRITICAL",
+							"expression_list_join": "&&",
+							"expression_list": []map[string]interface{}{
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"period":              "60",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"period":              "60",
+									"statistics":          "Average",
+									"threshold":           "85",
+								},
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"period":              "60",
+									"statistics":          "Average",
+									"threshold":           "90",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_expression 12865  twin
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12865_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12865)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12865)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"composite_expression": []map[string]interface{}{
+						{
+							"times":          "3",
+							"expression_raw": "$Average > 80",
+							"level":          "CRITICAL",
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_targets 12866  twin
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12866_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12866)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12866)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_preconditions 12867  twin
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12867_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12867)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12867)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_prometheus 12868  twin
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12868_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12868)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12868)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"prometheus": []map[string]interface{}{
+						{
+							"annotations": []map[string]interface{}{
+								{
+									"value": "High request rate on {{ $labels.instance }}",
+									"key":   "summary",
+								},
+								{
+									"value": "Request rate is elevated",
+									"key":   "description",
+								},
+								{
+									"value": "critical",
+									"key":   "severity",
+								},
+							},
+							"prom_ql": "avg(rate(http_requests_total[5m])) by (instance) > 100",
+							"times":   "3",
+							"level":   "2",
+						},
+					},
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":     "KEEP_LAST_STATE",
+					"namespace":          "acs_prometheus",
+					"metric_name":        "IOPSUsageOfDN",
+					"resources":          "",
+					"rule_name":          "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_prometheus",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            "",
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_info_init 12869  twin
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12869_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12869)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12869)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":                "true",
+					"send_ok":               "true",
+					"contact_groups":        "云账号报警联系人",
+					"silence_time":          "86400",
+					"no_effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"metric_alarm_rule_id":  "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":                "60",
+					"labels": []map[string]interface{}{
+						{
+							"value": "prod",
+							"key":   "env",
+						},
+						{
+							"value": "platform",
+							"key":   "team",
+						},
+						{
+							"value": "hangzhou",
+							"key":   "region",
+						},
+					},
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":     "KEEP_LAST_STATE",
+					"namespace":          "acs_drds",
+					"metric_name":        "IOPSUsageOfDN",
+					"email_subject":      "test-email-subject",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+							"info": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "3",
+									"statistics":          "Average",
+									"threshold":           "50",
+								},
+							},
+						},
+					},
+					"webhook":   "https://www.aliyun.com/webhook",
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+					"interval":  "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":                "true",
+						"send_ok":               "true",
+						"contact_groups":        "云账号报警联系人",
+						"silence_time":          CHECKSET,
+						"no_effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"metric_alarm_rule_id":  CHECKSET,
+						"period":                CHECKSET,
+						"labels.#":              "3",
+						"effective_interval":    "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":        "KEEP_LAST_STATE",
+						"namespace":             "acs_drds",
+						"metric_name":           "IOPSUsageOfDN",
+						"email_subject":         "test-email-subject",
+						"webhook":               "https://www.aliyun.com/webhook",
+						"resources":             CHECKSET,
+						"rule_name":             CHECKSET,
+						"interval":              CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_warn_init 12870  twin
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12870_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12870)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12870)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"warn": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_info_labels 12863  raw
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12863_raw(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12863)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12863)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+					"escalations": []map[string]interface{}{
+						{
+							"info": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "3",
+									"statistics":          "Average",
+									"threshold":           "50",
+								},
+							},
+						},
+					},
+					"no_effective_interval": "00:00-23:59",
+					"labels": []map[string]interface{}{
+						{
+							"value": "testValue",
+							"key":   "testKey",
+						},
+					},
+					"email_subject": "test alarm",
+					"webhook":       "https://www.aliyun.com/webhook",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok":               "false",
+						"no_effective_interval": "00:00-23:59",
+						"labels.#":              "1",
+						"email_subject":         "test alarm",
+						"webhook":               "https://www.aliyun.com/webhook",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_composite 12864  raw
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12864_raw(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12864)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12864)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"composite_expression": []map[string]interface{}{
+						{
+							"times":                "3",
+							"level":                "CRITICAL",
+							"expression_list_join": "&&",
+							"expression_list": []map[string]interface{}{
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"period":              "60",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"period":              "60",
+									"statistics":          "Average",
+									"threshold":           "85",
+								},
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"period":              "60",
+									"statistics":          "Average",
+									"threshold":           "90",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+					"composite_expression": []map[string]interface{}{
+						{
+							"times":                "5",
+							"level":                "WARN",
+							"expression_list_join": "||",
+							"expression_list": []map[string]interface{}{
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"period":              "60",
+									"statistics":          "Average",
+									"threshold":           "60",
+								},
+								{
+									"metric_name":         "IOPSUsageOfDN",
+									"comparison_operator": "GreaterThanThreshold",
+									"period":              "60",
+									"statistics":          "Average",
+									"threshold":           "90",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_expression 12865  raw
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12865_raw(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12865)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12865)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"composite_expression": []map[string]interface{}{
+						{
+							"times":          "3",
+							"expression_raw": "$Average > 80",
+							"level":          "CRITICAL",
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+					"composite_expression": []map[string]interface{}{
+						{
+							"times":          "5",
+							"expression_raw": "$Average > 90",
+							"level":          "WARN",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_targets 12866  raw
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12866_raw(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12866)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12866)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok":      "false",
+					"silence_time": "43200",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "90",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok":      "false",
+						"silence_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_preconditions 12867  raw
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12867_raw(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12867)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12867)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "90",
+								},
+							},
+							"info": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "3",
+									"statistics":          "Average",
+									"threshold":           "50",
+								},
+							},
+							"warn": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_prometheus 12868  raw
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12868_raw(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12868)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12868)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"prometheus": []map[string]interface{}{
+						{
+							"annotations": []map[string]interface{}{
+								{
+									"value": "High request rate on {{ $labels.instance }}",
+									"key":   "summary",
+								},
+								{
+									"value": "Request rate is elevated",
+									"key":   "description",
+								},
+								{
+									"value": "critical",
+									"key":   "severity",
+								},
+							},
+							"prom_ql": "avg(rate(http_requests_total[5m])) by (instance) > 100",
+							"times":   "3",
+							"level":   "2",
+						},
+					},
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":     "KEEP_LAST_STATE",
+					"namespace":          "acs_prometheus",
+					"metric_name":        "IOPSUsageOfDN",
+					"resources":          "",
+					"rule_name":          "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_prometheus",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            "",
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+					"prometheus": []map[string]interface{}{
+						{
+							"annotations": []map[string]interface{}{
+								{
+									"value": "Request rate is elevated on {{ $labels.instance }}",
+									"key":   "description",
+								},
+								{
+									"value": "warning",
+									"key":   "severity",
+								},
+							},
+							"prom_ql": "avg(rate(http_requests_total[5m])) by (instance) > 50",
+							"times":   "5",
+							"level":   "3",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_info_init 12869  raw
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12869_raw(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12869)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12869)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":                "true",
+					"send_ok":               "true",
+					"contact_groups":        "云账号报警联系人",
+					"silence_time":          "86400",
+					"no_effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"metric_alarm_rule_id":  "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":                "60",
+					"labels": []map[string]interface{}{
+						{
+							"value": "prod",
+							"key":   "env",
+						},
+						{
+							"value": "platform",
+							"key":   "team",
+						},
+						{
+							"value": "hangzhou",
+							"key":   "region",
+						},
+					},
+					"effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":     "KEEP_LAST_STATE",
+					"namespace":          "acs_drds",
+					"metric_name":        "IOPSUsageOfDN",
+					"email_subject":      "test-email-subject",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+							"info": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "3",
+									"statistics":          "Average",
+									"threshold":           "50",
+								},
+							},
+						},
+					},
+					"webhook":   "https://www.aliyun.com/webhook",
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+					"interval":  "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":                "true",
+						"send_ok":               "true",
+						"contact_groups":        "云账号报警联系人",
+						"silence_time":          CHECKSET,
+						"no_effective_interval": "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"metric_alarm_rule_id":  CHECKSET,
+						"period":                CHECKSET,
+						"labels.#":              "3",
+						"effective_interval":    "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":        "KEEP_LAST_STATE",
+						"namespace":             "acs_drds",
+						"metric_name":           "IOPSUsageOfDN",
+						"email_subject":         "test-email-subject",
+						"webhook":               "https://www.aliyun.com/webhook",
+						"resources":             CHECKSET,
+						"rule_name":             CHECKSET,
+						"interval":              CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+					"labels": []map[string]interface{}{
+						{
+							"value": "prod",
+							"key":   "env",
+						},
+						{
+							"value": "platform",
+							"key":   "team",
+						},
+					},
+					"email_subject": "updated-email-subject",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "90",
+								},
+							},
+							"info": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "60",
+								},
+							},
+							"warn": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "70",
+								},
+							},
+						},
+					},
+					"webhook": "https://www.aliyun.com/webhook2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok":       "false",
+						"labels.#":      "2",
+						"email_subject": "updated-email-subject",
+						"webhook":       "https://www.aliyun.com/webhook2",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case resourceCase_warn_init 12870  raw
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12870_raw(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCloudMonitorServiceMetricAlarmRuleMap12870)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudmonitorservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCloudMonitorServiceMetricAlarmRuleBasicDependence12870)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":               "true",
+					"send_ok":              "true",
+					"contact_groups":       "云账号报警联系人",
+					"silence_time":         "86400",
+					"metric_alarm_rule_id": "SystemDefault_acs_drds_IOPSUsageOfDo",
+					"period":               "60",
+					"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+					"no_data_policy":       "KEEP_LAST_STATE",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"escalations": []map[string]interface{}{
+						{
+							"warn": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+					"resources": "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"rule_name": "SystemDefault_acs_drds_IOPSUsageOfDN",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":               "true",
+						"send_ok":              "true",
+						"contact_groups":       "云账号报警联系人",
+						"silence_time":         CHECKSET,
+						"metric_alarm_rule_id": CHECKSET,
+						"period":               CHECKSET,
+						"effective_interval":   "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7",
+						"no_data_policy":       "KEEP_LAST_STATE",
+						"namespace":            "acs_drds",
+						"metric_name":          "IOPSUsageOfDN",
+						"resources":            CHECKSET,
+						"rule_name":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"send_ok": "false",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"send_ok": "false",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Test CloudMonitorService MetricAlarmRule. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_cloud_monitor_service_v2.go
+++ b/alicloud/service_alicloud_cloud_monitor_service_v2.go
@@ -628,3 +628,79 @@ func (s *CloudMonitorServiceServiceV2) CloudMonitorServiceAgentConfigStateRefres
 }
 
 // DescribeCloudMonitorServiceAgentConfig >>> Encapsulated.
+
+// DescribeCloudMonitorServiceMetricAlarmRule <<< Encapsulated get interface for CloudMonitorService MetricAlarmRule.
+
+func (s *CloudMonitorServiceServiceV2) DescribeCloudMonitorServiceMetricAlarmRule(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RuleIds"] = id
+
+	action := "DescribeMetricRuleList"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Cms", "2019-01-01", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Alarms.Alarm[*]", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Alarms.Alarm[*]", response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("MetricAlarmRule", id), NotFoundMsg, response)
+	}
+
+	return v.([]interface{})[0].(map[string]interface{}), nil
+}
+func (s *CloudMonitorServiceServiceV2) CloudMonitorServiceMetricAlarmRuleStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.CloudMonitorServiceMetricAlarmRuleStateRefreshFuncWithApi(id, field, failStates, s.DescribeCloudMonitorServiceMetricAlarmRule)
+}
+
+func (s *CloudMonitorServiceServiceV2) CloudMonitorServiceMetricAlarmRuleStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeCloudMonitorServiceMetricAlarmRule >>> Encapsulated.

--- a/website/docs/d/cloud_monitor_service_metric_alarm_rules.html.markdown
+++ b/website/docs/d/cloud_monitor_service_metric_alarm_rules.html.markdown
@@ -3,18 +3,16 @@ subcategory: "Cloud Monitor Service"
 layout: "alicloud"
 page_title: "Alicloud: alicloud_cloud_monitor_service_metric_alarm_rules"
 description: |-
-  Provides a list of Cloud Monitor Service Metric Alarm Rules to the user.
+  Provides a list of Cloud Monitor Service Metric Alarm Rule owned by an Alibaba Cloud account.
 ---
 
 # alicloud_cloud_monitor_service_metric_alarm_rules
 
-This data source provides the Cloud Monitor Service Metric Alarm Rules of the current Alibaba Cloud user.
+This data source provides Cloud Monitor Service Metric Alarm Rule available to the user.[What is Metric Alarm Rule](https://next.api.alibabacloud.com/document/Cms/2019-01-01/PutResourceMetricRule)
 
 -> **NOTE:** Available since v1.256.0.
 
 ## Example Usage
-
-Basic Usage
 
 ```terraform
 variable "name" {
@@ -79,73 +77,96 @@ output "cloud_monitor_service_metric_alarm_rules_id_0" {
 ## Argument Reference
 
 The following arguments are supported:
+* `dimensions` - (ForceNew, Optional) The monitoring dimensions for the specified resource.
+Format: a set of key:value pairs, for example: `{"userId":"120886317861****"}` and `{"instanceId":"i-2ze2d6j5uhg20x47****"}`.
+* `metric_alarm_rule_id` - (ForceNew, Optional) The ID of the alarm rule.
 
-* `ids` - (Optional, ForceNew, List) A list of Metric Alarm Rule IDs.
-* `dimensions` - (Optional, ForceNew) The monitoring dimensions of the specified resource.
-* `metric_name` - (Optional, ForceNew) The name of the metric.
-* `namespace` - (Optional, ForceNew) The namespace of the cloud service.
-* `rule_name` - (Optional, ForceNew) The name of the alert rule.
-* `status` - (Optional, ForceNew) Specifies whether to query enabled or disabled alert rules. Valid values: `true`, `false`.
-* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+You can specify a new alarm rule ID or use an existing alarm rule ID from CloudMonitor. For information about how to query alarm rule IDs, see [DescribeMetricRuleList](https://help.aliyun.com/document_detail/114941.html).
+
+-> **NOTE:**  Specifying a new alarm rule ID creates a threshold-based alarm rule.
+
+* `metric_name` - (ForceNew, Optional) The name of the metric. For information about how to query metric names, see [Cloud Service Metrics](https://help.aliyun.com/document_detail/163515.html).
+
+-> **NOTE:**  When you create a Prometheus alert rule for Enterprise Cloud Monitoring, this parameter specifies the metric store name. For information about how to obtain the metric store name, see [DescribeHybridMonitorNamespaceList](https://help.aliyun.com/document_detail/428880.html).
+
+* `namespace` - (ForceNew, Optional) The namespace of the cloud service metric data. For information about how to query the namespace of a cloud service, see [Cloud Service Metrics](https://help.aliyun.com/document_detail/163515.html).
+
+-> **NOTE:**  When you create a Prometheus alert rule for Enterprise Cloud Monitoring, this parameter must be set to `acs_prometheus`.
+
+* `rule_name` - (ForceNew, Optional) Alert rule name.
+
+You can enter a new alert rule name or use an existing alert rule name in CloudMonitor. For information about how to query alert rule names, see [DescribeMetricRuleList](https://help.aliyun.com/document_detail/114941.html).
+
+-> **NOTE:**  Entering a new alert rule name creates a threshold-based alert rule.
+
+* `status` - (ForceNew, Optional) The enabled status of the alarm rule. Valid values:
+  - true: enabled.
+  - false: disabled.
+* `ids` - (Optional, ForceNew, Computed) A list of Metric Alarm Rule IDs. 
+* `enable_details` - (Optional, ForceNew) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional, ForceNew) File name where to save data source results (after running `terraform plan`).
+
 
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
-
-* `rules` - A list of Hybrid Double Writes. Each element contains the following attributes:
-  * `id` - The ID of the alert rule.
-  * `contact_groups` - The alert contact group.
-  * `dimensions` - The dimensions of the alert rule.
-  * `effective_interval` - The time period during which the alert rule is effective.
-  * `email_subject` - The subject of the alert notification email.
-  * `metric_name` - The name of the metric.
-  * `namespace` - The namespace of the cloud service.
-  * `no_data_policy` - The method that is used to handle alerts when no monitoring data is found.
-  * `no_effective_interval` - The time period during which the alert rule is ineffective.
-  * `period` - The statistical period.
-  * `resources` - The resources that are associated with the alert rule.
-  * `rule_name` - The name of the alert rule.
-  * `silence_time` - The mute period during which new alert notifications are not sent even if the trigger conditions are met.
-  * `source_type` - The type of the alert rule.
-  * `status` - Indicates whether the alert rule is enabled.
-  * `webhook` - The callback URL.
-  * `composite_expression` - The trigger conditions for multiple metrics.
-    * `times` - The number of consecutive triggers.
-    * `expression_raw` - The trigger conditions that are created by using expressions.
-    * `expression_list_join` - The relationship between the trigger conditions for multiple metrics.
-    * `level` - The alert level.
-    * `expression_list` - The trigger conditions that are created in standard mode.
-      * `metric_name` - The metric that is used to monitor the cloud service.
-      * `comparison_operator` - The operator that is used to compare the metric value with the threshold.
-      * `period` - The aggregation period of the metric.
-      * `statistics` - The statistical method of the metric.
-      * `threshold` - The alert threshold.
-  * `escalations` - The conditions for triggering different levels of alerts.
-    * `critical` - The conditions for triggering Critical-level alerts.
-      * `comparison_operator` - The comparison operator that is used to compare the metric value with the threshold.
-      * `times` - The consecutive number of times for which the metric value meets the alert condition before a Critical-level alert is triggered.
-      * `pre_condition` - The additional conditions for triggering Critical-level alerts.
-      * `statistics` - The statistical methods for Critical-level alerts.
-      * `threshold` - The threshold for Critical-level alerts.
-    * `info` - The conditions for triggering Info-level alerts.
-      * `comparison_operator` - The comparison operator that is used to compare the metric value with the threshold.
-      * `times` - The consecutive number of times for which the metric value meets the alert condition before a Info-level alert is triggered.
-      * `pre_condition` - The additional conditions for triggering Info-level alerts.
-      * `statistics` - The statistical methods for Info-level alerts.
-      * `threshold` - The threshold for Info-level alerts.
-    * `warn` - The conditions for triggering Warn-level alerts.
-      * `comparison_operator` - The comparison operator that is used to compare the metric value with the threshold.
-      * `times` - The consecutive number of times for which the metric value meets the alert condition before a Warn-level alert is triggered.
-      * `pre_condition` - The additional conditions for triggering Warn-level alerts.
-      * `statistics` - The statistical methods for Warn-level alerts.
-      * `threshold` - The threshold for Warn-level alerts. 
-  * `labels` - The tags of the alert rule.
-    * `value` - The tag value of the alert rule.
-    * `key` - The tag key of the alert rule.
-  * `prometheus` - The Prometheus alerts.
-    * `prom_ql` - The PromQL query statement.
-    * `times` - The number of consecutive triggers.
-    * `level` - The alert level.
-    * `annotations` - The annotations of the Prometheus alert rule.
-      * `value` - The value of the annotation.
-      * `key` - The subject of the alert notificaThe key of the annotation.
+* `ids` - A list of Metric Alarm Rule IDs.
+* `rules` - A list of Metric Alarm Rule Entries. Each element contains the following attributes:
+    * `composite_expression` - Alert condition for multiple metrics.
+        * `expression_list` - A list of alert conditions created using standard expressions.
+            * `comparison_operator` - Threshold comparison operator.
+            * `metric_name` - The name of the cloud service metric.
+            * `period` - Aggregation period of the metric.
+            * `statistics` - Statistical method of the metric.
+            * `threshold` - Alert threshold.
+        * `expression_list_join` - The logical relationship between multiple metric-based alert conditions.
+        * `expression_raw` - The alert condition created by an expression.
+        * `level` - The alert severity level.
+        * `times` - Number of consecutive times the alert condition must be met before an alert notification is sent.
+    * `contact_groups` - Alarm contact groups.
+    * `dimensions` - The monitoring dimensions for the specified resource.
+    * `effective_interval` - The time range during which the alert rule is effective.
+    * `email_subject` - Subject of alert emails.
+    * `escalations` - The trigger conditions for alert levels.
+        * `critical` - The trigger condition for Critical-level alerts.
+            * `comparison_operator` - The comparison operator for the Critical-level threshold.
+            * `pre_condition` - The precondition for triggering a Critical-level alarm.
+            * `statistics` - Statistical method for Critical-level alerts.
+            * `threshold` - Threshold for Critical-level alerts.
+            * `times` - The number of consecutive occurrences required to trigger a Critical-level alarm.
+        * `info` - Trigger conditions for Info-level alerts.
+            * `comparison_operator` - Comparison operator for Info-level thresholds.
+            * `pre_condition` - Precondition for triggering an Info-level alert.
+            * `statistics` - Statistical method used for Info-level alerts.
+            * `threshold` - Threshold value for Info-level alerts.
+            * `times` - Number of consecutive occurrences required to trigger an Info-level alert.
+        * `warn` - Trigger condition for Warn-level alerts.
+            * `comparison_operator` - Comparison operator for the Warn-level threshold.
+            * `pre_condition` - Precondition for triggering a Warn-level alert.
+            * `statistics` - Statistical method for Warn-level alerts.
+            * `threshold` - Threshold for Warn-level alerts.
+            * `times` - Number of consecutive occurrences required to trigger a Warn-level alert.
+    * `labels` - When a metric meets the alert condition and an alert is triggered, the labels are written to the metric and displayed in the alert notification.
+        * `key` - The tag key.
+        * `value` - Label value.
+    * `metric_alarm_rule_id` - The ID of the alarm rule.
+    * `metric_name` - The name of the metric.
+    * `namespace` - The namespace of the cloud service metric data.
+    * `no_data_policy` - The policy to apply when no monitoring data is available.
+    * `no_effective_interval` - The time range during which the alarm rule is inactive.
+    * `period` - The statistical period of the metric.
+    * `prometheus` - Prometheus alert.
+        * `annotations` - When a Prometheus alert is triggered, the key-value pairs of annotations are rendered to help you better understand the metric or alert rule.
+            * `key` - The key of the annotation.
+            * `value` - The value of the annotation.
+        * `level` - Alert severity level.
+        * `prom_ql` - The PromQL query statement.
+        * `times` - The number of times the alert condition must be met before an alert notification is sent.
+    * `resources` - Resource information, for example: `[{"instanceId":"i-uf6j91r34rnwawoo****"}]`, `[{"userId":"100931896542****"}]`.
+    * `rule_name` - Alert rule name.
+    * `send_ok` - Specifies whether to send recovery notifications.
+    * `silence_time` - Channel silence period.
+    * `source_type` - The type of the alarm rule.
+    * `status` - The enabled status of the alarm rule.
+    * `webhook` - The URL address specified for callback when an alert is triggered.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/cloud_monitor_service_metric_alarm_rule.html.markdown
+++ b/website/docs/r/cloud_monitor_service_metric_alarm_rule.html.markdown
@@ -1,0 +1,295 @@
+---
+subcategory: "Cloud Monitor Service"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cloud_monitor_service_metric_alarm_rule"
+description: |-
+  Provides a Alicloud Cloud Monitor Service Metric Alarm Rule resource.
+---
+
+# alicloud_cloud_monitor_service_metric_alarm_rule
+
+Provides a Cloud Monitor Service Metric Alarm Rule resource.
+
+Describes the time-series metric alarm rule configured by the user.
+
+For information about Cloud Monitor Service Metric Alarm Rule and how to use it, see [What is Metric Alarm Rule](https://next.api.alibabacloud.com/document/Cms/2019-01-01/PutResourceMetricRule).
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_cloud_monitor_service_metric_alarm_rule" "default" {
+  status               = true
+  send_ok              = true
+  contact_groups       = "云账号报警联系人"
+  silence_time         = "86400"
+  metric_alarm_rule_id = "SystemDefault_acs_drds_IOPSUsageOfDo"
+  period               = "60"
+  effective_interval   = "00:00-23:59 +0800 dayofweek 1,2,3,4,5,6,7"
+  no_data_policy       = "KEEP_LAST_STATE"
+  namespace            = "acs_drds"
+  metric_name          = "IOPSUsageOfDN"
+  escalations {
+    critical {
+      comparison_operator = "GreaterThanThreshold"
+      times               = "5"
+      statistics          = "Average"
+      threshold           = "80"
+    }
+  }
+  resources = jsonencode([{ resource = "_ALL" }])
+  rule_name = "SystemDefault_acs_drds_IOPSUsageOfDN"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `composite_expression` - (Optional, Set) Alert condition for multiple metrics.
+
+-> **NOTE:**  Single-metric and multi-metric conditions are mutually exclusive and cannot be configured simultaneously.
+ See [`composite_expression`](#composite_expression) below.
+* `contact_groups` - (Required, ForceNew) Alarm contact groups. Alarm notifications are sent to the contacts in these groups.
+
+-> **NOTE:**  An alarm contact group is a collection of one or more alarm contacts. For information about how to create alarm contacts and alarm contact groups, see [PutContact](https://help.aliyun.com/document_detail/114923.html) and [PutContactGroup](https://help.aliyun.com/document_detail/114929.html).
+
+* `effective_interval` - (Optional) The time range during which the alert rule is effective.
+* `email_subject` - (Optional) Subject of alert emails.
+* `escalations` - (Optional, Set) The trigger conditions for alert levels. See [`escalations`](#escalations) below.
+* `interval` - (Optional) The trigger interval of the alarm rule. Unit: seconds.
+
+-> **NOTE:** For information about how to query the statistical period of a metric, see [Cloud Service Metrics](https://help.aliyun.com/document_detail/163515.html).
+
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `labels` - (Optional, Set) When a metric meets the alert condition and an alert is triggered, the labels are written to the metric and displayed in the alert notification.
+
+-> **NOTE:**  This feature is equivalent to the Label in Prometheus alerts.
+ See [`labels`](#labels) below.
+* `metric_alarm_rule_id` - (Required, ForceNew) The ID of the alarm rule.
+
+You can specify a new alarm rule ID or use an existing alarm rule ID from CloudMonitor. For information about how to query alarm rule IDs, see [DescribeMetricRuleList](https://help.aliyun.com/document_detail/114941.html).
+
+-> **NOTE:**  Specifying a new alarm rule ID creates a threshold-based alarm rule.
+
+* `metric_name` - (Required, ForceNew) The name of the metric. For information about how to query metric names, see [Cloud Service Metrics](https://help.aliyun.com/document_detail/163515.html).
+
+-> **NOTE:**  When you create a Prometheus alert rule for Enterprise Cloud Monitoring, this parameter specifies the metric store name. For information about how to obtain the metric store name, see [DescribeHybridMonitorNamespaceList](https://help.aliyun.com/document_detail/428880.html).
+
+* `namespace` - (Required, ForceNew) The namespace of the cloud service metric data. For information about how to query the namespace of a cloud service, see [Cloud Service Metrics](https://help.aliyun.com/document_detail/163515.html).
+
+-> **NOTE:**  When you create a Prometheus alert rule for Enterprise Cloud Monitoring, this parameter must be set to `acs_prometheus`.
+
+* `no_data_policy` - (Optional, Computed) The policy to apply when no monitoring data is available. Valid values:
+  - KEEP_LAST_STATE (default): No action is taken.
+  - INSUFFICIENT_DATA: The alert status is set to "Insufficient Data."
+  - OK: The alert status is set to "OK."
+* `no_effective_interval` - (Optional) The time range during which the alarm rule is inactive.
+* `period` - (Optional) The statistical period of the metric. Unit: seconds. By default, this is the original reporting period of the metric.
+
+-> **NOTE:**  For information about how to query the statistical period of a metric, see [Cloud Service Metrics](https://help.aliyun.com/document_detail/163515.html).
+
+* `prometheus` - (Optional, Set) Prometheus alert.
+
+-> **NOTE:**  You must specify this parameter only when you create a Prometheus alert rule for Enterprise Cloud Monitor.
+ See [`prometheus`](#prometheus) below.
+* `resources` - (Required) Resource information, for example: `[{"instanceId":"i-uf6j91r34rnwawoo****"}]`, `[{"userId":"100931896542****"}]`.
+For dimensions supported in resource information, see [Cloud Service Metrics](https://help.aliyun.com/document_detail/163515.html).
+* `rule_name` - (Required, ForceNew) Alert rule name.
+
+You can enter a new alert rule name or use an existing alert rule name in CloudMonitor. For information about how to query alert rule names, see [DescribeMetricRuleList](https://help.aliyun.com/document_detail/114941.html).
+
+-> **NOTE:**  Entering a new alert rule name creates a threshold-based alert rule.
+
+* `send_ok` - (Optional, Computed) Specifies whether to send recovery notifications.
+* `silence_time` - (Optional) Channel silence period. Unit: seconds. Default value: 86400.
+
+-> **NOTE:**  The channel silence period specifies how long to wait before resending an alarm notification if the alarm condition has not returned to normal after the initial alarm.
+
+* `status` - (Optional, Computed) The enabled status of the alarm rule. Valid values:
+  - true: enabled.
+  - false: disabled.
+* `webhook` - (Optional) The URL address specified for callback when an alert is triggered. A POST request is sent to this URL.
+
+### `composite_expression`
+
+The composite_expression supports the following:
+* `expression_list` - (Optional, Set) A list of alert conditions created using standard expressions. See [`expression_list`](#composite_expression-expression_list) below.
+* `expression_list_join` - (Optional) The logical relationship between multiple metric-based alert conditions. Valid values:
+  - `&&`: An alert is triggered only when all metrics meet their respective alert conditions. That is, an alert is triggered only when every expression in ExpressionList evaluates to `true`.
+  - `||`: An alert is triggered as soon as any one metric meets its alert condition.
+* `expression_raw` - (Optional) The alert condition created by an expression. This includes, but is not limited to, the following scenarios:
+  - Configure an alert blacklist for specific resources. For example: `$instanceId != 'i-io8kfvcpp7x5****' && $Average > 50` means that even if the `Average` metric of instance `i-io8kfvcpp7x5****` in the alert rule exceeds 50, no alert will be triggered.
+  - Set a special alert threshold for a specified instance in the rule. For example: `$Average > ($instanceId == 'i-io8kfvcpp7x5****' ? 80 : 50)` means that an alert is triggered only when the `Average` metric of instance `i-io8kfvcpp7x5****` exceeds 80, while for other instances, an alert is triggered when their `Average` exceeds 50.
+  - Limit the number of instances exceeding the threshold in the rule. For example: `count($Average > 20) > 3` means that an alert is triggered only when more than three instances in the alert rule have an `Average` metric greater than 20.
+* `level` - (Optional) The alert severity level. Valid values:
+  - CRITICAL: Critical.
+  - WARN: Warning.
+  - INFO: Information.
+* `times` - (Optional, Int) Number of consecutive times the alert condition must be met before an alert notification is sent.
+
+### `composite_expression-expression_list`
+
+The composite_expression-expression_list supports the following:
+* `comparison_operator` - (Optional) Threshold comparison operator. Valid values:
+  - GreaterThanOrEqualToThreshold: greater than or equal to
+  - GreaterThanThreshold: greater than
+  - LessThanOrEqualToThreshold: less than or equal to
+  - LessThanThreshold: less than
+  - NotEqualToThreshold: not equal to
+  - GreaterThanYesterday: higher than the same time yesterday
+  - LessThanYesterday: lower than the same time yesterday
+  - GreaterThanLastWeek: higher than the same time last week
+  - LessThanLastWeek: lower than the same time last week
+  - GreaterThanLastPeriod: higher than the previous period
+  - LessThanLastPeriod: lower than the previous period
+* `metric_name` - (Optional) The name of the cloud service metric.
+* `period` - (Optional, Int) Aggregation period of the metric.
+Unit: seconds.
+* `statistics` - (Optional) Statistical method of the metric. Valid values:
+  - $Maximum: maximum value.
+  - $Minimum: minimum value.
+  - $Average: average value.
+  - $Availability: availability rate (typically used for site monitoring).
+
+-> **NOTE:**  `$` is the unified prefix symbol for metrics. For supported cloud services, see [Cloud Service Metrics](https://help.aliyun.com/document_detail/163515.html).
+
+* `threshold` - (Optional) Alert threshold.
+
+### `escalations`
+
+The escalations supports the following:
+* `critical` - (Optional, Set) The trigger condition for Critical-level alerts. See [`critical`](#escalations-critical) below.
+* `info` - (Optional, Set) Trigger conditions for Info-level alerts. See [`info`](#escalations-info) below.
+* `warn` - (Optional, Set) Trigger condition for Warn-level alerts.   See [`warn`](#escalations-warn) below.
+
+### `escalations-critical`
+
+The escalations-critical supports the following:
+* `comparison_operator` - (Optional) The comparison operator for the Critical-level threshold. Valid values:
+  - GreaterThanOrEqualToThreshold: greater than or equal to
+  - GreaterThanThreshold: greater than
+  - LessThanOrEqualToThreshold: less than or equal to
+  - LessThanThreshold: less than
+  - NotEqualToThreshold: not equal to
+  - GreaterThanYesterday: increased compared to the same time yesterday
+  - LessThanYesterday: decreased compared to the same time yesterday
+  - GreaterThanLastWeek: increased compared to the same time last week
+  - LessThanLastWeek: decreased compared to the same time last week
+  - GreaterThanLastPeriod: increased compared to the previous period
+  - LessThanLastPeriod: decreased compared to the previous period
+* `statistics` - (Optional) Statistical method for Critical-level alerts.
+* `threshold` - (Optional) Threshold for Critical-level alerts.
+* `times` - (Optional, Int) The number of consecutive occurrences required to trigger a Critical-level alarm. An alarm is triggered only when the metric exceeds the threshold for this specified number of consecutive times.
+
+### `escalations-info`
+
+The escalations-info supports the following:
+* `comparison_operator` - (Optional) Comparison operator for Info-level thresholds. Valid values:
+  - GreaterThanOrEqualToThreshold: Greater than or equal to
+  - GreaterThanThreshold: Greater than
+  - LessThanOrEqualToThreshold: Less than or equal to
+  - LessThanThreshold: Less than
+  - NotEqualToThreshold: Not equal to
+  - GreaterThanYesterday: Increased compared to the same time yesterday
+  - LessThanYesterday: Decreased compared to the same time yesterday
+  - GreaterThanLastWeek: Increased compared to the same time last week
+  - LessThanLastWeek: Decreased compared to the same time last week
+  - GreaterThanLastPeriod: Increased compared to the previous period
+  - LessThanLastPeriod: Decreased compared to the previous period
+* `statistics` - (Optional) Statistical method used for Info-level alerts.
+* `threshold` - (Optional) Threshold value for Info-level alerts.
+* `times` - (Optional, Int) Number of consecutive occurrences required to trigger an Info-level alert. The alert is triggered only when the metric exceeds the threshold for this specified number of consecutive times.
+
+### `escalations-warn`
+
+The escalations-warn supports the following:
+* `comparison_operator` - (Optional) Comparison operator for the Warn-level threshold. Valid values:  
+  - GreaterThanOrEqualToThreshold: greater than or equal to  
+  - GreaterThanThreshold: greater than  
+  - LessThanOrEqualToThreshold: less than or equal to  
+  - LessThanThreshold: less than  
+  - NotEqualToThreshold: not equal to  
+  - GreaterThanYesterday: higher than the same time yesterday  
+  - LessThanYesterday: lower than the same time yesterday  
+  - GreaterThanLastWeek: higher than the same time last week  
+  - LessThanLastWeek: lower than the same time last week  
+  - GreaterThanLastPeriod: higher than the previous period  
+  - LessThanLastPeriod: lower than the previous period  
+* `statistics` - (Optional) Statistical method for Warn-level alerts.
+* `threshold` - (Optional) Threshold for Warn-level alerts.
+* `times` - (Optional, Int) Number of consecutive occurrences required to trigger a Warn-level alert. The alert is triggered only if the metric exceeds the threshold for this number of consecutive times.  
+
+### `labels`
+
+The labels supports the following:
+* `key` - (Optional) The tag key.
+* `value` - (Optional) Label value.
+
+-> **NOTE:**  The label value supports template parameters, which are replaced with actual label values.
+
+
+### `prometheus`
+
+The prometheus supports the following:
+* `annotations` - (Optional, Set) When a Prometheus alert is triggered, the key-value pairs of annotations are rendered to help you better understand the metric or alert rule.
+
+-> **NOTE:**  This feature is equivalent to Annotations in Prometheus.
+ See [`annotations`](#prometheus-annotations) below.
+* `level` - (Optional) Alert severity level. Valid values:
+  - CRITICAL: Critical
+  - WARN: Warning
+  - INFO: Information
+* `prom_ql` - (Optional) The PromQL query statement.
+
+-> **NOTE:**  The data retrieved by the PromQL query statement is used as alert data. Include the alert threshold in this statement.
+
+* `times` - (Optional, Int) The number of times the alert condition must be met before an alert notification is sent.
+
+### `prometheus-annotations`
+
+The prometheus-annotations supports the following:
+* `key` - (Optional) The key of the annotation.
+* `value` - (Optional) The value of the annotation.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+* `dimensions` - The monitoring dimensions for the specified resource.
+* `escalations` - The trigger conditions for alert levels.
+  * `critical` - The trigger condition for Critical-level alerts.
+    * `pre_condition` - The precondition for triggering a Critical-level alarm.
+  * `info` - Trigger conditions for Info-level alerts.
+    * `pre_condition` - Precondition for triggering an Info-level alert.
+  * `warn` - Trigger condition for Warn-level alerts.
+    * `pre_condition` - Precondition for triggering a Warn-level alert.
+* `source_type` - The type of the alarm rule.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Metric Alarm Rule.
+* `delete` - (Defaults to 5 mins) Used when delete the Metric Alarm Rule.
+* `update` - (Defaults to 5 mins) Used when update the Metric Alarm Rule.
+
+## Import
+
+Cloud Monitor Service Metric Alarm Rule can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cloud_monitor_service_metric_alarm_rule.example <metric_alarm_rule_id>
+```


### PR DESCRIPTION
## Summary

- Release the new `alicloud_cloud_monitor_service_metric_alarm_rule` resource and rewrite the existing `alicloud_cloud_monitor_service_metric_alarm_rules` data source on top of CMS `DescribeMetricRuleList` / `PutResourceMetricRule` / `PutMetricRuleTargets` / `DeleteMetricRules` / `EnableMetricRules` / `DisableMetricRules` / `DescribeMetricRuleTargets`.
- After confirming with the CMS team (Aone 83358430) that `PutResourceMetricRule` is a full-replace PUT, the `Update` path now sends the complete payload on every call, including the `composite_expression.expression_list` array that the generator template had been dropping. This was the root cause of several Apply-time fields (effective_interval, no_data_policy, email_subject, webhook, ...) being reset to defaults after the second PUT.
- `Read` no longer surfaces the synthetic `Escalations.Critical` rows that CMS injects for PROMETHEUS-style rules, and refreshes `targets` only when `DescribeMetricRuleTargets` returns entries, so resources that never managed targets do not pick up stale rows during import/refresh.
- Schema cleanups: drop `ForceNew` from `composite_expression` / `escalations` (CMS PUT updates them in place), and mark `email_subject` and `targets` as `Computed` alongside `Optional` so the server-side defaults stop showing as plan diffs.
- Data source bug fixes: stop forcing `metric_alarm_rule_id` / `metric_name` / `namespace` / `rule_name` / `status` defaults into `DescribeMetricRuleList`, replace the residual JSONPath key when filtering by ids, and switch the test fixture `status` filter to a bool literal so the data source schema validation passes.

## Test plan

- [x] Remote ACC: 8 resource cases (`TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12863..12870`) all pass
- [x] Remote ACC: data source case (`TestAccAlicloudCloudMonitorServiceMetricAlarmRuleDataSource`) passes

```
=== RUN   TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12863
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12863 (10.34s)

=== RUN   TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12864
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12864 (9.21s)

=== RUN   TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12865
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12865 (8.74s)

=== RUN   TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12866
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12866 (16.41s)

=== RUN   TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12867
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12867 (10.85s)

=== RUN   TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12868
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12868 (8.79s)

=== RUN   TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12869
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12869 (12.13s)

=== RUN   TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12870
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12870 (9.42s)

=== RUN   TestAccAlicloudCloudMonitorServiceMetricAlarmRuleDataSource
--- PASS: TestAccAlicloudCloudMonitorServiceMetricAlarmRuleDataSource (147.32s)
```