### PR TITLE
resource/alicloud_apig_gateway: regenerate; New Data Source: alicloud_apig_gateways

### DIFF
--- a/alicloud/data_source_alicloud_apig_gateways.go
+++ b/alicloud/data_source_alicloud_apig_gateways.go
@@ -1,0 +1,740 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudApigGateways() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudApigGatewayRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"gateway_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": tagsSchema(),
+			"gateways": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"create_from": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"environments": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"environment_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"alias": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"expire_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"gateway_edition": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"load_balancers": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ipv4_addresses": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"address_ip_version": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"gateway_default": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"address": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"mode": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ports": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"port": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"protocol": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"load_balancer_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ipv6_addresses": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"address_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"payment_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_group": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"security_group_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"spec": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sub_domain_infos": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"domain_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"network_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"protocol": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"target_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"vswitch": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"vswitch_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"vpc_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"zones": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"zone_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"vswitch_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudApigGatewayRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListGateways
+	action := fmt.Sprintf("/v1/gateways")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	if v, ok := d.GetOk("gateway_id"); ok {
+		query["gatewayId"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("gateway_name"); ok {
+		query["name"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		query["resourceGroupId"] = StringPointer(v.(string))
+	}
+
+	tagsFilter := make(map[string]string)
+	if v, ok := d.GetOk("tags"); ok {
+		for key, value := range v.(map[string]interface{}) {
+			tagsFilter[key] = value.(string)
+		}
+	}
+
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	query["pageSize"] = StringPointer(strconv.Itoa(PageSizeLarge))
+	query["pageNumber"] = StringPointer("1")
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaGet("APIG", "2024-03-27", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.data.items[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["name"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["gatewayId"])]; !ok {
+					continue
+				}
+			}
+			if len(tagsFilter) > 0 {
+				itemTags := tagsToMap(item["tags"])
+				matched := true
+				for key, value := range tagsFilter {
+					if v, ok := itemTags[key]; !ok || v != value {
+						matched = false
+						break
+					}
+				}
+				if !matched {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		pageNum, _ := strconv.Atoi(*query["pageNumber"])
+		query["pageNumber"] = StringPointer(strconv.Itoa(pageNum + 1))
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(objectRaw["gatewayId"])
+
+		mapping["create_from"] = objectRaw["createFrom"]
+		mapping["create_time"] = objectRaw["createTimestamp"]
+		mapping["expire_time"] = objectRaw["expireTimestamp"]
+		mapping["gateway_edition"] = objectRaw["gatewayEdition"]
+		mapping["gateway_name"] = objectRaw["name"]
+		mapping["gateway_type"] = objectRaw["gatewayType"]
+		mapping["payment_type"] = convertApigGatewaydatachargeTypeResponse(objectRaw["chargeType"])
+		mapping["resource_group_id"] = objectRaw["resourceGroupId"]
+		mapping["spec"] = objectRaw["spec"]
+		mapping["status"] = objectRaw["status"]
+		mapping["target_version"] = objectRaw["targetVersion"]
+		mapping["update_time"] = objectRaw["updateTimestamp"]
+		mapping["version"] = objectRaw["version"]
+		mapping["gateway_id"] = objectRaw["gatewayId"]
+
+		loadBalancersRaw := objectRaw["loadBalancers"]
+		loadBalancersMaps := make([]map[string]interface{}, 0)
+		if loadBalancersRaw != nil {
+			for _, loadBalancersChildRaw := range convertToInterfaceArray(loadBalancersRaw) {
+				loadBalancersMap := make(map[string]interface{})
+				loadBalancersChildRaw := loadBalancersChildRaw.(map[string]interface{})
+				loadBalancersMap["address"] = loadBalancersChildRaw["address"]
+				loadBalancersMap["address_ip_version"] = loadBalancersChildRaw["addressIpVersion"]
+				loadBalancersMap["address_type"] = loadBalancersChildRaw["addressType"]
+				loadBalancersMap["gateway_default"] = loadBalancersChildRaw["gatewayDefault"]
+				loadBalancersMap["load_balancer_id"] = loadBalancersChildRaw["loadBalancerId"]
+				loadBalancersMap["mode"] = loadBalancersChildRaw["mode"]
+				loadBalancersMap["status"] = loadBalancersChildRaw["status"]
+				loadBalancersMap["type"] = loadBalancersChildRaw["type"]
+
+				ipv4AddressesRaw := make([]interface{}, 0)
+				if loadBalancersChildRaw["ipv4Addresses"] != nil {
+					ipv4AddressesRaw = convertToInterfaceArray(loadBalancersChildRaw["ipv4Addresses"])
+				}
+
+				loadBalancersMap["ipv4_addresses"] = ipv4AddressesRaw
+				ipv6AddressesRaw := make([]interface{}, 0)
+				if loadBalancersChildRaw["ipv6Addresses"] != nil {
+					ipv6AddressesRaw = convertToInterfaceArray(loadBalancersChildRaw["ipv6Addresses"])
+				}
+
+				loadBalancersMap["ipv6_addresses"] = ipv6AddressesRaw
+				portsRaw := loadBalancersChildRaw["ports"]
+				portsMaps := make([]map[string]interface{}, 0)
+				if portsRaw != nil {
+					for _, portsChildRaw := range convertToInterfaceArray(portsRaw) {
+						portsMap := make(map[string]interface{})
+						portsChildRaw := portsChildRaw.(map[string]interface{})
+						portsMap["port"] = portsChildRaw["port"]
+						portsMap["protocol"] = portsChildRaw["protocol"]
+
+						portsMaps = append(portsMaps, portsMap)
+					}
+				}
+				loadBalancersMap["ports"] = portsMaps
+				loadBalancersMaps = append(loadBalancersMaps, loadBalancersMap)
+			}
+		}
+		mapping["load_balancers"] = loadBalancersMaps
+		securityGroupMaps := make([]map[string]interface{}, 0)
+		securityGroupMap := make(map[string]interface{})
+		securityGroupRaw := make(map[string]interface{})
+		if objectRaw["securityGroup"] != nil {
+			securityGroupRaw = objectRaw["securityGroup"].(map[string]interface{})
+		}
+		if len(securityGroupRaw) > 0 {
+			securityGroupMap["name"] = securityGroupRaw["name"]
+			securityGroupMap["security_group_id"] = securityGroupRaw["securityGroupId"]
+
+			securityGroupMaps = append(securityGroupMaps, securityGroupMap)
+		}
+		mapping["security_group"] = securityGroupMaps
+		subDomainInfosRaw := objectRaw["subDomainInfos"]
+		subDomainInfosMaps := make([]map[string]interface{}, 0)
+		if subDomainInfosRaw != nil {
+			for _, subDomainInfosChildRaw := range convertToInterfaceArray(subDomainInfosRaw) {
+				subDomainInfosMap := make(map[string]interface{})
+				subDomainInfosChildRaw := subDomainInfosChildRaw.(map[string]interface{})
+				subDomainInfosMap["domain_id"] = subDomainInfosChildRaw["domainId"]
+				subDomainInfosMap["name"] = subDomainInfosChildRaw["name"]
+				subDomainInfosMap["network_type"] = subDomainInfosChildRaw["networkType"]
+				subDomainInfosMap["protocol"] = subDomainInfosChildRaw["protocol"]
+
+				subDomainInfosMaps = append(subDomainInfosMaps, subDomainInfosMap)
+			}
+		}
+		mapping["sub_domain_infos"] = subDomainInfosMaps
+		tagsMaps := objectRaw["tags"]
+		mapping["tags"] = tagsToMap(tagsMaps)
+		vpcMaps := make([]map[string]interface{}, 0)
+		vpcMap := make(map[string]interface{})
+		vpcRaw := make(map[string]interface{})
+		if objectRaw["vpc"] != nil {
+			vpcRaw = objectRaw["vpc"].(map[string]interface{})
+		}
+		if len(vpcRaw) > 0 {
+			vpcMap["name"] = vpcRaw["name"]
+			vpcMap["vpc_id"] = vpcRaw["vpcId"]
+
+			vpcMaps = append(vpcMaps, vpcMap)
+		}
+		mapping["vpc"] = vpcMaps
+		zonesRaw := objectRaw["zones"]
+		zonesMaps := make([]map[string]interface{}, 0)
+		if zonesRaw != nil {
+			for _, zonesChildRaw := range convertToInterfaceArray(zonesRaw) {
+				zonesMap := make(map[string]interface{})
+				zonesChildRaw := zonesChildRaw.(map[string]interface{})
+				zonesMap["name"] = zonesChildRaw["name"]
+				zonesMap["zone_id"] = zonesChildRaw["zoneId"]
+
+				vSwitchRawObj, _ := jsonpath.Get("$.vSwitch", zonesChildRaw)
+				vSwitchRaw := make(map[string]interface{})
+				if vSwitchRawObj != nil {
+					vSwitchRaw = vSwitchRawObj.(map[string]interface{})
+				}
+				zonesMap["vswitch_id"] = vSwitchRaw["vSwitchId"]
+
+				zonesMaps = append(zonesMaps, zonesMap)
+			}
+		}
+		mapping["zones"] = zonesMaps
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			names = append(names, objectRaw["name"])
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["gatewayId"])
+		mapping, err = dataSourceAliCloudApigGatewayReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["name"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("gateways", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudApigGatewayReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	apigServiceV2 := ApigServiceV2{client}
+	getResp, err := apigServiceV2.DescribeApigGateway(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["create_from"] = objectRaw["createFrom"]
+	mapping["create_time"] = objectRaw["createTimestamp"]
+	mapping["expire_time"] = objectRaw["expireTimestamp"]
+	mapping["gateway_edition"] = objectRaw["gatewayEdition"]
+	mapping["gateway_name"] = objectRaw["name"]
+	mapping["gateway_type"] = objectRaw["gatewayType"]
+	mapping["payment_type"] = convertApigGatewaydatachargeTypeResponse(objectRaw["chargeType"])
+	mapping["resource_group_id"] = objectRaw["resourceGroupId"]
+	mapping["spec"] = objectRaw["spec"]
+	mapping["status"] = objectRaw["status"]
+	mapping["target_version"] = objectRaw["targetVersion"]
+	mapping["update_time"] = objectRaw["updateTimestamp"]
+	mapping["version"] = objectRaw["version"]
+	mapping["gateway_id"] = objectRaw["gatewayId"]
+
+	environmentsRaw := objectRaw["environments"]
+	environmentsMaps := make([]map[string]interface{}, 0)
+	if environmentsRaw != nil {
+		for _, environmentsChildRaw := range convertToInterfaceArray(environmentsRaw) {
+			environmentsMap := make(map[string]interface{})
+			environmentsChildRaw := environmentsChildRaw.(map[string]interface{})
+			environmentsMap["alias"] = environmentsChildRaw["alias"]
+			environmentsMap["environment_id"] = environmentsChildRaw["environmentId"]
+			environmentsMap["name"] = environmentsChildRaw["name"]
+
+			environmentsMaps = append(environmentsMaps, environmentsMap)
+		}
+	}
+	mapping["environments"] = environmentsMaps
+	loadBalancersRaw := objectRaw["loadBalancers"]
+	loadBalancersMaps := make([]map[string]interface{}, 0)
+	if loadBalancersRaw != nil {
+		for _, loadBalancersChildRaw := range convertToInterfaceArray(loadBalancersRaw) {
+			loadBalancersMap := make(map[string]interface{})
+			loadBalancersChildRaw := loadBalancersChildRaw.(map[string]interface{})
+			loadBalancersMap["address"] = loadBalancersChildRaw["address"]
+			loadBalancersMap["address_ip_version"] = loadBalancersChildRaw["addressIpVersion"]
+			loadBalancersMap["address_type"] = loadBalancersChildRaw["addressType"]
+			loadBalancersMap["gateway_default"] = loadBalancersChildRaw["gatewayDefault"]
+			loadBalancersMap["load_balancer_id"] = loadBalancersChildRaw["loadBalancerId"]
+			loadBalancersMap["mode"] = loadBalancersChildRaw["mode"]
+			loadBalancersMap["status"] = loadBalancersChildRaw["status"]
+			loadBalancersMap["type"] = loadBalancersChildRaw["type"]
+
+			ipv4AddressesRaw := make([]interface{}, 0)
+			if loadBalancersChildRaw["ipv4Addresses"] != nil {
+				ipv4AddressesRaw = convertToInterfaceArray(loadBalancersChildRaw["ipv4Addresses"])
+			}
+
+			loadBalancersMap["ipv4_addresses"] = ipv4AddressesRaw
+			ipv6AddressesRaw := make([]interface{}, 0)
+			if loadBalancersChildRaw["ipv6Addresses"] != nil {
+				ipv6AddressesRaw = convertToInterfaceArray(loadBalancersChildRaw["ipv6Addresses"])
+			}
+
+			loadBalancersMap["ipv6_addresses"] = ipv6AddressesRaw
+			portsRaw := loadBalancersChildRaw["ports"]
+			portsMaps := make([]map[string]interface{}, 0)
+			if portsRaw != nil {
+				for _, portsChildRaw := range convertToInterfaceArray(portsRaw) {
+					portsMap := make(map[string]interface{})
+					portsChildRaw := portsChildRaw.(map[string]interface{})
+					portsMap["port"] = portsChildRaw["port"]
+					portsMap["protocol"] = portsChildRaw["protocol"]
+
+					portsMaps = append(portsMaps, portsMap)
+				}
+			}
+			loadBalancersMap["ports"] = portsMaps
+			loadBalancersMaps = append(loadBalancersMaps, loadBalancersMap)
+		}
+	}
+	mapping["load_balancers"] = loadBalancersMaps
+	securityGroupMaps := make([]map[string]interface{}, 0)
+	securityGroupMap := make(map[string]interface{})
+	securityGroupRaw := make(map[string]interface{})
+	if objectRaw["securityGroup"] != nil {
+		securityGroupRaw = objectRaw["securityGroup"].(map[string]interface{})
+	}
+	if len(securityGroupRaw) > 0 {
+		securityGroupMap["name"] = securityGroupRaw["name"]
+		securityGroupMap["security_group_id"] = securityGroupRaw["securityGroupId"]
+
+		securityGroupMaps = append(securityGroupMaps, securityGroupMap)
+	}
+	mapping["security_group"] = securityGroupMaps
+	tagsMaps := objectRaw["tags"]
+	mapping["tags"] = tagsToMap(tagsMaps)
+	vSwitchMaps := make([]map[string]interface{}, 0)
+	vSwitchMap := make(map[string]interface{})
+	vSwitchRaw := make(map[string]interface{})
+	if objectRaw["vSwitch"] != nil {
+		vSwitchRaw = objectRaw["vSwitch"].(map[string]interface{})
+	}
+	if len(vSwitchRaw) > 0 {
+		vSwitchMap["name"] = vSwitchRaw["name"]
+		vSwitchMap["vswitch_id"] = vSwitchRaw["vSwitchId"]
+
+		vSwitchMaps = append(vSwitchMaps, vSwitchMap)
+	}
+	mapping["vswitch"] = vSwitchMaps
+	vpcMaps := make([]map[string]interface{}, 0)
+	vpcMap := make(map[string]interface{})
+	vpcRaw := make(map[string]interface{})
+	if objectRaw["vpc"] != nil {
+		vpcRaw = objectRaw["vpc"].(map[string]interface{})
+	}
+	if len(vpcRaw) > 0 {
+		vpcMap["name"] = vpcRaw["name"]
+		vpcMap["vpc_id"] = vpcRaw["vpcId"]
+
+		vpcMaps = append(vpcMaps, vpcMap)
+	}
+	mapping["vpc"] = vpcMaps
+	zonesRaw := objectRaw["zones"]
+	zonesMaps := make([]map[string]interface{}, 0)
+	if zonesRaw != nil {
+		for _, zonesChildRaw := range convertToInterfaceArray(zonesRaw) {
+			zonesMap := make(map[string]interface{})
+			zonesChildRaw := zonesChildRaw.(map[string]interface{})
+			zonesMap["name"] = zonesChildRaw["name"]
+			zonesMap["zone_id"] = zonesChildRaw["zoneId"]
+
+			vSwitchRawObj, _ := jsonpath.Get("$.vSwitch", zonesChildRaw)
+			vSwitchRaw := make(map[string]interface{})
+			if vSwitchRawObj != nil {
+				vSwitchRaw = vSwitchRawObj.(map[string]interface{})
+			}
+			zonesMap["vswitch_id"] = vSwitchRaw["vSwitchId"]
+
+			zonesMaps = append(zonesMaps, zonesMap)
+		}
+	}
+	mapping["zones"] = zonesMaps
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_apig_gateways_test.go
+++ b/alicloud/data_source_alicloud_apig_gateways_test.go
@@ -1,0 +1,166 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudApigGatewayDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_apig_gateway.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_apig_gateway.default.id}_fake"]`,
+		}),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_apig_gateway.default.gateway_name}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_apig_gateway.default.gateway_name}_fake"`,
+		}),
+	}
+
+	gatewayNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_apig_gateway.default.id}"]`,
+			"gateway_name": `"${alicloud_apig_gateway.default.gateway_name}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_apig_gateway.default.id}"]`,
+			"gateway_name": `"${alicloud_apig_gateway.default.gateway_name}_fake"`,
+		}),
+	}
+
+	resourceGroupConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_apig_gateway.default.id}"]`,
+			"resource_group_id": `"${alicloud_apig_gateway.default.resource_group_id}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_apig_gateway.default.id}"]`,
+			"resource_group_id": `"${alicloud_apig_gateway.default.resource_group_id}_fake"`,
+		}),
+	}
+
+	enableDetailsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_apig_gateway.default.id}"]`,
+			"enable_details": `"true"`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_apig_gateway.default.id}_fake"]`,
+			"enable_details": `"true"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_apig_gateway.default.id}"]`,
+			"name_regex":        `"${alicloud_apig_gateway.default.gateway_name}"`,
+			"gateway_name":      `"${alicloud_apig_gateway.default.gateway_name}"`,
+			"resource_group_id": `"${alicloud_apig_gateway.default.resource_group_id}"`,
+			"enable_details":    `"true"`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigGatewaysDataSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_apig_gateway.default.id}_fake"]`,
+			"name_regex":        `"${alicloud_apig_gateway.default.gateway_name}_fake"`,
+			"gateway_name":      `"${alicloud_apig_gateway.default.gateway_name}_fake"`,
+			"resource_group_id": `"${alicloud_apig_gateway.default.resource_group_id}"`,
+			"enable_details":    `"true"`,
+		}),
+	}
+
+	AliCloudApigGatewaysCheckInfo.dataSourceTestCheck(t, rand, idsConf, nameRegexConf, gatewayNameConf, resourceGroupConf, enableDetailsConf, allConf)
+}
+
+var existAliCloudApigGatewaysMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"gateways.#":                   "1",
+		"gateways.0.id":                CHECKSET,
+		"gateways.0.gateway_id":        CHECKSET,
+		"gateways.0.gateway_name":      CHECKSET,
+		"gateways.0.payment_type":      "PayAsYouGo",
+		"gateways.0.spec":              CHECKSET,
+		"gateways.0.status":            CHECKSET,
+		"gateways.0.create_time":       CHECKSET,
+		"gateways.0.resource_group_id": CHECKSET,
+		"ids.#":                        "1",
+		"names.#":                      "1",
+	}
+}
+
+var fakeAliCloudApigGatewaysMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"gateways.#": "0",
+		"ids.#":      "0",
+		"names.#":    "0",
+	}
+}
+
+var AliCloudApigGatewaysCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_apig_gateways.default",
+	existMapFunc: existAliCloudApigGatewaysMapFunc,
+	fakeMapFunc:  fakeAliCloudApigGatewaysMapFunc,
+}
+
+func testAccCheckAliCloudApigGatewaysDataSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+  default = "tf-testacc-apig-gateway-ds-%d"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_apig_gateway" "default" {
+  gateway_name = var.name
+  spec         = "apigw.small.x1"
+  payment_type = "PayAsYouGo"
+  vpc {
+    vpc_id = data.alicloud_vpcs.default.ids.0
+  }
+  vswitch {
+    vswitch_id = data.alicloud_vswitches.default.ids.0
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  network_access_config {
+    type = "Intranet"
+  }
+  log_config {
+    sls {
+      enable = "false"
+    }
+  }
+  resource_group_id = data.alicloud_resource_manager_resource_groups.default.ids.1
+}
+
+data "alicloud_apig_gateways" "default" {
+  %s
+}
+`, rand, strings.Join(pairs, "\n  "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -171,6 +171,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_apig_gateways":                              dataSourceAliCloudApigGateways(),
 			"alicloud_express_connect_router_vpc_associations":    dataSourceAliCloudExpressConnectRouterVpcAssociations(),
 			"alicloud_express_connect_router_tr_associations":     dataSourceAliCloudExpressConnectRouterTrAssociations(),
 			"alicloud_express_connect_router_vbr_child_instances": dataSourceAliCloudExpressConnectRouterVbrChildInstances(),

--- a/alicloud/resource_alicloud_apig_gateway.go
+++ b/alicloud/resource_alicloud_apig_gateway.go
@@ -27,9 +27,43 @@ func resourceAliCloudApigGateway() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
+			"create_from": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"create_time": {
 				Type:     schema.TypeInt,
 				Computed: true,
+			},
+			"environments": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"environment_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alias": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"expire_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"gateway_edition": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
 			},
 			"gateway_name": {
 				Type:     schema.TypeString,
@@ -40,6 +74,72 @@ func resourceAliCloudApigGateway() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+			},
+			"load_balancers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ipv4_addresses": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"address_ip_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_default": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ports": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"port": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"protocol": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"load_balancer_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ipv6_addresses": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"address_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"log_config": {
 				Type:     schema.TypeList,
@@ -88,6 +188,22 @@ func resourceAliCloudApigGateway() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"security_group": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"spec": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -98,6 +214,14 @@ func resourceAliCloudApigGateway() *schema.Resource {
 				Computed: true,
 			},
 			"tags": tagsSchema(),
+			"target_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"vswitch": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -116,6 +240,10 @@ func resourceAliCloudApigGateway() *schema.Resource {
 						},
 					},
 				},
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"vpc": {
 				Type:     schema.TypeList,
@@ -200,7 +328,7 @@ func resourceAliCloudApigGatewayCreate(d *schema.ResourceData, meta interface{})
 		request["resourceGroupId"] = v
 	}
 	request["chargeType"] = convertApigGatewaychargeTypeRequest(d.Get("payment_type").(string))
-	dataList := make(map[string]interface{})
+	zoneConfig := make(map[string]interface{})
 
 	if v := d.Get("zones"); !IsNil(v) {
 		if v, ok := d.GetOk("zones"); ok {
@@ -209,7 +337,7 @@ func resourceAliCloudApigGatewayCreate(d *schema.ResourceData, meta interface{})
 				localData = make([]interface{}, 0)
 			}
 			localMaps := make([]interface{}, 0)
-			for _, dataLoop := range localData.([]interface{}) {
+			for _, dataLoop := range convertToInterfaceArray(localData) {
 				dataLoopTmp := make(map[string]interface{})
 				if dataLoop != nil {
 					dataLoopTmp = dataLoop.(map[string]interface{})
@@ -219,7 +347,7 @@ func resourceAliCloudApigGatewayCreate(d *schema.ResourceData, meta interface{})
 				dataLoopMap["vSwitchId"] = dataLoopTmp["vswitch_id"]
 				localMaps = append(localMaps, dataLoopMap)
 			}
-			dataList["zones"] = localMaps
+			zoneConfig["zones"] = localMaps
 		}
 
 	}
@@ -227,34 +355,39 @@ func resourceAliCloudApigGatewayCreate(d *schema.ResourceData, meta interface{})
 	if v, ok := d.GetOk("zone_config"); ok {
 		selectOption1, _ := jsonpath.Get("$[0].select_option", v)
 		if selectOption1 != nil && selectOption1 != "" {
-			dataList["selectOption"] = selectOption1
+			zoneConfig["selectOption"] = selectOption1
 		}
 	}
 
 	if v, ok := d.GetOk("vswitch"); ok {
 		vSwitchId3, _ := jsonpath.Get("$[0].vswitch_id", v)
 		if vSwitchId3 != nil && vSwitchId3 != "" {
-			dataList["vSwitchId"] = vSwitchId3
+			zoneConfig["vSwitchId"] = vSwitchId3
 		}
 	}
 
-	request["zoneConfig"] = dataList
+	request["zoneConfig"] = zoneConfig
 
+	if v, ok := d.GetOk("gateway_edition"); ok {
+		request["gatewayEdition"] = v
+	}
 	if v, ok := d.GetOk("gateway_name"); ok {
 		request["name"] = v
 	}
-	dataList1 := make(map[string]interface{})
+	logConfig := make(map[string]interface{})
 
 	if v := d.Get("log_config"); !IsNil(v) {
 		sls := make(map[string]interface{})
-		enable1, _ := jsonpath.Get("$[0].sls[0].enable", v)
+		enable1, _ := jsonpath.Get("$[0].sls[0].enable", d.Get("log_config"))
 		if enable1 != nil && enable1 != "" {
 			sls["enable"] = enable1
 		}
 
-		dataList1["sls"] = sls
+		if len(sls) > 0 {
+			logConfig["sls"] = sls
+		}
 
-		request["logConfig"] = dataList1
+		request["logConfig"] = logConfig
 	}
 
 	if v, ok := d.GetOk("spec"); ok {
@@ -263,15 +396,15 @@ func resourceAliCloudApigGatewayCreate(d *schema.ResourceData, meta interface{})
 	if v, ok := d.GetOk("gateway_type"); ok {
 		request["gatewayType"] = v
 	}
-	dataList2 := make(map[string]interface{})
+	networkAccessConfig := make(map[string]interface{})
 
 	if v := d.Get("network_access_config"); !IsNil(v) {
 		type1, _ := jsonpath.Get("$[0].type", v)
 		if type1 != nil && type1 != "" {
-			dataList2["type"] = type1
+			networkAccessConfig["type"] = type1
 		}
 
-		request["networkAccessConfig"] = dataList2
+		request["networkAccessConfig"] = networkAccessConfig
 	}
 
 	body = request
@@ -319,14 +452,97 @@ func resourceAliCloudApigGatewayRead(d *schema.ResourceData, meta interface{}) e
 		return WrapError(err)
 	}
 
+	d.Set("create_from", objectRaw["createFrom"])
 	d.Set("create_time", objectRaw["createTimestamp"])
+	d.Set("expire_time", objectRaw["expireTimestamp"])
+	d.Set("gateway_edition", objectRaw["gatewayEdition"])
 	d.Set("gateway_name", objectRaw["name"])
 	d.Set("gateway_type", objectRaw["gatewayType"])
 	d.Set("payment_type", convertApigGatewaydatachargeTypeResponse(objectRaw["chargeType"]))
 	d.Set("resource_group_id", objectRaw["resourceGroupId"])
 	d.Set("spec", objectRaw["spec"])
 	d.Set("status", objectRaw["status"])
+	d.Set("target_version", objectRaw["targetVersion"])
+	d.Set("update_time", objectRaw["updateTimestamp"])
+	d.Set("version", objectRaw["version"])
 
+	environmentsRaw := objectRaw["environments"]
+	environmentsMaps := make([]map[string]interface{}, 0)
+	if environmentsRaw != nil {
+		for _, environmentsChildRaw := range convertToInterfaceArray(environmentsRaw) {
+			environmentsMap := make(map[string]interface{})
+			environmentsChildRaw := environmentsChildRaw.(map[string]interface{})
+			environmentsMap["alias"] = environmentsChildRaw["alias"]
+			environmentsMap["environment_id"] = environmentsChildRaw["environmentId"]
+			environmentsMap["name"] = environmentsChildRaw["name"]
+
+			environmentsMaps = append(environmentsMaps, environmentsMap)
+		}
+	}
+	if err := d.Set("environments", environmentsMaps); err != nil {
+		return err
+	}
+	loadBalancersRaw := objectRaw["loadBalancers"]
+	loadBalancersMaps := make([]map[string]interface{}, 0)
+	if loadBalancersRaw != nil {
+		for _, loadBalancersChildRaw := range convertToInterfaceArray(loadBalancersRaw) {
+			loadBalancersMap := make(map[string]interface{})
+			loadBalancersChildRaw := loadBalancersChildRaw.(map[string]interface{})
+			loadBalancersMap["address"] = loadBalancersChildRaw["address"]
+			loadBalancersMap["address_ip_version"] = loadBalancersChildRaw["addressIpVersion"]
+			loadBalancersMap["address_type"] = loadBalancersChildRaw["addressType"]
+			loadBalancersMap["gateway_default"] = loadBalancersChildRaw["gatewayDefault"]
+			loadBalancersMap["load_balancer_id"] = loadBalancersChildRaw["loadBalancerId"]
+			loadBalancersMap["mode"] = loadBalancersChildRaw["mode"]
+			loadBalancersMap["status"] = loadBalancersChildRaw["status"]
+			loadBalancersMap["type"] = loadBalancersChildRaw["type"]
+
+			ipv4AddressesRaw := make([]interface{}, 0)
+			if loadBalancersChildRaw["ipv4Addresses"] != nil {
+				ipv4AddressesRaw = convertToInterfaceArray(loadBalancersChildRaw["ipv4Addresses"])
+			}
+
+			loadBalancersMap["ipv4_addresses"] = ipv4AddressesRaw
+			ipv6AddressesRaw := make([]interface{}, 0)
+			if loadBalancersChildRaw["ipv6Addresses"] != nil {
+				ipv6AddressesRaw = convertToInterfaceArray(loadBalancersChildRaw["ipv6Addresses"])
+			}
+
+			loadBalancersMap["ipv6_addresses"] = ipv6AddressesRaw
+			portsRaw := loadBalancersChildRaw["ports"]
+			portsMaps := make([]map[string]interface{}, 0)
+			if portsRaw != nil {
+				for _, portsChildRaw := range convertToInterfaceArray(portsRaw) {
+					portsMap := make(map[string]interface{})
+					portsChildRaw := portsChildRaw.(map[string]interface{})
+					portsMap["port"] = portsChildRaw["port"]
+					portsMap["protocol"] = portsChildRaw["protocol"]
+
+					portsMaps = append(portsMaps, portsMap)
+				}
+			}
+			loadBalancersMap["ports"] = portsMaps
+			loadBalancersMaps = append(loadBalancersMaps, loadBalancersMap)
+		}
+	}
+	if err := d.Set("load_balancers", loadBalancersMaps); err != nil {
+		return err
+	}
+	securityGroupMaps := make([]map[string]interface{}, 0)
+	securityGroupMap := make(map[string]interface{})
+	securityGroupRaw := make(map[string]interface{})
+	if objectRaw["securityGroup"] != nil {
+		securityGroupRaw = objectRaw["securityGroup"].(map[string]interface{})
+	}
+	if len(securityGroupRaw) > 0 {
+		securityGroupMap["name"] = securityGroupRaw["name"]
+		securityGroupMap["security_group_id"] = securityGroupRaw["securityGroupId"]
+
+		securityGroupMaps = append(securityGroupMaps, securityGroupMap)
+	}
+	if err := d.Set("security_group", securityGroupMaps); err != nil {
+		return err
+	}
 	tagsMaps := objectRaw["tags"]
 	d.Set("tags", tagsToMap(tagsMaps))
 	vSwitchMaps := make([]map[string]interface{}, 0)
@@ -359,28 +575,29 @@ func resourceAliCloudApigGatewayRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("vpc", vpcMaps); err != nil {
 		return err
 	}
-
 	zonesRaw := objectRaw["zones"]
 	zonesMaps := make([]map[string]interface{}, 0)
 	if zonesRaw != nil {
-		for _, zonesChildRaw := range zonesRaw.([]interface{}) {
+		for _, zonesChildRaw := range convertToInterfaceArray(zonesRaw) {
 			zonesMap := make(map[string]interface{})
 			zonesChildRaw := zonesChildRaw.(map[string]interface{})
 			zonesMap["name"] = zonesChildRaw["name"]
 			zonesMap["zone_id"] = zonesChildRaw["zoneId"]
 
-			if v, ok := zonesChildRaw["vSwitch"]; ok {
-				vSwitchArg := v.(map[string]interface{})
-
-				zonesMap["vswitch_id"] = vSwitchArg["vSwitchId"]
+			vSwitchRawObj, _ := jsonpath.Get("$.vSwitch", zonesChildRaw)
+			vSwitchRaw := make(map[string]interface{})
+			if vSwitchRawObj != nil {
+				vSwitchRaw = vSwitchRawObj.(map[string]interface{})
 			}
+			zonesMap["vswitch_id"] = vSwitchRaw["vSwitchId"]
 
 			zonesMaps = append(zonesMaps, zonesMap)
 		}
-		if err := d.Set("zones", zonesMaps); err != nil {
-			return err
-		}
 	}
+	if err := d.Set("zones", zonesMaps); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -391,7 +608,6 @@ func resourceAliCloudApigGatewayUpdate(d *schema.ResourceData, meta interface{})
 	var query map[string]*string
 	var body map[string]interface{}
 	update := false
-	d.Partial(true)
 
 	var err error
 	gatewayId := d.Id()
@@ -399,7 +615,6 @@ func resourceAliCloudApigGatewayUpdate(d *schema.ResourceData, meta interface{})
 	request = make(map[string]interface{})
 	query = make(map[string]*string)
 	body = make(map[string]interface{})
-	request["gatewayId"] = d.Id()
 
 	if d.HasChange("gateway_name") {
 		update = true
@@ -460,6 +675,12 @@ func resourceAliCloudApigGatewayUpdate(d *schema.ResourceData, meta interface{})
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
+		apigServiceV2 := ApigServiceV2{client}
+		expectedResourceGroupId := d.Get("resource_group_id").(string)
+		stateConf := BuildStateConf([]string{}, []string{expectedResourceGroupId}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, apigServiceV2.ApigGatewayStateRefreshFunc(d.Id(), "resourceGroupId", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
 	}
 
 	if d.HasChange("tags") {
@@ -468,56 +689,55 @@ func resourceAliCloudApigGatewayUpdate(d *schema.ResourceData, meta interface{})
 			return WrapError(err)
 		}
 	}
-	d.Partial(false)
 	return resourceAliCloudApigGatewayRead(d, meta)
 }
 
 func resourceAliCloudApigGatewayDelete(d *schema.ResourceData, meta interface{}) error {
 
-	if v, ok := d.GetOk("payment_type"); ok {
-		if v == "Subscription" {
-			log.Printf("[WARN] Cannot destroy resource alicloud_apig_gateway which payment_type valued Subscription. Terraform will remove this resource from the state file, however resources may remain.")
-			return nil
+	client := meta.(*connectivity.AliyunClient)
+	enableDelete := false
+	if v, ok := d.GetOkExists("payment_type"); ok {
+		if InArray(fmt.Sprint(v), []string{"PayAsYouGo"}) {
+			enableDelete = true
 		}
 	}
-	client := meta.(*connectivity.AliyunClient)
-	gatewayId := d.Id()
-	action := fmt.Sprintf("/v1/gateways/%s", gatewayId)
-	var request map[string]interface{}
-	var response map[string]interface{}
-	query := make(map[string]*string)
-	var err error
-	request = make(map[string]interface{})
-	request["gatewayId"] = d.Id()
+	if enableDelete {
+		gatewayId := d.Id()
+		action := fmt.Sprintf("/v1/gateways/%s", gatewayId)
+		var request map[string]interface{}
+		var response map[string]interface{}
+		query := make(map[string]*string)
+		var err error
+		request = make(map[string]interface{})
 
-	wait := incrementalWait(3*time.Second, 5*time.Second)
-	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		response, err = client.RoaDelete("APIG", "2024-03-27", action, query, nil, nil, true)
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+			response, err = client.RoaDelete("APIG", "2024-03-27", action, query, nil, nil, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
 
 		if err != nil {
-			if NeedRetry(err) {
-				wait()
-				return resource.RetryableError(err)
+			if IsExpectedErrors(err, []string{"NotFound.GatewayNotFound", "Conflict.GatewayIsDeleted"}) || NotFoundError(err) {
+				return nil
 			}
-			return resource.NonRetryableError(err)
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
-		return nil
-	})
-	addDebug(action, response, request)
 
-	if err != nil {
-		if IsExpectedErrors(err, []string{"NotFound.GatewayNotFound", "Conflict.GatewayIsDeleted"}) || NotFoundError(err) {
-			return nil
+		apigServiceV2 := ApigServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 30*time.Second, apigServiceV2.ApigGatewayStateRefreshFunc(d.Id(), "status", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
 		}
-		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
-	}
 
-	apigServiceV2 := ApigServiceV2{client}
-	stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 30*time.Second, apigServiceV2.ApigGatewayStateRefreshFunc(d.Id(), "status", []string{}))
-	if _, err := stateConf.WaitForState(); err != nil {
-		return WrapErrorf(err, IdMsg, d.Id())
 	}
-
 	return nil
 }
 
@@ -531,6 +751,7 @@ func convertApigGatewaydatachargeTypeResponse(source interface{}) interface{} {
 	}
 	return source
 }
+
 func convertApigGatewaychargeTypeRequest(source interface{}) interface{} {
 	source = fmt.Sprint(source)
 	switch source {

--- a/alicloud/resource_alicloud_apig_gateway_test.go
+++ b/alicloud/resource_alicloud_apig_gateway_test.go
@@ -499,3 +499,104 @@ resource "alicloud_vswitch" "j" {
 }
 
 // Test Apig Gateway. <<< Resource test cases, automatically generated.
+
+// Test Apig Gateway. gateway_edition coverage.
+func TestAccAliCloudApigGateway_basic_edition(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_gateway.default"
+	ra := resourceAttrInit(resourceId, AliCloudApigGatewayEditionMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigGateway")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sapiggwedition%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudApigGatewayEditionDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"gateway_name":    name,
+					"gateway_edition": "Professional",
+					"spec":            "apigw.small.x1",
+					"vpc": []map[string]interface{}{
+						{
+							"vpc_id": "${data.alicloud_vpcs.default.ids.0}",
+						},
+					},
+					"network_access_config": []map[string]interface{}{
+						{
+							"type": "Intranet",
+						},
+					},
+					"zone_config": []map[string]interface{}{
+						{
+							"select_option": "Auto",
+						},
+					},
+					"vswitch": []map[string]interface{}{
+						{
+							"vswitch_id": "${data.alicloud_vswitches.default.ids.0}",
+						},
+					},
+					"log_config": []map[string]interface{}{
+						{
+							"sls": []map[string]interface{}{
+								{
+									"enable": "false",
+								},
+							},
+						},
+					},
+					"payment_type":      "PayAsYouGo",
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"gateway_name":    name,
+						"gateway_edition": "Professional",
+						"spec":            "apigw.small.x1",
+						"payment_type":    "PayAsYouGo",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"log_config", "network_access_config", "zone_config"},
+			},
+		},
+	})
+}
+
+var AliCloudApigGatewayEditionMap = map[string]string{
+	"status":      CHECKSET,
+	"create_time": CHECKSET,
+}
+
+func AliCloudApigGatewayEditionDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+`, name)
+}

--- a/alicloud/service_alicloud_apig_v2.go
+++ b/alicloud/service_alicloud_apig_v2.go
@@ -173,7 +173,6 @@ func (s *ApigServiceV2) DescribeApigGateway(id string) (object map[string]interf
 	gatewayId := id
 	request = make(map[string]interface{})
 	query = make(map[string]*string)
-	request["gatewayId"] = id
 
 	action := fmt.Sprintf("/v1/gateways/%s", gatewayId)
 
@@ -191,11 +190,12 @@ func (s *ApigServiceV2) DescribeApigGateway(id string) (object map[string]interf
 		return nil
 	})
 	addDebug(action, response, request)
-	if err != nil {
-		if IsExpectedErrors(err, []string{"NotFound.GatewayNotFound", "Conflict.GatewayIsDeleted"}) {
-			return object, WrapErrorf(NotFoundErr("Gateway", id), NotFoundMsg, err)
-		}
-		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	if response == nil {
+		return object, WrapErrorf(NotFoundErr("Gateway", id), NotFoundMsg, response)
+	}
+	code, _ := jsonpath.Get("$.code", response)
+	if InArray(fmt.Sprint(code), []string{"NotFound.GatewayNotFound", "Conflict.GatewayIsDeleted"}) {
+		return object, WrapErrorf(NotFoundErr("Gateway", id), NotFoundMsg, response)
 	}
 
 	v, err := jsonpath.Get("$.data", response)
@@ -207,15 +207,19 @@ func (s *ApigServiceV2) DescribeApigGateway(id string) (object map[string]interf
 }
 
 func (s *ApigServiceV2) ApigGatewayStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ApigGatewayStateRefreshFuncWithApi(id, field, failStates, s.DescribeApigGateway)
+}
+
+func (s *ApigServiceV2) ApigGatewayStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		object, err := s.DescribeApigGateway(id)
+		object, err := call(id)
 		if err != nil {
 			if NotFoundError(err) {
 				return object, "", nil
 			}
 			return nil, "", WrapError(err)
 		}
-
+		object["chargeType"] = convertApigGatewaydatachargeTypeResponse(object["chargeType"])
 		v, err := jsonpath.Get(field, object)
 		currentStatus := fmt.Sprint(v)
 
@@ -240,8 +244,8 @@ func (s *ApigServiceV2) ApigGatewayStateRefreshFunc(id string, field string, fai
 // SetResourceTags <<< Encapsulated tag function for Apig.
 func (s *ApigServiceV2) SetResourceTags(d *schema.ResourceData, resourceType string) error {
 	if d.HasChange("tags") {
-		var err error
 		var action string
+		var err error
 		client := s.client
 		var request map[string]interface{}
 		var response map[string]interface{}
@@ -249,7 +253,7 @@ func (s *ApigServiceV2) SetResourceTags(d *schema.ResourceData, resourceType str
 		body := make(map[string]interface{})
 
 		added, removed := parsingTags(d)
-		removedTagKeys := make([]interface{}, 0)
+		removedTagKeys := make([]string, 0)
 		for _, v := range removed {
 			if !ignoredTags(v, "") {
 				removedTagKeys = append(removedTagKeys, v)
@@ -260,21 +264,14 @@ func (s *ApigServiceV2) SetResourceTags(d *schema.ResourceData, resourceType str
 			request = make(map[string]interface{})
 			query = make(map[string]*string)
 			body = make(map[string]interface{})
-			jsonString := "{}"
-			jsonString, _ = sjson.Set(jsonString, "ResourceId.0", d.Id())
-			err = json.Unmarshal([]byte(jsonString), &request)
-			if err != nil {
-				return WrapError(err)
-			}
+			query["ResourceId"] = StringPointer(convertListToJsonString(expandSingletonToList(d.Id())))
 			query["RegionId"] = StringPointer(client.RegionId)
-			query["TagKey"] = StringPointer(convertListToJsonString(removedTagKeys))
+			query["TagKey"] = StringPointer(convertListToJsonString(convertListStringToListInterface(removedTagKeys)))
 			query["ResourceType"] = StringPointer(resourceType)
-			query["ResourceId"] = StringPointer(convertListToJsonString(convertListStringToListInterface([]string{d.Id()})))
-
 			body = request
 			wait := incrementalWait(3*time.Second, 5*time.Second)
 			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
-				response, err = client.RoaDelete("APIG", "2024-03-27", action, query, nil, body, true)
+				response, err = client.RoaDelete("APIG", "2024-03-27", action, query, nil, nil, true)
 				if err != nil {
 					if NeedRetry(err) {
 						wait()
@@ -296,25 +293,23 @@ func (s *ApigServiceV2) SetResourceTags(d *schema.ResourceData, resourceType str
 			request = make(map[string]interface{})
 			query = make(map[string]*string)
 			body = make(map[string]interface{})
-			jsonString := "{}"
-			jsonString, _ = sjson.Set(jsonString, "resourceId.0", d.Id())
-			err = json.Unmarshal([]byte(jsonString), &request)
-			if err != nil {
-				return WrapError(err)
-			}
 
 			count := 1
 			tagsMaps := make([]map[string]interface{}, 0)
 			for key, value := range added {
 				tagsMap := make(map[string]interface{})
-				tagsMap["key"] = key
 				tagsMap["value"] = value
+				tagsMap["key"] = key
 				tagsMaps = append(tagsMaps, tagsMap)
 				count++
 			}
 			request["tag"] = tagsMaps
 
-			request["resourceType"] = resourceType
+			request["resourceType"] = "gateway"
+			jsonString := convertObjectToJsonString(request)
+			jsonString, _ = sjson.Set(jsonString, "resourceId.0", d.Id())
+			_ = json.Unmarshal([]byte(jsonString), &request)
+
 			body = request
 			wait := incrementalWait(3*time.Second, 5*time.Second)
 			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {

--- a/website/docs/d/apig_gateways.html.markdown
+++ b/website/docs/d/apig_gateways.html.markdown
@@ -1,0 +1,142 @@
+---
+subcategory: "Cloud Native API Gateway (APIG)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_apig_gateways"
+sidebar_current: "docs-alicloud-datasource-apig-gateways"
+description: |-
+  Provides a list of Apig Gateway owned by an Alibaba Cloud account.
+---
+
+# alicloud_apig_gateways
+
+This data source provides Apig Gateway available to the user.[What is Gateway](https://next.api.alibabacloud.com/document/APIG/2024-03-27/CreateGateway)
+
+-> **NOTE:** Available since v1.284.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_apig_gateway" "default" {
+  network_access_config {
+    type = "Intranet"
+  }
+  log_config {
+    sls {
+      enable = "false"
+    }
+  }
+  resource_group_id = data.alicloud_resource_manager_resource_groups.default.ids.1
+  spec              = "apigw.small.x1"
+  vpc {
+    vpc_id = data.alicloud_vpcs.default.ids.0
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vswitch {
+    vswitch_id = data.alicloud_vswitches.default.ids.0
+  }
+  payment_type = "PayAsYouGo"
+  gateway_name = var.name
+}
+
+data "alicloud_apig_gateways" "default" {
+  ids          = [alicloud_apig_gateway.default.id]
+  name_regex   = alicloud_apig_gateway.default.gateway_name
+  gateway_name = var.name
+}
+
+output "alicloud_apig_gateway_example_id" {
+  value = data.alicloud_apig_gateways.default.gateways.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `ids` - (Optional, ForceNew, Computed) A list of Gateway IDs.
+* `name_regex` - (Optional, ForceNew) A regex string to filter results by Gateway name.
+* `gateway_id` - (Optional, ForceNew) Cloud-native API gateway ID.
+* `gateway_name` - (Optional, ForceNew) The name of the gateway.
+* `resource_group_id` - (Optional, ForceNew) The ID of the resource group.
+* `tags` - (Optional, ForceNew, Map) The tag of the resource.
+* `enable_details` - (Optional, ForceNew) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional, ForceNew) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Gateway IDs.
+* `names` - A list of name of Gateways.
+* `gateways` - A list of Gateway Entries. Each element contains the following attributes:
+    * `create_from` - The source from which the gateway was created.
+    * `create_time` - Creation timestamp.
+    * `environments` - **NOTE:** This field is only available when `enable_details` is `true`. The list of environments associated with the gateway.
+        * `alias` - The alias of the environment.
+        * `environment_id` - The ID of the environment.
+        * `name` - The name of the environment.
+    * `expire_time` - Timestamp indicating when the subscription expires.
+    * `gateway_edition` - Gateway instance edition:.
+    * `gateway_id` - Cloud-native API gateway ID.
+    * `gateway_name` - Query by exact match of the gateway name.
+    * `gateway_type` - The gateway type.
+    * `load_balancers` - The list of Gateway ingress addresses.
+        * `address` - The address of the load balancer for the gateway.
+        * `address_ip_version` - IP version:.
+        * `address_type` - Load balancer address type:.
+        * `gateway_default` - Indicates whether this is the default ingress address of the gateway.
+        * `ipv4_addresses` - The list of IPv4 addresses.
+        * `ipv6_addresses` - The list of IPv6 addresses.
+        * `load_balancer_id` - The ID of the load balancer associated with the gateway.
+        * `mode` - Load balancing provisioning mode for the gateway:.
+        * `ports` - The list of listening ports.
+            * `port` - The port number of the load balancer listener.
+            * `protocol` - Protocol:.
+        * `status` - Load balancer status:.
+        * `type` - Load balancer type:.
+    * `payment_type` - Payment type:.
+    * `resource_group_id` - The ID of the destination resource group.
+    * `security_group` - Security group of the gateway.
+        * `name` - **NOTE:** This field is only available when `enable_details` is `true`. The name of the security group.
+        * `security_group_id` - The ID of the security group.
+    * `spec` - Gateway specification:.
+    * `status` - Gateway status:.
+    * `sub_domain_infos` - List of second-level domain names.
+        * `domain_id` - The ID of the secondary domain name for the gateway.
+        * `name` - The name of the secondary domain associated with the gateway.
+        * `network_type` - Network type:.
+        * `protocol` - The protocol used by the secondary domain name.
+    * `tags` - The tag of the resource.
+    * `target_version` - The target version of the gateway instance.
+    * `update_time` - The timestamp when the resource was last updated.
+    * `vswitch` - **NOTE:** This field is only available when `enable_details` is `true`. The vSwitch associated with the gateway.
+        * `name` - The name of the virtual switch associated with the gateway.
+        * `vswitch_id` - The ID of the virtual switch.
+    * `version` - The current running version of the gateway instance.
+    * `vpc` - The Virtual Private Cloud (VPC) associated with the gateway.
+        * `name` - **NOTE:** This field is only available when `enable_details` is `true`. The name of the VPC gateway.
+        * `vpc_id` - The ID of the VPC network associated with the gateway.
+    * `zones` - The list of zones associated with the gateway.
+        * `name` - **NOTE:** This field is only available when `enable_details` is `true`. The name of the availability zone for the gateway.
+        * `vswitch_id` - The ID of the virtual switch in the availability zone.
+        * `zone_id` - The ID of the availability zone for the gateway.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/apig_gateway.html.markdown
+++ b/website/docs/r/apig_gateway.html.markdown
@@ -10,21 +10,15 @@ description: |-
 
 Provides a APIG Gateway resource.
 
+Gateway instance  .
 
-
-For information about APIG Gateway and how to use it, see [What is Gateway](https://www.alibabacloud.com/help/en/).
+For information about APIG Gateway and how to use it, see [What is Gateway](https://next.api.alibabacloud.com/document/APIG/2024-03-27/CreateGateway).
 
 -> **NOTE:** Available since v1.240.0.
 
 ## Example Usage
 
 Basic Usage
-
-<div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
-  <a href="https://api.aliyun.com/terraform?resource=alicloud_apig_gateway&exampleId=6a041ca8-aa0e-8c55-950d-af10c2df89b01a30ef4f&activeTab=example&spm=docs.r.apig_gateway.0.6a041ca8aa&intl_lang=EN_US" target="_blank">
-    <img alt="Open in AliCloud" src="https://img.alicdn.com/imgextra/i1/O1CN01hjjqXv1uYUlY56FyX_!!6000000006049-55-tps-254-36.svg" style="max-height: 44px; max-width: 100%;">
-  </a>
-</div></div>
 
 ```terraform
 variable "name" {
@@ -79,40 +73,47 @@ The `alicloud_apig_gateway` resource allows you to manage  `payment_type = "Subs
 Deleting the subscription resource or removing it from your configuration will remove it from your state file and management, but will not destroy the Instance.
 You can resume managing the subscription instance via the AlibabaCloud Console.
 
-📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_apig_gateway&spm=docs.r.apig_gateway.example&intl_lang=EN_US)
-
 ## Argument Reference
 
 The following arguments are supported:
-* `gateway_name` - (Optional) The name of the resource
-* `gateway_type` - (Optional, ForceNew, Available since v1.260.1) Describes the gateway type, which is categorized into the following two types:
-  - API: indicates an API gateway
-  - AI: Indicates an AI gateway
-* `log_config` - (Optional, List) Log Configuration See [`log_config`](#log_config) below.
-* `network_access_config` - (Optional, List) Network Access Configuration See [`network_access_config`](#network_access_config) below.
-* `payment_type` - (Required, ForceNew) The payment type of the resource
-* `resource_group_id` - (Optional, Computed) The ID of the resource group
-* `spec` - (Optional, ForceNew) Gateway instance specifications
+* `gateway_edition` - (Optional, ForceNew, Computed, Available since v1.284.0) Gateway instance edition. Valid values:
+  - Professional: Standard instance.
+  - Serverless: Serverless instance.
+  - MultiTenantServerless: Multi-tenant Serverless instance.
+* `gateway_name` - (Optional) Query by exact match of the gateway name.
+* `gateway_type` - (Optional, ForceNew, Computed, Available since v1.260.1) The gateway type. Valid values:
+  - API: API Gateway
+  - AI: AI Gateway
+* `log_config` - (Optional, Set) The log configuration for the gateway instance. See [`log_config`](#log_config) below. **Note: The parameter is immutable after resource creation.**
+* `network_access_config` - (Optional, Set) The network access type of the gateway instance. See [`network_access_config`](#network_access_config) below. **Note: The parameter is immutable after resource creation.**
+
+* `payment_type` - (Required, ForceNew) Payment type. Valid values:
+  - PayAsYouGo: Pay-as-you-go.
+  - Subscription: Subscription.
+* `resource_group_id` - (Optional, Computed) The ID of the destination resource group.
+* `spec` - (Optional, ForceNew) Gateway specification:  
+  - apigw.small.x1: Small specification.  
 * `tags` - (Optional, Map) The tag of the resource
-* `vswitch` - (Optional, ForceNew, List) The virtual switch associated with the Gateway. See [`vswitch`](#vswitch) below.
-* `vpc` - (Optional, ForceNew, List) The VPC associated with the Gateway. See [`vpc`](#vpc) below.
-* `zone_config` - (Required, List) Availability Zone Configuration See [`zone_config`](#zone_config) below.
-* `zones` - (Optional, ForceNew, List, Available since v1.260.1) The List of zones associated with the Gateway. See [`zones`](#zones) below.
+* `vswitch` - (Optional, ForceNew, Set) The vSwitch associated with the gateway. See [`vswitch`](#vswitch) below.
+* `vpc` - (Optional, ForceNew, Set) The Virtual Private Cloud (VPC) associated with the gateway. See [`vpc`](#vpc) below.
+* `zone_config` - (Required, Set) The availability zone selection option for the gateway. See [`zone_config`](#zone_config) below. **Note: The parameter is immutable after resource creation.**
+
+* `zones` - (Optional, ForceNew, Computed, List) The list of zones associated with the gateway. See [`zones`](#zones) below.
 
 ### `log_config`
 
 The log_config supports the following:
-* `sls` - (Optional, List) Sls See [`sls`](#log_config-sls) below.
+* `sls` - (Optional, Set) The Simple Log Service configuration for the gateway. See [`sls`](#log_config-sls) below.
 
 ### `log_config-sls`
 
 The log_config-sls supports the following:
-* `enable` - (Optional) Enable Log Service
+* `enable` - (Optional) The Simple Log Service configuration for the gateway.
 
 ### `network_access_config`
 
 The network_access_config supports the following:
-* `type` - (Optional) Network Access Type
+* `type` - (Optional) The network access type of the gateway instance.
 
 ### `vswitch`
 
@@ -122,31 +123,57 @@ The vswitch supports the following:
 ### `vpc`
 
 The vpc supports the following:
-* `vpc_id` - (Required, ForceNew) The VPC network ID.
+* `vpc_id` - (Required, ForceNew) The ID of the VPC network associated with the gateway.
 
 ### `zone_config`
 
 The zone_config supports the following:
-* `select_option` - (Required) Availability Zone Options
+* `select_option` - (Required) Zone selection option.
 
 ### `zones`
 
 The zones supports the following:
-* `vswitch_id` - (Optional, ForceNew) The vswitch ID.
-* `zone_id` - (Optional, ForceNew) The zone ID.
+* `vswitch_id` - (Optional, ForceNew) The ID of the virtual switch in the availability zone.
+* `zone_id` - (Optional, ForceNew) The ID of the availability zone for the gateway.
 
 ## Attributes Reference
 
 The following attributes are exported:
 * `id` - The ID of the resource supplied above.
+* `create_from` - The source from which the gateway was created.
 * `create_time` - The creation timestamp. Unit: milliseconds.
-* `status` - The status of the resource
-* `vswitch` - The virtual switch associated with the Gateway.
-  * `name` - The virtual switch name.
-* `vpc` - The VPC associated with the Gateway.
-  * `name` - The name of the VPC gateway.
-* `zones` - The List of zones associated with the Gateway.
-  * `name` - The zone name.
+* `environments` - The list of environments associated with the gateway.
+    * `alias` - The alias of the environment.
+    * `environment_id` - The ID of the environment.
+    * `name` - The name of the environment.
+* `expire_time` - Timestamp indicating when the subscription expires. Unit: milliseconds.
+* `load_balancers` - The list of Gateway ingress addresses.
+    * `address` - The address of the load balancer for the gateway.
+    * `address_ip_version` - The IP version of the load balancer.
+    * `address_type` - The load balancer address type.
+    * `gateway_default` - Indicates whether this is the default ingress address of the gateway.
+    * `ipv4_addresses` - The list of IPv4 addresses.
+    * `ipv6_addresses` - The list of IPv6 addresses.
+    * `load_balancer_id` - The ID of the load balancer associated with the gateway.
+    * `mode` - The load balancing provisioning mode for the gateway.
+    * `ports` - The list of listening ports.
+        * `port` - The port number of the load balancer listener.
+        * `protocol` - The protocol of the load balancer listener.
+    * `status` - The status of the load balancer.
+    * `type` - The type of the load balancer.
+* `security_group` - The security group of the gateway.
+    * `name` - The name of the security group.
+    * `security_group_id` - The ID of the security group.
+* `status` - The status of the gateway.
+* `target_version` - The target version of the gateway instance.
+* `update_time` - The timestamp when the gateway was last updated. Unit: milliseconds.
+* `vswitch` - The vSwitch associated with the gateway.
+    * `name` - The name of the virtual switch associated with the gateway.
+* `version` - The current running version of the gateway instance.
+* `vpc` - The Virtual Private Cloud (VPC) associated with the gateway.
+    * `name` - The name of the VPC gateway.
+* `zones` - The list of zones associated with the gateway.
+    * `name` - The name of the availability zone for the gateway.
 
 ## Timeouts
 
@@ -160,5 +187,5 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 APIG Gateway can be imported using the id, e.g.
 
 ```shell
-$ terraform import alicloud_apig_gateway.example <id>
+$ terraform import alicloud_apig_gateway.example <gateway_id>
 ```


### PR DESCRIPTION
## Summary

- `resource/alicloud_apig_gateway`: regenerated from latest spec; added `gateway_edition` (Optional, ForceNew, Computed) and computed output fields `version`, `target_version`, `create_from`, `expire_time`, `update_time`, `load_balancers`, `security_group`, `environments`. Added a state-wait loop after `ChangeResourceGroup` so `resource_group_id` updates reflect in state before the next plan.
- `data-source/alicloud_apig_gateways`: new data source backed by `ListGateways`; supports filtering by `ids`, `name_regex`, `gateway_id`, `gateway_name`, `resource_group_id`, `tags`, and `enable_details` (merges `GetGateway` fields).

## Test plan

```
=== RUN TestAccAliCloudApigGateway_basic9249
--- PASS: TestAccAliCloudApigGateway_basic9249 (233.24s)

=== RUN TestAccAliCloudApigGateway_basic9246
--- PASS: TestAccAliCloudApigGateway_basic9246 (337.85s)

=== RUN TestAccAliCloudApigGateway_basic10903
--- PASS: TestAccAliCloudApigGateway_basic10903 (403.84s)

=== RUN TestAccAliCloudApigGateway_basic_edition
--- PASS: TestAccAliCloudApigGateway_basic_edition (342.76s)

=== RUN TestAccAliCloudApigGatewayDataSource
--- PASS: TestAccAliCloudApigGatewayDataSource (617.65s)
```