### PR TITLE
New Resource: alicloud_cr_artifact_lifecycle_rule; New Data Source: alicloud_cr_artifact_lifecycle_rules

### DIFF
--- a/alicloud/data_source_alicloud_cr_artifact_lifecycle_rules.go
+++ b/alicloud/data_source_alicloud_cr_artifact_lifecycle_rules.go
@@ -1,0 +1,208 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudCrArtifactLifecycleRules() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudCrArtifactLifecycleRuleRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"artifact_lifecycle_rule_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"auto": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"enable_delete_tag": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"enable_delete_untagged_manifest": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"modified_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"namespace_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"repo_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"retention_tag_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"schedule_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"scope": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tag_regexp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudCrArtifactLifecycleRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListArtifactLifecycleRule"
+	var err error
+	query = make(map[string]interface{})
+	query["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("instance_id"); ok {
+		query["InstanceId"] = v.(string)
+	}
+	query["EnableDeleteTag"] = "true"
+	query["EnableDeleteUntaggedManifest"] = "false"
+
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	query["PageSize"] = PageSizeLarge
+	query["PageNo"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcGet("cr", "2018-12-01", action, query, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, query)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.Rules[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["InstanceId"], ":", item["RuleId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		query["PageNo"] = query["PageNo"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(objectRaw["InstanceId"], ":", objectRaw["RuleId"])
+
+		mapping["auto"] = objectRaw["Auto"]
+		mapping["create_time"] = objectRaw["CreateTime"]
+		mapping["modified_time"] = objectRaw["ModifiedTime"]
+		mapping["namespace_name"] = objectRaw["NamespaceName"]
+		mapping["repo_name"] = objectRaw["RepoName"]
+		mapping["retention_tag_count"] = objectRaw["RetentionTagCount"]
+		mapping["schedule_time"] = objectRaw["ScheduleTime"]
+		mapping["scope"] = objectRaw["Scope"]
+		mapping["tag_regexp"] = objectRaw["TagRegexp"]
+		mapping["artifact_lifecycle_rule_id"] = objectRaw["RuleId"]
+		mapping["enable_delete_tag"] = objectRaw["EnableDeleteTag"]
+		mapping["enable_delete_untagged_manifest"] = objectRaw["EnableDeleteUntaggedManifest"]
+		mapping["instance_id"] = objectRaw["InstanceId"]
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("rules", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_cr_artifact_lifecycle_rules_test.go
+++ b/alicloud/data_source_alicloud_cr_artifact_lifecycle_rules_test.go
@@ -1,0 +1,133 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudCrArtifactLifecycleRuleDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCrArtifactLifecycleRuleSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_cr_artifact_lifecycle_rule.default.id}"]`,
+			"instance_id": `"${alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCrArtifactLifecycleRuleSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_cr_artifact_lifecycle_rule.default.id}_fake"]`,
+			"instance_id": `"${alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id}"`,
+		}),
+	}
+
+	InstanceIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCrArtifactLifecycleRuleSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_cr_artifact_lifecycle_rule.default.id}"]`,
+			"instance_id": `"${alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCrArtifactLifecycleRuleSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_cr_artifact_lifecycle_rule.default.id}_fake"]`,
+			"instance_id": `"${alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id}"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCrArtifactLifecycleRuleSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_cr_artifact_lifecycle_rule.default.id}"]`,
+			"instance_id": `"${alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCrArtifactLifecycleRuleSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_cr_artifact_lifecycle_rule.default.id}_fake"]`,
+			"instance_id": `"${alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id}"`,
+		}),
+	}
+
+	CrArtifactLifecycleRuleCheckInfo.dataSourceTestCheck(t, rand, idsConf, InstanceIdConf, allConf)
+}
+
+var existCrArtifactLifecycleRuleMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"rules.#":                            "1",
+		"rules.0.id":                         CHECKSET,
+		"rules.0.instance_id":                CHECKSET,
+		"rules.0.create_time":                CHECKSET,
+		"rules.0.repo_name":                  CHECKSET,
+		"rules.0.auto":                       CHECKSET,
+		"rules.0.namespace_name":             CHECKSET,
+		"rules.0.retention_tag_count":        CHECKSET,
+		"rules.0.schedule_time":              CHECKSET,
+		"rules.0.modified_time":              CHECKSET,
+		"rules.0.scope":                      CHECKSET,
+		"rules.0.tag_regexp":                 CHECKSET,
+		"rules.0.artifact_lifecycle_rule_id": CHECKSET,
+	}
+}
+
+var fakeCrArtifactLifecycleRuleMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"rules.#": "0",
+	}
+}
+
+var CrArtifactLifecycleRuleCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_cr_artifact_lifecycle_rules.default",
+	existMapFunc: existCrArtifactLifecycleRuleMapFunc,
+	fakeMapFunc:  fakeCrArtifactLifecycleRuleMapFunc,
+}
+
+func testAccCheckAlicloudCrArtifactLifecycleRuleSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tfacc-cr-alr-%d"
+}
+resource "alicloud_cr_ee_instance" "resourceCase_20260526_Mmd6on_1" {
+  default_oss_bucket = "true"
+  instance_name      = var.name
+  renewal_status     = "ManualRenewal"
+  image_scanner      = "DISABLE"
+  period             = "1"
+  payment_type       = "Subscription"
+  instance_type      = "Economy"
+}
+
+resource "alicloud_cr_ee_namespace" "namespaceCase_20260611_ArtifactLifecycleRule_1" {
+  instance_id        = alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id
+  name               = var.name
+  auto_create        = false
+  default_visibility = "PRIVATE"
+}
+
+resource "alicloud_cr_ee_repo" "repoCase_20260611_ArtifactLifecycleRule_1" {
+  instance_id = alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id
+  namespace   = alicloud_cr_ee_namespace.namespaceCase_20260611_ArtifactLifecycleRule_1.name
+  name        = var.name
+  repo_type   = "PRIVATE"
+  summary     = "test repository for lifecycle rule"
+}
+
+resource "alicloud_cr_artifact_lifecycle_rule" "default" {
+  auto                = true
+  namespace_name      = alicloud_cr_ee_namespace.namespaceCase_20260611_ArtifactLifecycleRule_1.name
+  retention_tag_count = "30"
+  schedule_time       = "WEEK"
+  scope               = "REPO"
+  instance_id         = alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id
+  tag_regexp          = ".*"
+  repo_name           = alicloud_cr_ee_repo.repoCase_20260611_ArtifactLifecycleRule_1.name
+}
+
+data "alicloud_cr_artifact_lifecycle_rules" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -171,6 +171,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_cr_artifact_lifecycle_rules":                dataSourceAliCloudCrArtifactLifecycleRules(),
 			"alicloud_oss_bucket_inventories":                     dataSourceAliCloudOssBucketInventories(),
 			"alicloud_wafv3_address_books":                        dataSourceAliCloudWafv3AddressBooks(),
 			"alicloud_wafv3_defense_rules":                        dataSourceAliCloudWafv3DefenseRules(),
@@ -930,6 +931,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_das_sql_log_configs":                              dataSourceAliCloudDasSqlLogConfigs(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_cr_artifact_lifecycle_rule":                           resourceAliCloudCrArtifactLifecycleRule(),
 			"alicloud_das_sql_log_config":                                   resourceAliCloudDasSqlLogConfig(),
 			"alicloud_oss_bucket_inventory":                                 resourceAliCloudOssBucketInventory(),
 			"alicloud_resource_manager_resource_directory_sharing":          resourceAliCloudResourceManagerResourceDirectorySharing(),

--- a/alicloud/resource_alicloud_cr_artifact_lifecycle_rule.go
+++ b/alicloud/resource_alicloud_cr_artifact_lifecycle_rule.go
@@ -1,0 +1,280 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudCrArtifactLifecycleRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCrArtifactLifecycleRuleCreate,
+		Read:   resourceAliCloudCrArtifactLifecycleRuleRead,
+		Update: resourceAliCloudCrArtifactLifecycleRuleUpdate,
+		Delete: resourceAliCloudCrArtifactLifecycleRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"artifact_lifecycle_rule_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"auto": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"modified_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"namespace_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"repo_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"retention_tag_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"schedule_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tag_regexp": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCrArtifactLifecycleRuleCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateArtifactLifecycleRule"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("instance_id"); ok {
+		request["InstanceId"] = v
+	}
+	request["RegionId"] = client.RegionId
+
+	if v, ok := d.GetOk("namespace_name"); ok {
+		request["NamespaceName"] = v
+	}
+	request["EnableDeleteUntaggedManifest"] = "false"
+	if v, ok := d.GetOk("schedule_time"); ok {
+		request["ScheduleTime"] = v
+	}
+	if v, ok := d.GetOk("repo_name"); ok {
+		request["RepoName"] = v
+	}
+	if v, ok := d.GetOk("scope"); ok {
+		request["Scope"] = v
+	}
+	if v, ok := d.GetOkExists("retention_tag_count"); ok {
+		request["RetentionTagCount"] = v
+	}
+	request["EnableDeleteTag"] = "true"
+	if v, ok := d.GetOk("tag_regexp"); ok {
+		request["TagRegexp"] = v
+	}
+	request["Auto"] = d.Get("auto")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("cr", "2018-12-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cr_artifact_lifecycle_rule", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", request["InstanceId"], response["RuleId"]))
+
+	return resourceAliCloudCrArtifactLifecycleRuleRead(d, meta)
+}
+
+func resourceAliCloudCrArtifactLifecycleRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	crServiceV2 := CrServiceV2{client}
+
+	objectRaw, err := crServiceV2.DescribeCrArtifactLifecycleRule(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cr_artifact_lifecycle_rule DescribeCrArtifactLifecycleRule Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("auto", objectRaw["Auto"])
+	d.Set("create_time", objectRaw["CreateTime"])
+	d.Set("modified_time", objectRaw["ModifiedTime"])
+	d.Set("namespace_name", objectRaw["NamespaceName"])
+	d.Set("repo_name", objectRaw["RepoName"])
+	d.Set("retention_tag_count", objectRaw["RetentionTagCount"])
+	d.Set("schedule_time", objectRaw["ScheduleTime"])
+	d.Set("scope", objectRaw["Scope"])
+	d.Set("tag_regexp", objectRaw["TagRegexp"])
+	d.Set("artifact_lifecycle_rule_id", objectRaw["RuleId"])
+	d.Set("instance_id", objectRaw["InstanceId"])
+
+	return nil
+}
+
+func resourceAliCloudCrArtifactLifecycleRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	action := "UpdateArtifactLifecycleRule"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RuleId"] = parts[1]
+	request["InstanceId"] = parts[0]
+	request["RegionId"] = client.RegionId
+	// The UpdateArtifactLifecycleRule API uses full-replacement semantics: any
+	// attribute absent from the request is cleared on the server side, so every
+	// attribute must be sent even when unchanged.
+	if d.HasChange("namespace_name") {
+		update = true
+	}
+	request["NamespaceName"] = d.Get("namespace_name")
+
+	request["EnableDeleteUntaggedManifest"] = "false"
+	if d.HasChange("schedule_time") {
+		update = true
+	}
+	request["ScheduleTime"] = d.Get("schedule_time")
+
+	if d.HasChange("repo_name") {
+		update = true
+	}
+	request["RepoName"] = d.Get("repo_name")
+
+	if d.HasChange("scope") {
+		update = true
+	}
+	request["Scope"] = d.Get("scope")
+	if d.HasChange("retention_tag_count") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("retention_tag_count"); ok {
+		request["RetentionTagCount"] = v
+	}
+
+	request["EnableDeleteTag"] = "true"
+	if d.HasChange("tag_regexp") {
+		update = true
+	}
+	request["TagRegexp"] = d.Get("tag_regexp")
+
+	if d.HasChange("auto") {
+		update = true
+	}
+	request["Auto"] = d.Get("auto")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("cr", "2018-12-01", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudCrArtifactLifecycleRuleRead(d, meta)
+}
+
+func resourceAliCloudCrArtifactLifecycleRuleDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := "DeleteArtifactLifecycleRule"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["RuleId"] = parts[1]
+	request["InstanceId"] = parts[0]
+	request["RegionId"] = client.RegionId
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("cr", "2018-12-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_cr_artifact_lifecycle_rule_test.go
+++ b/alicloud/resource_alicloud_cr_artifact_lifecycle_rule_test.go
@@ -1,0 +1,549 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Cr ArtifactLifecycleRule. >>> Resource test cases, automatically generated.
+// Case resource_ArtifactLifecycleRule_test 12942
+func TestAccAliCloudCrArtifactLifecycleRule_basic12942(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cr_artifact_lifecycle_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCrArtifactLifecycleRuleMap12942)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCrArtifactLifecycleRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrArtifactLifecycleRuleBasicDependence12942)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto":                "true",
+					"namespace_name":      "${alicloud_cr_ee_namespace.namespaceCase_20260611_ArtifactLifecycleRule_1.name}",
+					"retention_tag_count": "30",
+					"schedule_time":       "WEEK",
+					"scope":               "REPO",
+					"instance_id":         "${alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id}",
+					"tag_regexp":          ".*",
+					"repo_name":           "${alicloud_cr_ee_repo.repoCase_20260611_ArtifactLifecycleRule_1.name}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"auto":                "true",
+						"namespace_name":      CHECKSET,
+						"retention_tag_count": "30",
+						"schedule_time":       "WEEK",
+						"scope":               "REPO",
+						"instance_id":         CHECKSET,
+						"tag_regexp":          ".*",
+						"repo_name":           CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"retention_tag_count": "50",
+					"schedule_time":       "MONTH",
+					"scope":               "REPO",
+					"tag_regexp":          "v.*",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"retention_tag_count": "50",
+						"schedule_time":       "MONTH",
+						"scope":               "REPO",
+						"tag_regexp":          "v.*",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCrArtifactLifecycleRuleMap12942 = map[string]string{
+	"create_time":                CHECKSET,
+	"modified_time":              CHECKSET,
+	"artifact_lifecycle_rule_id": CHECKSET,
+}
+
+func AlicloudCrArtifactLifecycleRuleBasicDependence12942(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_cr_ee_instance" "resourceCase_20260526_Mmd6on_1" {
+  default_oss_bucket = "true"
+  instance_name      = var.name
+  renewal_status     = "ManualRenewal"
+  image_scanner      = "DISABLE"
+  period             = "1"
+  payment_type       = "Subscription"
+  instance_type      = "Economy"
+}
+
+resource "alicloud_cr_ee_namespace" "namespaceCase_20260611_ArtifactLifecycleRule_1" {
+  instance_id        = alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id
+  name               = var.name
+  auto_create        = false
+  default_visibility = "PRIVATE"
+}
+
+resource "alicloud_cr_ee_repo" "repoCase_20260611_ArtifactLifecycleRule_1" {
+  instance_id = alicloud_cr_ee_instance.resourceCase_20260526_Mmd6on_1.id
+  namespace   = alicloud_cr_ee_namespace.namespaceCase_20260611_ArtifactLifecycleRule_1.name
+  name        = var.name
+  repo_type   = "PRIVATE"
+  summary     = "test repository for lifecycle rule"
+}
+
+
+`, name)
+}
+
+// Case 保留策略生命周期 5221
+func TestAccAliCloudCrArtifactLifecycleRule_basic5221(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cr_artifact_lifecycle_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCrArtifactLifecycleRuleMap5221)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCrArtifactLifecycleRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrArtifactLifecycleRuleBasicDependence5221)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-shenzhen"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto":                "false",
+					"retention_tag_count": "30",
+					"scope":               "INSTANCE",
+					"instance_id":         "${alicloud_cr_ee_instance.defaultnKIyBE.id}",
+					"tag_regexp":          " ",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"auto":                "false",
+						"retention_tag_count": "30",
+						"scope":               "INSTANCE",
+						"instance_id":         CHECKSET,
+						"tag_regexp":          " ",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"retention_tag_count": "31",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"retention_tag_count": "31",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCrArtifactLifecycleRuleMap5221 = map[string]string{
+	"create_time":                CHECKSET,
+	"modified_time":              CHECKSET,
+	"artifact_lifecycle_rule_id": CHECKSET,
+}
+
+func AlicloudCrArtifactLifecycleRuleBasicDependence5221(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_cr_ee_instance" "defaultnKIyBE" {
+  instance_name  = var.name
+  renewal_status = "ManualRenewal"
+  payment_type   = "Subscription"
+  image_scanner  = "ACR"
+  period         = "1"
+  instance_type  = "Basic"
+}
+
+
+`, name)
+}
+
+// Case 保留策略生命周期_换账号可用_副本1709104286506 6046
+func TestAccAliCloudCrArtifactLifecycleRule_basic6046(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cr_artifact_lifecycle_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCrArtifactLifecycleRuleMap6046)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCrArtifactLifecycleRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrArtifactLifecycleRuleBasicDependence6046)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto":                "true",
+					"retention_tag_count": "30",
+					"scope":               "REPO",
+					"instance_id":         "${alicloud_cr_ee_instance.default2Rk8gT.id}",
+					"tag_regexp":          " .*",
+					"namespace_name":      "${alicloud_cr_ee_namespace.defaultevafKF.name}",
+					"repo_name":           "${alicloud_cr_ee_repo.defaultKunw72.name}",
+					"schedule_time":       "WEEK",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"auto":                "true",
+						"retention_tag_count": "30",
+						"scope":               "REPO",
+						"instance_id":         CHECKSET,
+						"tag_regexp":          " .*",
+						"namespace_name":      CHECKSET,
+						"repo_name":           CHECKSET,
+						"schedule_time":       "WEEK",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"retention_tag_count": "31",
+					"scope":               "INSTANCE",
+					"tag_regexp":          "release-v.*",
+					"schedule_time":       "MONTH",
+					"namespace_name":      REMOVEKEY,
+					"repo_name":           REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"retention_tag_count": "31",
+						"scope":               "INSTANCE",
+						"tag_regexp":          "release-v.*",
+						"schedule_time":       "MONTH",
+						"namespace_name":      REMOVEKEY,
+						"repo_name":           REMOVEKEY,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"retention_tag_count": "28",
+					"scope":               "REPO",
+					"namespace_name":      "${alicloud_cr_ee_namespace.defaultGPiaHQ.name}",
+					"repo_name":           "${alicloud_cr_ee_repo.defaultkCdOJ6.name}",
+					"schedule_time":       "WEEK",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"retention_tag_count": "28",
+						"scope":               "REPO",
+						"namespace_name":      CHECKSET,
+						"repo_name":           CHECKSET,
+						"schedule_time":       "WEEK",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto":                "false",
+					"retention_tag_count": "30",
+					"tag_regexp":          " .*",
+					"namespace_name":      "${alicloud_cr_ee_namespace.defaultevafKF.name}",
+					"repo_name":           "${alicloud_cr_ee_repo.defaultKunw72.name}",
+					"schedule_time":       REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"auto":                "false",
+						"retention_tag_count": "30",
+						"tag_regexp":          " .*",
+						"namespace_name":      CHECKSET,
+						"repo_name":           CHECKSET,
+						"schedule_time":       REMOVEKEY,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCrArtifactLifecycleRuleMap6046 = map[string]string{
+	"create_time":                CHECKSET,
+	"modified_time":              CHECKSET,
+	"artifact_lifecycle_rule_id": CHECKSET,
+}
+
+func AlicloudCrArtifactLifecycleRuleBasicDependence6046(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_cr_ee_instance" "default2Rk8gT" {
+  instance_name  = var.name
+  renewal_status = "ManualRenewal"
+  payment_type   = "Subscription"
+  image_scanner  = "ACR"
+  period         = "1"
+  instance_type  = "Basic"
+}
+
+resource "alicloud_cr_ee_namespace" "defaultevafKF" {
+  instance_id        = alicloud_cr_ee_instance.default2Rk8gT.id
+  name               = var.name
+  auto_create        = false
+  default_visibility = "PUBLIC"
+}
+
+resource "alicloud_cr_ee_repo" "defaultKunw72" {
+  instance_id = alicloud_cr_ee_instance.default2Rk8gT.id
+  namespace   = alicloud_cr_ee_namespace.defaultevafKF.name
+  name        = var.name
+  repo_type   = "PUBLIC"
+  summary     = "dd"
+}
+
+resource "alicloud_cr_ee_namespace" "defaultGPiaHQ" {
+  instance_id        = alicloud_cr_ee_instance.default2Rk8gT.id
+  name               = "${var.name}-2"
+  auto_create        = false
+  default_visibility = "PUBLIC"
+}
+
+resource "alicloud_cr_ee_repo" "defaultkCdOJ6" {
+  instance_id = alicloud_cr_ee_instance.default2Rk8gT.id
+  namespace   = alicloud_cr_ee_namespace.defaultGPiaHQ.name
+  name        = "${var.name}-2"
+  repo_type   = "PUBLIC"
+  summary     = "dddd"
+}
+
+
+`, name)
+}
+
+// Case 保留策略生命周期_使用固定Instance-SUCC 5605
+func TestAccAliCloudCrArtifactLifecycleRule_basic5605(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cr_artifact_lifecycle_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCrArtifactLifecycleRuleMap5605)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCrArtifactLifecycleRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrArtifactLifecycleRuleBasicDependence5605)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto":                "true",
+					"retention_tag_count": "30",
+					"scope":               "REPO",
+					"instance_id":         "${alicloud_cr_ee_instance.default2Rk8gT.id}",
+					"tag_regexp":          " .*",
+					"namespace_name":      "${alicloud_cr_ee_namespace.defaultevafKF.name}",
+					"repo_name":           "${alicloud_cr_ee_repo.defaultKunw72.name}",
+					"schedule_time":       "WEEK",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"auto":                "true",
+						"retention_tag_count": "30",
+						"scope":               "REPO",
+						"instance_id":         CHECKSET,
+						"tag_regexp":          " .*",
+						"namespace_name":      CHECKSET,
+						"repo_name":           CHECKSET,
+						"schedule_time":       "WEEK",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"retention_tag_count": "31",
+					"scope":               "INSTANCE",
+					"tag_regexp":          "release-v.*",
+					"schedule_time":       "MONTH",
+					"namespace_name":      REMOVEKEY,
+					"repo_name":           REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"retention_tag_count": "31",
+						"scope":               "INSTANCE",
+						"tag_regexp":          "release-v.*",
+						"schedule_time":       "MONTH",
+						"namespace_name":      REMOVEKEY,
+						"repo_name":           REMOVEKEY,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"retention_tag_count": "28",
+					"scope":               "REPO",
+					"namespace_name":      "${alicloud_cr_ee_namespace.defaultGPiaHQ.name}",
+					"repo_name":           "${alicloud_cr_ee_repo.defaultkCdOJ6.name}",
+					"schedule_time":       "WEEK",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"retention_tag_count": "28",
+						"scope":               "REPO",
+						"namespace_name":      CHECKSET,
+						"repo_name":           CHECKSET,
+						"schedule_time":       "WEEK",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto":                "false",
+					"retention_tag_count": "30",
+					"tag_regexp":          " .*",
+					"namespace_name":      "${alicloud_cr_ee_namespace.defaultevafKF.name}",
+					"repo_name":           "${alicloud_cr_ee_repo.defaultKunw72.name}",
+					"schedule_time":       REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"auto":                "false",
+						"retention_tag_count": "30",
+						"tag_regexp":          " .*",
+						"namespace_name":      CHECKSET,
+						"repo_name":           CHECKSET,
+						"schedule_time":       REMOVEKEY,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCrArtifactLifecycleRuleMap5605 = map[string]string{
+	"create_time":                CHECKSET,
+	"modified_time":              CHECKSET,
+	"artifact_lifecycle_rule_id": CHECKSET,
+}
+
+func AlicloudCrArtifactLifecycleRuleBasicDependence5605(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_cr_ee_instance" "default2Rk8gT" {
+  instance_name  = var.name
+  renewal_status = "ManualRenewal"
+  payment_type   = "Subscription"
+  image_scanner  = "ACR"
+  period         = "1"
+  instance_type  = "Basic"
+}
+
+resource "alicloud_cr_ee_namespace" "defaultevafKF" {
+  instance_id        = alicloud_cr_ee_instance.default2Rk8gT.id
+  name               = var.name
+  auto_create        = false
+  default_visibility = "PUBLIC"
+}
+
+resource "alicloud_cr_ee_repo" "defaultKunw72" {
+  instance_id = alicloud_cr_ee_instance.default2Rk8gT.id
+  namespace   = alicloud_cr_ee_namespace.defaultevafKF.name
+  name        = var.name
+  repo_type   = "PUBLIC"
+  summary     = "dd"
+}
+
+resource "alicloud_cr_ee_namespace" "defaultGPiaHQ" {
+  instance_id        = alicloud_cr_ee_instance.default2Rk8gT.id
+  name               = "${var.name}-2"
+  auto_create        = false
+  default_visibility = "PUBLIC"
+}
+
+resource "alicloud_cr_ee_repo" "defaultkCdOJ6" {
+  instance_id = alicloud_cr_ee_instance.default2Rk8gT.id
+  namespace   = alicloud_cr_ee_namespace.defaultGPiaHQ.name
+  name        = "${var.name}-2"
+  repo_type   = "PUBLIC"
+  summary     = "dddd"
+}
+
+
+`, name)
+}
+
+// Test Cr ArtifactLifecycleRule. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_cr_v2.go
+++ b/alicloud/service_alicloud_cr_v2.go
@@ -526,3 +526,80 @@ func (s *CrServiceV2) DescribeCrEERepo(id string) (object map[string]interface{}
 }
 
 // DescribeCrEERepo >>> Encapsulated.
+
+// DescribeCrArtifactLifecycleRule <<< Encapsulated get interface for Cr ArtifactLifecycleRule.
+
+func (s *CrServiceV2) DescribeCrArtifactLifecycleRule(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	query["RuleId"] = parts[1]
+	query["InstanceId"] = parts[0]
+	query["RegionId"] = client.RegionId
+	action := "GetArtifactLifecycleRule"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcGet("cr", "2018-12-01", action, query, request)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"INSTANCE_NOT_EXIST"}) {
+			return object, WrapErrorf(NotFoundErr("ArtifactLifecycleRule", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *CrServiceV2) CrArtifactLifecycleRuleStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.CrArtifactLifecycleRuleStateRefreshFuncWithApi(id, field, failStates, s.DescribeCrArtifactLifecycleRule)
+}
+
+func (s *CrServiceV2) CrArtifactLifecycleRuleStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeCrArtifactLifecycleRule >>> Encapsulated.

--- a/website/docs/d/cr_artifact_lifecycle_rules.html.markdown
+++ b/website/docs/d/cr_artifact_lifecycle_rules.html.markdown
@@ -1,0 +1,99 @@
+---
+subcategory: "Container Registry (CR)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cr_artifact_lifecycle_rules"
+sidebar_current: "docs-alicloud-datasource-cr-artifact-lifecycle-rules"
+description: |-
+  Provides a list of Cr Artifact Lifecycle Rule owned by an Alibaba Cloud account.
+---
+
+# alicloud_cr_artifact_lifecycle_rules
+
+This data source provides Cr Artifact Lifecycle Rule available to the user.[What is Artifact Lifecycle Rule](https://next.api.alibabacloud.com/document/cr/2018-12-01/CreateArtifactLifecycleRule)
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_cr_ee_instance" "default" {
+  default_oss_bucket = "true"
+  instance_name      = var.name
+  renewal_status     = "ManualRenewal"
+  image_scanner      = "DISABLE"
+  period             = "1"
+  payment_type       = "Subscription"
+  instance_type      = "Economy"
+}
+
+resource "alicloud_cr_ee_namespace" "default" {
+  instance_id        = alicloud_cr_ee_instance.default.id
+  name               = var.name
+  auto_create        = false
+  default_visibility = "PRIVATE"
+}
+
+resource "alicloud_cr_ee_repo" "default" {
+  instance_id = alicloud_cr_ee_instance.default.id
+  namespace   = alicloud_cr_ee_namespace.default.name
+  name        = var.name
+  repo_type   = "PRIVATE"
+  summary     = "example repository for lifecycle rule"
+}
+
+resource "alicloud_cr_artifact_lifecycle_rule" "default" {
+  auto                = true
+  namespace_name      = alicloud_cr_ee_namespace.default.name
+  retention_tag_count = "30"
+  schedule_time       = "WEEK"
+  scope               = "REPO"
+  instance_id         = alicloud_cr_ee_instance.default.id
+  tag_regexp          = ".*"
+  repo_name           = alicloud_cr_ee_repo.default.name
+}
+
+data "alicloud_cr_artifact_lifecycle_rules" "default" {
+  ids         = ["${alicloud_cr_artifact_lifecycle_rule.default.id}"]
+  instance_id = alicloud_cr_ee_instance.default.id
+}
+
+output "alicloud_cr_artifact_lifecycle_rule_example_id" {
+  value = data.alicloud_cr_artifact_lifecycle_rules.default.rules.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `instance_id` - (Required) Instance ID
+* `ids` - (Optional, Computed) A list of Artifact Lifecycle Rule IDs. The value is formulated as `<instance_id>:<artifact_lifecycle_rule_id>`.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Artifact Lifecycle Rule IDs.
+* `rules` - A list of Artifact Lifecycle Rule Entries. Each element contains the following attributes:
+    * `artifact_lifecycle_rule_id` - The first ID of the resource.
+    * `auto` - Whether to execute automatically.
+    * `create_time` - Creation time.
+    * `enable_delete_tag` - Activate the delete tag function.
+    * `enable_delete_untagged_manifest` - Open garbage collection.
+    * `instance_id` - Instance ID.
+    * `modified_time` - Change time.
+    * `namespace_name` - Namespace name.
+    * `repo_name` - Repository Name.
+    * `retention_tag_count` - Number of Retention Tags.
+    * `schedule_time` - Execution cycle.
+    * `scope` - Scope of cleaning.
+    * `tag_regexp` - Retain regular expressions for mirrored versions.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/cr_artifact_lifecycle_rule.html.markdown
+++ b/website/docs/r/cr_artifact_lifecycle_rule.html.markdown
@@ -1,0 +1,102 @@
+---
+subcategory: "Container Registry (CR)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cr_artifact_lifecycle_rule"
+description: |-
+  Provides a Alicloud CR Artifact Lifecycle Rule resource.
+---
+
+# alicloud_cr_artifact_lifecycle_rule
+
+Provides a CR Artifact Lifecycle Rule resource.
+
+Retention policies for versions in the warehouse.
+
+For information about CR Artifact Lifecycle Rule and how to use it, see [What is Artifact Lifecycle Rule](https://next.api.alibabacloud.com/document/cr/2018-12-01/CreateArtifactLifecycleRule).
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_cr_ee_instance" "default" {
+  default_oss_bucket = "true"
+  instance_name      = var.name
+  renewal_status     = "ManualRenewal"
+  image_scanner      = "DISABLE"
+  period             = "1"
+  payment_type       = "Subscription"
+  instance_type      = "Economy"
+}
+
+resource "alicloud_cr_ee_namespace" "default" {
+  instance_id        = alicloud_cr_ee_instance.default.id
+  name               = var.name
+  auto_create        = false
+  default_visibility = "PRIVATE"
+}
+
+resource "alicloud_cr_ee_repo" "default" {
+  instance_id = alicloud_cr_ee_instance.default.id
+  namespace   = alicloud_cr_ee_namespace.default.name
+  name        = var.name
+  repo_type   = "PRIVATE"
+  summary     = "example repository for lifecycle rule"
+}
+
+resource "alicloud_cr_artifact_lifecycle_rule" "default" {
+  auto                = true
+  namespace_name      = alicloud_cr_ee_namespace.default.name
+  retention_tag_count = "30"
+  schedule_time       = "WEEK"
+  scope               = "REPO"
+  instance_id         = alicloud_cr_ee_instance.default.id
+  tag_regexp          = ".*"
+  repo_name           = alicloud_cr_ee_repo.default.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `auto` - (Required) Whether to execute automatically
+* `instance_id` - (Required, ForceNew) Instance ID
+* `namespace_name` - (Optional) Namespace name
+* `repo_name` - (Optional) Repository Name
+* `retention_tag_count` - (Optional, Int) Number of Retention Tags
+* `schedule_time` - (Optional) Execution cycle
+* `scope` - (Optional) Scope of cleaning
+* `tag_regexp` - (Optional) Retain regular expressions for mirrored versions
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<instance_id>:<artifact_lifecycle_rule_id>`.
+* `artifact_lifecycle_rule_id` - The first ID of the resource.
+* `create_time` - Creation time.
+* `modified_time` - Change time.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Artifact Lifecycle Rule.
+* `delete` - (Defaults to 5 mins) Used when delete the Artifact Lifecycle Rule.
+* `update` - (Defaults to 5 mins) Used when update the Artifact Lifecycle Rule.
+
+## Import
+
+CR Artifact Lifecycle Rule can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cr_artifact_lifecycle_rule.example <instance_id>:<artifact_lifecycle_rule_id>
+```


### PR DESCRIPTION
Support a new resource `alicloud_cr_artifact_lifecycle_rule` and a new data source `alicloud_cr_artifact_lifecycle_rules` for managing Container Registry artifact lifecycle (retention) rules.

- New Resource: `alicloud_cr_artifact_lifecycle_rule`
- New Data Source: `alicloud_cr_artifact_lifecycle_rules`

All acceptance tests passed:

```
=== RUN TestAccAliCloudCrArtifactLifecycleRule_basic12942
--- PASS: TestAccAliCloudCrArtifactLifecycleRule_basic12942 (152.28s)

=== RUN TestAccAliCloudCrArtifactLifecycleRule_basic5221
--- PASS: TestAccAliCloudCrArtifactLifecycleRule_basic5221 (159.89s)

=== RUN TestAccAliCloudCrArtifactLifecycleRule_basic6046
--- PASS: TestAccAliCloudCrArtifactLifecycleRule_basic6046 (190.87s)

=== RUN TestAccAliCloudCrArtifactLifecycleRule_basic5605
--- PASS: TestAccAliCloudCrArtifactLifecycleRule_basic5605 (231.33s)

=== RUN TestAccAlicloudCrArtifactLifecycleRuleDataSource
--- PASS: TestAccAlicloudCrArtifactLifecycleRuleDataSource (176.26s)
```