### PR TITLE
docs: wafv3_defense_rule - list in-list and not-in-list op_value enums

### DIFF
--- a/website/docs/r/wafv3_defense_rule.html.markdown
+++ b/website/docs/r/wafv3_defense_rule.html.markdown
@@ -275,6 +275,8 @@ The config-conditions supports the following:
   - mpty: Indicates that the content is empty.
   - exists: Indicates that the field exists.
   - inl: indicates in the list.
+  - in-list: Indicates that the value is in the list.
+  - not-in-list: Indicates that the value is not in the list.
 
 -> **NOTE:**  Not all logical characters (opvalues) can be configured for the match field (key) of each custom rule. For the logical characters supported by different matching fields, please refer to the association relationship between the matching fields and the logical characters in the custom rules of the WAF console.
 


### PR DESCRIPTION
## Summary

The `op_value` enum list under `config.conditions` in `website/docs/r/wafv3_defense_rule.html.markdown` was missing `in-list` and `not-in-list`. Both are valid per the resource schema's `StringInSlice` validation in [alicloud/resource_alicloud_wafv3_defense_rule.go:172](https://github.com/aliyun/terraform-provider-alicloud/blob/master/alicloud/resource_alicloud_wafv3_defense_rule.go#L172) and are exercised by the data-source example added in #9883.

Follow-up to #9883 — docs-only.

## Test plan

- [x] `go run scripts/document/document_check.go website/docs/r/wafv3_defense_rule.html.markdown` passes