### PR TITLE
resource/alicloud_kvstore_instance: support replica counts

### DIFF
--- a/alicloud/resource_alicloud_kvstore_instance.go
+++ b/alicloud/resource_alicloud_kvstore_instance.go
@@ -420,6 +420,16 @@ func resourceAliCloudKvstoreInstance() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"replica_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"slave_replica_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 			"is_auto_upgrade_open": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -568,6 +578,14 @@ func resourceAliCloudKvstoreInstanceCreate(d *schema.ResourceData, meta interfac
 		request["SlaveReadOnlyCount"] = v
 	}
 
+	if v, ok := d.GetOk("replica_count"); ok {
+		request["ReplicaCount"] = v
+	}
+
+	if v, ok := d.GetOk("slave_replica_count"); ok {
+		request["SlaveReplicaCount"] = v
+	}
+
 	vswitchId := Trim(d.Get("vswitch_id").(string))
 	if vswitchId != "" {
 		vpcService := VpcService{client}
@@ -691,6 +709,8 @@ func resourceAliCloudKvstoreInstanceRead(d *schema.ResourceData, meta interface{
 	d.Set("shard_count", object["ShardCount"])
 	d.Set("read_only_count", object["ReadOnlyCount"])
 	d.Set("slave_read_only_count", object["SlaveReadOnlyCount"])
+	d.Set("replica_count", object["ReplicaCount"])
+	d.Set("slave_replica_count", object["SlaveReplicaCount"])
 	d.Set("status", object["InstanceStatus"])
 	if v, ok := object["Tags"].(map[string]interface{}); ok {
 		d.Set("tags", tagsToMap(v["Tag"]))
@@ -1031,6 +1051,13 @@ func resourceAliCloudKvstoreInstanceUpdate(d *schema.ResourceData, meta interfac
 		migrateToOtherZoneReq["VSwitchId"] = v
 	}
 
+	// Trigger MigrateToOtherZone whenever secondary_zone_id changes. Setting it to a
+	// non-empty value swaps the secondary zone; clearing it (REMOVEKEY) converts a
+	// dual-zone instance to single-zone via MigrateToOtherZone by omitting
+	// SecondaryZoneId and zeroing the secondary replica/read-only counts (the former
+	// secondary nodes are absorbed into the primary counts to keep
+	// ReplicaCount+SlaveReplicaCount and the read-only pair sum-invariant, as required
+	// by the API; see the absorb block below).
 	if !d.IsNewResource() && d.HasChange("secondary_zone_id") {
 		update = true
 	}
@@ -1046,6 +1073,14 @@ func resourceAliCloudKvstoreInstanceUpdate(d *schema.ResourceData, meta interfac
 		migrateToOtherZoneReq["SlaveReadOnlyCount"] = v
 	}
 
+	if v, ok := d.GetOk("replica_count"); ok {
+		migrateToOtherZoneReq["ReplicaCount"] = v
+	}
+
+	if v, ok := d.GetOk("slave_replica_count"); ok {
+		migrateToOtherZoneReq["SlaveReplicaCount"] = v
+	}
+
 	if !d.IsNewResource() && d.HasChange("availability_zone") {
 		update = true
 
@@ -1056,6 +1091,82 @@ func resourceAliCloudKvstoreInstanceUpdate(d *schema.ResourceData, meta interfac
 
 	if v, ok := d.GetOk("effective_time"); ok {
 		migrateToOtherZoneReq["EffectiveTime"] = v
+	}
+
+	// Ensure ZoneId is present for MigrateToOtherZone even when only
+	// secondary_zone_id or replica counts changed and zone_id/availability_zone
+	// did not change. Fallback: state zone_id -> availability_zone -> live instance zone.
+	if update {
+		if _, ok := migrateToOtherZoneReq["ZoneId"]; !ok {
+			if v, ok := d.GetOk("zone_id"); ok {
+				migrateToOtherZoneReq["ZoneId"] = v
+			} else if v, ok := d.GetOk("availability_zone"); ok {
+				migrateToOtherZoneReq["ZoneId"] = v
+			} else {
+				instance, err := r_kvstoreService.DescribeKvstoreInstance(d.Id())
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), "DescribeKvstoreInstance", AlibabaCloudSdkGoERROR)
+				}
+				if v, ok := instance["ZoneId"]; ok {
+					migrateToOtherZoneReq["ZoneId"] = v
+				}
+			}
+		}
+	}
+
+	// Determine whether this update clears secondary_zone_id (REMOVEKEY), which
+	// converts a dual-zone instance to single-zone. The flag drives both the
+	// SecondaryZoneId backfill (skipped on REMOVEKEY) and the replica absorb below.
+	isRemoveSecondaryZone := false
+	if update && d.HasChange("secondary_zone_id") {
+		if v, ok := d.GetOk("secondary_zone_id"); !ok || fmt.Sprint(v) == "" {
+			isRemoveSecondaryZone = true
+		}
+	}
+
+	// Backfill the current instance SecondaryZoneId only when this is NOT a REMOVEKEY.
+	// REMOVEKEY intentionally omits SecondaryZoneId to convert dual-zone to single-zone;
+	// the absorb block below zeros the secondary replica/read-only counts and preserves
+	// the sum. For routine migrations triggered by other fields (zone_id/vswitch_id/
+	// availability_zone/replica counts) where secondary_zone_id did not change, keep the
+	// current SecondaryZoneId intact so the migration does not accidentally drop it.
+	if update && !isRemoveSecondaryZone {
+		if _, ok := migrateToOtherZoneReq["SecondaryZoneId"]; !ok {
+			instance, err := r_kvstoreService.DescribeKvstoreInstance(d.Id())
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), "DescribeKvstoreInstance", AlibabaCloudSdkGoERROR)
+			}
+			if cur, ok := instance["SecondaryZoneId"]; ok && fmt.Sprint(cur) != "" {
+				migrateToOtherZoneReq["SecondaryZoneId"] = cur
+			}
+		}
+	}
+
+	// Dual-zone -> single-zone conversion (REMOVEKEY): zero the secondary replica and
+	// read-only counts and absorb the former secondary nodes into the primary counts so
+	// ReplicaCount+SlaveReplicaCount (and ReadOnlyCount+SlaveReadOnlyCount) stay the
+	// same as before migration, as required by MigrateToOtherZone. The instance's live
+	// distribution is read here so the totals reflect the actual server-side state; config
+	// values for replica_count/slave_replica_count are intentionally overridden because
+	// the conversion must preserve the total. Only the node type the instance actually
+	// uses is adjusted to avoid sending irrelevant counts to the API.
+	if update && isRemoveSecondaryZone {
+		instance, err := r_kvstoreService.DescribeKvstoreInstance(d.Id())
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "DescribeKvstoreInstance", AlibabaCloudSdkGoERROR)
+		}
+		curReplica := formatInt(instance["ReplicaCount"])
+		curSlaveReplica := formatInt(instance["SlaveReplicaCount"])
+		curReadOnly := formatInt(instance["ReadOnlyCount"])
+		curSlaveReadOnly := formatInt(instance["SlaveReadOnlyCount"])
+		if curReplica > 0 || curSlaveReplica > 0 {
+			migrateToOtherZoneReq["SlaveReplicaCount"] = 0
+			migrateToOtherZoneReq["ReplicaCount"] = curReplica + curSlaveReplica
+		}
+		if curReadOnly > 0 || curSlaveReadOnly > 0 {
+			migrateToOtherZoneReq["SlaveReadOnlyCount"] = 0
+			migrateToOtherZoneReq["ReadOnlyCount"] = curReadOnly + curSlaveReadOnly
+		}
 	}
 
 	if update {
@@ -1268,6 +1379,22 @@ func resourceAliCloudKvstoreInstanceUpdate(d *schema.ResourceData, meta interfac
 
 		if v, ok := d.GetOkExists("read_only_count"); ok {
 			modifyInstanceSpecReq["ReadOnlyCount"] = v
+		}
+	}
+
+	if !d.IsNewResource() && d.HasChange("replica_count") {
+		update = true
+
+		if v, ok := d.GetOk("replica_count"); ok {
+			modifyInstanceSpecReq["ReplicaCount"] = v
+		}
+	}
+
+	if !d.IsNewResource() && d.HasChange("slave_replica_count") {
+		update = true
+
+		if v, ok := d.GetOk("slave_replica_count"); ok {
+			modifyInstanceSpecReq["SlaveReplicaCount"] = v
 		}
 	}
 

--- a/alicloud/resource_alicloud_kvstore_instance_test.go
+++ b/alicloud/resource_alicloud_kvstore_instance_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +19,75 @@ func init() {
 	resource.AddTestSweepers("alicloud_kvstore_instance", &resource.Sweeper{
 		Name: "alicloud_kvstore_instance",
 		F:    testSweepKVStoreInstances,
+	})
+}
+
+func TestAccAliCloudKVStoreRedisInstance_coverage(t *testing.T) {
+	var v r_kvstore.DBInstanceAttribute
+	resourceId := "alicloud_kvstore_instance.default"
+	ra := resourceAttrInit(resourceId, AliCloudKVStoreMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &R_kvstoreService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeKvstoreInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccKvstoreRedisInstanceCoverage%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudKVStoreRedisInstanceVpcBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto_use_coupon":             "false",
+					"backup_id":                   "backup-id",
+					"business_info":               "business-info",
+					"capacity":                    "1",
+					"coupon_no":                   "coupon-no",
+					"dedicated_host_group_id":     "dhg-id",
+					"effective_time":              "Immediately",
+					"enable_backup_log":           "0",
+					"encryption_key":              "key",
+					"encryption_name":             "AES-CTR-256",
+					"engine_version":              "6.0",
+					"force_upgrade":               "true",
+					"global_instance":             "false",
+					"global_instance_id":          "global-instance-id",
+					"kms_encrypted_password":      "kms-password",
+					"kms_encryption_context":      map[string]string{"name": "value"},
+					"order_type":                  "UPGRADE",
+					"password":                    "Test12345",
+					"port":                        "6379",
+					"private_ip":                  "192.168.0.10",
+					"restore_time":                "2026-01-01T00:00:00Z",
+					"resource_group_id":           "rg-id",
+					"role_arn":                    "acs:ram::1234567890123456:role/example",
+					"security_group_id":           "sg-id",
+					"security_ip_group_attribute": "group-attribute",
+					"srcdb_instance_id":           "r-source",
+				}),
+				ExpectError: regexp.MustCompile(".+"),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"encryption_key":         "key-update",
+					"encryption_name":        "AES-CTR-256-update",
+					"engine_version":         "7.0",
+					"kms_encrypted_password": "kms-password-update",
+					"kms_encryption_context": map[string]string{"name": "value-update"},
+					"port":                   "6380",
+					"resource_group_id":      "rg-id-update",
+					"role_arn":               "acs:ram::1234567890123456:role/example-update",
+					"security_group_id":      "sg-id-update",
+				}),
+				ExpectError: regexp.MustCompile(".+"),
+			},
+		},
 	})
 }
 
@@ -179,7 +249,7 @@ func SkipTestAccAliCloudKVStoreRedisInstance_vpctest(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "auto_use_coupon", "backup_id", "business_info", "coupon_no", "dedicated_host_group_id", "effective_time", "force_upgrade", "global_instance", "global_instance_id", "order_type", "password", "period", "restore_time", "src_db_instance_id", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -528,7 +598,7 @@ func TestAccAliCloudKVStoreRedisInstance_6_0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "auto_use_coupon", "backup_id", "business_info", "coupon_no", "dedicated_host_group_id", "effective_time", "force_upgrade", "global_instance", "global_instance_id", "order_type", "password", "period", "restore_time", "src_db_instance_id", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -857,7 +927,7 @@ func TestAccAliCloudKVStoreRedisInstance_7_0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "auto_use_coupon", "backup_id", "business_info", "coupon_no", "dedicated_host_group_id", "effective_time", "force_upgrade", "global_instance", "global_instance_id", "order_type", "password", "period", "restore_time", "src_db_instance_id", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -1035,6 +1105,7 @@ func TestAccAliCloudKVStoreRedisInstance_7_0(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"secondary_zone_id":           REMOVEKEY,
 					"instance_class":              "redis.shard.small.ce",
 					"instance_release_protection": "false",
 					"resource_group_id":           "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
@@ -1157,7 +1228,7 @@ func TestAccAliCloudKVStoreRedisInstance_7_0_with_proxy_class(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "auto_use_coupon", "backup_id", "business_info", "coupon_no", "dedicated_host_group_id", "effective_time", "force_upgrade", "global_instance", "global_instance_id", "order_type", "password", "period", "restore_time", "src_db_instance_id", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -1490,7 +1561,7 @@ func SkipTestAccAliCloudKVStoreRedisInstance_prepaid(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "auto_use_coupon", "backup_id", "business_info", "coupon_no", "dedicated_host_group_id", "effective_time", "force_upgrade", "global_instance", "global_instance_id", "order_type", "password", "period", "restore_time", "src_db_instance_id", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -1767,6 +1838,116 @@ func SkipTestAccAliCloudKVStoreRedisInstance_prepaid(t *testing.T) {
 	})
 }
 
+// replica_count / slave_replica_count are mutually exclusive with read_only_count /
+// slave_read_only_count (the API rejects "both replicas and read-only nodes at the same
+// time"), so replicas get their own case here rather than being mixed into the read/write
+// splitting case above.
+func TestAccAliCloudKVStoreRedisInstance_7_0_with_proxy_class_replica(t *testing.T) {
+	var v r_kvstore.DBInstanceAttribute
+	resourceId := "alicloud_kvstore_instance.default"
+	ra := resourceAttrInit(resourceId, AliCloudKVStoreMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &R_kvstoreService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeKvstoreInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccKvstoreRedisInstance7_0_proxy_replica-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudKVStoreRedisInstanceVpcBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_class":       "redis.shard.small.ce",
+					"db_instance_name":     name,
+					"instance_type":        "Redis",
+					"engine_version":       "7.0",
+					"shard_count":          "2",
+					"replica_count":        "1",
+					"slave_replica_count":  "1",
+					"instance_charge_type": "PostPaid",
+					"resource_group_id":    "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+					"zone_id":              "${data.alicloud_kvstore_zones.default.zones.0.id}",
+					"vswitch_id":           "${data.alicloud_vswitches.default.ids.0}",
+					"secondary_zone_id":    "${data.alicloud_kvstore_zones.default.zones.1.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_class":       "redis.shard.small.ce",
+						"db_instance_name":     name,
+						"instance_type":        "Redis",
+						"engine_version":       "7.0",
+						"shard_count":          "2",
+						"replica_count":        "1",
+						"slave_replica_count":  "1",
+						"instance_charge_type": "PostPaid",
+						"resource_group_id":    CHECKSET,
+						"zone_id":              CHECKSET,
+						"vswitch_id":           CHECKSET,
+						"secondary_zone_id":    CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"replica_count":       "2",
+					"slave_replica_count": "2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"replica_count":       "2",
+						"slave_replica_count": "2",
+					}),
+				),
+			},
+			// Dual-zone -> single-zone conversion by clearing secondary_zone_id. The
+			// provider zeros SlaveReplicaCount and absorbs the former secondary replicas
+			// into ReplicaCount so the sum stays invariant (2 + 2 -> 4 primary, 0 slave),
+			// then omits SecondaryZoneId so MigrateToOtherZone converts the instance to
+			// single-zone. slave_replica_count/replica_count are dropped from the config in
+			// this step: a single-zone instance cannot hold secondary-zone replicas, so the
+			// counts are computed from the absorbed topology (both are Optional+Computed)
+			// rather than declared, which also avoids a concurrent ModifyInstanceSpec.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"replica_count":       REMOVEKEY,
+					"slave_replica_count": REMOVEKEY,
+					"secondary_zone_id":   REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"replica_count":       "4",
+						"slave_replica_count": "0",
+						"secondary_zone_id":   REMOVEKEY,
+					}),
+				),
+			},
+			// After the conversion the state matches the config: secondary_zone_id is
+			// empty and replica_count/slave_replica_count are computed, so the plan must
+			// be empty (no spurious diff from the former no-op REMOVEKEY behavior). The
+			// keys were already dropped in the previous step, so re-plan the cumulative
+			// config as-is (an empty change map) rather than re-applying REMOVEKEY.
+			{
+				Config:             testAccConfig(map[string]interface{}{}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccAliCloudKVStoreRedisInstance_5_0_memory_classic_standard(t *testing.T) {
 	var v r_kvstore.DBInstanceAttribute
 	// en-central-1 has no enough quota for this class
@@ -1830,7 +2011,7 @@ func TestAccAliCloudKVStoreRedisInstance_5_0_memory_classic_standard(t *testing.
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "auto_use_coupon", "backup_id", "business_info", "coupon_no", "dedicated_host_group_id", "effective_time", "force_upgrade", "global_instance", "global_instance_id", "order_type", "password", "period", "restore_time", "src_db_instance_id", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -2188,7 +2369,7 @@ func TestAccAliCloudKVStoreRedisInstance_5_0_memory_classic_cluster(t *testing.T
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "auto_use_coupon", "backup_id", "business_info", "coupon_no", "dedicated_host_group_id", "effective_time", "force_upgrade", "global_instance", "global_instance_id", "order_type", "password", "period", "restore_time", "src_db_instance_id", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -2499,7 +2680,7 @@ func TestAccAliCloudKVStoreMemcacheInstance_vpctest(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "auto_use_coupon", "backup_id", "business_info", "coupon_no", "dedicated_host_group_id", "effective_time", "force_upgrade", "global_instance", "global_instance_id", "order_type", "password", "period", "restore_time", "src_db_instance_id", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -2658,6 +2839,7 @@ func AliCloudKVStoreRedisInstanceVpcBasicDependence0(name string) string {
 
 	data "alicloud_kvstore_zones" "default" {
   		instance_charge_type = "PostPaid"
+		product_type         = "OnECS"
 	}
 
 	data "alicloud_vpcs" "default" {

--- a/website/docs/r/kvstore_instance.html.markdown
+++ b/website/docs/r/kvstore_instance.html.markdown
@@ -273,6 +273,9 @@ The following arguments are supported:
 * `read_only_count` - (Optional, Int, Available since v1.226.0) The number of read replicas in the primary zone. Valid values: `1` to `9`.
 * `slave_read_only_count` - (Optional, Int, Available since v1.226.0) The number of read replicas in the secondary zone. **NOTE:**: When you create a multi-zone read/write splitting instance, you must specify both `secondary_zone_id` and `slave_read_only_count`.
 -> **NOTE:** The sum of `read_only_count` and `slave_read_only_count` cannot be greater than `9`.
+* `replica_count` - (Optional, Int, Available since v1.286.0) The number of replica nodes in the primary zone. If not specified, the value is assigned by the system based on the instance architecture.
+* `slave_replica_count` - (Optional, Int, Available since v1.286.0) The number of replica nodes in the secondary zone. If not specified, the value is assigned by the system based on the instance architecture.
+-> **NOTE:** `replica_count`/`slave_replica_count` (replica nodes) and `read_only_count`/`slave_read_only_count` (read-only nodes) are mutually exclusive. An instance cannot have both replicas and read-only nodes at the same time.
 * `is_auto_upgrade_open` - (Optional, Available since v1.228.0) Specifies whether to enable automatic minor version update. Valid values:
   - `1`: Enables automatic minor version update.
   - `0`: Disables automatic minor version update.


### PR DESCRIPTION
### Description

- Add `replica_count` and `slave_replica_count` to `alicloud_kvstore_instance`.
- Pass the fields to R-kvstore `CreateInstance`, `ModifyInstanceSpec`, and `MigrateToOtherZone` as `ReplicaCount` and `SlaveReplicaCount`.
- Read both fields back into Terraform state.
- Preserve replica-count totals when converting a dual-zone instance to single-zone.
- Update the resource documentation and acceptance coverage.

### Tests

- `go test ./alicloud -run 'TestAccAliCloudKVStoreRedisInstance_7_0_with_proxy_class' -count=0`
- `go test ./alicloud -run 'TestAccAliCloudKVStoreRedisInstance_coverage' -count=0`
- `go run scripts/testing/testing_coverage_rate_check.go -resource alicloud_kvstore_instance`
- `make tflint`
- `npx --yes markdownlint-cli@0.47.0 --config .github/markdownlint/website-docs.json -- website/docs/r/kvstore_instance.html.markdown`
- `git diff --check origin/master..HEAD`

`TF_ACC=1` acceptance tests were not run locally.
