### PR TITLE
resource/alicloud_wafv3_defense_rule: Added the field gmt_modified; New Data Source: alicloud_wafv3_defense_rules; data-source/alicloud_wafv3_domains: Added the field domain_id

### DIFF
--- a/alicloud/data_source_alicloud_wafv3_defense_rules.go
+++ b/alicloud/data_source_alicloud_wafv3_defense_rules.go
@@ -1,0 +1,971 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudWafv3DefenseRules() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudWafv3DefenseRuleRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"defense_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"query": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rule_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"bypass_tags": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"gray_config": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"gray_target": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"gray_rate": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"gray_sub_key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"rule_action": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"mode": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"bypass_regular_rules": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"cn_regions": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"time_config": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"time_zone": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"time_periods": {
+													Type:     schema.TypeSet,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"start": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"end": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"time_scope": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"week_time_periods": {
+													Type:     schema.TypeSet,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"day_periods": {
+																Type:     schema.TypeSet,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"start": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																		"end": {
+																			Type:     schema.TypeInt,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+															"day": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"bypass_regular_types": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"ua": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"remote_addr": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"conditions": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"op_value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"values": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"sub_key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"url": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"abroad_regions": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"rate_limit": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"status": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"ratio": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"count": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"code": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"target": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"ttl": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"interval": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"threshold": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"sub_key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"cc_effect": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"throttle_threhold": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"throttle_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"auto_update": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"cc_status": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"account_identifiers": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"position": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"priority": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"decode_type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"sub_key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"gray_status": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"waf_base_config": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"rule_type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"rule_detail": {
+													Type:     schema.TypeSet,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"rule_id": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"rule_action": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"rule_status": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"rule_batch_operation_config": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"protocol": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"codec_list": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"defense_origin": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"defense_scene": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"defense_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gmt_modified": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"rule_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"rule_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"rule_status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"template_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudWafv3DefenseRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeDefenseRules"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	request["InstanceId"] = d.Get("instance_id")
+	if v, ok := d.GetOk("defense_type"); ok {
+		request["DefenseType"] = v
+	}
+	if v, ok := d.GetOk("query"); ok {
+		request["Query"] = v
+	}
+	if v, ok := d.GetOk("rule_type"); ok {
+		request["RuleType"] = v
+	}
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	request["PageSize"] = PageSizeLarge
+	request["PageNumber"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("waf-openapi", "2021-10-01", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.Rules[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(request["InstanceId"], ":", item["DefenseType"], ":", item["RuleId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(request["InstanceId"], ":", objectRaw["DefenseType"], ":", objectRaw["RuleId"])
+
+		mapping["defense_origin"] = objectRaw["DefenseOrigin"]
+		mapping["defense_scene"] = objectRaw["DefenseScene"]
+		mapping["gmt_modified"] = objectRaw["GmtModified"]
+		mapping["resource"] = objectRaw["Resource"]
+		mapping["rule_name"] = objectRaw["RuleName"]
+		mapping["rule_status"] = objectRaw["Status"]
+		mapping["template_id"] = objectRaw["TemplateId"]
+		mapping["defense_type"] = objectRaw["DefenseType"]
+		mapping["rule_id"] = objectRaw["RuleId"]
+
+		configMaps := make([]map[string]interface{}, 0)
+		configMap := make(map[string]interface{})
+		configRaw := make(map[string]interface{})
+		if objectRaw["Config"] != nil {
+			configRaw = convertJsonStringToObject(objectRaw["Config"])
+			if len(configRaw) > 0 {
+				configMap["abroad_regions"] = configRaw["abroadRegionList"]
+				configMap["auto_update"] = formatBool(configRaw["autoUpdate"])
+				configMap["cc_effect"] = configRaw["effect"]
+				configMap["cc_status"] = formatInt(configRaw["ccStatus"])
+				configMap["cn_regions"] = configRaw["cnRegionList"]
+				configMap["gray_status"] = formatInt(configRaw["grayStatus"])
+				configMap["mode"] = formatInt(configRaw["mode"])
+				configMap["protocol"] = configRaw["protocol"]
+				configMap["rule_action"] = configRaw["action"]
+				configMap["throttle_threhold"] = formatInt(configRaw["threshold"])
+				configMap["throttle_type"] = configRaw["type"]
+				configMap["ua"] = configRaw["ua"]
+				configMap["url"] = configRaw["url"]
+
+				accountIdentifiersRaw := configRaw["accountIdentifiers"]
+				accountIdentifiersMaps := make([]map[string]interface{}, 0)
+				if accountIdentifiersRaw != nil {
+					for _, accountIdentifiersChildRaw := range convertToInterfaceArray(accountIdentifiersRaw) {
+						accountIdentifiersMap := make(map[string]interface{})
+						accountIdentifiersChildRaw := accountIdentifiersChildRaw.(map[string]interface{})
+						accountIdentifiersMap["decode_type"] = accountIdentifiersChildRaw["decodeType"]
+						accountIdentifiersMap["key"] = accountIdentifiersChildRaw["key"]
+						accountIdentifiersMap["position"] = accountIdentifiersChildRaw["position"]
+						accountIdentifiersMap["priority"] = formatInt(accountIdentifiersChildRaw["priority"])
+						accountIdentifiersMap["sub_key"] = accountIdentifiersChildRaw["subKey"]
+
+						accountIdentifiersMaps = append(accountIdentifiersMaps, accountIdentifiersMap)
+					}
+				}
+				configMap["account_identifiers"] = accountIdentifiersMaps
+				regularRulesRaw := make([]interface{}, 0)
+				if configRaw["regularRules"] != nil {
+					regularRulesRaw = convertToInterfaceArray(configRaw["regularRules"])
+				}
+
+				configMap["bypass_regular_rules"] = regularRulesRaw
+				regularTypesRaw := make([]interface{}, 0)
+				if configRaw["regularTypes"] != nil {
+					regularTypesRaw = convertToInterfaceArray(configRaw["regularTypes"])
+				}
+
+				configMap["bypass_regular_types"] = regularTypesRaw
+				tagsRaw := make([]interface{}, 0)
+				if configRaw["tags"] != nil {
+					tagsRaw = convertToInterfaceArray(configRaw["tags"])
+				}
+
+				configMap["bypass_tags"] = tagsRaw
+				codecListRaw := make([]interface{}, 0)
+				if configRaw["codecList"] != nil {
+					codecListRaw = convertToInterfaceArray(configRaw["codecList"])
+				}
+
+				configMap["codec_list"] = codecListRaw
+				conditionsRaw := configRaw["conditions"]
+				conditionsMaps := make([]map[string]interface{}, 0)
+				if conditionsRaw != nil {
+					for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+						conditionsMap := make(map[string]interface{})
+						conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+						conditionsMap["key"] = conditionsChildRaw["key"]
+						conditionsMap["op_value"] = conditionsChildRaw["opValue"]
+						conditionsMap["sub_key"] = conditionsChildRaw["subKey"]
+						conditionsMap["values"] = conditionsChildRaw["values"]
+
+						conditionsMaps = append(conditionsMaps, conditionsMap)
+					}
+				}
+				configMap["conditions"] = conditionsMaps
+				grayConfigMaps := make([]map[string]interface{}, 0)
+				grayConfigMap := make(map[string]interface{})
+				grayConfigRaw := make(map[string]interface{})
+				if configRaw["grayConfig"] != nil {
+					grayConfigRaw = configRaw["grayConfig"].(map[string]interface{})
+				}
+				if len(grayConfigRaw) > 0 {
+					grayConfigMap["gray_rate"] = formatInt(grayConfigRaw["grayRate"])
+					grayConfigMap["gray_sub_key"] = grayConfigRaw["graySubKey"]
+					grayConfigMap["gray_target"] = grayConfigRaw["grayTarget"]
+
+					grayConfigMaps = append(grayConfigMaps, grayConfigMap)
+				}
+				configMap["gray_config"] = grayConfigMaps
+				rateLimitMaps := make([]map[string]interface{}, 0)
+				rateLimitMap := make(map[string]interface{})
+				ratelimitRaw := make(map[string]interface{})
+				if configRaw["ratelimit"] != nil {
+					ratelimitRaw = configRaw["ratelimit"].(map[string]interface{})
+				}
+				if len(ratelimitRaw) > 0 {
+					rateLimitMap["interval"] = formatInt(ratelimitRaw["interval"])
+					rateLimitMap["sub_key"] = ratelimitRaw["subKey"]
+					rateLimitMap["target"] = ratelimitRaw["target"]
+					rateLimitMap["threshold"] = formatInt(ratelimitRaw["threshold"])
+					rateLimitMap["ttl"] = formatInt(ratelimitRaw["ttl"])
+
+					statusMaps := make([]map[string]interface{}, 0)
+					statusMap := make(map[string]interface{})
+					statusRaw := make(map[string]interface{})
+					if ratelimitRaw["status"] != nil {
+						statusRaw = ratelimitRaw["status"].(map[string]interface{})
+					}
+					if len(statusRaw) > 0 {
+						statusMap["code"] = formatInt(statusRaw["code"])
+						statusMap["count"] = formatInt(statusRaw["count"])
+						statusMap["ratio"] = formatInt(statusRaw["ratio"])
+
+						statusMaps = append(statusMaps, statusMap)
+					}
+					rateLimitMap["status"] = statusMaps
+					rateLimitMaps = append(rateLimitMaps, rateLimitMap)
+				}
+				configMap["rate_limit"] = rateLimitMaps
+				remoteAddrRaw := make([]interface{}, 0)
+				if configRaw["remoteAddr"] != nil {
+					remoteAddrRaw = convertToInterfaceArray(configRaw["remoteAddr"])
+				}
+
+				configMap["remote_addr"] = remoteAddrRaw
+				timeConfigMaps := make([]map[string]interface{}, 0)
+				timeConfigMap := make(map[string]interface{})
+				timeConfigRaw := make(map[string]interface{})
+				if configRaw["timeConfig"] != nil {
+					timeConfigRaw = configRaw["timeConfig"].(map[string]interface{})
+				}
+				if len(timeConfigRaw) > 0 {
+					timeConfigMap["time_scope"] = timeConfigRaw["timeScope"]
+					timeConfigMap["time_zone"] = formatInt(timeConfigRaw["timeZone"])
+
+					timePeriodsRaw := timeConfigRaw["timePeriods"]
+					timePeriodsMaps := make([]map[string]interface{}, 0)
+					if timePeriodsRaw != nil {
+						for _, timePeriodsChildRaw := range convertToInterfaceArray(timePeriodsRaw) {
+							timePeriodsMap := make(map[string]interface{})
+							timePeriodsChildRaw := timePeriodsChildRaw.(map[string]interface{})
+							timePeriodsMap["end"] = formatInt(timePeriodsChildRaw["end"])
+							timePeriodsMap["start"] = formatInt(timePeriodsChildRaw["start"])
+
+							timePeriodsMaps = append(timePeriodsMaps, timePeriodsMap)
+						}
+					}
+					timeConfigMap["time_periods"] = timePeriodsMaps
+					weekTimePeriodsRaw := timeConfigRaw["weekTimePeriods"]
+					weekTimePeriodsMaps := make([]map[string]interface{}, 0)
+					if weekTimePeriodsRaw != nil {
+						for _, weekTimePeriodsChildRaw := range convertToInterfaceArray(weekTimePeriodsRaw) {
+							weekTimePeriodsMap := make(map[string]interface{})
+							weekTimePeriodsChildRaw := weekTimePeriodsChildRaw.(map[string]interface{})
+							weekTimePeriodsMap["day"] = weekTimePeriodsChildRaw["day"]
+
+							dayPeriodsRaw := weekTimePeriodsChildRaw["dayPeriods"]
+							dayPeriodsMaps := make([]map[string]interface{}, 0)
+							if dayPeriodsRaw != nil {
+								for _, dayPeriodsChildRaw := range convertToInterfaceArray(dayPeriodsRaw) {
+									dayPeriodsMap := make(map[string]interface{})
+									dayPeriodsChildRaw := dayPeriodsChildRaw.(map[string]interface{})
+									dayPeriodsMap["end"] = formatInt(dayPeriodsChildRaw["end"])
+									dayPeriodsMap["start"] = formatInt(dayPeriodsChildRaw["start"])
+
+									dayPeriodsMaps = append(dayPeriodsMaps, dayPeriodsMap)
+								}
+							}
+							weekTimePeriodsMap["day_periods"] = dayPeriodsMaps
+							weekTimePeriodsMaps = append(weekTimePeriodsMaps, weekTimePeriodsMap)
+						}
+					}
+					timeConfigMap["week_time_periods"] = weekTimePeriodsMaps
+					timeConfigMaps = append(timeConfigMaps, timeConfigMap)
+				}
+				configMap["time_config"] = timeConfigMaps
+				config1Raw := configRaw["config"]
+				wafBaseConfigMaps := make([]map[string]interface{}, 0)
+				if config1Raw != nil {
+					for _, configChildRaw := range convertToInterfaceArray(config1Raw) {
+						wafBaseConfigMap := make(map[string]interface{})
+						configChildRaw := configChildRaw.(map[string]interface{})
+						wafBaseConfigMap["rule_batch_operation_config"] = configChildRaw["ruleBatchOperationConfig"]
+						wafBaseConfigMap["rule_type"] = configChildRaw["ruleType"]
+
+						ruleDetailRaw := configChildRaw["ruleDetail"]
+						ruleDetailMaps := make([]map[string]interface{}, 0)
+						if ruleDetailRaw != nil {
+							for _, ruleDetailChildRaw := range convertToInterfaceArray(ruleDetailRaw) {
+								ruleDetailMap := make(map[string]interface{})
+								ruleDetailChildRaw := ruleDetailChildRaw.(map[string]interface{})
+								ruleDetailMap["rule_action"] = ruleDetailChildRaw["ruleAction"]
+								if v := ruleDetailChildRaw["ruleId"]; v != nil {
+									ruleDetailMap["rule_id"] = fmt.Sprint(v)
+								}
+								ruleDetailMap["rule_status"] = formatInt(ruleDetailChildRaw["ruleStatus"])
+
+								ruleDetailMaps = append(ruleDetailMaps, ruleDetailMap)
+							}
+						}
+						wafBaseConfigMap["rule_detail"] = ruleDetailMaps
+						wafBaseConfigMaps = append(wafBaseConfigMaps, wafBaseConfigMap)
+					}
+				}
+				configMap["waf_base_config"] = wafBaseConfigMaps
+				configMaps = append(configMaps, configMap)
+			}
+		}
+		mapping["config"] = configMaps
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(request["InstanceId"], ":", objectRaw["DefenseType"], ":", objectRaw["RuleId"])
+		mapping, err = dataSourceAliCloudWafv3DefenseRuleReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("rules", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudWafv3DefenseRuleReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	wafv3ServiceV2 := Wafv3ServiceV2{client}
+	getResp, err := wafv3ServiceV2.DescribeWafv3DefenseRule(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["defense_origin"] = objectRaw["DefenseOrigin"]
+	mapping["defense_scene"] = objectRaw["DefenseScene"]
+	mapping["gmt_modified"] = objectRaw["GmtModified"]
+	mapping["resource"] = objectRaw["Resource"]
+	mapping["rule_name"] = objectRaw["RuleName"]
+	mapping["rule_status"] = objectRaw["Status"]
+	mapping["template_id"] = objectRaw["TemplateId"]
+	mapping["defense_type"] = objectRaw["DefenseType"]
+	mapping["rule_id"] = objectRaw["RuleId"]
+
+	configMaps := make([]map[string]interface{}, 0)
+	configMap := make(map[string]interface{})
+	configRaw := make(map[string]interface{})
+	if objectRaw["Config"] != nil {
+		configRaw = convertJsonStringToObject(objectRaw["Config"])
+		if len(configRaw) > 0 {
+			configMap["abroad_regions"] = configRaw["abroadRegionList"]
+			configMap["auto_update"] = formatBool(configRaw["autoUpdate"])
+			configMap["cc_effect"] = configRaw["effect"]
+			configMap["cc_status"] = formatInt(configRaw["ccStatus"])
+			configMap["cn_regions"] = configRaw["cnRegionList"]
+			configMap["gray_status"] = formatInt(configRaw["grayStatus"])
+			configMap["mode"] = formatInt(configRaw["mode"])
+			configMap["protocol"] = configRaw["protocol"]
+			configMap["rule_action"] = configRaw["action"]
+			configMap["throttle_threhold"] = formatInt(configRaw["threshold"])
+			configMap["throttle_type"] = configRaw["type"]
+			configMap["ua"] = configRaw["ua"]
+			configMap["url"] = configRaw["url"]
+
+			accountIdentifiersRaw := configRaw["accountIdentifiers"]
+			accountIdentifiersMaps := make([]map[string]interface{}, 0)
+			if accountIdentifiersRaw != nil {
+				for _, accountIdentifiersChildRaw := range convertToInterfaceArray(accountIdentifiersRaw) {
+					accountIdentifiersMap := make(map[string]interface{})
+					accountIdentifiersChildRaw := accountIdentifiersChildRaw.(map[string]interface{})
+					accountIdentifiersMap["decode_type"] = accountIdentifiersChildRaw["decodeType"]
+					accountIdentifiersMap["key"] = accountIdentifiersChildRaw["key"]
+					accountIdentifiersMap["position"] = accountIdentifiersChildRaw["position"]
+					accountIdentifiersMap["priority"] = formatInt(accountIdentifiersChildRaw["priority"])
+					accountIdentifiersMap["sub_key"] = accountIdentifiersChildRaw["subKey"]
+
+					accountIdentifiersMaps = append(accountIdentifiersMaps, accountIdentifiersMap)
+				}
+			}
+			configMap["account_identifiers"] = accountIdentifiersMaps
+			regularRulesRaw := make([]interface{}, 0)
+			if configRaw["regularRules"] != nil {
+				regularRulesRaw = convertToInterfaceArray(configRaw["regularRules"])
+			}
+
+			configMap["bypass_regular_rules"] = regularRulesRaw
+			regularTypesRaw := make([]interface{}, 0)
+			if configRaw["regularTypes"] != nil {
+				regularTypesRaw = convertToInterfaceArray(configRaw["regularTypes"])
+			}
+
+			configMap["bypass_regular_types"] = regularTypesRaw
+			tagsRaw := make([]interface{}, 0)
+			if configRaw["tags"] != nil {
+				tagsRaw = convertToInterfaceArray(configRaw["tags"])
+			}
+
+			configMap["bypass_tags"] = tagsRaw
+			codecListRaw := make([]interface{}, 0)
+			if configRaw["codecList"] != nil {
+				codecListRaw = convertToInterfaceArray(configRaw["codecList"])
+			}
+
+			configMap["codec_list"] = codecListRaw
+			conditionsRaw := configRaw["conditions"]
+			conditionsMaps := make([]map[string]interface{}, 0)
+			if conditionsRaw != nil {
+				for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+					conditionsMap := make(map[string]interface{})
+					conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+					conditionsMap["key"] = conditionsChildRaw["key"]
+					conditionsMap["op_value"] = conditionsChildRaw["opValue"]
+					conditionsMap["sub_key"] = conditionsChildRaw["subKey"]
+					conditionsMap["values"] = conditionsChildRaw["values"]
+
+					conditionsMaps = append(conditionsMaps, conditionsMap)
+				}
+			}
+			configMap["conditions"] = conditionsMaps
+			grayConfigMaps := make([]map[string]interface{}, 0)
+			grayConfigMap := make(map[string]interface{})
+			grayConfigRaw := make(map[string]interface{})
+			if configRaw["grayConfig"] != nil {
+				grayConfigRaw = configRaw["grayConfig"].(map[string]interface{})
+			}
+			if len(grayConfigRaw) > 0 {
+				grayConfigMap["gray_rate"] = formatInt(grayConfigRaw["grayRate"])
+				grayConfigMap["gray_sub_key"] = grayConfigRaw["graySubKey"]
+				grayConfigMap["gray_target"] = grayConfigRaw["grayTarget"]
+
+				grayConfigMaps = append(grayConfigMaps, grayConfigMap)
+			}
+			configMap["gray_config"] = grayConfigMaps
+			rateLimitMaps := make([]map[string]interface{}, 0)
+			rateLimitMap := make(map[string]interface{})
+			ratelimitRaw := make(map[string]interface{})
+			if configRaw["ratelimit"] != nil {
+				ratelimitRaw = configRaw["ratelimit"].(map[string]interface{})
+			}
+			if len(ratelimitRaw) > 0 {
+				rateLimitMap["interval"] = formatInt(ratelimitRaw["interval"])
+				rateLimitMap["sub_key"] = ratelimitRaw["subKey"]
+				rateLimitMap["target"] = ratelimitRaw["target"]
+				rateLimitMap["threshold"] = formatInt(ratelimitRaw["threshold"])
+				rateLimitMap["ttl"] = formatInt(ratelimitRaw["ttl"])
+
+				statusMaps := make([]map[string]interface{}, 0)
+				statusMap := make(map[string]interface{})
+				statusRaw := make(map[string]interface{})
+				if ratelimitRaw["status"] != nil {
+					statusRaw = ratelimitRaw["status"].(map[string]interface{})
+				}
+				if len(statusRaw) > 0 {
+					statusMap["code"] = formatInt(statusRaw["code"])
+					statusMap["count"] = formatInt(statusRaw["count"])
+					statusMap["ratio"] = formatInt(statusRaw["ratio"])
+
+					statusMaps = append(statusMaps, statusMap)
+				}
+				rateLimitMap["status"] = statusMaps
+				rateLimitMaps = append(rateLimitMaps, rateLimitMap)
+			}
+			configMap["rate_limit"] = rateLimitMaps
+			remoteAddrRaw := make([]interface{}, 0)
+			if configRaw["remoteAddr"] != nil {
+				remoteAddrRaw = convertToInterfaceArray(configRaw["remoteAddr"])
+			}
+
+			configMap["remote_addr"] = remoteAddrRaw
+			timeConfigMaps := make([]map[string]interface{}, 0)
+			timeConfigMap := make(map[string]interface{})
+			timeConfigRaw := make(map[string]interface{})
+			if configRaw["timeConfig"] != nil {
+				timeConfigRaw = configRaw["timeConfig"].(map[string]interface{})
+			}
+			if len(timeConfigRaw) > 0 {
+				timeConfigMap["time_scope"] = timeConfigRaw["timeScope"]
+				timeConfigMap["time_zone"] = formatInt(timeConfigRaw["timeZone"])
+
+				timePeriodsRaw := timeConfigRaw["timePeriods"]
+				timePeriodsMaps := make([]map[string]interface{}, 0)
+				if timePeriodsRaw != nil {
+					for _, timePeriodsChildRaw := range convertToInterfaceArray(timePeriodsRaw) {
+						timePeriodsMap := make(map[string]interface{})
+						timePeriodsChildRaw := timePeriodsChildRaw.(map[string]interface{})
+						timePeriodsMap["end"] = formatInt(timePeriodsChildRaw["end"])
+						timePeriodsMap["start"] = formatInt(timePeriodsChildRaw["start"])
+
+						timePeriodsMaps = append(timePeriodsMaps, timePeriodsMap)
+					}
+				}
+				timeConfigMap["time_periods"] = timePeriodsMaps
+				weekTimePeriodsRaw := timeConfigRaw["weekTimePeriods"]
+				weekTimePeriodsMaps := make([]map[string]interface{}, 0)
+				if weekTimePeriodsRaw != nil {
+					for _, weekTimePeriodsChildRaw := range convertToInterfaceArray(weekTimePeriodsRaw) {
+						weekTimePeriodsMap := make(map[string]interface{})
+						weekTimePeriodsChildRaw := weekTimePeriodsChildRaw.(map[string]interface{})
+						weekTimePeriodsMap["day"] = weekTimePeriodsChildRaw["day"]
+
+						dayPeriodsRaw := weekTimePeriodsChildRaw["dayPeriods"]
+						dayPeriodsMaps := make([]map[string]interface{}, 0)
+						if dayPeriodsRaw != nil {
+							for _, dayPeriodsChildRaw := range convertToInterfaceArray(dayPeriodsRaw) {
+								dayPeriodsMap := make(map[string]interface{})
+								dayPeriodsChildRaw := dayPeriodsChildRaw.(map[string]interface{})
+								dayPeriodsMap["end"] = formatInt(dayPeriodsChildRaw["end"])
+								dayPeriodsMap["start"] = formatInt(dayPeriodsChildRaw["start"])
+
+								dayPeriodsMaps = append(dayPeriodsMaps, dayPeriodsMap)
+							}
+						}
+						weekTimePeriodsMap["day_periods"] = dayPeriodsMaps
+						weekTimePeriodsMaps = append(weekTimePeriodsMaps, weekTimePeriodsMap)
+					}
+				}
+				timeConfigMap["week_time_periods"] = weekTimePeriodsMaps
+				timeConfigMaps = append(timeConfigMaps, timeConfigMap)
+			}
+			configMap["time_config"] = timeConfigMaps
+			config1Raw := configRaw["config"]
+			wafBaseConfigMaps := make([]map[string]interface{}, 0)
+			if config1Raw != nil {
+				for _, configChildRaw := range convertToInterfaceArray(config1Raw) {
+					wafBaseConfigMap := make(map[string]interface{})
+					configChildRaw := configChildRaw.(map[string]interface{})
+					wafBaseConfigMap["rule_batch_operation_config"] = configChildRaw["ruleBatchOperationConfig"]
+					wafBaseConfigMap["rule_type"] = configChildRaw["ruleType"]
+
+					ruleDetailRaw := configChildRaw["ruleDetail"]
+					ruleDetailMaps := make([]map[string]interface{}, 0)
+					if ruleDetailRaw != nil {
+						for _, ruleDetailChildRaw := range convertToInterfaceArray(ruleDetailRaw) {
+							ruleDetailMap := make(map[string]interface{})
+							ruleDetailChildRaw := ruleDetailChildRaw.(map[string]interface{})
+							ruleDetailMap["rule_action"] = ruleDetailChildRaw["ruleAction"]
+							if v := ruleDetailChildRaw["ruleId"]; v != nil {
+								ruleDetailMap["rule_id"] = fmt.Sprint(v)
+							}
+							ruleDetailMap["rule_status"] = formatInt(ruleDetailChildRaw["ruleStatus"])
+
+							ruleDetailMaps = append(ruleDetailMaps, ruleDetailMap)
+						}
+					}
+					wafBaseConfigMap["rule_detail"] = ruleDetailMaps
+					wafBaseConfigMaps = append(wafBaseConfigMaps, wafBaseConfigMap)
+				}
+			}
+			configMap["waf_base_config"] = wafBaseConfigMaps
+			configMaps = append(configMaps, configMap)
+		}
+	}
+	mapping["config"] = configMaps
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_wafv3_defense_rules_test.go
+++ b/alicloud/data_source_alicloud_wafv3_defense_rules_test.go
@@ -1,0 +1,193 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudWafv3DefenseRuleDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudWafv3DefenseRuleSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_wafv3_defense_rule.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudWafv3DefenseRuleSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_wafv3_defense_rule.default.id}_fake"]`,
+		}),
+	}
+
+	DefenseTypeConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudWafv3DefenseRuleSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_wafv3_defense_rule.default.id}"]`,
+			"defense_type": `"template"`,
+		}),
+		fakeConfig: testAccCheckAlicloudWafv3DefenseRuleSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_wafv3_defense_rule.default.id}_fake"]`,
+			"defense_type": `"resource"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudWafv3DefenseRuleSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_wafv3_defense_rule.default.id}"]`,
+			"defense_type": `"template"`,
+		}),
+		fakeConfig: testAccCheckAlicloudWafv3DefenseRuleSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_wafv3_defense_rule.default.id}_fake"]`,
+			"defense_type": `"resource"`,
+		}),
+	}
+
+	Wafv3DefenseRuleCheckInfo.dataSourceTestCheck(t, rand, idsConf, DefenseTypeConf, allConf)
+}
+
+var existWafv3DefenseRuleMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"rules.#":                "1",
+		"rules.0.defense_origin": CHECKSET,
+		"rules.0.config.#":       CHECKSET,
+		"rules.0.rule_id":        CHECKSET,
+		"rules.0.gmt_modified":   CHECKSET,
+		"rules.0.defense_type":   CHECKSET,
+		"rules.0.defense_scene":  CHECKSET,
+		"rules.0.rule_status":    CHECKSET,
+		"rules.0.template_id":    CHECKSET,
+		"rules.0.rule_name":      CHECKSET,
+	}
+}
+
+var fakeWafv3DefenseRuleMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"rules.#": "0",
+	}
+}
+
+var Wafv3DefenseRuleCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_wafv3_defense_rules.default",
+	existMapFunc: existWafv3DefenseRuleMapFunc,
+	fakeMapFunc:  fakeWafv3DefenseRuleMapFunc,
+}
+
+func testAccCheckAlicloudWafv3DefenseRuleSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccWafv3DefenseRule%d"
+}
+variable "region_id" {
+  default = "cn-hangzhou"
+}
+
+data "alicloud_wafv3_instances" "default" {
+}
+
+resource "alicloud_wafv3_defense_template" "defaultfIoHt5" {
+  status                = "1"
+  description           = "testCreate"
+  instance_id           = data.alicloud_wafv3_instances.default.ids.0
+  defense_template_name = "tf-tpl-${var.name}"
+  template_origin       = "custom"
+  defense_scene         = "custom_acl"
+  template_type         = "user_custom"
+}
+
+resource "alicloud_wafv3_address_book" "default9dtEmt" {
+  description       = "test"
+  instance_id       = data.alicloud_wafv3_instances.default.ids.0
+  address_book_name = "tf-ab-${var.name}"
+  address_list      = ["100.100.100.100/32", "101.101.101.101/32", "102.102.102.102/32"]
+  address_book_type = "ip"
+}
+
+resource "alicloud_wafv3_defense_rule" "default" {
+  defense_origin = "custom"
+  instance_id    = data.alicloud_wafv3_instances.default.ids.0
+  config {
+    rule_action = "block"
+    conditions {
+      op_value = "contain"
+      values   = "abc"
+      key      = "URL"
+    }
+    conditions {
+      op_value = "contain"
+      values   = "abc"
+      key      = "URLPath"
+    }
+    conditions {
+      op_value = "contain"
+      values   = "1.1.1.2"
+      key      = "IP"
+    }
+    conditions {
+      key      = "IP"
+      op_value = "in-list"
+      values   = alicloud_wafv3_address_book.default9dtEmt.address_book_id
+    }
+    cc_status = "0"
+    cc_effect = "service"
+    rate_limit {
+      target    = "remote_addr"
+      interval  = "16"
+      threshold = "204"
+      ttl       = "68"
+      status {
+        code  = "414"
+        count = "333"
+      }
+      sub_key = "testky1"
+    }
+    gray_status = "1"
+    gray_config {
+      gray_target = "remote_addr"
+      gray_rate   = "80"
+    }
+    time_config {
+      time_scope = "period"
+      time_zone  = "8"
+      time_periods {
+        start = "1760174804000"
+        end   = "1760175804000"
+      }
+      time_periods {
+        start = "1760171804000"
+        end   = "1760172804000"
+      }
+      time_periods {
+        start = "1760176804000"
+        end   = "1760177804000"
+      }
+      time_periods {
+        start = "1760178804000"
+        end   = "1760179804000"
+      }
+      time_periods {
+        start = "1760170804000"
+        end   = "1760171804000"
+      }
+    }
+  }
+  defense_scene = "custom_acl"
+  rule_status   = "1"
+  defense_type  = "template"
+  template_id   = alicloud_wafv3_defense_template.defaultfIoHt5.defense_template_id
+  rule_name     = "custom_acl-create"
+}
+
+data "alicloud_wafv3_defense_rules" "default" {
+  instance_id = data.alicloud_wafv3_instances.default.ids.0
+  %s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/data_source_alicloud_wafv3_domains.go
+++ b/alicloud/data_source_alicloud_wafv3_domains.go
@@ -63,6 +63,10 @@ func dataSourceAliCloudWafv3Domains() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"domain_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"resource_manager_resource_group_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -319,6 +323,10 @@ func dataSourceAliCloudWafv3DomainsRead(d *schema.ResourceData, meta interface{}
 		object, err = wafOpenapiService.DescribeWafv3Domain(fmt.Sprint(mapping["id"]))
 		if err != nil {
 			return WrapError(err)
+		}
+
+		if domainId, ok := object["DomainId"]; ok && domainId != nil {
+			mapping["domain_id"] = fmt.Sprint(domainId)
 		}
 
 		if listen, ok := object["Listen"]; ok {

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"alicloud_wafv3_address_books":                        dataSourceAliCloudWafv3AddressBooks(),
+			"alicloud_wafv3_defense_rules":                        dataSourceAliCloudWafv3DefenseRules(),
 			"alicloud_amqp_open_source_accounts":                  dataSourceAliCloudAmqpOpenSourceAccounts(),
 			"alicloud_vpc_ipv6_cidr_blocks":                       dataSourceAliCloudVpcIpv6CidrBlocks(),
 			"alicloud_amqp_open_source_permissions":               dataSourceAliCloudAmqpOpenSourcePermissions(),

--- a/alicloud/resource_alicloud_wafv3_defense_rule.go
+++ b/alicloud/resource_alicloud_wafv3_defense_rule.go
@@ -169,7 +169,7 @@ func resourceAliCloudWafv3DefenseRule() *schema.Resource {
 									"op_value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: StringInSlice([]string{"not-contain", "contain", "none", "ne", "eq", "lt", "gt", "len-lt", "len-eq", "len-gt", "not-match", "match-one", "all-not-match", "all-not-contain", "contain-one", "not-regex", "regex", "all-not-regex", "regex-one", "prefix-match", "suffix-match", "empty", "exists", "inl"}, false),
+										ValidateFunc: StringInSlice([]string{"not-contain", "contain", "none", "ne", "eq", "lt", "gt", "len-lt", "len-eq", "len-gt", "not-match", "match-one", "all-not-match", "all-not-contain", "contain-one", "not-regex", "regex", "all-not-regex", "regex-one", "prefix-match", "suffix-match", "empty", "exists", "inl", "in-list", "not-in-list"}, false),
 									},
 									"values": {
 										Type:     schema.TypeString,
@@ -380,6 +380,10 @@ func resourceAliCloudWafv3DefenseRule() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: StringInSlice([]string{"template", "resource", "global"}, false),
+			},
+			"gmt_modified": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"instance_id": {
 				Type:     schema.TypeString,
@@ -823,6 +827,7 @@ func resourceAliCloudWafv3DefenseRuleRead(d *schema.ResourceData, meta interface
 
 	d.Set("defense_origin", objectRaw["DefenseOrigin"])
 	d.Set("defense_scene", objectRaw["DefenseScene"])
+	d.Set("gmt_modified", objectRaw["GmtModified"])
 	d.Set("resource", objectRaw["Resource"])
 	d.Set("rule_name", objectRaw["RuleName"])
 	d.Set("rule_status", objectRaw["Status"])
@@ -1023,7 +1028,9 @@ func resourceAliCloudWafv3DefenseRuleRead(d *schema.ResourceData, meta interface
 						ruleDetailMap := make(map[string]interface{})
 						ruleDetailChildRaw := ruleDetailChildRaw.(map[string]interface{})
 						ruleDetailMap["rule_action"] = ruleDetailChildRaw["ruleAction"]
-						ruleDetailMap["rule_id"] = ruleDetailChildRaw["ruleId"]
+						if v := ruleDetailChildRaw["ruleId"]; v != nil {
+							ruleDetailMap["rule_id"] = fmt.Sprint(v)
+						}
 						ruleDetailMap["rule_status"] = formatInt(ruleDetailChildRaw["ruleStatus"])
 
 						ruleDetailMaps = append(ruleDetailMaps, ruleDetailMap)
@@ -1052,7 +1059,6 @@ func resourceAliCloudWafv3DefenseRuleUpdate(d *schema.ResourceData, meta interfa
 	var response map[string]interface{}
 	var query map[string]interface{}
 	update := false
-	d.Partial(true)
 
 	var err error
 	parts := strings.Split(d.Id(), ":")
@@ -1498,7 +1504,6 @@ func resourceAliCloudWafv3DefenseRuleUpdate(d *schema.ResourceData, meta interfa
 		}
 	}
 
-	d.Partial(false)
 	return resourceAliCloudWafv3DefenseRuleRead(d, meta)
 }
 

--- a/alicloud/resource_alicloud_wafv3_defense_rule_test.go
+++ b/alicloud/resource_alicloud_wafv3_defense_rule_test.go
@@ -42,7 +42,7 @@ func TestAccAliCloudWafv3DefenseRule_basic12317(t *testing.T) {
 								"oct", "js-unicode", "space-zip", "hex", "comment", "url"},
 						},
 					},
-					"resource":      "${alicloud_wafv3_domain.defaultICMRhk.domain_id}",
+					"resource":      "${data.alicloud_wafv3_domains.default.domains.0.domain_id}",
 					"defense_scene": "waf_codec",
 					"defense_type":  "resource",
 					"rule_status":   "1",
@@ -114,20 +114,9 @@ variable "region_id" {
 data "alicloud_wafv3_instances" "default" {
 }
 
-resource "alicloud_wafv3_domain" "defaultICMRhk" {
-  redirect {
-    loadbalance = "iphash"
-    backends    = ["39.98.217.197"]
-    connect_timeout = 5
-    read_timeout    = 120
-    write_timeout   = 120
-  }
-  domain      = "testfromtftest01.wafqax.top"
-  access_type = "share"
-  instance_id = data.alicloud_wafv3_instances.default.ids.0
-  listen {
-    http_ports = ["80"]
-  }
+data "alicloud_wafv3_domains" "default" {
+  instance_id    = data.alicloud_wafv3_instances.default.ids.0
+  enable_details = true
 }
 
 
@@ -339,31 +328,20 @@ variable "region_id" {
 data "alicloud_wafv3_instances" "default" {
 }
 
-resource "alicloud_wafv3_domain" "defaultgkyil3" {
-  redirect {
-    loadbalance = "iphash"
-    backends    = ["39.98.217.197"]
-    connect_timeout = 5
-    read_timeout    = 120
-    write_timeout   = 120
-  }
-  domain      = "testfromtftest01.wafqax.top"
-  access_type = "share"
-  instance_id = data.alicloud_wafv3_instances.default.ids.0
-  listen {
-    http_ports = ["80"]
-  }
+data "alicloud_wafv3_domains" "default" {
+  instance_id    = data.alicloud_wafv3_instances.default.ids.0
+  enable_details = true
 }
 
 resource "alicloud_wafv3_defense_template" "defaultD3YVaa" {
   status                = "1"
   description           = "testTF"
   instance_id           = data.alicloud_wafv3_instances.default.ids.0
-  defense_template_name = "testBaseRule"
+  defense_template_name = "tf-tpl-${var.name}"
   template_origin       = "custom"
   defense_scene         = "waf_base"
   template_type         = "user_custom"
-  resources             = ["${alicloud_wafv3_domain.defaultgkyil3.domain_id}"]
+  resources             = [data.alicloud_wafv3_domains.default.domains.0.domain_id]
 }
 
 
@@ -520,6 +498,597 @@ resource "alicloud_wafv3_defense_template" "defaultfIoHt5-hf" {
 }
 
 // Test Wafv3 DefenseRule. >>> Resource test cases, automatically generated.
+// Case  DefenseRule_地址簿_自定义规则 12723
+func TestAccAliCloudWafv3DefenseRule_basic12723(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_wafv3_defense_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudWafv3DefenseRuleMap12723)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &Wafv3ServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeWafv3DefenseRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccwafv3%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudWafv3DefenseRuleBasicDependence12723)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"defense_origin": "custom",
+					"instance_id":    "${data.alicloud_wafv3_instances.default.ids.0}",
+					"config": []map[string]interface{}{
+						{
+							"rule_action": "block",
+							"conditions": []map[string]interface{}{
+								{
+									"op_value": "contain",
+									"values":   "abc",
+									"key":      "URL",
+								},
+								{
+									"op_value": "contain",
+									"values":   "abc",
+									"key":      "URLPath",
+								},
+								{
+									"op_value": "contain",
+									"values":   "1.1.1.2",
+									"key":      "IP",
+								},
+								{
+									"key":      "IP",
+									"op_value": "in-list",
+									"values":   "${alicloud_wafv3_address_book.default9dtEmt.address_book_id}",
+								},
+							},
+							"cc_status": "0",
+							"cc_effect": "service",
+							"rate_limit": []map[string]interface{}{
+								{
+									"target":    "remote_addr",
+									"interval":  "16",
+									"threshold": "204",
+									"ttl":       "68",
+									"status": []map[string]interface{}{
+										{
+											"code":  "414",
+											"count": "333",
+										},
+									},
+									"sub_key": "testky1",
+								},
+							},
+							"gray_status": "1",
+							"gray_config": []map[string]interface{}{
+								{
+									"gray_target": "remote_addr",
+									"gray_rate":   "80",
+								},
+							},
+							"time_config": []map[string]interface{}{
+								{
+									"time_scope": "period",
+									"time_zone":  "8",
+									"time_periods": []map[string]interface{}{
+										{
+											"start": "1760174804000",
+											"end":   "1760175804000",
+										},
+										{
+											"start": "1760171804000",
+											"end":   "1760172804000",
+										},
+										{
+											"start": "1760176804000",
+											"end":   "1760177804000",
+										},
+										{
+											"start": "1760178804000",
+											"end":   "1760179804000",
+										},
+										{
+											"start": "1760170804000",
+											"end":   "1760171804000",
+										},
+									},
+								},
+							},
+						},
+					},
+					"defense_scene": "custom_acl",
+					"rule_status":   "1",
+					"defense_type":  "template",
+					"template_id":   "${alicloud_wafv3_defense_template.defaultfIoHt5.defense_template_id}",
+					"rule_name":     "custom_acl-create",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"defense_origin": "custom",
+						"instance_id":    CHECKSET,
+						"defense_scene":  "custom_acl",
+						"rule_status":    "1",
+						"defense_type":   "template",
+						"template_id":    CHECKSET,
+						"rule_name":      "custom_acl-create",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"config": []map[string]interface{}{
+						{
+							"rule_action": "monitor",
+							"conditions": []map[string]interface{}{
+								{
+									"op_value": "eq",
+									"values":   "abcd",
+									"key":      "Header",
+									"sub_key":  "testkey",
+								},
+							},
+							"cc_status": "1",
+							"cc_effect": "rule",
+							"rate_limit": []map[string]interface{}{
+								{
+									"target":    "header",
+									"interval":  "6",
+									"threshold": "3",
+									"ttl":       "61",
+									"status": []map[string]interface{}{
+										{
+											"code":  "404",
+											"ratio": "34",
+										},
+									},
+									"sub_key": "abc",
+								},
+							},
+							"gray_status": "1",
+							"gray_config": []map[string]interface{}{
+								{
+									"gray_target":  "queryarg",
+									"gray_sub_key": "abc",
+									"gray_rate":    "77",
+								},
+							},
+							"time_config": []map[string]interface{}{
+								{
+									"time_scope": "cycle",
+									"time_zone":  "9",
+									"week_time_periods": []map[string]interface{}{
+										{
+											"day": "1,5",
+											"day_periods": []map[string]interface{}{
+												{
+													"start": "10",
+													"end":   "888",
+												},
+												{
+													"start": "999",
+													"end":   "1999",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"rule_name": "testtt",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rule_name": "testtt",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"config": []map[string]interface{}{
+						{
+							"rule_action": "js",
+							"cc_status":   "0",
+							"conditions": []map[string]interface{}{
+								{
+									"op_value": "contain",
+									"values":   "123",
+									"key":      "Header",
+									"sub_key":  "test",
+								},
+							},
+							"gray_status": "0",
+							"time_config": []map[string]interface{}{
+								{
+									"time_scope": "permanent",
+								},
+							},
+						},
+					},
+					"rule_status": "0",
+					"rule_name":   "custom_acl_update1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rule_status": "0",
+						"rule_name":   "custom_acl_update1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"config": []map[string]interface{}{
+						{
+							"rule_action": "block",
+							"conditions": []map[string]interface{}{
+								{
+									"key":      "URL",
+									"op_value": "contain",
+									"values":   "/anbs",
+								},
+							},
+							"cc_status": "1",
+							"gray_config": []map[string]interface{}{
+								{
+									"gray_target":  "cookie",
+									"gray_sub_key": "saaa",
+									"gray_rate":    "11",
+								},
+							},
+							"time_config": []map[string]interface{}{
+								{
+									"time_scope": "period",
+									"time_zone":  "9",
+									"time_periods": []map[string]interface{}{
+										{
+											"start": "1760172104000",
+											"end":   "1760172804000",
+										},
+									},
+								},
+							},
+							"gray_status": "1",
+							"cc_effect":   "service",
+							"rate_limit": []map[string]interface{}{
+								{
+									"target":    "header",
+									"interval":  "300",
+									"threshold": "50",
+									"ttl":       "500",
+									"status": []map[string]interface{}{
+										{
+											"code":  "306",
+											"count": "50",
+										},
+									},
+								},
+							},
+						},
+					},
+					"rule_status": "1",
+					"rule_name":   "tet2222111",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rule_status": "1",
+						"rule_name":   "tet2222111",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"config": []map[string]interface{}{
+						{
+							"rule_action": "monitor",
+							"conditions": []map[string]interface{}{
+								{
+									"key":      "Header",
+									"sub_key":  "ssss",
+									"op_value": "contain",
+									"values":   "ssss",
+								},
+							},
+							"cc_status":   "0",
+							"gray_status": "0",
+							"time_config": []map[string]interface{}{
+								{
+									"time_scope": "cycle",
+									"time_zone":  "-8",
+									"week_time_periods": []map[string]interface{}{
+										{
+											"day": "3,4",
+											"day_periods": []map[string]interface{}{
+												{
+													"start": "1",
+													"end":   "10",
+												},
+												{
+													"start": "20",
+													"end":   "30",
+												},
+												{
+													"start": "40",
+													"end":   "50",
+												},
+												{
+													"start": "60",
+													"end":   "70",
+												},
+												{
+													"start": "80",
+													"end":   "90",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"rule_name": "testfromamp",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rule_name": "testfromamp",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudWafv3DefenseRuleMap12723 = map[string]string{
+	"rule_id":      CHECKSET,
+	"gmt_modified": CHECKSET,
+}
+
+func AlicloudWafv3DefenseRuleBasicDependence12723(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "region_id" {
+  default = "cn-hangzhou"
+}
+
+data "alicloud_wafv3_instances" "default" {
+}
+
+resource "alicloud_wafv3_defense_template" "defaultfIoHt5" {
+  status                = "1"
+  description           = "testCreate"
+instance_id           = data.alicloud_wafv3_instances.default.ids.0
+  defense_template_name = "1782219455"
+  template_origin       = "custom"
+  defense_scene         = "custom_acl"
+  template_type         = "user_custom"
+}
+
+resource "alicloud_wafv3_address_book" "default9dtEmt" {
+  description       = "test"
+  instance_id       = data.alicloud_wafv3_instances.default.ids.0
+  address_book_name = "1782219456-a-${var.name}"
+  address_list      = ["100.100.100.100/32", "101.101.101.101/32", "102.102.102.102/32"]
+  address_book_type = "ip"
+}
+
+resource "alicloud_wafv3_address_book" "defaultSB0uHV" {
+  description       = "test"
+  instance_id       = data.alicloud_wafv3_instances.default.ids.0
+  address_book_name = "1782219456-b-${var.name}"
+  address_list      = ["100.100.100.100/32", "101.101.101.101/32", "102.102.102.102/32"]
+  address_book_type = "ip"
+}
+
+
+`, name)
+}
+
+// Case  DefenseRule__地址簿_白名单 12724
+func TestAccAliCloudWafv3DefenseRule_basic12724(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_wafv3_defense_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudWafv3DefenseRuleMap12724)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &Wafv3ServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeWafv3DefenseRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccwafv3%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudWafv3DefenseRuleBasicDependence12724)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_id":    "${data.alicloud_wafv3_instances.default.ids.0}",
+					"defense_type":   "template",
+					"defense_scene":  "whitelist",
+					"rule_status":    "1",
+					"template_id":    "${alicloud_wafv3_defense_template.defaultBQg9ZY.defense_template_id}",
+					"rule_name":      "tf-whitelist",
+					"defense_origin": "custom",
+					"config": []map[string]interface{}{
+						{
+							"conditions": []map[string]interface{}{
+								{
+									"op_value": "contain",
+									"values":   "abc",
+									"key":      "URL",
+									"sub_key":  "request_url",
+								},
+								{
+									"op_value": "contain",
+									"values":   "test",
+									"key":      "URLPath",
+									"sub_key":  "reqeust-url",
+								},
+								{
+									"op_value": "eq",
+									"values":   "2.2.2.2",
+									"key":      "IP",
+									"sub_key":  "requset-ip",
+								},
+								{
+									"key":      "IP",
+									"op_value": "in-list",
+									"values":   "${alicloud_wafv3_address_book.defaultURndOy.address_book_id}",
+								},
+							},
+							"bypass_tags": []string{
+								"customrule", "blacklist", "antiscan", "regular_type"},
+							"bypass_regular_types": []string{
+								"xss", "sql", "code_exec"},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_id":    CHECKSET,
+						"defense_type":   "template",
+						"defense_scene":  "whitelist",
+						"rule_status":    "1",
+						"template_id":    CHECKSET,
+						"rule_name":      "tf-whitelist",
+						"defense_origin": "custom",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rule_status": "0",
+					"rule_name":   "test-whietest-update",
+					"config": []map[string]interface{}{
+						{
+							"conditions": []map[string]interface{}{
+								{
+									"op_value": "lt",
+									"values":   "10",
+									"key":      "Content-Length",
+									"sub_key":  "requeset-content-length",
+								},
+							},
+							"bypass_tags": []string{
+								"cc", "regular_type"},
+							"bypass_regular_types": []string{
+								"xss"},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rule_status": "0",
+						"rule_name":   "test-whietest-update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rule_status": "1",
+					"rule_name":   "whitelist-update-2",
+					"config": []map[string]interface{}{
+						{
+							"conditions": []map[string]interface{}{
+								{
+									"op_value": "contain",
+									"values":   "abc",
+									"key":      "URL",
+									"sub_key":  "testurl",
+								},
+							},
+							"bypass_tags": []string{
+								"regular_type"},
+							"bypass_regular_types": []string{
+								"sqli", "xss", "code_exec"},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rule_status": "1",
+						"rule_name":   "whitelist-update-2",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudWafv3DefenseRuleMap12724 = map[string]string{
+	"rule_id":      CHECKSET,
+	"gmt_modified": CHECKSET,
+}
+
+func AlicloudWafv3DefenseRuleBasicDependence12724(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "region_id" {
+  default = "cn-hangzhou"
+}
+
+data "alicloud_wafv3_instances" "default" {
+}
+
+resource "alicloud_wafv3_defense_template" "defaultBQg9ZY" {
+  status                = "1"
+  description           = "testCreate"
+  instance_id           = data.alicloud_wafv3_instances.default.ids.0
+  defense_template_name = "1782219460"
+  template_origin       = "custom"
+  defense_scene         = "whitelist"
+  template_type         = "user_custom"
+}
+
+resource "alicloud_wafv3_address_book" "defaultURndOy" {
+  description       = "test"
+  instance_id       = data.alicloud_wafv3_instances.default.ids.0
+  address_book_name = "1782219460"
+  address_book_type = "ip"
+  address_list      = ["100.100.100.100/32"]
+}
+
+resource "alicloud_wafv3_address_book" "default1aeUw7" {
+  description       = "test"
+  instance_id       = data.alicloud_wafv3_instances.default.ids.0
+  address_book_name = "1782219461"
+  address_book_type = "ip"
+  address_list      = ["100.100.100.100/32"]
+}
+
+
+`, name)
+}
+
 // Case  DefenseRule-20250715_resource 11029
 func TestAccAliCloudWafv3DefenseRule_basic11029(t *testing.T) {
 	var v map[string]interface{}
@@ -548,7 +1117,7 @@ func TestAccAliCloudWafv3DefenseRule_basic11029(t *testing.T) {
 					"defense_type":   "resource",
 					"defense_scene":  "account_identifier",
 					"rule_status":    "1",
-					"resource":       "${alicloud_wafv3_domain.defaultICMRhk.domain_id}",
+					"resource":       "${data.alicloud_wafv3_domains.default.domains.0.domain_id}",
 					"defense_origin": "custom",
 					"config": []map[string]interface{}{
 						{
@@ -631,7 +1200,8 @@ func TestAccAliCloudWafv3DefenseRule_basic11029(t *testing.T) {
 }
 
 var AlicloudWafv3DefenseRuleMap11029 = map[string]string{
-	"rule_id": CHECKSET,
+	"rule_id":      CHECKSET,
+	"gmt_modified": CHECKSET,
 }
 
 func AlicloudWafv3DefenseRuleBasicDependence11029(name string) string {
@@ -651,20 +1221,9 @@ variable "domain" {
 data "alicloud_wafv3_instances" "default" {
 }
 
-resource "alicloud_wafv3_domain" "defaultICMRhk" {
-  redirect {
-    loadbalance = "iphash"
-    backends    = ["39.98.217.197"]
-    connect_timeout = 5
-    read_timeout    = 120
-    write_timeout   = 120
-  }
-  domain      = "testfromtftest01.wafqax.top"
-  access_type = "share"
-  instance_id = data.alicloud_wafv3_instances.default.ids.0
-  listen {
-    http_ports = ["80"]
-  }
+data "alicloud_wafv3_domains" "default" {
+  instance_id    = data.alicloud_wafv3_instances.default.ids.0
+  enable_details = true
 }
 
 
@@ -1019,7 +1578,8 @@ func TestAccAliCloudWafv3DefenseRule_basic11017(t *testing.T) {
 }
 
 var AlicloudWafv3DefenseRuleMap11017 = map[string]string{
-	"rule_id": CHECKSET,
+	"rule_id":      CHECKSET,
+	"gmt_modified": CHECKSET,
 }
 
 func AlicloudWafv3DefenseRuleBasicDependence11017(name string) string {
@@ -1036,9 +1596,9 @@ data "alicloud_wafv3_instances" "default" {
 }
 
 resource "alicloud_wafv3_defense_template" "defaultfIoHt5" {
-  instance_id           = data.alicloud_wafv3_instances.default.ids.0
+instance_id           = data.alicloud_wafv3_instances.default.ids.0
   template_origin       = "custom"
-  defense_template_name = "1758078439"
+  defense_template_name = "1782219466"
   defense_scene         = "custom_acl"
   template_type         = "user_custom"
   status                = "1"
@@ -1189,7 +1749,8 @@ func TestAccAliCloudWafv3DefenseRule_basic11097(t *testing.T) {
 }
 
 var AlicloudWafv3DefenseRuleMap11097 = map[string]string{
-	"rule_id": CHECKSET,
+	"rule_id":      CHECKSET,
+	"gmt_modified": CHECKSET,
 }
 
 func AlicloudWafv3DefenseRuleBasicDependence11097(name string) string {
@@ -1206,9 +1767,9 @@ data "alicloud_wafv3_instances" "default" {
 }
 
 resource "alicloud_wafv3_defense_template" "defaultZmPPmw" {
-  instance_id           = data.alicloud_wafv3_instances.default.ids.0
+instance_id           = data.alicloud_wafv3_instances.default.ids.0
   template_origin       = "custom"
-  defense_template_name = "1758078467"
+  defense_template_name = "1782219467"
   defense_scene         = "whitelist"
   template_type         = "user_custom"
   status                = "1"
@@ -1300,7 +1861,8 @@ func TestAccAliCloudWafv3DefenseRule_basic11070(t *testing.T) {
 }
 
 var AlicloudWafv3DefenseRuleMap11070 = map[string]string{
-	"rule_id": CHECKSET,
+	"rule_id":      CHECKSET,
+	"gmt_modified": CHECKSET,
 }
 
 func AlicloudWafv3DefenseRuleBasicDependence11070(name string) string {
@@ -1317,9 +1879,9 @@ data "alicloud_wafv3_instances" "default" {
 }
 
 resource "alicloud_wafv3_defense_template" "defaultZmPPmw-ipblack" {
-  instance_id           = data.alicloud_wafv3_instances.default.ids.0
+instance_id           = data.alicloud_wafv3_instances.default.ids.0
   template_origin       = "custom"
-  defense_template_name = "1758078494"
+  defense_template_name = "1782219469"
   defense_scene         = "ip_blacklist"
   template_type         = "user_custom"
   status                = "1"
@@ -1435,7 +1997,8 @@ func TestAccAliCloudWafv3DefenseRule_basic11081(t *testing.T) {
 }
 
 var AlicloudWafv3DefenseRuleMap11081 = map[string]string{
-	"rule_id": CHECKSET,
+	"rule_id":      CHECKSET,
+	"gmt_modified": CHECKSET,
 }
 
 func AlicloudWafv3DefenseRuleBasicDependence11081(name string) string {
@@ -1452,9 +2015,9 @@ data "alicloud_wafv3_instances" "default" {
 }
 
 resource "alicloud_wafv3_defense_template" "defaultZmPPmw-dlp" {
-  instance_id           = data.alicloud_wafv3_instances.default.ids.0
+instance_id           = data.alicloud_wafv3_instances.default.ids.0
   template_origin       = "custom"
-  defense_template_name = "1758078522"
+  defense_template_name = "1782219471"
   defense_scene         = "dlp"
   template_type         = "user_custom"
   status                = "1"
@@ -1546,7 +2109,8 @@ func TestAccAliCloudWafv3DefenseRule_basic11079(t *testing.T) {
 }
 
 var AlicloudWafv3DefenseRuleMap11079 = map[string]string{
-	"rule_id": CHECKSET,
+	"rule_id":      CHECKSET,
+	"gmt_modified": CHECKSET,
 }
 
 func AlicloudWafv3DefenseRuleBasicDependence11079(name string) string {
@@ -1563,9 +2127,9 @@ data "alicloud_wafv3_instances" "default" {
 }
 
 resource "alicloud_wafv3_defense_template" "defaultZmPPmw-fcg" {
-  instance_id           = data.alicloud_wafv3_instances.default.ids.0
+instance_id           = data.alicloud_wafv3_instances.default.ids.0
   template_origin       = "custom"
-  defense_template_name = "1758078550"
+  defense_template_name = "1782219473"
   defense_scene         = "tamperproof"
   template_type         = "user_custom"
   status                = "1"
@@ -1715,7 +2279,8 @@ func TestAccAliCloudWafv3DefenseRule_basic11076(t *testing.T) {
 }
 
 var AlicloudWafv3DefenseRuleMap11076 = map[string]string{
-	"rule_id": CHECKSET,
+	"rule_id":      CHECKSET,
+	"gmt_modified": CHECKSET,
 }
 
 func AlicloudWafv3DefenseRuleBasicDependence11076(name string) string {
@@ -1732,9 +2297,9 @@ data "alicloud_wafv3_instances" "default" {
 }
 
 resource "alicloud_wafv3_defense_template" "defaultBQg9ZY" {
-  instance_id           = data.alicloud_wafv3_instances.default.ids.0
+instance_id           = data.alicloud_wafv3_instances.default.ids.0
   template_origin       = "custom"
-  defense_template_name = "1758078580"
+  defense_template_name = "1782219475"
   defense_scene         = "whitelist"
   template_type         = "user_custom"
   status                = "1"
@@ -1857,7 +2422,8 @@ func TestAccAliCloudWafv3DefenseRule_basic11084(t *testing.T) {
 }
 
 var AlicloudWafv3DefenseRuleMap11084 = map[string]string{
-	"rule_id": CHECKSET,
+	"rule_id":      CHECKSET,
+	"gmt_modified": CHECKSET,
 }
 
 func AlicloudWafv3DefenseRuleBasicDependence11084(name string) string {
@@ -1874,9 +2440,9 @@ data "alicloud_wafv3_instances" "default" {
 }
 
 resource "alicloud_wafv3_defense_template" "defaultfIoHt5-hf" {
-  instance_id           = data.alicloud_wafv3_instances.default.ids.0
+instance_id           = data.alicloud_wafv3_instances.default.ids.0
   template_origin       = "custom"
-  defense_template_name = "1758078609"
+  defense_template_name = "1782219477"
   defense_scene         = "spike_throttle"
   template_type         = "user_custom"
   status                = "1"

--- a/alicloud/service_alicloud_wafv3_v2.go
+++ b/alicloud/service_alicloud_wafv3_v2.go
@@ -357,6 +357,7 @@ func (s *Wafv3ServiceV2) DescribeWafv3DefenseRule(id string) (object map[string]
 	parts := strings.Split(id, ":")
 	if len(parts) != 3 {
 		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 3, len(parts)))
+		return nil, err
 	}
 	request = make(map[string]interface{})
 	query = make(map[string]interface{})

--- a/website/docs/d/wafv3_defense_rules.html.markdown
+++ b/website/docs/d/wafv3_defense_rules.html.markdown
@@ -1,0 +1,242 @@
+---
+subcategory: "Web Application Firewall(WAF)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_wafv3_defense_rules"
+sidebar_current: "docs-alicloud-datasource-wafv3-defense-rules"
+description: |-
+  Provides a list of Wafv3 Defense Rule owned by an Alibaba Cloud account.
+---
+
+# alicloud_wafv3_defense_rules
+
+This data source provides Wafv3 Defense Rule available to the user.[What is Defense Rule](https://next.api.alibabacloud.com/document/waf-openapi/2021-10-01/CreateDefenseRule)
+
+-> **NOTE:** Available since v1.283.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "region_id" {
+  default = "cn-hangzhou"
+}
+
+resource "alicloud_wafv3_instance" "defaultnxb04D" {
+}
+
+resource "alicloud_wafv3_defense_template" "defaultfIoHt5" {
+  status                = "1"
+  description           = "testCreate"
+  instance_id           = alicloud_wafv3_instance.defaultnxb04D.id
+  defense_template_name = "1782219650"
+  template_origin       = "custom"
+  defense_scene         = "custom_acl"
+  template_type         = "user_custom"
+}
+
+resource "alicloud_wafv3_address_book" "default9dtEmt" {
+  description       = "test"
+  instance_id       = alicloud_wafv3_instance.defaultnxb04D.id
+  address_book_name = "1782219650"
+  address_list      = ["100.100.100.100/32", "101.101.101.101/32", "102.102.102.102/32"]
+  address_book_type = "ip"
+}
+
+resource "alicloud_wafv3_address_book" "defaultSB0uHV" {
+  description       = "test"
+  instance_id       = alicloud_wafv3_instance.defaultnxb04D.id
+  address_book_name = "1782219650"
+  address_list      = ["100.100.100.100/32", "101.101.101.101/32", "102.102.102.102/32"]
+  address_book_type = "ip"
+}
+
+
+resource "alicloud_wafv3_defense_rule" "default" {
+  defense_origin = "custom"
+  instance_id    = alicloud_wafv3_instance.defaultnxb04D.id
+  config {
+    rule_action = "block"
+    conditions {
+      op_value = "contain"
+      values   = "abc"
+      key      = "URL"
+    }
+    conditions {
+      op_value = "contain"
+      values   = "abc"
+      key      = "URLPath"
+    }
+    conditions {
+      op_value = "contain"
+      values   = "1.1.1.2"
+      key      = "IP"
+    }
+    conditions {
+      key      = "IP"
+      op_value = "in-list"
+      values   = alicloud_wafv3_address_book.default9dtEmt.address_book_id
+    }
+    cc_status = "0"
+    cc_effect = "service"
+    rate_limit {
+      target    = "remote_addr"
+      interval  = "16"
+      threshold = "204"
+      ttl       = "68"
+      status {
+        code  = "414"
+        count = "333"
+      }
+      sub_key = "testky1"
+    }
+    gray_status = "1"
+    gray_config {
+      gray_target = "remote_addr"
+      gray_rate   = "80"
+    }
+    time_config {
+      time_scope = "period"
+      time_zone  = "8"
+      time_periods {
+        start = "1760174804000"
+        end   = "1760175804000"
+      }
+      time_periods {
+        start = "1760171804000"
+        end   = "1760172804000"
+      }
+      time_periods {
+        start = "1760176804000"
+        end   = "1760177804000"
+      }
+      time_periods {
+        start = "1760178804000"
+        end   = "1760179804000"
+      }
+      time_periods {
+        start = "1760170804000"
+        end   = "1760171804000"
+      }
+    }
+  }
+  defense_scene = "custom_acl"
+  rule_status   = "1"
+  defense_type  = "template"
+  template_id   = alicloud_wafv3_defense_template.defaultfIoHt5.defense_template_id
+  rule_name     = "custom_acl-create"
+}
+
+data "alicloud_wafv3_defense_rules" "default" {
+  ids          = ["${alicloud_wafv3_defense_rule.default.id}"]
+  defense_type = "template"
+  instance_id  = alicloud_wafv3_instance.defaultnxb04D.id
+}
+
+output "alicloud_wafv3_defense_rule_example_id" {
+  value = data.alicloud_wafv3_defense_rules.default.rules.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `defense_type` - (Optional) The protection rule type. Value:
+  - `template` (default): indicates the template protection rule.
+  - `resource`: indicates the rule of the protected object dimension.
+* `instance_id` - (Required) The ID of the Web Application Firewall (WAF) instance.
+* `query` - (Optional) The query condition is converted into a string in JSON format constructed with a series of parameters.
+
+-> **NOTE:**  The results of the protection rules vary according to different query conditions. For more information, see **Query parameter description**.
+
+* `rule_type` - (Optional) The protection rule type. Value:
+  - `whitelist`: whitelist rules
+  - `defense` (default): protection rules
+* `ids` - (Optional, Computed) A list of Defense Rule IDs. The value is formulated as `<instance_id>:<defense_type>:<rule_id>`.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `enable_details` - (Optional) Default to `false`. Set it to `true` to call the per-rule `DescribeDefenseRule` API and fetch the full `config` block for each rule.
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Defense Rule IDs.
+* `rules` - A list of Defense Rule Entries. Each element contains the following attributes:
+    * `config` - Rule configuration content, in JSON format, constructed with a series of parameters.
+        * `abroad_regions` - The regions outside China from which you want to block requests.
+        * `account_identifiers` - The policies for account extraction.
+            * `decode_type` - The authentication mode.
+            * `key` - The field from which you want to extract account information.
+            * `position` - The field that stores the decoded account information.
+            * `priority` - The priority of the current extraction configuration.
+            * `sub_key` - The child match field.
+        * `auto_update` - Whether the new Web core protection rules are automatically updated.
+        * `bypass_regular_rules` - The list of regular rule IDs that are not detected.
+        * `bypass_regular_types` - The regular rule type is not detected.
+        * `bypass_tags` - The modules to which the whitelist applies.
+        * `cc_effect` - Set the effective range of the speed limit.
+        * `cc_status` - Whether to open the speed limit.
+        * `cn_regions` - The regions in China from which you want to block requests.
+        * `codec_list` - The type to enable decoding.
+        * `conditions` - The traffic characteristics of ACL, which are described in JSON format.
+            * `key` - Match field.
+            * `op_value` - Logical character.
+            * `sub_key` - Custom child match fields.
+            * `values` - Match the content and fill in the corresponding content as needed.
+        * `gray_config` - The canary release configuration for the rule.
+            * `gray_rate` - The percentage of traffic for which the canary release takes effect.
+            * `gray_sub_key` - The sub-feature of the statistical object.
+            * `gray_target` - The type of the canary release object.
+        * `gray_status` - Specifies whether to enable canary release for the rule.
+        * `mode` - The HTTP flood protection mode.
+        * `protocol` - The protocol type of the cached page address.
+        * `rate_limit` - The detailed speed limit configuration, which is described in the JSON string format.
+            * `interval` - The statistical period, in seconds.
+            * `status` - Response code frequency setting.
+                * `code` - Required.
+                * `count` - The threshold for the number of occurrences.
+                * `ratio` - The threshold for the proportion of occurrences (percentage).
+            * `sub_key` - The characteristics of the statistical object.
+            * `target` - The type of the statistical object.
+            * `threshold` - The maximum number of requests that can be sent from a statistical object.
+            * `ttl` - The period of time during which you want the specified action to be valid.
+        * `remote_addr` - The IP addresses that you want to add to the blacklist.
+        * `rule_action` - Protection rule action.
+        * `throttle_threhold` - The throttling threshold.
+        * `throttle_type` - The throttling method.
+        * `time_config` - The scheduled rule configuration.
+            * `time_periods` - The time period during which the rule is effective.
+                * `end` - The end time of the rule.
+                * `start` - The start time of the rule.
+            * `time_scope` - The effective period of the rule.
+            * `time_zone` - The time zone in which the rule is effective.
+            * `week_time_periods` - The periodic time period during which the rule is effective.
+                * `day` - The time period of each day when the rule is effective.
+                * `day_periods` - The time period of each day when the rule is effective.
+                    * `end` - The end time of each day when the rule is effective.
+                    * `start` - The start time of each day when the rule is effective.
+        * `ua` - The User-Agent string that is allowed for access to the address.
+        * `url` - The address of the cached page.
+        * `waf_base_config` - The configuration of the Web core protection rules to be modified.
+            * `rule_batch_operation_config` - The batch operation on rules.
+            * `rule_detail` - The configuration of the Web core protection rules to be modified.
+                * `rule_action` - Web core protection rule action.
+                * `rule_id` - The ID of the core Web protection rule.
+                * `rule_status` - The status of Web core protection rules.
+            * `rule_type` - The type of the rule.
+    * `defense_origin` - Sources of protection.
+    * `defense_scene` - The WAF protection scenario to be created.
+    * `defense_type` - The protection rule type.
+    * `gmt_modified` - The modification time of the protection rule.
+    * `resource` - The protection object corresponding to the rule to be queried.
+    * `rule_id` - The protection rule ID.
+    * `rule_name` - The rule name.
+    * `rule_status` - Protection rule status.
+    * `template_id` - The protection template ID of the protection rule to be created.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/d/wafv3_domains.html.markdown
+++ b/website/docs/d/wafv3_domains.html.markdown
@@ -58,6 +58,7 @@ The following attributes are exported in addition to the arguments listed above:
 * `domains` - A list of Domain Entries. Each element contains the following attributes:
   * `id` - The ID of the domain. It formats as `<instance_id>:<domain>`.
   * `domain` - The name of the domain.
+  * `domain_id` - The numeric domain ID assigned by WAF. Populated only when `enable_details` is `true`.
   * `cname` - The CNAME assigned by WAF to the domain name.
   * `resource_manager_resource_group_id` - The ID of the resource group.
   * `status` - The status of the domain.

--- a/website/docs/r/wafv3_defense_rule.html.markdown
+++ b/website/docs/r/wafv3_defense_rule.html.markdown
@@ -20,12 +20,6 @@ For information about WAFV3 Defense Rule and how to use it, see [What is Defense
 
 Basic Usage
 
-<div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
-  <a href="https://api.aliyun.com/terraform?resource=alicloud_wafv3_defense_rule&exampleId=01d1c027-929f-99d1-543b-6d6409dc210c0d7ebd0d&activeTab=example&spm=docs.r.wafv3_defense_rule.0.01d1c02792&intl_lang=EN_US" target="_blank">
-    <img alt="Open in AliCloud" src="https://img.alicdn.com/imgextra/i1/O1CN01hjjqXv1uYUlY56FyX_!!6000000006049-55-tps-254-36.svg" style="max-height: 44px; max-width: 100%;">
-  </a>
-</div></div>
-
 ```terraform
 provider "alicloud" {
   region = "cn-hangzhou"
@@ -82,8 +76,6 @@ resource "alicloud_wafv3_defense_rule" "default" {
 }
 ```
 
-📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_wafv3_defense_rule&spm=docs.r.wafv3_defense_rule.example&intl_lang=EN_US)
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -109,7 +101,7 @@ When the protection rule type `DefenseType` is set to `template`, the value is a
 
 When the protection rule type `DefenseType` is set to `resource`, the value is as follows:
   - `account_identifier`: indicates account extraction.
-  - `waf_codec`: (Available since v1.269.0) indicates decode setting.
+  - `waf_codec`: indicates decode setting.
 * `defense_type` - (Required, ForceNew) The protection rule type. Value:
   - `template` (default): indicates the template protection rule.
   - `resource`: indicates the rule of the protected object dimension.
@@ -172,7 +164,7 @@ The config supports the following:
   - dlp: indicates information leakage prevention.
   - tamperproof: indicates web tamper-proofing.
   - spike_throttle: indicates peak traffic throttling.
-* `cc_effect` - (Optional) Set the effective range of the speed limit. This information is configured only when ccStatus is set to 1. Value:
+* `cc_effect` - (Optional, Computed) Set the effective range of the speed limit. This information is configured only when ccStatus is set to 1. Value:
   - service: indicates that the effective object is a protected object.
   - rule: indicates that the effective object is a single rule.
 * `cc_status` - (Optional, Int) Whether to open the speed limit. Value:
@@ -227,7 +219,7 @@ The config supports the following:
 * `time_config` - (Optional, Computed, Set, Available since v1.262.0) The scheduled rule configuration. The value is a JSON.  See [`time_config`](#config-time_config) below.
 * `ua` - (Optional) The User-Agent string that is allowed for access to the address.
 * `url` - (Optional) The address of the cached page.
-* `waf_base_config` - (Optional, List, Available since v1.269.0) The configuration of the Web core protection rules to be modified. See [`waf_base_config`](#config-waf_base_config) below.
+* `waf_base_config` - (Optional, List) The configuration of the Web core protection rules to be modified. See [`waf_base_config`](#config-waf_base_config) below.
 
 ### `config-account_identifiers`
 
@@ -335,7 +327,7 @@ The config-waf_base_config supports the following:
   - `all_block`: sets the action of all rules to Block.
   - `all_monitor`: sets the action of all rules to Monitor.
 * `rule_detail` - (Optional, List, Available since v1.269.0) The configuration of the Web core protection rules to be modified. See [`rule_detail`](#config-waf_base_config-rule_detail) below.
-* `rule_type` - (Optional, Available since v1.269.0) The type of the rule. Valid values:
+* `rule_type` - (Optional) The type of the rule. Valid values:
   - `system`: a system rule for basic protection.
   - `custom`: a custom regular expression rule for basic protection.
 
@@ -346,7 +338,7 @@ The config-waf_base_config-rule_detail supports the following:
   - `block`: blocks requests.
   - `monitor`: places requests in observation mode.
 * `rule_id` - (Optional, Available since v1.269.0) The ID of the core Web protection rule.
-* `rule_status` - (Optional, Int, Available since v1.269.0) The status of Web core protection rules.
+* `rule_status` - (Optional, Int) The status of Web core protection rules.
 
 ### `config-time_config-time_periods`
 
@@ -377,6 +369,7 @@ The config-rate_limit-status supports the following:
 
 The following attributes are exported:
 * `id` - The ID of the resource supplied above. The value is formulated as `<instance_id>:<defense_type>:<rule_id>`.
+* `gmt_modified` - The modification time of the protection rule.
 * `rule_id` - The protection rule ID.
 
 ## Timeouts


### PR DESCRIPTION
## Summary

Regeneration of `alicloud_wafv3_defense_rule` against the latest production spec:
- Add `gmt_modified` (Computed, `TypeString` to match the actual API which returns ISO 8601 strings, and to match the repo convention for `gmt_modified` across 6 other resources).
- Add two `op_value` enum values to the `conditions` block: `in-list`, `not-in-list`.
- Drop the obsolete `d.Partial(true/false)` calls in Update (no longer needed since SDK >= v0.12).
- Guard `DescribeWafv3DefenseRule` against ID parts != 3 by returning early after WrapError.
- Read the nested `rule_detail.0.rule_id` through `fmt.Sprint(...)` — API returns the rule id as a number while the schema declares a string.

Also adds the new `alicloud_wafv3_defense_rules` data source (with pagination via `PageNumber`/`PageSize=PageSizeLarge`, plus the `enable_details` toggle that does a per-rule `DescribeDefenseRule` to populate the full `config` block).

Test fixture cleanup:
- 13 references to `alicloud_wafv3_instance.defaultnxbXX.id` (which were never declared) rewritten to `data.alicloud_wafv3_instances.default.ids.0`.
- Three fixtures that used to hardcode `alicloud_wafv3_domain "testfromtftest01.wafqax.top"` (failed with `Waf.Control.DomainOwnerNotVerify` on the ACC account) now look up an existing domain via `data "alicloud_wafv3_domains"` and pass its `domain_id` to the rule's `resource` field.

> **Note:** `alicloud_wafv3_domains` was extended to expose `domain_id` for each list item (populated through `DescribeDomain` when `enable_details = true`). It is technically out of scope for `wafv3_defense_rule`, but the three test fixtures above cannot bind a defense rule to a verified domain without that field. Happy to split into a follow-up PR if reviewers prefer.

## Test Plan

```
=== RUN   TestAccAliCloudWafv3DefenseRule_longitude12001
--- PASS: TestAccAliCloudWafv3DefenseRule_longitude12001 (14.53s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic11017
--- PASS: TestAccAliCloudWafv3DefenseRule_basic11017 (27.37s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic11029
--- PASS: TestAccAliCloudWafv3DefenseRule_basic11029 (16.85s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic11070
--- PASS: TestAccAliCloudWafv3DefenseRule_basic11070 (10.14s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic11076
--- PASS: TestAccAliCloudWafv3DefenseRule_basic11076 (14.17s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic11079
--- PASS: TestAccAliCloudWafv3DefenseRule_basic11079 (10.00s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic11081
--- PASS: TestAccAliCloudWafv3DefenseRule_basic11081 (10.97s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic11084
--- PASS: TestAccAliCloudWafv3DefenseRule_basic11084 (14.00s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic11097
--- PASS: TestAccAliCloudWafv3DefenseRule_basic11097 (14.28s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic12303
--- PASS: TestAccAliCloudWafv3DefenseRule_basic12303 (37.05s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic12317
--- PASS: TestAccAliCloudWafv3DefenseRule_basic12317 (20.30s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic12723
--- PASS: TestAccAliCloudWafv3DefenseRule_basic12723 (23.65s)

=== RUN   TestAccAliCloudWafv3DefenseRule_basic12724
--- PASS: TestAccAliCloudWafv3DefenseRule_basic12724 (15.26s)

=== RUN   TestAccAlicloudWafv3DefenseRuleDataSource
--- PASS: TestAccAlicloudWafv3DefenseRuleDataSource (31.17s)
```

`TestAccAliCloudWafv3DefenseRule_basic11078` remains `t.Skipf("there is a bug in delete api")` carried over from master.