### PR TITLE
New Resource: alicloud_resource_manager_handshake_acceptance

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1583,6 +1583,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_resource_manager_resource_group":                       resourceAliCloudResourceManagerResourceGroup(),
 			"alicloud_resource_manager_folder":                               resourceAliCloudResourceManagerFolder(),
 			"alicloud_resource_manager_handshake":                            resourceAliCloudResourceManagerHandshake(),
+			"alicloud_resource_manager_handshake_acceptance":                 resourceAliCloudResourceManagerHandshakeAcceptance(),
 			"alicloud_cen_private_zone":                                      resourceAliCloudCenPrivateZone(),
 			"alicloud_resource_manager_policy":                               resourceAlicloudResourceManagerPolicy(),
 			"alicloud_resource_manager_account":                              resourceAliCloudResourceManagerAccount(),

--- a/alicloud/resource_alicloud_resource_manager_handshake_acceptance.go
+++ b/alicloud/resource_alicloud_resource_manager_handshake_acceptance.go
@@ -1,0 +1,162 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudResourceManagerHandshakeAcceptance() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudResourceManagerHandshakeAcceptanceCreate,
+		Read:   resourceAliCloudResourceManagerHandshakeAcceptanceRead,
+		Delete: resourceAliCloudResourceManagerHandshakeAcceptanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"handshake_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expire_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"invited_account_real_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_real_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modify_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"note": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_directory_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_entity": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudResourceManagerHandshakeAcceptanceCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "AcceptHandshake"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	if v, ok := d.GetOk("handshake_id"); ok {
+		request["HandshakeId"] = v
+	}
+
+	wait := incrementalWait(5*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("ResourceDirectoryMaster", "2022-04-19", action, query, request, true)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"ConcurrentCallNotSupported"}) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_resource_manager_handshake_acceptance", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, err := jsonpath.Get("$.Handshake.HandshakeId", response)
+	if err != nil || fmt.Sprint(id) == "" {
+		id = d.Get("handshake_id")
+	}
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudResourceManagerHandshakeAcceptanceRead(d, meta)
+}
+
+func resourceAliCloudResourceManagerHandshakeAcceptanceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	resourceManagerServiceV2 := ResourceManagerServiceV2{client}
+
+	objectRaw, err := resourceManagerServiceV2.DescribeResourceManagerHandshakeAcceptance(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_resource_manager_handshake_acceptance DescribeResourceManagerHandshakeAcceptance Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("handshake_id", d.Id())
+	d.Set("create_time", objectRaw["CreateTime"])
+	d.Set("expire_time", objectRaw["ExpireTime"])
+	d.Set("invited_account_real_name", objectRaw["InvitedAccountRealName"])
+	d.Set("master_account_id", objectRaw["MasterAccountId"])
+	d.Set("master_account_name", objectRaw["MasterAccountName"])
+	d.Set("master_account_real_name", objectRaw["MasterAccountRealName"])
+	d.Set("modify_time", objectRaw["ModifyTime"])
+	d.Set("note", objectRaw["Note"])
+	d.Set("resource_directory_id", objectRaw["ResourceDirectoryId"])
+	d.Set("status", objectRaw["Status"])
+	d.Set("target_entity", objectRaw["TargetEntity"])
+	d.Set("target_type", objectRaw["TargetType"])
+
+	return nil
+}
+
+func resourceAliCloudResourceManagerHandshakeAcceptanceDelete(d *schema.ResourceData, meta interface{}) error {
+	// Accepting a handshake is irreversible: once the invited account joins the resource directory,
+	// there is no API to revoke the acceptance. Removing this resource only drops it from state.
+	log.Printf("[WARN] Cannot destroy alicloud_resource_manager_handshake_acceptance. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_resource_manager_handshake_acceptance_test.go
+++ b/alicloud/resource_alicloud_resource_manager_handshake_acceptance_test.go
@@ -1,0 +1,126 @@
+package alicloud
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+var ResourceManagerHandshakeAcceptanceMap = map[string]string{
+	"status": CHECKSET,
+}
+
+func TestAccAliCloudResourceManagerHandshakeAcceptance_schema(t *testing.T) {
+	resourceSchema := resourceAliCloudResourceManagerHandshakeAcceptance().Schema
+	expected := map[string]struct {
+		required bool
+		computed bool
+		forceNew bool
+	}{
+		"create_time":               {computed: true},
+		"expire_time":               {computed: true},
+		"handshake_id":              {required: true, forceNew: true},
+		"invited_account_real_name": {computed: true},
+		"master_account_id":         {computed: true},
+		"master_account_name":       {computed: true},
+		"master_account_real_name":  {computed: true},
+		"modify_time":               {computed: true},
+		"note":                      {computed: true},
+		"resource_directory_id":     {computed: true},
+		"status":                    {computed: true},
+		"target_entity":             {computed: true},
+		"target_type":               {computed: true},
+	}
+
+	if len(resourceSchema) != len(expected) {
+		t.Fatalf("schema field count = %d, want %d", len(resourceSchema), len(expected))
+	}
+
+	for name, want := range expected {
+		got, ok := resourceSchema[name]
+		if !ok {
+			t.Fatalf("schema missing field %q", name)
+		}
+		if got.Type != schema.TypeString {
+			t.Fatalf("schema field %q type = %v, want TypeString", name, got.Type)
+		}
+		if got.Required != want.required || got.Computed != want.computed || got.ForceNew != want.forceNew {
+			t.Fatalf("schema field %q flags = required:%t computed:%t force_new:%t, want required:%t computed:%t force_new:%t",
+				name, got.Required, got.Computed, got.ForceNew, want.required, want.computed, want.forceNew)
+		}
+	}
+}
+
+// Accepting a handshake must be performed by the invited account, so this test needs two accounts.
+// The management (master) account is the default provider (ALICLOUD_ACCESS_KEY/SECRET_KEY) and sends
+// the invitation; the invited account is supplied via ALICLOUD_ACCESS_KEY_2/SECRET_KEY_2 (uid in
+// ALICLOUD_ACCOUNT_ID_2) and accepts it. handshake_id is ForceNew, so no second/update step is needed.
+func ResourceManagerHandshakeAcceptanceBasicdependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+# Invited account (accepts the invitation), explicit credentials so it overrides the default keys.
+provider "alicloud" {
+  alias      = "invited"
+  access_key = "%s"
+  secret_key = "%s"
+}
+
+# Management account (default provider) sends the invitation.
+resource "alicloud_resource_manager_handshake" "default" {
+  target_entity = "%s"
+  target_type   = "Account"
+  note          = "tf-test-acceptance"
+}
+`, name, os.Getenv("ALICLOUD_ACCESS_KEY_2"), os.Getenv("ALICLOUD_SECRET_KEY_2"), os.Getenv("ALICLOUD_ACCOUNT_ID_2"))
+}
+
+func testAccPreCheckHandshakeAcceptanceProfiles(t *testing.T) {
+	if os.Getenv("ALICLOUD_ACCESS_KEY_2") == "" || os.Getenv("ALICLOUD_SECRET_KEY_2") == "" ||
+		os.Getenv("ALICLOUD_ACCOUNT_ID_2") == "" {
+		t.Skipf("Skipping: set ALICLOUD_ACCESS_KEY_2/SECRET_KEY_2/ALICLOUD_ACCOUNT_ID_2 for the invited account")
+	}
+}
+
+func TestAccAliCloudResourceManagerHandshakeAcceptance_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_resource_manager_handshake_acceptance.default"
+	ra := resourceAttrInit(resourceId, ResourceManagerHandshakeAcceptanceMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ResourceManagerServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeResourceManagerHandshakeAcceptance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccResourceManagerHandshakeAcceptance%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, ResourceManagerHandshakeAcceptanceBasicdependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckEnterpriseAccountEnabled(t)
+			testAccPreCheckHandshakeAcceptanceProfiles(t)
+		},
+
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"handshake_id": "${alicloud_resource_manager_handshake.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"handshake_id": CHECKSET,
+						"status":       "Accepted",
+					}),
+				),
+			},
+		},
+	})
+}

--- a/alicloud/service_alicloud_resource_manager_v2.go
+++ b/alicloud/service_alicloud_resource_manager_v2.go
@@ -1114,6 +1114,86 @@ func (s *ResourceManagerServiceV2) ResourceManagerHandshakeStateRefreshFunc(id s
 }
 
 // DescribeResourceManagerHandshake >>> Encapsulated.
+// DescribeResourceManagerHandshakeAcceptance <<< Encapsulated get interface for ResourceManager HandshakeAcceptance.
+
+func (s *ResourceManagerServiceV2) DescribeResourceManagerHandshakeAcceptance(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["HandshakeId"] = id
+
+	action := "GetHandshake"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"EntityNotExists.Handshake"}) {
+			return object, WrapErrorf(NotFoundErr("HandshakeAcceptance", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Handshake", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Handshake", response)
+	}
+
+	currentStatus := v.(map[string]interface{})["Status"]
+	if fmt.Sprint(currentStatus) != "Accepted" {
+		return object, WrapErrorf(NotFoundErr("HandshakeAcceptance", id), NotFoundMsg, response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *ResourceManagerServiceV2) ResourceManagerHandshakeAcceptanceStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ResourceManagerHandshakeAcceptanceStateRefreshFuncWithApi(id, field, failStates, s.DescribeResourceManagerHandshakeAcceptance)
+}
+
+func (s *ResourceManagerServiceV2) ResourceManagerHandshakeAcceptanceStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeResourceManagerHandshakeAcceptance >>> Encapsulated.
 // DescribeResourceManagerControlPolicy <<< Encapsulated get interface for ResourceManager ControlPolicy.
 
 func (s *ResourceManagerServiceV2) DescribeResourceManagerControlPolicy(id string) (object map[string]interface{}, err error) {

--- a/website/docs/r/resource_manager_handshake_acceptance.html.markdown
+++ b/website/docs/r/resource_manager_handshake_acceptance.html.markdown
@@ -1,0 +1,74 @@
+---
+subcategory: "Resource Manager"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_resource_manager_handshake_acceptance"
+description: |-
+  Provides a Alicloud Resource Manager Handshake Acceptance resource.
+---
+
+# alicloud_resource_manager_handshake_acceptance
+
+Provides a Resource Manager Handshake Acceptance resource. It is used by the **invited account** to accept an invitation (handshake) to join a resource directory.
+
+For information about Resource Manager Handshake Acceptance and how to use it, see [What is Handshake](https://www.alibabacloud.com/help/en/doc-detail/135287.htm) and the [AcceptHandshake](https://next.api.alibabacloud.com/document/ResourceDirectoryMaster/2022-04-19/AcceptHandshake) API.
+
+-> **NOTE:** This resource must be applied with the credentials of the **invited account**, not the management (master) account that sent the invitation. The invitation itself is created by the management account via `alicloud_resource_manager_handshake`. Use a separate [provider alias](https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations) configured with the invited account's credentials.
+
+-> **NOTE:** Accepting a handshake is irreversible. Destroying this resource only removes it from the Terraform state; it does not make the invited account leave the resource directory.
+
+-> **NOTE:** Available since v1.282.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+# The management account sends the invitation.
+resource "alicloud_resource_manager_handshake" "example" {
+  target_entity = "1182775234******"
+  target_type   = "Account"
+  note          = "test resource manager handshake"
+}
+
+# The invited account accepts it (configure invited_account with the invited account's credentials).
+resource "alicloud_resource_manager_handshake_acceptance" "example" {
+  provider     = alicloud.invited_account
+  handshake_id = alicloud_resource_manager_handshake.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `handshake_id` - (Required, ForceNew) The ID of the invitation.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource. The value is the same as `handshake_id`.
+* `create_time` - The time when the invitation was created. The time is displayed in UTC.
+* `expire_time` - The time when the invitation expires. The time is displayed in UTC.
+* `invited_account_real_name` - The real-name verification information of the invited account.
+* `master_account_id` - The ID of the management account of the resource directory.
+* `master_account_name` - The name of the management account of the resource directory.
+* `master_account_real_name` - The real-name verification information of the management account.
+* `modify_time` - The time when the invitation was modified. The time is displayed in UTC.
+* `note` - The note of the invitation.
+* `resource_directory_id` - The ID of the resource directory.
+* `status` - The status of the invitation. The acceptance resource exists only when the status is `Accepted`.
+* `target_entity` - The invited account. The value is an account ID when `target_type` is `Account`, or a logon email address when `target_type` is `Email`.
+* `target_type` - The type of the invited account. Valid values: `Account` and `Email`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when accept the Handshake.
+* `delete` - (Defaults to 5 mins) Used when delete the Handshake Acceptance.
+
+## Import
+
+Resource Manager Handshake Acceptance can be imported using the id (handshake id), e.g.
+
+```shell
+$ terraform import alicloud_resource_manager_handshake_acceptance.example <id>
+```


### PR DESCRIPTION
## Summary
- Add alicloud_resource_manager_handshake_acceptance for accepting Resource Manager invitations from the invited account.
- Align the resource schema and orchestration APIs with the Acube/Cloudspec HandshakeAcceptance definition.
- Keep the hand-written provider alias example, state-only delete behavior, and two-account acceptance test path.

## Context
- Source Aone: https://project.aone.alibaba-inc.com/v2/project/1086837/req/82910323
- This branch follows the Acube-generated HandshakeAcceptance spec while preserving provider-specific behavior needed for Terraform usage.

## Validation
- git diff --check
- go test ./alicloud -run TestResourceAliCloudResourceManagerHandshakeAcceptanceSchema -count=1
- go test ./alicloud -run '^$'\n- go test ./alicloud -run TestAccAliCloudResourceManagerHandshakeAcceptance_basic -count=0\n\n## Notes\n- Real TF_ACC execution still requires a second invited account credential set: ALICLOUD_ACCESS_KEY_2, ALICLOUD_SECRET_KEY_2, and ALICLOUD_ACCOUNT_ID_2.\n