### PR TITLE
provider: widen configuration_source length limit to 1024

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -117,7 +117,7 @@ func Provider() terraform.ResourceProvider {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  descriptions["configuration_source"],
-				ValidateFunc: validation.StringLenBetween(0, 128),
+				ValidateFunc: validation.StringLenBetween(0, 1024),
 				DefaultFunc:  schema.EnvDefaultFunc("TF_APPEND_USER_AGENT", ""),
 			},
 			"protocol": {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -352,7 +352,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 * `skip_region_validation` - (Optional, Available since v1.52.0) Skip static validation of region ID. Used by users of alternative AlibabaCloud-like APIs or users w/ access to regions that are not public (yet).
 
 * `configuration_source` - (Optional, Available since v1.56.0) Use a string to mark a configuration file source, like `terraform-alicloud-modules/terraform-alicloud-ecs-instance` or `terraform-provider-alicloud/examples/vpc`.
-The length should not more than 128(Before 1.207.2, it should not more than 64). Since the version 1.145.0, it supports to be set by environment variable `TF_APPEND_USER_AGENT`. See `Custom User-Agent Information`.
+The length should not more than 1024(Before 1.283.0, it should not more than 128. Before 1.207.2, it should not more than 64). Since the version 1.145.0, it supports to be set by environment variable `TF_APPEND_USER_AGENT`. See `Custom User-Agent Information`.
 
 * `protocol` - (Optional, Available since v1.72.0) The Protocol of used by API request. Valid values: `HTTP` and `HTTPS`. Default to `HTTPS`. 
 


### PR DESCRIPTION
### Motivation

`configuration_source` (default sourced from `TF_APPEND_USER_AGENT`) is validated as `StringLenBetween(0, 128)`. Automation platforms that pass through the caller UserAgent (`iacservice/<jobId>` + caller UA) easily exceed 128 chars, which fails provider init and breaks `terraform plan`. The POP gateway accepts far longer signed values (~128KB), so the only bottleneck is this hard 128 cap.

### Change

Raise `configuration_source` ValidateFunc upper bound from 128 to 1024. Default behavior unchanged; values under 128 unaffected.

Aone: 83342476