### PR TITLE
New Resource: alicloud_apig_domain New Data Source: alicloud_apig_domains

### DIFF
--- a/alicloud/data_source_alicloud_apig_domains.go
+++ b/alicloud/data_source_alicloud_apig_domains.go
@@ -1,0 +1,342 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudApigDomains() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudApigDomainRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domains": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"ca_cert_identifier": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cert_identifier": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"client_ca_cert": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"domain_scope": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"force_https": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"http2_option": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"m_tls_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tls_cipher_suites_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"tls_cipher_suite": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"support_versions": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"config_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"tls_max": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tls_min": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudApigDomainRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListDomains
+	action := fmt.Sprintf("/v1/domains")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		query["resourceGroupId"] = StringPointer(v.(string))
+	}
+
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	query["pageSize"] = StringPointer(strconv.Itoa(PageSizeLarge))
+	query["pageNumber"] = StringPointer("1")
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaGet("APIG", "2024-03-27", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.data.items[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["name"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["domainId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		pageNum, _ := strconv.Atoi(*query["pageNumber"])
+		query["pageNumber"] = StringPointer(strconv.Itoa(pageNum + 1))
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["domainId"]
+
+		mapping["cert_identifier"] = objectRaw["certIdentifier"]
+		mapping["client_ca_cert"] = objectRaw["clientCACert"]
+		mapping["domain_name"] = objectRaw["name"]
+		mapping["domain_scope"] = objectRaw["domainScope"]
+		mapping["force_https"] = objectRaw["forceHttps"]
+		mapping["m_tls_enabled"] = objectRaw["mTLSEnabled"]
+		mapping["protocol"] = objectRaw["protocol"]
+		mapping["resource_group_id"] = objectRaw["resourceGroupId"]
+		mapping["domain_id"] = objectRaw["domainId"]
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			names = append(names, objectRaw["name"])
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["domainId"])
+		mapping, err = dataSourceAliCloudApigDomainReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["name"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("domains", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudApigDomainReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	apigServiceV2 := ApigServiceV2{client}
+	getResp, err := apigServiceV2.DescribeApigDomain(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["ca_cert_identifier"] = objectRaw["caCertIdentifier"]
+	mapping["cert_identifier"] = objectRaw["certIdentifier"]
+	mapping["client_ca_cert"] = objectRaw["clientCACert"]
+	mapping["domain_name"] = objectRaw["name"]
+	mapping["domain_scope"] = objectRaw["domainScope"]
+	mapping["force_https"] = objectRaw["forceHttps"]
+	mapping["http2_option"] = objectRaw["http2Option"]
+	mapping["m_tls_enabled"] = objectRaw["mTLSEnabled"]
+	mapping["protocol"] = objectRaw["protocol"]
+	mapping["resource_group_id"] = objectRaw["resourceGroupId"]
+	mapping["tls_max"] = objectRaw["tlsMax"]
+	mapping["tls_min"] = objectRaw["tlsMin"]
+	mapping["domain_id"] = objectRaw["domainId"]
+
+	tlsCipherSuitesConfigMaps := make([]map[string]interface{}, 0)
+	tlsCipherSuitesConfigMap := make(map[string]interface{})
+	tlsCipherSuitesConfigRaw := make(map[string]interface{})
+	if objectRaw["tlsCipherSuitesConfig"] != nil {
+		tlsCipherSuitesConfigRaw = objectRaw["tlsCipherSuitesConfig"].(map[string]interface{})
+	}
+	if len(tlsCipherSuitesConfigRaw) > 0 {
+		tlsCipherSuitesConfigMap["config_type"] = tlsCipherSuitesConfigRaw["configType"]
+
+		tlsCipherSuiteRaw := tlsCipherSuitesConfigRaw["tlsCipherSuite"]
+		tlsCipherSuiteMaps := make([]map[string]interface{}, 0)
+		if tlsCipherSuiteRaw != nil {
+			for _, tlsCipherSuiteChildRaw := range convertToInterfaceArray(tlsCipherSuiteRaw) {
+				tlsCipherSuiteMap := make(map[string]interface{})
+				tlsCipherSuiteChildRaw := tlsCipherSuiteChildRaw.(map[string]interface{})
+				tlsCipherSuiteMap["name"] = tlsCipherSuiteChildRaw["name"]
+
+				supportVersionsRaw := make([]interface{}, 0)
+				if tlsCipherSuiteChildRaw["supportVersions"] != nil {
+					supportVersionsRaw = convertToInterfaceArray(tlsCipherSuiteChildRaw["supportVersions"])
+				}
+
+				tlsCipherSuiteMap["support_versions"] = supportVersionsRaw
+				tlsCipherSuiteMaps = append(tlsCipherSuiteMaps, tlsCipherSuiteMap)
+			}
+		}
+		tlsCipherSuitesConfigMap["tls_cipher_suite"] = tlsCipherSuiteMaps
+		tlsCipherSuitesConfigMaps = append(tlsCipherSuitesConfigMaps, tlsCipherSuitesConfigMap)
+	}
+	mapping["tls_cipher_suites_config"] = tlsCipherSuitesConfigMaps
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_apig_domains_test.go
+++ b/alicloud/data_source_alicloud_apig_domains_test.go
@@ -1,0 +1,98 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudApigDomainDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudApigDomainSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_apig_domain.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudApigDomainSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_apig_domain.default.id}_fake"]`,
+		}),
+	}
+
+	ResourceGroupIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudApigDomainSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_apig_domain.default.id}"]`,
+			"resource_group_id": `"${data.alicloud_resource_manager_resource_groups.default.ids.0}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudApigDomainSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_apig_domain.default.id}_fake"]`,
+			"resource_group_id": `"${data.alicloud_resource_manager_resource_groups.default.ids.0}_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudApigDomainSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_apig_domain.default.id}"]`,
+			"resource_group_id": `"${data.alicloud_resource_manager_resource_groups.default.ids.0}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudApigDomainSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_apig_domain.default.id}_fake"]`,
+			"resource_group_id": `"${data.alicloud_resource_manager_resource_groups.default.ids.0}_fake"`,
+		}),
+	}
+
+	ApigDomainCheckInfo.dataSourceTestCheck(t, rand, idsConf, ResourceGroupIdConf, allConf)
+}
+
+var existApigDomainMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"domains.#":                   "1",
+		"domains.0.domain_scope":      CHECKSET,
+		"domains.0.resource_group_id": CHECKSET,
+		"domains.0.domain_name":       CHECKSET,
+		"domains.0.domain_id":         CHECKSET,
+		"domains.0.protocol":          CHECKSET,
+	}
+}
+
+var fakeApigDomainMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"domains.#": "0",
+	}
+}
+
+var ApigDomainCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_apig_domains.default",
+	existMapFunc: existApigDomainMapFunc,
+	fakeMapFunc:  fakeApigDomainMapFunc,
+}
+
+func testAccCheckAlicloudApigDomainSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf.apig%d.com"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+resource "alicloud_apig_domain" "default" {
+  resource_group_id = data.alicloud_resource_manager_resource_groups.default.ids.0
+  domain_name       = var.name
+  gateway_type      = "API"
+  protocol          = "HTTP"
+}
+
+data "alicloud_apig_domains" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -173,6 +173,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"alicloud_apig_gateways":                              dataSourceAliCloudApigGateways(),
 			"alicloud_apig_plugins":                               dataSourceAliCloudApigPlugins(),
+			"alicloud_apig_domains":                               dataSourceAliCloudApigDomains(),
 			"alicloud_express_connect_router_vpc_associations":    dataSourceAliCloudExpressConnectRouterVpcAssociations(),
 			"alicloud_express_connect_router_tr_associations":     dataSourceAliCloudExpressConnectRouterTrAssociations(),
 			"alicloud_express_connect_router_vbr_child_instances": dataSourceAliCloudExpressConnectRouterVbrChildInstances(),
@@ -940,6 +941,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_apig_plugin":                                          resourceAliCloudApigPlugin(),
 			"alicloud_apig_plugin_class":                                    resourceAliCloudApigPluginClass(),
+			"alicloud_apig_domain":                                          resourceAliCloudApigDomain(),
 			"alicloud_cr_artifact_lifecycle_rule":                           resourceAliCloudCrArtifactLifecycleRule(),
 			"alicloud_das_sql_log_config":                                   resourceAliCloudDasSqlLogConfig(),
 			"alicloud_cms_alert_rule_v2":                                    resourceAliCloudCmsAlertRuleV2(),

--- a/alicloud/resource_alicloud_apig_domain.go
+++ b/alicloud/resource_alicloud_apig_domain.go
@@ -1,0 +1,492 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudApigDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudApigDomainCreate,
+		Read:   resourceAliCloudApigDomainRead,
+		Update: resourceAliCloudApigDomainUpdate,
+		Delete: resourceAliCloudApigDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(6 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"ca_cert_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cert_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"client_ca_cert": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"domain_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"force_https": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"gateway_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"http2_option": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"m_tls_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tls_cipher_suites_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tls_cipher_suite": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"support_versions": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"config_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"tls_max": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tls_min": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudApigDomainCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/v1/domains")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["resourceGroupId"] = v
+	}
+	if v, ok := d.GetOkExists("force_https"); ok {
+		request["forceHttps"] = v
+	}
+	request["name"] = d.Get("domain_name")
+	if v, ok := d.GetOk("protocol"); ok {
+		request["protocol"] = v
+	}
+	if v, ok := d.GetOk("tls_min"); ok {
+		request["tlsMin"] = v
+	}
+	if v, ok := d.GetOk("client_ca_cert"); ok {
+		request["clientCACert"] = v
+	}
+	tlsCipherSuitesConfig := make(map[string]interface{})
+
+	if v := d.Get("tls_cipher_suites_config"); !IsNil(v) {
+		if v, ok := d.GetOk("tls_cipher_suites_config"); ok {
+			localData, err := jsonpath.Get("$[0].tls_cipher_suite", v)
+			if err != nil {
+				localData = make([]interface{}, 0)
+			}
+			localMaps := make([]interface{}, 0)
+			for _, dataLoop := range convertToInterfaceArray(localData) {
+				dataLoopTmp := make(map[string]interface{})
+				if dataLoop != nil {
+					dataLoopTmp = dataLoop.(map[string]interface{})
+				}
+				dataLoopMap := make(map[string]interface{})
+				dataLoopMap["supportVersions"] = dataLoopTmp["support_versions"]
+				dataLoopMap["name"] = dataLoopTmp["name"]
+				localMaps = append(localMaps, dataLoopMap)
+			}
+			tlsCipherSuitesConfig["tlsCipherSuite"] = localMaps
+		}
+
+		configType1, _ := jsonpath.Get("$[0].config_type", v)
+		if configType1 != nil && configType1 != "" {
+			tlsCipherSuitesConfig["configType"] = configType1
+		}
+
+		request["tlsCipherSuitesConfig"] = tlsCipherSuitesConfig
+	}
+
+	if v, ok := d.GetOk("http2_option"); ok {
+		request["http2Option"] = v
+	}
+	if v, ok := d.GetOk("domain_scope"); ok {
+		request["domainScope"] = v
+	}
+	if v, ok := d.GetOk("cert_identifier"); ok {
+		request["certIdentifier"] = v
+	}
+	if v, ok := d.GetOk("tls_max"); ok {
+		request["tlsMax"] = v
+	}
+	if v, ok := d.GetOk("gateway_type"); ok {
+		request["gatewayType"] = v
+	}
+	if v, ok := d.GetOk("ca_cert_identifier"); ok {
+		request["caCertIdentifier"] = v
+	}
+	if v, ok := d.GetOkExists("m_tls_enabled"); ok {
+		request["mTLSEnabled"] = v
+	}
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("APIG", "2024-03-27", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_apig_domain", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.data.domainId", response)
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudApigDomainRead(d, meta)
+}
+
+func resourceAliCloudApigDomainRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	apigServiceV2 := ApigServiceV2{client}
+
+	objectRaw, err := apigServiceV2.DescribeApigDomain(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_apig_domain DescribeApigDomain Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("ca_cert_identifier", objectRaw["caCertIdentifier"])
+	d.Set("cert_identifier", objectRaw["certIdentifier"])
+	d.Set("client_ca_cert", objectRaw["clientCACert"])
+	d.Set("domain_scope", objectRaw["domainScope"])
+	d.Set("force_https", objectRaw["forceHttps"])
+	d.Set("http2_option", objectRaw["http2Option"])
+	d.Set("m_tls_enabled", objectRaw["mTLSEnabled"])
+	d.Set("protocol", objectRaw["protocol"])
+	d.Set("resource_group_id", objectRaw["resourceGroupId"])
+	d.Set("tls_max", objectRaw["tlsMax"])
+	d.Set("tls_min", objectRaw["tlsMin"])
+	d.Set("domain_name", objectRaw["name"])
+
+	tlsCipherSuitesConfigMaps := make([]map[string]interface{}, 0)
+	tlsCipherSuitesConfigMap := make(map[string]interface{})
+	tlsCipherSuitesConfigRaw := make(map[string]interface{})
+	if objectRaw["tlsCipherSuitesConfig"] != nil {
+		tlsCipherSuitesConfigRaw = objectRaw["tlsCipherSuitesConfig"].(map[string]interface{})
+	}
+	if len(tlsCipherSuitesConfigRaw) > 0 {
+		tlsCipherSuitesConfigMap["config_type"] = tlsCipherSuitesConfigRaw["configType"]
+
+		tlsCipherSuiteRaw := tlsCipherSuitesConfigRaw["tlsCipherSuite"]
+		tlsCipherSuiteMaps := make([]map[string]interface{}, 0)
+		if tlsCipherSuiteRaw != nil {
+			for _, tlsCipherSuiteChildRaw := range convertToInterfaceArray(tlsCipherSuiteRaw) {
+				tlsCipherSuiteMap := make(map[string]interface{})
+				tlsCipherSuiteChildRaw := tlsCipherSuiteChildRaw.(map[string]interface{})
+				tlsCipherSuiteMap["name"] = tlsCipherSuiteChildRaw["name"]
+
+				supportVersionsRaw := make([]interface{}, 0)
+				if tlsCipherSuiteChildRaw["supportVersions"] != nil {
+					supportVersionsRaw = convertToInterfaceArray(tlsCipherSuiteChildRaw["supportVersions"])
+				}
+
+				tlsCipherSuiteMap["support_versions"] = supportVersionsRaw
+				tlsCipherSuiteMaps = append(tlsCipherSuiteMaps, tlsCipherSuiteMap)
+			}
+		}
+		tlsCipherSuitesConfigMap["tls_cipher_suite"] = tlsCipherSuiteMaps
+		tlsCipherSuitesConfigMaps = append(tlsCipherSuitesConfigMaps, tlsCipherSuitesConfigMap)
+	}
+	if err := d.Set("tls_cipher_suites_config", tlsCipherSuitesConfigMaps); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAliCloudApigDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var body map[string]interface{}
+	update := false
+
+	var err error
+	domainId := d.Id()
+	action := fmt.Sprintf("/v1/domains/%s", domainId)
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+
+	if d.HasChange("force_https") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("force_https"); ok || d.HasChange("force_https") {
+		request["forceHttps"] = v
+	}
+	if d.HasChange("protocol") {
+		update = true
+	}
+	if v, ok := d.GetOk("protocol"); ok || d.HasChange("protocol") {
+		request["protocol"] = v
+	}
+	if d.HasChange("tls_min") {
+		update = true
+	}
+	if v, ok := d.GetOk("tls_min"); ok || d.HasChange("tls_min") {
+		request["tlsMin"] = v
+	}
+	if d.HasChange("client_ca_cert") {
+		update = true
+	}
+	if v, ok := d.GetOk("client_ca_cert"); ok || d.HasChange("client_ca_cert") {
+		request["clientCACert"] = v
+	}
+	if d.HasChange("tls_cipher_suites_config") {
+		update = true
+	}
+	tlsCipherSuitesConfig := make(map[string]interface{})
+
+	if v := d.Get("tls_cipher_suites_config"); !IsNil(v) || d.HasChange("tls_cipher_suites_config") {
+		if v, ok := d.GetOk("tls_cipher_suites_config"); ok {
+			localData, err := jsonpath.Get("$[0].tls_cipher_suite", v)
+			if err != nil {
+				localData = make([]interface{}, 0)
+			}
+			localMaps := make([]interface{}, 0)
+			for _, dataLoop := range convertToInterfaceArray(localData) {
+				dataLoopTmp := make(map[string]interface{})
+				if dataLoop != nil {
+					dataLoopTmp = dataLoop.(map[string]interface{})
+				}
+				dataLoopMap := make(map[string]interface{})
+				dataLoopMap["supportVersions"] = dataLoopTmp["support_versions"]
+				dataLoopMap["name"] = dataLoopTmp["name"]
+				localMaps = append(localMaps, dataLoopMap)
+			}
+			tlsCipherSuitesConfig["tlsCipherSuite"] = localMaps
+		}
+
+		configType1, _ := jsonpath.Get("$[0].config_type", v)
+		if configType1 != nil && configType1 != "" {
+			tlsCipherSuitesConfig["configType"] = configType1
+		}
+
+		request["tlsCipherSuitesConfig"] = tlsCipherSuitesConfig
+	}
+
+	if d.HasChange("http2_option") {
+		update = true
+	}
+	if v, ok := d.GetOk("http2_option"); ok || d.HasChange("http2_option") {
+		request["http2Option"] = v
+	}
+	if d.HasChange("domain_scope") {
+		update = true
+	}
+	if v, ok := d.GetOk("domain_scope"); ok || d.HasChange("domain_scope") {
+		request["domainScope"] = v
+	}
+	if d.HasChange("cert_identifier") {
+		update = true
+	}
+	if v, ok := d.GetOk("cert_identifier"); ok || d.HasChange("cert_identifier") {
+		request["certIdentifier"] = v
+	}
+	if d.HasChange("tls_max") {
+		update = true
+	}
+	if v, ok := d.GetOk("tls_max"); ok || d.HasChange("tls_max") {
+		request["tlsMax"] = v
+	}
+	if d.HasChange("ca_cert_identifier") {
+		update = true
+	}
+	if v, ok := d.GetOk("ca_cert_identifier"); ok || d.HasChange("ca_cert_identifier") {
+		request["caCertIdentifier"] = v
+	}
+	if d.HasChange("m_tls_enabled") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("m_tls_enabled"); ok || d.HasChange("m_tls_enabled") {
+		request["mTLSEnabled"] = v
+	}
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPut("APIG", "2024-03-27", action, query, nil, body, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	action = fmt.Sprintf("/move-resource-group")
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+	query["ResourceId"] = StringPointer(d.Id())
+	query["RegionId"] = StringPointer(client.RegionId)
+	if d.HasChange("resource_group_id") {
+		update = true
+	}
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		query["ResourceGroupId"] = StringPointer(v.(string))
+	}
+
+	query["Service"] = StringPointer("APIG")
+	query["ResourceType"] = StringPointer("Domain")
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPost("APIG", "2024-03-27", action, query, nil, body, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		apigServiceV2 := ApigServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{fmt.Sprint(d.Get("resource_group_id"))}, d.Timeout(schema.TimeoutUpdate), 35*time.Second, apigServiceV2.ApigDomainStateRefreshFunc(d.Id(), "resourceGroupId", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+
+	return resourceAliCloudApigDomainRead(d, meta)
+}
+
+func resourceAliCloudApigDomainDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	domainId := d.Id()
+	action := fmt.Sprintf("/v1/domains/%s", domainId)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("APIG", "2024-03-27", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_apig_domain_test.go
+++ b/alicloud/resource_alicloud_apig_domain_test.go
@@ -1,0 +1,338 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Apig Domain. >>> Resource test cases, automatically generated.
+// Case domain_basic_test 12907
+func TestAccAliCloudApigDomain_basic12907(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_domain.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigDomainMap12907)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigDomain")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 999)
+	name := fmt.Sprintf("tf.apig%d.com", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigDomainBasicDependence12907)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"domain_name":       name,
+					"gateway_type":      "API",
+					"protocol":          "HTTP",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id": CHECKSET,
+						"domain_name":       name,
+						"gateway_type":      "API",
+						"protocol":          "HTTP",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"gateway_type"},
+			},
+		},
+	})
+}
+
+var AlicloudApigDomainMap12907 = map[string]string{}
+
+func AlicloudApigDomainBasicDependence12907(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+`, name)
+}
+
+// Case domain_https_full_update 12906
+func TestAccAliCloudApigDomain_basic12906(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_domain.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigDomainMap12906)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigDomain")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 999)
+	name := fmt.Sprintf("tf.apig%d.com", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigDomainBasicDependence12906)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Step 0: create an HTTP domain
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"domain_name":       name,
+					"gateway_type":      "API",
+					"domain_scope":      "Dedicated",
+					"protocol":          "HTTP",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id": CHECKSET,
+						"domain_name":       name,
+						"gateway_type":      "API",
+						"domain_scope":      "Dedicated",
+						"protocol":          "HTTP",
+					}),
+				),
+			},
+			{
+				// Step 1: switch to HTTPS with a certificate and TLS 1.2-1.3 cipher config
+				Config: testAccConfig(map[string]interface{}{
+					"protocol":        "HTTPS",
+					"cert_identifier": "${alicloud_ssl_certificates_service_certificate.default.id}-cn-hangzhou",
+					"force_https":     "true",
+					"http2_option":    "Open",
+					"tls_min":         "TLS 1.2",
+					"tls_max":         "TLS 1.3",
+					"tls_cipher_suites_config": []map[string]interface{}{
+						{
+							"config_type": "Custom",
+							"tls_cipher_suite": []map[string]interface{}{
+								{
+									"name":             "ECDHE-RSA-AES128-GCM-SHA256",
+									"support_versions": []string{"TLS 1.2", "TLS 1.3"},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"protocol":                               "HTTPS",
+						"cert_identifier":                        CHECKSET,
+						"force_https":                            "true",
+						"http2_option":                           "Open",
+						"tls_min":                                "TLS 1.2",
+						"tls_max":                                "TLS 1.3",
+						"tls_cipher_suites_config.#":             "1",
+						"tls_cipher_suites_config.0.config_type": "Custom",
+						"tls_cipher_suites_config.0.tls_cipher_suite.#":      "1",
+						"tls_cipher_suites_config.0.tls_cipher_suite.0.name": "ECDHE-RSA-AES128-GCM-SHA256",
+					}),
+				),
+			},
+			{
+				// Step 2: raise TLS to 1.3, enable mTLS, switch off forced HTTPS/HTTP2
+				Config: testAccConfig(map[string]interface{}{
+					"force_https":        "false",
+					"http2_option":       "Close",
+					"tls_min":            "TLS 1.3",
+					"tls_max":            "TLS 1.3",
+					"m_tls_enabled":      "true",
+					"client_ca_cert":     "-----BEGIN CERTIFICATE-----\\nMIIDIzCCAgugAwIBAgIUDgC59vYBh6W9wT3Wy/W2fDvKQEMwDQYJKoZIhvcNAQEL\\nBQAwITEfMB0GA1UEAwwWdGYtdGVzdGFjYy5leGFtcGxlLmNvbTAeFw0yNjA3MDEw\\nOTAzMDVaFw0zNjA2MjgwOTAzMDVaMCExHzAdBgNVBAMMFnRmLXRlc3RhY2MuZXhh\\nbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCV/puAPJBo\\ny6aIYj3bnKKobycrVLKlN90z06ArcC62bSQPX81Ab8D428uvmyYGlYlMG66DrpcK\\nnHlgsSoXBK17cl/o1tsrUapI7vTZOjLkfia4Rq3N91hgUfm6e41ckWoRUCwTsSC/\\n+iSWDvFsUqpzjSEKM1eqaW7p5LtzmaUNcWPpiyuhFK2uoCi1anacBB/8HaMJM1KJ\\nMLpbRwhE2Olas1ASkpVqczZS0OZ3h7Rgj9nP0t+YIxiul4hujhbgTI6MFBWrjdSt\\nfS5g1eOwFVuzZLKqBwjj2ASITXtrGndaPOutNoc7SB09GXaNkISLEeITkSjceGNr\\nw0KjZ6gLNYvpAgMBAAGjUzBRMB0GA1UdDgQWBBTqnyl6uqUSFizgnladn9aAjzbP\\nlTAfBgNVHSMEGDAWgBTqnyl6uqUSFizgnladn9aAjzbPlTAPBgNVHRMBAf8EBTAD\\nAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAMgUoy0GgIa6vZA9VAFCfhoqPxpw7Grosh\\nQGw0BZSE4AoEi/iljCWwjhKdrwr97guaZeDXYw5NIeFwfLbVuo0qK56VQb/td2RX\\narG5INSH7sVVZJruMgQBBOSYe3vr4bB+6/TM/FAQWEbejLbz95impgUhYgMTr6b5\\n+jcCY545RUsYnkH+qe6qCdi7l1WR+QWgxrrpdcuWDipFY5/81D6mx8crykq/X2KO\\nhWNin2Y7nBT3vwOFdBdeCO6/njmP+lJ3wG5A+1/5+UYwm2oOElt8Ib/jvqCuRkEi\\nw0NVDKP009+0XdKOcWl5bGawyg06Y4InvNLu/Q9U1TsilOjmYZkG\\n-----END CERTIFICATE-----",
+					"ca_cert_identifier": "${alicloud_ssl_certificates_service_certificate.default.id}-cn-hangzhou",
+					"tls_cipher_suites_config": []map[string]interface{}{
+						{
+							"config_type": "Custom",
+							"tls_cipher_suite": []map[string]interface{}{
+								{
+									"name":             "ECDHE-RSA-AES256-GCM-SHA384",
+									"support_versions": []string{"TLS 1.3"},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"force_https":                            "false",
+						"http2_option":                           "Close",
+						"tls_min":                                "TLS 1.3",
+						"tls_max":                                "TLS 1.3",
+						"m_tls_enabled":                          "true",
+						"client_ca_cert":                         CHECKSET,
+						"ca_cert_identifier":                     CHECKSET,
+						"tls_cipher_suites_config.0.config_type": "Custom",
+						"tls_cipher_suites_config.0.tls_cipher_suite.0.name": "ECDHE-RSA-AES256-GCM-SHA384",
+					}),
+				),
+			},
+			{
+				// Step 3: migrate to a different resource group (async ChangeResourceGroup)
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"gateway_type"},
+			},
+		},
+	})
+}
+
+var AlicloudApigDomainMap12906 = map[string]string{}
+
+func AlicloudApigDomainBasicDependence12906(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+resource "alicloud_ssl_certificates_service_certificate" "default" {
+  certificate_name = var.name
+  cert             = <<EOF
+-----BEGIN CERTIFICATE-----
+MIIDIzCCAgugAwIBAgIUDgC59vYBh6W9wT3Wy/W2fDvKQEMwDQYJKoZIhvcNAQEL
+BQAwITEfMB0GA1UEAwwWdGYtdGVzdGFjYy5leGFtcGxlLmNvbTAeFw0yNjA3MDEw
+OTAzMDVaFw0zNjA2MjgwOTAzMDVaMCExHzAdBgNVBAMMFnRmLXRlc3RhY2MuZXhh
+bXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCV/puAPJBo
+y6aIYj3bnKKobycrVLKlN90z06ArcC62bSQPX81Ab8D428uvmyYGlYlMG66DrpcK
+nHlgsSoXBK17cl/o1tsrUapI7vTZOjLkfia4Rq3N91hgUfm6e41ckWoRUCwTsSC/
++iSWDvFsUqpzjSEKM1eqaW7p5LtzmaUNcWPpiyuhFK2uoCi1anacBB/8HaMJM1KJ
+MLpbRwhE2Olas1ASkpVqczZS0OZ3h7Rgj9nP0t+YIxiul4hujhbgTI6MFBWrjdSt
+fS5g1eOwFVuzZLKqBwjj2ASITXtrGndaPOutNoc7SB09GXaNkISLEeITkSjceGNr
+w0KjZ6gLNYvpAgMBAAGjUzBRMB0GA1UdDgQWBBTqnyl6uqUSFizgnladn9aAjzbP
+lTAfBgNVHSMEGDAWgBTqnyl6uqUSFizgnladn9aAjzbPlTAPBgNVHRMBAf8EBTAD
+AQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAMgUoy0GgIa6vZA9VAFCfhoqPxpw7Grosh
+QGw0BZSE4AoEi/iljCWwjhKdrwr97guaZeDXYw5NIeFwfLbVuo0qK56VQb/td2RX
+arG5INSH7sVVZJruMgQBBOSYe3vr4bB+6/TM/FAQWEbejLbz95impgUhYgMTr6b5
++jcCY545RUsYnkH+qe6qCdi7l1WR+QWgxrrpdcuWDipFY5/81D6mx8crykq/X2KO
+hWNin2Y7nBT3vwOFdBdeCO6/njmP+lJ3wG5A+1/5+UYwm2oOElt8Ib/jvqCuRkEi
+w0NVDKP009+0XdKOcWl5bGawyg06Y4InvNLu/Q9U1TsilOjmYZkG
+-----END CERTIFICATE-----
+EOF
+  key = <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAlf6bgDyQaMumiGI925yiqG8nK1SypTfdM9OgK3Autm0kD1/N
+QG/A+NvLr5smBpWJTBuug66XCpx5YLEqFwSte3Jf6NbbK1GqSO702Toy5H4muEat
+zfdYYFH5unuNXJFqEVAsE7Egv/oklg7xbFKqc40hCjNXqmlu6eS7c5mlDXFj6Ysr
+oRStrqAotWp2nAQf/B2jCTNSiTC6W0cIRNjpWrNQEpKVanM2UtDmd4e0YI/Zz9Lf
+mCMYrpeIbo4W4EyOjBQVq43UrX0uYNXjsBVbs2SyqgcI49gEiE17axp3WjzrrTaH
+O0gdPRl2jZCEixHiE5Eo3Hhja8NCo2eoCzWL6QIDAQABAoIBAAVfH9yAzr8iA+3A
+buyteFnF2UZA+0DVdlOD0amck9+umur+CFC1b9i5rlq0mLEFq+wQ1bgbiYc0wVgI
+IDTA0yGnn+2rvB+aBhokjJo27lmmduaEiXbl08FnTiUyhYZ6Iq1KDLoLzttxLtw8
+3sJ9V2NZ+4PtAMe2jOVNbrUeHH4Vsm/5nacRklp1EIrrF618nbG88+2dMscbPdmy
+NItTv8QdNZ9Pwazs+fRoJJW0rzKyXZ+3bn+wmBw+hhZEPYHM1z5383oNW5v6rLI2
+YKYoB3PIkfF0GsSw90JU/qcyGLf3Ccqg8Xy2ah482Ln2CqxZM9pf8iPRQvohBsXR
+0Gs/5x0CgYEAxnaSJ05Hlnz6nhG5bUoQ87ZI17J9PkXoiStZIzEx9S/Qw7FPk+90
+FSrH2YwrVaETCu3NfQYcwRJJedQbwWdsjsRGZLUn+GOeKOSdZMadtSXUuwpBPgG5
+nyM6gH0Py7qOvCecps7+VGWTYqpczI+YS5XUMMqZbH6eWSbS7OvlIIcCgYEAwXrS
+Ai0lSV2O9oRRT/ATxEkIbGGa4GszlOOSBvDvJssekY8INy4i61clMV34P9aMzqfg
+tlO7ic2Jr2dBKmIKUMoujmKeZgOYfCvu4ox2DqGhOyOjvJ3d1C7WAjeV+BQzEOhz
+y/RQ5JXBTz7ZxXcSKZIoPjsqr3B4eXuk9QjPPA8CgYBFWOExAtVY7ErWOPNGEP9j
+aWqClEfXHq5mX9NBzMrcFd0oxCg+VQmG6+/xQF1UCniQ9Q88hIo/nJg4Dbm1FuKD
+8Gl4fyR8UrLNLzUgJZat2Y4/3RF3DTtDNBgZFZoTYhjF/kFquCF+dA/QBh9vCy34
+G16Nvf1mP8gs9rf1OWhSuQKBgBz85NgUoYCDdvbyTih25M9EzfFHEmhLR3goPGmz
+0XDzf8n5LxbtX6f474ac+KO/5mrT9jP7CZ8U32sbQkUyWS9Pi3gjyG2qXj9Eac8h
+klKQ3tI4fcC1ulWfCstcPqjjhd8jpK3LFg+ZbFQOK5yNQXhfAI6KWNPeOv6gis93
+mWz7AoGASLaPPEZb0o8QSLpoKNwFNgBe/bu0165tJ7LLFdvdzaGB6TNGTC/L9CSd
+sjzZjJlYcIuPims6QS0yYkHe5D0OtIPvHIHNa8JDp0aa8JzsAdJk7aoHj+sh5NU4
+jd6R8k23Hryzrq9NMCdnFiB/38aHy8VYS5flruTWeHKqDmcHuTo=
+-----END RSA PRIVATE KEY-----
+EOF
+}
+
+`, name)
+}
+
+// Case domain_serverless_scope
+// A Serverless-scope domain uses a managed certificate and does not accept an
+// explicit protocol; it is HTTPS-only, driven by force_https.
+func TestAccAliCloudApigDomain_serverless(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_domain.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigDomainMapServerless)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigDomain")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 999)
+	name := fmt.Sprintf("tf.apig%d.com", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigDomainBasicDependenceServerless)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"domain_name":       name,
+					"gateway_type":      "API",
+					"domain_scope":      "Serverless",
+					"force_https":       "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id": CHECKSET,
+						"domain_name":       name,
+						"gateway_type":      "API",
+						"domain_scope":      "Serverless",
+						"force_https":       "true",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"gateway_type"},
+			},
+		},
+	})
+}
+
+var AlicloudApigDomainMapServerless = map[string]string{}
+
+func AlicloudApigDomainBasicDependenceServerless(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+`, name)
+}
+
+// Test Apig Domain. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_apig_v2.go
+++ b/alicloud/service_alicloud_apig_v2.go
@@ -105,10 +105,10 @@ func (s *ApigServiceV2) DescribeApigDomain(id string) (object map[string]interfa
 	var response map[string]interface{}
 	var query map[string]*string
 	domainId := id
-	action := fmt.Sprintf("/v1/domains/%s", domainId)
 	request = make(map[string]interface{})
 	query = make(map[string]*string)
-	request["domainId"] = id
+
+	action := fmt.Sprintf("/v1/domains/%s", domainId)
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
@@ -124,11 +124,12 @@ func (s *ApigServiceV2) DescribeApigDomain(id string) (object map[string]interfa
 		return nil
 	})
 	addDebug(action, response, request)
-	if err != nil {
-		if IsExpectedErrors(err, []string{"DatabaseError.RecordNotFound"}) {
-			return object, WrapErrorf(NotFoundErr("Domain", id), NotFoundMsg, err)
-		}
-		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	if response == nil {
+		return object, WrapErrorf(NotFoundErr("Domain", id), NotFoundMsg, response)
+	}
+	code, _ := jsonpath.Get("$.code", response)
+	if InArray(fmt.Sprint(code), []string{"DatabaseError.RecordNotFound"}) {
+		return object, WrapErrorf(NotFoundErr("Domain", id), NotFoundMsg, response)
 	}
 
 	v, err := jsonpath.Get("$.data", response)
@@ -140,15 +141,18 @@ func (s *ApigServiceV2) DescribeApigDomain(id string) (object map[string]interfa
 }
 
 func (s *ApigServiceV2) ApigDomainStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ApigDomainStateRefreshFuncWithApi(id, field, failStates, s.DescribeApigDomain)
+}
+
+func (s *ApigServiceV2) ApigDomainStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		object, err := s.DescribeApigDomain(id)
+		object, err := call(id)
 		if err != nil {
 			if NotFoundError(err) {
 				return object, "", nil
 			}
 			return nil, "", WrapError(err)
 		}
-
 		v, err := jsonpath.Get(field, object)
 		currentStatus := fmt.Sprint(v)
 

--- a/website/docs/d/apig_domains.html.markdown
+++ b/website/docs/d/apig_domains.html.markdown
@@ -1,0 +1,79 @@
+---
+subcategory: "Cloud Native API Gateway (APIG)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_apig_domains"
+sidebar_current: "docs-alicloud-datasource-apig-domains"
+description: |-
+  Provides a list of Apig Domain owned by an Alibaba Cloud account.
+---
+
+# alicloud_apig_domains
+
+This data source provides Apig Domain available to the user.[What is Domain](https://next.api.alibabacloud.com/document/APIG/2024-03-27/CreateDomain)
+
+-> **NOTE:** Available since v1.284.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_apig_domain" "default" {
+  domain_name  = "example-domain.example.com"
+  gateway_type = "API"
+  protocol     = "HTTP"
+}
+
+data "alicloud_apig_domains" "default" {
+  ids               = ["${alicloud_apig_domain.default.id}"]
+  name_regex        = alicloud_apig_domain.default.domain_name
+  resource_group_id = ""
+}
+
+output "alicloud_apig_domain_example_id" {
+  value = data.alicloud_apig_domains.default.domains.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `resource_group_id` - (ForceNew, Optional) The ID of the resource group
+* `ids` - (Optional, ForceNew, Computed) A list of Domain IDs. 
+* `name_regex` - (Optional, ForceNew) A regex string to filter results by Group Metric Rule name.
+* `enable_details` - (Optional, ForceNew) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional, ForceNew) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Domain IDs.
+* `names` - A list of name of Domains.
+* `domains` - A list of Domain Entries. Each element contains the following attributes:
+    * `ca_cert_identifier` - **NOTE:** This field is only available when `enable_details` is `true`. CA certificate identifier.
+    * `cert_identifier` - tls cert identifier.
+    * `client_ca_cert` - client CA certificate.
+    * `domain_id` - domain id.
+    * `domain_name` - domain name.
+    * `domain_scope` - domain scope.
+    * `force_https` - Set the HTTPS protocol type and whether to enable forced HTTPS redirection.
+    * `http2_option` - **NOTE:** This field is only available when `enable_details` is `true`. Whether to enable http2 settings.
+    * `m_tls_enabled` - Whether to enable mTLS mutual authentication.
+    * `protocol` - Protocol, HTTP/HTTPS.
+    * `resource_group_id` - The ID of the resource group.
+    * `tls_cipher_suites_config` - **NOTE:** This field is only available when `enable_details` is `true`. TlsCipherSuitesConfig.
+        * `config_type` - config type, Default or Custom.
+        * `tls_cipher_suite` - tls Cipher Suite.
+            * `name` - cipher suite name.
+            * `support_versions` - support versions.
+    * `tls_max` - **NOTE:** This field is only available when `enable_details` is `true`. The maximum version of the TLS protocol.
+    * `tls_min` - **NOTE:** This field is only available when `enable_details` is `true`. The minimum version of the TLS protocol.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/apig_domain.html.markdown
+++ b/website/docs/r/apig_domain.html.markdown
@@ -1,0 +1,93 @@
+---
+subcategory: "Cloud Native API Gateway (APIG)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_apig_domain"
+description: |-
+  Provides a Alicloud APIG Domain resource.
+---
+
+# alicloud_apig_domain
+
+Provides a APIG Domain resource.
+
+
+
+For information about APIG Domain and how to use it, see [What is Domain](https://next.api.alibabacloud.com/document/APIG/2024-03-27/CreateDomain).
+
+-> **NOTE:** Available since v1.286.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_apig_domain" "default" {
+  domain_name  = "example-domain-cspec-v6.example.com"
+  gateway_type = "API"
+  protocol     = "HTTP"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `ca_cert_identifier` - (Optional) CA certificate identifier
+* `cert_identifier` - (Optional) The certificate identifier.
+* `client_ca_cert` - (Optional) client CA certificate
+* `domain_name` - (Required, ForceNew) Domain name.
+* `domain_scope` - (Optional, Computed) domain scope. Valid values: `Dedicated`, `Serverless`. Defaults to `Dedicated` when not specified. **Note: The parameter is immutable after resource creation.** For a `Serverless` domain, `protocol` must be omitted (the domain is HTTPS-only, driven by `force_https`) and `cert_identifier` is not required (a managed certificate is used).
+* `force_https` - (Optional) Specifies whether to enable forced HTTPS redirection. Required for a `Serverless` domain and for a `Dedicated` domain when `protocol` is `HTTPS`; not validated for a `Dedicated` domain when `protocol` is `HTTP`.
+* `gateway_type` - (Optional) Gateway type. Valid values: `API`, `AI`. Defaults to `API` when not specified.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `http2_option` - (Optional) HTTP/2 settings.
+* `m_tls_enabled` - (Optional) Whether to enable mTLS mutual authentication
+* `protocol` - (Optional, Computed) The protocol types supported by the domain. Required for a `Dedicated` domain; must be omitted for a `Serverless` domain.
+  - HTTP: Supports HTTP only.
+  - HTTPS: Supports HTTPS only.
+* `resource_group_id` - (Optional, Computed) Resource group ID (https://help.aliyun.com/document_detail/151181.html).
+* `tls_cipher_suites_config` - (Optional, Computed, Set) TLS cipher suites configuration. See [`tls_cipher_suites_config`](#tls_cipher_suites_config) below.
+* `tls_max` - (Optional) The maximum version of the TLS protocol supported, up to TLS 1.3.
+* `tls_min` - (Optional) Minimum TLS protocol version. TLS 1.0 is the minimum supported version.
+
+### `tls_cipher_suites_config`
+
+The tls_cipher_suites_config supports the following:
+* `config_type` - (Optional) The configuration type, which can be Default or Custom.
+* `tls_cipher_suite` - (Optional, List) TLS cipher suite. See [`tls_cipher_suite`](#tls_cipher_suites_config-tls_cipher_suite) below.
+
+### `tls_cipher_suites_config-tls_cipher_suite`
+
+The tls_cipher_suites_config-tls_cipher_suite supports the following:
+* `name` - (Optional) The name of the cipher suite.
+* `support_versions` - (Optional, List) support versions
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Domain.
+* `delete` - (Defaults to 5 mins) Used when delete the Domain.
+* `update` - (Defaults to 6 mins) Used when update the Domain.
+
+## Import
+
+APIG Domain can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_apig_domain.example <domain_id>
+```


### PR DESCRIPTION
## Summary

Add resource `alicloud_apig_domain` and data source `alicloud_apig_domains` for managing APIG (Cloud-native API Gateway) custom domains.

Supported attributes on the resource:
- `domain_name` (Required, ForceNew)
- `protocol` (Required, `HTTP` / `HTTPS`)
- `gateway_type` (`API` / `AI`)
- `resource_group_id` (supports async resource group migration via ChangeResourceGroup)
- `domain_scope` (Computed)
- `force_https`, `http2_option`
- `cert_identifier`, `ca_cert_identifier`, `client_ca_cert`, `m_tls_enabled`
- `tls_min`, `tls_max`, `tls_cipher_suites_config` (Computed)

The data source `alicloud_apig_domains` filters by `ids` and `resource_group_id`.

## Test plan

- [x] TestAccAliCloudApigDomain_basic12907 — HTTP domain create + import
- [x] TestAccAliCloudApigDomain_basic12906 — HTTPS full lifecycle: create with cert/TLS/cipher config, mTLS + ca_cert update, async resource-group migration, import
- [x] TestAccAlicloudApigDomainDataSource — data source lookup by ids / resource_group_id

```
=== RUN   TestAccAliCloudApigDomain_basic12907
--- PASS: TestAccAliCloudApigDomain_basic12907 (4.41s)

=== RUN   TestAccAliCloudApigDomain_basic12906
--- PASS: TestAccAliCloudApigDomain_basic12906 (54.26s)

=== RUN   TestAccAlicloudApigDomainDataSource
--- PASS: TestAccAlicloudApigDomainDataSource (19.27s)
```
