### PR TITLE
docs: fix Available since version for auto_asset_protection in alicloud_cloud_firewall_instance

### DIFF
--- a/website/docs/r/cloud_firewall_instance.html.markdown
+++ b/website/docs/r/cloud_firewall_instance.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
   * `enterprise_version` - The valid cfw_log_storage is [2, 200] with the step size 1. Default Value: `2`.
   * `ultimate_version` - The valid cfw_log_storage is [5, 500] with the step size 1. Default Value: `5`.
 * `instance_count` - (Optional)  The number of assets.
-* `auto_asset_protection` - (Optional, Computed, Available since v1.282.0) Internet asset protection switch. Valid values: `true`, `false`.
+* `auto_asset_protection` - (Optional, Computed, Available since v1.283.0) Internet asset protection switch. Valid values: `true`, `false`.
 * `cfw_account` - (Optional, Available since v1.209.1, Bool) Whether to use multi-account. Valid values: `true`, `false`.
 * `account_number` - (Optional, Available since v1.209.1, Int) The number of multi account. It will be ignored when `cfw_account = false`.
   * `premium_version` - The valid account number is [1, 20].


### PR DESCRIPTION
## Summary

PR [#9854](https://github.com/aliyun/terraform-provider-alicloud/pull/9854) introduced the `auto_asset_protection` field on `alicloud_cloud_firewall_instance` with a doc note marking it as `Available since v1.282.0`. That release tag, however, was cut **before** the PR was merged (master at the time was already on the `Cleanup after release v1.282.0` commit), so the field actually first ships in v1.283.0.

This PR corrects the annotation: `v1.282.0` → `v1.283.0`.

## Test plan

- [x] grep confirms the only `auto_asset_protection` occurrence in cloud_firewall_instance docs is the fixed line