### PR TITLE
data-source/alicloud_vpn_gateways: add gateway_type filter and fix panic on enhanced gateways

### DIFF
--- a/alicloud/data_source_alicloud_vpn_gateways.go
+++ b/alicloud/data_source_alicloud_vpn_gateways.go
@@ -67,6 +67,11 @@ func dataSourceAlicloudVpnGateways() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"enable", "disable"}, false),
 			},
+			"gateway_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Traditional", "Enhanced.SiteToSite"}, false),
+			},
 			"include_reservation_data": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -208,6 +213,10 @@ func dataSourceAlicloudVpnGatewaysRead(d *schema.ResourceData, meta interface{})
 		request["BusinessStatus"] = v.(string)
 	}
 
+	if v, ok := d.GetOk("gateway_type"); ok && v.(string) != "" {
+		request["GatewayType"] = v.(string)
+	}
+
 	var objects []map[string]interface{}
 	var vpnGatewayNameRegex *regexp.Regexp
 	if v, ok := d.GetOk("name_regex"); ok {
@@ -284,6 +293,14 @@ func dataSourceAlicloudVpnGatewaysRead(d *schema.ResourceData, meta interface{})
 		if sslVpn != "" && sslVpn != fmt.Sprint(object["SslVpn"]) {
 			continue
 		}
+		status := ""
+		if v, ok := object["Status"].(string); ok && v != "" {
+			status = convertStatus(v)
+		}
+		instanceChargeType := ""
+		if v, ok := object["ChargeType"].(string); ok && v != "" {
+			instanceChargeType = convertChargeType(v)
+		}
 		mapping := map[string]interface{}{
 			"id":                            object["VpnGatewayId"],
 			"vpc_id":                        object["VpcId"],
@@ -291,9 +308,9 @@ func dataSourceAlicloudVpnGatewaysRead(d *schema.ResourceData, meta interface{})
 			"specification":                 object["Spec"],
 			"name":                          object["Name"],
 			"description":                   object["Description"],
-			"status":                        convertStatus(object["Status"].(string)),
+			"status":                        status,
 			"business_status":               object["BusinessStatus"],
-			"instance_charge_type":          convertChargeType(object["ChargeType"].(string)),
+			"instance_charge_type":          instanceChargeType,
 			"enable_ipsec":                  object["IpsecVpn"],
 			"enable_ssl":                    object["SslVpn"],
 			"ssl_vpn":                       object["SslVpn"],

--- a/alicloud/data_source_alicloud_vpn_gateways_test.go
+++ b/alicloud/data_source_alicloud_vpn_gateways_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
@@ -65,6 +66,19 @@ func TestAccAlicloudVPNGatewaysDataSource(t *testing.T) {
 		}),
 	}
 
+	gatewayTypeConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVpnGatewaysDataSourceConfig(rand, map[string]string{
+			"name_regex":   `"${alicloud_vpn_gateway.default.name}"`,
+			"gateway_type": `"Traditional"`,
+		}),
+		// The default gateway is a Traditional type, so filtering by the
+		// Enhanced.SiteToSite type must return no matches.
+		fakeConfig: testAccCheckAlicloudVpnGatewaysDataSourceConfig(rand, map[string]string{
+			"name_regex":   `"${alicloud_vpn_gateway.default.name}"`,
+			"gateway_type": `"Enhanced.SiteToSite"`,
+		}),
+	}
+
 	allConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudVpnGatewaysDataSourceConfig(rand, map[string]string{
 			"ids":             `[ "${alicloud_vpn_gateway.default.id}" ]`,
@@ -72,6 +86,7 @@ func TestAccAlicloudVPNGatewaysDataSource(t *testing.T) {
 			"vpc_id":          `"${alicloud_vpn_gateway.default.vpc_id}"`,
 			"status":          `"Active"`,
 			"business_status": `"Normal"`,
+			"gateway_type":    `"Traditional"`,
 		}),
 		fakeConfig: testAccCheckAlicloudVpnGatewaysDataSourceConfig(rand, map[string]string{
 			"ids":             `[ "${alicloud_vpn_gateway.default.id}" ]`,
@@ -79,10 +94,11 @@ func TestAccAlicloudVPNGatewaysDataSource(t *testing.T) {
 			"vpc_id":          `"${alicloud_vpn_gateway.default.vpc_id}"`,
 			"status":          `"Active"`,
 			"business_status": `"FinancialLocked"`,
+			"gateway_type":    `"Traditional"`,
 		}),
 	}
 
-	vpnGatewaysCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, idsConf, nameRegexConf, vpcIdConf, statusConf, businessStatusConf, allConf)
+	vpnGatewaysCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, idsConf, nameRegexConf, vpcIdConf, statusConf, businessStatusConf, gatewayTypeConf, allConf)
 }
 
 func testAccCheckAlicloudVpnGatewaysDataSourceConfig(rand int, attrMap map[string]string) string {
@@ -93,7 +109,7 @@ func testAccCheckAlicloudVpnGatewaysDataSourceConfig(rand int, attrMap map[strin
 
 	config := fmt.Sprintf(`
 variable "name" {
-	default = "tf-testAccVpcGatewayConfig%d"
+  default = "tf-testAccVpcGatewayConfig%d"
 }
 
 variable "spec" {
@@ -143,7 +159,7 @@ resource "alicloud_vpn_gateway" "default" {
   vpn_type                     = "Normal"
   disaster_recovery_vswitch_id = local.vswitch_id2
   vpn_gateway_name             = "${var.name}"
-  description = "${var.name}"
+  description                  = "${var.name}"
 
   vswitch_id   = local.vswitch_id
   auto_pay     = true
@@ -153,8 +169,8 @@ resource "alicloud_vpn_gateway" "default" {
   enable_ipsec = true
   bandwidth    = var.spec
   tags = {
-	Created = "tfTestAcc0"
-	For     = "Tftestacc 0"
+    Created = "tfTestAcc0"
+    For     = "Tftestacc 0"
   }
 }
 
@@ -201,4 +217,109 @@ var vpnGatewaysCheckInfo = dataSourceAttr{
 	resourceId:   "data.alicloud_vpn_gateways.default",
 	existMapFunc: existVpnGatewaysMapFunc,
 	fakeMapFunc:  fakeVpnGatewaysMapFunc,
+}
+
+// TestAccAlicloudVPNGatewaysDataSourceEnhanced covers reading an enhanced (Enhance.SiteToSite)
+// VPN gateway through the alicloud_vpn_gateways data source. Enhanced gateways are returned by
+// DescribeVpnGateways without a ChargeType/Status field, which used to panic the provider
+// (interface conversion: interface {} is nil, not string). It also exercises the new
+// gateway_type query argument.
+func TestAccAlicloudVPNGatewaysDataSourceEnhanced(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"ap-southeast-3"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+	preCheck := func() {
+		testAccPreCheck(t)
+	}
+
+	gatewayTypeConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVpnGatewaysEnhancedDataSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_vpn_gateway_enhanced_vpn_gateway.default.id}"]`,
+			"gateway_type": `"Enhanced.SiteToSite"`,
+		}),
+		fakeConfig: testAccCheckAlicloudVpnGatewaysEnhancedDataSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_vpn_gateway_enhanced_vpn_gateway.default.id}"]`,
+			"gateway_type": `"Traditional"`,
+		}),
+	}
+
+	vpnGatewaysEnhancedCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, gatewayTypeConf)
+}
+
+func testAccCheckAlicloudVpnGatewaysEnhancedDataSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+
+	config := fmt.Sprintf(`
+variable "name" {
+  default = "tf-testAccVpnGatewaysEnhanced%d"
+}
+
+variable "zone1" {
+  default = "ap-southeast-3b"
+}
+
+variable "zone2" {
+  default = "ap-southeast-3a"
+}
+
+resource "alicloud_vpc" "default" {
+  cidr_block = "192.168.0.0/16"
+  is_default = false
+}
+
+resource "alicloud_vswitch" "default1" {
+  vpc_id     = alicloud_vpc.default.id
+  zone_id    = var.zone1
+  cidr_block = "192.168.10.0/24"
+}
+
+resource "alicloud_vswitch" "default2" {
+  vpc_id     = alicloud_vpc.default.id
+  zone_id    = var.zone2
+  cidr_block = "192.168.20.0/24"
+}
+
+resource "alicloud_vpn_gateway_enhanced_vpn_gateway" "default" {
+  vpn_type                     = "Normal"
+  description                  = var.name
+  disaster_recovery_vswitch_id = alicloud_vswitch.default2.id
+  vpc_id                       = alicloud_vpc.default.id
+  vpn_gateway_name             = var.name
+  network_type                 = "public"
+  vswitch_id                   = alicloud_vswitch.default1.id
+  gateway_type                 = "Enhanced.SiteToSite"
+  auto_propagate               = false
+}
+
+data "alicloud_vpn_gateways" "default" {
+	%s
+}
+`, rand, strings.Join(pairs, "\n  "))
+	return config
+}
+
+var existVpnGatewaysEnhancedMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"gateways.#":              "1",
+		"ids.#":                   "1",
+		"gateways.0.id":           CHECKSET,
+		"gateways.0.vpc_id":       CHECKSET,
+		"gateways.0.status":       CHECKSET,
+		"gateways.0.network_type": CHECKSET,
+	}
+}
+
+var fakeVpnGatewaysEnhancedMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"ids.#":      "0",
+		"gateways.#": "0",
+	}
+}
+
+var vpnGatewaysEnhancedCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_vpn_gateways.default",
+	existMapFunc: existVpnGatewaysEnhancedMapFunc,
+	fakeMapFunc:  fakeVpnGatewaysEnhancedMapFunc,
 }

--- a/website/docs/d/vpn_gateways.html.markdown
+++ b/website/docs/d/vpn_gateways.html.markdown
@@ -85,6 +85,7 @@ The following arguments are supported:
 * `output_file` - (Optional) Save the result to the file.
 * `enable_ipsec` - (Deprecated, Optional, Available 1.161.0+, has been deprecated from provider version 1.193.0, it will be removed in the future version.) Indicates whether the IPsec-VPN feature is enabled.
 * `ssl_vpn` - (Optional, ForceNew, Available since v1.243.0) Indicates whether the SSL-VPN feature is enabled. Valid value is `enable`, `disable`.
+* `gateway_type` - (Optional, ForceNew, Available since v1.285.0) Limit search to specific gateway type. Valid values: `Traditional`, `Enhanced.SiteToSite`.
 * `include_reservation_data` - (Optional, ForceNew, Available 1.193.0+) Include ineffective ordering data.
 
 ## Attributes Reference


### PR DESCRIPTION
1. Enhanced (Enhanced.SiteToSite) VPN gateways are returned by DescribeVpnGateways without Status/ChargeType fields, which panicked the provider on the unguarded `interface{}.(string)` conversions. Extract both fields with a checked type assertion instead.

2. Add a `gateway_type` query argument to filter results by gateway type.

```log
=== RUN   TestAccAlicloudVPNGatewaysDataSource
--- PASS: TestAccAlicloudVPNGatewaysDataSource (203.58s)
=== RUN   TestAccAlicloudVPNGatewaysDataSourceEnhanced
    provider_test.go:215: Skipping unsupported region cn-chengdu. Supported regions: [ap-southeast-3]. Using ap-southeast-3 as this test region
--- PASS: TestAccAlicloudVPNGatewaysDataSourceEnhanced (61.82s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  270.545s

```