### PR TITLE
New Resource: alicloud_resource_manager_handshake_acceptance; resource/alicloud_resource_manager_handshake: remove accepted account

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1583,6 +1583,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_resource_manager_resource_group":                       resourceAliCloudResourceManagerResourceGroup(),
 			"alicloud_resource_manager_folder":                               resourceAliCloudResourceManagerFolder(),
 			"alicloud_resource_manager_handshake":                            resourceAliCloudResourceManagerHandshake(),
+			"alicloud_resource_manager_handshake_acceptance":                 resourceAliCloudResourceManagerHandshakeAcceptance(),
 			"alicloud_cen_private_zone":                                      resourceAliCloudCenPrivateZone(),
 			"alicloud_resource_manager_policy":                               resourceAlicloudResourceManagerPolicy(),
 			"alicloud_resource_manager_account":                              resourceAliCloudResourceManagerAccount(),

--- a/alicloud/resource_alicloud_resource_manager_handshake.go
+++ b/alicloud/resource_alicloud_resource_manager_handshake.go
@@ -12,6 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+var resourceManagerHandshakeRpcPost = func(client *connectivity.AliyunClient, apiProductCode string, apiVersion string, apiName string, query map[string]interface{}, body map[string]interface{}, autoRetry bool) (map[string]interface{}, error) {
+	return client.RpcPost(apiProductCode, apiVersion, apiName, query, body, autoRetry)
+}
+
 func resourceAliCloudResourceManagerHandshake() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAliCloudResourceManagerHandshakeCreate,
@@ -90,9 +94,9 @@ func resourceAliCloudResourceManagerHandshakeCreate(d *schema.ResourceData, meta
 	request["TargetEntity"] = d.Get("target_entity")
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+		response, err = resourceManagerHandshakeRpcPost(client, "ResourceManager", "2020-03-31", action, query, request, true)
 		if err != nil {
-			if IsExpectedErrors(err, []string{"ConcurrentCallNotSupported"}) || NeedRetry(err) {
+			if IsExpectedErrors(err, []string{"ConcurrentCallNotSupported", "LimitExceeded.InvitationRate", "LimitExceeded.SameTargetInvitationRate"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}
@@ -153,7 +157,7 @@ func resourceAliCloudResourceManagerHandshakeDelete(d *schema.ResourceData, meta
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+		response, err = resourceManagerHandshakeRpcPost(client, "ResourceManager", "2020-03-31", action, query, request, true)
 
 		if err != nil {
 			if NeedRetry(err) {
@@ -167,10 +171,81 @@ func resourceAliCloudResourceManagerHandshakeDelete(d *schema.ResourceData, meta
 	addDebug(action, response, request)
 
 	if err != nil {
-		if IsExpectedErrors(err, []string{"HandshakeStatusMismatch", "EntityNotExists.Handshake"}) || NotFoundError(err) {
+		if IsExpectedErrors(err, []string{"HandshakeStatusMismatch"}) {
+			return resourceAliCloudResourceManagerHandshakeRemoveAcceptedAccount(d, meta)
+		}
+		if IsExpectedErrors(err, []string{"EntityNotExists.Handshake"}) || NotFoundError(err) {
 			return nil
 		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}
+
+func resourceAliCloudResourceManagerHandshakeRemoveAcceptedAccount(d *schema.ResourceData, meta interface{}) error {
+	targetType := d.Get("target_type").(string)
+	accountId := d.Get("target_entity").(string)
+	if targetType != "Account" || accountId == "" {
+		log.Printf("[WARN] Cannot remove accepted Resource Manager handshake %s because target_type is %q and target_entity is %q. Terraform will remove this resource from the state file, however resources may remain.", d.Id(), targetType, accountId)
+		return nil
+	}
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "RemoveCloudAccount"
+	request := map[string]interface{}{
+		"AccountId": accountId,
+	}
+	query := make(map[string]interface{})
+	var response map[string]interface{}
+	var err error
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = resourceManagerHandshakeRpcPost(client, "ResourceManager", "2020-03-31", action, query, request, true)
+
+		if err != nil {
+			if IsExpectedErrors(err, []string{"ConcurrentCallNotSupported"}) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			if IsExpectedErrors(err, []string{"EntityNotExists.Account", "EntityNotExists.ResourceDirectory"}) || NotFoundError(err) {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, accountId, action, AlibabaCloudSdkGoERROR)
+	}
+
+	action = "GetAccount"
+	request = map[string]interface{}{
+		"AccountId": accountId,
+	}
+	response = nil
+	wait = incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = resourceManagerHandshakeRpcPost(client, "ResourceManager", "2020-03-31", action, query, request, true)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"EntityNotExists.Account", "EntityNotExists.ResourceDirectory"}) || NotFoundError(err) {
+				return nil
+			}
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		wait()
+		return resource.RetryableError(fmt.Errorf("Resource Manager member account %s is still attached", accountId))
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, accountId, "GetAccount", AlibabaCloudSdkGoERROR)
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_resource_manager_handshake_acceptance.go
+++ b/alicloud/resource_alicloud_resource_manager_handshake_acceptance.go
@@ -1,0 +1,179 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudResourceManagerHandshakeAcceptance() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudResourceManagerHandshakeAcceptanceCreate,
+		Read:   resourceAliCloudResourceManagerHandshakeAcceptanceRead,
+		Delete: resourceAliCloudResourceManagerHandshakeAcceptanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"handshake_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expire_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"invited_account_real_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"master_account_real_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modify_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"note": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_directory_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_entity": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudResourceManagerHandshakeAcceptanceCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "AcceptHandshake"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	if v, ok := d.GetOk("handshake_id"); ok {
+		request["HandshakeId"] = v
+	}
+
+	wait := incrementalWait(5*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("ResourceManager", "2020-03-31", "GetHandshake", query, request, true)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"EntityNotExists.Handshake"}) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug("GetHandshake", response, request)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_resource_manager_handshake_acceptance", "GetHandshake", AlibabaCloudSdkGoERROR)
+	}
+
+	wait = incrementalWait(5*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"ConcurrentCallNotSupported", "EntityNotExists.Handshake"}) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_resource_manager_handshake_acceptance", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, err := jsonpath.Get("$.Handshake.HandshakeId", response)
+	if err != nil || fmt.Sprint(id) == "" {
+		id = d.Get("handshake_id")
+	}
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudResourceManagerHandshakeAcceptanceRead(d, meta)
+}
+
+func resourceAliCloudResourceManagerHandshakeAcceptanceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	resourceManagerServiceV2 := ResourceManagerServiceV2{client}
+
+	objectRaw, err := resourceManagerServiceV2.DescribeResourceManagerHandshakeAcceptance(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_resource_manager_handshake_acceptance DescribeResourceManagerHandshakeAcceptance Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("handshake_id", d.Id())
+	d.Set("create_time", objectRaw["CreateTime"])
+	d.Set("expire_time", objectRaw["ExpireTime"])
+	d.Set("invited_account_real_name", objectRaw["InvitedAccountRealName"])
+	d.Set("master_account_id", objectRaw["MasterAccountId"])
+	d.Set("master_account_name", objectRaw["MasterAccountName"])
+	d.Set("master_account_real_name", objectRaw["MasterAccountRealName"])
+	d.Set("modify_time", objectRaw["ModifyTime"])
+	d.Set("note", objectRaw["Note"])
+	d.Set("resource_directory_id", objectRaw["ResourceDirectoryId"])
+	d.Set("status", objectRaw["Status"])
+	d.Set("target_entity", objectRaw["TargetEntity"])
+	d.Set("target_type", objectRaw["TargetType"])
+
+	return nil
+}
+
+func resourceAliCloudResourceManagerHandshakeAcceptanceDelete(d *schema.ResourceData, meta interface{}) error {
+	// Accepting a handshake is irreversible: once the invited account joins the resource directory,
+	// there is no API to revoke the acceptance. Removing this resource only drops it from state.
+	log.Printf("[WARN] Cannot destroy alicloud_resource_manager_handshake_acceptance. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_resource_manager_handshake_acceptance_test.go
+++ b/alicloud/resource_alicloud_resource_manager_handshake_acceptance_test.go
@@ -1,0 +1,413 @@
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+var ResourceManagerHandshakeAcceptanceMap = map[string]string{
+	"status": CHECKSET,
+}
+
+var resourceManagerHandshakeInvitedAccountId string
+
+const resourceManagerHandshakeConsistencyDelay = 90 * time.Second
+
+func TestAccAliCloudResourceManagerHandshakeAcceptance_schema(t *testing.T) {
+	resourceSchema := resourceAliCloudResourceManagerHandshakeAcceptance().Schema
+	expected := map[string]struct {
+		required bool
+		computed bool
+		forceNew bool
+	}{
+		"create_time":               {computed: true},
+		"expire_time":               {computed: true},
+		"handshake_id":              {required: true, forceNew: true},
+		"invited_account_real_name": {computed: true},
+		"master_account_id":         {computed: true},
+		"master_account_name":       {computed: true},
+		"master_account_real_name":  {computed: true},
+		"modify_time":               {computed: true},
+		"note":                      {computed: true},
+		"resource_directory_id":     {computed: true},
+		"status":                    {computed: true},
+		"target_entity":             {computed: true},
+		"target_type":               {computed: true},
+	}
+
+	if len(resourceSchema) != len(expected) {
+		t.Fatalf("schema field count = %d, want %d", len(resourceSchema), len(expected))
+	}
+
+	for name, want := range expected {
+		got, ok := resourceSchema[name]
+		if !ok {
+			t.Fatalf("schema missing field %q", name)
+		}
+		if got.Type != schema.TypeString {
+			t.Fatalf("schema field %q type = %v, want TypeString", name, got.Type)
+		}
+		if got.Required != want.required || got.Computed != want.computed || got.ForceNew != want.forceNew {
+			t.Fatalf("schema field %q flags = required:%t computed:%t force_new:%t, want required:%t computed:%t force_new:%t",
+				name, got.Required, got.Computed, got.ForceNew, want.required, want.computed, want.forceNew)
+		}
+	}
+}
+
+// Accepting a handshake must be performed by the invited account, so this test needs two accounts.
+// The management (master) account is supplied via ALICLOUD_ACCESS_KEY_1/SECRET_KEY_1 and sends the
+// invitation; the invited account is supplied via ALICLOUD_ACCESS_KEY_2/SECRET_KEY_2 and accepts it.
+// The invited account id is read from ALICLOUD_ACCOUNT_ID_2 / INVITED_ALICLOUD_ACCOUNT_ID, or derived
+// from ALICLOUD_ACCESS_KEY_2 / ALICLOUD_SECRET_KEY_2 via STS GetCallerIdentity. Both providers are configured explicitly so generic
+// credential environment variables cannot override the account used by the provider alias.
+func ResourceManagerHandshakeAcceptanceBasicdependence(name string, invitedAccountId string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+# Management account (default provider) sends the invitation, explicit credentials to avoid env fallback.
+provider "alicloud" {
+  access_key = "%s"
+  secret_key = "%s"
+}
+
+# Invited account (accepts the invitation), explicit credentials so it overrides the default keys.
+provider "alicloud" {
+  alias      = "invited"
+  access_key = "%s"
+  secret_key = "%s"
+}
+
+# Management account (default provider) sends the invitation.
+resource "alicloud_resource_manager_handshake" "default" {
+  target_entity = "%s"
+  target_type   = "Account"
+  note          = "tf-test-acceptance"
+}
+`, name, os.Getenv("ALICLOUD_ACCESS_KEY_1"), os.Getenv("ALICLOUD_SECRET_KEY_1"), os.Getenv("ALICLOUD_ACCESS_KEY_2"), os.Getenv("ALICLOUD_SECRET_KEY_2"), invitedAccountId)
+}
+
+func ResourceManagerHandshakeAcceptanceBasic(name string, invitedAccountId string) string {
+	return ResourceManagerHandshakeAcceptanceBasicdependence(name, invitedAccountId) + `
+resource "alicloud_resource_manager_handshake_acceptance" "default" {
+  provider     = alicloud.invited
+  handshake_id = "${alicloud_resource_manager_handshake.default.id}"
+}
+`
+}
+
+func testAccPreCheckHandshakeAcceptanceProfiles(t *testing.T) {
+	testAccUseResourceManagerHandshakeManagementAccount(t)
+	if os.Getenv("ALICLOUD_ACCESS_KEY_2") == "" || os.Getenv("ALICLOUD_SECRET_KEY_2") == "" {
+		t.Skipf("Skipping: set ALICLOUD_ACCESS_KEY_1/SECRET_KEY_1 and ALICLOUD_ACCESS_KEY_2/SECRET_KEY_2 for the management and invited accounts")
+	}
+	testAccResolveResourceManagerHandshakeInvitedAccountId(t)
+}
+
+func testAccResourceManagerHandshakeManagementCredentialValues() (string, string) {
+	ak := strings.TrimSpace(os.Getenv("ALICLOUD_ACCESS_KEY_1"))
+	sk := strings.TrimSpace(os.Getenv("ALICLOUD_SECRET_KEY_1"))
+	if ak != "" && sk != "" {
+		return ak, sk
+	}
+	return strings.TrimSpace(os.Getenv("ALICLOUD_ACCESS_KEY")), strings.TrimSpace(os.Getenv("ALICLOUD_SECRET_KEY"))
+}
+
+func testAccResourceManagerHandshakeManagementCredentials(t *testing.T) (string, string) {
+	ak, sk := testAccResourceManagerHandshakeManagementCredentialValues()
+	if ak == "" || sk == "" {
+		t.Skipf("Skipping: set ALICLOUD_ACCESS_KEY_1/SECRET_KEY_1 or ALICLOUD_ACCESS_KEY/SECRET_KEY for the management account")
+	}
+	return ak, sk
+}
+
+func testAccUseResourceManagerHandshakeManagementAccount(t *testing.T) {
+	ak, sk := testAccResourceManagerHandshakeManagementCredentials(t)
+	os.Setenv("ALICLOUD_ACCESS_KEY", ak)
+	os.Setenv("ALICLOUD_SECRET_KEY", sk)
+	os.Setenv("ALICLOUD_REGION", "cn-hangzhou")
+}
+
+func testAccResolveResourceManagerHandshakeInvitedAccountId(t *testing.T) string {
+	if resourceManagerHandshakeInvitedAccountId != "" {
+		return resourceManagerHandshakeInvitedAccountId
+	}
+	for _, envName := range []string{"ALICLOUD_ACCOUNT_ID_2", "INVITED_ALICLOUD_ACCOUNT_ID"} {
+		if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
+			resourceManagerHandshakeInvitedAccountId = v
+			return resourceManagerHandshakeInvitedAccountId
+		}
+	}
+
+	ak := strings.TrimSpace(os.Getenv("ALICLOUD_ACCESS_KEY_2"))
+	sk := strings.TrimSpace(os.Getenv("ALICLOUD_SECRET_KEY_2"))
+	if ak == "" || sk == "" {
+		t.Skipf("Skipping: set ALICLOUD_ACCOUNT_ID_2 or INVITED_ALICLOUD_ACCOUNT_ID, or set ALICLOUD_ACCESS_KEY_2/SECRET_KEY_2 so the invited account id can be derived")
+	}
+
+	region := os.Getenv("ALICLOUD_REGION")
+	if region == "" {
+		region = "cn-beijing"
+	}
+	client, err := sdk.NewClientWithAccessKey(region, ak, sk)
+	if err != nil {
+		t.Fatalf("failed to build STS client for invited account: %s", err)
+	}
+	result, err := testAccResourceManagerHandshakeCommonRequest(client, "Sts", "2015-04-01", "sts.aliyuncs.com", "GetCallerIdentity", nil)
+	if err != nil {
+		t.Skipf("Skipping: failed to derive invited account id from ALICLOUD_ACCESS_KEY_2: %s", err)
+	}
+	accountId := strings.TrimSpace(fmt.Sprint(result["AccountId"]))
+	if accountId == "" || accountId == "<nil>" {
+		t.Skipf("Skipping: STS GetCallerIdentity did not return AccountId for ALICLOUD_ACCESS_KEY_2")
+	}
+	resourceManagerHandshakeInvitedAccountId = accountId
+	return resourceManagerHandshakeInvitedAccountId
+}
+
+func testAccResourceManagerHandshakeInvitedAccountId() string {
+	if resourceManagerHandshakeInvitedAccountId != "" {
+		return resourceManagerHandshakeInvitedAccountId
+	}
+	for _, envName := range []string{"ALICLOUD_ACCOUNT_ID_2", "INVITED_ALICLOUD_ACCOUNT_ID"} {
+		if v := strings.TrimSpace(os.Getenv(envName)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func testAccPreCheckHandshakeAcceptanceAccountDetached(t *testing.T) {
+	testAccPreCheckResourceManagerHandshakeAccountDetached(t, testAccResolveResourceManagerHandshakeInvitedAccountId(t))
+}
+
+func testAccPreCheckResourceManagerHandshakeAccountDetached(t *testing.T, accountId string) {
+	region := os.Getenv("ALICLOUD_REGION")
+	if region == "" {
+		region = "cn-beijing"
+	}
+	ak, sk := testAccResourceManagerHandshakeManagementCredentials(t)
+	client, err := sdk.NewClientWithAccessKey(region, ak, sk)
+	if err != nil {
+		t.Fatalf("failed to build Resource Manager client: %s", err)
+	}
+
+	testAccPreCheckHandshakeAcceptancePendingHandshakesCanceled(t, client, accountId)
+	if _, err := testAccPreCheckHandshakeAcceptanceResourceManagerRequest(client, "GetAccount", map[string]string{"AccountId": accountId}); err != nil {
+		if IsExpectedErrors(err, []string{"EntityNotExists.Account"}) || NotFoundError(err) {
+			time.Sleep(resourceManagerHandshakeConsistencyDelay)
+			return
+		}
+		t.Fatalf("failed to check Resource Manager member account %s: %s", accountId, err)
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err = testAccPreCheckHandshakeAcceptanceResourceManagerRequest(client, "RemoveCloudAccount", map[string]string{"AccountId": accountId})
+		if err != nil {
+			if IsExpectedErrors(err, []string{"ConcurrentCallNotSupported"}) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			if IsExpectedErrors(err, []string{"EntityNotExists.Account"}) || NotFoundError(err) {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to remove Resource Manager member account %s before handshake acceptance test: %s", accountId, err)
+	}
+
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err = testAccPreCheckHandshakeAcceptanceResourceManagerRequest(client, "GetAccount", map[string]string{"AccountId": accountId})
+		if err != nil {
+			if IsExpectedErrors(err, []string{"EntityNotExists.Account"}) || NotFoundError(err) {
+				return nil
+			}
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		wait()
+		return resource.RetryableError(fmt.Errorf("Resource Manager member account %s is still attached", accountId))
+	})
+	if err != nil {
+		t.Fatalf("failed waiting for Resource Manager member account %s to detach: %s", accountId, err)
+	}
+	// Resource Manager may report the account as detached before new invitations are acceptable.
+	time.Sleep(resourceManagerHandshakeConsistencyDelay)
+}
+
+func testAccPreCheckHandshakeAcceptancePendingHandshakesCanceled(t *testing.T, client *sdk.Client, accountId string) {
+	t.Helper()
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	pageNumber := 1
+	for {
+		response, err := testAccPreCheckHandshakeAcceptanceResourceManagerRequest(client, "ListHandshakesForResourceDirectory", map[string]string{
+			"PageSize":   "100",
+			"PageNumber": fmt.Sprint(pageNumber),
+		})
+		if err != nil {
+			if IsExpectedErrors(err, []string{"EntityNotExists.ResourceDirectory"}) || NotFoundError(err) {
+				return
+			}
+			t.Fatalf("failed to list Resource Manager handshakes before test: %s", err)
+		}
+
+		handshakes, _ := response["Handshakes"].(map[string]interface{})
+		items, _ := handshakes["Handshake"].([]interface{})
+		for _, raw := range items {
+			item, _ := raw.(map[string]interface{})
+			if fmt.Sprint(item["TargetEntity"]) != accountId || fmt.Sprint(item["Status"]) != "Pending" {
+				continue
+			}
+			handshakeId := strings.TrimSpace(fmt.Sprint(item["HandshakeId"]))
+			if handshakeId == "" || handshakeId == "<nil>" {
+				continue
+			}
+			err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+				_, err := testAccPreCheckHandshakeAcceptanceResourceManagerRequest(client, "CancelHandshake", map[string]string{"HandshakeId": handshakeId})
+				if err != nil {
+					if IsExpectedErrors(err, []string{"EntityNotExists.Handshake"}) || NotFoundError(err) {
+						return nil
+					}
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("failed to cancel pending Resource Manager handshake %s before test: %s", handshakeId, err)
+			}
+		}
+		if len(items) < 100 {
+			return
+		}
+		pageNumber++
+	}
+}
+
+func testAccPreCheckHandshakeAcceptanceResourceManagerRequest(client *sdk.Client, action string, params map[string]string) (map[string]interface{}, error) {
+	return testAccResourceManagerHandshakeCommonRequest(client, "ResourceManager", "2020-03-31", "resourcemanager.aliyuncs.com", action, params)
+}
+
+func testAccResourceManagerHandshakeCommonRequest(client *sdk.Client, product string, version string, domain string, action string, params map[string]string) (map[string]interface{}, error) {
+	request := requests.NewCommonRequest()
+	request.Method = requests.POST
+	request.Scheme = "https"
+	request.Domain = domain
+	request.Version = version
+	request.Product = product
+	request.ApiName = action
+	for key, value := range params {
+		request.QueryParams[key] = value
+	}
+	request.TransToAcsRequest()
+
+	response, err := client.ProcessCommonRequest(request)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(response.GetHttpContentString()), &result)
+	if response.IsSuccess() {
+		return result, nil
+	}
+
+	code := fmt.Sprint(result["Code"])
+	if code == "" || code == "<nil>" {
+		code = fmt.Sprint(response.GetHttpStatus())
+	}
+	return nil, &ProviderError{
+		errorCode: code,
+		message:   fmt.Sprint(result["Message"]),
+	}
+}
+
+func TestAccAliCloudResourceManagerHandshakeAcceptance_basic(t *testing.T) {
+	resourceId := "alicloud_resource_manager_handshake_acceptance.default"
+	ra := resourceAttrInit(resourceId, ResourceManagerHandshakeAcceptanceMap)
+	testAccCheck := ra.resourceAttrMapUpdateSet()
+	providerFactories := map[string]terraform.ResourceProviderFactory{
+		"alicloud": func() (terraform.ResourceProvider, error) {
+			return Provider(), nil
+		},
+	}
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccResourceManagerHandshakeAcceptance%d", rand)
+	testAccUseResourceManagerHandshakeManagementAccount(t)
+	invitedAccountId := testAccResolveResourceManagerHandshakeInvitedAccountId(t)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckEnterpriseAccountEnabled(t)
+			testAccPreCheckHandshakeAcceptanceProfiles(t)
+			testAccPreCheckHandshakeAcceptanceAccountDetached(t)
+		},
+
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckResourceManagerHandshakeAcceptanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: ResourceManagerHandshakeAcceptanceBasic(name, invitedAccountId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"handshake_id": CHECKSET,
+						"status":       "Accepted",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckResourceManagerHandshakeAcceptanceDestroy(s *terraform.State) error {
+	region := os.Getenv("ALICLOUD_REGION")
+	if region == "" {
+		region = "cn-beijing"
+	}
+	ak, sk := testAccResourceManagerHandshakeManagementCredentialValues()
+	if ak == "" || sk == "" {
+		return WrapError(fmt.Errorf("management account credentials are not set"))
+	}
+	client, err := sdk.NewClientWithAccessKey(region, ak, sk)
+	if err != nil {
+		return WrapError(err)
+	}
+
+	accountId := testAccResourceManagerHandshakeInvitedAccountId()
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := testAccPreCheckHandshakeAcceptanceResourceManagerRequest(client, "GetAccount", map[string]string{"AccountId": accountId})
+		if err != nil {
+			if IsExpectedErrors(err, []string{"EntityNotExists.Account"}) || NotFoundError(err) {
+				return nil
+			}
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		wait()
+		return resource.RetryableError(fmt.Errorf("Resource Manager member account %s is still attached", accountId))
+	})
+}

--- a/alicloud/resource_alicloud_resource_manager_handshake_test.go
+++ b/alicloud/resource_alicloud_resource_manager_handshake_test.go
@@ -106,11 +106,14 @@ func TestAccAliCloudResourceManagerHandshake_basic(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(1000000, 9999999)
 	name := fmt.Sprintf("tf-testAccResourceManagerHandshake%d", rand)
+	testAccUseResourceManagerHandshakeManagementAccount(t)
+	invitedAccountId := testAccResolveResourceManagerHandshakeInvitedAccountId(t)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, ResourceManagerHandshakeBasicdependence)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckEnterpriseAccountEnabled(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 			testAccPreCheck(t)
+			testAccPreCheckResourceManagerHandshakeAccountDetached(t, invitedAccountId)
 		},
 
 		IDRefreshName: resourceId,
@@ -119,7 +122,7 @@ func TestAccAliCloudResourceManagerHandshake_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"target_entity": "${alicloud_resource_manager_account.example.id}",
+					"target_entity": invitedAccountId,
 					"target_type":   "Account",
 					"note":          "test resource manager handshake",
 				}),
@@ -143,11 +146,7 @@ func TestAccAliCloudResourceManagerHandshake_basic(t *testing.T) {
 var ResourceManagerHandshakeMap = map[string]string{}
 
 func ResourceManagerHandshakeBasicdependence(name string) string {
-	return fmt.Sprintf(`
-resource "alicloud_resource_manager_account" "example" {
-  display_name = "%s"
-}
-`, name)
+	return resourceManagerHandshakeManagementProviderDependence(name)
 }
 
 // lintignore: R001
@@ -230,7 +229,7 @@ func TestUnitAlicloudResourceManagerHandshake(t *testing.T) {
 		patches.Reset()
 		assert.NotNil(t, err)
 		ReadMockResponseDiff = map[string]interface{}{}
-		errorCodes := []string{"NonRetryableError", "Throttling", "nil"}
+		errorCodes := []string{"NonRetryableError", "LimitExceeded.InvitationRate", "LimitExceeded.SameTargetInvitationRate", "Throttling", "nil"}
 		for index, errorCode := range errorCodes {
 			retryIndex := index - 1 // a counter used to cover retry scenario; the same below
 			patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, action *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
@@ -357,11 +356,14 @@ func TestAccAliCloudResourceManagerHandshake_basic11272(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tfaccresourcemanager%d", rand)
+	testAccUseResourceManagerHandshakeManagementAccount(t)
+	invitedAccountId := testAccResolveResourceManagerHandshakeInvitedAccountId(t)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudResourceManagerHandshakeBasicDependence11272)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 			testAccPreCheck(t)
+			testAccPreCheckResourceManagerHandshakeAccountDetached(t, invitedAccountId)
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
@@ -371,7 +373,7 @@ func TestAccAliCloudResourceManagerHandshake_basic11272(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"note":          "test",
 					"target_type":   "Account",
-					"target_entity": "1382956792949863",
+					"target_entity": invitedAccountId,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -402,13 +404,22 @@ var AlicloudResourceManagerHandshakeMap11272 = map[string]string{
 }
 
 func AlicloudResourceManagerHandshakeBasicDependence11272(name string) string {
-	return fmt.Sprintf(`
-variable "name" {
-    default = "%s"
+	return resourceManagerHandshakeManagementProviderDependence(name)
 }
 
+func resourceManagerHandshakeManagementProviderDependence(name string) string {
+	ak, sk := testAccResourceManagerHandshakeManagementCredentialValues()
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
 
-`, name)
+provider "alicloud" {
+  region     = "cn-hangzhou"
+  access_key = "%s"
+  secret_key = "%s"
+}
+`, name, ak, sk)
 }
 
 // Test ResourceManager Handshake. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_resource_manager_v2.go
+++ b/alicloud/service_alicloud_resource_manager_v2.go
@@ -1065,6 +1065,13 @@ func (s *ResourceManagerServiceV2) DescribeResourceManagerHandshake(id string) (
 	})
 	addDebug(action, response, request)
 	if err != nil {
+		if IsExpectedErrors(err, []string{"HandshakeStatusMismatch"}) {
+			// The handshake can no longer be read normally after it has been accepted.
+			return map[string]interface{}{
+				"HandshakeId": id,
+				"Status":      "Accepted",
+			}, nil
+		}
 		if IsExpectedErrors(err, []string{"EntityNotExists.Handshake"}) {
 			return object, WrapErrorf(NotFoundErr("Handshake", id), NotFoundMsg, response)
 		}
@@ -1114,6 +1121,93 @@ func (s *ResourceManagerServiceV2) ResourceManagerHandshakeStateRefreshFunc(id s
 }
 
 // DescribeResourceManagerHandshake >>> Encapsulated.
+// DescribeResourceManagerHandshakeAcceptance <<< Encapsulated get interface for ResourceManager HandshakeAcceptance.
+
+func (s *ResourceManagerServiceV2) DescribeResourceManagerHandshakeAcceptance(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["HandshakeId"] = id
+
+	action := "GetHandshake"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"HandshakeStatusMismatch"}) {
+			// The invited account can no longer read the consumed handshake after a successful acceptance.
+			return map[string]interface{}{
+				"HandshakeId": id,
+				"Status":      "Accepted",
+			}, nil
+		}
+		if IsExpectedErrors(err, []string{"EntityNotExists.Handshake"}) {
+			return object, WrapErrorf(NotFoundErr("HandshakeAcceptance", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Handshake", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Handshake", response)
+	}
+
+	currentStatus := v.(map[string]interface{})["Status"]
+	if fmt.Sprint(currentStatus) != "Accepted" {
+		return object, WrapErrorf(NotFoundErr("HandshakeAcceptance", id), NotFoundMsg, response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *ResourceManagerServiceV2) ResourceManagerHandshakeAcceptanceStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ResourceManagerHandshakeAcceptanceStateRefreshFuncWithApi(id, field, failStates, s.DescribeResourceManagerHandshakeAcceptance)
+}
+
+func (s *ResourceManagerServiceV2) ResourceManagerHandshakeAcceptanceStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeResourceManagerHandshakeAcceptance >>> Encapsulated.
 // DescribeResourceManagerControlPolicy <<< Encapsulated get interface for ResourceManager ControlPolicy.
 
 func (s *ResourceManagerServiceV2) DescribeResourceManagerControlPolicy(id string) (object map[string]interface{}, err error) {

--- a/website/docs/r/resource_manager_handshake.html.markdown
+++ b/website/docs/r/resource_manager_handshake.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a Resource Manager Handshake resource.
 
+-> **NOTE:** If the invitation has been accepted and `target_type` is `Account`, destroying this resource removes the invited cloud account from the resource directory.
+
 
 
 For information about Resource Manager Handshake and how to use it, see [What is Handshake](https://www.alibabacloud.com/help/en/doc-detail/135287.htm).

--- a/website/docs/r/resource_manager_handshake_acceptance.html.markdown
+++ b/website/docs/r/resource_manager_handshake_acceptance.html.markdown
@@ -1,0 +1,126 @@
+---
+subcategory: "Resource Manager"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_resource_manager_handshake_acceptance"
+description: |-
+  Provides a Alicloud Resource Manager Handshake Acceptance resource.
+---
+
+# alicloud_resource_manager_handshake_acceptance
+
+Provides a Resource Manager Handshake Acceptance resource. It is used by the **invited account** to accept an invitation (handshake) to join a resource directory.
+
+For information about Resource Manager Handshake Acceptance and how to use it, see [What is Handshake](https://www.alibabacloud.com/help/en/doc-detail/135287.htm) and the [AcceptHandshake](https://next.api.alibabacloud.com/document/ResourceDirectoryMaster/2022-04-19/AcceptHandshake) API.
+
+-> **NOTE:** This resource must be applied with the credentials of the **invited account**, not the management (master) account that sent the invitation. The invitation itself is created by the management account via `alicloud_resource_manager_handshake`. Use a separate [provider alias](https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations) configured with the invited account's credentials.
+
+-> **NOTE:** Destroying this resource only removes the acceptance record from Terraform state. If the invitation is also managed by `alicloud_resource_manager_handshake` with `target_type = "Account"`, destroying the management-side handshake resource removes the invited cloud account from the resource directory.
+
+-> **NOTE:** Available since v1.284.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+terraform {
+  required_providers {
+    alicloud = {
+      source = "aliyun/alicloud"
+    }
+  }
+}
+
+variable "region" {
+  default = "cn-hangzhou"
+}
+
+variable "management_access_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "management_secret_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "invited_access_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "invited_secret_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "invited_account_id" {
+  type = string
+}
+
+provider "alicloud" {
+  alias      = "management"
+  region     = var.region
+  access_key = var.management_access_key
+  secret_key = var.management_secret_key
+}
+
+provider "alicloud" {
+  alias      = "invited"
+  region     = var.region
+  access_key = var.invited_access_key
+  secret_key = var.invited_secret_key
+}
+
+# The management account sends the invitation.
+resource "alicloud_resource_manager_handshake" "example" {
+  provider = alicloud.management
+
+  target_entity = var.invited_account_id
+  target_type   = "Account"
+  note          = "test resource manager handshake"
+}
+
+# The invited account accepts it.
+resource "alicloud_resource_manager_handshake_acceptance" "example" {
+  provider     = alicloud.invited
+  handshake_id = alicloud_resource_manager_handshake.example.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `handshake_id` - (Required, ForceNew) The ID of the invitation.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource. The value is the same as `handshake_id`.
+* `create_time` - The time when the invitation was created. The time is displayed in UTC.
+* `expire_time` - The time when the invitation expires. The time is displayed in UTC.
+* `invited_account_real_name` - The real-name verification information of the invited account.
+* `master_account_id` - The ID of the management account of the resource directory.
+* `master_account_name` - The name of the management account of the resource directory.
+* `master_account_real_name` - The real-name verification information of the management account.
+* `modify_time` - The time when the invitation was modified. The time is displayed in UTC.
+* `note` - The note of the invitation.
+* `resource_directory_id` - The ID of the resource directory.
+* `status` - The status of the invitation. The acceptance resource exists only when the status is `Accepted`.
+* `target_entity` - The invited account. The value is an account ID when `target_type` is `Account`, or a logon email address when `target_type` is `Email`.
+* `target_type` - The type of the invited account. Valid values: `Account` and `Email`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when accept the Handshake.
+* `delete` - (Defaults to 5 mins) Used when delete the Handshake Acceptance.
+
+## Import
+
+Resource Manager Handshake Acceptance can be imported using the id (handshake id), e.g.
+
+```shell
+$ terraform import alicloud_resource_manager_handshake_acceptance.example <id>
+```


### PR DESCRIPTION
## Summary
- Add alicloud_resource_manager_handshake_acceptance for accepting Resource Manager invitations from the invited account.
- Align the resource schema and orchestration APIs with the Acube/Cloudspec HandshakeAcceptance definition.
- Keep the hand-written provider alias example, state-only delete behavior, and two-account acceptance test path.

## Context
- Source Aone: https://project.aone.alibaba-inc.com/v2/project/1086837/req/82910323
- This branch follows the Acube-generated HandshakeAcceptance spec while preserving provider-specific behavior needed for Terraform usage.

## Validation
- git diff --check
- go test ./alicloud -run TestAccAliCloudResourceManagerHandshakeAcceptance_schema -count=1
- go test ./alicloud -run ^$
- go test ./alicloud -run TestAccAliCloudResourceManagerHandshakeAcceptance_basic -count=0

## Notes
- Real TF_ACC execution still requires a second invited account credential set: ALICLOUD_ACCESS_KEY_2, ALICLOUD_SECRET_KEY_2, and ALICLOUD_ACCOUNT_ID_2.