### PR TITLE
docs: fix broken DescribeInstance link in alicloud_wafv3_address_book{,s}

### DIFF
--- a/website/docs/d/wafv3_address_books.html.markdown
+++ b/website/docs/d/wafv3_address_books.html.markdown
@@ -51,7 +51,7 @@ output "alicloud_wafv3_address_book_example_id" {
 The following arguments are supported:
 * `instance_id` - (Required) The ID of the WAF instance.
 
--> **NOTE:**  You can call [DescribeInstance](~~ 433756 ~~) to view the ID of the current WAF instance.
+-> **NOTE:**  You can call [DescribeInstance](https://next.api.alibabacloud.com/document/waf-openapi/2021-10-01/DescribeInstance) to view the ID of the current WAF instance.
 
 * `ids` - (Optional, Computed) A list of Address Book IDs. The value is formulated as `<instance_id>:<address_book_id>`.
 * `name_regex` - (Optional) A regex string to filter results by Address Book name.

--- a/website/docs/r/wafv3_address_book.html.markdown
+++ b/website/docs/r/wafv3_address_book.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `description` - (Optional) The description of the Address Book.
 * `instance_id` - (Required, ForceNew) The ID of the WAF instance.
 
--> **NOTE:**  You can call [DescribeInstance](~~ 433756 ~~) to view the ID of the current WAF instance.
+-> **NOTE:**  You can call [DescribeInstance](https://next.api.alibabacloud.com/document/waf-openapi/2021-10-01/DescribeInstance) to view the ID of the current WAF instance.
 
 
 ## Attributes Reference


### PR DESCRIPTION
## Summary

`website/docs/r/wafv3_address_book.html.markdown` and `website/docs/d/wafv3_address_books.html.markdown` contain an unrendered Aliyun doc-id placeholder `[DescribeInstance](~~ 433756 ~~)` left over from generation. Renders as literal `~~ 433756 ~~` on the published site instead of a working link.

Replaced with the OpenAPI Explorer URL to match the style of the "What is Address Book" link at the top of each page.

## Test plan

- [x] grep confirms no remaining `~~ 433756 ~~` occurrences in the two files
- [x] Other `~~XXX~~` placeholders elsewhere in the repo are left alone — scope is the WAFV3 Address Book docs only