### PR TITLE
resource/alicloud_apig_http_api: support ai_protocols, deploy_configs, enable_auth, model_category

### DIFF
--- a/alicloud/resource_alicloud_apig_http_api.go
+++ b/alicloud/resource_alicloud_apig_http_api.go
@@ -2,6 +2,7 @@
 package alicloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -23,22 +24,40 @@ func resourceAliCloudApigHttpApi() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(6 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
+			"ai_protocols": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"base_path": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"deploy_configs": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"description": {
 				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_auth": {
+				Type:     schema.TypeBool,
 				Optional: true,
 			},
 			"http_api_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+			"model_category": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"protocols": {
 				Type:     schema.TypeList,
@@ -52,7 +71,7 @@ func resourceAliCloudApigHttpApi() *schema.Resource {
 			},
 			"type": {
 				Type:     schema.TypeString,
-				Optional: true,
+				Required: true,
 				ForceNew: true,
 			},
 		},
@@ -72,23 +91,48 @@ func resourceAliCloudApigHttpApiCreate(d *schema.ResourceData, meta interface{})
 	request = make(map[string]interface{})
 	query["RegionId"] = StringPointer(client.RegionId)
 
-	if v, ok := d.GetOk("description"); ok {
-		request["description"] = v
-	}
 	if v, ok := d.GetOk("protocols"); ok {
-		protocolsMapsArray := v.([]interface{})
+		protocolsMapsArray := convertToInterfaceArray(v)
+
 		request["protocols"] = protocolsMapsArray
 	}
 
-	if v, ok := d.GetOk("base_path"); ok {
-		request["basePath"] = v
+	if v, ok := d.GetOkExists("enable_auth"); ok {
+		request["enableAuth"] = v
 	}
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["resourceGroupId"] = v
+	}
+	if v, ok := d.GetOk("description"); ok {
+		request["description"] = v
+	}
+	if v, ok := d.GetOk("ai_protocols"); ok {
+		aiProtocolsMapsArray := convertToInterfaceArray(v)
+
+		request["aiProtocols"] = aiProtocolsMapsArray
+	}
+
+	if v, ok := d.GetOk("deploy_configs"); ok {
+		deployConfigsMapsArray := make([]interface{}, 0)
+		for _, item := range v.([]interface{}) {
+			deployConfigMap := make(map[string]interface{})
+			if err := json.Unmarshal([]byte(item.(string)), &deployConfigMap); err != nil {
+				return WrapError(err)
+			}
+			deployConfigsMapsArray = append(deployConfigsMapsArray, deployConfigMap)
+		}
+		request["deployConfigs"] = deployConfigsMapsArray
+	}
+
 	if v, ok := d.GetOk("type"); ok {
 		request["type"] = v
 	}
 	request["name"] = d.Get("http_api_name")
-	if v, ok := d.GetOk("resource_group_id"); ok {
-		request["resourceGroupId"] = v
+	if v, ok := d.GetOk("base_path"); ok {
+		request["basePath"] = v
+	}
+	if v, ok := d.GetOk("model_category"); ok {
+		request["modelCategory"] = v
 	}
 	body = request
 	wait := incrementalWait(3*time.Second, 5*time.Second)
@@ -129,9 +173,6 @@ func resourceAliCloudApigHttpApiRead(d *schema.ResourceData, meta interface{}) e
 		return WrapError(err)
 	}
 
-	if objectRaw["basePath"] != nil {
-		d.Set("base_path", objectRaw["basePath"])
-	}
 	if objectRaw["description"] != nil {
 		d.Set("description", objectRaw["description"])
 	}
@@ -144,13 +185,16 @@ func resourceAliCloudApigHttpApiRead(d *schema.ResourceData, meta interface{}) e
 	if objectRaw["type"] != nil {
 		d.Set("type", objectRaw["type"])
 	}
-
-	protocols1Raw := make([]interface{}, 0)
-	if objectRaw["protocols"] != nil {
-		protocols1Raw = objectRaw["protocols"].([]interface{})
+	if objectRaw["enableAuth"] != nil {
+		d.Set("enable_auth", objectRaw["enableAuth"])
 	}
 
-	d.Set("protocols", protocols1Raw)
+	protocolsRaw := make([]interface{}, 0)
+	if objectRaw["protocols"] != nil {
+		protocolsRaw = convertToInterfaceArray(objectRaw["protocols"])
+	}
+
+	d.Set("protocols", protocolsRaw)
 
 	return nil
 }
@@ -162,34 +206,44 @@ func resourceAliCloudApigHttpApiUpdate(d *schema.ResourceData, meta interface{})
 	var query map[string]*string
 	var body map[string]interface{}
 	update := false
-	d.Partial(true)
 
+	var err error
 	httpApiId := d.Id()
 	action := fmt.Sprintf("/v1/http-apis/%s", httpApiId)
-	var err error
 	request = make(map[string]interface{})
 	query = make(map[string]*string)
 	body = make(map[string]interface{})
-	request["httpApiId"] = d.Id()
 
-	if d.HasChange("description") {
+	if !d.IsNewResource() && d.HasChange("protocols") {
+		update = true
+	}
+	if v, ok := d.GetOk("protocols"); ok || d.HasChange("protocols") {
+		protocolsMapsArray := convertToInterfaceArray(v)
+
+		request["protocols"] = protocolsMapsArray
+	}
+
+	if !d.IsNewResource() && d.HasChange("description") {
 		update = true
 	}
 	if v, ok := d.GetOk("description"); ok || d.HasChange("description") {
 		request["description"] = v
 	}
-	if d.HasChange("protocols") {
+	if !d.IsNewResource() && d.HasChange("deploy_configs") {
 		update = true
-	}
-	if v, ok := d.GetOk("protocols"); ok || d.HasChange("protocols") {
-		protocolsMapsArray := v.([]interface{})
-		request["protocols"] = protocolsMapsArray
+		if v, ok := d.GetOk("deploy_configs"); ok || d.HasChange("deploy_configs") {
+			deployConfigsMapsArray := make([]interface{}, 0)
+			for _, item := range v.([]interface{}) {
+				deployConfigMap := make(map[string]interface{})
+				if err := json.Unmarshal([]byte(item.(string)), &deployConfigMap); err != nil {
+					return WrapError(err)
+				}
+				deployConfigsMapsArray = append(deployConfigsMapsArray, deployConfigMap)
+			}
+			request["deployConfigs"] = deployConfigsMapsArray
+		}
 	}
 
-	if d.HasChange("base_path") {
-		update = true
-	}
-	request["basePath"] = d.Get("base_path")
 	body = request
 	if update {
 		wait := incrementalWait(3*time.Second, 5*time.Second)
@@ -216,7 +270,7 @@ func resourceAliCloudApigHttpApiUpdate(d *schema.ResourceData, meta interface{})
 	body = make(map[string]interface{})
 	query["ResourceId"] = StringPointer(d.Id())
 	query["RegionId"] = StringPointer(client.RegionId)
-	if d.HasChange("resource_group_id") {
+	if !d.IsNewResource() && d.HasChange("resource_group_id") {
 		update = true
 	}
 	if v, ok := d.GetOk("resource_group_id"); ok {
@@ -242,9 +296,13 @@ func resourceAliCloudApigHttpApiUpdate(d *schema.ResourceData, meta interface{})
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
+		apigServiceV2 := ApigServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{fmt.Sprint(d.Get("resource_group_id"))}, d.Timeout(schema.TimeoutUpdate), 35*time.Second, apigServiceV2.ApigHttpApiStateRefreshFunc(d.Id(), "resourceGroupId", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
 	}
 
-	d.Partial(false)
 	return resourceAliCloudApigHttpApiRead(d, meta)
 }
 
@@ -258,12 +316,10 @@ func resourceAliCloudApigHttpApiDelete(d *schema.ResourceData, meta interface{})
 	query := make(map[string]*string)
 	var err error
 	request = make(map[string]interface{})
-	request["httpApiId"] = d.Id()
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		response, err = client.RoaDelete("APIG", "2024-03-27", action, query, nil, nil, true)
-
 		if err != nil {
 			if NeedRetry(err) {
 				wait()

--- a/alicloud/resource_alicloud_apig_http_api_test.go
+++ b/alicloud/resource_alicloud_apig_http_api_test.go
@@ -10,19 +10,137 @@ import (
 )
 
 // Test Apig HttpApi. >>> Resource test cases, automatically generated.
-// Case HttpApi测试_CCApi_2 9288
-func TestAccAliCloudApigHttpApi_basic9288(t *testing.T) {
+// Case http_api_crud_test 12898
+func TestAccAliCloudApigHttpApi_basic12898(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_apig_http_api.default"
-	ra := resourceAttrInit(resourceId, AlicloudApigHttpApiMap9288)
+	ra := resourceAttrInit(resourceId, AlicloudApigHttpApiMap12898)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
 		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}, "DescribeApigHttpApi")
 	rac := resourceAttrCheckInit(rc, ra)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc%sapighttpapi%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigHttpApiBasicDependence9288)
+	name := fmt.Sprintf("tfaccapig%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigHttpApiBasicDependence12898)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"http_api_name": name,
+					"protocols": []string{
+						"HTTP"},
+					"type":              "Rest",
+					"description":       "test description for cspec",
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"ai_protocols": []string{
+						"OpenAI"},
+					"base_path":      "/cspec-test",
+					"enable_auth":    "false",
+					"model_category": "LLM",
+					"deploy_configs": []string{
+						"{\\\"autoDeploy\\\":false}"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"http_api_name":     name,
+						"protocols.#":       "1",
+						"type":              "Rest",
+						"description":       "test description for cspec",
+						"resource_group_id": CHECKSET,
+						"ai_protocols.#":    "1",
+						"base_path":         "/cspec-test",
+						"enable_auth":       "false",
+						"model_category":    "LLM",
+						"deploy_configs.#":  "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "updated description for cspec",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "updated description for cspec",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"protocols": []string{
+						"HTTPS"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"protocols.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"protocols": []string{
+						"HTTP", "HTTPS"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"protocols.#": "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"protocols": []string{
+						"HTTP"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"protocols.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ai_protocols", "base_path", "deploy_configs", "model_category"},
+			},
+		},
+	})
+}
+
+var AlicloudApigHttpApiMap12898 = map[string]string{}
+
+func AlicloudApigHttpApiBasicDependence12898(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+`, name)
+}
+
+// Case HttpApi测试 6880
+func TestAccAliCloudApigHttpApi_basic6880(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_http_api.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigHttpApiMap6880)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigHttpApi")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccapig%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigHttpApiBasicDependence6880)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
@@ -37,19 +155,17 @@ func TestAccAliCloudApigHttpApi_basic9288(t *testing.T) {
 					"http_api_name": name,
 					"protocols": []string{
 						"${var.protocol}"},
-					"base_path":         "/v1",
-					"description":       "zhiwei_pop_testcase",
-					"type":              "Rest",
-					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+					"base_path":   "/v1",
+					"description": "zhiwei_pop_testcase",
+					"type":        "Rest",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"http_api_name":     name,
-						"protocols.#":       "1",
-						"base_path":         "/v1",
-						"description":       "zhiwei_pop_testcase",
-						"type":              "Rest",
-						"resource_group_id": CHECKSET,
+						"http_api_name": name,
+						"protocols.#":   "1",
+						"base_path":     "/v1",
+						"description":   "zhiwei_pop_testcase",
+						"type":          "Rest",
 					}),
 				),
 			},
@@ -57,16 +173,14 @@ func TestAccAliCloudApigHttpApi_basic9288(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"protocols": []string{
 						"${var.protocol_https}", "${var.protocol}"},
-					"base_path":         "/v2",
-					"description":       "1735184737",
-					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"base_path":   "/v2",
+					"description": "1783585689",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"protocols.#":       "2",
-						"base_path":         "/v2",
-						"description":       CHECKSET,
-						"resource_group_id": CHECKSET,
+						"protocols.#": "2",
+						"base_path":   "/v2",
+						"description": CHECKSET,
 					}),
 				),
 			},
@@ -87,15 +201,15 @@ func TestAccAliCloudApigHttpApi_basic9288(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"ai_protocols", "base_path", "deploy_configs", "enable_auth", "model_category"},
 			},
 		},
 	})
 }
 
-var AlicloudApigHttpApiMap9288 = map[string]string{}
+var AlicloudApigHttpApiMap6880 = map[string]string{}
 
-func AlicloudApigHttpApiBasicDependence9288(name string) string {
+func AlicloudApigHttpApiBasicDependence6880(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
     default = "%s"
@@ -108,8 +222,6 @@ variable "protocol" {
 variable "protocol_https" {
   default = "HTTPS"
 }
-
-data "alicloud_resource_manager_resource_groups" "default" {}
 
 
 `, name)
@@ -126,7 +238,7 @@ func TestAccAliCloudApigHttpApi_basic9287(t *testing.T) {
 	rac := resourceAttrCheckInit(rc, ra)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc%sapighttpapi%d", defaultRegionToTest, rand)
+	name := fmt.Sprintf("tfaccapig%d", rand)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigHttpApiBasicDependence9287)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -163,7 +275,7 @@ func TestAccAliCloudApigHttpApi_basic9287(t *testing.T) {
 					"protocols": []string{
 						"${var.protocol_https}", "${var.protocol}"},
 					"base_path":         "/v2",
-					"description":       "1735184737",
+					"description":       "1783585689",
 					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -192,7 +304,7 @@ func TestAccAliCloudApigHttpApi_basic9287(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"ai_protocols", "base_path", "deploy_configs", "enable_auth", "model_category"},
 			},
 		},
 	})
@@ -201,6 +313,111 @@ func TestAccAliCloudApigHttpApi_basic9287(t *testing.T) {
 var AlicloudApigHttpApiMap9287 = map[string]string{}
 
 func AlicloudApigHttpApiBasicDependence9287(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "protocol" {
+  default = "HTTP"
+}
+
+variable "protocol_https" {
+  default = "HTTPS"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+
+`, name)
+}
+
+// Case HttpApi测试_CCApi_2 9288
+func TestAccAliCloudApigHttpApi_basic9288(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_http_api.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigHttpApiMap9288)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigHttpApi")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccapig%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigHttpApiBasicDependence9288)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"http_api_name": name,
+					"protocols": []string{
+						"${var.protocol}"},
+					"base_path":         "/v1",
+					"description":       "zhiwei_pop_testcase",
+					"type":              "Rest",
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"http_api_name":     name,
+						"protocols.#":       "1",
+						"base_path":         "/v1",
+						"description":       "zhiwei_pop_testcase",
+						"type":              "Rest",
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"protocols": []string{
+						"${var.protocol_https}", "${var.protocol}"},
+					"base_path":         "/v2",
+					"description":       "1783585689",
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"protocols.#":       "2",
+						"base_path":         "/v2",
+						"description":       CHECKSET,
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"protocols": []string{
+						"${var.protocol}"},
+					"base_path": "/v1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"protocols.#": "1",
+						"base_path":   "/v1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ai_protocols", "base_path", "deploy_configs", "enable_auth", "model_category"},
+			},
+		},
+	})
+}
+
+var AlicloudApigHttpApiMap9288 = map[string]string{}
+
+func AlicloudApigHttpApiBasicDependence9288(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
     default = "%s"
@@ -231,7 +448,7 @@ func TestAccAliCloudApigHttpApi_basic9021(t *testing.T) {
 	rac := resourceAttrCheckInit(rc, ra)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc%sapighttpapi%d", defaultRegionToTest, rand)
+	name := fmt.Sprintf("tfaccapig%d", rand)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigHttpApiBasicDependence9021)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -268,7 +485,7 @@ func TestAccAliCloudApigHttpApi_basic9021(t *testing.T) {
 					"protocols": []string{
 						"${var.protocol_https}", "${var.protocol}"},
 					"base_path":         "/v2",
-					"description":       "1735184737",
+					"description":       "1783585689",
 					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -297,7 +514,7 @@ func TestAccAliCloudApigHttpApi_basic9021(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"ai_protocols", "base_path", "deploy_configs", "enable_auth", "model_category"},
 			},
 		},
 	})
@@ -325,22 +542,26 @@ data "alicloud_resource_manager_resource_groups" "default" {}
 `, name)
 }
 
-// Case HttpApi测试 6880
-func TestAccAliCloudApigHttpApi_basic6880(t *testing.T) {
+// Test Apig HttpApi. <<< Resource test cases, automatically generated.
+
+// Case minimal attribute set: create with only the fields the API requires
+// (http_api_name + protocols + type, plus base_path which is required when type=Rest),
+// to verify that the optional fields have no server-side default that would produce a
+// perpetual diff.
+func TestAccAliCloudApigHttpApi_minimal(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_apig_http_api.default"
-	ra := resourceAttrInit(resourceId, AlicloudApigHttpApiMap6880)
+	ra := resourceAttrInit(resourceId, AlicloudApigHttpApiMapMinimal)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
 		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}, "DescribeApigHttpApi")
 	rac := resourceAttrCheckInit(rc, ra)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc%sapighttpapi%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigHttpApiBasicDependence6880)
+	name := fmt.Sprintf("tfaccapig%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigHttpApiBasicDependenceMinimal)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 			testAccPreCheck(t)
 		},
 		IDRefreshName: resourceId,
@@ -351,46 +572,16 @@ func TestAccAliCloudApigHttpApi_basic6880(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"http_api_name": name,
 					"protocols": []string{
-						"${var.protocol}"},
-					"base_path":   "/v1",
-					"description": "zhiwei_pop_testcase",
-					"type":        "Rest",
+						"HTTP"},
+					"type":      "Rest",
+					"base_path": "/v1",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"http_api_name": name,
 						"protocols.#":   "1",
-						"base_path":     "/v1",
-						"description":   "zhiwei_pop_testcase",
 						"type":          "Rest",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"protocols": []string{
-						"${var.protocol_https}", "${var.protocol}"},
-					"base_path":   "/v2",
-					"description": "1735184737",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"protocols.#": "2",
-						"base_path":   "/v2",
-						"description": CHECKSET,
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"protocols": []string{
-						"${var.protocol}"},
-					"base_path": "/v1",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"protocols.#": "1",
-						"base_path":   "/v1",
+						"base_path":     "/v1",
 					}),
 				),
 			},
@@ -398,30 +589,18 @@ func TestAccAliCloudApigHttpApi_basic6880(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"ai_protocols", "base_path", "deploy_configs", "model_category"},
 			},
 		},
 	})
 }
 
-var AlicloudApigHttpApiMap6880 = map[string]string{}
+var AlicloudApigHttpApiMapMinimal = map[string]string{}
 
-func AlicloudApigHttpApiBasicDependence6880(name string) string {
+func AlicloudApigHttpApiBasicDependenceMinimal(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
     default = "%s"
 }
-
-variable "protocol" {
-  default = "HTTP"
-}
-
-variable "protocol_https" {
-  default = "HTTPS"
-}
-
-
 `, name)
 }
-
-// Test Apig HttpApi. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_apig_v2.go
+++ b/alicloud/service_alicloud_apig_v2.go
@@ -25,10 +25,10 @@ func (s *ApigServiceV2) DescribeApigHttpApi(id string) (object map[string]interf
 	var response map[string]interface{}
 	var query map[string]*string
 	httpApiId := id
-	action := fmt.Sprintf("/v1/http-apis/%s", httpApiId)
 	request = make(map[string]interface{})
 	query = make(map[string]*string)
-	request["httpApiId"] = id
+
+	action := fmt.Sprintf("/v1/http-apis/%s", httpApiId)
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
@@ -50,6 +50,10 @@ func (s *ApigServiceV2) DescribeApigHttpApi(id string) (object map[string]interf
 		}
 		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
 	}
+	code, _ := jsonpath.Get("$.code", response)
+	if InArray(fmt.Sprint(code), []string{"DatabaseError.RecordNotFound"}) {
+		return object, WrapErrorf(NotFoundErr("HttpApi", id), NotFoundMsg, response)
+	}
 
 	v, err := jsonpath.Get("$.data", response)
 	if err != nil {
@@ -60,15 +64,18 @@ func (s *ApigServiceV2) DescribeApigHttpApi(id string) (object map[string]interf
 }
 
 func (s *ApigServiceV2) ApigHttpApiStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ApigHttpApiStateRefreshFuncWithApi(id, field, failStates, s.DescribeApigHttpApi)
+}
+
+func (s *ApigServiceV2) ApigHttpApiStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		object, err := s.DescribeApigHttpApi(id)
+		object, err := call(id)
 		if err != nil {
 			if NotFoundError(err) {
 				return object, "", nil
 			}
 			return nil, "", WrapError(err)
 		}
-
 		v, err := jsonpath.Get(field, object)
 		currentStatus := fmt.Sprint(v)
 

--- a/website/docs/r/apig_http_api.html.markdown
+++ b/website/docs/r/apig_http_api.html.markdown
@@ -20,12 +20,6 @@ For information about APIG Http Api and how to use it, see [What is Http Api](ht
 
 Basic Usage
 
-<div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
-  <a href="https://api.aliyun.com/terraform?resource=alicloud_apig_http_api&exampleId=663376aa-68d1-c514-bf85-c36ddfc4ff787f19c9d2&activeTab=example&spm=docs.r.apig_http_api.0.663376aa68&intl_lang=EN_US" target="_blank">
-    <img alt="Open in AliCloud" src="https://img.alicdn.com/imgextra/i1/O1CN01hjjqXv1uYUlY56FyX_!!6000000006049-55-tps-254-36.svg" style="max-height: 44px; max-width: 100%;">
-  </a>
-</div></div>
-
 ```terraform
 variable "name" {
   default = "terraform-example"
@@ -55,34 +49,56 @@ resource "alicloud_apig_http_api" "default" {
 }
 ```
 
-📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_apig_http_api&spm=docs.r.apig_http_api.example&intl_lang=EN_US)
-
 ## Argument Reference
 
 The following arguments are supported:
-* `base_path` - (Optional) API path
-* `description` - (Optional) Description of API
-* `http_api_name` - (Required, ForceNew) The name of the resource
-* `protocols` - (Required, List) API protocol
-* `resource_group_id` - (Optional, Computed) The ID of the resource group
-* `type` - (Optional, ForceNew) API type
+* `ai_protocols` - (Optional, List, Available since v1.285.0) AI API protocols. Currently the supported value is `OpenAI/v1`.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `base_path` - (Optional) API base path. It must start with a forward slash (/), be at most 256 bytes long, and must not contain spaces. It is required when `type` is `Rest`; when `type` is `LLM`, `Ai`, or `Agent`, it can be omitted and defaults to `/`.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `deploy_configs` - (Optional, List, Available since v1.285.0) API deployment configurations. It is required when `type` is `LLM` or `Ai`, and only a single deployment configuration can be specified. Other types do not need this field.
+
+-> **NOTE:** This parameter is only evaluated during resource creation and update. Modifying it in isolation will not trigger any action.
+
+* `description` - (Optional) API description.
+* `enable_auth` - (Optional, Available since v1.285.0) Whether to enable authentication.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `http_api_name` - (Required, ForceNew) Perform an exact search by name.
+* `model_category` - (Optional, Available since v1.285.0) AI model category
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `protocols` - (Required, List) List of API access protocols. Valid values: `HTTP`, `HTTPS`.
+* `resource_group_id` - (Optional, Computed) The ID of the resource group. It can be modified to migrate the resource to another resource group.
+* `type` - (Required, ForceNew) The type of the HTTP API. Multiple types are supported and must be separated by commas (,).
+  - Http
+  - Rest  
+  - LLM  
+  - WebSocket  
+  - HttpIngress  
 
 ## Attributes Reference
 
 The following attributes are exported:
-* `id` - The ID of the resource supplied above.
+* `id` - The ID of the resource supplied above. 
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
 * `create` - (Defaults to 5 mins) Used when create the Http Api.
 * `delete` - (Defaults to 5 mins) Used when delete the Http Api.
-* `update` - (Defaults to 5 mins) Used when update the Http Api.
+* `update` - (Defaults to 6 mins) Used when update the Http Api.
 
 ## Import
 
 APIG Http Api can be imported using the id, e.g.
 
 ```shell
-$ terraform import alicloud_apig_http_api.example <id>
+$ terraform import alicloud_apig_http_api.example <http_api_id>
 ```


### PR DESCRIPTION
Adds new arguments on `alicloud_apig_http_api`: `ai_protocols`, `deploy_configs`, `enable_auth`, `model_category`. `deploy_configs` accepts per-environment deployment configuration as JSON strings.

```
=== RUN   TestAccAliCloudApigHttpApi_basic12898
--- PASS: TestAccAliCloudApigHttpApi_basic12898 (21.35s)
=== RUN   TestAccAliCloudApigHttpApi_basic6880
--- PASS: TestAccAliCloudApigHttpApi_basic6880 (9.26s)
=== RUN   TestAccAliCloudApigHttpApi_basic9287
--- PASS: TestAccAliCloudApigHttpApi_basic9287 (11.27s)
=== RUN   TestAccAliCloudApigHttpApi_basic9288
--- PASS: TestAccAliCloudApigHttpApi_basic9288 (11.07s)
=== RUN   TestAccAliCloudApigHttpApi_basic9021
--- PASS: TestAccAliCloudApigHttpApi_basic9021 (11.19s)
PASS
ok  	github.com/aliyun/terraform-provider-alicloud/alicloud	64.14s
```