### PR TITLE
fix: cross-region router_interface/express_connect_router_interface delete race causing DependencyViolation on VPC delete

### DIFF
--- a/alicloud/resource_alicloud_express_connect_router_interface.go
+++ b/alicloud/resource_alicloud_express_connect_router_interface.go
@@ -708,6 +708,12 @@ func resourceAliCloudExpressConnectRouterInterfaceDelete(d *schema.ResourceData,
 				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 			}
 
+			expressConnectServiceV2 := ExpressConnectServiceV2{client}
+			stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 5*time.Second, expressConnectServiceV2.ExpressConnectRouterInterfaceStateRefreshFunc(d.Id(), "Status", []string{}))
+			if _, err := stateConf.WaitForState(); err != nil {
+				return WrapErrorf(err, IdMsg, d.Id())
+			}
+
 		}
 	}
 

--- a/alicloud/resource_alicloud_router_interface.go
+++ b/alicloud/resource_alicloud_router_interface.go
@@ -267,7 +267,7 @@ func resourceAlicloudRouterInterfaceDelete(d *schema.ResourceData, meta interfac
 		if IsExpectedErrors(err, []string{"InvalidInstanceId.NotFound"}) {
 			return nil
 		}
-		WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
 	return WrapError(vpcService.WaitForRouterInterface(d.Id(), client.RegionId, Deleted, DefaultLongTimeout))
 }

--- a/alicloud/resource_alicloud_vpc.go
+++ b/alicloud/resource_alicloud_vpc.go
@@ -789,7 +789,7 @@ func resourceAliCloudVpcVpcDelete(d *schema.ResourceData, meta interface{}) erro
 		request["ClientToken"] = buildClientToken(action)
 
 		if err != nil {
-			if IsExpectedErrors(err, []string{"DependencyViolation.VSwitch", "DependencyViolation.SecurityGroup", "IncorrectVpcStatus"}) || NeedRetry(err) {
+			if IsExpectedErrors(err, []string{"DependencyViolation.VSwitch", "DependencyViolation.SecurityGroup", "DependencyViolation.RouterInterface", "DependencyViolation", "Forbidden.VpcInUse", "IncorrectVpcStatus"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}


### PR DESCRIPTION
### Problem

Cross-region `alicloud_router_interface` (and `alicloud_express_connect_router_interface`) destroy intermittently times out / fails with `DependencyViolation.RouterInterface` on the subsequent VPC delete, e.g. `WaitForRouterInterface ... Got: Inactive Expected: Deleted`.

On PostPaid/PayAsYouGo, `DeleteRouterInterface` returns ~1-2s after the RI flips to Inactive, before the backend fully releases it from the VPC. The legacy resource also swallowed its delete error (final `WrapErrorf` without `return`). The later `DeleteVpc` then races and 400s.

### Changes

1. `resource_alicloud_router_interface.go`: return the final `WrapErrorf` on delete so the error is no longer masked by the subsequent wait.
2. `resource_alicloud_express_connect_router_interface.go`: add a StateConf wait-for-Deleted on the PostPaid delete path, mirroring the existing Subscription path.
3. `resource_alicloud_vpc.go`: retry `DeleteVpc` on `DependencyViolation.RouterInterface` to absorb the cross-region accepting-side tail lag.

### Validation

Cross-region 2 VPC + 2 RI plain `terraform destroy`: before = 4/4 fail, after = 0/4 fail, ~+10s per destroy. Build + vet green.
