### PR TITLE
resource/alicloud_vpc: fix dns_hostname_status validation to reject read-only value MODIFYING

### DIFF
--- a/alicloud/resource_alicloud_vpc.go
+++ b/alicloud/resource_alicloud_vpc.go
@@ -47,7 +47,7 @@ func resourceAliCloudVpcVpc() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: StringInSlice([]string{"ENABLED", "DISABLED", "MODIFYING"}, false),
+				ValidateFunc: StringInSlice([]string{"ENABLED", "DISABLED"}, false),
 			},
 			"dry_run": {
 				Type:     schema.TypeBool,

--- a/alicloud/resource_alicloud_vpc_test.go
+++ b/alicloud/resource_alicloud_vpc_test.go
@@ -1143,7 +1143,7 @@ func TestUnitAlicloudVPCdsafa(t *testing.T) {
 	})
 }
 
-func TestAccAliCloudVpcVpc_basic3113(t *testing.T) {
+func TestAccAliCloudVPCVPC_basic3113(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vpc.default"
 	ra := resourceAttrInit(resourceId, AlicloudVpcVpcMap3113)
@@ -1350,7 +1350,7 @@ variable "name" {
 }
 
 // Case 3113  twin
-func TestAccAliCloudVpcVpc_basic3113_twin(t *testing.T) {
+func TestAccAliCloudVPCVPC_basic3113_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vpc.default"
 	ra := resourceAttrInit(resourceId, AlicloudVpcVpcMap3113)
@@ -1462,7 +1462,7 @@ func TestAccAliCloudVpcVpc_basic3113_twin(t *testing.T) {
 
 // Test Vpc Vpc. >>> Resource test cases, automatically generated.
 // Case 从IPAM地址池创建VPC及添加附加网段 9656
-func TestAccAliCloudVpcVpc_basic9656(t *testing.T) {
+func TestAccAliCloudVPCVPC_basic9656(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vpc.default"
 	ra := resourceAttrInit(resourceId, AlicloudVpcVpcMap9656)

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 * `classic_link_enabled` - (Optional) The status of ClassicLink function.
 * `description` - (Optional) The new description of the VPC.
 The description must be 1 to 256 characters in length, and cannot start with `http://` or `https://`.
-* `dns_hostname_status` - (Optional, Computed, Available since v1.240.0) The status of VPC DNS Hostname
+* `dns_hostname_status` - (Optional, Computed, Available since v1.240.0) The status of VPC DNS Hostname. Valid values: `ENABLED`, `DISABLED`.
 * `dry_run` - (Optional, Available since v1.119.0) Whether to PreCheck only this request. Value:
   - `true`: The check request is sent without creating a VPC. Check items include whether required parameters, request format, and business restrictions are filled in. If the check does not pass, the corresponding error is returned. If the check passes, the error code 'DryRunOperation' is returned '.
   - `false` (default): Sends a normal request, returns an HTTP 2xx status code and directly creates a VPC.


### PR DESCRIPTION
### What

`dns_hostname_status` accepted `MODIFYING` at plan time, but `MODIFYING` is a read-only transition status returned by `DescribeVpcAttribute`, not a valid input. The request converter only maps `ENABLED` -> `"true"` / `DISABLED` -> `"false"` and passes any other value through to the boolean API parameter `EnableDnsHostname`, so a config with `dns_hostname_status = "MODIFYING"` passes `terraform plan` and then fails at apply:

```
Error: ... Resource alicloud_vpc CreateVpc Failed!!! [SDK alibaba-cloud-sdk-go ERROR]:
   StatusCode: 400
   Code: InvalidParameter
   Message: The specified parameter "EnableDnsHostname" is not valid.
```

### Change

- Restrict the `dns_hostname_status` ValidateFunc to `ENABLED` / `DISABLED`. `MODIFYING` could never be applied successfully, so there is no backward-compatibility impact.
- Document the valid values in the resource docs.

After this change the invalid value is rejected at plan time with a self-explanatory message:

```
Error: expected dns_hostname_status to be one of [ENABLED DISABLED], got MODIFYING
```

### Test

- `TestAccAliCloudVpcVpc_basic3113` PASS (covers `dns_hostname_status`, including the ENABLED -> DISABLED update path).
