### PR TITLE
resource/alicloud_db_backup_policy: Added enable_pitr_protection and inc_backup_interval, optimized backup_interval and backup_retention_period

### DIFF
--- a/alicloud/resource_alicloud_db_backup_policy.go
+++ b/alicloud/resource_alicloud_db_backup_policy.go
@@ -177,6 +177,17 @@ func resourceAlicloudDBBackupPolicy() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"-1", "15", "30", "60", "120", "180", "240", "360", "480", "720"}, false),
 			},
+			"enable_pitr_protection": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"inc_backup_interval": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntInSlice([]int{60, 120, 240, 360, 720}),
+			},
 			"backup_priority": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -263,6 +274,14 @@ func resourceAlicloudDBBackupPolicyRead(d *schema.ResourceData, meta interface{}
 	d.Set("archive_backup_retention_period", formatInt(object["ArchiveBackupRetentionPeriod"]))
 	d.Set("archive_backup_keep_count", formatInt(object["ArchiveBackupKeepCount"]))
 	d.Set("archive_backup_keep_policy", object["ArchiveBackupKeepPolicy"])
+	if instance["Engine"] == "MySQL" && instance["DBInstanceStorageType"] == "local_ssd" && object["EnableIncrementDataBackup"].(bool) {
+		d.Set("inc_backup_interval", object["IncBackupInterval"])
+	}
+	if instance["Engine"] == "MySQL" && object["EnableBackupLog"] == "1" {
+		if v, ok := object["EnablePitrProtection"]; ok && v != nil {
+			d.Set("enable_pitr_protection", v.(bool))
+		}
+	}
 	return nil
 }
 
@@ -274,8 +293,8 @@ func resourceAlicloudDBBackupPolicyUpdate(d *schema.ResourceData, meta interface
 
 	if d.HasChanges("backup_period", "backup_time", "retention_period", "preferred_backup_period", "preferred_backup_time",
 		"backup_retention_period", "compress_type", "log_backup_frequency", "archive_backup_retention_period", "archive_backup_keep_count",
-		"archive_backup_keep_policy", "released_keep_policy", "category", "backup_interval", "backup_priority", "backup_method",
-		"enable_increment_data_backup") {
+		"archive_backup_keep_policy", "released_keep_policy", "category", "backup_interval", "inc_backup_interval", "backup_priority",
+		"backup_method", "enable_increment_data_backup", "enable_pitr_protection") {
 		updateForData = true
 	}
 

--- a/alicloud/resource_alicloud_db_backup_policy_test.go
+++ b/alicloud/resource_alicloud_db_backup_policy_test.go
@@ -66,6 +66,16 @@ func TestAccAliCloudRdsDBBackupPolicyMySql(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"enable_pitr_protection": true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable_pitr_protection": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"backup_retention_period": "600",
 					"retention_period":        "600",
 				}),
@@ -234,6 +244,121 @@ resource "alicloud_db_instance" "default" {
  	db_instance_storage_type = "cloud_essd"
   	instance_type            = "mysql.x4.large.2c"
   	instance_storage         = "20"
+	vswitch_id = local.vswitch_id
+	instance_name = var.name
+	security_group_ids = alicloud_security_group.default.*.id
+}`, name)
+}
+
+// lintignore: AT001
+func TestAccAliCloudRdsDBBackupPolicyMySqlLocalDisk(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_db_backup_policy.default"
+	serverFunc := func() interface{} {
+		return &RdsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serverFunc, "DescribeBackupPolicy")
+	ra := resourceAttrInit(resourceId, nil)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := "tf-testAccDBbackuppolicy"
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceDBBackupPolicyMysqlLocalDiskConfigDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		//CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_id":                  "${alicloud_db_instance.default.id}",
+					"preferred_backup_period":      []string{"Monday", "Wednesday"},
+					"preferred_backup_time":        "02:00Z-03:00Z",
+					"enable_increment_data_backup": "true",
+					"inc_backup_interval":          "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_id":                  CHECKSET,
+						"enable_increment_data_backup": "true",
+						"inc_backup_interval":          "60",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"inc_backup_interval": "120",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"inc_backup_interval": "120",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func resourceDBBackupPolicyMysqlLocalDiskConfigDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+data "alicloud_db_zones" "default"{
+	engine = "MySQL"
+	engine_version = "8.0"
+	instance_charge_type = "PostPaid"
+	category = "HighAvailability"
+ 	db_instance_storage_type = "local_ssd"
+}
+
+data "alicloud_db_instance_classes" "default" {
+    zone_id = data.alicloud_db_zones.default.zones.0.id
+	engine = "MySQL"
+	engine_version = "8.0"
+	category = "HighAvailability"
+ 	db_instance_storage_type = "local_ssd"
+	instance_charge_type = "PostPaid"
+}
+
+data "alicloud_vpcs" "default" {
+    name_regex = "^default-NODELETING$"
+}
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+  zone_id = data.alicloud_db_zones.default.zones.0.id
+}
+
+resource "alicloud_vswitch" "this" {
+ count = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
+ vswitch_name = var.name
+ vpc_id = data.alicloud_vpcs.default.ids.0
+ zone_id = data.alicloud_db_zones.default.ids.0
+ cidr_block = cidrsubnet(data.alicloud_vpcs.default.vpcs.0.cidr_block, 8, 4)
+}
+locals {
+  vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids.0 : concat(alicloud_vswitch.this.*.id, [""])[0]
+  zone_id = data.alicloud_db_zones.default.ids.0
+}
+
+resource "alicloud_security_group" "default" {
+	name   = var.name
+	vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_db_instance" "default" {
+    engine = "MySQL"
+	engine_version = "8.0"
+ 	db_instance_storage_type = "local_ssd"
+  	instance_type            = data.alicloud_db_instance_classes.default.instance_classes.0.instance_class
+  	instance_storage         = data.alicloud_db_instance_classes.default.instance_classes.0.storage_range.min
 	vswitch_id = local.vswitch_id
 	instance_name = var.name
 	security_group_ids = alicloud_security_group.default.*.id

--- a/alicloud/service_alicloud_rds.go
+++ b/alicloud/service_alicloud_rds.go
@@ -950,7 +950,20 @@ func (s *RdsService) ModifyDBBackupPolicy(d *schema.ResourceData, updateForData,
 			"BackupPolicyMode":      "DataBackupPolicy",
 			"SourceIp":              s.client.SourceIp,
 			"ReleasedKeepPolicy":    releasedKeepPolicy,
-			"Category":              category,
+		}
+		// MySQL local disk instances do not support the flash backup feature and reject Category
+		// whatever its value. Category is Computed, so once Read has stored the queried value it
+		// would otherwise be sent back on every subsequent update
+		if !(instance["Engine"] == "MySQL" && instance["DBInstanceStorageType"] == "local_ssd") {
+			request["Category"] = category
+		}
+		if instance["Engine"] == "MySQL" && instance["DBInstanceStorageType"] == "local_ssd" {
+			// Incremental backup applies to SQL Server cloud disk and MySQL local disk instances,
+			// and IncBackupInterval only takes effect once it is enabled
+			request["EnableIncrementDataBackup"] = enableIncrementDataBackup
+			if v, ok := d.GetOk("inc_backup_interval"); ok {
+				request["IncBackupInterval"] = v.(int)
+			}
 		}
 		if instance["Engine"] == "SQLServer" && instance["Category"] == "AlwaysOn" {
 			if v, ok := d.GetOk("backup_priority"); ok {
@@ -986,6 +999,11 @@ func (s *RdsService) ModifyDBBackupPolicy(d *schema.ResourceData, updateForData,
 			// Basic version cannot set backup interval
 			if v, ok := instance["Category"].(string); ok && v != "Basic" {
 				request["BackupInterval"] = backupInterval
+			}
+		}
+		if instance["Engine"] == "MySQL" && d.Get("enable_backup_log").(bool) {
+			if v, ok := d.GetOkExists("enable_pitr_protection"); ok {
+				request["EnablePitrProtection"] = v.(bool)
 			}
 		}
 

--- a/website/docs/r/db_backup_policy.html.markdown
+++ b/website/docs/r/db_backup_policy.html.markdown
@@ -79,6 +79,7 @@ The following arguments are supported:
 * `local_log_retention_hours` - (Optional, Available since v1.69.0) Instance log backup local retention hours. Valid when the `enable_backup_log` is `true`. Valid values: [0-7*24].
 * `local_log_retention_space` - (Optional, Available since v1.69.0) Instance log backup local retention space. Valid when the `enable_backup_log` is `true`. Valid values: [0-50].
 * `high_space_usage_protection` - (Optional, Available since v1.69.0) Instance high space usage protection policy. Valid when the `enable_backup_log` is `true`. Valid values are `Enable`, `Disable`.
+* `inc_backup_interval` - (Optional, Int, Available since v1.XXX) The frequency at which you want to perform incremental backup on the MySQL instance. Valid when the `enable_increment_data_backup` is `true` and instance is MySQL local disk. Valid values: [60, 120, 240, 360, 720].
 * `log_backup_frequency` - (Optional, Available since v1.69.0) Instance log backup frequency. Valid when the instance engine is `SQLServer`. Valid values are `LogInterval`.
 * `compress_type` - (Optional, Available since v1.69.0) The compress type of instance policy. Valid values are `1`, `4`, `8`.
 * `archive_backup_retention_period` - (Optional, Available since v1.69.0) Instance archive backup retention days. Valid when the `enable_backup_log` is `true` and instance is mysql local disk. Valid values: [30-1095], and `archive_backup_retention_period` must larger than `backup_retention_period` 730.
@@ -110,6 +111,7 @@ The following arguments are supported:
   - false (default): disables the feature.
   - true: enables the feature.
     ->**NOTE:** This parameter takes effect only on instances that run SQL Server with cloud disks. This parameter takes effect only when BackupPolicyMode is set to DataBackupPolicy.
+* `enable_pitr_protection` - (Optional, Bool, Available since v1.XXX) Specifies whether to enable PITR (Point-in-Time Recovery) on the MySQL instance. Valid values are `true`, `false`. This parameter takes effect only when `enable_backup_log` is `true` and BackupPolicyMode is set to DataBackupPolicy.
 * `log_backup_local_retention_number` - (Optional, Int, Available since v1.229.1)  The number of binary log files that you want to retain on the instance. Default value: 60. Valid values: 6 to 100.
   ->**NOTE:** This parameter takes effect only when you set the BackupPolicyMode parameter to LogBackupPolicy. If the instance runs MySQL, you can set this parameter to -1. The value -1 specifies that an unlimited number of binary log files can be retained on the instance.
 * `backup_method` - (Optional, Available since v1.229.1)  The backup method of the instance. Valid values:


### PR DESCRIPTION
- Added `enable_pitr_protection` (TypeBool, MySQL only, LogBackupPolicy mode)
- Added `inc_backup_interval` (TypeInt, DataBackupPolicy mode)
- Fixed `backup_interval` default value bug: no longer sends -1 when not set
- Fixed `backup_retention_period` bug: removed != 7 check that prevented setting value back to default 7