### PR TITLE
New Resource: alicloud_das_sql_log_config, New Data Source: alicloud_das_sql_log_configs

### DIFF
--- a/alicloud/data_source_alicloud_das_sql_log_configs.go
+++ b/alicloud/data_source_alicloud_das_sql_log_configs.go
@@ -1,0 +1,147 @@
+package alicloud
+
+import (
+	"fmt"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudDasSqlLogConfigs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudDasSqlLogConfigsRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"configs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"request_enable": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"retention": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"hot_retention": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cold_retention": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"log_filter": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"sql_log_visible_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudDasSqlLogConfigsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	dasServiceV2 := DasServiceV2{client}
+
+	instanceId := d.Get("instance_id").(string)
+
+	objectRaw, err := dasServiceV2.DescribeDasSqlLogConfig(instanceId)
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId(dataResourceIdHash([]string{instanceId}))
+			d.Set("ids", []string{})
+			d.Set("configs", []map[string]interface{}{})
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	dataRawObj, _ := jsonpath.Get("$.Data", objectRaw)
+	dataRaw := make(map[string]interface{})
+	if dataRawObj != nil {
+		dataRaw = dataRawObj.(map[string]interface{})
+	}
+
+	toBool := func(v interface{}) bool {
+		b, _ := v.(bool)
+		return b
+	}
+	toStr := func(v interface{}) string {
+		if v == nil {
+			return ""
+		}
+		s, _ := v.(string)
+		return s
+	}
+
+	mapping := map[string]interface{}{
+		"id":                   instanceId,
+		"instance_id":          instanceId,
+		"enable":               toBool(dataRaw["SqlLogEnable"]),
+		"request_enable":       toBool(dataRaw["RequestEnable"]),
+		"retention":            formatInt(dataRaw["Retention"]),
+		"hot_retention":        formatInt(dataRaw["HotRetention"]),
+		"cold_retention":       formatInt(dataRaw["ColdRetention"]),
+		"version":              toStr(dataRaw["Version"]),
+		"log_filter":           toStr(dataRaw["LogFilter"]),
+		"sql_log_visible_time": formatInt(dataRaw["SqlLogVisibleTime"]),
+	}
+
+	d.SetId(dataResourceIdHash([]string{instanceId}))
+	if err := d.Set("instance_id", instanceId); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("ids", []string{instanceId}); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("configs", []map[string]interface{}{mapping}); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		if err := writeToFile(output.(string), []map[string]interface{}{mapping}); err != nil {
+			return WrapError(fmt.Errorf("writing output file: %w", err))
+		}
+	}
+
+	return nil
+}

--- a/alicloud/data_source_alicloud_das_sql_log_configs_test.go
+++ b/alicloud/data_source_alicloud_das_sql_log_configs_test.go
@@ -1,0 +1,105 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudDasSqlLogConfigDataSource(t *testing.T) {
+	checkoutSupportedRegions(t, true, connectivity.TestSalveRegions)
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	instanceIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudDasSqlLogConfigDataSourceConfig(rand, map[string]string{
+			"instance_id": `"${alicloud_das_sql_log_config.default.instance_id}"`,
+		}),
+	}
+
+	DasSqlLogConfigCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, func() {
+		testAccPreCheck(t)
+	}, instanceIdConf)
+}
+
+var existDasSqlLogConfigMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"configs.#":               "1",
+		"configs.0.id":            CHECKSET,
+		"configs.0.instance_id":   CHECKSET,
+		"configs.0.retention":     "30",
+		"configs.0.hot_retention": "7",
+		"ids.#":                   "1",
+	}
+}
+
+var fakeDasSqlLogConfigMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"configs.#": "1",
+		"ids.#":     "1",
+	}
+}
+
+var DasSqlLogConfigCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_das_sql_log_configs.default",
+	existMapFunc: existDasSqlLogConfigMapFunc,
+	fakeMapFunc:  fakeDasSqlLogConfigMapFunc,
+}
+
+func testAccCheckAliCloudDasSqlLogConfigDataSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccDasSqlLogConfig%d"
+}
+
+data "alicloud_polardb_zones" "default" {}
+
+data "alicloud_polardb_node_classes" "default" {
+  db_type    = "MySQL"
+  db_version = "8.0"
+  pay_type   = "PostPaid"
+  zone_id    = data.alicloud_polardb_zones.default.ids[length(data.alicloud_polardb_zones.default.ids) - 1]
+  category   = "Normal"
+}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+  zone_id      = data.alicloud_polardb_zones.default.ids[length(data.alicloud_polardb_zones.default.ids) - 1]
+  vpc_id       = alicloud_vpc.default.id
+  vswitch_name = var.name
+  cidr_block   = "172.16.0.0/24"
+}
+
+resource "alicloud_polardb_cluster" "default" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  pay_type      = "PostPaid"
+  db_node_class = data.alicloud_polardb_node_classes.default.classes.0.supported_engines.0.available_resources.0.db_node_class
+  vswitch_id    = alicloud_vswitch.default.id
+  description   = var.name
+}
+
+resource "alicloud_das_sql_log_config" "default" {
+  instance_id    = alicloud_polardb_cluster.default.id
+  enable         = true
+  request_enable = true
+  retention      = 30
+  hot_retention  = 7
+}
+
+data "alicloud_das_sql_log_configs" "default" {
+  %s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -926,8 +926,10 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cloud_monitor_service_hybrid_double_writes":       dataSourceAliCloudCloudMonitorServiceHybridDoubleWrites(),
 			"alicloud_cms_site_monitors":                                dataSourceAliCloudCloudMonitorServiceSiteMonitors(),
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
+			"alicloud_das_sql_log_configs":                              dataSourceAliCloudDasSqlLogConfigs(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_das_sql_log_config":                                   resourceAliCloudDasSqlLogConfig(),
 			"alicloud_oss_bucket_inventory":                                 resourceAliCloudOssBucketInventory(),
 			"alicloud_resource_manager_resource_directory_sharing":          resourceAliCloudResourceManagerResourceDirectorySharing(),
 			"alicloud_wafv3_address_book":                                   resourceAliCloudWafv3AddressBook(),

--- a/alicloud/resource_alicloud_das_sql_log_config.go
+++ b/alicloud/resource_alicloud_das_sql_log_config.go
@@ -1,0 +1,218 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudDasSqlLogConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudDasSqlLogConfigCreate,
+		Read:   resourceAliCloudDasSqlLogConfigRead,
+		Update: resourceAliCloudDasSqlLogConfigUpdate,
+		Delete: resourceAliCloudDasSqlLogConfigDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"cold_retention": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"hot_retention": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"log_filter": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"request_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"retention": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"sql_log_visible_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudDasSqlLogConfigCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	var err error
+	action := "ModifySqlLogConfig"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	instanceId := d.Get("instance_id").(string)
+	request["InstanceId"] = instanceId
+
+	if v, ok := d.GetOkExists("enable"); ok {
+		request["Enable"] = v
+	}
+	if v, ok := d.GetOkExists("request_enable"); ok {
+		request["RequestEnable"] = v
+	}
+	if v, ok := d.GetOkExists("retention"); ok {
+		request["Retention"] = v
+	}
+	if v, ok := d.GetOkExists("hot_retention"); ok {
+		request["HotRetention"] = v
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("DAS", "2020-01-16", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_das_sql_log_config", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(instanceId)
+
+	return resourceAliCloudDasSqlLogConfigRead(d, meta)
+}
+
+func resourceAliCloudDasSqlLogConfigRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	dasServiceV2 := DasServiceV2{client}
+
+	objectRaw, err := dasServiceV2.DescribeDasSqlLogConfig(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_das_sql_log_config DescribeDasSqlLogConfig Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	dataRawObj, _ := jsonpath.Get("$.Data", objectRaw)
+	dataRaw := make(map[string]interface{})
+	if dataRawObj != nil {
+		dataRaw = dataRawObj.(map[string]interface{})
+	}
+	d.Set("instance_id", d.Id())
+	d.Set("cold_retention", dataRaw["ColdRetention"])
+	d.Set("hot_retention", dataRaw["HotRetention"])
+	d.Set("log_filter", dataRaw["LogFilter"])
+	d.Set("request_enable", dataRaw["RequestEnable"])
+	d.Set("retention", dataRaw["Retention"])
+	d.Set("sql_log_visible_time", dataRaw["SqlLogVisibleTime"])
+	d.Set("version", dataRaw["Version"])
+	d.Set("enable", dataRaw["SqlLogEnable"])
+
+	return nil
+}
+
+func resourceAliCloudDasSqlLogConfigUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "ModifySqlLogConfig"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["InstanceId"] = d.Id()
+
+	if d.HasChange("enable") {
+		update = true
+	}
+	if d.HasChange("request_enable") {
+		update = true
+	}
+	if d.HasChange("retention") {
+		update = true
+	}
+	if d.HasChange("hot_retention") {
+		update = true
+	}
+
+	if update {
+		if v, ok := d.GetOkExists("enable"); ok {
+			request["Enable"] = v
+		}
+		if v, ok := d.GetOkExists("request_enable"); ok {
+			request["RequestEnable"] = v
+		}
+		if v, ok := d.GetOkExists("retention"); ok {
+			request["Retention"] = v
+		}
+		if v, ok := d.GetOkExists("hot_retention"); ok {
+			request["HotRetention"] = v
+		}
+
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("DAS", "2020-01-16", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudDasSqlLogConfigRead(d, meta)
+}
+
+func resourceAliCloudDasSqlLogConfigDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource AliCloud Resource Sql Log Config. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_das_sql_log_config_test.go
+++ b/alicloud/resource_alicloud_das_sql_log_config_test.go
@@ -1,0 +1,127 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudDasSqlLogConfig_basic0(t *testing.T) {
+	var v map[string]interface{}
+	checkoutSupportedRegions(t, true, connectivity.TestSalveRegions)
+	resourceId := "alicloud_das_sql_log_config.default"
+	ra := resourceAttrInit(resourceId, AliCloudDasSqlLogConfigMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &DasServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeDasSqlLogConfig")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccDasSqlLogConfig-name%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudDasSqlLogConfigBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_id":    "${alicloud_polardb_cluster.default.id}",
+					"enable":         "true",
+					"request_enable": "true",
+					"retention":      "30",
+					"hot_retention":  "7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_id":    CHECKSET,
+						"enable":         "true",
+						"request_enable": "true",
+						"retention":      "30",
+						"hot_retention":  "7",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"retention":     "180",
+					"hot_retention": "7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"retention":     "180",
+						"hot_retention": "7",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"retention":     "180",
+					"hot_retention": "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"retention":     "180",
+						"hot_retention": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"enable", "request_enable"},
+			},
+		},
+	})
+}
+
+var AliCloudDasSqlLogConfigMap0 = map[string]string{
+	"instance_id": CHECKSET,
+}
+
+func AliCloudDasSqlLogConfigBasicDependence0(name string) string {
+	return fmt.Sprintf(`
+	variable "name" {
+  		default = "%s"
+	}
+
+	data "alicloud_polardb_zones" "default" {
+	}
+
+	data "alicloud_polardb_node_classes" "default" {
+  		db_type    = "MySQL"
+  		db_version = "8.0"
+  		pay_type   = "PostPaid"
+  		zone_id    = data.alicloud_polardb_zones.default.ids[length(data.alicloud_polardb_zones.default.ids) - 1]
+  		category   = "Normal"
+	}
+
+	resource "alicloud_vpc" "default" {
+  		vpc_name   = var.name
+  		cidr_block = "172.16.0.0/16"
+	}
+
+	resource "alicloud_vswitch" "default" {
+  		zone_id      = data.alicloud_polardb_zones.default.ids[length(data.alicloud_polardb_zones.default.ids) - 1]
+  		vpc_id       = alicloud_vpc.default.id
+  		vswitch_name = var.name
+  		cidr_block   = "172.16.0.0/24"
+	}
+
+	resource "alicloud_polardb_cluster" "default" {
+  		db_type       = "MySQL"
+  		db_version    = "8.0"
+  		pay_type      = "PostPaid"
+  		db_node_class = data.alicloud_polardb_node_classes.default.classes.0.supported_engines.0.available_resources.0.db_node_class
+  		vswitch_id    = alicloud_vswitch.default.id
+  		description   = var.name
+	}
+`, name)
+}

--- a/alicloud/service_alicloud_das_v2.go
+++ b/alicloud/service_alicloud_das_v2.go
@@ -1,0 +1,86 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+type DasServiceV2 struct {
+	client *connectivity.AliyunClient
+}
+
+// DescribeDasSqlLogConfig <<< Encapsulated get interface for Das SqlLogConfig.
+
+func (s *DasServiceV2) DescribeDasSqlLogConfig(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["InstanceId"] = id
+
+	action := "DescribeSqlLogConfig"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("DAS", "2020-01-16", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	code, _ := jsonpath.Get("$.Data", response)
+	if InArray(fmt.Sprint(code), []string{"-404"}) {
+		return object, WrapErrorf(NotFoundErr("SqlLogConfig", id), NotFoundMsg, response)
+	}
+
+	return response, nil
+}
+
+func (s *DasServiceV2) DasSqlLogConfigStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.DasSqlLogConfigStateRefreshFuncWithApi(id, field, failStates, s.DescribeDasSqlLogConfig)
+}
+
+func (s *DasServiceV2) DasSqlLogConfigStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeDasSqlLogConfig >>> Encapsulated.

--- a/website/docs/d/das_sql_log_configs.html.markdown
+++ b/website/docs/d/das_sql_log_configs.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "DAS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_das_sql_log_configs"
+description: |-
+  Provides a list of DAS Sql Log Configs to the user.
+---
+
+# alicloud_das_sql_log_configs
+
+This data source provides the DAS Sql Log Config of the current Alibaba Cloud user.
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+data "alicloud_db_instances" "default" {
+  status = "Running"
+}
+
+data "alicloud_das_sql_log_configs" "default" {
+  instance_id = data.alicloud_db_instances.default.instances.0.id
+}
+
+output "das_sql_log_config_enable" {
+  value = data.alicloud_das_sql_log_configs.default.configs.0.enable
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `instance_id` - (Required) The ID of the database instance to query the SQL log configuration for.
+* `ids` - (Optional, Computed) A list of Sql Log Config IDs. Its element value is same as the instance ID.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `configs` - A list of Sql Log Config Entries. Each element contains the following attributes:
+    * `id` - The ID of the Sql Log Config. Its value is same as `instance_id`.
+    * `instance_id` - The ID of the database instance.
+    * `enable` - Specifies whether SQL Explorer is enabled.
+    * `request_enable` - The requested state of SQL Explorer.
+    * `retention` - The retention period of SQL audit logs. Unit: days.
+    * `hot_retention` - The retention period of hot SQL audit logs. Unit: days.
+    * `cold_retention` - The retention period of cold SQL audit logs. Calculated as `retention - hot_retention`.
+    * `version` - The current version of SQL audit logs.
+    * `log_filter` - The configuration of log filters.
+    * `sql_log_visible_time` - The visible start time of SQL audit logs.

--- a/website/docs/r/das_sql_log_config.html.markdown
+++ b/website/docs/r/das_sql_log_config.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "DAS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_das_sql_log_config"
+description: |-
+  Provides a Alicloud DAS Sql Log Config resource.
+---
+
+# alicloud_das_sql_log_config
+
+Provides a DAS Sql Log Config resource.
+
+SQL audit log configuration for database instances.
+
+For information about DAS Sql Log Config and how to use it, see [What is Sql Log Config](https://next.api.alibabacloud.com/document/DAS/2020-01-16/DescribeSqlLogConfig).
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "tf-example"
+}
+
+data "alicloud_db_instances" "default" {
+  status = "Running"
+}
+
+resource "alicloud_das_sql_log_config" "default" {
+  instance_id    = data.alicloud_db_instances.default.instances.0.id
+  enable         = true
+  request_enable = true
+  retention      = 30
+  hot_retention  = 7
+}
+```
+
+### Deleting `alicloud_das_sql_log_config` or removing it from your configuration
+
+Terraform cannot destroy resource `alicloud_das_sql_log_config`. Terraform will remove this resource from the state file, however resources may remain.
+
+## Argument Reference
+
+The following arguments are supported:
+* `instance_id` - (Required, ForceNew) The ID of the database instance.
+* `enable` - (Optional, Computed) Specifies whether SQL Explorer is enabled.
+* `request_enable` - (Optional, Computed) The requested state of SQL Explorer.
+* `retention` - (Optional, Computed, Int) The retention period of SQL audit logs. Unit: days.
+* `hot_retention` - (Optional, Computed, Int) The retention period of hot SQL audit logs. Unit: days.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource, formatted as `<instance_id>`.
+* `cold_retention` - The retention period of cold SQL audit logs. Calculated as `retention - hot_retention`.
+* `log_filter` - The configuration of log filters.
+* `sql_log_visible_time` - The visible start time of SQL audit logs.
+* `version` - The current version of SQL audit logs.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when creating the Sql Log Config.
+* `update` - (Defaults to 5 mins) Used when updating the Sql Log Config.
+* `delete` - (Defaults to 5 mins) Used when deleting the Sql Log Config.
+
+## Import
+
+DAS Sql Log Config can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_das_sql_log_config.example <instance_id>
+```


### PR DESCRIPTION
## Summary
- New resource `alicloud_das_sql_log_config` and data source `alicloud_das_sql_log_configs` for managing DAS SQL audit log configuration on database instances.
- Backed by DAS OpenAPI `ModifySqlLogConfig` (create/update) and `DescribeSqlLogConfig` (read). Config-style resource: no cloud-side delete.

## Test plan
```
=== RUN   TestAccAliCloudDasSqlLogConfig_basic0
--- PASS: TestAccAliCloudDasSqlLogConfig_basic0 (414.14s)

=== RUN   TestAccAliCloudDasSqlLogConfigDataSource
--- PASS: TestAccAliCloudDasSqlLogConfigDataSource (406.93s)
```