### PR TITLE
New Resource: alicloud_cms_alert_rule_v2; New Data Source: alicloud_cms_alert_rule_v2s

### DIFF
--- a/alicloud/data_source_alicloud_cms_alert_rule_v2s.go
+++ b/alicloud/data_source_alicloud_cms_alert_rule_v2s.go
@@ -1,0 +1,1352 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudCmsAlertRuleV2s() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudCmsAlertRuleV2Read,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"filter_datasource_type_eq": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_display_name_contains": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_display_name_not_contains": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_enabled_eq": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"filter_labels_all_of_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_labels_all_of_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_labels_any_of_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_labels_any_of_value": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_notify_strategy_id_eq": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_observe_resource_global_scope_eq": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"filter_observe_resource_instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_observe_resource_list_contains": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_observe_resource_type_eq": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_partition_key_eq": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_severity_levels_contains": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_status_eq": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_uuid_eq": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"filter_uuid_in": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"workspace": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"v2s": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"action_integration_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"actions": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"alert_rule_v2_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"annotations": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"arms_integration_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"condition_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"operator": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"legacy_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"legacy_raw": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"prometheus": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"prom_ql": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"times": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"severity": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"severity": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"no_data_policy": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"simple_escalation": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"metric_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"escalations": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"comparison_operator": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"times": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"pre_condition": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"severity": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"statistics": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"threshold": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"period": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"yoy_time_unit": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"compare_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"operator": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"aggregate": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"yoy_time_value": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"threshold": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+												"yoy_time_unit": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"escalation_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"relation": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"composite_escalation": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"relation": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"times": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"escalations": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"metric_name": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"comparison_operator": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"pre_condition": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"period": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"statistics": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"threshold": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"severity": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"duration_secs": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"aggregate": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"express_escalation": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"raw_expression": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"times": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"severity": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"yoy_time_value": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"threshold_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"severity": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"threshold": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"threshold": {
+										Type:     schema.TypeFloat,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"content_template": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"datasource_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"legacy_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"instance_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"legacy_raw": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"product_category": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"region_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"datasource_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"display_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"labels": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"notify_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"utc_offset": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"notify_strategies": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"active_days": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeInt},
+									},
+									"active_end_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"silence_time_secs": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"active_start_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"channels": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"identifiers": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"notify_strategy_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"observe_resource_global_scope": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"observe_resource_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"partition_key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"query_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"legacy_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"prom_ql": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"legacy_raw": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"entity_filters": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"operator": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"field": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"dimensions": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeMap, Elem: &schema.Schema{Type: schema.TypeString}},
+									},
+									"filter_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"label_filters": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"operator": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"namespace": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"metric_set": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"group_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"entity_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"measure_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"measure_code": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"group_by": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"window_secs": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"expr": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"entity_domain": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"relation_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"metric": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"service_id_list": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"enable_data_complete_check": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"entity_fields": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"field": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"schedule_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"interval_secs": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"severity_levels": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"workspace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudCmsAlertRuleV2Read(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var body map[string]interface{}
+	// QueryAlertRules
+	action := fmt.Sprintf("/queryAlertRules")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+	query["RegionId"] = StringPointer(client.RegionId)
+	filter := make(map[string]interface{})
+	if v := d.Get("filter_datasource_type_eq"); !IsNil(v) {
+		datasourceType := make(map[string]interface{})
+		datasourceType["eq"] = v
+		if len(datasourceType) > 0 {
+			filter["datasourceType"] = datasourceType
+		}
+	}
+	displayName := make(map[string]interface{})
+	if v := d.Get("filter_display_name_contains"); !IsNil(v) {
+		displayName["contains"] = v
+	}
+	if v := d.Get("filter_display_name_not_contains"); !IsNil(v) {
+		displayName["notContains"] = v
+	}
+	if len(displayName) > 0 {
+		filter["displayName"] = displayName
+	}
+	if v, ok := d.GetOkExists("filter_enabled_eq"); ok {
+		enabled := make(map[string]interface{})
+		enabled["eq"] = v
+		if len(enabled) > 0 {
+			filter["enabled"] = enabled
+		}
+	}
+	if v := d.Get("filter_notify_strategy_id_eq"); !IsNil(v) {
+		notifyStrategyId := make(map[string]interface{})
+		notifyStrategyId["eq"] = v
+		if len(notifyStrategyId) > 0 {
+			filter["notifyStrategyId"] = notifyStrategyId
+		}
+	}
+	if v, ok := d.GetOkExists("filter_observe_resource_global_scope_eq"); ok {
+		observeResourceGlobalScope := make(map[string]interface{})
+		observeResourceGlobalScope["eq"] = v
+		if len(observeResourceGlobalScope) > 0 {
+			filter["observeResourceGlobalScope"] = observeResourceGlobalScope
+		}
+	}
+	if v, ok := d.GetOk("filter_observe_resource_instance_id"); ok {
+		filter["observeResourceInstanceId"] = v
+	}
+	if v := d.Get("filter_observe_resource_list_contains"); !IsNil(v) {
+		observeResourceList := make(map[string]interface{})
+		observeResourceList["contains"] = []interface{}{v}
+		if len(observeResourceList) > 0 {
+			filter["observeResourceList"] = observeResourceList
+		}
+	}
+	if v := d.Get("filter_observe_resource_type_eq"); !IsNil(v) {
+		observeResourceType := make(map[string]interface{})
+		observeResourceType["eq"] = v
+		if len(observeResourceType) > 0 {
+			filter["observeResourceType"] = observeResourceType
+		}
+	}
+	if v := d.Get("filter_partition_key_eq"); !IsNil(v) {
+		partitionKey := make(map[string]interface{})
+		partitionKey["eq"] = v
+		if len(partitionKey) > 0 {
+			filter["partitionKey"] = partitionKey
+		}
+	}
+	if v := d.Get("filter_severity_levels_contains"); !IsNil(v) {
+		severityLevels := make(map[string]interface{})
+		severityLevels["contains"] = []interface{}{v}
+		if len(severityLevels) > 0 {
+			filter["severityLevels"] = severityLevels
+		}
+	}
+	if v := d.Get("filter_status_eq"); !IsNil(v) {
+		status := make(map[string]interface{})
+		status["eq"] = v
+		if len(status) > 0 {
+			filter["status"] = status
+		}
+	}
+	uuid := make(map[string]interface{})
+	if v := d.Get("filter_uuid_eq"); !IsNil(v) {
+		uuid["eq"] = v
+	}
+	if v, ok := d.GetOk("filter_uuid_in"); ok {
+		uuidIn := make([]interface{}, 0)
+		for _, item := range strings.Split(v.(string), ",") {
+			uuidIn = append(uuidIn, strings.TrimSpace(item))
+		}
+		uuid["in"] = uuidIn
+	}
+	if len(uuid) > 0 {
+		filter["uuid"] = uuid
+	}
+	labels := make(map[string]interface{})
+	labelsAllOf := make(map[string]interface{})
+	if v := d.Get("filter_labels_all_of_key"); !IsNil(v) {
+		labelsAllOf["key"] = v
+	}
+	if v := d.Get("filter_labels_all_of_value"); !IsNil(v) {
+		labelsAllOf["value"] = v
+	}
+	if len(labelsAllOf) > 0 {
+		labels["allOf"] = []interface{}{labelsAllOf}
+	}
+	labelsAnyOf := make(map[string]interface{})
+	if v := d.Get("filter_labels_any_of_key"); !IsNil(v) {
+		labelsAnyOf["key"] = v
+	}
+	if v := d.Get("filter_labels_any_of_value"); !IsNil(v) {
+		labelsAnyOf["value"] = v
+	}
+	if len(labelsAnyOf) > 0 {
+		labels["anyOf"] = []interface{}{labelsAnyOf}
+	}
+	if len(labels) > 0 {
+		filter["labels"] = labels
+	}
+
+	if len(idsMap) > 0 {
+		if _, ok := filter["uuid"]; !ok {
+			uuidIn := make([]interface{}, 0, len(idsMap))
+			for id := range idsMap {
+				uuidIn = append(uuidIn, id)
+			}
+			filter["uuid"] = map[string]interface{}{"in": uuidIn}
+		}
+	}
+	if len(filter) > 0 {
+		request["filter"] = filter
+	}
+
+	if v, ok := d.GetOk("workspace"); ok {
+		request["workspace"] = v
+	}
+	if len(request) == 0 {
+		request["maxResults"] = PageSizeLarge
+	}
+	body = request
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	query["maxResults"] = StringPointer(strconv.Itoa(PageSizeLarge))
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaPost("Cms", "2024-03-30", action, query, nil, body, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.data.alertRules[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["uuid"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if nextToken, ok := response["nextToken"].(string); ok && nextToken != "" {
+			query["nextToken"] = StringPointer(nextToken)
+		} else {
+			break
+		}
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["uuid"]
+
+		mapping["annotations"] = objectRaw["annotations"]
+		mapping["content_template"] = objectRaw["contentTemplate"]
+		mapping["created_at"] = objectRaw["createdAt"]
+		mapping["datasource_type"] = objectRaw["datasourceType"]
+		mapping["display_name"] = objectRaw["displayName"]
+		mapping["enabled"] = objectRaw["enabled"]
+		mapping["labels"] = objectRaw["labels"]
+		mapping["notify_strategy_id"] = objectRaw["notifyStrategyId"]
+		mapping["observe_resource_global_scope"] = objectRaw["observeResourceGlobalScope"]
+		mapping["observe_resource_type"] = objectRaw["observeResourceType"]
+		mapping["partition_key"] = objectRaw["partitionKey"]
+		mapping["severity_levels"] = objectRaw["severityLevels"]
+		mapping["status"] = objectRaw["status"]
+		mapping["updated_at"] = objectRaw["updatedAt"]
+		mapping["workspace"] = objectRaw["workspace"]
+		mapping["alert_rule_v2_id"] = objectRaw["uuid"]
+
+		actionIntegrationConfigMaps := make([]map[string]interface{}, 0)
+		actionIntegrationConfigMap := make(map[string]interface{})
+		actionIntegrationConfigRaw := make(map[string]interface{})
+		if objectRaw["actionIntegrationConfig"] != nil {
+			actionIntegrationConfigRaw = objectRaw["actionIntegrationConfig"].(map[string]interface{})
+		}
+		if len(actionIntegrationConfigRaw) > 0 {
+			actionIntegrationConfigMap["enabled"] = actionIntegrationConfigRaw["enabled"]
+
+			actionsRaw := make([]interface{}, 0)
+			if actionIntegrationConfigRaw["actions"] != nil {
+				actionsRaw = convertToInterfaceArray(actionIntegrationConfigRaw["actions"])
+			}
+
+			actionIntegrationConfigMap["actions"] = actionsRaw
+			actionIntegrationConfigMaps = append(actionIntegrationConfigMaps, actionIntegrationConfigMap)
+		}
+		mapping["action_integration_config"] = actionIntegrationConfigMaps
+		armsIntegrationConfigMaps := make([]map[string]interface{}, 0)
+		armsIntegrationConfigMap := make(map[string]interface{})
+
+		armsIntegrationConfigRaw := make(map[string]interface{})
+		if objectRaw["armsIntegrationConfig"] != nil {
+			armsIntegrationConfigRaw = objectRaw["armsIntegrationConfig"].(map[string]interface{})
+		}
+		if len(armsIntegrationConfigRaw) > 0 {
+			armsIntegrationConfigMap["enabled"] = armsIntegrationConfigRaw["enabled"]
+
+			armsIntegrationConfigMaps = append(armsIntegrationConfigMaps, armsIntegrationConfigMap)
+		}
+		mapping["arms_integration_config"] = armsIntegrationConfigMaps
+		conditionConfigMaps := make([]map[string]interface{}, 0)
+		conditionConfigMap := make(map[string]interface{})
+
+		conditionConfigRaw := make(map[string]interface{})
+		if objectRaw["conditionConfig"] != nil {
+			conditionConfigRaw = objectRaw["conditionConfig"].(map[string]interface{})
+		}
+		if len(conditionConfigRaw) > 0 {
+			conditionConfigMap["aggregate"] = conditionConfigRaw["aggregate"]
+			conditionConfigMap["duration_secs"] = conditionConfigRaw["durationSecs"]
+			conditionConfigMap["escalation_type"] = conditionConfigRaw["escalationType"]
+			conditionConfigMap["legacy_raw"] = conditionConfigRaw["legacyRaw"]
+			conditionConfigMap["legacy_type"] = conditionConfigRaw["legacyType"]
+			conditionConfigMap["no_data_policy"] = conditionConfigRaw["noDataPolicy"]
+			conditionConfigMap["operator"] = conditionConfigRaw["operator"]
+			conditionConfigMap["relation"] = conditionConfigRaw["relation"]
+			conditionConfigMap["severity"] = conditionConfigRaw["severity"]
+			conditionConfigMap["threshold"] = conditionConfigRaw["threshold"]
+			conditionConfigMap["type"] = conditionConfigRaw["type"]
+			conditionConfigMap["yoy_time_unit"] = conditionConfigRaw["yoyTimeUnit"]
+			conditionConfigMap["yoy_time_value"] = conditionConfigRaw["yoyTimeValue"]
+
+			compareListRaw := conditionConfigRaw["compareList"]
+			compareListMaps := make([]map[string]interface{}, 0)
+			if compareListRaw != nil {
+				for _, compareListChildRaw := range convertToInterfaceArray(compareListRaw) {
+					compareListMap := make(map[string]interface{})
+
+					compareListChildRaw := compareListChildRaw.(map[string]interface{})
+					compareListMap["aggregate"] = compareListChildRaw["aggregate"]
+					compareListMap["operator"] = compareListChildRaw["operator"]
+					compareListMap["threshold"] = compareListChildRaw["threshold"]
+					compareListMap["yoy_time_unit"] = compareListChildRaw["yoyTimeUnit"]
+					compareListMap["yoy_time_value"] = compareListChildRaw["yoyTimeValue"]
+
+					compareListMaps = append(compareListMaps, compareListMap)
+				}
+			}
+			conditionConfigMap["compare_list"] = compareListMaps
+			compositeEscalationMaps := make([]map[string]interface{}, 0)
+			compositeEscalationMap := make(map[string]interface{})
+
+			compositeEscalationRaw := make(map[string]interface{})
+			if conditionConfigRaw["compositeEscalation"] != nil {
+				compositeEscalationRaw = conditionConfigRaw["compositeEscalation"].(map[string]interface{})
+			}
+			if len(compositeEscalationRaw) > 0 {
+				compositeEscalationMap["relation"] = compositeEscalationRaw["relation"]
+				compositeEscalationMap["severity"] = compositeEscalationRaw["severity"]
+				compositeEscalationMap["times"] = compositeEscalationRaw["times"]
+
+				escalationsRaw := compositeEscalationRaw["escalations"]
+				escalationsMaps := make([]map[string]interface{}, 0)
+				if escalationsRaw != nil {
+					for _, escalationsChildRaw := range convertToInterfaceArray(escalationsRaw) {
+						escalationsMap := make(map[string]interface{})
+
+						escalationsChildRaw := escalationsChildRaw.(map[string]interface{})
+						escalationsMap["comparison_operator"] = escalationsChildRaw["comparisonOperator"]
+						escalationsMap["metric_name"] = escalationsChildRaw["metricName"]
+						escalationsMap["period"] = escalationsChildRaw["period"]
+						escalationsMap["pre_condition"] = escalationsChildRaw["preCondition"]
+						escalationsMap["statistics"] = escalationsChildRaw["statistics"]
+						escalationsMap["threshold"] = escalationsChildRaw["threshold"]
+
+						escalationsMaps = append(escalationsMaps, escalationsMap)
+					}
+				}
+				compositeEscalationMap["escalations"] = escalationsMaps
+				compositeEscalationMaps = append(compositeEscalationMaps, compositeEscalationMap)
+			}
+			conditionConfigMap["composite_escalation"] = compositeEscalationMaps
+			expressEscalationMaps := make([]map[string]interface{}, 0)
+			expressEscalationMap := make(map[string]interface{})
+
+			expressEscalationRaw := make(map[string]interface{})
+			if conditionConfigRaw["expressEscalation"] != nil {
+				expressEscalationRaw = conditionConfigRaw["expressEscalation"].(map[string]interface{})
+			}
+			if len(expressEscalationRaw) > 0 {
+				expressEscalationMap["raw_expression"] = expressEscalationRaw["rawExpression"]
+				expressEscalationMap["severity"] = expressEscalationRaw["severity"]
+				expressEscalationMap["times"] = expressEscalationRaw["times"]
+
+				expressEscalationMaps = append(expressEscalationMaps, expressEscalationMap)
+			}
+			conditionConfigMap["express_escalation"] = expressEscalationMaps
+			prometheusMaps := make([]map[string]interface{}, 0)
+			prometheusMap := make(map[string]interface{})
+
+			prometheusRaw := make(map[string]interface{})
+			if conditionConfigRaw["prometheus"] != nil {
+				prometheusRaw = conditionConfigRaw["prometheus"].(map[string]interface{})
+			}
+			if len(prometheusRaw) > 0 {
+				prometheusMap["prom_ql"] = prometheusRaw["promQl"]
+				prometheusMap["severity"] = prometheusRaw["severity"]
+				prometheusMap["times"] = prometheusRaw["times"]
+
+				prometheusMaps = append(prometheusMaps, prometheusMap)
+			}
+			conditionConfigMap["prometheus"] = prometheusMaps
+			simpleEscalationMaps := make([]map[string]interface{}, 0)
+			simpleEscalationMap := make(map[string]interface{})
+
+			simpleEscalationRaw := make(map[string]interface{})
+			if conditionConfigRaw["simpleEscalation"] != nil {
+				simpleEscalationRaw = conditionConfigRaw["simpleEscalation"].(map[string]interface{})
+			}
+			if len(simpleEscalationRaw) > 0 {
+				simpleEscalationMap["metric_name"] = simpleEscalationRaw["metricName"]
+				simpleEscalationMap["period"] = simpleEscalationRaw["period"]
+
+				escalationsRaw := simpleEscalationRaw["escalations"]
+				escalationsMaps := make([]map[string]interface{}, 0)
+				if escalationsRaw != nil {
+					for _, escalationsChildRaw := range convertToInterfaceArray(escalationsRaw) {
+						escalationsMap := make(map[string]interface{})
+
+						escalationsChildRaw := escalationsChildRaw.(map[string]interface{})
+						escalationsMap["comparison_operator"] = escalationsChildRaw["comparisonOperator"]
+						escalationsMap["pre_condition"] = escalationsChildRaw["preCondition"]
+						escalationsMap["severity"] = escalationsChildRaw["severity"]
+						escalationsMap["statistics"] = escalationsChildRaw["statistics"]
+						escalationsMap["threshold"] = escalationsChildRaw["threshold"]
+						escalationsMap["times"] = escalationsChildRaw["times"]
+
+						escalationsMaps = append(escalationsMaps, escalationsMap)
+					}
+				}
+				simpleEscalationMap["escalations"] = escalationsMaps
+				simpleEscalationMaps = append(simpleEscalationMaps, simpleEscalationMap)
+			}
+			conditionConfigMap["simple_escalation"] = simpleEscalationMaps
+
+			thresholdListRaw := conditionConfigRaw["thresholdList"]
+			thresholdListMaps := make([]map[string]interface{}, 0)
+			if thresholdListRaw != nil {
+				for _, thresholdListChildRaw := range convertToInterfaceArray(thresholdListRaw) {
+					thresholdListMap := make(map[string]interface{})
+
+					thresholdListChildRaw := thresholdListChildRaw.(map[string]interface{})
+					thresholdListMap["severity"] = thresholdListChildRaw["severity"]
+					thresholdListMap["threshold"] = thresholdListChildRaw["threshold"]
+
+					thresholdListMaps = append(thresholdListMaps, thresholdListMap)
+				}
+			}
+			conditionConfigMap["threshold_list"] = thresholdListMaps
+			conditionConfigMaps = append(conditionConfigMaps, conditionConfigMap)
+		}
+		mapping["condition_config"] = conditionConfigMaps
+		datasourceConfigMaps := make([]map[string]interface{}, 0)
+		datasourceConfigMap := make(map[string]interface{})
+		datasourceConfigRaw := make(map[string]interface{})
+		if objectRaw["datasourceConfig"] != nil {
+			datasourceConfigRaw = objectRaw["datasourceConfig"].(map[string]interface{})
+		}
+		if len(datasourceConfigRaw) > 0 {
+			datasourceConfigMap["instance_id"] = datasourceConfigRaw["instanceId"]
+			datasourceConfigMap["legacy_raw"] = datasourceConfigRaw["legacyRaw"]
+			datasourceConfigMap["legacy_type"] = datasourceConfigRaw["legacyType"]
+			datasourceConfigMap["product_category"] = datasourceConfigRaw["productCategory"]
+			datasourceConfigMap["region_id"] = datasourceConfigRaw["regionId"]
+			datasourceConfigMap["type"] = datasourceConfigRaw["type"]
+
+			datasourceConfigMaps = append(datasourceConfigMaps, datasourceConfigMap)
+		}
+		mapping["datasource_config"] = datasourceConfigMaps
+		notifyConfigMaps := make([]map[string]interface{}, 0)
+		notifyConfigMap := make(map[string]interface{})
+		notifyConfigRaw := make(map[string]interface{})
+		if objectRaw["notifyConfig"] != nil {
+			notifyConfigRaw = objectRaw["notifyConfig"].(map[string]interface{})
+		}
+		if len(notifyConfigRaw) > 0 {
+			notifyConfigMap["active_end_time"] = notifyConfigRaw["activeEndTime"]
+			notifyConfigMap["active_start_time"] = notifyConfigRaw["activeStartTime"]
+			notifyConfigMap["silence_time_secs"] = notifyConfigRaw["silenceTimeSecs"]
+			notifyConfigMap["type"] = notifyConfigRaw["type"]
+			notifyConfigMap["utc_offset"] = notifyConfigRaw["utcOffset"]
+
+			activeDaysRaw := make([]interface{}, 0)
+			if notifyConfigRaw["activeDays"] != nil {
+				activeDaysRaw = convertToInterfaceArray(notifyConfigRaw["activeDays"])
+			}
+
+			notifyConfigMap["active_days"] = activeDaysRaw
+			channelsRaw := notifyConfigRaw["channels"]
+			channelsMaps := make([]map[string]interface{}, 0)
+			if channelsRaw != nil {
+				for _, channelsChildRaw := range convertToInterfaceArray(channelsRaw) {
+					channelsMap := make(map[string]interface{})
+					channelsChildRaw := channelsChildRaw.(map[string]interface{})
+					channelsMap["type"] = channelsChildRaw["type"]
+
+					identifiersRaw := make([]interface{}, 0)
+					if channelsChildRaw["identifiers"] != nil {
+						identifiersRaw = convertToInterfaceArray(channelsChildRaw["identifiers"])
+					}
+
+					channelsMap["identifiers"] = identifiersRaw
+					channelsMaps = append(channelsMaps, channelsMap)
+				}
+			}
+			notifyConfigMap["channels"] = channelsMaps
+			notifyStrategiesRaw := make([]interface{}, 0)
+			if notifyConfigRaw["notifyStrategies"] != nil {
+				notifyStrategiesRaw = convertToInterfaceArray(notifyConfigRaw["notifyStrategies"])
+			}
+
+			notifyConfigMap["notify_strategies"] = notifyStrategiesRaw
+			notifyConfigMaps = append(notifyConfigMaps, notifyConfigMap)
+		}
+		mapping["notify_config"] = notifyConfigMaps
+		queryConfigMaps := make([]map[string]interface{}, 0)
+		queryConfigMap := make(map[string]interface{})
+		queryConfigRaw := make(map[string]interface{})
+		if objectRaw["queryConfig"] != nil {
+			queryConfigRaw = objectRaw["queryConfig"].(map[string]interface{})
+		}
+		if len(queryConfigRaw) > 0 {
+			queryConfigMap["enable_data_complete_check"] = queryConfigRaw["enableDataCompleteCheck"]
+			queryConfigMap["entity_domain"] = queryConfigRaw["entityDomain"]
+			queryConfigMap["entity_type"] = queryConfigRaw["entityType"]
+			queryConfigMap["expr"] = queryConfigRaw["expr"]
+			queryConfigMap["group_id"] = queryConfigRaw["groupId"]
+			queryConfigMap["legacy_raw"] = queryConfigRaw["legacyRaw"]
+			queryConfigMap["legacy_type"] = queryConfigRaw["legacyType"]
+			queryConfigMap["metric"] = queryConfigRaw["metric"]
+			queryConfigMap["metric_set"] = queryConfigRaw["metricSet"]
+			queryConfigMap["namespace"] = queryConfigRaw["namespace"]
+			queryConfigMap["prom_ql"] = queryConfigRaw["promQl"]
+			queryConfigMap["relation_type"] = queryConfigRaw["relationType"]
+			queryConfigMap["type"] = queryConfigRaw["type"]
+
+			queryConfigMap["dimensions"] = queryConfigRaw["dimensions"]
+
+			entityFieldsRaw := queryConfigRaw["entityFields"]
+			entityFieldsMaps := make([]map[string]interface{}, 0)
+			if entityFieldsRaw != nil {
+				for _, entityFieldsChildRaw := range convertToInterfaceArray(entityFieldsRaw) {
+					entityFieldsMap := make(map[string]interface{})
+
+					entityFieldsChildRaw := entityFieldsChildRaw.(map[string]interface{})
+					entityFieldsMap["field"] = entityFieldsChildRaw["field"]
+					entityFieldsMap["value"] = entityFieldsChildRaw["value"]
+
+					entityFieldsMaps = append(entityFieldsMaps, entityFieldsMap)
+				}
+			}
+			queryConfigMap["entity_fields"] = entityFieldsMaps
+			entityFiltersRaw := queryConfigRaw["entityFilters"]
+			entityFiltersMaps := make([]map[string]interface{}, 0)
+			if entityFiltersRaw != nil {
+				for _, entityFiltersChildRaw := range convertToInterfaceArray(entityFiltersRaw) {
+					entityFiltersMap := make(map[string]interface{})
+					entityFiltersChildRaw := entityFiltersChildRaw.(map[string]interface{})
+					entityFiltersMap["field"] = entityFiltersChildRaw["field"]
+					entityFiltersMap["operator"] = entityFiltersChildRaw["operator"]
+					entityFiltersMap["value"] = entityFiltersChildRaw["value"]
+
+					entityFiltersMaps = append(entityFiltersMaps, entityFiltersMap)
+				}
+			}
+			queryConfigMap["entity_filters"] = entityFiltersMaps
+
+			filterListRaw := queryConfigRaw["filterList"]
+			filterListMaps := make([]map[string]interface{}, 0)
+			if filterListRaw != nil {
+				for _, filterListChildRaw := range convertToInterfaceArray(filterListRaw) {
+					filterListMap := make(map[string]interface{})
+
+					filterListChildRaw := filterListChildRaw.(map[string]interface{})
+					filterListMap["key"] = filterListChildRaw["key"]
+					filterListMap["type"] = filterListChildRaw["type"]
+					filterListMap["value"] = filterListChildRaw["value"]
+
+					filterListMaps = append(filterListMaps, filterListMap)
+				}
+			}
+			queryConfigMap["filter_list"] = filterListMaps
+
+			labelFiltersRaw := queryConfigRaw["labelFilters"]
+			labelFiltersMaps := make([]map[string]interface{}, 0)
+			if labelFiltersRaw != nil {
+				for _, labelFiltersChildRaw := range convertToInterfaceArray(labelFiltersRaw) {
+					labelFiltersMap := make(map[string]interface{})
+
+					labelFiltersChildRaw := labelFiltersChildRaw.(map[string]interface{})
+					labelFiltersMap["name"] = labelFiltersChildRaw["name"]
+					labelFiltersMap["operator"] = labelFiltersChildRaw["operator"]
+					labelFiltersMap["value"] = labelFiltersChildRaw["value"]
+
+					labelFiltersMaps = append(labelFiltersMaps, labelFiltersMap)
+				}
+			}
+			queryConfigMap["label_filters"] = labelFiltersMaps
+
+			measureListRaw := queryConfigRaw["measureList"]
+			measureListMaps := make([]map[string]interface{}, 0)
+			if measureListRaw != nil {
+				for _, measureListChildRaw := range convertToInterfaceArray(measureListRaw) {
+					measureListMap := make(map[string]interface{})
+
+					measureListChildRaw := measureListChildRaw.(map[string]interface{})
+					measureListMap["measure_code"] = measureListChildRaw["measureCode"]
+					measureListMap["window_secs"] = measureListChildRaw["windowSecs"]
+
+					groupByRaw := make([]interface{}, 0)
+					if measureListChildRaw["groupBy"] != nil {
+						groupByRaw = convertToInterfaceArray(measureListChildRaw["groupBy"])
+					}
+
+					measureListMap["group_by"] = groupByRaw
+					measureListMaps = append(measureListMaps, measureListMap)
+				}
+			}
+			queryConfigMap["measure_list"] = measureListMaps
+
+			serviceIdListRaw := make([]interface{}, 0)
+			if queryConfigRaw["serviceIdList"] != nil {
+				serviceIdListRaw = convertToInterfaceArray(queryConfigRaw["serviceIdList"])
+			}
+
+			queryConfigMap["service_id_list"] = serviceIdListRaw
+			queryConfigMaps = append(queryConfigMaps, queryConfigMap)
+		}
+		mapping["query_config"] = queryConfigMaps
+		scheduleConfigMaps := make([]map[string]interface{}, 0)
+		scheduleConfigMap := make(map[string]interface{})
+
+		scheduleConfigRaw := make(map[string]interface{})
+		if objectRaw["scheduleConfig"] != nil {
+			scheduleConfigRaw = objectRaw["scheduleConfig"].(map[string]interface{})
+		}
+		if len(scheduleConfigRaw) > 0 {
+			scheduleConfigMap["interval_secs"] = scheduleConfigRaw["intervalSecs"]
+			scheduleConfigMap["type"] = scheduleConfigRaw["type"]
+
+			scheduleConfigMaps = append(scheduleConfigMaps, scheduleConfigMap)
+		}
+		mapping["schedule_config"] = scheduleConfigMaps
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("v2s", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_cms_alert_rule_v2s_test.go
+++ b/alicloud/data_source_alicloud_cms_alert_rule_v2s_test.go
@@ -1,0 +1,155 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudCmsAlertRuleV2DataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_cms_alert_rule_v2.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_cms_alert_rule_v2.default.id}_fake"]`,
+		}),
+	}
+
+	WorkspaceConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_alert_rule_v2.default.id}"]`,
+			"workspace": `"default-cms-1511928242963727-cn-hangzhou"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_alert_rule_v2.default.id}_fake"]`,
+			"workspace": `"default-cms-1511928242963727-cn-hangzhou"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_alert_rule_v2.default.id}"]`,
+			"workspace": `"default-cms-1511928242963727-cn-hangzhou"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_alert_rule_v2.default.id}_fake"]`,
+			"workspace": `"default-cms-1511928242963727-cn-hangzhou"`,
+		}),
+	}
+
+	CmsAlertRuleV2CheckInfo.dataSourceTestCheck(t, rand, idsConf, WorkspaceConf, allConf)
+}
+
+var existCmsAlertRuleV2MapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"v2s.#":                               "1",
+		"v2s.0.created_at":                    CHECKSET,
+		"v2s.0.observe_resource_type":         CHECKSET,
+		"v2s.0.datasource_type":               CHECKSET,
+		"v2s.0.datasource_config.#":           CHECKSET,
+		"v2s.0.display_name":                  CHECKSET,
+		"v2s.0.notify_config.#":               CHECKSET,
+		"v2s.0.status":                        CHECKSET,
+		"v2s.0.observe_resource_global_scope": CHECKSET,
+		"v2s.0.action_integration_config.#":   CHECKSET,
+		"v2s.0.severity_levels":               CHECKSET,
+		"v2s.0.query_config.#":                CHECKSET,
+		"v2s.0.enabled":                       CHECKSET,
+		"v2s.0.alert_rule_v2_id":              CHECKSET,
+		"v2s.0.updated_at":                    CHECKSET,
+		"v2s.0.content_template":              CHECKSET,
+		"v2s.0.schedule_config.#":             CHECKSET,
+		"v2s.0.arms_integration_config.#":     CHECKSET,
+		"v2s.0.condition_config.#":            CHECKSET,
+		"v2s.0.workspace":                     CHECKSET,
+	}
+}
+
+var fakeCmsAlertRuleV2MapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"v2s.#": "0",
+	}
+}
+
+var CmsAlertRuleV2CheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_cms_alert_rule_v2s.default",
+	existMapFunc: existCmsAlertRuleV2MapFunc,
+	fakeMapFunc:  fakeCmsAlertRuleV2MapFunc,
+}
+
+func testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccCmsAlertRuleV2%d"
+}
+
+
+resource "alicloud_cms_alert_rule_v2" "default" {
+  content_template = "umodel test alert on $${metric}"
+  schedule_config {
+    type          = "FIXED"
+    interval_secs = "60"
+  }
+  datasource_config {
+    type = "UMODEL"
+  }
+  action_integration_config {
+    enabled = false
+  }
+  arms_integration_config {
+    enabled = false
+  }
+  query_config {
+    entity_type   = "instance"
+    type          = "UMODEL_METRICSET_QUERY"
+    entity_domain = "ecs"
+    metric        = "CPUUtilization"
+    label_filters {
+      operator = "="
+      value    = "web-server"
+      name     = "app"
+    }
+    label_filters {
+      operator = "="
+      value    = "production"
+      name     = "env"
+    }
+    metric_set = "acs_ecs_dashboard"
+  }
+  display_name = "regression-umodel-10"
+  enabled      = true
+  notify_config {
+    type = "DIRECT_NOTIFY"
+    channels {
+      type        = "GROUP"
+      identifiers = ["regression-test"]
+    }
+  }
+  condition_config {
+    operator      = "GT"
+    type          = "UMODEL_METRICSET_CONDITION"
+    severity      = "CRITICAL"
+    duration_secs = "60"
+    threshold     = 90
+  }
+  workspace = "default-cms-1511928242963727-cn-hangzhou"
+}
+
+data "alicloud_cms_alert_rule_v2s" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"alicloud_cr_artifact_lifecycle_rules":                dataSourceAliCloudCrArtifactLifecycleRules(),
+			"alicloud_cms_alert_rule_v2s":                         dataSourceAliCloudCmsAlertRuleV2s(),
 			"alicloud_oss_bucket_inventories":                     dataSourceAliCloudOssBucketInventories(),
 			"alicloud_wafv3_address_books":                        dataSourceAliCloudWafv3AddressBooks(),
 			"alicloud_wafv3_defense_rules":                        dataSourceAliCloudWafv3DefenseRules(),
@@ -933,6 +934,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_cr_artifact_lifecycle_rule":                           resourceAliCloudCrArtifactLifecycleRule(),
 			"alicloud_das_sql_log_config":                                   resourceAliCloudDasSqlLogConfig(),
+			"alicloud_cms_alert_rule_v2":                                    resourceAliCloudCmsAlertRuleV2(),
 			"alicloud_oss_bucket_inventory":                                 resourceAliCloudOssBucketInventory(),
 			"alicloud_resource_manager_resource_directory_sharing":          resourceAliCloudResourceManagerResourceDirectorySharing(),
 			"alicloud_wafv3_address_book":                                   resourceAliCloudWafv3AddressBook(),

--- a/alicloud/resource_alicloud_cms_alert_rule_v2.go
+++ b/alicloud/resource_alicloud_cms_alert_rule_v2.go
@@ -1,0 +1,1816 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudCmsAlertRuleV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCmsAlertRuleV2Create,
+		Read:   resourceAliCloudCmsAlertRuleV2Read,
+		Update: resourceAliCloudCmsAlertRuleV2Update,
+		Delete: resourceAliCloudCmsAlertRuleV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"action_integration_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"actions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"alert_rule_v2_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"annotations": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"arms_integration_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"condition_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"operator": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"legacy_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"legacy_raw": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"prometheus": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"prom_ql": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"times": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"severity": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"severity": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"no_data_policy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"simple_escalation": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"metric_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"escalations": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"comparison_operator": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"times": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"pre_condition": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"severity": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"statistics": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"threshold": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"period": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"yoy_time_unit": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"compare_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"operator": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"aggregate": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"yoy_time_value": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"threshold": {
+										Type:     schema.TypeFloat,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"yoy_time_unit": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+						"escalation_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"relation": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"composite_escalation": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"relation": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"times": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"escalations": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"metric_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"comparison_operator": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"pre_condition": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"period": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"statistics": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"threshold": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"severity": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"duration_secs": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"aggregate": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"express_escalation": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"raw_expression": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"times": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"severity": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"yoy_time_value": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"threshold_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"severity": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"threshold": {
+										Type:     schema.TypeFloat,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+						"threshold": {
+							Type:     schema.TypeFloat,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"content_template": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"datasource_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"legacy_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"legacy_raw": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"product_category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"datasource_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"labels": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"notify_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"utc_offset": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"notify_strategies": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"active_days": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+						},
+						"active_end_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"silence_time_secs": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"active_start_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"channels": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"identifiers": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"notify_strategy_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"observe_resource_global_scope": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"observe_resource_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"partition_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"query_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"legacy_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"prom_ql": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"legacy_raw": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"entity_filters": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"operator": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"field": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+						"dimensions": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeMap, Elem: &schema.Schema{Type: schema.TypeString}},
+						},
+						"filter_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"key": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+						"label_filters": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"operator": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+						"namespace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"metric_set": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"entity_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"measure_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"measure_code": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"group_by": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"window_secs": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"expr": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"entity_domain": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"relation_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"metric": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"service_id_list": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"enable_data_complete_check": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+						"entity_fields": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"field": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"schedule_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"interval_secs": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"severity_levels": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"workspace": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCmsAlertRuleV2Create(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/manageAlertRules")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("alert_rule_v2_id"); ok {
+		request["uuid"] = v
+	}
+	query["RegionId"] = StringPointer(client.RegionId)
+
+	if v := d.Get("notify_config"); !IsNil(v) {
+		request["notifyConfig"] = expandCmsAlertRuleV2NotifyConfig(v)
+	}
+
+	if v := d.Get("query_config"); !IsNil(v) {
+		request["queryConfig"] = expandCmsAlertRuleV2QueryConfig(v)
+	}
+
+	if v := d.Get("condition_config"); !IsNil(v) {
+		request["conditionConfig"] = expandCmsAlertRuleV2ConditionConfig(v)
+	}
+
+	armsIntegrationConfig := make(map[string]interface{})
+
+	if v := d.Get("arms_integration_config"); !IsNil(v) {
+		enabled1, _ := jsonpath.Get("$[0].enabled", v)
+		if enabled1 != nil && enabled1 != "" {
+			armsIntegrationConfig["enabled"] = enabled1
+		}
+
+		request["armsIntegrationConfig"] = armsIntegrationConfig
+	}
+
+	if v, ok := d.GetOkExists("enabled"); ok {
+		request["enabled"] = v
+	}
+	if v, ok := d.GetOk("labels"); ok {
+		request["labels"] = v
+	}
+	actionIntegrationConfig := make(map[string]interface{})
+
+	if v := d.Get("action_integration_config"); !IsNil(v) {
+		actions1, _ := jsonpath.Get("$[0].actions", v)
+		if actionsList, ok := actions1.([]interface{}); ok && len(actionsList) > 0 {
+			actionIntegrationConfig["actions"] = actions1
+		}
+		enabled3, _ := jsonpath.Get("$[0].enabled", v)
+		if enabled3 != nil && enabled3 != "" {
+			actionIntegrationConfig["enabled"] = enabled3
+		}
+
+		request["actionIntegrationConfig"] = actionIntegrationConfig
+	}
+
+	datasourceConfig := make(map[string]interface{})
+
+	if v := d.Get("datasource_config"); !IsNil(v) {
+		instanceId1, _ := jsonpath.Get("$[0].instance_id", v)
+		if instanceId1 != nil && instanceId1 != "" {
+			datasourceConfig["instanceId"] = instanceId1
+		}
+		legacyRaw5, _ := jsonpath.Get("$[0].legacy_raw", v)
+		if legacyRaw5 != nil && legacyRaw5 != "" {
+			datasourceConfig["legacyRaw"] = legacyRaw5
+		}
+		legacyType5, _ := jsonpath.Get("$[0].legacy_type", v)
+		if legacyType5 != nil && legacyType5 != "" {
+			datasourceConfig["legacyType"] = legacyType5
+		}
+		productCategory1, _ := jsonpath.Get("$[0].product_category", v)
+		if productCategory1 != nil && productCategory1 != "" {
+			datasourceConfig["productCategory"] = productCategory1
+		}
+		type7, _ := jsonpath.Get("$[0].type", v)
+		if type7 != nil && type7 != "" {
+			datasourceConfig["type"] = type7
+		}
+		regionId1, _ := jsonpath.Get("$[0].region_id", v)
+		if regionId1 != nil && regionId1 != "" {
+			datasourceConfig["regionId"] = regionId1
+		}
+
+		request["datasourceConfig"] = datasourceConfig
+	}
+
+	if v, ok := d.GetOk("annotations"); ok {
+		request["annotations"] = v
+	}
+	if v, ok := d.GetOk("display_name"); ok {
+		request["displayName"] = v
+	}
+	scheduleConfig := make(map[string]interface{})
+
+	if v := d.Get("schedule_config"); !IsNil(v) {
+		type9, _ := jsonpath.Get("$[0].type", v)
+		if type9 != nil && type9 != "" {
+			scheduleConfig["type"] = type9
+		}
+		intervalSecs1, _ := jsonpath.Get("$[0].interval_secs", v)
+		if intervalSecsInt, ok := intervalSecs1.(int); ok && intervalSecsInt != 0 {
+			scheduleConfig["intervalSecs"] = intervalSecs1
+		}
+
+		request["scheduleConfig"] = scheduleConfig
+	}
+
+	if v, ok := d.GetOk("content_template"); ok {
+		request["contentTemplate"] = v
+	}
+	if v, ok := d.GetOk("workspace"); ok {
+		request["workspace"] = v
+	}
+	request["action"] = "CREATE"
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("Cms", "2024-03-30", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cms_alert_rule_v2", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.data.alertRule.uuid", response)
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudCmsAlertRuleV2Read(d, meta)
+}
+
+func resourceAliCloudCmsAlertRuleV2Read(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cmsServiceV2 := CmsServiceV2{client}
+
+	objectRaw, err := cmsServiceV2.DescribeCmsAlertRuleV2(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cms_alert_rule_v2 DescribeCmsAlertRuleV2 Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("annotations", objectRaw["annotations"])
+	d.Set("content_template", objectRaw["contentTemplate"])
+	d.Set("created_at", objectRaw["createdAt"])
+	d.Set("datasource_type", objectRaw["datasourceType"])
+	d.Set("display_name", objectRaw["displayName"])
+	d.Set("enabled", objectRaw["enabled"])
+	if labelsRaw, ok := objectRaw["labels"].(map[string]interface{}); ok {
+		userLabels := make(map[string]interface{})
+		for labelKey, labelValue := range labelsRaw {
+			if strings.HasPrefix(labelKey, "_cms_") {
+				continue
+			}
+			userLabels[labelKey] = labelValue
+		}
+		d.Set("labels", userLabels)
+	} else {
+		d.Set("labels", objectRaw["labels"])
+	}
+	d.Set("notify_strategy_id", objectRaw["notifyStrategyId"])
+	d.Set("observe_resource_global_scope", objectRaw["observeResourceGlobalScope"])
+	d.Set("observe_resource_type", objectRaw["observeResourceType"])
+	d.Set("partition_key", objectRaw["partitionKey"])
+	d.Set("severity_levels", objectRaw["severityLevels"])
+	d.Set("status", objectRaw["status"])
+	d.Set("updated_at", objectRaw["updatedAt"])
+	d.Set("workspace", objectRaw["workspace"])
+	d.Set("alert_rule_v2_id", objectRaw["uuid"])
+
+	actionIntegrationConfigMaps := make([]map[string]interface{}, 0)
+	actionIntegrationConfigMap := make(map[string]interface{})
+	actionIntegrationConfigRaw := make(map[string]interface{})
+	if objectRaw["actionIntegrationConfig"] != nil {
+		actionIntegrationConfigRaw = objectRaw["actionIntegrationConfig"].(map[string]interface{})
+	}
+	if len(actionIntegrationConfigRaw) > 0 {
+		actionIntegrationConfigMap["enabled"] = actionIntegrationConfigRaw["enabled"]
+
+		actionsRaw := make([]interface{}, 0)
+		if actionIntegrationConfigRaw["actions"] != nil {
+			actionsRaw = convertToInterfaceArray(actionIntegrationConfigRaw["actions"])
+		}
+
+		actionIntegrationConfigMap["actions"] = actionsRaw
+		actionIntegrationConfigMaps = append(actionIntegrationConfigMaps, actionIntegrationConfigMap)
+	}
+	if err := d.Set("action_integration_config", actionIntegrationConfigMaps); err != nil {
+		return err
+	}
+	armsIntegrationConfigMaps := make([]map[string]interface{}, 0)
+	armsIntegrationConfigMap := make(map[string]interface{})
+
+	armsIntegrationConfigRaw := make(map[string]interface{})
+	if objectRaw["armsIntegrationConfig"] != nil {
+		armsIntegrationConfigRaw = objectRaw["armsIntegrationConfig"].(map[string]interface{})
+	}
+	if len(armsIntegrationConfigRaw) > 0 {
+		armsIntegrationConfigMap["enabled"] = armsIntegrationConfigRaw["enabled"]
+
+		armsIntegrationConfigMaps = append(armsIntegrationConfigMaps, armsIntegrationConfigMap)
+	}
+	if err := d.Set("arms_integration_config", armsIntegrationConfigMaps); err != nil {
+		return err
+	}
+	conditionConfigMaps := make([]map[string]interface{}, 0)
+	conditionConfigMap := make(map[string]interface{})
+
+	conditionConfigRaw := make(map[string]interface{})
+	if objectRaw["conditionConfig"] != nil {
+		conditionConfigRaw = objectRaw["conditionConfig"].(map[string]interface{})
+	}
+	if len(conditionConfigRaw) > 0 {
+		conditionConfigMap["aggregate"] = conditionConfigRaw["aggregate"]
+		conditionConfigMap["duration_secs"] = conditionConfigRaw["durationSecs"]
+		conditionConfigMap["escalation_type"] = conditionConfigRaw["escalationType"]
+		conditionConfigMap["legacy_raw"] = conditionConfigRaw["legacyRaw"]
+		conditionConfigMap["legacy_type"] = conditionConfigRaw["legacyType"]
+		conditionConfigMap["no_data_policy"] = conditionConfigRaw["noDataPolicy"]
+		conditionConfigMap["operator"] = conditionConfigRaw["operator"]
+		conditionConfigMap["relation"] = conditionConfigRaw["relation"]
+		conditionConfigMap["severity"] = conditionConfigRaw["severity"]
+		conditionConfigMap["threshold"] = conditionConfigRaw["threshold"]
+		conditionConfigMap["type"] = conditionConfigRaw["type"]
+		conditionConfigMap["yoy_time_unit"] = conditionConfigRaw["yoyTimeUnit"]
+		conditionConfigMap["yoy_time_value"] = conditionConfigRaw["yoyTimeValue"]
+
+		compareListRaw := conditionConfigRaw["compareList"]
+		compareListMaps := make([]map[string]interface{}, 0)
+		if compareListRaw != nil {
+			for _, compareListChildRaw := range convertToInterfaceArray(compareListRaw) {
+				compareListMap := make(map[string]interface{})
+
+				compareListChildRaw := compareListChildRaw.(map[string]interface{})
+				compareListMap["aggregate"] = compareListChildRaw["aggregate"]
+				compareListMap["operator"] = compareListChildRaw["operator"]
+				compareListMap["threshold"] = compareListChildRaw["threshold"]
+				compareListMap["yoy_time_unit"] = compareListChildRaw["yoyTimeUnit"]
+				compareListMap["yoy_time_value"] = compareListChildRaw["yoyTimeValue"]
+
+				compareListMaps = append(compareListMaps, compareListMap)
+			}
+		}
+		conditionConfigMap["compare_list"] = compareListMaps
+		compositeEscalationMaps := make([]map[string]interface{}, 0)
+		compositeEscalationMap := make(map[string]interface{})
+
+		compositeEscalationRaw := make(map[string]interface{})
+		if conditionConfigRaw["compositeEscalation"] != nil {
+			compositeEscalationRaw = conditionConfigRaw["compositeEscalation"].(map[string]interface{})
+		}
+		if len(compositeEscalationRaw) > 0 {
+			compositeEscalationMap["relation"] = compositeEscalationRaw["relation"]
+			compositeEscalationMap["severity"] = compositeEscalationRaw["severity"]
+			compositeEscalationMap["times"] = compositeEscalationRaw["times"]
+
+			escalationsRaw := compositeEscalationRaw["escalations"]
+			escalationsMaps := make([]map[string]interface{}, 0)
+			if escalationsRaw != nil {
+				for _, escalationsChildRaw := range convertToInterfaceArray(escalationsRaw) {
+					escalationsMap := make(map[string]interface{})
+
+					escalationsChildRaw := escalationsChildRaw.(map[string]interface{})
+					escalationsMap["comparison_operator"] = escalationsChildRaw["comparisonOperator"]
+					escalationsMap["metric_name"] = escalationsChildRaw["metricName"]
+					escalationsMap["period"] = escalationsChildRaw["period"]
+					escalationsMap["pre_condition"] = escalationsChildRaw["preCondition"]
+					escalationsMap["statistics"] = escalationsChildRaw["statistics"]
+					escalationsMap["threshold"] = escalationsChildRaw["threshold"]
+
+					escalationsMaps = append(escalationsMaps, escalationsMap)
+				}
+			}
+			compositeEscalationMap["escalations"] = escalationsMaps
+			compositeEscalationMaps = append(compositeEscalationMaps, compositeEscalationMap)
+		}
+		conditionConfigMap["composite_escalation"] = compositeEscalationMaps
+		expressEscalationMaps := make([]map[string]interface{}, 0)
+		expressEscalationMap := make(map[string]interface{})
+
+		expressEscalationRaw := make(map[string]interface{})
+		if conditionConfigRaw["expressEscalation"] != nil {
+			expressEscalationRaw = conditionConfigRaw["expressEscalation"].(map[string]interface{})
+		}
+		if len(expressEscalationRaw) > 0 {
+			expressEscalationMap["raw_expression"] = expressEscalationRaw["rawExpression"]
+			expressEscalationMap["severity"] = expressEscalationRaw["severity"]
+			expressEscalationMap["times"] = expressEscalationRaw["times"]
+
+			expressEscalationMaps = append(expressEscalationMaps, expressEscalationMap)
+		}
+		conditionConfigMap["express_escalation"] = expressEscalationMaps
+		prometheusMaps := make([]map[string]interface{}, 0)
+		prometheusMap := make(map[string]interface{})
+
+		prometheusRaw := make(map[string]interface{})
+		if conditionConfigRaw["prometheus"] != nil {
+			prometheusRaw = conditionConfigRaw["prometheus"].(map[string]interface{})
+		}
+		if len(prometheusRaw) > 0 {
+			prometheusMap["prom_ql"] = prometheusRaw["promQl"]
+			prometheusMap["severity"] = prometheusRaw["severity"]
+			prometheusMap["times"] = prometheusRaw["times"]
+
+			prometheusMaps = append(prometheusMaps, prometheusMap)
+		}
+		conditionConfigMap["prometheus"] = prometheusMaps
+		simpleEscalationMaps := make([]map[string]interface{}, 0)
+		simpleEscalationMap := make(map[string]interface{})
+
+		simpleEscalationRaw := make(map[string]interface{})
+		if conditionConfigRaw["simpleEscalation"] != nil {
+			simpleEscalationRaw = conditionConfigRaw["simpleEscalation"].(map[string]interface{})
+		}
+		if len(simpleEscalationRaw) > 0 {
+			simpleEscalationMap["metric_name"] = simpleEscalationRaw["metricName"]
+			simpleEscalationMap["period"] = simpleEscalationRaw["period"]
+
+			escalationsRaw := simpleEscalationRaw["escalations"]
+			escalationsMaps := make([]map[string]interface{}, 0)
+			if escalationsRaw != nil {
+				for _, escalationsChildRaw := range convertToInterfaceArray(escalationsRaw) {
+					escalationsMap := make(map[string]interface{})
+
+					escalationsChildRaw := escalationsChildRaw.(map[string]interface{})
+					escalationsMap["comparison_operator"] = escalationsChildRaw["comparisonOperator"]
+					escalationsMap["pre_condition"] = escalationsChildRaw["preCondition"]
+					escalationsMap["severity"] = escalationsChildRaw["severity"]
+					escalationsMap["statistics"] = escalationsChildRaw["statistics"]
+					escalationsMap["threshold"] = escalationsChildRaw["threshold"]
+					escalationsMap["times"] = escalationsChildRaw["times"]
+
+					escalationsMaps = append(escalationsMaps, escalationsMap)
+				}
+			}
+			simpleEscalationMap["escalations"] = escalationsMaps
+			simpleEscalationMaps = append(simpleEscalationMaps, simpleEscalationMap)
+		}
+		conditionConfigMap["simple_escalation"] = simpleEscalationMaps
+
+		thresholdListRaw := conditionConfigRaw["thresholdList"]
+		thresholdListMaps := make([]map[string]interface{}, 0)
+		if thresholdListRaw != nil {
+			for _, thresholdListChildRaw := range convertToInterfaceArray(thresholdListRaw) {
+				thresholdListMap := make(map[string]interface{})
+
+				thresholdListChildRaw := thresholdListChildRaw.(map[string]interface{})
+				thresholdListMap["severity"] = thresholdListChildRaw["severity"]
+				thresholdListMap["threshold"] = thresholdListChildRaw["threshold"]
+
+				thresholdListMaps = append(thresholdListMaps, thresholdListMap)
+			}
+		}
+		conditionConfigMap["threshold_list"] = thresholdListMaps
+		conditionConfigMaps = append(conditionConfigMaps, conditionConfigMap)
+	}
+	if err := d.Set("condition_config", conditionConfigMaps); err != nil {
+		return err
+	}
+	datasourceConfigMaps := make([]map[string]interface{}, 0)
+	datasourceConfigMap := make(map[string]interface{})
+	datasourceConfigRaw := make(map[string]interface{})
+	if objectRaw["datasourceConfig"] != nil {
+		datasourceConfigRaw = objectRaw["datasourceConfig"].(map[string]interface{})
+	}
+	if len(datasourceConfigRaw) > 0 {
+		datasourceConfigMap["instance_id"] = datasourceConfigRaw["instanceId"]
+		datasourceConfigMap["legacy_raw"] = datasourceConfigRaw["legacyRaw"]
+		datasourceConfigMap["legacy_type"] = datasourceConfigRaw["legacyType"]
+		datasourceConfigMap["product_category"] = datasourceConfigRaw["productCategory"]
+		datasourceConfigMap["region_id"] = datasourceConfigRaw["regionId"]
+		datasourceConfigMap["type"] = datasourceConfigRaw["type"]
+
+		datasourceConfigMaps = append(datasourceConfigMaps, datasourceConfigMap)
+	}
+	if err := d.Set("datasource_config", datasourceConfigMaps); err != nil {
+		return err
+	}
+	notifyConfigMaps := make([]map[string]interface{}, 0)
+	notifyConfigMap := make(map[string]interface{})
+	notifyConfigRaw := make(map[string]interface{})
+	if objectRaw["notifyConfig"] != nil {
+		notifyConfigRaw = objectRaw["notifyConfig"].(map[string]interface{})
+	}
+	if len(notifyConfigRaw) > 0 {
+		notifyConfigMap["active_end_time"] = notifyConfigRaw["activeEndTime"]
+		notifyConfigMap["active_start_time"] = notifyConfigRaw["activeStartTime"]
+		notifyConfigMap["silence_time_secs"] = notifyConfigRaw["silenceTimeSecs"]
+		notifyConfigMap["type"] = notifyConfigRaw["type"]
+		notifyConfigMap["utc_offset"] = notifyConfigRaw["utcOffset"]
+
+		activeDaysRaw := make([]interface{}, 0)
+		if notifyConfigRaw["activeDays"] != nil {
+			activeDaysRaw = convertToInterfaceArray(notifyConfigRaw["activeDays"])
+		}
+
+		notifyConfigMap["active_days"] = activeDaysRaw
+		channelsRaw := notifyConfigRaw["channels"]
+		channelsMaps := make([]map[string]interface{}, 0)
+		if channelsRaw != nil {
+			for _, channelsChildRaw := range convertToInterfaceArray(channelsRaw) {
+				channelsMap := make(map[string]interface{})
+				channelsChildRaw := channelsChildRaw.(map[string]interface{})
+				channelsMap["type"] = channelsChildRaw["type"]
+
+				identifiersRaw := make([]interface{}, 0)
+				if channelsChildRaw["identifiers"] != nil {
+					identifiersRaw = convertToInterfaceArray(channelsChildRaw["identifiers"])
+				}
+
+				channelsMap["identifiers"] = identifiersRaw
+				channelsMaps = append(channelsMaps, channelsMap)
+			}
+		}
+		notifyConfigMap["channels"] = channelsMaps
+		notifyStrategiesRaw := make([]interface{}, 0)
+		if notifyConfigRaw["notifyStrategies"] != nil {
+			notifyStrategiesRaw = convertToInterfaceArray(notifyConfigRaw["notifyStrategies"])
+		}
+
+		notifyConfigMap["notify_strategies"] = notifyStrategiesRaw
+		notifyConfigMaps = append(notifyConfigMaps, notifyConfigMap)
+	}
+	if err := d.Set("notify_config", notifyConfigMaps); err != nil {
+		return err
+	}
+	queryConfigMaps := make([]map[string]interface{}, 0)
+	queryConfigMap := make(map[string]interface{})
+	queryConfigRaw := make(map[string]interface{})
+	if objectRaw["queryConfig"] != nil {
+		queryConfigRaw = objectRaw["queryConfig"].(map[string]interface{})
+	}
+	if len(queryConfigRaw) > 0 {
+		queryConfigMap["enable_data_complete_check"] = queryConfigRaw["enableDataCompleteCheck"]
+		queryConfigMap["entity_domain"] = queryConfigRaw["entityDomain"]
+		queryConfigMap["entity_type"] = queryConfigRaw["entityType"]
+		queryConfigMap["expr"] = queryConfigRaw["expr"]
+		queryConfigMap["group_id"] = queryConfigRaw["groupId"]
+		queryConfigMap["legacy_raw"] = queryConfigRaw["legacyRaw"]
+		queryConfigMap["legacy_type"] = queryConfigRaw["legacyType"]
+		queryConfigMap["metric"] = queryConfigRaw["metric"]
+		queryConfigMap["metric_set"] = queryConfigRaw["metricSet"]
+		queryConfigMap["namespace"] = queryConfigRaw["namespace"]
+		queryConfigMap["prom_ql"] = queryConfigRaw["promQl"]
+		queryConfigMap["relation_type"] = queryConfigRaw["relationType"]
+		queryConfigMap["type"] = queryConfigRaw["type"]
+
+		queryConfigMap["dimensions"] = queryConfigRaw["dimensions"]
+
+		entityFieldsRaw := queryConfigRaw["entityFields"]
+		entityFieldsMaps := make([]map[string]interface{}, 0)
+		if entityFieldsRaw != nil {
+			for _, entityFieldsChildRaw := range convertToInterfaceArray(entityFieldsRaw) {
+				entityFieldsMap := make(map[string]interface{})
+
+				entityFieldsChildRaw := entityFieldsChildRaw.(map[string]interface{})
+				entityFieldsMap["field"] = entityFieldsChildRaw["field"]
+				entityFieldsMap["value"] = entityFieldsChildRaw["value"]
+
+				entityFieldsMaps = append(entityFieldsMaps, entityFieldsMap)
+			}
+		}
+		queryConfigMap["entity_fields"] = entityFieldsMaps
+		entityFiltersRaw := queryConfigRaw["entityFilters"]
+		entityFiltersMaps := make([]map[string]interface{}, 0)
+		if entityFiltersRaw != nil {
+			for _, entityFiltersChildRaw := range convertToInterfaceArray(entityFiltersRaw) {
+				entityFiltersMap := make(map[string]interface{})
+				entityFiltersChildRaw := entityFiltersChildRaw.(map[string]interface{})
+				entityFiltersMap["field"] = entityFiltersChildRaw["field"]
+				entityFiltersMap["operator"] = entityFiltersChildRaw["operator"]
+				entityFiltersMap["value"] = entityFiltersChildRaw["value"]
+
+				entityFiltersMaps = append(entityFiltersMaps, entityFiltersMap)
+			}
+		}
+		queryConfigMap["entity_filters"] = entityFiltersMaps
+
+		filterListRaw := queryConfigRaw["filterList"]
+		filterListMaps := make([]map[string]interface{}, 0)
+		if filterListRaw != nil {
+			for _, filterListChildRaw := range convertToInterfaceArray(filterListRaw) {
+				filterListMap := make(map[string]interface{})
+
+				filterListChildRaw := filterListChildRaw.(map[string]interface{})
+				filterListMap["key"] = filterListChildRaw["key"]
+				filterListMap["type"] = filterListChildRaw["type"]
+				filterListMap["value"] = filterListChildRaw["value"]
+
+				filterListMaps = append(filterListMaps, filterListMap)
+			}
+		}
+		queryConfigMap["filter_list"] = filterListMaps
+
+		labelFiltersRaw := queryConfigRaw["labelFilters"]
+		labelFiltersMaps := make([]map[string]interface{}, 0)
+		if labelFiltersRaw != nil {
+			for _, labelFiltersChildRaw := range convertToInterfaceArray(labelFiltersRaw) {
+				labelFiltersMap := make(map[string]interface{})
+
+				labelFiltersChildRaw := labelFiltersChildRaw.(map[string]interface{})
+				labelFiltersMap["name"] = labelFiltersChildRaw["name"]
+				labelFiltersMap["operator"] = labelFiltersChildRaw["operator"]
+				labelFiltersMap["value"] = labelFiltersChildRaw["value"]
+
+				labelFiltersMaps = append(labelFiltersMaps, labelFiltersMap)
+			}
+		}
+		queryConfigMap["label_filters"] = labelFiltersMaps
+
+		measureListRaw := queryConfigRaw["measureList"]
+		measureListMaps := make([]map[string]interface{}, 0)
+		if measureListRaw != nil {
+			for _, measureListChildRaw := range convertToInterfaceArray(measureListRaw) {
+				measureListMap := make(map[string]interface{})
+
+				measureListChildRaw := measureListChildRaw.(map[string]interface{})
+				measureListMap["measure_code"] = measureListChildRaw["measureCode"]
+				measureListMap["window_secs"] = measureListChildRaw["windowSecs"]
+
+				groupByRaw := make([]interface{}, 0)
+				if measureListChildRaw["groupBy"] != nil {
+					groupByRaw = convertToInterfaceArray(measureListChildRaw["groupBy"])
+				}
+
+				measureListMap["group_by"] = groupByRaw
+				measureListMaps = append(measureListMaps, measureListMap)
+			}
+		}
+		queryConfigMap["measure_list"] = measureListMaps
+
+		serviceIdListRaw := make([]interface{}, 0)
+		if queryConfigRaw["serviceIdList"] != nil {
+			serviceIdListRaw = convertToInterfaceArray(queryConfigRaw["serviceIdList"])
+		}
+
+		queryConfigMap["service_id_list"] = serviceIdListRaw
+		queryConfigMaps = append(queryConfigMaps, queryConfigMap)
+	}
+	if err := d.Set("query_config", queryConfigMaps); err != nil {
+		return err
+	}
+	scheduleConfigMaps := make([]map[string]interface{}, 0)
+	scheduleConfigMap := make(map[string]interface{})
+
+	scheduleConfigRaw := make(map[string]interface{})
+	if objectRaw["scheduleConfig"] != nil {
+		scheduleConfigRaw = objectRaw["scheduleConfig"].(map[string]interface{})
+	}
+	if len(scheduleConfigRaw) > 0 {
+		scheduleConfigMap["interval_secs"] = scheduleConfigRaw["intervalSecs"]
+		scheduleConfigMap["type"] = scheduleConfigRaw["type"]
+
+		scheduleConfigMaps = append(scheduleConfigMaps, scheduleConfigMap)
+	}
+	if err := d.Set("schedule_config", scheduleConfigMaps); err != nil {
+		return err
+	}
+
+	d.Set("alert_rule_v2_id", d.Id())
+
+	return nil
+}
+
+func resourceAliCloudCmsAlertRuleV2Update(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var body map[string]interface{}
+	update := false
+
+	var err error
+	action := fmt.Sprintf("/manageAlertRules")
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+	request["uuid"] = d.Id()
+	query["RegionId"] = StringPointer(client.RegionId)
+	if d.HasChange("notify_config") {
+		update = true
+	}
+	if v := d.Get("notify_config"); !IsNil(v) || d.HasChange("notify_config") {
+		request["notifyConfig"] = expandCmsAlertRuleV2NotifyConfig(v)
+	}
+
+	if d.HasChange("query_config") {
+		update = true
+	}
+	if v := d.Get("query_config"); !IsNil(v) || d.HasChange("query_config") {
+		request["queryConfig"] = expandCmsAlertRuleV2QueryConfig(v)
+	}
+
+	if d.HasChange("condition_config") {
+		update = true
+	}
+	if v := d.Get("condition_config"); !IsNil(v) || d.HasChange("condition_config") {
+		request["conditionConfig"] = expandCmsAlertRuleV2ConditionConfig(v)
+	}
+
+	if d.HasChange("arms_integration_config") {
+		update = true
+	}
+	armsIntegrationConfig := make(map[string]interface{})
+
+	if v := d.Get("arms_integration_config"); !IsNil(v) || d.HasChange("arms_integration_config") {
+		enabled1, _ := jsonpath.Get("$[0].enabled", v)
+		if enabled1 != nil && enabled1 != "" {
+			armsIntegrationConfig["enabled"] = enabled1
+		}
+
+		request["armsIntegrationConfig"] = armsIntegrationConfig
+	}
+
+	if d.HasChange("enabled") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("enabled"); ok || d.HasChange("enabled") {
+		request["enabled"] = v
+	}
+	if d.HasChange("labels") {
+		update = true
+	}
+	if v, ok := d.GetOk("labels"); ok || d.HasChange("labels") {
+		request["labels"] = v
+	}
+	if d.HasChange("action_integration_config") {
+		update = true
+	}
+	actionIntegrationConfig := make(map[string]interface{})
+
+	if v := d.Get("action_integration_config"); !IsNil(v) || d.HasChange("action_integration_config") {
+		actions1, _ := jsonpath.Get("$[0].actions", v)
+		if actionsList, ok := actions1.([]interface{}); ok && len(actionsList) > 0 {
+			actionIntegrationConfig["actions"] = actions1
+		}
+		enabled3, _ := jsonpath.Get("$[0].enabled", v)
+		if enabled3 != nil && enabled3 != "" {
+			actionIntegrationConfig["enabled"] = enabled3
+		}
+
+		request["actionIntegrationConfig"] = actionIntegrationConfig
+	}
+
+	if d.HasChange("datasource_config") {
+		update = true
+	}
+	datasourceConfig := make(map[string]interface{})
+
+	if v := d.Get("datasource_config"); !IsNil(v) || d.HasChange("datasource_config") {
+		instanceId1, _ := jsonpath.Get("$[0].instance_id", v)
+		if instanceId1 != nil && instanceId1 != "" {
+			datasourceConfig["instanceId"] = instanceId1
+		}
+		legacyRaw5, _ := jsonpath.Get("$[0].legacy_raw", v)
+		if legacyRaw5 != nil && legacyRaw5 != "" {
+			datasourceConfig["legacyRaw"] = legacyRaw5
+		}
+		legacyType5, _ := jsonpath.Get("$[0].legacy_type", v)
+		if legacyType5 != nil && legacyType5 != "" {
+			datasourceConfig["legacyType"] = legacyType5
+		}
+		productCategory1, _ := jsonpath.Get("$[0].product_category", v)
+		if productCategory1 != nil && productCategory1 != "" {
+			datasourceConfig["productCategory"] = productCategory1
+		}
+		type7, _ := jsonpath.Get("$[0].type", v)
+		if type7 != nil && type7 != "" {
+			datasourceConfig["type"] = type7
+		}
+		regionId1, _ := jsonpath.Get("$[0].region_id", v)
+		if regionId1 != nil && regionId1 != "" {
+			datasourceConfig["regionId"] = regionId1
+		}
+
+		request["datasourceConfig"] = datasourceConfig
+	}
+
+	if d.HasChange("annotations") {
+		update = true
+	}
+	if v, ok := d.GetOk("annotations"); ok || d.HasChange("annotations") {
+		request["annotations"] = v
+	}
+	if d.HasChange("display_name") {
+		update = true
+	}
+	if v, ok := d.GetOk("display_name"); ok || d.HasChange("display_name") {
+		request["displayName"] = v
+	}
+	if d.HasChange("schedule_config") {
+		update = true
+	}
+	scheduleConfig := make(map[string]interface{})
+
+	if v := d.Get("schedule_config"); !IsNil(v) || d.HasChange("schedule_config") {
+		type9, _ := jsonpath.Get("$[0].type", v)
+		if type9 != nil && type9 != "" {
+			scheduleConfig["type"] = type9
+		}
+		intervalSecs1, _ := jsonpath.Get("$[0].interval_secs", v)
+		if intervalSecsInt, ok := intervalSecs1.(int); ok && intervalSecsInt != 0 {
+			scheduleConfig["intervalSecs"] = intervalSecs1
+		}
+
+		request["scheduleConfig"] = scheduleConfig
+	}
+
+	if d.HasChange("content_template") {
+		update = true
+	}
+	if v, ok := d.GetOk("content_template"); ok || d.HasChange("content_template") {
+		request["contentTemplate"] = v
+	}
+	if d.HasChange("workspace") {
+		update = true
+	}
+	if v, ok := d.GetOk("workspace"); ok || d.HasChange("workspace") {
+		request["workspace"] = v
+	}
+	request["action"] = "UPDATE"
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPost("Cms", "2024-03-30", action, query, nil, body, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudCmsAlertRuleV2Read(d, meta)
+}
+
+func resourceAliCloudCmsAlertRuleV2Delete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := fmt.Sprintf("/manageAlertRules")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["uuid"] = d.Id()
+	query["RegionId"] = StringPointer(client.RegionId)
+
+	if v, ok := d.GetOk("workspace"); ok {
+		request["workspace"] = v
+	}
+	request["action"] = "DELETE"
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaPost("Cms", "2024-03-30", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}
+
+func expandCmsAlertRuleV2ObjectList(l []interface{}, stringKeys map[string]string, intKeys map[string]string, floatKeys map[string]string, listKeys map[string]string) []interface{} {
+	items := make([]interface{}, 0, len(l))
+	for _, item := range l {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		out := make(map[string]interface{})
+		for tfKey, apiKey := range stringKeys {
+			if s, ok := itemMap[tfKey].(string); ok && s != "" {
+				out[apiKey] = s
+			}
+		}
+		for tfKey, apiKey := range intKeys {
+			if n, ok := itemMap[tfKey].(int); ok && n != 0 {
+				out[apiKey] = n
+			}
+		}
+		for tfKey, apiKey := range floatKeys {
+			if n, ok := itemMap[tfKey].(float64); ok {
+				out[apiKey] = n
+			}
+		}
+		for tfKey, apiKey := range listKeys {
+			if lv, ok := itemMap[tfKey].([]interface{}); ok && len(lv) > 0 {
+				out[apiKey] = lv
+			}
+		}
+		if len(out) > 0 {
+			items = append(items, out)
+		}
+	}
+	return items
+}
+
+func expandCmsAlertRuleV2NotifyConfig(v interface{}) map[string]interface{} {
+	notifyConfig := make(map[string]interface{})
+	raw, ok := v.([]interface{})
+	if !ok || len(raw) == 0 || raw[0] == nil {
+		return notifyConfig
+	}
+	m, ok := raw[0].(map[string]interface{})
+	if !ok {
+		return notifyConfig
+	}
+	for tfKey, apiKey := range map[string]string{"type": "type", "utc_offset": "utcOffset", "active_start_time": "activeStartTime", "active_end_time": "activeEndTime"} {
+		if s, ok := m[tfKey].(string); ok && s != "" {
+			notifyConfig[apiKey] = s
+		}
+	}
+	if n, ok := m["silence_time_secs"].(int); ok && n != 0 {
+		notifyConfig["silenceTimeSecs"] = n
+	}
+	if l, ok := m["active_days"].([]interface{}); ok && len(l) > 0 {
+		notifyConfig["activeDays"] = l
+	}
+	if l, ok := m["notify_strategies"].([]interface{}); ok && len(l) > 0 {
+		notifyConfig["notifyStrategies"] = l
+	}
+	if l, ok := m["channels"].([]interface{}); ok && len(l) > 0 {
+		notifyConfig["channels"] = expandCmsAlertRuleV2ObjectList(l,
+			map[string]string{"type": "type"}, nil, nil,
+			map[string]string{"identifiers": "identifiers"})
+	}
+	return notifyConfig
+}
+
+func expandCmsAlertRuleV2QueryConfig(v interface{}) map[string]interface{} {
+	queryConfig := make(map[string]interface{})
+	raw, ok := v.([]interface{})
+	if !ok || len(raw) == 0 || raw[0] == nil {
+		return queryConfig
+	}
+	m, ok := raw[0].(map[string]interface{})
+	if !ok {
+		return queryConfig
+	}
+	queryType, _ := m["type"].(string)
+	for tfKey, apiKey := range map[string]string{"type": "type", "expr": "expr", "prom_ql": "promQl", "metric_set": "metricSet", "metric": "metric", "entity_domain": "entityDomain", "entity_type": "entityType", "namespace": "namespace", "relation_type": "relationType", "group_id": "groupId", "legacy_type": "legacyType", "legacy_raw": "legacyRaw"} {
+		if s, ok := m[tfKey].(string); ok && s != "" {
+			queryConfig[apiKey] = s
+		}
+	}
+	if queryType == "PROMETHEUS_SINGLE_QUERY" {
+		if b, ok := m["enable_data_complete_check"].(bool); ok && b {
+			queryConfig["enableDataCompleteCheck"] = b
+		}
+	}
+	if l, ok := m["service_id_list"].([]interface{}); ok && len(l) > 0 {
+		queryConfig["serviceIdList"] = l
+	}
+	if l, ok := m["dimensions"].([]interface{}); ok && len(l) > 0 {
+		queryConfig["dimensions"] = l
+	}
+	if l, ok := m["entity_filters"].([]interface{}); ok && len(l) > 0 {
+		queryConfig["entityFilters"] = expandCmsAlertRuleV2ObjectList(l,
+			map[string]string{"field": "field", "operator": "operator", "value": "value"}, nil, nil, nil)
+	}
+	if l, ok := m["label_filters"].([]interface{}); ok && len(l) > 0 {
+		queryConfig["labelFilters"] = expandCmsAlertRuleV2ObjectList(l,
+			map[string]string{"name": "name", "operator": "operator", "value": "value"}, nil, nil, nil)
+	}
+	if l, ok := m["entity_fields"].([]interface{}); ok && len(l) > 0 {
+		queryConfig["entityFields"] = expandCmsAlertRuleV2ObjectList(l,
+			map[string]string{"field": "field", "value": "value"}, nil, nil, nil)
+	}
+	if l, ok := m["filter_list"].([]interface{}); ok && len(l) > 0 {
+		queryConfig["filterList"] = expandCmsAlertRuleV2ObjectList(l,
+			map[string]string{"key": "key", "type": "type", "value": "value"}, nil, nil, nil)
+	}
+	if l, ok := m["measure_list"].([]interface{}); ok && len(l) > 0 {
+		queryConfig["measureList"] = expandCmsAlertRuleV2ObjectList(l,
+			map[string]string{"measure_code": "measureCode"},
+			map[string]string{"window_secs": "windowSecs"}, nil,
+			map[string]string{"group_by": "groupBy"})
+	}
+	return queryConfig
+}
+
+func expandCmsAlertRuleV2ConditionConfig(v interface{}) map[string]interface{} {
+	conditionConfig := make(map[string]interface{})
+	raw, ok := v.([]interface{})
+	if !ok || len(raw) == 0 || raw[0] == nil {
+		return conditionConfig
+	}
+	m, ok := raw[0].(map[string]interface{})
+	if !ok {
+		return conditionConfig
+	}
+	for tfKey, apiKey := range map[string]string{"type": "type", "severity": "severity", "operator": "operator", "aggregate": "aggregate", "relation": "relation", "escalation_type": "escalationType", "no_data_policy": "noDataPolicy", "yoy_time_unit": "yoyTimeUnit", "legacy_type": "legacyType", "legacy_raw": "legacyRaw"} {
+		if s, ok := m[tfKey].(string); ok && s != "" {
+			conditionConfig[apiKey] = s
+		}
+	}
+	if n, ok := m["duration_secs"].(int); ok && n != 0 {
+		conditionConfig["durationSecs"] = n
+	}
+	if n, ok := m["yoy_time_value"].(int); ok && n != 0 {
+		conditionConfig["yoyTimeValue"] = n
+	}
+	if n, ok := m["threshold"].(float64); ok && n != 0 {
+		conditionConfig["threshold"] = n
+	}
+	if l, ok := m["threshold_list"].([]interface{}); ok && len(l) > 0 {
+		conditionConfig["thresholdList"] = expandCmsAlertRuleV2ObjectList(l,
+			map[string]string{"severity": "severity"}, nil,
+			map[string]string{"threshold": "threshold"}, nil)
+	}
+	if l, ok := m["compare_list"].([]interface{}); ok && len(l) > 0 {
+		conditionConfig["compareList"] = expandCmsAlertRuleV2ObjectList(l,
+			map[string]string{"aggregate": "aggregate", "operator": "operator", "yoy_time_unit": "yoyTimeUnit"},
+			map[string]string{"yoy_time_value": "yoyTimeValue"},
+			map[string]string{"threshold": "threshold"}, nil)
+	}
+	if l, ok := m["simple_escalation"].([]interface{}); ok && len(l) > 0 && l[0] != nil {
+		if sm, ok := l[0].(map[string]interface{}); ok {
+			simpleEscalation := make(map[string]interface{})
+			if s, ok := sm["metric_name"].(string); ok && s != "" {
+				simpleEscalation["metricName"] = s
+			}
+			if n, ok := sm["period"].(int); ok && n != 0 {
+				simpleEscalation["period"] = n
+			}
+			if el, ok := sm["escalations"].([]interface{}); ok && len(el) > 0 {
+				simpleEscalation["escalations"] = expandCmsAlertRuleV2ObjectList(el,
+					map[string]string{"comparison_operator": "comparisonOperator", "statistics": "statistics", "threshold": "threshold", "severity": "severity", "pre_condition": "preCondition"},
+					map[string]string{"times": "times"}, nil, nil)
+			}
+			if len(simpleEscalation) > 0 {
+				conditionConfig["simpleEscalation"] = simpleEscalation
+			}
+		}
+	}
+	if l, ok := m["composite_escalation"].([]interface{}); ok && len(l) > 0 && l[0] != nil {
+		if cm, ok := l[0].(map[string]interface{}); ok {
+			compositeEscalation := make(map[string]interface{})
+			for tfKey, apiKey := range map[string]string{"relation": "relation", "severity": "severity"} {
+				if s, ok := cm[tfKey].(string); ok && s != "" {
+					compositeEscalation[apiKey] = s
+				}
+			}
+			if n, ok := cm["times"].(int); ok && n != 0 {
+				compositeEscalation["times"] = n
+			}
+			if el, ok := cm["escalations"].([]interface{}); ok && len(el) > 0 {
+				compositeEscalation["escalations"] = expandCmsAlertRuleV2ObjectList(el,
+					map[string]string{"comparison_operator": "comparisonOperator", "metric_name": "metricName", "statistics": "statistics", "threshold": "threshold", "pre_condition": "preCondition"},
+					map[string]string{"period": "period"}, nil, nil)
+			}
+			if len(compositeEscalation) > 0 {
+				conditionConfig["compositeEscalation"] = compositeEscalation
+			}
+		}
+	}
+	if l, ok := m["express_escalation"].([]interface{}); ok && len(l) > 0 && l[0] != nil {
+		if em, ok := l[0].(map[string]interface{}); ok {
+			expressEscalation := make(map[string]interface{})
+			for tfKey, apiKey := range map[string]string{"raw_expression": "rawExpression", "severity": "severity"} {
+				if s, ok := em[tfKey].(string); ok && s != "" {
+					expressEscalation[apiKey] = s
+				}
+			}
+			if n, ok := em["times"].(int); ok && n != 0 {
+				expressEscalation["times"] = n
+			}
+			if len(expressEscalation) > 0 {
+				conditionConfig["expressEscalation"] = expressEscalation
+			}
+		}
+	}
+	if l, ok := m["prometheus"].([]interface{}); ok && len(l) > 0 && l[0] != nil {
+		if pm, ok := l[0].(map[string]interface{}); ok {
+			prometheus := make(map[string]interface{})
+			for tfKey, apiKey := range map[string]string{"prom_ql": "promQl", "severity": "severity"} {
+				if s, ok := pm[tfKey].(string); ok && s != "" {
+					prometheus[apiKey] = s
+				}
+			}
+			if n, ok := pm["times"].(int); ok && n != 0 {
+				prometheus["times"] = n
+			}
+			if len(prometheus) > 0 {
+				conditionConfig["prometheus"] = prometheus
+			}
+		}
+	}
+	return conditionConfig
+}

--- a/alicloud/resource_alicloud_cms_alert_rule_v2_test.go
+++ b/alicloud/resource_alicloud_cms_alert_rule_v2_test.go
@@ -1,0 +1,4289 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Cms AlertRuleV2. >>> Resource test cases, automatically generated.
+// Case resource_AlertRuleV2_UMODEL_test 12929
+func TestAccAliCloudCmsAlertRuleV2_basic12929(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12929)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12929)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"content_template": "umodel test alert on $${metric}",
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "UMODEL",
+						},
+					},
+					"action_integration_config": []map[string]interface{}{
+						{
+							"enabled": "false",
+						},
+					},
+					"arms_integration_config": []map[string]interface{}{
+						{
+							"enabled": "false",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"entity_type":   "instance",
+							"type":          "UMODEL_METRICSET_QUERY",
+							"entity_domain": "ecs",
+							"metric":        "CPUUtilization",
+							"label_filters": []map[string]interface{}{
+								{
+									"operator": "=",
+									"value":    "web-server",
+									"name":     "app",
+								},
+								{
+									"operator": "=",
+									"value":    "production",
+									"name":     "env",
+								},
+							},
+							"metric_set": "acs_ecs_dashboard",
+						},
+					},
+					"display_name": "regression-umodel-10",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":      "GT",
+							"type":          "UMODEL_METRICSET_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+							"threshold":     "90",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"content_template": CHECKSET,
+						"display_name":     "regression-umodel-10",
+						"enabled":          "true",
+						"workspace":        "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"content_template": "umodel test alert updated on $${metric}",
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"action_integration_config": []map[string]interface{}{
+						{
+							"actions": []string{
+								"action-integration-001"},
+							"enabled": "true",
+						},
+					},
+					"arms_integration_config": []map[string]interface{}{
+						{
+							"enabled": "true",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"entity_type":   "instance",
+							"type":          "UMODEL_METRICSET_QUERY",
+							"entity_domain": "ecs",
+							"metric":        "CPUUtilization",
+							"label_filters": []map[string]interface{}{
+								{
+									"operator": "=",
+									"value":    "api-gateway",
+									"name":     "app",
+								},
+								{
+									"operator": "=",
+									"value":    "staging",
+									"name":     "env",
+								},
+								{
+									"operator": "=",
+									"value":    "cn-hangzhou",
+									"name":     "region",
+								},
+							},
+							"metric_set": "acs_ecs_dashboard",
+						},
+					},
+					"display_name": "regression-umodel-10-updated",
+					"enabled":      "false",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":      "GT",
+							"type":          "UMODEL_METRICSET_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "120",
+							"threshold":     "95",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"content_template": CHECKSET,
+						"display_name":     "regression-umodel-10-updated",
+						"enabled":          "false",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12929 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12929(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_IntegrationConfig_test 12939
+func TestAccAliCloudCmsAlertRuleV2_basic12939(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12939)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12939)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type":        "PROMETHEUS",
+							"instance_id": "prom-regression-test",
+						},
+					},
+					"action_integration_config": []map[string]interface{}{
+						{
+							"actions": []string{
+								"action-id-001", "action-id-002", "action-id-003"},
+							"enabled": "true",
+						},
+					},
+					"arms_integration_config": []map[string]interface{}{
+						{
+							"enabled": "true",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up > 1",
+						},
+					},
+					"display_name": "integration-config-roundtrip-test",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "integration-config-roundtrip-test",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"action_integration_config": []map[string]interface{}{
+						{
+							"actions": []string{
+								"action-id-004"},
+							"enabled": "false",
+						},
+					},
+					"arms_integration_config": []map[string]interface{}{
+						{
+							"enabled": "false",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up > 2",
+						},
+					},
+					"display_name": "integration-config-roundtrip-test-s1",
+					"enabled":      "false",
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "120",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "integration-config-roundtrip-test-s1",
+						"enabled":      "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"action_integration_config": []map[string]interface{}{
+						{
+							"actions": []string{
+								"action-id-005", "action-id-006", "action-id-007"},
+							"enabled": "true",
+						},
+					},
+					"arms_integration_config": []map[string]interface{}{
+						{
+							"enabled": "true",
+						},
+					},
+					"display_name": "integration-config-roundtrip-test-s2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "integration-config-roundtrip-test-s2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"action_integration_config": []map[string]interface{}{
+						{
+							"actions": []string{
+								"action-id-008", "action-id-009", "action-id-010"},
+							"enabled": "true",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up > 1",
+						},
+					},
+					"display_name": "integration-config-roundtrip-test-s3",
+					"enabled":      "true",
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "integration-config-roundtrip-test-s3",
+						"enabled":      "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"action_integration_config": []map[string]interface{}{
+						{
+							"actions": []string{},
+							"enabled": "true",
+						},
+					},
+					"display_name": "integration-config-roundtrip-test-s4-empty",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "integration-config-roundtrip-test-s4-empty",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12939 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12939(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_Labels_Verify_test 12938
+func TestAccAliCloudCmsAlertRuleV2_basic12938(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12938)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12938)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type":        "PROMETHEUS",
+							"instance_id": "prom-regression-test",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up > 1",
+						},
+					},
+					"annotations": map[string]interface{}{
+						"\"summary\"":     "CPU usage high",
+						"\"description\"": "Node CPU is above 90%",
+					},
+					"display_name": "cloudspec_labels_verify_test",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"labels": map[string]interface{}{
+						"\"severity\"": "critical",
+						"\"env\"":      "test",
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "cloudspec_labels_verify_test",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up > 2",
+						},
+					},
+					"annotations": map[string]interface{}{
+						"\"summary\"":     "CPU usage updated",
+						"\"description\"": "Updated CPU alert",
+						"\"runbook\"":     "https://example.com",
+					},
+					"display_name": "cloudspec_labels_verify_test_updated",
+					"labels": map[string]interface{}{
+						"\"severity\"": "warning",
+						"\"team\"":     "dev",
+						"\"env\"":      "staging",
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "120",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "cloudspec_labels_verify_test_updated",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12938 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12938(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_APM_Aggregate_test 12937
+func TestAccAliCloudCmsAlertRuleV2_basic12937(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12937)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12937)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "APM",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "app_service_stats",
+									"group_by": []string{
+										"serviceName", "callType"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+								{
+									"type":  "EQ",
+									"value": "http",
+									"key":   "callType",
+								},
+							},
+							"service_id_list": []string{
+								"arms-agg-1", "arms-agg-2"},
+						},
+					},
+					"display_name": "regression-apm-aggregate",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "GT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "SUM",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "CRITICAL",
+									"threshold": "1000",
+								},
+								{
+									"severity":  "WARNING",
+									"threshold": "500",
+								},
+							},
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-aggregate",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "app_service_stats",
+									"group_by": []string{
+										"serviceName", "statusCode"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+								{
+									"type":  "EQ",
+									"value": "http",
+									"key":   "callType",
+								},
+							},
+							"service_id_list": []string{
+								"arms-agg-1", "arms-agg-2"},
+						},
+					},
+					"display_name": "regression-apm-aggregate-max",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "LT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "MAX",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "WARNING",
+									"threshold": "200",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-aggregate-max",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "app_service_stats",
+									"group_by": []string{
+										"serviceName", "interfaceName"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+								{
+									"type":  "EQ",
+									"value": "http",
+									"key":   "callType",
+								},
+							},
+							"service_id_list": []string{
+								"arms-agg-1", "arms-agg-2"},
+						},
+					},
+					"display_name": "regression-apm-aggregate-p50",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "GT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "P50",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "INFO",
+									"threshold": "50",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-aggregate-p50",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "app_service_stats",
+									"group_by": []string{
+										"serviceName", "regionId"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+								{
+									"type":  "EQ",
+									"value": "http",
+									"key":   "callType",
+								},
+							},
+							"service_id_list": []string{
+								"arms-agg-1", "arms-agg-2"},
+						},
+					},
+					"display_name": "regression-apm-aggregate-p75",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "GT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "P75",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "ERROR",
+									"threshold": "75",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-aggregate-p75",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "app_service_stats",
+									"group_by": []string{
+										"serviceName", "callType"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+								{
+									"type":  "EQ",
+									"value": "http",
+									"key":   "callType",
+								},
+							},
+							"service_id_list": []string{
+								"arms-agg-1", "arms-agg-2"},
+						},
+					},
+					"display_name": "regression-apm-aggregate-p90",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "LT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "P90",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "WARNING",
+									"threshold": "90",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-aggregate-p90",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "app_service_stats",
+									"group_by": []string{
+										"serviceName", "statusCode"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+								{
+									"type":  "EQ",
+									"value": "http",
+									"key":   "callType",
+								},
+							},
+							"service_id_list": []string{
+								"arms-agg-1", "arms-agg-2"},
+						},
+					},
+					"display_name": "regression-apm-aggregate-p99",
+					"enabled":      "false",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "GT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "P99",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "CRITICAL",
+									"threshold": "99",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-aggregate-p99",
+						"enabled":      "false",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12937 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12937(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_QueryConfig_Advanced_test 12936
+func TestAccAliCloudCmsAlertRuleV2_basic12936(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12936)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12936)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "UMODEL",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"entity_type":   "instance",
+							"type":          "UMODEL_METRICSET_QUERY",
+							"entity_domain": "ecs",
+							"entity_filters": []map[string]interface{}{
+								{
+									"operator": "=",
+									"field":    "regionId",
+									"value":    "cn-hangzhou",
+								},
+								{
+									"operator": "=",
+									"field":    "instanceId",
+									"value":    "i-bp1abc123def",
+								},
+							},
+							"metric":     "CPUUtilization",
+							"metric_set": "acs_ecs_dashboard",
+							"entity_fields": []map[string]interface{}{
+								{
+									"field": "name",
+									"value": "my-instance",
+								},
+							},
+						},
+					},
+					"display_name": "regression-queryconfig-advanced",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":      "GT",
+							"type":          "UMODEL_METRICSET_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+							"threshold":     "90",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-queryconfig-advanced",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"entity_type":   "instance",
+							"type":          "UMODEL_METRICSET_QUERY",
+							"entity_domain": "ecs",
+							"entity_filters": []map[string]interface{}{
+								{
+									"operator": "=",
+									"field":    "regionId",
+									"value":    "cn-shanghai",
+								},
+								{
+									"operator": "=",
+									"field":    "instanceId",
+									"value":    "i-bp2ghi456jkl",
+								},
+								{
+									"operator": "=",
+									"field":    "status",
+									"value":    "Running",
+								},
+							},
+							"metric":     "memory_usedutilization",
+							"metric_set": "acs_ecs_dashboard",
+							"entity_fields": []map[string]interface{}{
+								{
+									"field": "name",
+									"value": "my-ecs-instance",
+								},
+								{
+									"field": "hostName",
+									"value": "web-server-01",
+								},
+							},
+						},
+					},
+					"display_name": "regression-queryconfig-advanced-updated",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test-updated"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":      "GT",
+							"type":          "UMODEL_METRICSET_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "120",
+							"threshold":     "95",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-queryconfig-advanced-updated",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12936 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12936(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_APM_CompareList_test 12935
+func TestAccAliCloudCmsAlertRuleV2_basic12935(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12935)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12935)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "APM",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "http_response_time",
+									"group_by": []string{
+										"serviceName"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+							},
+							"service_id_list": []string{
+								"arms-svc-compare-1", "arms-svc-compare-2"},
+						},
+					},
+					"display_name": "regression-apm-comparelist",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"compare_list": []map[string]interface{}{
+								{
+									"operator":       "GT",
+									"aggregate":      "AVG",
+									"yoy_time_value": "1",
+									"threshold":      "80",
+									"yoy_time_unit":  "hour",
+								},
+							},
+							"type":     "APM_COMPOSITE_CONDITION",
+							"relation": "OR",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-comparelist",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-apm-comparelist-updated",
+					"condition_config": []map[string]interface{}{
+						{
+							"compare_list": []map[string]interface{}{
+								{
+									"operator":       "GT",
+									"aggregate":      "P99",
+									"yoy_time_value": "24",
+									"threshold":      "95",
+									"yoy_time_unit":  "hour",
+								},
+							},
+							"type":     "APM_COMPOSITE_CONDITION",
+							"relation": "AND",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-comparelist-updated",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12935 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12935(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_APM_Operator_test 12934
+func TestAccAliCloudCmsAlertRuleV2_basic12934(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12934)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12934)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "APM",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "app_service_stats",
+									"group_by": []string{
+										"serviceName"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+								{
+									"type":  "EQ",
+									"value": "http",
+									"key":   "callType",
+								},
+							},
+							"service_id_list": []string{
+								"arms-app-001", "arms-app-002"},
+						},
+					},
+					"display_name": "regression-apm-operator",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "GT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "COUNT",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "CRITICAL",
+									"threshold": "1000",
+								},
+								{
+									"severity":  "WARNING",
+									"threshold": "500",
+								},
+							},
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-operator",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"display_name": "regression-apm-operator-gte",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "GT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "MIN",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "WARNING",
+									"threshold": "800",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-operator-gte",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"display_name": "regression-apm-operator-lt",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "LT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "CONTINUES",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "INFO",
+									"threshold": "10",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-operator-lt",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-apm-operator-lte",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "LT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "COUNT",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "WARNING",
+									"threshold": "20",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-operator-lte",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-apm-operator-eq",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "EQ",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "MIN",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "ERROR",
+									"threshold": "0",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-operator-eq",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"display_name": "regression-apm-operator-ne",
+					"enabled":      "false",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "NE",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "CONTINUES",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "CRITICAL",
+									"threshold": "999",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-operator-ne",
+						"enabled":      "false",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12934 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12934(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_Prometheus_Basic_test 12933
+func TestAccAliCloudCmsAlertRuleV2_basic12933(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12933)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12933)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type":        "PROMETHEUS",
+							"instance_id": "prom-regression-test",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up > 1",
+						},
+					},
+					"display_name": "regression-basic-prometheus",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-basic-prometheus",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up > 2",
+						},
+					},
+					"display_name": "regression-basic-prometheus-updated",
+					"enabled":      "false",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test-updated"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "120",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-basic-prometheus-updated",
+						"enabled":      "false",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12933 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12933(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_SimpleEscalation_test 12932
+func TestAccAliCloudCmsAlertRuleV2_basic12932(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12932)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12932)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "UMODEL",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"entity_type":   "instance",
+							"type":          "UMODEL_METRICSET_QUERY",
+							"entity_domain": "ecs",
+							"metric":        "memory_usedutilization",
+							"metric_set":    "acs_ecs_dashboard",
+						},
+					},
+					"display_name": "regression-umodel-simple-escalation",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":      "GE",
+							"type":          "UMODEL_METRICSET_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "120",
+							"threshold":     "20",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-umodel-simple-escalation",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-umodel-simple-escalation-updated",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":      "LE",
+							"type":          "UMODEL_METRICSET_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "180",
+							"threshold":     "90",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-umodel-simple-escalation-updated",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12932 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12932(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_ExpressEscalation_test 12931
+func TestAccAliCloudCmsAlertRuleV2_basic12931(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12931)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12931)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type":        "PROMETHEUS",
+							"instance_id": "prom-regression-test",
+							"region_id":   "cn-hangzhou",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.2",
+						},
+					},
+					"display_name": "regression-prom-express-escalation",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-prom-express-escalation",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.1",
+						},
+					},
+					"display_name": "regression-prom-express-escalation-updated",
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "120",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-prom-express-escalation-updated",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12931 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12931(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_APM_Simple_test 12930
+func TestAccAliCloudCmsAlertRuleV2_basic12930(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12930)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12930)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "APM",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "responseTime",
+									"group_by": []string{
+										"serviceName", "endpoint"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type":  "EQ",
+									"value": "500",
+									"key":   "statusCode",
+								},
+								{
+									"type":  "NE",
+									"value": "/health",
+									"key":   "endpoint",
+								},
+							},
+							"service_id_list": []string{
+								"svc-001", "svc-002"},
+						},
+					},
+					"display_name": "regression-apm-simple-8",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "GT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "AVG",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "CRITICAL",
+									"threshold": "1000",
+								},
+								{
+									"severity":  "WARNING",
+									"threshold": "500",
+								},
+							},
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-simple-8",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "p99Latency",
+									"group_by": []string{
+										"region", "host", "method"},
+									"window_secs": "120",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type":  "EQ",
+									"value": "POST",
+									"key":   "method",
+								},
+							},
+							"service_id_list": []string{
+								"svc-001", "svc-003", "svc-004"},
+						},
+					},
+					"display_name": "regression-apm-simple-8-modified",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "GT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "AVG",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "WARNING",
+									"threshold": "50",
+								},
+								{
+									"severity":  "INFO",
+									"threshold": "30",
+								},
+								{
+									"severity":  "ERROR",
+									"threshold": "80",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-simple-8-modified",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "p99Latency",
+									"group_by": []string{
+										"zone"},
+									"window_secs": "120",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type":  "EQ",
+									"value": "POST",
+									"key":   "method",
+								},
+							},
+							"service_id_list": []string{
+								"svc-009"},
+						},
+					},
+					"display_name": "regression-apm-simple-8-modified-2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-simple-8-modified-2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "p99Latency",
+									"group_by": []string{
+										"cluster", "pod"},
+									"window_secs": "120",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type":  "EQ",
+									"value": "POST",
+									"key":   "method",
+								},
+							},
+							"service_id_list": []string{
+								"svc-010", "svc-011"},
+						},
+					},
+					"display_name": "regression-apm-simple-8-modified-3",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-simple-8-modified-3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "p99Latency",
+									"group_by":     []string{},
+									"window_secs":  "120",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type":  "EQ",
+									"value": "POST",
+									"key":   "method",
+								},
+							},
+							"service_id_list": []string{},
+						},
+					},
+					"display_name": "regression-apm-simple-8-modified-4-empty",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-simple-8-modified-4-empty",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12930 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12930(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_APM_YOY_test 12918
+func TestAccAliCloudCmsAlertRuleV2_basic12918(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12918)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12918)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "APM",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "http_status",
+									"group_by": []string{
+										"serviceName", "statusCode"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+								{
+									"type":  "NE",
+									"value": "internal",
+									"key":   "callType",
+								},
+							},
+							"service_id_list": []string{
+								"arms-svc-yoy-1", "arms-svc-yoy-2"},
+						},
+					},
+					"display_name": "regression-apm-yoy",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":       "YOY_UP",
+							"type":           "APM_SIMPLE_CONDITION",
+							"aggregate":      "AVG",
+							"yoy_time_value": "5",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "CRITICAL",
+									"threshold": "30",
+								},
+							},
+							"yoy_time_unit": "minute",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-yoy",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "http_status",
+									"group_by": []string{
+										"serviceName", "statusCode"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+								{
+									"type":  "NE",
+									"value": "internal",
+									"key":   "callType",
+								},
+							},
+							"service_id_list": []string{
+								"arms-svc-yoy-3", "arms-svc-yoy-4", "arms-svc-yoy-5"},
+						},
+					},
+					"display_name": "regression-apm-yoy-week",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":       "YOY_DOWN",
+							"type":           "APM_SIMPLE_CONDITION",
+							"aggregate":      "SUM",
+							"yoy_time_value": "2",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "WARNING",
+									"threshold": "20",
+								},
+							},
+							"yoy_time_unit": "week",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-yoy-week",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "http_status",
+									"group_by": []string{
+										"serviceName", "statusCode"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+								{
+									"type":  "NE",
+									"value": "internal",
+									"key":   "callType",
+								},
+							},
+							"service_id_list": []string{
+								"arms-svc-yoy-1", "arms-svc-yoy-2"},
+						},
+					},
+					"display_name": "regression-apm-yoy-month",
+					"enabled":      "false",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":       "YOY_UP",
+							"type":           "APM_SIMPLE_CONDITION",
+							"aggregate":      "MAX",
+							"yoy_time_value": "1",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "ERROR",
+									"threshold": "50",
+								},
+							},
+							"yoy_time_unit": "month",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-yoy-month",
+						"enabled":      "false",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12918 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12918(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_Prometheus_Rich_test 12928
+func TestAccAliCloudCmsAlertRuleV2_basic12928(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12928)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12928)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"content_template": "告警：$${alertName} 触发",
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type":        "PROMETHEUS",
+							"instance_id": "prom-regression-test",
+							"region_id":   "cn-hangzhou",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "rate(http_requests_total[5m]) > 100",
+						},
+					},
+					"display_name": "regression-enriched-1",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "2", "3", "4", "5", "6", "7"},
+							"active_end_time":   "23:59",
+							"silence_time_secs": "86400",
+							"active_start_time": "00:00",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"group-1", "group-2", "group-3"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"content_template": CHECKSET,
+						"display_name":     "regression-enriched-1",
+						"enabled":          "true",
+						"workspace":        "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"content_template": "更新告警：$${alertName}",
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "rate(http_requests_total[5m]) > 200",
+						},
+					},
+					"display_name": "regression-enriched-1-updated",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "2", "3", "4", "5"},
+							"active_end_time":   "18:00",
+							"silence_time_secs": "43200",
+							"active_start_time": "09:00",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test-updated"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "120",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"content_template": CHECKSET,
+						"display_name":     "regression-enriched-1-updated",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-enriched-1-m2",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "2", "3", "4", "5"},
+							"active_end_time":   "18:00",
+							"silence_time_secs": "43200",
+							"active_start_time": "09:00",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"group-4", "group-5", "group-6"},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-enriched-1-m2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-enriched-1-m3",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "2", "3", "4", "5"},
+							"active_end_time":   "18:00",
+							"silence_time_secs": "43200",
+							"active_start_time": "09:00",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"group-4", "group-5"},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-enriched-1-m3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-enriched-1-m4",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "2", "3", "4", "5"},
+							"active_end_time":   "18:00",
+							"silence_time_secs": "43200",
+							"active_start_time": "09:00",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"group-7"},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-enriched-1-m4",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12928 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12928(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_lifecycle_test 12927
+func TestAccAliCloudCmsAlertRuleV2_basic12927(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12927)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12927)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"content_template": "alert triggered on $${metric}",
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "UMODEL",
+						},
+					},
+					"action_integration_config": []map[string]interface{}{
+						{
+							"enabled": "false",
+						},
+					},
+					"arms_integration_config": []map[string]interface{}{
+						{
+							"enabled": "false",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"entity_type":   "instance",
+							"type":          "UMODEL_METRICSET_QUERY",
+							"entity_domain": "ecs",
+							"metric":        "CPUUtilization",
+							"metric_set":    "acs_ecs_dashboard",
+						},
+					},
+					"display_name": "cspec-lifecycle-test-rule",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":      "GT",
+							"type":          "UMODEL_METRICSET_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+							"threshold":     "90",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"content_template": CHECKSET,
+						"display_name":     "cspec-lifecycle-test-rule",
+						"enabled":          "true",
+						"workspace":        "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"content_template": "alert updated on $${metric}",
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"action_integration_config": []map[string]interface{}{
+						{
+							"actions": []string{
+								"action-integration-001"},
+							"enabled": "true",
+						},
+					},
+					"arms_integration_config": []map[string]interface{}{
+						{
+							"enabled": "true",
+						},
+					},
+					"display_name": "cspec-lifecycle-test-rule-updated",
+					"enabled":      "false",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":      "GT",
+							"type":          "UMODEL_METRICSET_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "120",
+							"threshold":     "95",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"content_template": CHECKSET,
+						"display_name":     "cspec-lifecycle-test-rule-updated",
+						"enabled":          "false",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12927 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12927(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_Prometheus_NotifyStrategies_test 12926
+func TestAccAliCloudCmsAlertRuleV2_basic12926(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12926)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12926)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type":        "PROMETHEUS",
+							"instance_id": "prom-regression-test",
+							"region_id":   "cn-hangzhou",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up > 1",
+						},
+					},
+					"display_name": "regression-notify-strategies",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "NOTIFY_POLICY",
+							"notify_strategies": []string{
+								"strategy-1"},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-notify-strategies",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up > 2",
+						},
+					},
+					"display_name": "regression-notify-strategies-m1",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "NOTIFY_POLICY",
+							"notify_strategies": []string{
+								"strategy-id-003"},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "120",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-notify-strategies-m1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-notify-strategies-m2",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "NOTIFY_POLICY",
+							"notify_strategies": []string{
+								"strategy-4"},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-notify-strategies-m2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-notify-strategies-m3",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "NOTIFY_POLICY",
+							"notify_strategies": []string{
+								"strategy-5"},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-notify-strategies-m3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-notify-strategies-m4",
+					"notify_config": []map[string]interface{}{
+						{
+							"type":              "NOTIFY_POLICY",
+							"notify_strategies": []string{},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-notify-strategies-m4",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12926 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12926(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case delete_minimal 12925
+func TestAccAliCloudCmsAlertRuleV2_basic12925(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12925)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12925)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"content_template": "minimal delete test",
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "UMODEL",
+						},
+					},
+					"action_integration_config": []map[string]interface{}{
+						{
+							"enabled": "false",
+						},
+					},
+					"arms_integration_config": []map[string]interface{}{
+						{
+							"enabled": "false",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"entity_type":   "instance",
+							"type":          "UMODEL_METRICSET_QUERY",
+							"entity_domain": "ecs",
+							"metric":        "CPUUtilization",
+							"metric_set":    "acs_ecs_dashboard",
+						},
+					},
+					"display_name": "cspec-delete-minimal-test",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":      "GT",
+							"type":          "UMODEL_METRICSET_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+							"threshold":     "90",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"content_template": "minimal delete test",
+						"display_name":     "cspec-delete-minimal-test",
+						"enabled":          "true",
+						"workspace":        "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12925 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12925(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_Prometheus_Array_test 12924
+func TestAccAliCloudCmsAlertRuleV2_basic12924(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12924)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12924)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type":        "PROMETHEUS",
+							"instance_id": "prom-regression-test",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up > 1",
+						},
+					},
+					"display_name": "regression-severity-array",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "2", "3", "4", "5", "6", "7"},
+							"active_end_time":   "23:59",
+							"active_start_time": "00:00",
+							"silence_time_secs": "86400",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"group-1", "group-2", "group-3"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "INFO",
+							"duration_secs": "60",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-severity-array",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up > 2",
+						},
+					},
+					"display_name": "regression-severity-array-updated",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "2", "3", "5", "6", "7"},
+							"active_end_time":   "20:00",
+							"active_start_time": "08:00",
+							"silence_time_secs": "43200",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"group-a", "group-b"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "ERROR",
+							"duration_secs": "120",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-severity-array-updated",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12924 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12924(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_NotifyChannels_test 12923
+func TestAccAliCloudCmsAlertRuleV2_basic12923(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12923)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12923)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type":        "PROMETHEUS",
+							"instance_id": "cmsxx-prometheus-1",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "up == 0",
+						},
+					},
+					"display_name": "regression-notify-channels",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "3", "5"},
+							"active_end_time":   "23:59",
+							"silence_time_secs": "86400",
+							"active_start_time": "00:00",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"cms-alarm-group-1", "cms-alarm-group-2"},
+								},
+								{
+									"type": "DINGTALK",
+									"identifiers": []string{
+										"dingtalk-webhook-url-1", "dingtalk-webhook-url-2"},
+								},
+								{
+									"type": "WEBHOOK",
+									"identifiers": []string{
+										"https://webhook.example.com/alert", "https://webhook2.example.com/alert"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-notify-channels",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-notify-channels-m1",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "2", "3", "4", "5", "6", "7"},
+							"active_end_time":   "23:59",
+							"silence_time_secs": "86400",
+							"active_start_time": "00:00",
+							"channels": []map[string]interface{}{
+								{
+									"type": "CONTACT",
+									"identifiers": []string{
+										"contact-1", "contact-2", "contact-3"},
+								},
+								{
+									"type": "FEISHU",
+									"identifiers": []string{
+										"feishu-webhook-url-1", "feishu-webhook-url-2"},
+								},
+								{
+									"type": "SLACK",
+									"identifiers": []string{
+										"slack-channel-url-1", "slack-channel-url-2"},
+								},
+								{
+									"type": "WEIXIN",
+									"identifiers": []string{
+										"weixin-bot-key-1", "weixin-bot-key-2"},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-notify-channels-m1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"display_name": "regression-notify-channels-m2",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"2", "4", "6"},
+							"active_end_time":   "20:00",
+							"silence_time_secs": "43200",
+							"active_start_time": "08:00",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"group-a", "group-b", "group-c"},
+								},
+								{
+									"type": "DINGTALK",
+									"identifiers": []string{
+										"dt-url-1", "dt-url-2", "dt-url-3"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "120",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-notify-channels-m2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"display_name": "regression-notify-channels-m3",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "2", "3", "4", "5"},
+							"active_end_time":   "18:00",
+							"silence_time_secs": "86400",
+							"active_start_time": "09:00",
+							"channels": []map[string]interface{}{
+								{
+									"type": "CONTACT",
+									"identifiers": []string{
+										"admin-1", "admin-2"},
+								},
+								{
+									"type": "WEBHOOK",
+									"identifiers": []string{
+										"https://hook1.example.com", "https://hook2.example.com"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-notify-channels-m3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-notify-channels-m4",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "2", "3", "4", "5", "6", "7"},
+							"active_end_time":   "23:59",
+							"silence_time_secs": "86400",
+							"active_start_time": "00:00",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"ops-group-1", "ops-group-2"},
+								},
+								{
+									"type": "DINGTALK",
+									"identifiers": []string{
+										"dt-1", "dt-2"},
+								},
+								{
+									"type": "FEISHU",
+									"identifiers": []string{
+										"feishu-1", "feishu-2"},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-notify-channels-m4",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "90",
+						},
+					},
+					"display_name": "regression-notify-channels-m5",
+					"notify_config": []map[string]interface{}{
+						{
+							"utc_offset": "+08:00",
+							"type":       "DIRECT_NOTIFY",
+							"active_days": []string{
+								"1", "3", "5", "7"},
+							"active_end_time":   "22:00",
+							"silence_time_secs": "86400",
+							"active_start_time": "06:00",
+							"channels": []map[string]interface{}{
+								{
+									"type": "CONTACT",
+									"identifiers": []string{
+										"dev-1", "dev-2", "dev-3"},
+								},
+								{
+									"type": "SLACK",
+									"identifiers": []string{
+										"slack-1", "slack-2"},
+								},
+								{
+									"type": "WEIXIN",
+									"identifiers": []string{
+										"wx-1", "wx-2", "wx-3"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "90",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-notify-channels-m5",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12923 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12923(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_Prometheus_DataCheck_test 12922
+func TestAccAliCloudCmsAlertRuleV2_basic12922(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12922)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12922)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type":        "PROMETHEUS",
+							"instance_id": "prom-regression-test",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type":                       "PROMETHEUS_SINGLE_QUERY",
+							"expr":                       "up > 1",
+							"enable_data_complete_check": "true",
+						},
+					},
+					"display_name": "regression-data-check",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-data-check",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "120",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type":                       "PROMETHEUS_SINGLE_QUERY",
+							"expr":                       "up > 2",
+							"enable_data_complete_check": "false",
+						},
+					},
+					"display_name": "regression-data-check-updated",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test-updated"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "120",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-data-check-updated",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12922 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12922(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_Prometheus_Condition_test 12921
+func TestAccAliCloudCmsAlertRuleV2_basic12921(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12921)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12921)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type":        "PROMETHEUS",
+							"instance_id": "prom-regression-test",
+							"region_id":   "cn-hangzhou",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "rate(http_errors_total[5m]) / rate(http_requests_total[5m]) > 0.05",
+						},
+					},
+					"display_name": "regression-prom-condition-rewrite",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "WARNING",
+							"duration_secs": "120",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-prom-condition-rewrite",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"query_config": []map[string]interface{}{
+						{
+							"type": "PROMETHEUS_SINGLE_QUERY",
+							"expr": "rate(http_errors_total[10m]) / rate(http_requests_total[10m]) > 0.1",
+						},
+					},
+					"display_name": "regression-prom-condition-rewrite-updated",
+					"condition_config": []map[string]interface{}{
+						{
+							"type":          "PROMETHEUS_SIMPLE_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "180",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-prom-condition-rewrite-updated",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12921 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12921(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_EmptyArray_Repro_test 12920
+func TestAccAliCloudCmsAlertRuleV2_basic12920(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12920)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12920)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"content_template": "empty array repro test",
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "UMODEL",
+						},
+					},
+					"action_integration_config": []map[string]interface{}{
+						{
+							"actions": []string{
+								"action-001", "action-002"},
+							"enabled": "true",
+						},
+					},
+					"arms_integration_config": []map[string]interface{}{
+						{
+							"enabled": "false",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"entity_type":   "instance",
+							"type":          "UMODEL_METRICSET_QUERY",
+							"entity_domain": "ecs",
+							"metric":        "CPUUtilization",
+							"metric_set":    "acs_ecs_dashboard",
+						},
+					},
+					"display_name": "empty-array-repro-init",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":      "GT",
+							"type":          "UMODEL_METRICSET_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+							"threshold":     "90",
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"content_template": "empty array repro test",
+						"display_name":     "empty-array-repro-init",
+						"enabled":          "true",
+						"workspace":        "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"content_template": "empty array repro test modified",
+					"action_integration_config": []map[string]interface{}{
+						{
+							"actions": []string{
+								"action-003"},
+							"enabled": "true",
+						},
+					},
+					"display_name": "empty-array-repro-modify-nonempty",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":      "GT",
+							"type":          "UMODEL_METRICSET_CONDITION",
+							"severity":      "CRITICAL",
+							"duration_secs": "60",
+							"threshold":     "95",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"content_template": "empty array repro test modified",
+						"display_name":     "empty-array-repro-modify-nonempty",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"content_template": "empty array repro test emptied",
+					"action_integration_config": []map[string]interface{}{
+						{
+							"actions": []string{},
+							"enabled": "true",
+						},
+					},
+					"display_name": "empty-array-repro-modify-empty-array-repro",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"content_template": "empty array repro test emptied",
+						"display_name":     "empty-array-repro-modify-empty-array-repro",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12920 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12920(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_AlertRuleV2_APM_Composite_test 12919
+func TestAccAliCloudCmsAlertRuleV2_basic12919(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_alert_rule_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsAlertRuleV2Map12919)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsAlertRuleV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsAlertRuleV2BasicDependence12919)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"schedule_config": []map[string]interface{}{
+						{
+							"type":          "FIXED",
+							"interval_secs": "60",
+						},
+					},
+					"datasource_config": []map[string]interface{}{
+						{
+							"type": "APM",
+						},
+					},
+					"query_config": []map[string]interface{}{
+						{
+							"measure_list": []map[string]interface{}{
+								{
+									"measure_code": "error_rate",
+									"group_by": []string{
+										"serviceName"},
+									"window_secs": "60",
+								},
+							},
+							"type": "APM_MULTI_QUERY",
+							"filter_list": []map[string]interface{}{
+								{
+									"type": "ALL",
+									"key":  "interfaceName",
+								},
+							},
+							"service_id_list": []string{
+								"arms-svc-composite-1", "arms-svc-composite-2"},
+						},
+					},
+					"display_name": "regression-apm-composite-rewrite",
+					"enabled":      "true",
+					"notify_config": []map[string]interface{}{
+						{
+							"type": "DIRECT_NOTIFY",
+							"channels": []map[string]interface{}{
+								{
+									"type": "GROUP",
+									"identifiers": []string{
+										"regression-test"},
+								},
+							},
+						},
+					},
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "GT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "SUM",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "WARNING",
+									"threshold": "5",
+								},
+							},
+						},
+					},
+					"workspace": "default-cms-1511928242963727-cn-hangzhou",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-composite-rewrite",
+						"enabled":      "true",
+						"workspace":    "default-cms-1511928242963727-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": "regression-apm-composite-rewrite-updated",
+					"condition_config": []map[string]interface{}{
+						{
+							"operator":  "GT",
+							"type":      "APM_SIMPLE_CONDITION",
+							"aggregate": "SUM",
+							"threshold_list": []map[string]interface{}{
+								{
+									"severity":  "CRITICAL",
+									"threshold": "10",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": "regression-apm-composite-rewrite-updated",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsAlertRuleV2Map12919 = map[string]string{
+	"created_at":                    CHECKSET,
+	"datasource_type":               CHECKSET,
+	"status":                        CHECKSET,
+	"observe_resource_global_scope": CHECKSET,
+	"severity_levels":               CHECKSET,
+	"updated_at":                    CHECKSET,
+}
+
+func AlicloudCmsAlertRuleV2BasicDependence12919(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Test Cms AlertRuleV2. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_cms_v2.go
+++ b/alicloud/service_alicloud_cms_v2.go
@@ -2,6 +2,7 @@
 package alicloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/PaesslerAG/jsonpath"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/tidwall/sjson"
 )
 
 type CmsServiceV2 struct {
@@ -472,3 +474,86 @@ func (s *CmsServiceV2) CmsAggTaskGroupStateRefreshFuncWithApi(id string, field s
 }
 
 // DescribeCmsAggTaskGroup >>> Encapsulated.
+
+// DescribeCmsAlertRuleV2 <<< Encapsulated get interface for Cms AlertRuleV2.
+
+func (s *CmsServiceV2) DescribeCmsAlertRuleV2(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	query["RegionId"] = StringPointer(client.RegionId)
+	jsonString := convertObjectToJsonString(request)
+	jsonString, _ = sjson.Set(jsonString, "filter.uuid.eq", id)
+	_ = json.Unmarshal([]byte(jsonString), &request)
+
+	action := fmt.Sprintf("/queryAlertRules")
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RoaPost("Cms", "2024-03-30", action, query, nil, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"ResourceNotFound"}) {
+			return object, WrapErrorf(NotFoundErr("AlertRuleV2", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.data.alertRules[*]", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.data.alertRules[*]", response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("AlertRuleV2", id), NotFoundMsg, response)
+	}
+
+	return v.([]interface{})[0].(map[string]interface{}), nil
+}
+
+func (s *CmsServiceV2) CmsAlertRuleV2StateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.CmsAlertRuleV2StateRefreshFuncWithApi(id, field, failStates, s.DescribeCmsAlertRuleV2)
+}
+
+func (s *CmsServiceV2) CmsAlertRuleV2StateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeCmsAlertRuleV2 >>> Encapsulated.

--- a/website/docs/d/cms_alert_rule_v2s.html.markdown
+++ b/website/docs/d/cms_alert_rule_v2s.html.markdown
@@ -1,0 +1,247 @@
+---
+subcategory: "Cms"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_alert_rule_v2s"
+sidebar_current: "docs-alicloud-datasource-cms-alert-rule-v2s"
+description: |-
+  Provides a list of Cms Alert Rule V2 owned by an Alibaba Cloud account.
+---
+
+# alicloud_cms_alert_rule_v2s
+
+This data source provides Cms Alert Rule V2 available to the user.[What is Alert Rule V2](https://next.api.alibabacloud.com/document/Cms/2024-03-30/ManageAlertRules)
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_cms_alert_rule_v2" "default" {
+  content_template = "umodel test alert on $${metric}"
+  schedule_config {
+    type          = "FIXED"
+    interval_secs = "60"
+  }
+  datasource_config {
+    type = "UMODEL"
+  }
+  action_integration_config {
+    enabled = false
+  }
+  arms_integration_config {
+    enabled = false
+  }
+  query_config {
+    entity_type   = "instance"
+    type          = "UMODEL_METRICSET_QUERY"
+    entity_domain = "ecs"
+    metric        = "CPUUtilization"
+    label_filters {
+      operator = "="
+      value    = "web-server"
+      name     = "app"
+    }
+    label_filters {
+      operator = "="
+      value    = "production"
+      name     = "env"
+    }
+    metric_set = "acs_ecs_dashboard"
+  }
+  display_name = "regression-umodel-10"
+  enabled      = true
+  notify_config {
+    type = "DIRECT_NOTIFY"
+    channels {
+      type        = "GROUP"
+      identifiers = ["regression-test"]
+    }
+  }
+  condition_config {
+    operator      = "GT"
+    type          = "UMODEL_METRICSET_CONDITION"
+    severity      = "CRITICAL"
+    duration_secs = "60"
+    threshold     = 90
+  }
+}
+
+data "alicloud_cms_alert_rule_v2s" "default" {
+  ids = ["${alicloud_cms_alert_rule_v2.default.id}"]
+}
+
+output "alicloud_cms_alert_rule_v2_example_id" {
+  value = data.alicloud_cms_alert_rule_v2s.default.v2s.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `filter_datasource_type_eq` - (Optional) Filter by exact match of data source type
+* `filter_display_name_contains` - (Optional) Filter by display name using contains matching
+* `filter_display_name_not_contains` - (Optional) Filter by display name that does not contain the specified value
+* `filter_enabled_eq` - (Optional) Filter by exact match on enabled status.
+* `filter_labels_all_of_key` - (Optional) Filter by full match of label keys (all specified keys must exist)
+* `filter_labels_all_of_value` - (Optional) Filter by label values using full matching (all specified key-value pairs must match)
+* `filter_labels_any_of_key` - (Optional) Filter by label keys using any matching (any of the specified keys exist)
+* `filter_labels_any_of_value` - (Optional) Filter by matching any label value (matches if any specified key-value pair matches)
+* `filter_notify_strategy_id_eq` - (Optional) Filter by Exact Match on Notification Policy ID
+* `filter_observe_resource_global_scope_eq` - (Optional) Filters by exact match based on whether the rule applies globally to the resource type.
+* `filter_observe_resource_instance_id` - (Optional) Filter by observable resource instance ID
+* `filter_observe_resource_list_contains` - (Optional) Filter by matching based on the inclusion of observable resources in the list
+* `filter_observe_resource_type_eq` - (Optional) Filters by exact match of the observable resource type.
+* `filter_partition_key_eq` - (Optional) Filter by partition key using exact matching
+* `filter_severity_levels_contains` - (Optional) Filter by severity levels that contain the specified value
+* `filter_status_eq` - (Optional) Filter by alert status using exact matching
+* `filter_uuid_eq` - (Optional) Filter by exact UUID match
+* `filter_uuid_in` - (Optional) Filter by UUID list inclusion match. Separate multiple UUIDs with commas (,).
+* `workspace` - (Optional) Workspace.
+* `ids` - (Optional, Computed) A list of Alert Rule V2 IDs. 
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Alert Rule V2 IDs.
+* `v2s` - A list of Alert Rule V2 Entries. Each element contains the following attributes:
+    * `action_integration_config` - Action integration configuration.
+        * `actions` - List of actions.
+        * `enabled` - Indicates whether action integration is enabled.
+    * `alert_rule_v2_id` - The unique identifier of the alert rule, mapped to a UUID (system-generated).
+    * `annotations` - Annotations.
+    * `arms_integration_config` - ARMS integration configuration.
+        * `enabled` - Specifies whether to enable ARMS integration.
+    * `condition_config` - Unified alert condition configuration.
+        * `aggregate` - Aggregation function (used when APM_SIMPLE is specified).
+        * `compare_list` - Comparison condition list (type=APM_COMPOSITE).
+            * `aggregate` - Aggregation Function.
+            * `operator` - Comparison Operator.
+            * `threshold` - Threshold.
+            * `yoy_time_unit` - Year-over-year time unit.
+            * `yoy_time_value` - Year-over-year time value.
+        * `composite_escalation` - The multi-metric composite trigger configuration.
+            * `escalations` - List of trigger conditions.
+                * `comparison_operator` - Comparison operator.
+                * `metric_name` - Metric name.
+                * `period` - Collection period (s).
+                * `pre_condition` - Precondition.
+                * `statistics` - Statistical Method.
+                * `threshold` - Threshold.
+            * `relation` - The logical relationship between multiple metrics.
+            * `severity` - Severity Level.
+            * `times` - Consecutive Trigger Count.
+        * `duration_secs` - Duration (seconds).
+        * `escalation_type` - The escalation policy type (type=CLOUD_MONITORING).
+        * `express_escalation` - Expression trigger configuration.
+            * `raw_expression` - Raw Expression.
+            * `severity` - Severity Level.
+            * `times` - Consecutive Trigger Count.
+        * `legacy_raw` - The original V1 condition JSON string returned when type=UNKNOWN and parsing fails.
+        * `legacy_type` - Returned when type=UNKNOWN, indicating that this rule cannot be edited by using the new API.
+        * `no_data_policy` - No-data processing policy (type=CLOUD_MONITORING).
+        * `operator` - The comparison operator.
+        * `prometheus` - The PromQL trigger configuration.
+            * `prom_ql` - Prometheus Query Expression.
+            * `severity` - Severity Level.
+            * `times` - Consecutive Trigger Count.
+        * `relation` - The logical relationship between conditions (type=APM_COMPOSITE).
+        * `severity` - The severity level.
+        * `simple_escalation` - Single-metric trigger configuration (Required when type=CLOUD_MONITORING and escalationType=simple).
+            * `escalations` - Trigger Condition List.
+                * `comparison_operator` - Comparison Operator.
+                * `pre_condition` - Precondition.
+                * `severity` - Severity level.
+                * `statistics` - Statistical Method.
+                * `threshold` - Threshold.
+                * `times` - Consecutive Trigger Count.
+            * `metric_name` - Metric Name.
+            * `period` - Collection Period (Seconds).
+        * `threshold` - Threshold (used when UMODEL_METRICSET is specified).
+        * `threshold_list` - Multi-severity threshold list (used when UMODEL_METRICSET is specified).
+            * `severity` - Severity Level.
+            * `threshold` - Threshold.
+        * `type` - The detection condition type.
+        * `yoy_time_unit` - Year-over-year time unit.
+        * `yoy_time_value` - Year-over-Year Time Value (Effective only when type=APM_SIMPLE and operator=YOY_UP or YOY_DOWN).
+    * `content_template` - The alert content template.
+    * `created_at` - Creation time (read-only), in ISO 8601 format.
+    * `datasource_config` - Unified data source configuration.
+        * `instance_id` - The Prometheus instance ID.
+        * `legacy_raw` - The original V1 datasource JSON string returned when type=UNKNOWN and parsing fails.
+        * `legacy_type` - Returned when type=UNKNOWN, indicating that this rule cannot be edited by using the new API.
+        * `product_category` - The cloud service category.
+        * `region_id` - The region ID.
+        * `type` - The data source type.
+    * `datasource_type` - Data source type (read-only, derived).
+    * `display_name` - The display name of the alert rule.
+    * `enabled` - Specifies whether the alert rule is enabled.
+    * `labels` - Labels.
+    * `notify_config` - Unified notification configuration.
+        * `active_days` - The days of the week on which notifications are sent, 1-7 (type=DIRECT_NOTIFY).
+        * `active_end_time` - The daily end time of the effective notification period (HH:mm, type=DIRECT_NOTIFY).
+        * `active_start_time` - The daily start time of the effective notification period (HH:mm, type=DIRECT_NOTIFY).
+        * `channels` - List of notification channels (type=DIRECT_NOTIFY).
+            * `identifiers` - List of channel identifiers.
+            * `type` - Notification Channel Type.
+        * `notify_strategies` - List of notification policy IDs (type=NOTIFY_POLICY, up to 1 for the current business).
+        * `silence_time_secs` - The channel silence period in seconds (type=DIRECT_NOTIFY).
+        * `type` - Notification configuration type.
+        * `utc_offset` - UTC time zone offset (type=DIRECT_NOTIFY).
+    * `notify_strategy_id` - Notification policy ID (read-only, derived).
+    * `observe_resource_global_scope` - Indicates whether the rule applies to all resources of this resource type (read-only, derived).
+    * `observe_resource_type` - Observable resource type (read-only, derived).
+    * `partition_key` - The partition key.
+    * `query_config` - Unified query configuration.
+        * `dimensions` - The dimension list (type=CLOUD_MONITORING_QUERY).
+        * `enable_data_complete_check` - Whether to Enable Data Completeness Check (type=PROMETHEUS_SINGLE_QUERY).
+        * `entity_domain` - Domain to which the entity belongs (type=UMODEL_METRICSET_QUERY).
+        * `entity_fields` - List of Entity Fields to Return (type=UMODEL_METRICSET_QUERY).
+            * `field` - Entity Field Name.
+            * `value` - Entity Field Value.
+        * `entity_filters` - The list of entity filter conditions (type=UMODEL_METRICSET_QUERY).
+            * `field` - The entity filter field name.
+            * `operator` - The entity filter operator.
+            * `value` - The entity filter value.
+        * `entity_type` - Entity type (type=UMODEL_METRICSET_QUERY).
+        * `expr` - Prometheus query statement (type=PROMETHEUS_SINGLE_QUERY, recommended field).
+        * `filter_list` - The APM filter condition list (type=APM_MULTI_QUERY).
+            * `key` - APM filter dimension key.
+            * `type` - The APM filter type.
+            * `value` - APM filter value (can be empty when type=ALL/DISABLED).
+        * `group_id` - Resource group ID (used when type=CLOUD_MONITORING_QUERY and relationType=GROUP).
+        * `label_filters` - List of label filter conditions (type=UMODEL_METRICSET_QUERY).
+            * `name` - Label name.
+            * `operator` - Label filter operator.
+            * `value` - Label value.
+        * `legacy_raw` - The raw V1 query JSON string returned when type=UNKNOWN_QUERY and parsing fails.
+        * `legacy_type` - Returned when type=UNKNOWN_QUERY, indicating that this rule cannot be edited through the new API.
+        * `measure_list` - APM measure configuration list (type=APM_MULTI_QUERY).
+            * `group_by` - Grouping dimension list.
+            * `measure_code` - APM metric code.
+            * `window_secs` - Query Time Window (Seconds).
+        * `metric` - Metric name (type=UMODEL_METRICSET_QUERY).
+        * `metric_set` - Metric set name (type=UMODEL_METRICSET_QUERY).
+        * `namespace` - CloudMonitor namespace (cloud service name, type=CLOUD_MONITORING_QUERY).
+        * `prom_ql` - [Deprecated] Legacy PromQL field.
+        * `relation_type` - Resource association type (type=CLOUD_MONITORING_QUERY).
+        * `service_id_list` - Application Service ID List (type=APM_MULTI_QUERY).
+        * `type` - Query type.
+    * `schedule_config` - Unified scheduling configuration.
+        * `interval_secs` - The scheduling interval in seconds.
+        * `type` - The scheduling type.
+    * `severity_levels` - The severity levels covered by this rule, separated by commas (read-only derived).
+    * `status` - Alert status (read-only).
+    * `updated_at` - The update time (read-only), in ISO 8601 format.
+    * `workspace` - Workspace.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/cms_alert_rule_v2.html.markdown
+++ b/website/docs/r/cms_alert_rule_v2.html.markdown
@@ -1,0 +1,323 @@
+---
+subcategory: "Cms"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_alert_rule_v2"
+description: |-
+  Provides a Alicloud Cms Alert Rule V2 resource.
+---
+
+# alicloud_cms_alert_rule_v2
+
+Provides a Cms Alert Rule V2 resource.
+
+CloudMonitor 2.0 alert rules (Unified Action V2 OpenAPI, based on ManageAlertRules and QueryAlertRules).
+
+For information about Cms Alert Rule V2 and how to use it, see [What is Alert Rule V2](https://next.api.alibabacloud.com/document/Cms/2024-03-30/ManageAlertRules).
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_cms_alert_rule_v2" "default" {
+  content_template = "umodel example alert on $${metric}"
+  schedule_config {
+    type          = "FIXED"
+    interval_secs = "60"
+  }
+  datasource_config {
+    type = "UMODEL"
+  }
+  action_integration_config {
+    enabled = false
+  }
+  arms_integration_config {
+    enabled = false
+  }
+  query_config {
+    entity_type   = "instance"
+    type          = "UMODEL_METRICSET_QUERY"
+    entity_domain = "ecs"
+    metric        = "CPUUtilization"
+    label_filters {
+      operator = "="
+      value    = "web-server"
+      name     = "app"
+    }
+    label_filters {
+      operator = "="
+      value    = "production"
+      name     = "env"
+    }
+    metric_set = "acs_ecs_dashboard"
+  }
+  display_name = "regression-umodel-10"
+  enabled      = true
+  notify_config {
+    type = "DIRECT_NOTIFY"
+    channels {
+      type        = "GROUP"
+      identifiers = ["regression-example"]
+    }
+  }
+  condition_config {
+    operator      = "GT"
+    type          = "UMODEL_METRICSET_CONDITION"
+    severity      = "CRITICAL"
+    duration_secs = "60"
+    threshold     = 90
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `action_integration_config` - (Optional, Set) Action integration configuration. See [`action_integration_config`](#action_integration_config) below.
+* `alert_rule_v2_id` - (Computed) The unique identifier of the alert rule, mapped to a UUID (system-generated).
+* `annotations` - (Optional, Map) Annotations.
+* `arms_integration_config` - (Optional, Set) ARMS integration configuration. See [`arms_integration_config`](#arms_integration_config) below.
+* `condition_config` - (Optional, Set) Unified alert condition configuration. See [`condition_config`](#condition_config) below.
+* `content_template` - (Optional) The alert content template.
+* `datasource_config` - (Optional, ForceNew, Set) Unified data source configuration. See [`datasource_config`](#datasource_config) below.
+* `display_name` - (Optional) The display name of the alert rule.
+* `enabled` - (Optional) Specifies whether the alert rule is enabled.
+* `labels` - (Optional, Map) Labels.
+* `notify_config` - (Optional, Set) Unified notification configuration. See [`notify_config`](#notify_config) below.
+* `query_config` - (Optional, Set) Unified query configuration. See [`query_config`](#query_config) below.
+* `schedule_config` - (Optional, Set) Unified scheduling configuration. See [`schedule_config`](#schedule_config) below.
+* `workspace` - (Optional, ForceNew) Workspace.
+
+### `action_integration_config`
+
+The action_integration_config supports the following:
+* `actions` - (Optional, ForceNew, List) List of actions
+* `enabled` - (Optional, ForceNew) Indicates whether action integration is enabled
+
+### `arms_integration_config`
+
+The arms_integration_config supports the following:
+* `enabled` - (Optional, ForceNew) Specifies whether to enable ARMS integration.
+
+### `condition_config`
+
+The condition_config supports the following:
+* `aggregate` - (Optional, ForceNew) Aggregation function (used when APM_SIMPLE is specified). Valid values include AVG, MAX, MIN, and SUM.
+* `compare_list` - (Optional, ForceNew, List) Multiple comparison list (used when type=APM_COMPOSITE) See [`compare_list`](#condition_config-compare_list) below.
+* `composite_escalation` - (Computed) The multi-metric composite trigger configuration. This parameter is required when type is set to CLOUD_MONITORING and escalationType is set to composite. See [`composite_escalation`](#condition_config-composite_escalation) below.
+* `duration_secs` - (Optional, ForceNew, Int) Duration (seconds). Used when type=PROMETHEUS_SIMPLE or UMODEL_METRICSET.
+* `escalation_type` - (Computed) The escalation policy type (type=CLOUD_MONITORING). Valid values: SIMPLE, COMPOSITE, EXPRESS, and PROMETHEUS.
+* `express_escalation` - (Computed) Expression trigger configuration. This parameter is required when type=CLOUD_MONITORING and escalationType=express. See [`express_escalation`](#condition_config-express_escalation) below.
+* `legacy_raw` - (Computed) The original V1 condition JSON string returned when type=UNKNOWN and parsing fails. The frontend displays this field as read-only.
+* `legacy_type` - (Computed) Returned when type=UNKNOWN, indicating that this rule cannot be edited by using the new API.
+* `no_data_policy` - (Computed) No-data processing policy (type=CLOUD_MONITORING)
+* `operator` - (Optional, ForceNew) The comparison operator. Valid values include GT, GE, LT, LE, EQ, and NE.
+* `prometheus` - (Computed) The PromQL trigger configuration. This field is not empty when type=CLOUD_MONITORING and escalationType=prometheus. See [`prometheus`](#condition_config-prometheus) below.
+* `relation` - (Optional, ForceNew) The logical relationship between conditions (type=APM_COMPOSITE). Valid values: AND and OR.
+* `severity` - (Optional, ForceNew) The severity level. Valid values: CRITICAL, ERROR, WARNING, and INFO.
+* `simple_escalation` - (Computed) Single-metric trigger configuration (Required when type=CLOUD_MONITORING and escalationType=simple) See [`simple_escalation`](#condition_config-simple_escalation) below.
+* `threshold` - (Optional, ForceNew, Float) Threshold (used when UMODEL_METRICSET is specified)
+* `threshold_list` - (Optional, ForceNew, List) Multi-Threshold List (Used for APM_SIMPLE or UMODEL_METRICSET_MULTI_SEVERITY) See [`threshold_list`](#condition_config-threshold_list) below.
+* `type` - (Required, ForceNew) The detection condition type. Valid values: PROMETHEUS_SIMPLE, UMODEL_METRICSET, APM_SIMPLE, APM_COMPOSITE, CLOUD_MONITORING, and UNKNOWN.
+* `yoy_time_unit` - (Optional, ForceNew) Year-over-year time unit. This parameter takes effect only when type is set to APM_SIMPLE and operator is set to YOY_UP or YOY_DOWN. Valid values: minute, hour, day, week, and month
+* `yoy_time_value` - (Optional, ForceNew, Int) Year-over-Year Time Value (Effective only when type=APM_SIMPLE and operator=YOY_UP or YOY_DOWN)
+
+### `condition_config-compare_list`
+
+The condition_config-compare_list supports the following:
+* `aggregate` - (Optional, ForceNew) Aggregation Function
+* `operator` - (Optional, ForceNew) Comparison Operator
+* `threshold` - (Optional, ForceNew, Float) Threshold
+* `yoy_time_unit` - (Optional, ForceNew) Year-over-year time unit. This parameter takes effect only when operator=YOY_UP or YOY_DOWN.
+* `yoy_time_value` - (Optional, ForceNew, Int) Year-over-year time value. This parameter takes effect only when operator=YOY_UP or YOY_DOWN.
+
+### `condition_config-composite_escalation`
+
+The condition_config-composite_escalation supports the following:
+* `escalations` - (Computed) List of trigger conditions See [`escalations`](#condition_config-composite_escalation-escalations) below.
+* `relation` - (Computed) The logical relationship between multiple metrics
+* `severity` - (Computed) Severity Level
+* `times` - (Computed) Consecutive Trigger Count
+
+### `condition_config-express_escalation`
+
+The condition_config-express_escalation supports the following:
+* `raw_expression` - (Computed) Raw Expression
+* `severity` - (Computed) Severity Level
+* `times` - (Computed) Consecutive Trigger Count
+
+### `condition_config-prometheus`
+
+The condition_config-prometheus supports the following:
+* `prom_ql` - (Computed) Prometheus Query Expression
+* `severity` - (Computed) Severity Level
+* `times` - (Computed) Consecutive Trigger Count
+
+### `condition_config-simple_escalation`
+
+The condition_config-simple_escalation supports the following:
+* `escalations` - (Computed) Trigger Condition List See [`escalations`](#condition_config-simple_escalation-escalations) below.
+* `metric_name` - (Computed) Metric Name
+* `period` - (Computed) Collection Period (Seconds)
+
+### `condition_config-threshold_list`
+
+The condition_config-threshold_list supports the following:
+* `severity` - (Optional, ForceNew) Severity Level
+* `threshold` - (Optional, ForceNew, Float) Threshold
+
+### `condition_config-simple_escalation-escalations`
+
+The condition_config-simple_escalation-escalations supports the following:
+* `comparison_operator` - (Computed) Comparison Operator
+* `pre_condition` - (Computed) Precondition
+* `severity` - (Computed) Severity level. Valid values: CRITICAL, ERROR, WARNING, and INFO
+* `statistics` - (Computed) Statistical Method
+* `threshold` - (Computed) Threshold
+* `times` - (Computed) Consecutive Trigger Count
+
+### `condition_config-composite_escalation-escalations`
+
+The condition_config-composite_escalation-escalations supports the following:
+* `comparison_operator` - (Computed) Comparison operator
+* `metric_name` - (Computed) Metric name
+* `period` - (Computed) Collection period (s)
+* `pre_condition` - (Computed) Precondition
+* `statistics` - (Computed) Statistical Method
+* `threshold` - (Computed) Threshold
+
+### `datasource_config`
+
+The datasource_config supports the following:
+* `instance_id` - (Optional, ForceNew) The Prometheus instance ID. This parameter is used when type=PROMETHEUS.
+* `legacy_raw` - (Computed) The original V1 datasource JSON string returned when type=UNKNOWN and parsing fails. The frontend displays this string in read-only mode.
+* `legacy_type` - (Computed) Returned when type=UNKNOWN, indicating that this rule cannot be edited by using the new API.
+* `product_category` - (Computed) The cloud service category. This parameter is used when type=CLOUD_MONITORING. If this parameter is not specified, unknown is returned.
+* `region_id` - (Optional, ForceNew) The region ID. This parameter is available for all types. By default, the value is the same as the region where the rule resides.
+* `type` - (Required, ForceNew) The data source type. Valid values: PROMETHEUS, UMODEL, APM, CLOUD_MONITORING, and UNKNOWN.
+
+### `notify_config`
+
+The notify_config supports the following:
+* `active_days` - (Optional, ForceNew, List) The days of the week on which notifications are sent, 1-7 (type=DIRECT_NOTIFY). Default: [1,2,3,4,5,6,7]
+* `active_end_time` - (Optional, ForceNew) The daily end time of the effective notification period (HH:mm, type=DIRECT_NOTIFY). Default: 23:59
+* `active_start_time` - (Optional, ForceNew) The daily start time of the effective notification period (HH:mm, type=DIRECT_NOTIFY). Default: 00:00
+* `channels` - (Optional, ForceNew, List) The list of notification channels (type=DIRECT_NOTIFY) See [`channels`](#notify_config-channels) below.
+* `notify_strategies` - (Optional, ForceNew, List) List of notification policy IDs (type=NOTIFY_POLICY, up to 1 for the current business)
+* `silence_time_secs` - (Optional, ForceNew, Int) The channel silence period in seconds (type=DIRECT_NOTIFY). Default: 86400
+* `type` - (Required, ForceNew) Notification configuration type. Valid values: DIRECT_NOTIFY and NOTIFY_POLICY
+* `utc_offset` - (Optional, ForceNew) UTC time zone offset (type=DIRECT_NOTIFY). Default: +08:00
+
+### `notify_config-channels`
+
+The notify_config-channels supports the following:
+* `identifiers` - (Optional, ForceNew, List) List of channel identifiers
+* `type` - (Optional, ForceNew) Notification Channel Type
+
+### `query_config`
+
+The query_config supports the following:
+* `dimensions` - (Computed) The dimension list (type=CLOUD_MONITORING_QUERY). Each dimension is a key-value string mapping. See [`dimensions`](#query_config-dimensions) below.
+* `enable_data_complete_check` - (Optional, ForceNew) Whether to Enable Data Completeness Check (type=PROMETHEUS_SINGLE_QUERY)
+* `entity_domain` - (Optional, ForceNew) Domain to which the entity belongs (type=UMODEL_METRICSET_QUERY)
+* `entity_fields` - (Optional, ForceNew, List) List of Entity Fields to Return (type=UMODEL_METRICSET_QUERY) See [`entity_fields`](#query_config-entity_fields) below.
+* `entity_filters` - (Optional, ForceNew, List) The list of entity filter conditions (type=UMODEL_METRICSET_QUERY). See [`entity_filters`](#query_config-entity_filters) below.
+* `entity_type` - (Optional, ForceNew) Entity type (type=UMODEL_METRICSET_QUERY)
+* `expr` - (Optional, ForceNew) Prometheus query statement (type=PROMETHEUS_SINGLE_QUERY, recommended field)
+* `filter_list` - (Optional, ForceNew, List) The APM filter condition list (type=APM_MULTI_QUERY). See [`filter_list`](#query_config-filter_list) below.
+* `group_id` - (Computed) Resource group ID (used when type=CLOUD_MONITORING_QUERY and relationType=GROUP)
+* `label_filters` - (Optional, ForceNew, List) List of label filter conditions (type=UMODEL_METRICSET_QUERY) See [`label_filters`](#query_config-label_filters) below.
+* `legacy_raw` - (Computed) The raw V1 query JSON string returned when type=UNKNOWN_QUERY and parsing fails. The frontend displays this field as read-only only.
+* `legacy_type` - (Computed) Returned when type=UNKNOWN_QUERY, indicating that this rule cannot be edited through the new API.
+* `measure_list` - (Optional, ForceNew, List) APM measure configuration list (type=APM_MULTI_QUERY) See [`measure_list`](#query_config-measure_list) below.
+* `metric` - (Optional, ForceNew) Metric name (type=UMODEL_METRICSET_QUERY)
+* `metric_set` - (Optional, ForceNew) Metric set name (type=UMODEL_METRICSET_QUERY)
+* `namespace` - (Computed) CloudMonitor namespace (cloud service name, type=CLOUD_MONITORING_QUERY)
+* `prom_ql` - (Computed) [Deprecated] Legacy PromQL field. Use Expr instead. The backend automatically normalizes this field to Expr.
+* `relation_type` - (Computed) Resource association type (type=CLOUD_MONITORING_QUERY). Valid values: INSTANCE, GROUP, and USER.
+* `service_id_list` - (Optional, ForceNew, List) Application Service ID List (type=APM_MULTI_QUERY)
+* `type` - (Required, ForceNew) Query type. Valid values: PROMETHEUS_SINGLE_QUERY, UMODEL_METRICSET_QUERY, APM_MULTI_QUERY, CLOUD_MONITORING_QUERY, and UNKNOWN_QUERY.
+
+### `query_config-dimensions`
+
+The query_config-dimensions supports the following:
+
+### `query_config-entity_fields`
+
+The query_config-entity_fields supports the following:
+* `field` - (Optional, ForceNew) Entity Field Name
+* `value` - (Optional, ForceNew) Entity Field Value
+
+### `query_config-entity_filters`
+
+The query_config-entity_filters supports the following:
+* `field` - (Optional, ForceNew) The entity filter field name.
+* `operator` - (Optional, ForceNew) The entity filter operator. Valid values: = and !=.
+* `value` - (Optional, ForceNew) The entity filter value.
+
+### `query_config-filter_list`
+
+The query_config-filter_list supports the following:
+* `key` - (Optional, ForceNew) APM filter dimension key
+* `type` - (Optional, ForceNew) The APM filter type. Valid values: ALL, EQ, NE, and DISABLED.
+* `value` - (Optional, ForceNew) APM filter value (can be empty when type=ALL/DISABLED)
+
+### `query_config-label_filters`
+
+The query_config-label_filters supports the following:
+* `name` - (Optional, ForceNew) Label name
+* `operator` - (Optional, ForceNew) Label filter operator. Valid values: = / !=
+* `value` - (Optional, ForceNew) Label value
+
+### `query_config-measure_list`
+
+The query_config-measure_list supports the following:
+* `group_by` - (Optional, ForceNew, List) Grouping dimension list
+* `measure_code` - (Optional, ForceNew) APM metric code
+* `window_secs` - (Optional, ForceNew, Int) Query Time Window (Seconds)
+
+### `schedule_config`
+
+The schedule_config supports the following:
+* `interval_secs` - (Optional, ForceNew, Int) The scheduling interval in seconds. This parameter is used when the type is set to FIXED.
+* `type` - (Required, ForceNew) The scheduling type. Valid values: FIXED and CRON.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+* `created_at` - Creation time (read-only), in ISO 8601 format.
+* `datasource_type` - Data source type (read-only, derived).
+* `notify_strategy_id` - Notification policy ID (read-only, derived).
+* `observe_resource_global_scope` - Indicates whether the rule applies to all resources of this resource type (read-only, derived).
+* `observe_resource_type` - Observable resource type (read-only, derived).
+* `partition_key` - The partition key.
+* `severity_levels` - The severity levels covered by this rule, separated by commas (read-only derived).
+* `status` - Alert status (read-only).
+* `updated_at` - The update time (read-only), in ISO 8601 format.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Alert Rule V2.
+* `delete` - (Defaults to 5 mins) Used when delete the Alert Rule V2.
+* `update` - (Defaults to 5 mins) Used when update the Alert Rule V2.
+
+## Import
+
+Cms Alert Rule V2 can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cms_alert_rule_v2.example <alert_rule_v2_id>
+```


### PR DESCRIPTION
Add a new resource `alicloud_cms_alert_rule_v2` and a new data source `alicloud_cms_alert_rule_v2s` for CloudMonitor 2.0 alert rules, backed by the Cms 2024-03-30 APIs `ManageAlertRules` (Create/Update/Delete) and `QueryAlertRules` (Read/List).

- The resource supports datasource/query/condition/schedule/notify/action-integration/ARMS-integration configurations, labels and annotations.
- Configuration families that the service does not allow to be created through this API (CLOUD_MONITORING datasource/query/condition, legacy fields) are modeled as read-only (Computed) attributes so that rules migrated from the previous generation can still be read and imported.
- The data source supports server-side filters (display name, status, labels, uuid, workspace, etc.) with nextToken pagination.
- Documentation for both the resource and the data source is included.

Acceptance test results:

```
=== RUN TestAccAliCloudCmsAlertRuleV2_basic12918
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12918 (9.39s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12919
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12919 (6.81s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12920
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12920 (9.19s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12921
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12921 (6.79s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12922
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12922 (6.5s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12923
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12923 (17.03s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12924
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12924 (6.79s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12925
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12925 (4.11s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12926
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12926 (14.85s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12927
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12927 (6.45s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12928
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12928 (14.05s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12929
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12929 (6.67s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12930
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12930 (14.44s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12931
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12931 (6.23s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12932
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12932 (6.89s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12933
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12933 (6.91s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12934
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12934 (16.34s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12935
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12935 (6.31s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12936
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12936 (6.91s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12937
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12937 (17.39s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12938
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12938 (6.9s)

=== RUN TestAccAliCloudCmsAlertRuleV2_basic12939
--- PASS: TestAccAliCloudCmsAlertRuleV2_basic12939 (14.48s)

=== RUN TestAccAlicloudCmsAlertRuleV2DataSource
--- PASS: TestAccAlicloudCmsAlertRuleV2DataSource (14.83s)
```
