### PR TITLE
New Resource: alicloud_oss_bucket_inventory; New Data Source: alicloud_oss_bucket_inventories

### DIFF
--- a/alicloud/data_source_alicloud_oss_bucket_inventories.go
+++ b/alicloud/data_source_alicloud_oss_bucket_inventories.go
@@ -1,0 +1,441 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudOssBucketInventories() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudOssBucketInventoryRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"inventories": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"destination": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"oss_bucket_destination": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"format": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"account_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"bucket": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"prefix": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"encryption": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"ssekms": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"key_id": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+															"sseoss": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"role_arn": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"filter": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"lower_size_bound": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"storage_class": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"last_modify_begin_time_stamp": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"last_modify_end_time_stamp": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"upper_size_bound": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"prefix": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"included_object_versions": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"incremental_inventory": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"optional_fields": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"field": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"is_enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"schedule": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"frequency": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"inventory_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"optional_fields": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"field": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"schedule": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"frequency": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudOssBucketInventoryRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListBucketInventory
+	action := fmt.Sprintf("/?inventory")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	hostMap := make(map[string]*string)
+
+	hostMap["bucket"] = StringPointer(d.Get("bucket").(string))
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlParam("GET", "2019-05-17", "ListBucketInventory", action), query, nil, nil, hostMap, false)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	resp, _ := jsonpath.Get("$.ListInventoryConfigurationsResult.InventoryConfiguration[*]", response)
+
+	result, _ := resp.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		if len(idsMap) > 0 {
+			if _, ok := idsMap[fmt.Sprint(*hostMap["bucket"], ":", item["Id"])]; !ok {
+				continue
+			}
+		}
+		objects = append(objects, item)
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(*hostMap["bucket"], ":", objectRaw["Id"])
+
+		mapping["included_object_versions"] = objectRaw["IncludedObjectVersions"]
+		mapping["is_enabled"] = objectRaw["IsEnabled"]
+		mapping["inventory_id"] = objectRaw["Id"]
+
+		destinationMaps := make([]map[string]interface{}, 0)
+		destinationMap := make(map[string]interface{})
+		destinationRaw := make(map[string]interface{})
+		if objectRaw["Destination"] != nil {
+			destinationRaw = objectRaw["Destination"].(map[string]interface{})
+		}
+		if len(destinationRaw) > 0 {
+
+			oSSBucketDestinationMaps := make([]map[string]interface{}, 0)
+			oSSBucketDestinationMap := make(map[string]interface{})
+			oSSBucketDestinationRaw := make(map[string]interface{})
+			if destinationRaw["OSSBucketDestination"] != nil {
+				oSSBucketDestinationRaw = destinationRaw["OSSBucketDestination"].(map[string]interface{})
+			}
+			if len(oSSBucketDestinationRaw) > 0 {
+				oSSBucketDestinationMap["account_id"] = oSSBucketDestinationRaw["AccountId"]
+				oSSBucketDestinationMap["bucket"] = oSSBucketDestinationRaw["Bucket"]
+				oSSBucketDestinationMap["format"] = oSSBucketDestinationRaw["Format"]
+				oSSBucketDestinationMap["prefix"] = oSSBucketDestinationRaw["Prefix"]
+				oSSBucketDestinationMap["role_arn"] = oSSBucketDestinationRaw["RoleArn"]
+
+				encryptionMaps := make([]map[string]interface{}, 0)
+				encryptionMap := make(map[string]interface{})
+				encryptionRaw := make(map[string]interface{})
+				if oSSBucketDestinationRaw["Encryption"] != nil {
+					encryptionRaw = oSSBucketDestinationRaw["Encryption"].(map[string]interface{})
+				}
+				if len(encryptionRaw) > 0 {
+					encryptionMap["sseoss"] = encryptionRaw["SSE-OSS"]
+
+					sSEKMSMaps := make([]map[string]interface{}, 0)
+					sSEKMSMap := make(map[string]interface{})
+					sSEKMSRaw := make(map[string]interface{})
+					if encryptionRaw["SSE-KMS"] != nil {
+						sSEKMSRaw = encryptionRaw["SSE-KMS"].(map[string]interface{})
+					}
+					if len(sSEKMSRaw) > 0 {
+						sSEKMSMap["key_id"] = sSEKMSRaw["KeyId"]
+
+						sSEKMSMaps = append(sSEKMSMaps, sSEKMSMap)
+					}
+					encryptionMap["ssekms"] = sSEKMSMaps
+					encryptionMaps = append(encryptionMaps, encryptionMap)
+				}
+				oSSBucketDestinationMap["encryption"] = encryptionMaps
+				oSSBucketDestinationMaps = append(oSSBucketDestinationMaps, oSSBucketDestinationMap)
+			}
+			destinationMap["oss_bucket_destination"] = oSSBucketDestinationMaps
+			destinationMaps = append(destinationMaps, destinationMap)
+		}
+		mapping["destination"] = destinationMaps
+		filterMaps := make([]map[string]interface{}, 0)
+		filterMap := make(map[string]interface{})
+		filterRaw := make(map[string]interface{})
+		if objectRaw["Filter"] != nil {
+			filterRaw = objectRaw["Filter"].(map[string]interface{})
+		}
+		if len(filterRaw) > 0 {
+			filterMap["last_modify_begin_time_stamp"] = filterRaw["LastModifyBeginTimeStamp"]
+			filterMap["last_modify_end_time_stamp"] = filterRaw["LastModifyEndTimeStamp"]
+			filterMap["lower_size_bound"] = filterRaw["LowerSizeBound"]
+			filterMap["prefix"] = filterRaw["Prefix"]
+			filterMap["storage_class"] = filterRaw["StorageClass"]
+			filterMap["upper_size_bound"] = filterRaw["UpperSizeBound"]
+
+			filterMaps = append(filterMaps, filterMap)
+		}
+		mapping["filter"] = filterMaps
+		incrementalInventoryMaps := make([]map[string]interface{}, 0)
+		incrementalInventoryMap := make(map[string]interface{})
+		incrementalInventoryRaw := make(map[string]interface{})
+		if objectRaw["IncrementalInventory"] != nil {
+			incrementalInventoryRaw = objectRaw["IncrementalInventory"].(map[string]interface{})
+		}
+		if len(incrementalInventoryRaw) > 0 {
+			incrementalInventoryMap["is_enabled"] = incrementalInventoryRaw["IsEnabled"]
+
+			optionalFieldsMaps := make([]map[string]interface{}, 0)
+			optionalFieldsMap := make(map[string]interface{})
+			optionalFieldsRaw := make(map[string]interface{})
+			if incrementalInventoryRaw["OptionalFields"] != nil {
+				optionalFieldsRaw = incrementalInventoryRaw["OptionalFields"].(map[string]interface{})
+			}
+			if len(optionalFieldsRaw) > 0 {
+
+				fieldRaw := make([]interface{}, 0)
+				if optionalFieldsRaw["Field"] != nil {
+					fieldRaw = convertToInterfaceArray(optionalFieldsRaw["Field"])
+				}
+
+				optionalFieldsMap["field"] = fieldRaw
+				optionalFieldsMaps = append(optionalFieldsMaps, optionalFieldsMap)
+			}
+			incrementalInventoryMap["optional_fields"] = optionalFieldsMaps
+			scheduleMaps := make([]map[string]interface{}, 0)
+			scheduleMap := make(map[string]interface{})
+			scheduleRaw := make(map[string]interface{})
+			if incrementalInventoryRaw["Schedule"] != nil {
+				scheduleRaw = incrementalInventoryRaw["Schedule"].(map[string]interface{})
+			}
+			if len(scheduleRaw) > 0 {
+				scheduleMap["frequency"] = scheduleRaw["Frequency"]
+
+				scheduleMaps = append(scheduleMaps, scheduleMap)
+			}
+			incrementalInventoryMap["schedule"] = scheduleMaps
+			incrementalInventoryMaps = append(incrementalInventoryMaps, incrementalInventoryMap)
+		}
+		mapping["incremental_inventory"] = incrementalInventoryMaps
+		optionalFieldsMaps := make([]map[string]interface{}, 0)
+		optionalFieldsMap := make(map[string]interface{})
+		optionalFieldsRaw := make(map[string]interface{})
+		if objectRaw["OptionalFields"] != nil {
+			optionalFieldsRaw = objectRaw["OptionalFields"].(map[string]interface{})
+		}
+		if len(optionalFieldsRaw) > 0 {
+
+			fieldRaw := make([]interface{}, 0)
+			if optionalFieldsRaw["Field"] != nil {
+				fieldRaw = convertToInterfaceArray(optionalFieldsRaw["Field"])
+			}
+
+			optionalFieldsMap["field"] = fieldRaw
+			optionalFieldsMaps = append(optionalFieldsMaps, optionalFieldsMap)
+		}
+		mapping["optional_fields"] = optionalFieldsMaps
+		scheduleMaps := make([]map[string]interface{}, 0)
+		scheduleMap := make(map[string]interface{})
+		scheduleRaw := make(map[string]interface{})
+		if objectRaw["Schedule"] != nil {
+			scheduleRaw = objectRaw["Schedule"].(map[string]interface{})
+		}
+		if len(scheduleRaw) > 0 {
+			scheduleMap["frequency"] = scheduleRaw["Frequency"]
+
+			scheduleMaps = append(scheduleMaps, scheduleMap)
+		}
+		mapping["schedule"] = scheduleMaps
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("inventories", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_oss_bucket_inventories_test.go
+++ b/alicloud/data_source_alicloud_oss_bucket_inventories_test.go
@@ -1,0 +1,154 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudOssBucketInventoriesDataSource_basic(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+	resourceId := "data.alicloud_oss_bucket_inventories.default"
+
+	testAccConfig := dataSourceTestAccConfigFunc(resourceId,
+		fmt.Sprintf("tfaccossinv%d", rand),
+		dataSourceOssBucketInventoriesConfigDependence)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"bucket": "${alicloud_oss_bucket_inventory.default.bucket}",
+			"ids":    []string{"${alicloud_oss_bucket_inventory.default.id}"},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"bucket": "${alicloud_oss_bucket_inventory.default.bucket}",
+			"ids":    []string{"${alicloud_oss_bucket_inventory.default.id}-fake"},
+		}),
+	}
+
+	var existMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":                                                "1",
+			"ids.0":                                                CHECKSET,
+			"inventories.#":                                        "1",
+			"inventories.0.id":                                     CHECKSET,
+			"inventories.0.inventory_id":                           fmt.Sprintf("tfaccossinv%d", rand),
+			"inventories.0.is_enabled":                             "true",
+			"inventories.0.included_object_versions":               "All",
+			"inventories.0.schedule.#":                             "1",
+			"inventories.0.schedule.0.frequency":                   "Daily",
+			"inventories.0.optional_fields.#":                      "1",
+			"inventories.0.optional_fields.0.field.#":              "2",
+			"inventories.0.destination.#":                          "1",
+			"inventories.0.destination.0.oss_bucket_destination.#": "1",
+			"inventories.0.destination.0.oss_bucket_destination.0.format": "CSV",
+		}
+	}
+
+	var fakeMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":         "0",
+			"inventories.#": "0",
+		}
+	}
+
+	var checkInfo = dataSourceAttr{
+		resourceId:   resourceId,
+		existMapFunc: existMapFunc,
+		fakeMapFunc:  fakeMapFunc,
+	}
+	checkInfo.dataSourceTestCheck(t, rand, idsConf)
+}
+
+func dataSourceOssBucketInventoriesConfigDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_account" "current" {
+}
+
+resource "alicloud_oss_bucket" "source" {
+  bucket        = "${var.name}-src"
+  storage_class = "Standard"
+}
+
+resource "alicloud_oss_bucket" "dest" {
+  bucket        = "${var.name}-dst"
+  storage_class = "Standard"
+}
+
+resource "alicloud_ram_role" "default" {
+  name        = "${var.name}"
+  document    = <<EOF
+{
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": [
+            "oss.aliyuncs.com"
+          ]
+        }
+      }
+    ],
+    "Version": "1"
+  }
+EOF
+  description = "this is a test for bucket inventory."
+  force       = true
+}
+
+resource "alicloud_ram_policy" "default" {
+  name     = "${var.name}"
+  document = <<EOF
+{
+  "Statement": [
+    {
+      "Action": ["oss:PutObject", "oss:AbortMultipartUpload"],
+      "Effect": "Allow",
+      "Resource": ["acs:oss:*:*:${alicloud_oss_bucket.dest.id}/*"]
+    }
+  ],
+  "Version": "1"
+}
+EOF
+  force    = true
+}
+
+resource "alicloud_ram_role_policy_attachment" "default" {
+  policy_name = "${alicloud_ram_policy.default.name}"
+  policy_type = "${alicloud_ram_policy.default.type}"
+  role_name   = "${alicloud_ram_role.default.name}"
+}
+
+resource "alicloud_oss_bucket_inventory" "default" {
+  bucket       = "${alicloud_oss_bucket.source.id}"
+  inventory_id = "${var.name}"
+  is_enabled   = true
+
+  included_object_versions = "All"
+
+  schedule {
+    frequency = "Daily"
+  }
+
+  optional_fields {
+    field = ["Size", "LastModifiedDate"]
+  }
+
+  destination {
+    oss_bucket_destination {
+      format     = "CSV"
+      account_id = "${data.alicloud_account.current.id}"
+      role_arn   = "acs:ram::${data.alicloud_account.current.id}:role/${alicloud_ram_role_policy_attachment.default.role_name}"
+      bucket     = "acs:oss:::${alicloud_oss_bucket.dest.id}"
+      prefix     = "inv/"
+    }
+  }
+}
+
+`, name)
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -171,6 +171,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_oss_bucket_inventories":                     dataSourceAliCloudOssBucketInventories(),
 			"alicloud_wafv3_address_books":                        dataSourceAliCloudWafv3AddressBooks(),
 			"alicloud_wafv3_defense_rules":                        dataSourceAliCloudWafv3DefenseRules(),
 			"alicloud_amqp_open_source_accounts":                  dataSourceAliCloudAmqpOpenSourceAccounts(),
@@ -927,6 +928,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_oss_bucket_inventory":                                 resourceAliCloudOssBucketInventory(),
 			"alicloud_resource_manager_resource_directory_sharing":          resourceAliCloudResourceManagerResourceDirectorySharing(),
 			"alicloud_wafv3_address_book":                                   resourceAliCloudWafv3AddressBook(),
 			"alicloud_threat_detection_service_linked_role":                 resourceAliCloudThreatDetectionServiceLinkedRole(),

--- a/alicloud/resource_alicloud_oss_bucket_inventory.go
+++ b/alicloud/resource_alicloud_oss_bucket_inventory.go
@@ -1,0 +1,843 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudOssBucketInventory() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudOssBucketInventoryCreate,
+		Read:   resourceAliCloudOssBucketInventoryRead,
+		Update: resourceAliCloudOssBucketInventoryUpdate,
+		Delete: resourceAliCloudOssBucketInventoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"destination": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"oss_bucket_destination": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"format": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"account_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"bucket": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"prefix": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"encryption": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"ssekms": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"key_id": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+												"sseoss": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"role_arn": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"lower_size_bound": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"storage_class": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"last_modify_begin_time_stamp": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"last_modify_end_time_stamp": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"upper_size_bound": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"included_object_versions": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"incremental_inventory": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"optional_fields": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"field": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"is_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"schedule": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"frequency": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"inventory_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"is_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"optional_fields": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"schedule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"frequency": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAliCloudOssBucketInventoryCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/?inventory")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	hostMap := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+	hostMap["bucket"] = StringPointer(d.Get("bucket").(string))
+	query["inventoryId"] = StringPointer(d.Get("inventory_id").(string))
+
+	inventoryConfiguration := make(map[string]interface{})
+	if v := d.Get("optional_fields"); !IsNil(v) {
+		optionalFields := make(map[string]interface{})
+		field1, _ := jsonpath.Get("$[0].field", d.Get("optional_fields"))
+		if field1 != nil && field1 != "" {
+			optionalFields["Field"] = field1
+		}
+
+		if len(optionalFields) > 0 {
+			inventoryConfiguration["OptionalFields"] = optionalFields
+		}
+	}
+	if v, ok := d.GetOk("is_enabled"); ok {
+		inventoryConfiguration["IsEnabled"] = v
+	}
+	if v := d.Get("filter"); !IsNil(v) {
+		filter := make(map[string]interface{})
+		storageClass1, _ := jsonpath.Get("$[0].storage_class", d.Get("filter"))
+		if storageClass1 != nil && storageClass1 != "" {
+			filter["StorageClass"] = storageClass1
+		}
+		lastModifyEndTimeStamp1, _ := jsonpath.Get("$[0].last_modify_end_time_stamp", d.Get("filter"))
+		if lastModifyEndTimeStamp1 != nil && lastModifyEndTimeStamp1 != "" {
+			filter["LastModifyEndTimeStamp"] = lastModifyEndTimeStamp1
+		}
+		upperSizeBound1, _ := jsonpath.Get("$[0].upper_size_bound", d.Get("filter"))
+		if upperSizeBound1 != nil && upperSizeBound1 != "" {
+			filter["UpperSizeBound"] = upperSizeBound1
+		}
+		prefix1, _ := jsonpath.Get("$[0].prefix", d.Get("filter"))
+		if prefix1 != nil && prefix1 != "" {
+			filter["Prefix"] = prefix1
+		}
+		lastModifyBeginTimeStamp1, _ := jsonpath.Get("$[0].last_modify_begin_time_stamp", d.Get("filter"))
+		if lastModifyBeginTimeStamp1 != nil && lastModifyBeginTimeStamp1 != "" {
+			filter["LastModifyBeginTimeStamp"] = lastModifyBeginTimeStamp1
+		}
+		lowerSizeBound1, _ := jsonpath.Get("$[0].lower_size_bound", d.Get("filter"))
+		if lowerSizeBound1 != nil && lowerSizeBound1 != "" {
+			filter["LowerSizeBound"] = lowerSizeBound1
+		}
+
+		if len(filter) > 0 {
+			inventoryConfiguration["Filter"] = filter
+		}
+	}
+	if v := d.Get("incremental_inventory"); !IsNil(v) {
+		incrementalInventory := make(map[string]interface{})
+		isEnabled3, _ := jsonpath.Get("$[0].is_enabled", d.Get("incremental_inventory"))
+		if isEnabled3 != nil && isEnabled3 != "" {
+			incrementalInventory["IsEnabled"] = isEnabled3
+		}
+		optionalFields1 := make(map[string]interface{})
+		field3, _ := jsonpath.Get("$[0].optional_fields[0].field", d.Get("incremental_inventory"))
+		if field3 != nil && field3 != "" {
+			optionalFields1["Field"] = field3
+		}
+
+		if len(optionalFields1) > 0 {
+			incrementalInventory["OptionalFields"] = optionalFields1
+		}
+		schedule := make(map[string]interface{})
+		frequency1, _ := jsonpath.Get("$[0].schedule[0].frequency", d.Get("incremental_inventory"))
+		if frequency1 != nil && frequency1 != "" {
+			schedule["Frequency"] = frequency1
+		}
+
+		if len(schedule) > 0 {
+			incrementalInventory["Schedule"] = schedule
+		}
+
+		if len(incrementalInventory) > 0 {
+			inventoryConfiguration["IncrementalInventory"] = incrementalInventory
+		}
+	}
+	if v, ok := d.GetOk("included_object_versions"); ok {
+		inventoryConfiguration["IncludedObjectVersions"] = v
+	}
+	if v := d.Get("schedule"); !IsNil(v) {
+		schedule1 := make(map[string]interface{})
+		frequency3, _ := jsonpath.Get("$[0].frequency", d.Get("schedule"))
+		if frequency3 != nil && frequency3 != "" {
+			schedule1["Frequency"] = frequency3
+		}
+
+		if len(schedule1) > 0 {
+			inventoryConfiguration["Schedule"] = schedule1
+		}
+	}
+	if v := d.Get("destination"); !IsNil(v) {
+		destination := make(map[string]interface{})
+		oSSBucketDestination := make(map[string]interface{})
+		encryption := make(map[string]interface{})
+		sSEOSS1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].encryption[0].sseoss", d.Get("destination"))
+		if sSEOSS1 != nil && sSEOSS1 != "" {
+			encryption["SSE-OSS"] = sSEOSS1
+		}
+		sSEKMS := make(map[string]interface{})
+		keyId1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].encryption[0].ssekms[0].key_id", d.Get("destination"))
+		if keyId1 != nil && keyId1 != "" {
+			sSEKMS["KeyId"] = keyId1
+		}
+
+		if len(sSEKMS) > 0 {
+			encryption["SSE-KMS"] = sSEKMS
+		}
+
+		if len(encryption) > 0 {
+			oSSBucketDestination["Encryption"] = encryption
+		}
+		prefix3, _ := jsonpath.Get("$[0].oss_bucket_destination[0].prefix", d.Get("destination"))
+		if prefix3 != nil && prefix3 != "" {
+			oSSBucketDestination["Prefix"] = prefix3
+		}
+		accountId1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].account_id", d.Get("destination"))
+		if accountId1 != nil && accountId1 != "" {
+			oSSBucketDestination["AccountId"] = accountId1
+		}
+		format1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].format", d.Get("destination"))
+		if format1 != nil && format1 != "" {
+			oSSBucketDestination["Format"] = format1
+		}
+		bucket1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].bucket", d.Get("destination"))
+		if bucket1 != nil && bucket1 != "" {
+			oSSBucketDestination["Bucket"] = bucket1
+		}
+		roleArn1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].role_arn", d.Get("destination"))
+		if roleArn1 != nil && roleArn1 != "" {
+			oSSBucketDestination["RoleArn"] = roleArn1
+		}
+
+		if len(oSSBucketDestination) > 0 {
+			destination["OSSBucketDestination"] = oSSBucketDestination
+		}
+
+		if len(destination) > 0 {
+			inventoryConfiguration["Destination"] = destination
+		}
+	}
+
+	inventoryConfiguration["Id"] = d.Get("inventory_id")
+	request["InventoryConfiguration"] = inventoryConfiguration
+
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlParam("PUT", "2019-05-17", "PutBucketInventory", action), query, body, nil, hostMap, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_oss_bucket_inventory", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", *hostMap["bucket"], *query["inventoryId"]))
+
+	return resourceAliCloudOssBucketInventoryRead(d, meta)
+}
+
+func resourceAliCloudOssBucketInventoryRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ossServiceV2 := OssServiceV2{client}
+
+	objectRaw, err := ossServiceV2.DescribeOssBucketInventory(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_oss_bucket_inventory DescribeOssBucketInventory Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("included_object_versions", objectRaw["IncludedObjectVersions"])
+	d.Set("is_enabled", objectRaw["IsEnabled"])
+	d.Set("inventory_id", objectRaw["Id"])
+
+	destinationMaps := make([]map[string]interface{}, 0)
+	destinationMap := make(map[string]interface{})
+	destinationRaw := make(map[string]interface{})
+	if objectRaw["Destination"] != nil {
+		destinationRaw = objectRaw["Destination"].(map[string]interface{})
+	}
+	if len(destinationRaw) > 0 {
+
+		oSSBucketDestinationMaps := make([]map[string]interface{}, 0)
+		oSSBucketDestinationMap := make(map[string]interface{})
+		oSSBucketDestinationRaw := make(map[string]interface{})
+		if destinationRaw["OSSBucketDestination"] != nil {
+			oSSBucketDestinationRaw = destinationRaw["OSSBucketDestination"].(map[string]interface{})
+		}
+		if len(oSSBucketDestinationRaw) > 0 {
+			oSSBucketDestinationMap["account_id"] = oSSBucketDestinationRaw["AccountId"]
+			oSSBucketDestinationMap["bucket"] = oSSBucketDestinationRaw["Bucket"]
+			oSSBucketDestinationMap["format"] = oSSBucketDestinationRaw["Format"]
+			oSSBucketDestinationMap["prefix"] = oSSBucketDestinationRaw["Prefix"]
+			oSSBucketDestinationMap["role_arn"] = oSSBucketDestinationRaw["RoleArn"]
+
+			encryptionMaps := make([]map[string]interface{}, 0)
+			encryptionMap := make(map[string]interface{})
+			encryptionRaw := make(map[string]interface{})
+			if oSSBucketDestinationRaw["Encryption"] != nil {
+				encryptionRaw = oSSBucketDestinationRaw["Encryption"].(map[string]interface{})
+			}
+			if len(encryptionRaw) > 0 {
+				encryptionMap["sseoss"] = encryptionRaw["SSE-OSS"]
+
+				sSEKMSMaps := make([]map[string]interface{}, 0)
+				sSEKMSMap := make(map[string]interface{})
+				sSEKMSRaw := make(map[string]interface{})
+				if encryptionRaw["SSE-KMS"] != nil {
+					sSEKMSRaw = encryptionRaw["SSE-KMS"].(map[string]interface{})
+				}
+				if len(sSEKMSRaw) > 0 {
+					sSEKMSMap["key_id"] = sSEKMSRaw["KeyId"]
+
+					sSEKMSMaps = append(sSEKMSMaps, sSEKMSMap)
+				}
+				encryptionMap["ssekms"] = sSEKMSMaps
+				encryptionMaps = append(encryptionMaps, encryptionMap)
+			}
+			oSSBucketDestinationMap["encryption"] = encryptionMaps
+			oSSBucketDestinationMaps = append(oSSBucketDestinationMaps, oSSBucketDestinationMap)
+		}
+		destinationMap["oss_bucket_destination"] = oSSBucketDestinationMaps
+		destinationMaps = append(destinationMaps, destinationMap)
+	}
+	if err := d.Set("destination", destinationMaps); err != nil {
+		return err
+	}
+	filterMaps := make([]map[string]interface{}, 0)
+	filterMap := make(map[string]interface{})
+	filterRaw := make(map[string]interface{})
+	if objectRaw["Filter"] != nil {
+		filterRaw = objectRaw["Filter"].(map[string]interface{})
+	}
+	// OSS's GetBucketInventory always echoes back a Filter block populated with
+	// zero-value defaults even when the caller did not set one. Treat an
+	// all-empty payload as "no filter" to avoid a perpetual plan diff.
+	filterHasValue := false
+	for _, k := range []string{"LastModifyBeginTimeStamp", "LastModifyEndTimeStamp", "LowerSizeBound", "Prefix", "StorageClass", "UpperSizeBound"} {
+		if v, ok := filterRaw[k]; ok && v != nil && fmt.Sprint(v) != "" && fmt.Sprint(v) != "0" {
+			filterHasValue = true
+			break
+		}
+	}
+	if filterHasValue {
+		filterMap["last_modify_begin_time_stamp"] = filterRaw["LastModifyBeginTimeStamp"]
+		filterMap["last_modify_end_time_stamp"] = filterRaw["LastModifyEndTimeStamp"]
+		filterMap["lower_size_bound"] = filterRaw["LowerSizeBound"]
+		filterMap["prefix"] = filterRaw["Prefix"]
+		filterMap["storage_class"] = filterRaw["StorageClass"]
+		filterMap["upper_size_bound"] = filterRaw["UpperSizeBound"]
+
+		filterMaps = append(filterMaps, filterMap)
+	}
+	if err := d.Set("filter", filterMaps); err != nil {
+		return err
+	}
+	incrementalInventoryMaps := make([]map[string]interface{}, 0)
+	incrementalInventoryMap := make(map[string]interface{})
+	incrementalInventoryRaw := make(map[string]interface{})
+	if objectRaw["IncrementalInventory"] != nil {
+		incrementalInventoryRaw = objectRaw["IncrementalInventory"].(map[string]interface{})
+	}
+	if len(incrementalInventoryRaw) > 0 {
+		incrementalInventoryMap["is_enabled"] = incrementalInventoryRaw["IsEnabled"]
+
+		optionalFieldsMaps := make([]map[string]interface{}, 0)
+		optionalFieldsMap := make(map[string]interface{})
+		optionalFieldsRaw := make(map[string]interface{})
+		if incrementalInventoryRaw["OptionalFields"] != nil {
+			optionalFieldsRaw = incrementalInventoryRaw["OptionalFields"].(map[string]interface{})
+		}
+		if len(optionalFieldsRaw) > 0 {
+
+			fieldRaw := make([]interface{}, 0)
+			if optionalFieldsRaw["Field"] != nil {
+				fieldRaw = convertToInterfaceArray(optionalFieldsRaw["Field"])
+			}
+
+			optionalFieldsMap["field"] = fieldRaw
+			optionalFieldsMaps = append(optionalFieldsMaps, optionalFieldsMap)
+		}
+		incrementalInventoryMap["optional_fields"] = optionalFieldsMaps
+		scheduleMaps := make([]map[string]interface{}, 0)
+		scheduleMap := make(map[string]interface{})
+		scheduleRaw := make(map[string]interface{})
+		if incrementalInventoryRaw["Schedule"] != nil {
+			scheduleRaw = incrementalInventoryRaw["Schedule"].(map[string]interface{})
+		}
+		if len(scheduleRaw) > 0 {
+			scheduleMap["frequency"] = scheduleRaw["Frequency"]
+
+			scheduleMaps = append(scheduleMaps, scheduleMap)
+		}
+		incrementalInventoryMap["schedule"] = scheduleMaps
+		incrementalInventoryMaps = append(incrementalInventoryMaps, incrementalInventoryMap)
+	}
+	if err := d.Set("incremental_inventory", incrementalInventoryMaps); err != nil {
+		return err
+	}
+	optionalFieldsMaps := make([]map[string]interface{}, 0)
+	optionalFieldsMap := make(map[string]interface{})
+	optionalFieldsRaw := make(map[string]interface{})
+	if objectRaw["OptionalFields"] != nil {
+		optionalFieldsRaw = objectRaw["OptionalFields"].(map[string]interface{})
+	}
+	if len(optionalFieldsRaw) > 0 {
+
+		fieldRaw := make([]interface{}, 0)
+		if optionalFieldsRaw["Field"] != nil {
+			fieldRaw = convertToInterfaceArray(optionalFieldsRaw["Field"])
+		}
+
+		optionalFieldsMap["field"] = fieldRaw
+		optionalFieldsMaps = append(optionalFieldsMaps, optionalFieldsMap)
+	}
+	if err := d.Set("optional_fields", optionalFieldsMaps); err != nil {
+		return err
+	}
+	scheduleMaps := make([]map[string]interface{}, 0)
+	scheduleMap := make(map[string]interface{})
+	scheduleRaw := make(map[string]interface{})
+	if objectRaw["Schedule"] != nil {
+		scheduleRaw = objectRaw["Schedule"].(map[string]interface{})
+	}
+	if len(scheduleRaw) > 0 {
+		scheduleMap["frequency"] = scheduleRaw["Frequency"]
+
+		scheduleMaps = append(scheduleMaps, scheduleMap)
+	}
+	if err := d.Set("schedule", scheduleMaps); err != nil {
+		return err
+	}
+
+	parts := strings.Split(d.Id(), ":")
+	d.Set("bucket", parts[0])
+
+	return nil
+}
+
+func resourceAliCloudOssBucketInventoryUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var body map[string]interface{}
+	update := false
+
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	action := fmt.Sprintf("/?inventory")
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+	hostMap := make(map[string]*string)
+	hostMap["bucket"] = StringPointer(parts[0])
+	query["inventoryId"] = StringPointer(parts[1])
+
+	inventoryConfiguration := make(map[string]interface{})
+	if d.HasChange("optional_fields") {
+		update = true
+	}
+	if v := d.Get("optional_fields"); !IsNil(v) || d.HasChange("optional_fields") {
+		optionalFields := make(map[string]interface{})
+		field1, _ := jsonpath.Get("$[0].field", d.Get("optional_fields"))
+		if field1 != nil && field1 != "" {
+			optionalFields["Field"] = field1
+		}
+
+		if len(optionalFields) > 0 {
+			inventoryConfiguration["OptionalFields"] = optionalFields
+		}
+	}
+	if d.HasChange("is_enabled") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("is_enabled"); ok {
+		inventoryConfiguration["IsEnabled"] = v
+	}
+	if d.HasChange("filter") {
+		update = true
+	}
+	if v := d.Get("filter"); !IsNil(v) || d.HasChange("filter") {
+		filter := make(map[string]interface{})
+		storageClass1, _ := jsonpath.Get("$[0].storage_class", d.Get("filter"))
+		if storageClass1 != nil && storageClass1 != "" {
+			filter["StorageClass"] = storageClass1
+		}
+		lastModifyEndTimeStamp1, _ := jsonpath.Get("$[0].last_modify_end_time_stamp", d.Get("filter"))
+		if lastModifyEndTimeStamp1 != nil && lastModifyEndTimeStamp1 != "" {
+			filter["LastModifyEndTimeStamp"] = lastModifyEndTimeStamp1
+		}
+		upperSizeBound1, _ := jsonpath.Get("$[0].upper_size_bound", d.Get("filter"))
+		if upperSizeBound1 != nil && upperSizeBound1 != "" {
+			filter["UpperSizeBound"] = upperSizeBound1
+		}
+		prefix1, _ := jsonpath.Get("$[0].prefix", d.Get("filter"))
+		if prefix1 != nil && prefix1 != "" {
+			filter["Prefix"] = prefix1
+		}
+		lastModifyBeginTimeStamp1, _ := jsonpath.Get("$[0].last_modify_begin_time_stamp", d.Get("filter"))
+		if lastModifyBeginTimeStamp1 != nil && lastModifyBeginTimeStamp1 != "" {
+			filter["LastModifyBeginTimeStamp"] = lastModifyBeginTimeStamp1
+		}
+		lowerSizeBound1, _ := jsonpath.Get("$[0].lower_size_bound", d.Get("filter"))
+		if lowerSizeBound1 != nil && lowerSizeBound1 != "" {
+			filter["LowerSizeBound"] = lowerSizeBound1
+		}
+
+		if len(filter) > 0 {
+			inventoryConfiguration["Filter"] = filter
+		}
+	}
+	if d.HasChange("incremental_inventory") {
+		update = true
+	}
+	if v := d.Get("incremental_inventory"); !IsNil(v) || d.HasChange("incremental_inventory") {
+		incrementalInventory := make(map[string]interface{})
+		isEnabled3, _ := jsonpath.Get("$[0].is_enabled", d.Get("incremental_inventory"))
+		if isEnabled3 != nil && isEnabled3 != "" {
+			incrementalInventory["IsEnabled"] = isEnabled3
+		}
+		optionalFields1 := make(map[string]interface{})
+		field3, _ := jsonpath.Get("$[0].optional_fields[0].field", d.Get("incremental_inventory"))
+		if field3 != nil && field3 != "" {
+			optionalFields1["Field"] = field3
+		}
+
+		if len(optionalFields1) > 0 {
+			incrementalInventory["OptionalFields"] = optionalFields1
+		}
+		schedule := make(map[string]interface{})
+		frequency1, _ := jsonpath.Get("$[0].schedule[0].frequency", d.Get("incremental_inventory"))
+		if frequency1 != nil && frequency1 != "" {
+			schedule["Frequency"] = frequency1
+		}
+
+		if len(schedule) > 0 {
+			incrementalInventory["Schedule"] = schedule
+		}
+
+		if len(incrementalInventory) > 0 {
+			inventoryConfiguration["IncrementalInventory"] = incrementalInventory
+		}
+	}
+	if d.HasChange("included_object_versions") {
+		update = true
+	}
+	if v, ok := d.GetOk("included_object_versions"); ok {
+		inventoryConfiguration["IncludedObjectVersions"] = v
+	}
+	if d.HasChange("schedule") {
+		update = true
+	}
+	if v := d.Get("schedule"); !IsNil(v) || d.HasChange("schedule") {
+		schedule1 := make(map[string]interface{})
+		frequency3, _ := jsonpath.Get("$[0].frequency", d.Get("schedule"))
+		if frequency3 != nil && frequency3 != "" {
+			schedule1["Frequency"] = frequency3
+		}
+
+		if len(schedule1) > 0 {
+			inventoryConfiguration["Schedule"] = schedule1
+		}
+	}
+	if d.HasChange("destination") {
+		update = true
+	}
+	if v := d.Get("destination"); !IsNil(v) || d.HasChange("destination") {
+		destination := make(map[string]interface{})
+		oSSBucketDestination := make(map[string]interface{})
+		encryption := make(map[string]interface{})
+		sSEOSS1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].encryption[0].sseoss", d.Get("destination"))
+		if sSEOSS1 != nil && sSEOSS1 != "" {
+			encryption["SSE-OSS"] = sSEOSS1
+		}
+		sSEKMS := make(map[string]interface{})
+		keyId1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].encryption[0].ssekms[0].key_id", d.Get("destination"))
+		if keyId1 != nil && keyId1 != "" {
+			sSEKMS["KeyId"] = keyId1
+		}
+
+		if len(sSEKMS) > 0 {
+			encryption["SSE-KMS"] = sSEKMS
+		}
+
+		if len(encryption) > 0 {
+			oSSBucketDestination["Encryption"] = encryption
+		}
+		prefix3, _ := jsonpath.Get("$[0].oss_bucket_destination[0].prefix", d.Get("destination"))
+		if prefix3 != nil && prefix3 != "" {
+			oSSBucketDestination["Prefix"] = prefix3
+		}
+		accountId1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].account_id", d.Get("destination"))
+		if accountId1 != nil && accountId1 != "" {
+			oSSBucketDestination["AccountId"] = accountId1
+		}
+		format1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].format", d.Get("destination"))
+		if format1 != nil && format1 != "" {
+			oSSBucketDestination["Format"] = format1
+		}
+		bucket1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].bucket", d.Get("destination"))
+		if bucket1 != nil && bucket1 != "" {
+			oSSBucketDestination["Bucket"] = bucket1
+		}
+		roleArn1, _ := jsonpath.Get("$[0].oss_bucket_destination[0].role_arn", d.Get("destination"))
+		if roleArn1 != nil && roleArn1 != "" {
+			oSSBucketDestination["RoleArn"] = roleArn1
+		}
+
+		if len(oSSBucketDestination) > 0 {
+			destination["OSSBucketDestination"] = oSSBucketDestination
+		}
+
+		if len(destination) > 0 {
+			inventoryConfiguration["Destination"] = destination
+		}
+	}
+
+	inventoryConfiguration["Id"] = d.Get("inventory_id")
+	request["InventoryConfiguration"] = inventoryConfiguration
+
+	body = request
+	if update {
+		// OSS PutBucketInventory is create-only; if the rule already exists it
+		// returns 409 InventoryConfigurationAlreadyExists. Delete the existing
+		// rule first, then re-create with the new configuration.
+		deleteAction := fmt.Sprintf("/?inventory&inventoryId=%s", parts[1])
+		waitDel := incrementalWait(3*time.Second, 5*time.Second)
+		errDel := resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			_, err = client.Do("Oss", xmlParam("DELETE", "2019-05-17", "DeleteBucketInventory", deleteAction), query, nil, nil, hostMap, false)
+			if err != nil {
+				if NeedRetry(err) {
+					waitDel()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		if errDel != nil && !IsExpectedErrors(errDel, []string{"NoSuchInventoryConfiguration"}) && !NotFoundError(errDel) {
+			return WrapErrorf(errDel, DefaultErrorMsg, d.Id(), deleteAction, AlibabaCloudSdkGoERROR)
+		}
+
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.Do("Oss", xmlParam("PUT", "2019-05-17", "PutBucketInventory", action), query, body, nil, hostMap, false)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudOssBucketInventoryRead(d, meta)
+}
+
+func resourceAliCloudOssBucketInventoryDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := fmt.Sprintf("/?inventory")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	hostMap := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+	hostMap["bucket"] = StringPointer(parts[0])
+	query["inventoryId"] = StringPointer(parts[1])
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlParam("DELETE", "2019-05-17", "DeleteBucketInventory", action), query, nil, nil, hostMap, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_oss_bucket_inventory_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_inventory_test.go
@@ -1,0 +1,352 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Oss BucketInventory. >>> Resource test cases.
+
+func TestAccAliCloudOssBucketInventory_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_oss_bucket_inventory.default"
+	ra := resourceAttrInit(resourceId, AliCloudOssBucketInventoryMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OssServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOssBucketInventory")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccossinv%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudOssBucketInventoryBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"bucket":                   "${alicloud_oss_bucket.source.id}",
+					"inventory_id":             name,
+					"is_enabled":               "true",
+					"included_object_versions": "All",
+					"schedule": []map[string]interface{}{
+						{
+							"frequency": "Daily",
+						},
+					},
+					"optional_fields": []map[string]interface{}{
+						{
+							"field": []string{"Size", "LastModifiedDate"},
+						},
+					},
+					"destination": []map[string]interface{}{
+						{
+							"oss_bucket_destination": []map[string]interface{}{
+								{
+									"format":     "CSV",
+									"account_id": "${data.alicloud_account.current.id}",
+									"role_arn":   "acs:ram::${data.alicloud_account.current.id}:role/${alicloud_ram_role_policy_attachment.default.role_name}",
+									"bucket":     "acs:oss:::${alicloud_oss_bucket.dest.id}",
+									"prefix":     "inv/",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"bucket":                                 CHECKSET,
+						"inventory_id":                           name,
+						"is_enabled":                             "true",
+						"included_object_versions":               "All",
+						"schedule.#":                             "1",
+						"schedule.0.frequency":                   "Daily",
+						"optional_fields.#":                      "1",
+						"optional_fields.0.field.#":              "2",
+						"destination.#":                          "1",
+						"destination.0.oss_bucket_destination.#": "1",
+						"destination.0.oss_bucket_destination.0.format":     "CSV",
+						"destination.0.oss_bucket_destination.0.account_id": CHECKSET,
+						"destination.0.oss_bucket_destination.0.role_arn":   CHECKSET,
+						"destination.0.oss_bucket_destination.0.bucket":     CHECKSET,
+						"destination.0.oss_bucket_destination.0.prefix":     "inv/",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"is_enabled":               "false",
+					"included_object_versions": "Current",
+					"schedule": []map[string]interface{}{
+						{
+							"frequency": "Weekly",
+						},
+					},
+					"optional_fields": []map[string]interface{}{
+						{
+							"field": []string{
+								"Size", "LastModifiedDate", "ETag", "StorageClass",
+								"IsMultipartUploaded", "EncryptionStatus",
+							},
+						},
+					},
+					"filter": []map[string]interface{}{
+						{
+							"prefix":                       "logs/",
+							"storage_class":                "Standard",
+							"lower_size_bound":             "1024",
+							"upper_size_bound":             "1048576",
+							"last_modify_begin_time_stamp": "1262275200",
+							"last_modify_end_time_stamp":   "2000000000",
+						},
+					},
+					"destination": []map[string]interface{}{
+						{
+							"oss_bucket_destination": []map[string]interface{}{
+								{
+									"format":     "CSV",
+									"account_id": "${data.alicloud_account.current.id}",
+									"role_arn":   "acs:ram::${data.alicloud_account.current.id}:role/${alicloud_ram_role.default.name}",
+									"bucket":     "acs:oss:::${alicloud_oss_bucket.dest.id}",
+									"prefix":     "inv-v2/",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"is_enabled":                                    "false",
+						"included_object_versions":                      "Current",
+						"schedule.0.frequency":                          "Weekly",
+						"optional_fields.0.field.#":                     "6",
+						"filter.#":                                      "1",
+						"filter.0.prefix":                               "logs/",
+						"filter.0.storage_class":                        "Standard",
+						"filter.0.lower_size_bound":                     "1024",
+						"filter.0.upper_size_bound":                     "1048576",
+						"filter.0.last_modify_begin_time_stamp":         "1262275200",
+						"filter.0.last_modify_end_time_stamp":           "2000000000",
+						"destination.0.oss_bucket_destination.0.format": "CSV",
+						"destination.0.oss_bucket_destination.0.prefix": "inv-v2/",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AliCloudOssBucketInventoryMap = map[string]string{}
+
+func AliCloudOssBucketInventoryBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_account" "current" {
+}
+
+resource "alicloud_oss_bucket" "source" {
+  bucket        = "${var.name}-src"
+  storage_class = "Standard"
+}
+
+resource "alicloud_oss_bucket" "dest" {
+  bucket        = "${var.name}-dst"
+  storage_class = "Standard"
+}
+
+resource "alicloud_kms_key" "default" {
+  description             = "${var.name}"
+  pending_window_in_days  = 7
+  key_state               = "Enabled"
+}
+
+resource "alicloud_ram_role" "default" {
+  name        = "${var.name}"
+  document    = <<EOF
+{
+    "Statement": [
+      {
+        "Action": "sts:AssumeRole",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": [
+            "oss.aliyuncs.com"
+          ]
+        }
+      }
+    ],
+    "Version": "1"
+  }
+EOF
+  description = "this is a test for bucket inventory."
+  force       = true
+}
+
+resource "alicloud_ram_policy" "default" {
+  name     = "${var.name}"
+  document = <<EOF
+{
+  "Statement": [
+    {
+      "Action": ["oss:PutObject", "oss:AbortMultipartUpload"],
+      "Effect": "Allow",
+      "Resource": ["acs:oss:*:*:${alicloud_oss_bucket.dest.id}/*"]
+    }
+  ],
+  "Version": "1"
+}
+EOF
+  force    = true
+}
+
+resource "alicloud_ram_role_policy_attachment" "default" {
+  policy_name = "${alicloud_ram_policy.default.name}"
+  policy_type = "${alicloud_ram_policy.default.type}"
+  role_name   = "${alicloud_ram_role.default.name}"
+}
+
+`, name)
+}
+
+// TestAccAliCloudOssBucketInventory_incremental covers the incremental_inventory
+// attribute tree. It is skipped by default because OSS's Incremental Inventory
+// feature is not enabled on every account; when enabled, this test creates a
+// bucket inventory rule that also exports an incremental report every 600s.
+func TestAccAliCloudOssBucketInventory_incremental(t *testing.T) {
+	t.Skip("OSS Incremental Inventory is an account-level opt-in feature; skip by default.")
+	var v map[string]interface{}
+	resourceId := "alicloud_oss_bucket_inventory.default"
+	ra := resourceAttrInit(resourceId, AliCloudOssBucketInventoryMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OssServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOssBucketInventory")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccossinv%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudOssBucketInventoryBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"bucket":                   "${alicloud_oss_bucket.source.id}",
+					"inventory_id":             name,
+					"is_enabled":               "true",
+					"included_object_versions": "All",
+					"schedule": []map[string]interface{}{
+						{
+							"frequency": "Daily",
+						},
+					},
+					"optional_fields": []map[string]interface{}{
+						{
+							"field": []string{"Size", "LastModifiedDate"},
+						},
+					},
+					"destination": []map[string]interface{}{
+						{
+							"oss_bucket_destination": []map[string]interface{}{
+								{
+									"format":     "CSV",
+									"account_id": "${data.alicloud_account.current.id}",
+									"role_arn":   "acs:ram::${data.alicloud_account.current.id}:role/${alicloud_ram_role_policy_attachment.default.role_name}",
+									"bucket":     "acs:oss:::${alicloud_oss_bucket.dest.id}",
+									"prefix":     "inv/",
+									"encryption": []map[string]interface{}{
+										{
+											"sseoss": "",
+											"ssekms": []map[string]interface{}{
+												{
+													"key_id": "${alicloud_kms_key.default.id}",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"incremental_inventory": []map[string]interface{}{
+						{
+							"is_enabled": "true",
+							"schedule": []map[string]interface{}{
+								{
+									"frequency": "600",
+								},
+							},
+							"optional_fields": []map[string]interface{}{
+								{
+									"field": []string{"Size", "LastModifiedDate"},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"destination.0.oss_bucket_destination.0.encryption.#":                 "1",
+						"destination.0.oss_bucket_destination.0.encryption.0.ssekms.#":        "1",
+						"destination.0.oss_bucket_destination.0.encryption.0.ssekms.0.key_id": CHECKSET,
+						"destination.0.oss_bucket_destination.0.encryption.0.sseoss":          "",
+						"incremental_inventory.#":                                             "1",
+						"incremental_inventory.0.is_enabled":                                  "true",
+						"incremental_inventory.0.schedule.#":                                  "1",
+						"incremental_inventory.0.schedule.0.frequency":                        "600",
+						"incremental_inventory.0.optional_fields.#":                           "1",
+						"incremental_inventory.0.optional_fields.0.field.#":                   "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"incremental_inventory": []map[string]interface{}{
+						{
+							"is_enabled": "false",
+							"schedule": []map[string]interface{}{
+								{
+									"frequency": "600",
+								},
+							},
+							"optional_fields": []map[string]interface{}{
+								{
+									"field": []string{"Size", "LastModifiedDate", "ETag"},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"incremental_inventory.0.is_enabled":                "false",
+						"incremental_inventory.0.optional_fields.0.field.#": "3",
+					}),
+				),
+			},
+		},
+	})
+}
+
+// Test Oss BucketInventory. <<< Resource test cases.

--- a/alicloud/service_alicloud_oss_v2.go
+++ b/alicloud/service_alicloud_oss_v2.go
@@ -1985,3 +1985,85 @@ func (s *OssServiceV2) OssBucketObjectWormConfigurationStateRefreshFuncWithApi(i
 }
 
 // DescribeOssBucketObjectWormConfiguration >>> Encapsulated.
+// DescribeOssBucketInventory <<< Encapsulated get interface for Oss BucketInventory.
+
+func (s *OssServiceV2) DescribeOssBucketInventory(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	hostMap := make(map[string]*string)
+	hostMap["bucket"] = StringPointer(parts[0])
+	query["inventoryId"] = StringPointer(parts[1])
+
+	action := fmt.Sprintf("/?inventory&inventoryId=%s", parts[1])
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlParam("GET", "2019-05-17", "GetBucketInventory", action), query, nil, nil, hostMap, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NoSuchBucket", "NoSuchInventoryConfiguration"}) {
+			return object, WrapErrorf(NotFoundErr("BucketInventory", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.InventoryConfiguration", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.InventoryConfiguration", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *OssServiceV2) OssBucketInventoryStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.OssBucketInventoryStateRefreshFuncWithApi(id, field, failStates, s.DescribeOssBucketInventory)
+}
+
+func (s *OssServiceV2) OssBucketInventoryStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeOssBucketInventory >>> Encapsulated.

--- a/website/docs/d/oss_bucket_inventories.html.markdown
+++ b/website/docs/d/oss_bucket_inventories.html.markdown
@@ -1,0 +1,107 @@
+---
+subcategory: "OSS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_oss_bucket_inventories"
+sidebar_current: "docs-alicloud-datasource-oss-bucket-inventories"
+description: |-
+  Provides a list of Oss Bucket Inventory owned by an Alibaba Cloud account.
+---
+
+# alicloud_oss_bucket_inventories
+
+This data source provides Oss Bucket Inventory available to the user.[What is Bucket Inventory](https://next.api.alibabacloud.com/document/Oss/2019-05-17/PutBucketInventory)
+
+-> **NOTE:** Available since v1.284.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = ""
+}
+
+resource "alicloud_oss_bucket" "CreateBucket" {
+  storage_class = "Standard"
+}
+
+
+resource "alicloud_oss_bucket_inventory" "default" {
+  destination {
+  }
+  optional_fields {
+    field = ["Size", "LastModifiedDate", "ETag"]
+  }
+  bucket = alicloud_oss_bucket.CreateBucket.id
+  filter {
+    prefix           = "Pics/"
+    lower_size_bound = "256"
+    upper_size_bound = "999999"
+    storage_class    = "Standard"
+  }
+  included_object_versions = "Current"
+  schedule {
+    frequency = "Daily"
+  }
+  inventory_id = "report01"
+  is_enabled   = false
+}
+
+data "alicloud_oss_bucket_inventories" "default" {
+  ids    = ["${alicloud_oss_bucket_inventory.default.id}"]
+  bucket = alicloud_oss_bucket.CreateBucket.id
+}
+
+output "alicloud_oss_bucket_inventory_example_id" {
+  value = data.alicloud_oss_bucket_inventories.default.inventories.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `bucket` - (Required, ForceNew) The name of the bucket.
+* `ids` - (Optional, ForceNew, Computed) A list of Bucket Inventory IDs. The value is formulated as `<bucket>:<inventory_id>`.
+* `output_file` - (Optional, ForceNew) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Bucket Inventory IDs.
+* `inventories` - A list of Bucket Inventory Entries. Each element contains the following attributes:
+    * `destination` - Holds the container that holds the location of the inventory results.
+        * `oss_bucket_destination` - The Bucket information stored after the list result is exported.
+            * `account_id` - The account ID granted by the Bucket owner.
+            * `bucket` - The Bucket where the exported manifest file is stored.
+            * `encryption` - The encryption method of the manifest file.
+                * `ssekms` - The container that holds the SSE-KMS encryption key.
+                    * `key_id` - KMS key ID.
+                * `sseoss` - The container that holds the SSE-OSS encryption method.
+            * `format` - The file format of the manifest file.
+            * `prefix` - The storage path prefix for the manifest file.
+            * `role_arn` - The name of the role that has the permission to read all files in the source Bucket and write files to the target Bucket.
+    * `filter` - Container for inventory filtering rules.
+        * `last_modify_begin_time_stamp` - The start timestamp of the last modification time of the filter file, in seconds.
+        * `last_modify_end_time_stamp` - The end timestamp of the last modification time of the filter file, in seconds.
+        * `lower_size_bound` - The minimum size of the filter file, in B.
+        * `prefix` - The match prefix of the filter rule.
+        * `storage_class` - The storage type of the filter file.
+        * `upper_size_bound` - The maximum size of the filter file, in B.
+    * `included_object_versions` - Whether the Object version information is included in the list.
+    * `incremental_inventory` - Configuration container for incremental inventory.
+        * `is_enabled` - Incremental inventory enabled.
+        * `optional_fields` - Configuration container for incremental manifest file properties.
+            * `field` - Incremental inventory export field list.
+        * `schedule` - Incremental inventory export cycle container.
+            * `frequency` - Describes the period of incremental inventory file export, in seconds, currently fixed at 10 minutes.
+    * `inventory_id` - The ID of the inventory rule.
+    * `is_enabled` - Identification of whether the manifest feature is enabled.
+    * `optional_fields` - Sets the configuration items included in the manifest results.
+        * `field` - The configuration items contained in the manifest results.
+    * `schedule` - Container for storing inventory export cycle information.
+        * `frequency` - Period for manifest file export.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/oss_bucket_inventory.html.markdown
+++ b/website/docs/r/oss_bucket_inventory.html.markdown
@@ -1,0 +1,153 @@
+---
+subcategory: "OSS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_oss_bucket_inventory"
+description: |-
+  Provides a Alicloud OSS Bucket Inventory resource.
+---
+
+# alicloud_oss_bucket_inventory
+
+Provides a OSS Bucket Inventory resource.
+
+The inventory rule of an OSS bucket. Inventory periodically exports object metadata from a bucket.
+
+For information about OSS Bucket Inventory and how to use it, see [What is Bucket Inventory](https://next.api.alibabacloud.com/document/Oss/2019-05-17/PutBucketInventory).
+
+-> **NOTE:** Available since v1.284.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_oss_bucket" "CreateBucket" {
+  storage_class = "Standard"
+}
+
+
+resource "alicloud_oss_bucket_inventory" "default" {
+  destination {
+  }
+  optional_fields {
+    field = ["Size", "LastModifiedDate", "ETag"]
+  }
+  bucket = alicloud_oss_bucket.CreateBucket.id
+  filter {
+    prefix           = "Pics/"
+    lower_size_bound = "256"
+    upper_size_bound = "999999"
+    storage_class    = "Standard"
+  }
+  included_object_versions = "Current"
+  schedule {
+    frequency = "Daily"
+  }
+  inventory_id = "report01"
+  is_enabled   = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `bucket` - (Required, ForceNew) The name of the bucket.
+* `destination` - (Optional, Set) Holds the container that holds the location of the inventory results. **Note:** The parameter is immutable after resource creation and the exported storage location cannot be modified without recreating the rule. See [`destination`](#destination) below.
+* `filter` - (Optional, Set) Container for inventory filtering rules. See [`filter`](#filter) below.
+* `included_object_versions` - (Optional) Whether the Object version information is included in the list. Valid values: All: export All version information of the Object. Current: exports the Current version of the Object.
+* `incremental_inventory` - (Optional, Set) Configuration container for incremental inventory. **Note:** The parameter is immutable after resource creation; OSS fixes the incremental export cycle server-side. See [`incremental_inventory`](#incremental_inventory) below.
+* `inventory_id` - (Required, ForceNew) The ID of the inventory rule. The ID must be unique in the bucket.
+* `is_enabled` - (Optional) Identification of whether the manifest feature is enabled. Valid values: true: Enable the inventory feature. false: Do not enable the manifest feature.
+* `optional_fields` - (Optional, Set) Sets the configuration items included in the manifest results. See [`optional_fields`](#optional_fields) below.
+* `schedule` - (Optional, Set) Container for storing inventory export cycle information. See [`schedule`](#schedule) below.
+
+### `destination`
+
+The destination supports the following:
+* `oss_bucket_destination` - (Optional, Set) The Bucket information stored after the list result is exported. See [`oss_bucket_destination`](#destination-oss_bucket_destination) below.
+
+### `destination-oss_bucket_destination`
+
+The destination-oss_bucket_destination supports the following:
+* `account_id` - (Optional) The account ID granted by the Bucket owner.
+* `bucket` - (Optional) The Bucket where the exported manifest file is stored.
+* `encryption` - (Optional, Set) The encryption method of the manifest file. Valid value: SSE-OSS: Use the OSS fully managed key for encryption and decryption. SSE-KMS: Use the default KMS-managed CMK(Customer Master Key) or a specified CMK for encryption and decryption. See [`encryption`](#destination-oss_bucket_destination-encryption) below.
+* `format` - (Optional) The file format of the manifest file.
+* `prefix` - (Optional) The storage path prefix for the manifest file.
+* `role_arn` - (Optional) The name of the role that has the permission to read all files in the source Bucket and write files to the target Bucket. The format is acs:ram::uid:role/rolename.
+
+### `destination-oss_bucket_destination-encryption`
+
+The destination-oss_bucket_destination-encryption supports the following:
+* `ssekms` - (Optional, Set) The container that holds the SSE-KMS encryption key. See [`ssekms`](#destination-oss_bucket_destination-encryption-ssekms) below.
+* `sseoss` - (Optional) The container that holds the SSE-OSS encryption method. Set it to an empty string when OSS-managed keys are used.
+
+### `destination-oss_bucket_destination-encryption-ssekms`
+
+The destination-oss_bucket_destination-encryption-ssekms supports the following:
+* `key_id` - (Optional) KMS key ID.
+
+### `filter`
+
+The filter supports the following:
+* `last_modify_begin_time_stamp` - (Optional, Int) The start timestamp of the last modification time of the filter file, in seconds. Value range:[1262275200, 253402271999]
+* `last_modify_end_time_stamp` - (Optional, Int) The end timestamp of the last modification time of the filter file, in seconds. Value range:[1262275200, 253402271999]
+* `lower_size_bound` - (Optional, Int) The minimum size of the filter file, in B. Value range: greater than or equal to 0 B, less than or equal to 48.8 TB.
+* `prefix` - (Optional) The match prefix of the filter rule.
+* `storage_class` - (Optional) The storage type of the filter file. Multiple storage types can be specified. Optional values: Standard: Standard storage IA: low-frequency access Archive: Archive storage ColdArchive: cold Archive storage All (default): All storage types
+* `upper_size_bound` - (Optional, Int) The maximum size of the filter file, in B. Value range: greater than 0 B, less than or equal to 48.8 TB.
+
+### `incremental_inventory`
+
+The incremental_inventory supports the following:
+* `is_enabled` - (Optional) Incremental inventory enabled
+* `optional_fields` - (Optional, Set) Configuration container for incremental manifest file properties See [`optional_fields`](#incremental_inventory-optional_fields) below.
+* `schedule` - (Optional, Set) Incremental inventory export cycle container See [`schedule`](#incremental_inventory-schedule) below.
+
+### `incremental_inventory-optional_fields`
+
+The incremental_inventory-optional_fields supports the following:
+* `field` - (Optional, List) Incremental inventory export field list
+
+### `incremental_inventory-schedule`
+
+The incremental_inventory-schedule supports the following:
+* `frequency` - (Optional, Int) Describes the period of incremental inventory file export, in seconds, currently fixed at 10 minutes.
+
+### `optional_fields`
+
+The optional_fields supports the following:
+* `field` - (Optional, List) The configuration items contained in the manifest results.
+
+### `schedule`
+
+The schedule supports the following:
+* `frequency` - (Optional) Period for manifest file export.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<bucket>:<inventory_id>`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Bucket Inventory.
+* `delete` - (Defaults to 5 mins) Used when delete the Bucket Inventory.
+* `update` - (Defaults to 5 mins) Used when update the Bucket Inventory.
+
+## Import
+
+OSS Bucket Inventory can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_oss_bucket_inventory.example <bucket>:<inventory_id>
+```


### PR DESCRIPTION
## Summary

- Add resource `alicloud_oss_bucket_inventory` (Create / Read / Update / Delete + Import) backed by OSS `PutBucketInventory` / `GetBucketInventory` / `DeleteBucketInventory`.
- Add data source `alicloud_oss_bucket_inventories` (List) backed by OSS `ListBucketInventory`, with per-item detail fields.
- Cover the full attribute set from the OSS Bucket Inventory API: `bucket`, `inventory_id`, `is_enabled`, `included_object_versions`, `schedule.frequency`, `filter.{prefix, storage_class, lower_size_bound, upper_size_bound, last_modify_begin_time_stamp, last_modify_end_time_stamp}`, `optional_fields.field`, `incremental_inventory.{is_enabled, schedule.frequency, optional_fields.field}`, and `destination.oss_bucket_destination.{format, bucket, account_id, role_arn, prefix, encryption.{sseoss, ssekms.key_id}}`.

## Notes

- Update path uses Delete + Put because `PutBucketInventory` is create-only on the OSS service side (returns 409 `InventoryConfigurationAlreadyExists` on an existing rule).
- `destination.oss_bucket_destination.bucket` follows the OSS API contract and must be the ACS ARN form `acs:oss:::<bucket_name>`.

## Acc test

```
=== RUN   TestAccAliCloudOssBucketInventory_basic
--- PASS: TestAccAliCloudOssBucketInventory_basic (16.12s)

=== RUN   TestAccAliCloudOssBucketInventoriesDataSource_basic
--- PASS: TestAccAliCloudOssBucketInventoriesDataSource_basic (15.29s)
```