### PR TITLE
resource/alicloud_eflo_cluster: support node group provisioning fields and computed node_group_ids

### DIFF
--- a/alicloud/resource_alicloud_eflo_cluster.go
+++ b/alicloud/resource_alicloud_eflo_cluster.go
@@ -312,6 +312,48 @@ func resourceAliCloudEfloCluster() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"key_pair_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"login_password": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+						},
+						"bond_num": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"file_system_mount_enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"hpn_zone": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"system_disk": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"size": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"performance_level": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"category": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
 						"nodes": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -355,6 +397,11 @@ func resourceAliCloudEfloCluster() *schema.Resource {
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"node_group_ids": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"tags": tagsSchema(),
 		},
@@ -578,6 +625,35 @@ func resourceAliCloudEfloClusterCreate(d *schema.ResourceData, meta interface{})
 			dataLoop8Map["NodeGroupName"] = dataLoop8Tmp["node_group_name"]
 			dataLoop8Map["MachineType"] = dataLoop8Tmp["machine_type"]
 			dataLoop8Map["ImageId"] = dataLoop8Tmp["image_id"]
+			if v, ok := dataLoop8Tmp["key_pair_name"]; ok && v.(string) != "" {
+				dataLoop8Map["KeyPairName"] = v
+			}
+			if v, ok := dataLoop8Tmp["login_password"]; ok && v.(string) != "" {
+				dataLoop8Map["LoginPassword"] = v
+			}
+			if v, ok := dataLoop8Tmp["hpn_zone"]; ok && v.(string) != "" {
+				dataLoop8Map["HpnZone"] = v
+			}
+			if v, ok := dataLoop8Tmp["bond_num"]; ok && v.(int) > 0 {
+				dataLoop8Map["BondNum"] = v
+			}
+			if v, ok := dataLoop8Tmp["file_system_mount_enabled"]; ok {
+				dataLoop8Map["FileSystemMountEnabled"] = v
+			}
+			if v, ok := dataLoop8Tmp["system_disk"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+				sdm := v[0].(map[string]interface{})
+				systemDisk := make(map[string]interface{})
+				if x, ok := sdm["size"]; ok && x.(int) > 0 {
+					systemDisk["Size"] = x
+				}
+				if x, ok := sdm["performance_level"]; ok && x.(string) != "" {
+					systemDisk["PerformanceLevel"] = x
+				}
+				if x, ok := sdm["category"]; ok && x.(string) != "" {
+					systemDisk["Category"] = x
+				}
+				dataLoop8Map["SystemDisk"] = systemDisk
+			}
 			nodeGroupsMapsArray = append(nodeGroupsMapsArray, dataLoop8Map)
 		}
 		nodeGroupsMapsJson, err := json.Marshal(nodeGroupsMapsArray)
@@ -699,6 +775,53 @@ func resourceAliCloudEfloClusterRead(d *schema.ResourceData, meta interface{}) e
 
 	tagsMaps, _ := jsonpath.Get("$.TagResources.TagResource", objectRaw)
 	d.Set("tags", tagsToMap(tagsMaps))
+
+	nodeGroupIds := make(map[string]interface{})
+	listAction := "ListNodeGroups"
+	listRequest := map[string]interface{}{"ClusterId": d.Id(), "RegionId": client.RegionId, "MaxResults": PageSizeLarge}
+	listQuery := make(map[string]interface{})
+	for {
+		var listResponse map[string]interface{}
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			listResponse, err = client.RpcPost("eflo-controller", "2022-12-15", listAction, listQuery, listRequest, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(listAction, listResponse, listRequest)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), listAction, AlibabaCloudSdkGoERROR)
+		}
+
+		groupsRaw, _ := jsonpath.Get("$.Groups", listResponse)
+		if groups, ok := groupsRaw.([]interface{}); ok {
+			for _, g := range groups {
+				gm, ok := g.(map[string]interface{})
+				if !ok {
+					log.Printf("[WARN] Resource alicloud_eflo_cluster ListNodeGroups: skipping unexpected group item type %T", g)
+					continue
+				}
+				name, _ := gm["GroupName"].(string)
+				gid, _ := gm["GroupId"].(string)
+				if name != "" {
+					nodeGroupIds[name] = gid
+				}
+			}
+		}
+
+		if next, exists := listResponse["NextToken"]; !exists || next == nil || fmt.Sprint(next) == "" {
+			break
+		} else {
+			listRequest["NextToken"] = fmt.Sprint(next)
+		}
+	}
+	d.Set("node_group_ids", nodeGroupIds)
 
 	return nil
 }

--- a/alicloud/resource_alicloud_eflo_cluster_test.go
+++ b/alicloud/resource_alicloud_eflo_cluster_test.go
@@ -109,11 +109,51 @@ func TestAccAliCloudEfloCluster_basic10311(t *testing.T) {
 					"resource_group_id":        "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
 					"node_groups": []map[string]interface{}{
 						{
-							"node_group_name":        "cluster-resource-test",
-							"node_group_description": "cluster-resource-test",
+							"node_group_name":           "cluster-resource-test",
+							"node_group_description":    "cluster-resource-test",
+							"machine_type":              "efg1.nvga1n",
+							"image_id":                  "i190982651690986913088",
+							"zone_id":                   "cn-wulanchabu-b",
+							"key_pair_name":             "${alicloud_ecs_key_pair.default.key_pair_name}",
+							"hpn_zone":                  "B1",
+							"bond_num":                  "2",
+							"file_system_mount_enabled": "true",
+							"user_data":                 "IyEvYmluL2Jhc2gKZWNobyBoZWxsbwo=",
+							"system_disk": []map[string]interface{}{
+								{
+									"size":              "500",
+									"performance_level": "PL1",
+									"category":          "cloud_essd",
+								},
+							},
+							"nodes": []map[string]interface{}{
+								{
+									"node_id":        "e01-cn-test0000001",
+									"hostname":       "test-node",
+									"vpc_id":         "${alicloud_vpc.create_vpc.id}",
+									"vswitch_id":     "${alicloud_vswitch.create_vswitch.id}",
+									"login_password": "Terraform@1234",
+								},
+							},
+						},
+						{
+							"node_group_name":        "cluster-resource-test-2",
+							"node_group_description": "cluster-resource-test-2",
 							"machine_type":           "efg1.nvga1n",
 							"image_id":               "i190982651690986913088",
 							"zone_id":                "cn-wulanchabu-b",
+							"login_password":         "Terraform@1234",
+						},
+					},
+					"components": []map[string]interface{}{
+						{
+							"component_type": "AckEdge",
+							"component_config": []map[string]interface{}{
+								{
+									"basic_args": "{}",
+									"node_units": []string{"{}"},
+								},
+							},
 						},
 					},
 					"nimiz_vswitches": []string{
@@ -122,15 +162,17 @@ func TestAccAliCloudEfloCluster_basic10311(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"hpn_zone":                 "B1",
-						"ignore_failed_node_tasks": "true",
-						"cluster_type":             "Lite",
-						"cluster_name":             name,
-						"cluster_description":      "cluster-resource-test",
-						"resource_group_id":        CHECKSET,
-						"node_groups.#":            "1",
-						"nimiz_vswitches.#":        "1",
-						"open_eni_jumbo_frame":     "false",
+						"hpn_zone":                    "B1",
+						"ignore_failed_node_tasks":    "true",
+						"cluster_type":                "Lite",
+						"cluster_name":                name,
+						"cluster_description":         "cluster-resource-test",
+						"resource_group_id":           CHECKSET,
+						"node_groups.#":               "2",
+						"node_groups.0.key_pair_name": CHECKSET,
+						"node_group_ids.%":            CHECKSET,
+						"nimiz_vswitches.#":           "1",
+						"open_eni_jumbo_frame":        "false",
 					}),
 				),
 			},
@@ -226,6 +268,10 @@ resource "alicloud_security_group" "create_security_group" {
   security_group_name = "cluster-resoure-test"
   security_group_type = "normal"
   vpc_id              = alicloud_vpc.create_vpc.id
+}
+
+resource "alicloud_ecs_key_pair" "default" {
+  key_pair_name = "${var.name}-kp"
 }
 
 

--- a/website/docs/r/eflo_cluster.html.markdown
+++ b/website/docs/r/eflo_cluster.html.markdown
@@ -138,12 +138,12 @@ The following arguments are supported:
 * `cluster_description` - (Optional, ForceNew) cluster description
 * `cluster_name` - (Optional, ForceNew) ClusterName
 * `cluster_type` - (Optional, ForceNew) cluster type
-* `components` - (Optional, List) Component (software instance) See [`components`](#components) below.
+* `components` - (Optional, List) Component (software instance) See [`components`](#components) below. **Note:** The parameter is immutable after resource creation.
 * `hpn_zone` - (Optional) Cluster Number
 * `ignore_failed_node_tasks` - (Optional) Whether to allow skipping failed nodes. Default value: False
-* `networks` - (Optional, List) Network Information See [`networks`](#networks) below.
+* `networks` - (Optional, List) Network Information See [`networks`](#networks) below. **Note:** The parameter is immutable after resource creation.
 * `nimiz_vswitches` - (Optional, List) Node virtual switch
-* `node_groups` - (Optional, List) Node Group List See [`node_groups`](#node_groups) below.
+* `node_groups` - (Optional, List) Node Group List See [`node_groups`](#node_groups) below. **Note:** The parameter is immutable after resource creation.
 * `open_eni_jumbo_frame` - (Optional) Whether the network interface supports jumbo frames
 * `resource_group_id` - (Optional, Computed) The ID of the resource group
 * `tags` - (Optional, Map) tag
@@ -243,11 +243,17 @@ The networks-ip_allocation_policy-bond_policy-bonds supports the following:
 ### `node_groups`
 
 The node_groups supports the following:
+* `bond_num` - (Optional, Int) The number of RDMA network bonds to configure on each node in the group.
+* `file_system_mount_enabled` - (Optional, Bool) Whether to enable file system mounting for the nodes in the group.
+* `hpn_zone` - (Optional) The high-performance network (HPN) zone of the node group.
 * `image_id` - (Optional) System Image ID
+* `key_pair_name` - (Optional) The name of the key pair used to log on to the nodes in the group. Conflicts with `login_password`.
+* `login_password` - (Optional, Sensitive) The password used to log on to the nodes in the group. Conflicts with `key_pair_name`.
 * `machine_type` - (Optional) Model
 * `node_group_description` - (Optional) Node Group Description
 * `node_group_name` - (Optional) Node Group Name
 * `nodes` - (Optional, List) Node List See [`nodes`](#node_groups-nodes) below.
+* `system_disk` - (Optional, List) The system disk configuration of the nodes in the group. See [`system_disk`](#node_groups-system_disk) below.
 * `user_data` - (Optional) Instance custom data. It needs to be encoded in Base64 mode, and the original data is at most 16KB.
 * `zone_id` - (Optional) Zone ID
 
@@ -260,11 +266,19 @@ The node_groups-nodes supports the following:
 * `vswitch_id` - (Optional) Virtual Switch ID
 * `vpc_id` - (Optional) VPC ID
 
+### `node_groups-system_disk`
+
+The node_groups-system_disk supports the following:
+* `category` - (Optional) The category of the system disk.
+* `performance_level` - (Optional) The performance level of the system disk.
+* `size` - (Optional, Int) The size of the system disk in GiB.
+
 ## Attributes Reference
 
 The following attributes are exported:
 * `id` - The ID of the resource supplied above.
 * `create_time` - The creation time of the resource
+* `node_group_ids` - A mapping of node group names to their generated node group IDs, populated from the Lingjun (EFLO) control plane after the cluster is created.
 * `status` - The status of the resource
 
 ## Timeouts


### PR DESCRIPTION
### Why

The `alicloud_eflo_cluster` resource cannot fully provision Lingjun (EFLO) GPU node groups today. Creating a node group for GPU machines (e.g. B300 / `efg2.GN9D`) requires:

- group-level node authentication (`key_pair_name` / `login_password`),
- an RDMA bond count (`bond_num`),
- a cloud system disk — so the backend boots from a cloud disk instead of building a whitelist-restricted local disk group,
- the high-performance network zone (`hpn_zone`),
- optional file-system mounting (`file_system_mount_enabled`).

None of these are exposed, so node groups created through Terraform cannot provision these machine types. There is also no way to obtain the generated node group IDs, which are required to bind an ACK `type = "lingjun"` node pool to the cluster via `eflo_node_group.group_id`.

### What are you changing?

Add the following optional arguments to `node_groups`:

- `key_pair_name` — key pair used to log on to the nodes
- `login_password` — password used to log on to the nodes (sensitive)
- `bond_num` — number of RDMA network bonds
- `file_system_mount_enabled` — enable file system mounting
- `hpn_zone` — high-performance network zone
- `system_disk` block — `size`, `performance_level`, `category`

Add a computed top-level `node_group_ids` (map of node group name → ID), populated from `ListNodeGroups` in the read, so an ACK Lingjun node pool can reference the group.

The resource documentation is updated accordingly. `gofmt` is clean and `go build ./alicloud/` passes. All changes are additive and backward-compatible (new arguments are Optional; `node_group_ids` is Computed).


---

## Coverage & remaining SDK options

`alicloud_eflo_cluster` dispatches `CreateCluster` through the generic `client.RpcPost("eflo-controller", "2022-12-15", ...)` path with a hand-built `map[string]interface{}` request (`node_groups` is JSON-marshaled into `request["NodeGroups"]`), not a typed request struct. Each new attribute is therefore added as a schema field plus a matching entry in the Create request map (see the `node_groups` loop), and `node_group_ids` is populated on Read from `ListNodeGroups`.

**Fields this PR adds to `node_groups`:** `key_pair_name`, `login_password` (Sensitive), `file_system_mount_enabled`, `system_disk` block (`size`, `performance_level`, `category`), plus `bond_num` and node-group-level `hpn_zone` (RDMA bonding / HPN zone). It also adds the computed top-level `node_group_ids` map (node-group name → generated id) so an ACK `type="lingjun"` node pool can bind to the cluster.

### SDK model additions not yet exposed

Because the provider hand-builds the request map rather than consuming the typed [`eflo-controller-20221215`](https://github.com/alibabacloud-go/eflo-controller-20221215) Go SDK, it does not automatically track additions to the SDK's `CreateClusterRequestNodeGroups` model. The node-group fields below were added to that SDK model in the releases shown and are all still present at the latest SDK release (v3.0.7, `client/create_cluster_request_model.go`), but none are surfaced by the provider's `resource_alicloud_eflo_cluster.go` schema. They are out of scope for this PR (future work):

| SDK model field | SDK struct | Added to SDK in | Provider status |
| --- | --- | --- | --- |
| `Nodes[].DataDisk` | `CreateClusterRequestNodeGroupsNodes` (`DataDisk []*CreateClusterRequestNodeGroupsNodesDataDisk`) | [v2.6.3](https://github.com/alibabacloud-go/eflo-controller-20221215/releases/tag/v2.6.3) | Still not exposed |
| `VirtualGpuEnabled` | `CreateClusterRequestNodeGroups` (`VirtualGpuEnabled *bool`) | [v2.6.4](https://github.com/alibabacloud-go/eflo-controller-20221215/releases/tag/v2.6.4) | Still not exposed |
| `HyperNodes` | `CreateClusterRequestNodeGroups` (`HyperNodes []*CreateClusterRequestNodeGroupsHyperNodes`) | [v2.8.3](https://github.com/alibabacloud-go/eflo-controller-20221215/releases/tag/v2.8.3) | Still not exposed |
| `RamRoleName` | `CreateClusterRequestNodeGroups` (`RamRoleName *string`) | [v3.0.6](https://github.com/alibabacloud-go/eflo-controller-20221215/releases/tag/v3.0.6) | Still not exposed |

## Docs & tests

- Documents the new arguments, and marks the create-only blocks (`networks`, `node_groups`, `components`) as **immutable after resource creation** — the resource has no update path for them (they sit in `ImportStateVerifyIgnore`), so this reflects real behavior.
- Extends `TestAccAliCloudEfloCluster_basic10311` to cover the new `node_groups` attributes (`key_pair_name`, `login_password`, `bond_num`, `file_system_mount_enabled`, `hpn_zone`, `system_disk`) plus `nodes`, a `components` block, and the computed `node_group_ids`. Placeholder values (e.g. on `efg1.nvga1n` in `cn-wulanchabu`) can be adjusted for a real acceptance run.
