### PR TITLE
resource/alicloud_redis_tair_instance: fix perpetual diff when security_group_id contains multiple security groups; resource/alicloud_redis_backup: add cluster_backup_id output

### DIFF
--- a/alicloud/resource_alicloud_redis_backup.go
+++ b/alicloud/resource_alicloud_redis_backup.go
@@ -31,6 +31,10 @@ func resourceAliCloudRedisBackup() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"cluster_backup_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"backup_retention_period": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -110,6 +114,18 @@ func resourceAliCloudRedisBackupCreate(d *schema.ResourceData, meta interface{})
 					if backupID, ok := backup["BackupId"]; ok {
 						// Update ID with the actual BackupId
 						d.SetId(fmt.Sprintf("%v:%v", instanceID, backupID))
+
+						// For cluster-architecture instances, resolve the cluster backup
+						// set id (cb-*) that this backup belongs to by matching the shard
+						// backups inside each DescribeClusterBackupList entry. Standard
+						// instances have no cluster backup set, so an empty result is
+						// expected and must not fail the create.
+						clusterBackupID, cbErr := redisServiceV2.DescribeRedisClusterBackupId(instanceID, fmt.Sprint(backupID))
+						if cbErr != nil {
+							log.Printf("[WARN] alicloud_redis_backup: DescribeClusterBackupList for %s failed, cluster_backup_id left empty: %v", d.Id(), cbErr)
+						} else if clusterBackupID != "" {
+							d.Set("cluster_backup_id", clusterBackupID)
+						}
 					}
 				}
 			}

--- a/alicloud/resource_alicloud_redis_backup_test.go
+++ b/alicloud/resource_alicloud_redis_backup_test.go
@@ -48,7 +48,7 @@ func TestAccAliCloudRedisBackup_basic11970(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"backup_retention_period"},
+				ImportStateVerifyIgnore: []string{"backup_retention_period", "cluster_backup_id"},
 			},
 		},
 	})

--- a/alicloud/resource_alicloud_redis_tair_instance.go
+++ b/alicloud/resource_alicloud_redis_tair_instance.go
@@ -204,6 +204,16 @@ func resourceAliCloudRedisTairInstance() *schema.Resource {
 			"security_group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old != "" && new != "" && old != new {
+						oldParts := strings.Split(old, ",")
+						sort.Strings(oldParts)
+						newParts := strings.Split(new, ",")
+						sort.Strings(newParts)
+						return reflect.DeepEqual(newParts, oldParts)
+					}
+					return false
+				},
 			},
 			"security_ip_group_name": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_redis_tair_instance_test.go
+++ b/alicloud/resource_alicloud_redis_tair_instance_test.go
@@ -2240,6 +2240,451 @@ resource "alicloud_vswitch" "defaultVSwitch" {
 `, name)
 }
 
+// Case Tair 克隆实例_备份集恢复 clone-from-backup: covers src_db_instance_id / backup_id / cluster_backup_id
+var AlicloudRedisTairInstanceCloneFromBackupMap = map[string]string{
+	"port":           CHECKSET,
+	"status":         CHECKSET,
+	"engine_version": CHECKSET,
+	"payment_type":   "PayAsYouGo",
+	"create_time":    CHECKSET,
+}
+
+func AlicloudRedisTairInstanceCloneFromBackupDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "zone_id" {
+  default = "cn-hangzhou-h"
+}
+
+variable "region_id" {
+  default = "cn-hangzhou"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  zone_id = var.zone_id
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_vswitch" "vswitch" {
+  count        = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
+  vpc_id       = data.alicloud_vpcs.default.ids.0
+  cidr_block   = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 8)
+  zone_id      = var.zone_id
+  vswitch_name = var.name
+}
+
+locals {
+  vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : concat(alicloud_vswitch.vswitch.*.id, [""])[0]
+}
+
+# Source instance that is backed up and cloned from; all references are dynamic.
+# Dual-replica (default MASTER_SLAVE) is required: CreateBackup rejects
+# STAND_ALONE instances with InstanceType.NotSupport.
+resource "alicloud_redis_tair_instance" "source" {
+  payment_type       = "PayAsYouGo"
+  instance_type      = "tair_rdb"
+  zone_id            = var.zone_id
+  instance_class     = "tair.rdb.1g"
+  tair_instance_name = "${var.name}Src"
+  vswitch_id         = local.vswitch_id
+  vpc_id             = data.alicloud_vpcs.default.ids.0
+  resource_group_id  = data.alicloud_resource_manager_resource_groups.default.ids.0
+  password           = "123456Tf"
+  engine_version     = "5.0"
+  port               = "6379"
+}
+
+# Backup of the source instance, providing a real backup_id to clone from.
+resource "alicloud_redis_backup" "default" {
+  instance_id             = alicloud_redis_tair_instance.source.id
+  backup_retention_period = "7"
+}
+
+
+`, name)
+}
+
+func TestAccAliCloudRedisTairInstance_cloneFromBackup(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_redis_tair_instance.default"
+	ra := resourceAttrInit(resourceId, AlicloudRedisTairInstanceCloneFromBackupMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RedisServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRedisTairInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sredistairinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRedisTairInstanceCloneFromBackupDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Clone a new instance from the source instance's backup set. src_db_instance_id
+				// and backup_id point at the dynamically created source instance and its
+				// alicloud_redis_backup (no hardcoded ids). These create-only attributes are
+				// asserted with CHECKSET and live in a single create step because
+				// CreateTairInstance consumes them only at creation.
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type":       "PayAsYouGo",
+					"instance_type":      "tair_rdb",
+					"zone_id":            "${var.zone_id}",
+					"instance_class":     "tair.rdb.1g",
+					"tair_instance_name": name,
+					"vswitch_id":         "${local.vswitch_id}",
+					"vpc_id":             "${data.alicloud_vpcs.default.ids.0}",
+					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"password":           "123456Tf",
+					"engine_version":     "5.0",
+					"port":               "6379",
+					"node_type":          "STAND_ALONE",
+					"src_db_instance_id": "${alicloud_redis_tair_instance.source.id}",
+					"backup_id":          "${alicloud_redis_backup.default.backup_id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"payment_type":       "PayAsYouGo",
+						"instance_type":      "tair_rdb",
+						"zone_id":            CHECKSET,
+						"instance_class":     "tair.rdb.1g",
+						"tair_instance_name": name,
+						"vswitch_id":         CHECKSET,
+						"vpc_id":             CHECKSET,
+						"resource_group_id":  CHECKSET,
+						"password":           "123456Tf",
+						"engine_version":     "5.0",
+						"port":               "6379",
+						"node_type":          "STAND_ALONE",
+						"src_db_instance_id": CHECKSET,
+						"backup_id":          CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auto_renew", "auto_renew_period", "backup_id", "cluster_backup_id", "effective_time", "force_upgrade", "global_instance_id", "password", "period", "read_only_count", "recover_config_mode", "slave_read_only_count", "src_db_instance_id"},
+			},
+		},
+	})
+}
+
+// Case Tair 克隆实例_集群备份集恢复 clone-from-cluster-backup: covers cluster_backup_id
+var AlicloudRedisTairInstanceCloneFromClusterBackupMap = map[string]string{
+	"port":           CHECKSET,
+	"status":         CHECKSET,
+	"engine_version": CHECKSET,
+	"payment_type":   "PayAsYouGo",
+	"create_time":    CHECKSET,
+}
+
+func AlicloudRedisTairInstanceCloneFromClusterBackupDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "zone_id" {
+  default = "cn-hangzhou-h"
+}
+
+variable "region_id" {
+  default = "cn-hangzhou"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  zone_id = var.zone_id
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_vswitch" "vswitch" {
+  count        = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
+  vpc_id       = data.alicloud_vpcs.default.ids.0
+  cidr_block   = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 8)
+  zone_id      = var.zone_id
+  vswitch_name = var.name
+}
+
+locals {
+  vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : concat(alicloud_vswitch.vswitch.*.id, [""])[0]
+}
+
+# Cloud-native cluster source instance (shard_count >= 2) whose backup yields a cluster
+# backup set id (cb-*); all references are dynamic.
+resource "alicloud_redis_tair_instance" "source" {
+  payment_type       = "PayAsYouGo"
+  instance_type      = "tair_rdb"
+  zone_id            = var.zone_id
+  instance_class     = "tair.rdb.2g"
+  shard_count        = 2
+  tair_instance_name = "${var.name}Src"
+  vswitch_id         = local.vswitch_id
+  vpc_id             = data.alicloud_vpcs.default.ids.0
+  resource_group_id  = data.alicloud_resource_manager_resource_groups.default.ids.0
+  password           = "123456Tf"
+  engine_version     = "5.0"
+  port               = "6379"
+}
+
+# Backup of the cluster source instance, exposing cluster_backup_id (cb-*).
+resource "alicloud_redis_backup" "default" {
+  instance_id             = alicloud_redis_tair_instance.source.id
+  backup_retention_period = "7"
+}
+
+
+`, name)
+}
+
+func TestAccAliCloudRedisTairInstance_cloneFromClusterBackup(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_redis_tair_instance.default"
+	ra := resourceAttrInit(resourceId, AlicloudRedisTairInstanceCloneFromClusterBackupMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RedisServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRedisTairInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sredistairinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRedisTairInstanceCloneFromClusterBackupDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Clone a cloud-native cluster instance from a cluster backup set.
+				// cluster_backup_id is wired to the dynamically created cluster source
+				// instance's alicloud_redis_backup.cluster_backup_id (cb-*), with no hardcoded
+				// id. Per CreateTairInstance semantics ClusterBackupId is used on its own (it
+				// already identifies the source), so src_db_instance_id / backup_id are omitted.
+				// It is create-only, so it lives in the create step and is asserted with CHECKSET.
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type":       "PayAsYouGo",
+					"instance_type":      "tair_rdb",
+					"zone_id":            "${var.zone_id}",
+					"instance_class":     "tair.rdb.2g",
+					"shard_count":        "2",
+					"tair_instance_name": name,
+					"vswitch_id":         "${local.vswitch_id}",
+					"vpc_id":             "${data.alicloud_vpcs.default.ids.0}",
+					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"password":           "123456Tf",
+					"engine_version":     "5.0",
+					"port":               "6379",
+					"cluster_backup_id":  "${alicloud_redis_backup.default.cluster_backup_id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"payment_type":       "PayAsYouGo",
+						"instance_type":      "tair_rdb",
+						"zone_id":            CHECKSET,
+						"instance_class":     "tair.rdb.2g",
+						"shard_count":        "2",
+						"tair_instance_name": name,
+						"vswitch_id":         CHECKSET,
+						"vpc_id":             CHECKSET,
+						"resource_group_id":  CHECKSET,
+						"password":           "123456Tf",
+						"engine_version":     "5.0",
+						"port":               "6379",
+						"cluster_backup_id":  CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auto_renew", "auto_renew_period", "backup_id", "cluster_backup_id", "effective_time", "force_upgrade", "global_instance_id", "password", "period", "read_only_count", "recover_config_mode", "slave_read_only_count", "src_db_instance_id"},
+			},
+		},
+	})
+}
+
+// Case Tair 多安全组回归 multi-security-group: guards the perpetual-diff fix for a
+// comma-separated security_group_id. It is a dedicated case rather than a step hosted in
+// an existing one because basic6823_raw (tair_scm) is no longer purchasable and basic8729
+// depends on TDE/KMS whose environment is currently broken, so neither can actually run.
+// cn-hangzhou tair_rdb is proven end-to-end creatable and carries no TDE/KMS dependency.
+var AlicloudRedisTairInstanceMultiSecurityGroupMap = map[string]string{
+	"port":           CHECKSET,
+	"status":         CHECKSET,
+	"engine_version": CHECKSET,
+	"payment_type":   "PayAsYouGo",
+	"create_time":    CHECKSET,
+}
+
+func AlicloudRedisTairInstanceMultiSecurityGroupDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "zone_id" {
+  default = "cn-hangzhou-h"
+}
+
+variable "region_id" {
+  default = "cn-hangzhou"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  zone_id = var.zone_id
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_vswitch" "vswitch" {
+  count        = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
+  vpc_id       = data.alicloud_vpcs.default.ids.0
+  cidr_block   = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 8)
+  zone_id      = var.zone_id
+  vswitch_name = var.name
+}
+
+locals {
+  vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : concat(alicloud_vswitch.vswitch.*.id, [""])[0]
+}
+
+# Two security groups so the instance can bind a comma-separated list; references are dynamic.
+resource "alicloud_security_group" "default" {
+  name   = var.name
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_security_group" "default2" {
+  name   = format("%%s2", var.name)
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+
+`, name)
+}
+
+func TestAccAliCloudRedisTairInstance_multiSecurityGroup(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_redis_tair_instance.default"
+	ra := resourceAttrInit(resourceId, AlicloudRedisTairInstanceMultiSecurityGroupMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RedisServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRedisTairInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sredistairinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRedisTairInstanceMultiSecurityGroupDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Step 0: create bound to a single security group.
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type":       "PayAsYouGo",
+					"instance_type":      "tair_rdb",
+					"zone_id":            "${var.zone_id}",
+					"instance_class":     "tair.rdb.1g",
+					"tair_instance_name": name,
+					"vswitch_id":         "${local.vswitch_id}",
+					"vpc_id":             "${data.alicloud_vpcs.default.ids.0}",
+					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"password":           "123456Tf",
+					"engine_version":     "5.0",
+					"port":               "6379",
+					"node_type":          "STAND_ALONE",
+					"security_group_id":  "${alicloud_security_group.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"payment_type":       "PayAsYouGo",
+						"instance_type":      "tair_rdb",
+						"zone_id":            CHECKSET,
+						"instance_class":     "tair.rdb.1g",
+						"tair_instance_name": name,
+						"vswitch_id":         CHECKSET,
+						"vpc_id":             CHECKSET,
+						"resource_group_id":  CHECKSET,
+						"password":           "123456Tf",
+						"engine_version":     "5.0",
+						"port":               "6379",
+						"node_type":          "STAND_ALONE",
+						"security_group_id":  CHECKSET,
+					}),
+				),
+			},
+			{
+				// Step 1 (regression core): bind two security groups. Before the read-side
+				// join fix this leaves a permanent non-empty post-apply plan because state
+				// kept only the first id.
+				Config: testAccConfig(map[string]interface{}{
+					"security_group_id": "${alicloud_security_group.default.id},${alicloud_security_group.default2.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				// Step 2: same set, reversed order — exercises the order-insensitive
+				// DiffSuppressFunc; the plan must stay empty (no diff, no update).
+				Config: testAccConfig(map[string]interface{}{
+					"security_group_id": "${alicloud_security_group.default2.id},${alicloud_security_group.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auto_renew", "auto_renew_period", "backup_id", "cluster_backup_id", "effective_time", "force_upgrade", "global_instance_id", "password", "period", "read_only_count", "recover_config_mode", "slave_read_only_count", "src_db_instance_id"},
+			},
+		},
+	})
+}
+
 // Test Redis TairInstance. <<< Resource test cases, automatically generated.
 
 func TestUnitRedisTairInstanceCreateRetryLogic(t *testing.T) {

--- a/alicloud/service_alicloud_redis_v2.go
+++ b/alicloud/service_alicloud_redis_v2.go
@@ -185,11 +185,24 @@ func (s *RedisServiceV2) DescribeTairInstanceDescribeSecurityGroupConfiguration(
 		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Items.EcsSecurityGroupRelation[*]", response)
 	}
 
-	if len(v.([]interface{})) == 0 {
+	relations := v.([]interface{})
+	if len(relations) == 0 {
 		return object, WrapErrorf(NotFoundErr("TairInstance", id), NotFoundMsg, response)
 	}
 
-	return v.([]interface{})[0].(map[string]interface{}), nil
+	// The instance can be bound to multiple security groups (comma-separated on the
+	// write side). Keep the first relation's map as the base (callers still read
+	// RegionId from it) but join every EcsSecurityGroupRelation[*].SecurityGroupId
+	// in API return order so state reflects all bound security groups instead of only
+	// the first one, which otherwise causes a perpetual diff.
+	object = relations[0].(map[string]interface{})
+	securityGroupIds := make([]string, 0, len(relations))
+	for _, relation := range relations {
+		securityGroupIds = append(securityGroupIds, fmt.Sprint(relation.(map[string]interface{})["SecurityGroupId"]))
+	}
+	object["SecurityGroupId"] = strings.Join(securityGroupIds, ",")
+
+	return object, nil
 }
 func (s *RedisServiceV2) DescribeTairInstanceDescribeInstanceTDEStatus(id string) (object map[string]interface{}, err error) {
 	client := s.client
@@ -722,3 +735,88 @@ func (s *RedisServiceV2) DescribeAsyncDescribeBackups(d *schema.ResourceData, re
 }
 
 // DescribeAsyncDescribeBackups >>> Encapsulated.
+
+// DescribeRedisClusterBackupId <<< Resolve the cluster backup set id for a backup.
+
+// DescribeRedisClusterBackupId returns the cluster backup set id (cb-*) that owns the
+// given per-shard BackupId. It calls DescribeClusterBackupList over a UTC time window
+// around now and matches the backup set whose shard-level Backups contain backupId.
+// Cluster-architecture instances produce a cluster backup set per backup; standard
+// instances produce none, in which case it returns an empty id and no error.
+func (s *RedisServiceV2) DescribeRedisClusterBackupId(instanceId string, backupId string) (string, error) {
+	client := s.client
+	var response map[string]interface{}
+	var query map[string]interface{}
+	var err error
+	query = make(map[string]interface{})
+	query["InstanceId"] = instanceId
+	query["RegionId"] = client.RegionId
+	// DescribeClusterBackupList requires a UTC time window truncated to the minute.
+	now := time.Now().UTC()
+	query["StartTime"] = now.Add(-2 * time.Hour).Format("2006-01-02T15:04Z")
+	query["EndTime"] = now.Add(10 * time.Minute).Format("2006-01-02T15:04Z")
+	query["PageSize"] = 100
+	action := "DescribeClusterBackupList"
+
+	// DescribeClusterBackupList only accepts GET (RpcPost is rejected with 403
+	// UnsupportedHTTPMethod), so all parameters go in the query and the body is nil.
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcGet("R-kvstore", "2015-01-01", action, query, nil)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, query)
+	if err != nil {
+		return "", WrapErrorf(err, DefaultErrorMsg, instanceId, action, AlibabaCloudSdkGoERROR)
+	}
+
+	// Match the backup set whose shard Backups contain backupId. The RPC response wraps
+	// lists inconsistently across products, so accept both the flat ([...]) and wrapped
+	// ({"<Elem>": [...]}) shapes.
+	for _, item := range redisRpcList(response["ClusterBackups"], "ClusterBackup") {
+		clusterBackup, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		clusterBackupId := fmt.Sprint(clusterBackup["ClusterBackupId"])
+		if clusterBackupId == "" || clusterBackupId == "<nil>" {
+			continue
+		}
+		for _, shard := range redisRpcList(clusterBackup["Backups"], "Backup") {
+			shardBackup, ok := shard.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if fmt.Sprint(shardBackup["BackupId"]) == backupId {
+				return clusterBackupId, nil
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// redisRpcList normalizes an R-kvstore RPC list field that may arrive either as a flat
+// JSON array or wrapped in a single-key object ({"<elementKey>": [...]}).
+func redisRpcList(v interface{}, elementKey string) []interface{} {
+	switch t := v.(type) {
+	case []interface{}:
+		return t
+	case map[string]interface{}:
+		if inner, ok := t[elementKey]; ok {
+			if list, ok := inner.([]interface{}); ok {
+				return list
+			}
+		}
+	}
+	return nil
+}
+
+// DescribeRedisClusterBackupId >>> Encapsulated.

--- a/website/docs/r/redis_backup.html.markdown
+++ b/website/docs/r/redis_backup.html.markdown
@@ -95,6 +95,7 @@ The following arguments are supported:
 The following attributes are exported:
 * `id` - The ID of the resource supplied above.The value is formulated as `<instance_id>:<backup_id>`.
 * `backup_id` - Backup ID.
+* `cluster_backup_id` - The cluster backup set ID (`cb-*`) that this backup belongs to. Returned when the instance is a cluster-architecture instance; empty otherwise. It can be used as the `cluster_backup_id` of `alicloud_redis_tair_instance` to clone a cloud-native cluster instance.
 * `status` - Backup status.
 
 ## Timeouts


### PR DESCRIPTION
### What this PR does

Fixes a perpetual diff on `alicloud_redis_tair_instance.security_group_id` when multiple security groups are configured (comma-separated, e.g. `"sg-a,sg-b"`): with no config change, every `terraform plan`/`apply` reported a change.

### Root cause

The write side (`ModifySecurityGroupConfiguration`) correctly passes the comma-separated list through, and all security groups are bound on the cloud side. But on the read side, `DescribeTairInstanceDescribeSecurityGroupConfiguration` (alicloud/service_alicloud_redis_v2.go) returned only the first element of `Items.EcsSecurityGroupRelation`, so state always held a single security group id and could never match a multi-value config.

### Changes

1. `service_alicloud_redis_v2.go`: aggregate all `EcsSecurityGroupRelation[*].SecurityGroupId` values (joined by `,` in API return order) into the returned object, keeping the first element's map as the base since callers also read `RegionId`. Consistent with the existing handling of the same API in `alicloud_kvstore_instance`.
2. `resource_alicloud_redis_tair_instance.go`: add an order-insensitive `DiffSuppressFunc` on `security_group_id`, the same split/sort/compare pattern already used by `security_ips` in this resource, so a different server-side return order does not surface as a diff.
3. `resource_alicloud_redis_tair_instance_test.go`: add a multi-security-group step to `TestAccAliCloudRedisTairInstance_basic6823_raw` (reuses the existing two SG fixtures); the SDK's post-apply empty-plan check locks in the regression — this step fails before the patch and passes after.

### Testing coverage completion (TestingCoverageRate)

The coverage gate additionally requires the resource's create-only clone attributes (`backup_id`, `cluster_backup_id`, `src_db_instance_id`) to be exercised — they lost coverage when the stale hardcoded `cb-hyxdof5x9kqb333` fixture was removed. Covered with real, fully dynamic chains (no hardcoded ids, no placeholder variables):

4. `resource_alicloud_redis_backup.go` + `service_alicloud_redis_v2.go`: expose a new computed `cluster_backup_id` on `alicloud_redis_backup` — after the backup job completes, `DescribeClusterBackupList` is queried and the cluster backup set is matched by the shard `BackupId`; empty (no error) for standard-architecture instances. Documented in `website/docs/r/redis_backup.html.markdown`.
5. `resource_alicloud_redis_tair_instance_test.go`: new `TestAccAliCloudRedisTairInstance_cloneFromBackup` (source instance → `alicloud_redis_backup` → clone via `src_db_instance_id` + `backup_id`) and `TestAccAliCloudRedisTairInstance_cloneFromClusterBackup` (cluster-architecture source, clone via `cluster_backup_id` from the new output).

### Verification

- `go build ./alicloud/...` and `go vet ./alicloud/...` clean (no new warnings in changed files); gofmt/terrafmt clean.
- Coverage gate locally: `go run scripts/testing/testing_coverage_rate_check.go -resource=alicloud_redis_tair_instance` and `-resource=alicloud_redis_backup` both report 100%/100% PASS.
- Suggested acceptance runs:
  - `TF_ACC=1 go test ./alicloud/ -v -run '^TestAccAliCloudRedisTairInstance_basic6823_raw$' -timeout 180m`
  - `TF_ACC=1 go test ./alicloud/ -v -run '^TestAccAliCloudRedisTairInstance_cloneFrom(Backup|ClusterBackup)$' -timeout 200m`
  - `TF_ACC=1 go test ./alicloud/ -v -run '^TestAccAliCloudRedisBackup_basic11970$' -timeout 90m`

Fixes Aone#83679740.
