### PR TITLE
New Resource: alicloud_threat_detection_service_linked_role

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -927,6 +927,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_wafv3_address_book":                                   resourceAliCloudWafv3AddressBook(),
+			"alicloud_threat_detection_service_linked_role":                 resourceAliCloudThreatDetectionServiceLinkedRole(),
 			"alicloud_amqp_open_source_account":                             resourceAliCloudAmqpOpenSourceAccount(),
 			"alicloud_vpc_ipv6_cidr_block":                                  resourceAliCloudVpcIpv6CidrBlock(),
 			"alicloud_amqp_open_source_permission":                          resourceAliCloudAmqpOpenSourcePermission(),

--- a/alicloud/resource_alicloud_threat_detection_service_linked_role.go
+++ b/alicloud/resource_alicloud_threat_detection_service_linked_role.go
@@ -1,0 +1,139 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudThreatDetectionServiceLinkedRole() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudThreatDetectionServiceLinkedRoleCreate,
+		Read:   resourceAliCloudThreatDetectionServiceLinkedRoleRead,
+		Delete: resourceAliCloudThreatDetectionServiceLinkedRoleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"role_status": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"service_linked_role": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"AliyunServiceRoleForSas", "AliyunServiceRoleForSasCspm", "AliyunServiceRoleForSasAgentless", "AliyunServiceRoleForOssMfd", "AliyunServiceRoleForAntiRansomwareMssp", "AliyunServiceRoleForSasSecllm", "AliyunServiceRoleForSasAI", "AliyunLogETLRole"}, false),
+			},
+		},
+	}
+}
+
+func resourceAliCloudThreatDetectionServiceLinkedRoleCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateServiceLinkedRole"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("service_linked_role"); ok {
+		request["ServiceLinkedRole"] = v
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_service_linked_role", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(request["ServiceLinkedRole"]))
+
+	return resourceAliCloudThreatDetectionServiceLinkedRoleRead(d, meta)
+}
+
+func resourceAliCloudThreatDetectionServiceLinkedRoleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	threatDetectionServiceV2 := ThreatDetectionServiceV2{client}
+
+	objectRaw, err := threatDetectionServiceV2.DescribeThreatDetectionServiceLinkedRole(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_threat_detection_service_linked_role DescribeThreatDetectionServiceLinkedRole Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("role_status", objectRaw["Status"])
+
+	d.Set("service_linked_role", d.Id())
+
+	return nil
+}
+
+func resourceAliCloudThreatDetectionServiceLinkedRoleDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteServiceLinkedRole"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["RoleName"] = d.Id()
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	threatDetectionServiceV2 := ThreatDetectionServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{"false"}, d.Timeout(schema.TimeoutDelete), 10*time.Second, threatDetectionServiceV2.DescribeAsyncThreatDetectionServiceLinkedRoleStateRefreshFunc(d, response, "$.RoleStatus.Status", []string{}))
+	if jobDetail, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id(), jobDetail)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_threat_detection_service_linked_role_test.go
+++ b/alicloud/resource_alicloud_threat_detection_service_linked_role_test.go
@@ -1,0 +1,179 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test ThreatDetection ServiceLinkedRole. >>> Resource test cases, automatically generated.
+// Case resource_ServiceLinkedRole_test_1 12848
+func TestAccAliCloudThreatDetectionServiceLinkedRole_basic12848(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_service_linked_role.default"
+	ra := resourceAttrInit(resourceId, AlicloudThreatDetectionServiceLinkedRoleMap12848)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionServiceLinkedRole")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetection%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudThreatDetectionServiceLinkedRoleBasicDependence12848)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"service_linked_role": "AliyunServiceRoleForAntiRansomwareMssp",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"service_linked_role": "AliyunServiceRoleForAntiRansomwareMssp",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudThreatDetectionServiceLinkedRoleMap12848 = map[string]string{
+	"role_status": CHECKSET,
+}
+
+func AlicloudThreatDetectionServiceLinkedRoleBasicDependence12848(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_ServiceLinkedRole_test_2 12849
+func TestAccAliCloudThreatDetectionServiceLinkedRole_basic12849(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_service_linked_role.default"
+	ra := resourceAttrInit(resourceId, AlicloudThreatDetectionServiceLinkedRoleMap12849)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionServiceLinkedRole")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetection%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudThreatDetectionServiceLinkedRoleBasicDependence12849)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"service_linked_role": "AliyunServiceRoleForSas",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"service_linked_role": "AliyunServiceRoleForSas",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudThreatDetectionServiceLinkedRoleMap12849 = map[string]string{
+	"role_status": CHECKSET,
+}
+
+func AlicloudThreatDetectionServiceLinkedRoleBasicDependence12849(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_ServiceLinkedRole_test 12850
+func TestAccAliCloudThreatDetectionServiceLinkedRole_basic12850(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_service_linked_role.default"
+	ra := resourceAttrInit(resourceId, AlicloudThreatDetectionServiceLinkedRoleMap12850)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionServiceLinkedRole")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetection%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudThreatDetectionServiceLinkedRoleBasicDependence12850)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"service_linked_role": "AliyunServiceRoleForSasSecllm",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"service_linked_role": "AliyunServiceRoleForSasSecllm",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudThreatDetectionServiceLinkedRoleMap12850 = map[string]string{
+	"role_status": CHECKSET,
+}
+
+func AlicloudThreatDetectionServiceLinkedRoleBasicDependence12850(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Test ThreatDetection ServiceLinkedRole. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_threat_detection_v2.go
+++ b/alicloud/service_alicloud_threat_detection_v2.go
@@ -1323,3 +1323,145 @@ func (s *ThreatDetectionServiceV2) ThreatDetectionCheckConfigStateRefreshFuncWit
 }
 
 // DescribeThreatDetectionCheckConfig >>> Encapsulated.
+// DescribeThreatDetectionServiceLinkedRole <<< Encapsulated get interface for ThreatDetection ServiceLinkedRole.
+
+func (s *ThreatDetectionServiceV2) DescribeThreatDetectionServiceLinkedRole(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ServiceLinkedRole"] = id
+
+	action := "DescribeServiceLinkedRoleStatus"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.RoleStatus", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.RoleStatus", response)
+	}
+
+	currentStatus := v.(map[string]interface{})["Status"]
+	if fmt.Sprint(currentStatus) == "false" {
+		return object, WrapErrorf(NotFoundErr("ServiceLinkedRole", id), NotFoundMsg, response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *ThreatDetectionServiceV2) ThreatDetectionServiceLinkedRoleStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ThreatDetectionServiceLinkedRoleStateRefreshFuncWithApi(id, field, failStates, s.DescribeThreatDetectionServiceLinkedRole)
+}
+
+func (s *ThreatDetectionServiceV2) ThreatDetectionServiceLinkedRoleStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+func (s *ThreatDetectionServiceV2) DescribeAsyncThreatDetectionServiceLinkedRoleStateRefreshFunc(d *schema.ResourceData, res map[string]interface{}, field string, failStates []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := s.DescribeAsyncDescribeServiceLinkedRoleStatus(d, res)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				if _err, ok := object["error"]; ok {
+					return _err, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+				}
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeThreatDetectionServiceLinkedRole >>> Encapsulated.
+// DescribeAsyncDescribeServiceLinkedRoleStatus <<< Encapsulated for ThreatDetection.
+func (s *ThreatDetectionServiceV2) DescribeAsyncDescribeServiceLinkedRoleStatus(d *schema.ResourceData, res map[string]interface{}) (object map[string]interface{}, err error) {
+	client := s.client
+	id := d.Id()
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ServiceLinkedRole"] = d.Id()
+
+	action := "DescribeServiceLinkedRoleStatus"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return response, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+// DescribeAsyncDescribeServiceLinkedRoleStatus >>> Encapsulated.

--- a/website/docs/r/threat_detection_service_linked_role.html.markdown
+++ b/website/docs/r/threat_detection_service_linked_role.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_service_linked_role"
+description: |-
+  Provides an Alicloud Threat Detection Service Linked Role resource.
+---
+
+# alicloud_threat_detection_service_linked_role
+
+Provides a Threat Detection Service Linked Role resource.
+
+Service Linked Role.
+
+For information about Threat Detection Service Linked Role and how to use it, see [What is Service Linked Role](https://www.alibabacloud.com/help/en/doc-detail/42302.htm).
+
+-> **NOTE:** Available since v1.283.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_threat_detection_service_linked_role" "default" {
+  service_linked_role = "AliyunServiceRoleForSas"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `service_linked_role` - (Optional, ForceNew, Computed, Available since v1.283.0) The name of the service linked role.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+* `role_status` - Whether the service linked role exists.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Service Linked Role.
+* `delete` - (Defaults to 5 mins) Used when delete the Service Linked Role.
+
+## Import
+
+Threat Detection Service Linked Role can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_threat_detection_service_linked_role.example <service_linked_role>
+```


### PR DESCRIPTION
## Summary

- Add `alicloud_threat_detection_service_linked_role` resource.
- Register the resource and add ThreatDetection service helpers for `DescribeServiceLinkedRoleStatus`.
- Add generated acceptance tests and resource documentation.
- Data source generation was attempted but skipped because the resource has no LIST API configured.

## Tests

Remote ACC task: `6910`

```
=== RUN TestAccAliCloudThreatDetectionServiceLinkedRole_basic12848
--- PASS: TestAccAliCloudThreatDetectionServiceLinkedRole_basic12848 (16.94s)

=== RUN TestAccAliCloudThreatDetectionServiceLinkedRole_basic12849
--- PASS: TestAccAliCloudThreatDetectionServiceLinkedRole_basic12849 (15.89s)

=== RUN TestAccAliCloudThreatDetectionServiceLinkedRole_basic12850
--- PASS: TestAccAliCloudThreatDetectionServiceLinkedRole_basic12850 (16.11s)
```