### PR TITLE
resource/alicloud_bastionhost_instance: Add bandwidth validation

### DIFF
--- a/alicloud/resource_alicloud_bastionhost_instance.go
+++ b/alicloud/resource_alicloud_bastionhost_instance.go
@@ -50,6 +50,17 @@ func resourceAliCloudBastionhostInstance() *schema.Resource {
 			"bandwidth": {
 				Type:     schema.TypeString,
 				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value, err := strconv.Atoi(v.(string))
+					if err != nil {
+						errors = append(errors, fmt.Errorf("%q must be a numeric string, got: %s", k, v.(string)))
+						return
+					}
+					if value < 0 || value%5 != 0 {
+						errors = append(errors, fmt.Errorf("%q must be a non-negative multiple of 5, got: %d", k, value))
+					}
+					return
+				},
 			},
 			"public_white_list": {
 				Type:     schema.TypeList,

--- a/website/docs/r/bastionhost_instance.html.markdown
+++ b/website/docs/r/bastionhost_instance.html.markdown
@@ -151,10 +151,16 @@ The following arguments are supported:
 * `plan_code` - (Required, ForceNew, Available since 1.193.0) The plan code of Cloud Bastionhost instance. Valid values:
   - `cloudbastion`: Basic Edition.
   - `cloudbastion_ha`: HA Edition.
-* `storage` - (Required, Available since 1.193.0) The storage of Cloud Bastionhost instance. Valid values: `0` to `500`. Unit: TB. **NOTE:** From version 1.251.0, `storage` can be modified.
-* `bandwidth` - (Required, Available since 1.193.0) The bandwidth of Cloud Bastionhost instance. **NOTE:** From version 1.263.0, `bandwidth` can be modified.
-  If [China-Site Account](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/guides/getting-account#sign-up-for-an-alibaba-cloud-china-site-account), its valid values: 0 to 150. Unit: Mbit/s. The value must be a multiple of 5.
-  If [International-Site Account](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/guides/getting-account#sign-up-for-an-alibaba-cloud-international-site-account), its valid values: 0 to 200. Unit: Mbit/s. The value must be a multiple of 10.
+* `storage` - (Required, Available since 1.193.0) The storage of Cloud Bastionhost instance. Valid values: `0` to `500`. Unit: TB.
+
+  ->**NOTE:** From version 1.251.0, `storage` can be modified.
+
+* `bandwidth` - (Required, Available since 1.193.0) The bandwidth of Cloud Bastionhost instance.
+
+  -> **NOTE:** From version 1.263.0, `bandwidth` can be modified.
+
+  - If [China-Site Account](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/guides/getting-account#sign-up-for-an-alibaba-cloud-china-site-account), its valid values: `0` to `150`. Unit: Mbit/s. The value must be a multiple of 5.
+  - If [International-Site Account](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/guides/getting-account#sign-up-for-an-alibaba-cloud-international-site-account), its valid values: `0` to `200`. Unit: Mbit/s. The value must be a multiple of 10.
 * `description` - (Required) Description of the instance. This name can have a string of 1 to 63 characters.
 * `period` - (Optional) Duration for initially producing the instance. Valid values: [1~9], 12, 24, 36. At present, the provider does not support modify "period".
 -> **NOTE:** The attribute `period` is only used to create Subscription instance or modify the PayAsYouGo instance to Subscription. Once effect, it will not be modified that means running `terraform apply` will not effect the resource.


### PR DESCRIPTION
Validate that bandwidth is a non-negative multiple of 5, and update documentation to reflect the constraint.