### PR TITLE
data-source/alicloud_das_sql_log_configs: address review feedback

### DIFF
--- a/alicloud/data_source_alicloud_das_sql_log_configs.go
+++ b/alicloud/data_source_alicloud_das_sql_log_configs.go
@@ -31,10 +31,6 @@ func dataSourceAliCloudDasSqlLogConfigs() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 						"instance_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -87,42 +83,27 @@ func dataSourceAliCloudDasSqlLogConfigsRead(d *schema.ResourceData, meta interfa
 	objectRaw, err := dasServiceV2.DescribeDasSqlLogConfig(instanceId)
 	if err != nil {
 		if NotFoundError(err) {
-			d.SetId(dataResourceIdHash([]string{instanceId}))
-			d.Set("ids", []string{})
-			d.Set("configs", []map[string]interface{}{})
+			d.SetId("")
 			return nil
 		}
 		return WrapError(err)
 	}
 
 	dataRawObj, _ := jsonpath.Get("$.Data", objectRaw)
-	dataRaw := make(map[string]interface{})
-	if dataRawObj != nil {
-		dataRaw = dataRawObj.(map[string]interface{})
-	}
-
-	toBool := func(v interface{}) bool {
-		b, _ := v.(bool)
-		return b
-	}
-	toStr := func(v interface{}) string {
-		if v == nil {
-			return ""
-		}
-		s, _ := v.(string)
-		return s
+	dataRaw, _ := dataRawObj.(map[string]interface{})
+	if dataRaw == nil {
+		dataRaw = map[string]interface{}{}
 	}
 
 	mapping := map[string]interface{}{
-		"id":                   instanceId,
 		"instance_id":          instanceId,
-		"enable":               toBool(dataRaw["SqlLogEnable"]),
-		"request_enable":       toBool(dataRaw["RequestEnable"]),
+		"enable":               formatBool(dataRaw["SqlLogEnable"]),
+		"request_enable":       formatBool(dataRaw["RequestEnable"]),
 		"retention":            formatInt(dataRaw["Retention"]),
 		"hot_retention":        formatInt(dataRaw["HotRetention"]),
 		"cold_retention":       formatInt(dataRaw["ColdRetention"]),
-		"version":              toStr(dataRaw["Version"]),
-		"log_filter":           toStr(dataRaw["LogFilter"]),
+		"version":              dataRaw["Version"],
+		"log_filter":           dataRaw["LogFilter"],
 		"sql_log_visible_time": formatInt(dataRaw["SqlLogVisibleTime"]),
 	}
 

--- a/alicloud/data_source_alicloud_das_sql_log_configs_test.go
+++ b/alicloud/data_source_alicloud_das_sql_log_configs_test.go
@@ -27,7 +27,6 @@ func TestAccAliCloudDasSqlLogConfigDataSource(t *testing.T) {
 var existDasSqlLogConfigMapFunc = func(rand int) map[string]string {
 	return map[string]string{
 		"configs.#":               "1",
-		"configs.0.id":            CHECKSET,
 		"configs.0.instance_id":   CHECKSET,
 		"configs.0.retention":     "30",
 		"configs.0.hot_retention": "7",

--- a/website/docs/d/das_sql_log_configs.html.markdown
+++ b/website/docs/d/das_sql_log_configs.html.markdown
@@ -41,7 +41,6 @@ The following arguments are supported:
 
 The following attributes are exported in addition to the arguments listed above:
 * `configs` - A list of Sql Log Config Entries. Each element contains the following attributes:
-    * `id` - The ID of the Sql Log Config. Its value is same as `instance_id`.
     * `instance_id` - The ID of the database instance.
     * `enable` - Specifies whether SQL Explorer is enabled.
     * `request_enable` - The requested state of SQL Explorer.


### PR DESCRIPTION
## Summary
Follow-up to #9917 addressing three review comments on the datasource:
- Set empty ID on NotFound so state does not persist for missing configs.
- Reuse the existing `formatBool` helper and drop the local string cast closure.
- Remove duplicate `id` field from each config entry; `instance_id` already identifies each row.

## Test plan
```
=== RUN   TestAccAliCloudDasSqlLogConfigDataSource
--- PASS: TestAccAliCloudDasSqlLogConfigDataSource (391.33s)
```