### PR TITLE
resource/alicloud_oos_execution: support tags attribute; data-source/alicloud_oos_executions: support tags attribute

### DIFF
--- a/alicloud/data_source_alicloud_oos_executions.go
+++ b/alicloud/data_source_alicloud_oos_executions.go
@@ -169,6 +169,11 @@ func dataSourceAlicloudOosExecutions() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 						"update_date": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -303,6 +308,9 @@ func dataSourceAlicloudOosExecutionsRead(d *schema.ResourceData, meta interface{
 			"template_name":       object["TemplateName"],
 			"template_version":    object["TemplateVersion"],
 			"update_date":         object["UpdateDate"],
+		}
+		if v, ok := object["Tags"].(map[string]interface{}); ok {
+			mapping["tags"] = tagsToMap(v)
 		}
 		ids = append(ids, fmt.Sprint(object["ExecutionId"]))
 		s = append(s, mapping)

--- a/alicloud/resource_alicloud_oos_execution.go
+++ b/alicloud/resource_alicloud_oos_execution.go
@@ -121,6 +121,7 @@ func resourceAlicloudOosExecution() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"tags": tagsSchemaForceNew(),
 			"update_date": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -162,6 +163,14 @@ func resourceAlicloudOosExecutionCreate(d *schema.ResourceData, meta interface{}
 
 	if v, ok := d.GetOk("template_content"); ok {
 		request["TemplateContent"] = v
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		respJson, err := convertMaptoJsonString(v.(map[string]interface{}))
+		if err != nil {
+			return WrapError(err)
+		}
+		request["Tags"] = respJson
 	}
 
 	request["TemplateName"] = d.Get("template_name")
@@ -209,20 +218,31 @@ func resourceAlicloudOosExecutionRead(d *schema.ResourceData, meta interface{}) 
 	}
 	d.Set("counters", object["Counters"])
 	d.Set("create_date", object["CreateDate"])
+	d.Set("description", object["Description"])
 	d.Set("end_date", object["EndDate"])
 	d.Set("executed_by", object["ExecutedBy"])
 	d.Set("is_parent", object["IsParent"])
+	d.Set("loop_mode", object["LoopMode"])
 	d.Set("mode", object["Mode"])
 	d.Set("outputs", object["Outputs"])
-	d.Set("parameters", object["Parameters"])
+	if v, ok := object["Parameters"].(map[string]interface{}); ok {
+		params, _ := convertMaptoJsonString(v)
+		d.Set("parameters", params)
+	} else {
+		d.Set("parameters", object["Parameters"])
+	}
 	d.Set("parent_execution_id", object["ParentExecutionId"])
 	d.Set("ram_role", object["RamRole"])
+	d.Set("safety_check", object["SafetyCheck"])
 	d.Set("start_date", object["StartDate"])
 	d.Set("status", object["Status"])
 	d.Set("status_message", object["StatusMessage"])
 	d.Set("template_id", object["TemplateId"])
 	d.Set("template_name", object["TemplateName"])
 	d.Set("template_version", object["TemplateVersion"])
+	if v, ok := object["Tags"].(map[string]interface{}); ok {
+		d.Set("tags", tagsToMap(v))
+	}
 	d.Set("update_date", object["UpdateDate"])
 	return nil
 }

--- a/alicloud/resource_alicloud_oos_execution_test.go
+++ b/alicloud/resource_alicloud_oos_execution_test.go
@@ -88,7 +88,7 @@ func testSweepOosExecution(region string) error {
 	return nil
 }
 
-func TestAccAlicloudOOSExecution_basic(t *testing.T) {
+func TestAccAliCloudOOSExecution_basic(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_oos_execution.default"
 	ra := resourceAttrInit(resourceId, OosExecutionMap)
@@ -111,15 +111,34 @@ func TestAccAlicloudOOSExecution_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"template_name": "${alicloud_oos_template.default.template_name}",
-					"description":   "From TF Test",
-					"parameters":    `{\"Status\":\"Running\"}`,
+					"template_name":       "${alicloud_oos_template.default.template_name}",
+					"description":         "From TF Test",
+					"parameters":          `{\"Status\":\"Running\"}`,
+					"safety_check":        "Skip",
+					"template_version":    "${alicloud_oos_template.default.template_version}",
+					"mode":                "Automatic",
+					"loop_mode":           "",
+					"parent_execution_id": "",
+					"template_content":    "",
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "Execution Test",
+					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"template_name": CHECKSET,
-						"description":   "From TF Test",
-						"parameters":    CHECKSET,
+						"template_name":       CHECKSET,
+						"description":         "From TF Test",
+						"parameters":          CHECKSET,
+						"safety_check":        "Skip",
+						"template_version":    CHECKSET,
+						"tags.%":              "2",
+						"tags.Created":        "TF",
+						"tags.For":            "Execution Test",
+						"mode":                "Automatic",
+						"loop_mode":           "",
+						"parent_execution_id": "",
+						"template_content":    "",
 					}),
 				),
 			},
@@ -127,7 +146,7 @@ func TestAccAlicloudOOSExecution_basic(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"description", "loop_mode", "safety_check", "parameters"},
+				ImportStateVerifyIgnore: []string{},
 			},
 		},
 	})
@@ -196,6 +215,10 @@ func TestUnitAlicloudOOSExecution(t *testing.T) {
 		"template_content":    "template_content",
 		"template_name":       "template_name",
 		"template_version":    "template_version",
+		"tags": map[string]interface{}{
+			"Created": "TF",
+			"For":     "Test",
+		},
 	} {
 		err := dCreate.Set(key, value)
 		assert.Nil(t, err)
@@ -212,14 +235,18 @@ func TestUnitAlicloudOOSExecution(t *testing.T) {
 	ReadMockResponse := map[string]interface{}{
 		"Executions": []interface{}{
 			map[string]interface{}{
-				"Counters":          "counters",
-				"CreateDate":        "create_date",
-				"EndDate":           "end_date",
-				"ExecutedBy":        "executed_by",
-				"IsParent":          "is_parent",
-				"Mode":              "mode",
-				"Outputs":           "outputs",
-				"Parameters":        "parameters",
+				"Counters":   "counters",
+				"CreateDate": "create_date",
+				"EndDate":    "end_date",
+				"ExecutedBy": "executed_by",
+				"IsParent":   "is_parent",
+				"Mode":       "mode",
+				"Outputs":    "outputs",
+				"Parameters": map[string]interface{}{"Status": "Running"},
+				"Tags": map[string]interface{}{
+					"Created": "TF",
+					"For":     "Test",
+				},
 				"ParentExecutionId": "parent_execution_id",
 				"RamRole":           "ram_role",
 				"StartDate":         "start_date",

--- a/website/docs/d/oos_executions.html.markdown
+++ b/website/docs/d/oos_executions.html.markdown
@@ -7,25 +7,25 @@ description: |-
     Provides a list of OOS Executions.
 ---
 
-# alicloud\_oos\_executions
+# alicloud_oos_executions
 
 This data source provides a list of OOS Executions in an Alibaba Cloud account according to the specified filters.
- 
--> **NOTE:** Available in v1.93.0+.
+
+-> **NOTE:** Available since v1.93.0.
 
 ## Example Usage
 
-```
+```terraform
 # Declare the data source
 
 data "alicloud_oos_executions" "example" {
-  ids = ["execution_id"]
+  ids           = ["execution_id"]
   template_name = "name"
-  status = "Success"
+  status        = "Success"
 }
 
 output "first_execution_id" {
-  value = "${data.alicloud_oos_executions.example.executions.0.id}"
+  value = data.alicloud_oos_executions.example.executions.0.id
 }
 ```
 
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `sort_order` - (Optional) The sort order.
 * `start_date_after` - (Optional) The execution whose start time is greater than or equal to the specified time.
 * `start_date_before` - (Optional) The execution with start time less than or equal to the specified time.
-* `status` - (Optional) The Status of OOS Execution. Valid: `Cancelled`, `Failed`, `Queued`, `Running`, `Started`, `Success`, `Waiting`.
+* `status` - (Optional) The Status of OOS Execution. Valid: `Canceled`, `Failed`, `Queued`, `Running`, `Started`, `Success`, `Waiting`.
 * `template_name` - (Optional) The name of execution template.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
@@ -58,15 +58,24 @@ The following attributes are exported in addition to the arguments listed above:
 * `ids` -  A list of OOS Execution ids.
 * `executions` - A list of OOS Executions. Each element contains the following attributes:
   * `id` - ID of the OOS Executions.
+  * `category` - The category of OOS Execution.
   * `counters` - The counters of OOS Execution.
   * `create_date` - The time when the execution was created.
+  * `end_date` - The time when the execution was ended.
+  * `executed_by` - The user who execute the template.
   * `execution_id` - ID of the OOS Executions.
   * `is_parent` - Whether to include subtasks.
+  * `mode` - The mode of OOS Execution.
   * `outputs` - The outputs of OOS Executions.
-  * `parameters` - The parameters required by the template
+  * `parameters` - The parameters required by the template.
+  * `parent_execution_id` - The id of parent OOS Execution.
+  * `ram_role` - The role that executes the current template.
   * `start_date` - The time when the template was started.
+  * `status` - The status of OOS Execution.
   * `status_message` - The message of status.
   * `status_reason` - The reason of status.
   * `template_id` - The id of execution template.
+  * `template_name` - The name of execution template.
   * `template_version` - The version of execution template.
+  * `tags` - A mapping of tags assigned to the OOS Execution.
   * `update_date` - The time when the template was updated.

--- a/website/docs/r/oos_execution.html.markdown
+++ b/website/docs/r/oos_execution.html.markdown
@@ -66,6 +66,10 @@ resource "alicloud_oos_execution" "example" {
   parameters    = <<EOF
 				{"Status":"Running"}
 		  	EOF
+  tags = {
+    "Created" = "TF",
+    "For"     = "execution Test"
+  }
 }
 ```
 
@@ -84,7 +88,8 @@ The following arguments are supported:
 * `template_name` - (Required, ForceNew) The name of execution template.
 * `template_version` - (Optional, ForceNew) The version of execution template.
 * `template_content` - (Optional, ForceNew, Available in v1.114.0+) The content of template. When the user selects an existing template to create and execute a task, it is not necessary to pass in this field.
-                    
+* `tags` - (Optional, ForceNew) A mapping of tags to assign to the resource.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
## Summary
- Add `tags` attribute (ForceNew) to `alicloud_oos_execution` resource
- Add `tags` output to `alicloud_oos_executions` data source
- Tags are serialized as JSON and passed to `StartExecution` API, read back from `ListExecutions` response

## Changes
- `alicloud/resource_alicloud_oos_execution.go`: Schema + Create + Read
- `alicloud/data_source_alicloud_oos_executions.go`: Output schema + mapping
- `alicloud/resource_alicloud_oos_execution_test.go`: ACC test + unit test coverage
- `website/docs/r/oos_execution.html.markdown`: Resource doc
- `website/docs/d/oos_executions.html.markdown`: Data source doc

## Test plan
- [ ] ACC test `TestAccAliCloudOOSExecution_basic`
- [x] `go build` passed
- [x] `go vet` passed