### PR TITLE
provider: add support for ap-southeast-8 region validation

### DIFF
--- a/alicloud/connectivity/regions.go
+++ b/alicloud/connectivity/regions.go
@@ -29,6 +29,7 @@ const (
 	APSouthEast5 = Region("ap-southeast-5")
 	APSouthEast6 = Region("ap-southeast-6")
 	APSouthEast7 = Region("ap-southeast-7")
+	APSouthEast8 = Region("ap-southeast-8")
 
 	APSouth1 = Region("ap-south-1")
 
@@ -63,7 +64,7 @@ const (
 var ValidRegions = []Region{
 	Hangzhou, Qingdao, Beijing, Shenzhen, Hongkong, Shanghai, Zhangjiakou, Huhehaote, ChengDu, HeYuan, WuLanChaBu, GuangZhou, NanJing, FuZhou, ZhongWei,
 	USWest1, USEast1, USSouthEast1,
-	APNorthEast1, APNorthEast2, APSouthEast1, APSouthEast2, APSouthEast3, APSouthEast5, APSouthEast6, APSouthEast7,
+	APNorthEast1, APNorthEast2, APSouthEast1, APSouthEast2, APSouthEast3, APSouthEast5, APSouthEast6, APSouthEast7, APSouthEast8,
 	APSouth1,
 	MEEast1, MECentral1,
 	EUCentral1, EUWest1, RusWest1,

--- a/alicloud/connectivity/regions_test.go
+++ b/alicloud/connectivity/regions_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestUnitCommonRegionDefinitions(t *testing.T) {
 	t.Run("AllExportedRegionsInValidRegions", func(t *testing.T) {
 		definedRegions := []Region{
-			Hangzhou, Qingdao, Beijing, ZhongWei,
+			Hangzhou, Qingdao, Beijing, ZhongWei, APSouthEast8,
 		}
 
 		validMap := make(map[Region]bool)


### PR DESCRIPTION
### Problem
Users specifying region `ap-southeast-8` encounter:
```
Error: Invalid Alibaba Cloud region: ap-southeast-8. You can skip checking this region by setting provider parameter 'skip_region_validation'.
```

### Change
Add `ap-southeast-8` to the provider's region whitelist (`ValidRegions` in `alicloud/connectivity/regions.go`) and update the corresponding unit test.

### Test
```bash
go test ./alicloud/connectivity/ -run TestUnitCommonRegionDefinitions -v
```
Result: PASS