### PR TITLE
resource/alicloud_drds_polardbx_instance: support ModifyDBInstanceClass; New Data Source: alicloud_drds_polardbx_instances

### DIFF
--- a/alicloud/data_source_alicloud_drds_polardbx_instances.go
+++ b/alicloud/data_source_alicloud_drds_polardbx_instances.go
@@ -1,0 +1,304 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAliCloudDrdsPolardbxInstances() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudDrdsPolardbxInstancesRead,
+		Schema: map[string]*schema.Schema{
+			"description_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsValidRegExp,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"page_number": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"page_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  100,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"descriptions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"total_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"polardbx_instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cn_class": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cn_node_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dn_class": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dn_node_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"engine_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"payment_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"primary_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"secondary_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"storage_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tertiary_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"topology_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"zone_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudDrdsPolardbxInstancesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "DescribeDBInstances"
+	request := make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
+	}
+	if v, ok := d.GetOk("page_number"); ok && v.(int) > 0 {
+		request["PageNumber"] = v.(int)
+	} else {
+		request["PageNumber"] = 1
+	}
+	if v, ok := d.GetOk("page_size"); ok && v.(int) > 0 {
+		request["PageSize"] = v.(int)
+	} else {
+		request["PageSize"] = PageSizeLarge
+	}
+
+	var descriptionRegex *regexp.Regexp
+	if v, ok := d.GetOk("description_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		descriptionRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	statusFilter := ""
+	if v, ok := d.GetOk("status"); ok {
+		statusFilter = v.(string)
+	}
+
+	var objects []interface{}
+	var response map[string]interface{}
+	var err error
+	for {
+		response, err = client.RpcPost("polardbx", "2020-02-02", action, nil, request, true)
+		if err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_drds_polardbx_instances", action, AlibabaCloudSdkGoERROR)
+		}
+		addDebug(action, response, request)
+
+		resp, err := jsonpath.Get("$.DBInstances", response)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.DBInstances", response)
+		}
+		result, _ := resp.([]interface{})
+		if isPagingRequest(d) {
+			objects = result
+			break
+		}
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if descriptionRegex != nil {
+				if !descriptionRegex.MatchString(fmt.Sprint(item["Description"])) {
+					continue
+				}
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["DBInstanceName"])]; !ok {
+					continue
+				}
+			}
+			if statusFilter != "" && fmt.Sprint(item["Status"]) != statusFilter {
+				continue
+			}
+			objects = append(objects, item)
+		}
+		if len(result) < request["PageSize"].(int) {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	descriptions := make([]string, 0)
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, v := range objects {
+		object := v.(map[string]interface{})
+		id := fmt.Sprint(object["DBInstanceName"])
+		mapping := map[string]interface{}{
+			"id":                   id,
+			"polardbx_instance_id": id,
+			"cn_class":             object["CnNodeClassCode"],
+			"cn_node_count":        object["CnNodeCount"],
+			"create_time":          object["CreateTime"],
+			"description":          object["Description"],
+			"dn_class":             object["DnNodeClassCode"],
+			"dn_node_count":        object["DnNodeCount"],
+			"engine_version":       object["EngineVersion"],
+			"network_type":         object["Network"],
+			"payment_type":         convertDrdsPolardbxInstancePaymentTypeResponse(object["PayType"]),
+			"primary_zone":         object["PrimaryZone"],
+			"region_id":            object["RegionId"],
+			"resource_group_id":    object["ResourceGroupId"],
+			"secondary_zone":       object["SecondaryZone"],
+			"status":               object["Status"],
+			"storage_type":         object["StorageType"],
+			"tertiary_zone":        object["TertiaryZone"],
+			"topology_type":        object["TopologyType"],
+			"vpc_id":               object["VPCId"],
+			"zone_id":              object["ZoneId"],
+		}
+		if desc, ok := object["Description"].(string); ok {
+			descriptions = append(descriptions, desc)
+		}
+		ids = append(ids, id)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("descriptions", descriptions); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("instances", s); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("total_count", formatInt(response["TotalNumber"])); err != nil {
+		return WrapError(err)
+	}
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+
+	return nil
+}
+
+func convertDrdsPolardbxInstancePaymentTypeResponse(source interface{}) interface{} {
+	switch fmt.Sprint(source) {
+	case "POSTPAY":
+		return "Postpaid"
+	case "PREPAY":
+		return "Prepaid"
+	}
+	return source
+}

--- a/alicloud/data_source_alicloud_drds_polardbx_instances_test.go
+++ b/alicloud/data_source_alicloud_drds_polardbx_instances_test.go
@@ -1,0 +1,129 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudDrdsPolardbxInstancesDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+	resourceId := "data.alicloud_drds_polardbx_instances.default"
+	name := fmt.Sprintf("tfaccdrdsds%d", rand)
+	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceDrdsPolardbxInstancesConfigDependence)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"ids": []string{"${alicloud_drds_polardbx_instance.default.id}"},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"ids": []string{"${alicloud_drds_polardbx_instance.default.id}-fake"},
+		}),
+	}
+
+	descriptionRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"description_regex": "${alicloud_drds_polardbx_instance.default.description}",
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"description_regex": "${alicloud_drds_polardbx_instance.default.description}-fake",
+		}),
+	}
+
+	statusConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"ids":    []string{"${alicloud_drds_polardbx_instance.default.id}"},
+			"status": "Running",
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"ids":    []string{"${alicloud_drds_polardbx_instance.default.id}"},
+			"status": "Deleting",
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"ids":               []string{"${alicloud_drds_polardbx_instance.default.id}"},
+			"description_regex": "${alicloud_drds_polardbx_instance.default.description}",
+			"status":            "Running",
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"ids":               []string{"${alicloud_drds_polardbx_instance.default.id}"},
+			"description_regex": "${alicloud_drds_polardbx_instance.default.description}-fake",
+			"status":            "Running",
+		}),
+	}
+
+	var existMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":                            "1",
+			"descriptions.#":                   "1",
+			"ids.0":                            CHECKSET,
+			"instances.#":                      "1",
+			"instances.0.id":                   CHECKSET,
+			"instances.0.polardbx_instance_id": CHECKSET,
+			"instances.0.description":          strings.ToLower(name),
+			"instances.0.cn_class":             CHECKSET,
+			"instances.0.dn_class":             CHECKSET,
+			"instances.0.cn_node_count":        CHECKSET,
+			"instances.0.dn_node_count":        CHECKSET,
+			"instances.0.topology_type":        CHECKSET,
+			"instances.0.status":               "Running",
+			"instances.0.primary_zone":         CHECKSET,
+			"instances.0.vpc_id":               CHECKSET,
+			"instances.0.create_time":          CHECKSET,
+			"instances.0.region_id":            CHECKSET,
+		}
+	}
+
+	var fakeMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":          "0",
+			"descriptions.#": "0",
+			"instances.#":    "0",
+		}
+	}
+
+	var checkInfo = dataSourceAttr{
+		resourceId:   resourceId,
+		existMapFunc: existMapFunc,
+		fakeMapFunc:  fakeMapFunc,
+	}
+
+	preCheck := func() {
+		testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+	}
+
+	checkInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, idsConf, descriptionRegexConf, statusConf, allConf)
+}
+
+func dataSourceDrdsPolardbxInstancesConfigDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+data "alicloud_vswitches" "default" {
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+  zone_id = "cn-beijing-f"
+}
+
+resource "alicloud_drds_polardbx_instance" "default" {
+  topology_type = "1azone"
+  vswitch_id    = data.alicloud_vswitches.default.ids.0
+  primary_zone  = "cn-beijing-f"
+  cn_node_count = 2
+  dn_class      = "mysql.n4.medium.25"
+  cn_class      = "polarx.x4.medium.2e"
+  dn_node_count = 2
+  vpc_id        = data.alicloud_vpcs.default.ids.0
+  description   = lower(var.name)
+}
+`, name)
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -348,6 +348,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_elasticsearch_instances":                          dataSourceAlicloudElasticsearch(),
 			"alicloud_elasticsearch_zones":                              dataSourceAlicloudElaticsearchZones(),
 			"alicloud_drds_instances":                                   dataSourceAlicloudDRDSInstances(),
+			"alicloud_drds_polardbx_instances":                          dataSourceAliCloudDrdsPolardbxInstances(),
 			"alicloud_nas_service":                                      dataSourceAlicloudNasService(),
 			"alicloud_nas_access_groups":                                dataSourceAlicloudNasAccessGroups(),
 			"alicloud_nas_access_rules":                                 dataSourceAlicloudAccessRules(),

--- a/alicloud/resource_alicloud_drds_polardbx_instance.go
+++ b/alicloud/resource_alicloud_drds_polardbx_instance.go
@@ -26,10 +26,8 @@ func resourceAliCloudDrdsPolardbxInstance() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"cn_class": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: StringInSlice([]string{"polarx.x4.medium.2e", "polarx.x4.large.2e", "polarx.x8.large.2e", "polarx.x4.xlarge.2e", "polarx.x8.xlarge.2e", "polarx.x4.2xlarge.2e", "polarx.x8.2xlarge.2e", "polarx.x4.4xlarge.2e", "polarx.x8.4xlarge.2e", "polarx.st.8xlarge.2e", "polarx.st.12xlarge.2e"}, false),
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"cn_node_count": {
 				Type:         schema.TypeInt,
@@ -45,15 +43,18 @@ func resourceAliCloudDrdsPolardbxInstance() *schema.Resource {
 				Optional: true,
 			},
 			"dn_class": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: StringInSlice([]string{"mysql.n4.medium.25", "mysql.n4.large.25", "mysql.x8.large.25", "mysql.n4.xlarge.25", "mysql.x8.xlarge.25", "mysql.n4.2xlarge.25", "mysql.x8.2xlarge.25", "mysql.x4.4xlarge.25", "mysql.x8.4xlarge.25", "mysql.st.8xlarge.25", "mysql.st.12xlarge.25"}, false),
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"dn_node_count": {
 				Type:         schema.TypeInt,
 				Required:     true,
 				ValidateFunc: IntAtLeast(2),
+			},
+			"dn_storage_space": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"engine_version": {
 				Type:         schema.TypeString,
@@ -89,9 +90,32 @@ func resourceAliCloudDrdsPolardbxInstance() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"specified_dn_scale": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"specified_dn_spec_map_json": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"storage_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"custom_local_ssd", "cloud_auto"}, false),
+			},
+			"switch_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"switch_time_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"tertiary_zone": {
 				Type:     schema.TypeString,
@@ -164,6 +188,12 @@ func resourceAliCloudDrdsPolardbxInstanceCreate(d *schema.ResourceData, meta int
 	if v, ok := d.GetOk("primary_db_instance_name"); ok {
 		request["PrimaryDBInstanceName"] = v
 	}
+	if v, ok := d.GetOk("storage_type"); ok {
+		request["StorageType"] = v
+	}
+	if v, ok := d.GetOk("dn_storage_space"); ok {
+		request["DnStorageSpace"] = v
+	}
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("polardbx", "2020-02-02", action, query, request, true)
@@ -213,12 +243,14 @@ func resourceAliCloudDrdsPolardbxInstanceRead(d *schema.ResourceData, meta inter
 	d.Set("description", objectRaw["Description"])
 	d.Set("dn_class", objectRaw["DnNodeClassCode"])
 	d.Set("dn_node_count", objectRaw["DnNodeCount"])
+	d.Set("dn_storage_space", objectRaw["DnStorageSpace"])
 	d.Set("engine_version", objectRaw["EngineVersion"])
 	d.Set("primary_zone", objectRaw["PrimaryZone"])
 	d.Set("region_id", objectRaw["RegionId"])
 	d.Set("resource_group_id", objectRaw["ResourceGroupId"])
 	d.Set("secondary_zone", objectRaw["SecondaryZone"])
 	d.Set("status", objectRaw["Status"])
+	d.Set("storage_type", objectRaw["StorageType"])
 	d.Set("tertiary_zone", objectRaw["TertiaryZone"])
 	d.Set("topology_type", objectRaw["TopologyType"])
 	d.Set("vswitch_id", objectRaw["VSwitchId"])
@@ -250,6 +282,68 @@ func resourceAliCloudDrdsPolardbxInstanceUpdate(d *schema.ResourceData, meta int
 		update = true
 	}
 	request["DNNodeCount"] = d.Get("dn_node_count")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("polardbx", "2020-02-02", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		drdsServiceV2 := DrdsServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{"Running"}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, drdsServiceV2.DrdsPolardbxInstanceStateRefreshFunc(d.Id(), "Status", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+	update = false
+	action = "ModifyDBInstanceClass"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["DBInstanceName"] = d.Id()
+	request["RegionId"] = client.RegionId
+	request["ClientToken"] = buildClientToken(action)
+	if !d.IsNewResource() && d.HasChange("cn_class") {
+		update = true
+	}
+	request["CnClass"] = d.Get("cn_class")
+	if !d.IsNewResource() && d.HasChange("dn_class") {
+		update = true
+	}
+	request["DnClass"] = d.Get("dn_class")
+	if !d.IsNewResource() && d.HasChange("dn_storage_space") {
+		update = true
+		request["DnStorageSpace"] = d.Get("dn_storage_space")
+	}
+	if d.HasChange("specified_dn_scale") {
+		if v, ok := d.GetOkExists("specified_dn_scale"); ok {
+			request["SpecifiedDNScale"] = v
+		}
+	}
+	if d.HasChange("specified_dn_spec_map_json") {
+		if v, ok := d.GetOk("specified_dn_spec_map_json"); ok {
+			request["SpecifiedDNSpecMapJson"] = v
+		}
+	}
+	if d.HasChange("switch_time_mode") {
+		if v, ok := d.GetOk("switch_time_mode"); ok {
+			request["SwitchTimeMode"] = v
+		}
+	}
+	if d.HasChange("switch_time") {
+		if v, ok := d.GetOk("switch_time"); ok {
+			request["SwitchTime"] = v
+		}
+	}
 	if update {
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {

--- a/alicloud/resource_alicloud_drds_polardbx_instance_test.go
+++ b/alicloud/resource_alicloud_drds_polardbx_instance_test.go
@@ -579,4 +579,190 @@ data "alicloud_vswitches" "default" {
 `, name)
 }
 
+// Case ModifyDBInstanceClass in-place class upgrade
+func TestAccAliCloudDrdsPolardbxInstance_basic83815836(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_drds_polardbx_instance.default"
+	ra := resourceAttrInit(resourceId, AlicloudDrdsPolardbxInstanceMap83815836)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &DrdsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeDrdsPolardbxInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccdrds%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudDrdsPolardbxInstanceBasicDependence83815836)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"topology_type":  "1azone",
+					"vswitch_id":     "${data.alicloud_vswitches.default.ids.0}",
+					"primary_zone":   "cn-beijing-f",
+					"cn_node_count":  "2",
+					"dn_class":       "mysql.n4.medium.25",
+					"cn_class":       "polarx.x4.medium.2e",
+					"dn_node_count":  "2",
+					"vpc_id":         "${data.alicloud_vpcs.default.ids.0}",
+					"engine_version": "8.0",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"topology_type":  "1azone",
+						"vswitch_id":     CHECKSET,
+						"primary_zone":   "cn-beijing-f",
+						"cn_node_count":  CHECKSET,
+						"dn_class":       "mysql.n4.medium.25",
+						"cn_class":       "polarx.x4.medium.2e",
+						"dn_node_count":  CHECKSET,
+						"vpc_id":         CHECKSET,
+						"engine_version": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"cn_class": "polarx.x4.large.2e",
+					"dn_class": "mysql.n4.large.25",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cn_class": "polarx.x4.large.2e",
+						"dn_class": "mysql.n4.large.25",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "test_modify_class",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "test_modify_class",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"specified_dn_scale",
+					"specified_dn_spec_map_json",
+					"switch_time",
+					"switch_time_mode",
+				},
+			},
+		},
+	})
+}
+
+var AlicloudDrdsPolardbxInstanceMap83815836 = map[string]string{
+	"status":      CHECKSET,
+	"create_time": CHECKSET,
+	"region_id":   CHECKSET,
+}
+
+func AlicloudDrdsPolardbxInstanceBasicDependence83815836(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_zones" "default" {
+  available_resource_creation = "VSwitch"
+}
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+data "alicloud_vswitches" "default" {
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+  zone_id = "cn-beijing-f"
+}
+
+`, name)
+}
+
+// Case cloud_auto storage + ModifyDBInstanceClass class change with dn_storage_space grow
+// Requires a region + class combination that has an active price plan for the c25/c2e cloud-disk family.
+// Not part of the default matrix — enable per region when pricing is available.
+func TestAccAliCloudDrdsPolardbxInstance_basic83815836_cloudauto(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_drds_polardbx_instance.default"
+	ra := resourceAttrInit(resourceId, AlicloudDrdsPolardbxInstanceMap83815836)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &DrdsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeDrdsPolardbxInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccdrds%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudDrdsPolardbxInstanceBasicDependence83815836)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+			testAccPreCheckWithEnvVariable(t, "ALICLOUD_TEST_DRDS_POLARDBX_CLOUDAUTO")
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"topology_type":              "1azone",
+					"vswitch_id":                 "${data.alicloud_vswitches.default.ids.0}",
+					"primary_zone":               "cn-beijing-f",
+					"cn_node_count":              "2",
+					"dn_class":                   "polarx.mysql.x4.large.c25",
+					"cn_class":                   "polarx.x4.large.c2e",
+					"dn_node_count":              "2",
+					"vpc_id":                     "${data.alicloud_vpcs.default.ids.0}",
+					"engine_version":             "8.0",
+					"storage_type":               "cloud_auto",
+					"dn_storage_space":           "50",
+					"specified_dn_scale":         "false",
+					"specified_dn_spec_map_json": "{}",
+					"switch_time_mode":           "Immediate",
+					"switch_time":                "2029-01-01T00:00:00Z",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"storage_type":     "cloud_auto",
+						"dn_storage_space": "50",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"dn_storage_space": "100",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"dn_storage_space": "100",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"specified_dn_scale",
+					"specified_dn_spec_map_json",
+					"switch_time",
+					"switch_time_mode",
+				},
+			},
+		},
+	})
+}
+
 // Test Drds PolardbxInstance. <<< Resource test cases, automatically generated.

--- a/website/docs/d/drds_polardbx_instances.html.markdown
+++ b/website/docs/d/drds_polardbx_instances.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "Distributed Relational Database Service (DRDS)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_drds_polardbx_instances"
+description: |-
+  Provides a list of Alicloud Distributed Relational Database Service (DRDS) Polardbx Instances to the user.
+---
+
+# alicloud_drds_polardbx_instances
+
+This data source provides the Distributed Relational Database Service (DRDS) PolarDB-X Instances of the current Alibaba Cloud user.
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+data "alicloud_drds_polardbx_instances" "ids" {
+  ids = ["pxc-xxxxxxxx"]
+}
+
+output "first_polardbx_instance_id" {
+  value = data.alicloud_drds_polardbx_instances.ids.instances.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional, ForceNew, Computed) A list of PolarDB-X Instance IDs.
+* `description_regex` - (Optional, ForceNew) A regex string to filter results by instance description.
+* `resource_group_id` - (Optional, ForceNew) The ID of the resource group used to filter instances.
+* `status` - (Optional, ForceNew) Filter results by instance status. Valid values: `Creating`, `Running`, `MinorVersionUpgrading`, `ClassChanging`, `NodeCreating`, `NodeDeleting`, `Deleting`.
+* `page_number` - (Optional) Number of the returned page. Valid values: 1 to `10000`. Default: `1`.
+* `page_size` - (Optional) Number of entries per page. Valid values: 1 to `1000`. Default: `100`.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `descriptions` - A list of PolarDB-X instance descriptions.
+* `total_count` - Total number of PolarDB-X instances returned by the API.
+* `instances` - A list of PolarDB-X instances. Each element contains the following attributes:
+  * `id` - The ID of the PolarDB-X instance.
+  * `polardbx_instance_id` - The ID of the PolarDB-X instance. Same as `id`.
+  * `cn_class` - Compute node specifications of the instance.
+  * `cn_node_count` - The number of compute nodes.
+  * `create_time` - The creation time of the instance.
+  * `description` - Instance remarks.
+  * `dn_class` - Storage node specifications of the instance.
+  * `dn_node_count` - The number of storage nodes.
+  * `engine_version` - Engine version of the instance.
+  * `network_type` - The network type of the instance.
+  * `payment_type` - The billing method of the instance. Valid values: `Postpaid`, `Prepaid`.
+  * `primary_zone` - Primary availability zone.
+  * `region_id` - Region ID of the instance.
+  * `resource_group_id` - The ID of the resource group the instance belongs to.
+  * `secondary_zone` - Secondary availability zone.
+  * `status` - Status of the instance.
+  * `storage_type` - Storage type of the instance. Valid values: `custom_local_ssd`, `cloud_auto`.
+  * `tertiary_zone` - Third availability zone.
+  * `topology_type` - Topology type of the instance. Valid values: `1azone`, `3azones`.
+  * `vpc_id` - VPC ID of the instance.
+  * `zone_id` - Availability zone of the instance.

--- a/website/docs/r/drds_polardbx_instance.html.markdown
+++ b/website/docs/r/drds_polardbx_instance.html.markdown
@@ -65,11 +65,12 @@ resource "alicloud_drds_polardbx_instance" "default" {
 ## Argument Reference
 
 The following arguments are supported:
-* `cn_class` - (Required, ForceNew) Compute node specifications.
+* `cn_class` - (Required) Compute node (CN) specifications. Since v1.285.0 the field is mutable and supports in-place class change. Refer to the `CnClass` parameter in the [CreateDBInstance API reference](https://www.alibabacloud.com/help/en/polardb/polardb-for-xscale/api-createdbinstance-1) for the list of valid values.
 * `cn_node_count` - (Required, Int) Number of computing nodes.
 * `description` - (Optional, Available since v1.268.0) Instance remarks
-* `dn_class` - (Required, ForceNew) Storage node specifications.
+* `dn_class` - (Required) Storage node (DN) specifications. Since v1.285.0 the field is mutable and supports in-place class change. Refer to the `DnClass` parameter in the [CreateDBInstance API reference](https://www.alibabacloud.com/help/en/polardb/polardb-for-xscale/api-createdbinstance-1) for the list of valid values.
 * `dn_node_count` - (Required, Int) The number of storage nodes.
+* `dn_storage_space` - (Optional, Computed, Available since v1.285.0) Storage space per storage node, in GB. Only applicable when `storage_type` is `cloud_auto`; leave unset for `custom_local_ssd` instances. Since v1.285.0 the field is mutable and supports in-place resize.
 * `engine_version` - (Optional, ForceNew, Computed, Available since v1.268.0) Engine version, default 5.7
 * `is_read_db_instance` - (Optional, Available since v1.268.0) Whether the instance is read-only.
   - `true`: Yes
@@ -84,6 +85,18 @@ The following arguments are supported:
 * `primary_zone` - (Required, ForceNew) Primary Availability Zone.
 * `resource_group_id` - (Optional, Computed) The resource group ID can be empty. This parameter is not supported for the time being.
 * `secondary_zone` - (Optional, ForceNew) Secondary availability zone.
+* `specified_dn_scale` - (Optional, Available since v1.285.0) Whether the storage node specification is customized per DN during a class change. Used together with `specified_dn_spec_map_json`.
+* `specified_dn_spec_map_json` - (Optional, Available since v1.285.0) JSON string describing the per-DN target specification during a class change.
+* `storage_type` - (Optional, ForceNew, Computed, Available since v1.285.0) Storage type of the instance. Valid values:
+  - `custom_local_ssd`: local disk;
+  - `cloud_auto`: cloud disk.
+* `switch_time` - (Optional, Available since v1.285.0) Scheduled switch start time in `yyyy-MM-ddTHH:mm:ssZ` (UTC); the actual switch runs during `[T, T + 30m]`.
+* `switch_time_mode` - (Optional, Available since v1.285.0) Effective time policy applied to a class change. Valid values:
+  - `0`: apply immediately;
+  - `1`: apply in the maintenance window.
+
+-> **NOTE:** `specified_dn_scale`, `specified_dn_spec_map_json`, `switch_time_mode` and `switch_time` are auxiliary parameters attached to a class change. They only take effect when one of `cn_class`, `dn_class` or `dn_storage_space` also changes; modifying only these four fields in isolation is silently ignored on Update.
+
 * `tertiary_zone` - (Optional, ForceNew) Third Availability Zone.
 * `topology_type` - (Required, ForceNew) Topology type:
   - `3azones`: three available areas;


### PR DESCRIPTION
## Summary

- resource/alicloud_drds_polardbx_instance:
  - Support in-place class change through the `ModifyDBInstanceClass` API — `cn_class` and `dn_class` are no longer `ForceNew`.
  - Add new arguments for the cloud-disk (`cloud_auto`) path and the class-change workflow: `storage_type`, `dn_storage_space`, `specified_dn_scale`, `specified_dn_spec_map_json`, `switch_time_mode`, `switch_time`.
- **New Data Source:** `alicloud_drds_polardbx_instances` — backed by `DescribeDBInstances`; supports `ids`, `description_regex`, `status`, `resource_group_id` filters.

## Test Result

```
=== RUN   TestAccAliCloudDrdsPolardbxInstance_basic4504
--- PASS: TestAccAliCloudDrdsPolardbxInstance_basic4504 (2015.73s)

=== RUN   TestAccAliCloudDrdsPolardbxInstance_basic12277
--- PASS: TestAccAliCloudDrdsPolardbxInstance_basic12277 (966.17s)

=== RUN   TestAccAliCloudDrdsPolardbxInstance_basic12278
--- PASS: TestAccAliCloudDrdsPolardbxInstance_basic12278 (905.80s)

=== RUN   TestAccAliCloudDrdsPolardbxInstance_basic12257
--- PASS: TestAccAliCloudDrdsPolardbxInstance_basic12257 (2039.16s)

=== RUN   TestAccAliCloudDrdsPolardbxInstance_basic12261
--- PASS: TestAccAliCloudDrdsPolardbxInstance_basic12261 (956.37s)

=== RUN   TestAccAliCloudDrdsPolardbxInstance_basic83815836
--- PASS: TestAccAliCloudDrdsPolardbxInstance_basic83815836 (1753.47s)

=== RUN   TestAccAliCloudDrdsPolardbxInstancesDataSource
--- PASS: TestAccAliCloudDrdsPolardbxInstancesDataSource (1082.58s)
```