### PR TITLE
New Resource: alicloud_resource_manager_resource_directory_sharing

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -926,6 +926,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_resource_manager_resource_directory_sharing":          resourceAliCloudResourceManagerResourceDirectorySharing(),
 			"alicloud_wafv3_address_book":                                   resourceAliCloudWafv3AddressBook(),
 			"alicloud_amqp_open_source_account":                             resourceAliCloudAmqpOpenSourceAccount(),
 			"alicloud_vpc_ipv6_cidr_block":                                  resourceAliCloudVpcIpv6CidrBlock(),

--- a/alicloud/resource_alicloud_resource_manager_resource_directory_sharing.go
+++ b/alicloud/resource_alicloud_resource_manager_resource_directory_sharing.go
@@ -1,0 +1,100 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudResourceManagerResourceDirectorySharing() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudResourceManagerResourceDirectorySharingCreate,
+		Read:   resourceAliCloudResourceManagerResourceDirectorySharingRead,
+		Delete: resourceAliCloudResourceManagerResourceDirectorySharingDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"enable_sharing_with_rd": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudResourceManagerResourceDirectorySharingCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "EnableSharingWithResourceDirectory"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("ResourceSharing", "2020-01-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		// EnableSharingWithResourceDirectory is idempotent at the account level: a 409
+		// "AlreadyEnabled" means the desired state is already in place, which Terraform
+		// should treat as a successful create.
+		if !IsExpectedErrors(err, []string{"AlreadyEnabled"}) {
+			return WrapErrorf(err, DefaultErrorMsg, "alicloud_resource_manager_resource_directory_sharing", action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	accountId, err := client.AccountId()
+	if err != nil {
+		return WrapError(err)
+	}
+	d.SetId(accountId)
+
+	return resourceAliCloudResourceManagerResourceDirectorySharingRead(d, meta)
+}
+
+func resourceAliCloudResourceManagerResourceDirectorySharingRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	resourceManagerServiceV2 := ResourceManagerServiceV2{client}
+
+	objectRaw, err := resourceManagerServiceV2.DescribeResourceManagerResourceDirectorySharing(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_resource_manager_resource_directory_sharing DescribeResourceManagerResourceDirectorySharing Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("enable_sharing_with_rd", objectRaw["EnableSharingWithRd"])
+
+	return nil
+}
+
+func resourceAliCloudResourceManagerResourceDirectorySharingDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource AliCloud Resource Resource Directory Sharing. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_resource_manager_resource_directory_sharing_test.go
+++ b/alicloud/resource_alicloud_resource_manager_resource_directory_sharing_test.go
@@ -1,0 +1,67 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test ResourceManager ResourceDirectorySharing. >>> Resource test cases, automatically generated.
+// Case resource_directory_sharing 11900
+func TestAccAliCloudResourceManagerResourceDirectorySharing_basic11900(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_resource_manager_resource_directory_sharing.default"
+	ra := resourceAttrInit(resourceId, AlicloudResourceManagerResourceDirectorySharingMap11900)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ResourceManagerServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeResourceManagerResourceDirectorySharing")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccresourcemanager%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudResourceManagerResourceDirectorySharingBasicDependence11900)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable_sharing_with_rd": "true",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudResourceManagerResourceDirectorySharingMap11900 = map[string]string{
+	"enable_sharing_with_rd": CHECKSET,
+}
+
+func AlicloudResourceManagerResourceDirectorySharingBasicDependence11900(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Test ResourceManager ResourceDirectorySharing. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_resource_manager_v2.go
+++ b/alicloud/service_alicloud_resource_manager_v2.go
@@ -1525,3 +1525,74 @@ func (s *ResourceManagerServiceV2) ResourceManagerDeliveryChannelStateRefreshFun
 }
 
 // DescribeResourceManagerDeliveryChannel >>> Encapsulated.
+// DescribeResourceManagerResourceDirectorySharing <<< Encapsulated get interface for ResourceManager ResourceDirectorySharing.
+
+func (s *ResourceManagerServiceV2) DescribeResourceManagerResourceDirectorySharing(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	action := "CheckSharingWithResourceDirectoryStatus"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("ResourceSharing", "2020-01-10", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	currentStatus := response["EnableSharingWithRd"]
+	if fmt.Sprint(currentStatus) == "" {
+		return object, WrapErrorf(NotFoundErr("ResourceDirectorySharing", id), NotFoundMsg, response)
+	}
+
+	return response, nil
+}
+
+func (s *ResourceManagerServiceV2) ResourceManagerResourceDirectorySharingStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ResourceManagerResourceDirectorySharingStateRefreshFuncWithApi(id, field, failStates, s.DescribeResourceManagerResourceDirectorySharing)
+}
+
+func (s *ResourceManagerServiceV2) ResourceManagerResourceDirectorySharingStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeResourceManagerResourceDirectorySharing >>> Encapsulated.

--- a/website/docs/r/resource_manager_resource_directory_sharing.html.markdown
+++ b/website/docs/r/resource_manager_resource_directory_sharing.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "Resource Manager"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_resource_manager_resource_directory_sharing"
+description: |-
+  Provides a Alicloud Resource Manager Resource Directory Sharing resource.
+---
+
+# alicloud_resource_manager_resource_directory_sharing
+
+Provides a Resource Manager Resource Directory Sharing resource.
+
+Resource directory sharing, which enables sharing with the resource directory.
+
+For information about Resource Manager Resource Directory Sharing and how to use it, see [What is Resource Directory Sharing](https://next.api.alibabacloud.com/document/ResourceSharing/2020-01-10/EnableSharingWithResourceDirectory).
+
+-> **NOTE:** Available since v1.283.0.
+
+-> **NOTE:** Sharing with the resource directory is an account-level capability. Once enabled, the underlying service API does not provide a way to disable it, so this resource cannot be torn down.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_resource_manager_resource_directory_sharing" "default" {
+}
+```
+
+### Deleting `alicloud_resource_manager_resource_directory_sharing` or removing it from your configuration
+
+Sharing with the resource directory is enabled at the Alibaba Cloud account level, and once enabled it cannot be disabled through the underlying API. Terraform cannot destroy resource `alicloud_resource_manager_resource_directory_sharing`: removing it from your configuration only removes it from the Terraform state file, and the feature will remain enabled on the account.
+
+## Argument Reference
+
+This resource has no configurable arguments.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<Alibaba Cloud Account ID>`.
+* `enable_sharing_with_rd` - Indicates whether sharing with the resource directory is enabled.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Resource Directory Sharing.
+
+## Import
+
+Resource Manager Resource Directory Sharing can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_resource_manager_resource_directory_sharing.example <Alibaba Cloud Account ID>
+```


### PR DESCRIPTION
Adds a new singleton resource `alicloud_resource_manager_resource_directory_sharing` for the `ResourceSharing` 2020-01-10 enablement API (`EnableSharingWithResourceDirectory` / `CheckSharingWithResourceDirectoryStatus`). The feature is account-level and cannot be disabled, so Delete only removes the entry from state.

```
=== RUN   TestAccAliCloudResourceManagerResourceDirectorySharing_basic11900
--- PASS: TestAccAliCloudResourceManagerResourceDirectorySharing_basic11900 (4.73s)
PASS
ok  	github.com/aliyun/terraform-provider-alicloud/alicloud	4.73s
```