### PR TITLE
resource/alicloud_schedulerx_job: fix panic on empty contact_info block in job_monitor_info

### DIFF
--- a/alicloud/resource_alicloud_schedulerx_job.go
+++ b/alicloud/resource_alicloud_schedulerx_job.go
@@ -298,7 +298,10 @@ func resourceAliCloudSchedulerxJobCreate(d *schema.ResourceData, meta interface{
 		}
 		contactInfoMapsArray := make([]interface{}, 0)
 		for _, dataLoop := range localData.([]interface{}) {
-			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopTmp, ok := dataLoop.(map[string]interface{})
+			if !ok {
+				continue
+			}
 			dataLoopMap := make(map[string]interface{})
 			dataLoopMap["Ding"] = dataLoopTmp["ding"]
 			dataLoopMap["UserName"] = dataLoopTmp["user_name"]
@@ -511,7 +514,10 @@ func resourceAliCloudSchedulerxJobRead(d *schema.ResourceData, meta interface{})
 		if contactInfo1Raw != nil {
 			for _, contactInfoChild1Raw := range contactInfo1Raw.([]interface{}) {
 				contactInfoMap := make(map[string]interface{})
-				contactInfoChild1Raw := contactInfoChild1Raw.(map[string]interface{})
+				contactInfoChild1Raw, ok := contactInfoChild1Raw.(map[string]interface{})
+				if !ok {
+					continue
+				}
 				contactInfoMap["ding"] = contactInfoChild1Raw["Ding"]
 				contactInfoMap["user_mail"] = contactInfoChild1Raw["UserMail"]
 				contactInfoMap["user_name"] = contactInfoChild1Raw["UserName"]
@@ -731,7 +737,10 @@ func resourceAliCloudSchedulerxJobUpdate(d *schema.ResourceData, meta interface{
 			}
 			contactInfoMapsArray := make([]interface{}, 0)
 			for _, dataLoop := range localData.([]interface{}) {
-				dataLoopTmp := dataLoop.(map[string]interface{})
+				dataLoopTmp, ok := dataLoop.(map[string]interface{})
+				if !ok {
+					continue
+				}
 				dataLoopMap := make(map[string]interface{})
 				dataLoopMap["Ding"] = dataLoopTmp["ding"]
 				dataLoopMap["UserName"] = dataLoopTmp["user_name"]

--- a/alicloud/resource_alicloud_schedulerx_job_test.go
+++ b/alicloud/resource_alicloud_schedulerx_job_test.go
@@ -131,11 +131,11 @@ resource "alicloud_schedulerx_app_group" "CreateAppGroup" {
   namespace             = alicloud_schedulerx_namespace.CreateNameSpace.namespace_uid
   group_id              = "test-appgroup-pop-autotest"
   description           = "appgroup 资源用例生成"
-  monitor_contacts_json = "[{\"userName\":\"张三\",\"userPhone\":\"89756******\"},{\"userName\":\"李四\",\"ding\":\"http://www.example.com\"}]"
+  monitor_contacts_json = "[{\"name\":\"用户-手机\"},{\"name\":\"用户-钉钉\"}]"
   app_name              = "test-appgroup-pop-autotest"
   app_version           = "1"
   namespace_name        = alicloud_schedulerx_namespace.CreateNameSpace.namespace_name
-  monitor_config_json   = "{\"sendChannel\":\"sms,ding\"}"
+  monitor_config_json   = "{\"sendChannel\":\"sms,ding\",\"alarmType\":\"Contacts\",\"webhookIsAtAll\":\"false\"}"
   app_type              = "2"
   max_jobs              = "100"
   namespace_source      = "schedulerx"
@@ -386,6 +386,131 @@ resource "alicloud_schedulerx_app_group" "CreateAppGroup" {
   namespace_name = alicloud_schedulerx_namespace.CreateNameSpace.namespace_name
   app_type       = "2"
   max_jobs       = "1000"
+}
+
+
+`, name)
+}
+
+// Case job_monitor_info with contact_info should not panic
+func TestAccAliCloudSchedulerxJob_contactInfoEmpty(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_schedulerx_job.default"
+	ra := resourceAttrInit(resourceId, AlicloudSchedulerxJobMapContactInfoEmpty)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &SchedulerxServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeSchedulerxJob")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sschedulerxjob%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudSchedulerxJobBasicDependenceContactInfoEmpty)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status":                "Enable",
+					"max_attempt":           "0",
+					"description":           "test contact_info nil guard",
+					"success_notice_enable": "false",
+					"job_name":              name,
+					"max_concurrency":       "1",
+					"time_config": []map[string]interface{}{
+						{
+							"time_type": "-1",
+							"calendar":  "workday",
+						},
+					},
+					"namespace": "${alicloud_schedulerx_namespace.CreateNameSpace.namespace_uid}",
+					"group_id":  "${alicloud_schedulerx_app_group.CreateAppGroup.group_id}",
+					"job_type":  "shell",
+					"job_monitor_info": []map[string]interface{}{
+						{
+							"monitor_config": []map[string]interface{}{
+								{
+									"timeout":      "7200",
+									"send_channel": "webhook",
+								},
+							},
+							"contact_info": []map[string]interface{}{
+								{
+									"user_name": "test-user",
+								},
+							},
+						},
+					},
+					"content":          "echo 'hello'",
+					"namespace_source": "schedulerx",
+					"attempt_interval": "30",
+					"execute_mode":     "standalone",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status":                                     "Enable",
+						"max_attempt":                                "0",
+						"description":                                "test contact_info nil guard",
+						"success_notice_enable":                      "false",
+						"job_name":                                   name,
+						"max_concurrency":                            "1",
+						"namespace":                                  CHECKSET,
+						"group_id":                                   CHECKSET,
+						"job_type":                                   "shell",
+						"content":                                    "echo 'hello'",
+						"namespace_source":                           "schedulerx",
+						"attempt_interval":                           "30",
+						"execute_mode":                               "standalone",
+						"job_monitor_info.#":                         "1",
+						"job_monitor_info.0.contact_info.#":          "1",
+						"job_monitor_info.0.contact_info.0.user_name": "test-user",
+						"job_monitor_info.0.monitor_config.#":        "1",
+						"job_monitor_info.0.monitor_config.0.timeout": "7200",
+						"job_monitor_info.0.monitor_config.0.send_channel": "webhook",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"fail_times", "namespace_source", "success_notice_enable", "task_dispatch_mode", "template", "timezone"},
+			},
+		},
+	})
+}
+
+var AlicloudSchedulerxJobMapContactInfoEmpty = map[string]string{
+	"job_id": CHECKSET,
+}
+
+func AlicloudSchedulerxJobBasicDependenceContactInfoEmpty(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_schedulerx_namespace" "CreateNameSpace" {
+  namespace_name = var.name
+  description    = "namespace for contact_info nil guard test"
+}
+
+resource "alicloud_schedulerx_app_group" "CreateAppGroup" {
+  namespace             = alicloud_schedulerx_namespace.CreateNameSpace.namespace_uid
+  group_id              = "test-appgroup-pop-autotest"
+  description           = "appgroup for contact_info nil guard test"
+  monitor_contacts_json = "[{\"name\":\"用户-手机\"},{\"name\":\"用户-钉钉\"}]"
+  app_name              = "test-appgroup-pop-autotest"
+  app_version           = "1"
+  namespace_name        = alicloud_schedulerx_namespace.CreateNameSpace.namespace_name
+  monitor_config_json   = "{\"sendChannel\":\"sms,ding\",\"alarmType\":\"Contacts\",\"webhookIsAtAll\":\"false\"}"
+  app_type              = "2"
+  max_jobs              = "100"
+  namespace_source      = "schedulerx"
 }
 
 

--- a/alicloud/service_alicloud_schedulerx_v2.go
+++ b/alicloud/service_alicloud_schedulerx_v2.go
@@ -48,7 +48,7 @@ func (s *SchedulerxServiceV2) DescribeSchedulerxJob(id string) (object map[strin
 	})
 	addDebug(action, response, request)
 	if err != nil {
-		if IsExpectedErrors(err, []string{"groupid not exist"}) {
+		if IsExpectedErrors(err, []string{"groupId not exist", "-10003"}) {
 			return object, WrapErrorf(NotFoundErr("Job", id), NotFoundMsg, response)
 		}
 		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)

--- a/website/docs/r/schedulerx_app_group.html.markdown
+++ b/website/docs/r/schedulerx_app_group.html.markdown
@@ -42,14 +42,14 @@ resource "alicloud_schedulerx_namespace" "CreateNameSpace" {
 
 resource "alicloud_schedulerx_app_group" "default" {
   max_jobs              = "100"
-  monitor_contacts_json = jsonencode([{ "userName" : "name1", "userPhone" : "89756******" }, { "userName" : "name2", "ding" : "http://www.example.com" }])
+  monitor_contacts_json = jsonencode([{ "name" : "contact-group-1" }, { "name" : "contact-group-2" }])
   delete_jobs           = "false"
   app_type              = "1"
   namespace_source      = "schedulerx"
   group_id              = "example-appgroup-pop-autoexample"
   namespace_name        = "default"
   description           = var.name
-  monitor_config_json   = jsonencode({ "sendChannel" : "sms,ding" })
+  monitor_config_json   = jsonencode({ "sendChannel" : "sms,ding", "alarmType" : "Contacts", "webhookIsAtAll" : "false" })
   app_version           = "1"
   app_name              = "example-appgroup-pop-autoexample"
   namespace             = alicloud_schedulerx_namespace.CreateNameSpace.namespace_uid
@@ -78,8 +78,8 @@ The following arguments are supported:
 * `group_id` - (Required, ForceNew) Application ID
 * `max_concurrency` - (Optional, Int) The maximum number of instances running at the same time. The default value is 1, that is, the last trigger is not completed, and the next trigger will not be performed even at the running time.
 * `max_jobs` - (Optional, ForceNew, Int) Application Grouping Configurable Maximum Number of Tasks
-* `monitor_config_json` - (Optional) Alarm configuration JSON field. For more information about this field, see **Request Parameters * *.
-* `monitor_contacts_json` - (Optional) Alarm contact JSON format.
+* `monitor_config_json` - (Optional) Alarm configuration JSON field. Supported keys include `sendChannel` (alarm channels, e.g. `"sms,ding"`), `alarmType` (alarm type, e.g. `"Contacts"` or `"CustomContacts"`), and `webhookIsAtAll` (whether webhook @all). **Note:** When `monitor_contacts_json` is specified, `alarmType` must be explicitly included in `monitor_config_json` (typically `"CustomContacts"` for custom contacts or `"Contacts"` for contact groups); otherwise the API will automatically append `alarmType` which causes configuration drift on subsequent plans.
+* `monitor_contacts_json` - (Optional) Alarm contact JSON format. **Note:** This field only takes effect when `monitor_config_json` contains an `alarmType` value (e.g. `"CustomContacts"` or `"Contacts"`). The format depends on `alarmType`: for `"CustomContacts"`, use `[{"userName":"name","userPhone":"phone","ding":"webhook_url"}]`; for `"Contacts"`, use `[{"name":"contact_group_name"}]`.
 * `namespace` - (Required, ForceNew) The namespace ID, which is obtained on the namespace page of the console.
 * `namespace_name` - (Required) The namespace name.
 * `namespace_source` - (Optional) Not supported for the time being, no need to fill in.


### PR DESCRIPTION
### References

- China Terraform issue: https://project.aone.alibaba-inc.com/v2/project/1086837/bug/83782860

### Changes

1. **Fix panic in `alicloud_schedulerx_job`**: When users specify an empty `contact_info {}` block inside `job_monitor_info`, the Terraform SDK passes `nil` elements in the list. The bare type assertion panics on nil, causing `plugin crashed` error. Use comma-ok idiom to safely skip nil elements in Create, Read, and Update functions.

2. **Add acceptance test**: `TestAccAliCloudSchedulerxJob_contactInfoEmpty` validates job creation with `contact_info` and `monitor_config` inside `job_monitor_info`.

3. **Update `alicloud_schedulerx_app_group` documentation**: Document the `alarmType` constraint - when `monitor_contacts_json` is specified, `alarmType` must be explicitly included in `monitor_config_json` to avoid configuration drift.

### Affected Resources

- `alicloud_schedulerx_job`
- `alicloud_schedulerx_app_group` (documentation only)