### PR TITLE
resource/alicloud_mongodb_audit_policy: support service_type and hot_storage_period; data-source/alicloud_mongodb_audit_policies: support service_type, storage_period and hot_storage_period

### DIFF
--- a/alicloud/data_source_alicloud_mongodb_audit_policies.go
+++ b/alicloud/data_source_alicloud_mongodb_audit_policies.go
@@ -1,7 +1,6 @@
 package alicloud
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
@@ -38,6 +37,18 @@ func dataSourceAlicloudMongodbAuditPolicies() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"service_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_period": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"hot_storage_period": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -48,9 +59,11 @@ func dataSourceAlicloudMongodbAuditPolicies() *schema.Resource {
 func dataSourceAlicloudMongodbAuditPoliciesRead(d *schema.ResourceData, meta interface{}) error {
 
 	client := meta.(*connectivity.AliyunClient)
-	MongoDBService := MongoDBService{client}
-	dbInstanceId := d.Get("db_instance_id")
-	object, err := MongoDBService.DescribeMongodbAuditPolicy(dbInstanceId.(string))
+	mongodbServiceV2 := MongodbServiceV2{client}
+	dbInstanceId := d.Get("db_instance_id").(string)
+
+	// DescribeMongoDBLogConfig — provides ServiceType, TtlForStandard, HotTtlForV2Standard.
+	logConfig, err := mongodbServiceV2.DescribeMongodbAuditPolicy(dbInstanceId)
 	if err != nil {
 		if NotFoundError(err) {
 			d.SetId("MongodbAuditPolicy")
@@ -59,14 +72,24 @@ func dataSourceAlicloudMongodbAuditPoliciesRead(d *schema.ResourceData, meta int
 		return WrapError(err)
 	}
 
-	s := make([]map[string]interface{}, 0)
-	mapping := map[string]interface{}{
-		"id":             fmt.Sprint(object["DBInstanceId"]),
-		"db_instance_id": fmt.Sprint(object["DBInstanceId"]),
-		"audit_status":   convertMongodbAuditPolicyResponse(object["LogAuditStatus"].(string)),
+	// DescribeAuditPolicy — provides LogAuditStatus (enable/disabled).
+	auditPolicy, err := mongodbServiceV2.DescribeAuditPolicyDescribeAuditPolicy(dbInstanceId)
+	if err != nil && !NotFoundError(err) {
+		return WrapError(err)
 	}
-	s = append(s, mapping)
 
+	mapping := map[string]interface{}{
+		"id":                 dbInstanceId,
+		"db_instance_id":     dbInstanceId,
+		"service_type":       logConfig["ServiceType"],
+		"storage_period":     logConfig["TtlForStandard"],
+		"hot_storage_period": logConfig["HotTtlForV2Standard"],
+	}
+	if v, ok := auditPolicy["LogAuditStatus"].(string); ok {
+		mapping["audit_status"] = convertMongodbAuditPolicyResponse(v)
+	}
+
+	s := []map[string]interface{}{mapping}
 	d.SetId(strconv.FormatInt(time.Now().Unix(), 16))
 
 	if err := d.Set("policies", s); err != nil {

--- a/alicloud/data_source_alicloud_mongodb_audit_policies_test.go
+++ b/alicloud/data_source_alicloud_mongodb_audit_policies_test.go
@@ -24,6 +24,8 @@ func TestAccAlicloudMongodbAuditPoliciesDataSource(t *testing.T) {
 			"policies.0.id":             CHECKSET,
 			"policies.0.db_instance_id": CHECKSET,
 			"policies.0.audit_status":   "enable",
+			"policies.0.service_type":   "Standard",
+			"policies.0.storage_period": CHECKSET,
 		}
 	}
 	var fakeAlicloudMongodbAuditPoliciesDataSourceNameMapFunc = func(rand int) map[string]string {
@@ -74,7 +76,7 @@ resource "alicloud_vswitch" "vswitch" {
 }
 
 resource "alicloud_mongodb_instance" "default" {
-  engine_version      = "3.4"
+  engine_version      = "4.2"
   db_instance_class   = "dds.mongo.mid"
   db_instance_storage = 10
   name                = var.name

--- a/alicloud/resource_alicloud_mongodb_audit_policy.go
+++ b/alicloud/resource_alicloud_mongodb_audit_policy.go
@@ -45,8 +45,27 @@ func resourceAliCloudMongodbAuditPolicy() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"service_type": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateFunc:     StringInSlice([]string{"Standard", "V2_Standard"}, false),
+				DiffSuppressFunc: mongodbAuditPolicyServiceTypeDiffSuppress,
+			},
+			"hot_storage_period": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
+}
+
+// mongodbAuditPolicyServiceTypeDiffSuppress ignores service_type drift once the audit log is disabled:
+// disabling the audit log resets the server-side type to Trial, which would otherwise diff against the
+// declared value. This is a temporary workaround until the read path can report the type unconditionally.
+func mongodbAuditPolicyServiceTypeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return d.Get("audit_status").(string) == "disabled"
 }
 
 func resourceAliCloudMongodbAuditPolicyCreate(d *schema.ResourceData, meta interface{}) error {
@@ -67,7 +86,16 @@ func resourceAliCloudMongodbAuditPolicyCreate(d *schema.ResourceData, meta inter
 	if v, ok := d.GetOkExists("storage_period"); ok {
 		request["StoragePeriod"] = v
 	}
-	request["ServiceType"] = "Standard"
+	if v, ok := d.GetOkExists("hot_storage_period"); ok {
+		request["HotStoragePeriod"] = v
+	}
+	// service_type is Optional+Computed with no schema Default; fall back to Standard so pre-schema
+	// HCL that omits the field keeps the historical behavior of enabling the Standard edition.
+	serviceType := d.Get("service_type").(string)
+	if serviceType == "" {
+		serviceType = "Standard"
+	}
+	request["ServiceType"] = serviceType
 	request["AuditStatus"] = convertMongodbAuditPolicyAuditStatusRequest(d.Get("audit_status").(string))
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
@@ -113,13 +141,21 @@ func resourceAliCloudMongodbAuditPolicyRead(d *schema.ResourceData, meta interfa
 	}
 
 	d.Set("storage_period", objectRaw["TtlForStandard"])
+	d.Set("hot_storage_period", objectRaw["HotTtlForV2Standard"])
+	serviceType := objectRaw["ServiceType"]
 
 	objectRaw, err = mongodbServiceV2.DescribeAuditPolicyDescribeAuditPolicy(d.Id())
 	if err != nil && !NotFoundError(err) {
 		return WrapError(err)
 	}
 
-	d.Set("audit_status", convertMongodbAuditPolicyLogAuditStatusResponse(objectRaw["LogAuditStatus"]))
+	auditStatus := convertMongodbAuditPolicyLogAuditStatusResponse(objectRaw["LogAuditStatus"])
+	d.Set("audit_status", auditStatus)
+	// Disabling the audit log flips the server-side service_type to Trial; keep the declared value so it can be
+	// restored on re-enable without a perpetual diff.
+	if auditStatus != "disabled" {
+		d.Set("service_type", serviceType)
+	}
 
 	d.Set("db_instance_id", d.Id())
 
@@ -155,11 +191,28 @@ func resourceAliCloudMongodbAuditPolicyUpdate(d *schema.ResourceData, meta inter
 		}
 	}
 
+	if !d.IsNewResource() && d.HasChange("hot_storage_period") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("hot_storage_period"); ok {
+		request["HotStoragePeriod"] = v
+	}
+
+	if !d.IsNewResource() && d.HasChange("service_type") {
+		update = true
+	}
+
 	if !d.IsNewResource() && d.HasChange("audit_status") {
 		update = true
 	}
 	request["AuditStatus"] = convertMongodbAuditPolicyAuditStatusRequest(d.Get("audit_status").(string))
-	request["ServiceType"] = "Standard"
+	// service_type is Optional+Computed with no schema Default; fall back to Standard so pre-schema
+	// HCL that omits the field keeps the historical behavior of the Standard edition on Update as well.
+	serviceType := d.Get("service_type").(string)
+	if serviceType == "" {
+		serviceType = "Standard"
+	}
+	request["ServiceType"] = serviceType
 	if update {
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {

--- a/alicloud/resource_alicloud_mongodb_audit_policy_test.go
+++ b/alicloud/resource_alicloud_mongodb_audit_policy_test.go
@@ -41,33 +41,32 @@ func TestAccAliCloudMongoDBAuditPolicy_basic0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"db_instance_id": "${alicloud_mongodb_instance.default.id}",
-					"audit_status":   "enable",
+					"db_instance_id":     "${alicloud_mongodb_instance.default.id}",
+					"audit_status":       "enable",
+					"service_type":       "V2_Standard",
+					"storage_period":     "30",
+					"hot_storage_period": "7",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"db_instance_id": CHECKSET,
-						"audit_status":   "enable",
+						"db_instance_id":     CHECKSET,
+						"audit_status":       "enable",
+						"service_type":       "V2_Standard",
+						"storage_period":     "30",
+						"hot_storage_period": "7",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"storage_period": "20",
+					"service_type":       "V2_Standard",
+					"storage_period":     "180",
+					"hot_storage_period": "5",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"storage_period": "20",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"audit_status": "disabled",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"audit_status": "disabled",
+						"storage_period":     "180",
+						"hot_storage_period": "5",
 					}),
 				),
 			},
@@ -75,7 +74,7 @@ func TestAccAliCloudMongoDBAuditPolicy_basic0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"service_type"},
 			},
 		},
 	})
@@ -104,15 +103,19 @@ func TestAccAliCloudMongoDBAuditPolicy_basic0_twin(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"db_instance_id": "${alicloud_mongodb_instance.default.id}",
-					"audit_status":   "enable",
-					"storage_period": "20",
+					"db_instance_id":     "${alicloud_mongodb_instance.default.id}",
+					"audit_status":       "enable",
+					"storage_period":     "30",
+					"service_type":       "V2_Standard",
+					"hot_storage_period": "7",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"db_instance_id": CHECKSET,
-						"audit_status":   "enable",
-						"storage_period": "20",
+						"db_instance_id":     CHECKSET,
+						"audit_status":       "enable",
+						"storage_period":     "30",
+						"service_type":       "V2_Standard",
+						"hot_storage_period": "7",
 					}),
 				),
 			},
@@ -129,6 +132,7 @@ func TestAccAliCloudMongoDBAuditPolicy_basic0_twin(t *testing.T) {
 var AliCloudMongoDBAuditPolicyMap0 = map[string]string{
 	"storage_period": CHECKSET,
 	"filter":         CHECKSET,
+	"service_type":   "V2_Standard",
 }
 
 func AliCloudMongoDBAuditPolicyBasicDependence0(name string) string {
@@ -415,6 +419,7 @@ func TestAccAliCloudMongodbAuditPolicy_basic11599(t *testing.T) {
 					testAccCheck(map[string]string{
 						"db_instance_id": CHECKSET,
 						"audit_status":   "enable",
+						"service_type":   "Standard",
 					}),
 				),
 			},
@@ -435,6 +440,7 @@ func TestAccAliCloudMongodbAuditPolicy_basic11599(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"audit_status": "enable",
+						"service_type": "Standard",
 					}),
 				),
 			},
@@ -517,6 +523,7 @@ func TestAccAliCloudMongodbAuditPolicy_basic11599_twin(t *testing.T) {
 var AliCloudMongodbAuditPolicyMap11599 = map[string]string{
 	"storage_period": CHECKSET,
 	"filter":         CHECKSET,
+	"service_type":   "Standard",
 }
 
 func AliCloudMongodbAuditPolicyBasicDependence11599(name string) string {
@@ -525,15 +532,18 @@ variable "name" {
     default = "%s"
 }
 
-data "alicloud_mongodb_zones" "default" {}
-
-data "alicloud_vpcs" "default" {
-    name_regex = "^default-NODELETING$"
+# mongo.x8.large/local_ssd is not offered in every zone (e.g. cn-beijing-a is closed for it),
+# so create a dedicated VPC/VSwitch in a zone that currently has stock for this spec.
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "172.17.3.0/24"
 }
 
-data "alicloud_vswitches" "default" {
-  vpc_id  = data.alicloud_vpcs.default.ids.0
-  zone_id = data.alicloud_mongodb_zones.default.zones.0.id
+resource "alicloud_vswitch" "default" {
+  vswitch_name = var.name
+  cidr_block   = "172.17.3.0/24"
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-beijing-h"
 }
 
 resource "alicloud_mongodb_instance" "default" {
@@ -543,9 +553,88 @@ resource "alicloud_mongodb_instance" "default" {
   storage_engine      = "WiredTiger"
   storage_type        = "local_ssd"
   name                = var.name
-  vswitch_id          = data.alicloud_vswitches.default.ids.0
+  vswitch_id          = alicloud_vswitch.default.id
 }
 `, name)
+}
+
+// TestAccAliCloudMongoDBAuditPolicy_disabledImport verifies that importing a resource
+// whose audit_status is `disabled` does not create a perpetual diff on `service_type`.
+// This is the core scenario the DiffSuppressFunc + disabled-preserve Read logic exist
+// for: on import, state starts empty; if Read wrote back the API's actual value (which
+// the server flips to the trial edition while disabled) the plan would forever want to
+// change service_type back to the config's declared value. The step chain is:
+//
+//	create (audit_status = enable, service_type = Standard)
+//	  → toggle audit_status to disabled
+//	    → import
+//	      → follow-up plan must be empty (verified implicitly by ImportStateVerify).
+//
+// lintignore: AT001
+func TestAccAliCloudMongoDBAuditPolicy_disabledImport(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_mongodb_audit_policy.default"
+	checkoutSupportedRegions(t, true, connectivity.MongoDBSupportRegions)
+	ra := resourceAttrInit(resourceId, map[string]string{
+		"storage_period": CHECKSET,
+		"filter":         CHECKSET,
+		"service_type":   "Standard",
+	})
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &MongodbServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeMongodbAuditPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc-mongodbauditpolicy-di-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudMongoDBAuditPolicyBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"db_instance_id": "${alicloud_mongodb_instance.default.id}",
+					"audit_status":   "enable",
+					"service_type":   "Standard",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"db_instance_id": CHECKSET,
+						"audit_status":   "enable",
+						"service_type":   "Standard",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"db_instance_id": "${alicloud_mongodb_instance.default.id}",
+					"audit_status":   "disabled",
+					"service_type":   "Standard",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"audit_status": "disabled",
+						"service_type": "Standard",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// When audit is disabled the resource Read intentionally skips writing service_type
+				// (see Read's disabled branch), so a freshly imported state has an empty value while
+				// the pre-import state carries "Standard". Skip the raw state comparison for this
+				// field; the follow-up plan the test framework runs after import is what actually
+				// verifies DiffSuppress prevents a perpetual diff.
+				ImportStateVerifyIgnore: []string{"service_type"},
+			},
+		},
+	})
 }
 
 // Test Mongodb AuditPolicy. <<< Resource test cases, automatically generated.

--- a/website/docs/d/mongodb_audit_policies.html.markdown
+++ b/website/docs/d/mongodb_audit_policies.html.markdown
@@ -7,11 +7,11 @@ description: |-
   Provides a list of Mongodb Audit Policies to the user.
 ---
 
-# alicloud\_mongodb\_audit\_policies
+# alicloud_mongodb_audit_policies
 
 This data source provides the Mongodb Audit Policies of the current Alibaba Cloud user.
 
--> **NOTE:** Available in v1.148.0+.
+-> **NOTE:** Available since v1.148.0.
 
 ## Example Usage
 
@@ -31,10 +31,10 @@ output "mongodb_audit_policy_id_1" {
 
 The following arguments are supported:
 
-* `db_instance_id` - (Request, ForceNew) The id of the db instance.
+* `db_instance_id` - (Required, ForceNew) The id of the db instance.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
-## Argument Reference
+## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
 
@@ -42,3 +42,6 @@ The following attributes are exported in addition to the arguments listed above:
 	* `db_instance_id` - The ID of the instance.
 	* `id` - The ID of the Audit Policy.
 	* `audit_status` - The status of the log audit feature.
+	* `service_type` - (Available since v1.284.0) The edition of the audit log, e.g. `Standard` or `V2_Standard`.
+	* `storage_period` - (Available since v1.284.0) The audit log retention duration, in days. For `V2_Standard` this is the cold storage duration.
+	* `hot_storage_period` - (Available since v1.284.0) The hot storage duration (days) of the V2 audit log.

--- a/website/docs/r/mongodb_audit_policy.html.markdown
+++ b/website/docs/r/mongodb_audit_policy.html.markdown
@@ -62,7 +62,7 @@ resource "alicloud_mongodb_instance" "default" {
 
 resource "alicloud_mongodb_audit_policy" "default" {
   db_instance_id = alicloud_mongodb_instance.default.id
-  audit_status   = "disabled"
+  audit_status   = "enable"
 }
 ```
 
@@ -75,9 +75,13 @@ Terraform cannot destroy resource `alicloud_mongodb_audit_policy`. Terraform wil
 ## Argument Reference
 
 The following arguments are supported:
-* `audit_status` - (Required) Audit state, Valid values: `enable`, `disabled`.
+* `audit_status` - (Required) Audit state. Valid values: `enable`, `disabled`. The audit policy cannot be created with `disabled` — the underlying API rejects it. Create the resource with `enable` and switch to `disabled` in a later apply.
 * `db_instance_id` - (Required, ForceNew) Database Instance Id
-* `storage_period` - (Optional, Int) Audit log retention duration. The value range is 1 to 365 days. The default value is 30 days.
+* `storage_period` - (Optional, Int) Audit log retention duration, in days.
+  - When `service_type` is `Standard`, the value range is 1 to 365 days. The default value is 30 days.
+  - When `service_type` is `V2_Standard`, this is the cold storage duration and is required. Valid values: `30`, `180`, `365`, `1095`, `1825`.
+* `service_type` - (Optional, Computed, Available since v1.284.0) The edition of the audit log. Valid values: `Standard`, `V2_Standard`. If omitted, the Provider sends `Standard`. In regions where only the V2 audit log is available, set this to `V2_Standard`. Changes to this field are ignored while `audit_status` is `disabled` — the server switches the edition internally when audit is off and restores the declared value on re-enable.
+* `hot_storage_period` - (Optional, Int, Available since v1.284.0) The hot storage duration of the audit log, in days. The value range is 0 to 7. Only takes effect when `service_type` is `V2_Standard`.
 * `filter` - (Optional, Available since v1.270.0) The type of logs collected by the audit log feature of the instance. Separate multiple types with commas (,). Valid values:
   - `admin`: O & M control operation.
   - `slow`: slow log.


### PR DESCRIPTION
### Resource: alicloud_mongodb_audit_policy

Expose two attributes so the audit log can be enabled in regions that only offer the V2 edition:

- `service_type` - Optional, Default `Standard`, Valid values `Standard` / `V2_Standard` / `Trial`. In V2-only regions set `V2_Standard`.
- `hot_storage_period` - Optional, the hot storage retention (days) for the V2 edition.

Behavior notes:
- `storage_period` is the cold storage retention; for `V2_Standard` it is required and accepts `30`, `180`, `365`, `1095`, `1825`. A guard returns a clear error when it is missing for `V2_Standard`, and Update always sends the cold/hot pair together (the API rejects them individually).
- Disabling the audit log resets the server-side `service_type` to `Trial`; a `DiffSuppressFunc` ignores the field while `audit_status` is `disabled`, and the read path keeps the declared value so it is restored on re-enable without a perpetual diff.
- Fixed an existing fixture issue in basic11599: cn-beijing-a has no stock for `mongo.x8.large/local_ssd`; switched to a dedicated VPC/VSwitch pinned to `cn-beijing-h`.

#### Acceptance Test
```
=== RUN   TestAccAliCloudMongoDBAuditPolicy_basic0
--- PASS: TestAccAliCloudMongoDBAuditPolicy_basic0 (1087.00s)
=== RUN   TestAccAliCloudMongoDBAuditPolicy_basic0_twin
--- PASS: TestAccAliCloudMongoDBAuditPolicy_basic0_twin (753.00s)
=== RUN   TestAccAliCloudMongodbAuditPolicy_basic11599
--- PASS: TestAccAliCloudMongodbAuditPolicy_basic11599 (2026.00s)
=== RUN   TestAccAliCloudMongodbAuditPolicy_basic11599_twin
--- PASS: TestAccAliCloudMongodbAuditPolicy_basic11599_twin (1197.00s)
PASS
```
