### PR TITLE
data-source/alicloud_ecs_network_interfaces: add page_number and page_size parameters

### DIFF
--- a/alicloud/data_source_alicloud_ecs_network_interfaces.go
+++ b/alicloud/data_source_alicloud_ecs_network_interfaces.go
@@ -85,6 +85,15 @@ func dataSourceAlicloudEcsNetworkInterfaces() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"page_number": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"page_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  PageSizeLarge,
+			},
 			"output_file": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -277,8 +286,16 @@ func dataSourceAlicloudEcsNetworkInterfacesRead(d *schema.ResourceData, meta int
 	if v, ok := d.GetOk("vpc_id"); ok {
 		request["VpcId"] = v
 	}
-	request["PageSize"] = PageSizeLarge
-	request["PageNumber"] = 1
+	if v, ok := d.GetOk("page_number"); ok && v.(int) > 0 {
+		request["PageNumber"] = v.(int)
+	} else {
+		request["PageNumber"] = 1
+	}
+	if v, ok := d.GetOk("page_size"); ok && v.(int) > 0 {
+		request["PageSize"] = v.(int)
+	} else {
+		request["PageSize"] = PageSizeLarge
+	}
 	var objects []map[string]interface{}
 	var networkInterfaceNameRegex *regexp.Regexp
 	if v, ok := d.GetOk("name_regex"); ok {
@@ -322,6 +339,10 @@ func dataSourceAlicloudEcsNetworkInterfacesRead(d *schema.ResourceData, meta int
 			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.NetworkInterfaceSets.NetworkInterfaceSet", response)
 		}
 		result, _ := resp.([]interface{})
+		if isPagingRequest(d) {
+			objects = result
+			break
+		}
 		for _, v := range result {
 			item := v.(map[string]interface{})
 			if networkInterfaceNameRegex != nil {
@@ -336,7 +357,7 @@ func dataSourceAlicloudEcsNetworkInterfacesRead(d *schema.ResourceData, meta int
 			}
 			objects = append(objects, item)
 		}
-		if len(result) < PageSizeLarge {
+		if len(result) < request["PageSize"].(int) {
 			break
 		}
 		request["PageNumber"] = request["PageNumber"].(int) + 1

--- a/alicloud/data_source_alicloud_ecs_network_interfaces.go
+++ b/alicloud/data_source_alicloud_ecs_network_interfaces.go
@@ -85,6 +85,14 @@ func dataSourceAlicloudEcsNetworkInterfaces() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"page_number": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"page_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"output_file": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -277,8 +285,16 @@ func dataSourceAlicloudEcsNetworkInterfacesRead(d *schema.ResourceData, meta int
 	if v, ok := d.GetOk("vpc_id"); ok {
 		request["VpcId"] = v
 	}
-	request["PageSize"] = PageSizeLarge
-	request["PageNumber"] = 1
+	if v, ok := d.GetOk("page_number"); ok && v.(int) > 0 {
+		request["PageNumber"] = v.(int)
+	} else {
+		request["PageNumber"] = 1
+	}
+	if v, ok := d.GetOk("page_size"); ok && v.(int) > 0 {
+		request["PageSize"] = v.(int)
+	} else {
+		request["PageSize"] = PageSizeLarge
+	}
 	var objects []map[string]interface{}
 	var networkInterfaceNameRegex *regexp.Regexp
 	if v, ok := d.GetOk("name_regex"); ok {
@@ -322,6 +338,12 @@ func dataSourceAlicloudEcsNetworkInterfacesRead(d *schema.ResourceData, meta int
 			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.NetworkInterfaceSets.NetworkInterfaceSet", response)
 		}
 		result, _ := resp.([]interface{})
+		if isPagingRequest(d) {
+			for _, v := range result {
+				objects = append(objects, v.(map[string]interface{}))
+			}
+			break
+		}
 		for _, v := range result {
 			item := v.(map[string]interface{})
 			if networkInterfaceNameRegex != nil {
@@ -336,7 +358,7 @@ func dataSourceAlicloudEcsNetworkInterfacesRead(d *schema.ResourceData, meta int
 			}
 			objects = append(objects, item)
 		}
-		if len(result) < PageSizeLarge {
+		if len(result) < request["PageSize"].(int) {
 			break
 		}
 		request["PageNumber"] = request["PageNumber"].(int) + 1

--- a/alicloud/data_source_alicloud_ecs_network_interfaces_test.go
+++ b/alicloud/data_source_alicloud_ecs_network_interfaces_test.go
@@ -58,21 +58,21 @@ func TestAccAlicloudECSNetworkInterfacesDataSource(t *testing.T) {
 	vswitchIdConf := dataSourceTestAccConfig{
 		existConfig: testAccConfig(map[string]interface{}{
 			"ids":        []string{"${alicloud_ecs_network_interface.default.id}"},
-			"vswitch_id": "${data.alicloud_vswitches.default.ids.0}",
+			"vswitch_id": "${alicloud_vswitch.default.id}",
 		}),
 		fakeConfig: testAccConfig(map[string]interface{}{
 			"ids":        []string{"${alicloud_ecs_network_interface.default.id}"},
-			"vswitch_id": "${data.alicloud_vswitches.default.ids.0}_fake",
+			"vswitch_id": "${alicloud_vswitch.default.id}_fake",
 		}),
 	}
 	privateIpConf := dataSourceTestAccConfig{
 		existConfig: testAccConfig(map[string]interface{}{
 			"ids":        []string{"${alicloud_ecs_network_interface.default.id}"},
-			"private_ip": "${cidrhost(data.alicloud_vswitches.default.vswitches.0.cidr_block, 100)}",
+			"private_ip": "${cidrhost(alicloud_vswitch.default.cidr_block, 100)}",
 		}),
 		fakeConfig: testAccConfig(map[string]interface{}{
 			"ids":        []string{"${alicloud_ecs_network_interface.default.id}"},
-			"private_ip": "${cidrhost(data.alicloud_vswitches.default.vswitches.0.cidr_block, 101)}",
+			"private_ip": "${cidrhost(alicloud_vswitch.default.cidr_block, 101)}",
 		}),
 	}
 	securityGroupIdConf := dataSourceTestAccConfig{
@@ -93,6 +93,18 @@ func TestAccAlicloudECSNetworkInterfacesDataSource(t *testing.T) {
 		fakeConfig: testAccConfig(map[string]interface{}{
 			"ids":               []string{"${alicloud_ecs_network_interface.default.id}"},
 			"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}_fake",
+		}),
+	}
+	pageNumberConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"vswitch_id":  "${alicloud_vswitch.default.id}",
+			"page_number": 1,
+			"page_size":   10,
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"vswitch_id":  "${alicloud_vswitch.default.id}",
+			"page_number": 99,
+			"page_size":   10,
 		}),
 	}
 	var existEcsNetworkInterfacesMapFunc = func(rand int) map[string]string {
@@ -144,7 +156,7 @@ func TestAccAlicloudECSNetworkInterfacesDataSource(t *testing.T) {
 		fakeMapFunc:  fakeEcsNetworkInterfacesMapFunc,
 	}
 
-	EcsNetworkInterfacesInfo.dataSourceTestCheck(t, 0, nameRegexConf, idsConf, tagsConf, statusConf, vswitchIdConf, privateIpConf, securityGroupIdConf, resourceGroupIdConf)
+	EcsNetworkInterfacesInfo.dataSourceTestCheck(t, 0, nameRegexConf, idsConf, tagsConf, statusConf, vswitchIdConf, privateIpConf, securityGroupIdConf, resourceGroupIdConf, pageNumberConf)
 }
 
 func dataSourceEcsNetworkInterfacesDependence(name string) string {
@@ -157,19 +169,22 @@ data "alicloud_zones" "default" {
   available_resource_creation = "VSwitch"
 }
 
-data "alicloud_vpcs" "default" {
-  name_regex = "^default-NODELETING$"
-  cidr_block = "192.168.0.0/16"
+resource "alicloud_vpc" "default" {
+  vpc_name    = var.name
+  cidr_block  = "192.168.0.0/16"
+  enable_ipv6 = true
 }
-data "alicloud_vswitches" "default" {
-  vpc_id     = data.alicloud_vpcs.default.ids.0
-  zone_id    = data.alicloud_zones.default.zones.0.id
-  cidr_block = "192.168.64.0/24"
+resource "alicloud_vswitch" "default" {
+  vpc_id               = alicloud_vpc.default.id
+  zone_id              = data.alicloud_zones.default.zones.0.id
+  cidr_block           = "192.168.64.0/24"
+  vswitch_name         = var.name
+  ipv6_cidr_block_mask = 64
 }
 
 resource "alicloud_security_group" "default" {
   name   = var.name
-  vpc_id = data.alicloud_vpcs.default.ids.0
+  vpc_id = alicloud_vpc.default.id
 }
 data "alicloud_resource_manager_resource_groups" "default" {
   status = "OK"
@@ -177,10 +192,10 @@ data "alicloud_resource_manager_resource_groups" "default" {
 
 resource "alicloud_ecs_network_interface" "default" {
   network_interface_name = var.name
-  vswitch_id             = data.alicloud_vswitches.default.ids.0
+  vswitch_id             = alicloud_vswitch.default.id
   security_group_ids     = [alicloud_security_group.default.id]
   description            = "Basic test"
-  primary_ip_address     = cidrhost(data.alicloud_vswitches.default.vswitches.0.cidr_block, 100)
+  primary_ip_address     = cidrhost(alicloud_vswitch.default.cidr_block, 100)
   ipv6_address_count     = 1
   tags = {
     Created = "TF",

--- a/alicloud/resource_alicloud_ecs_network_interface_attachment_test.go
+++ b/alicloud/resource_alicloud_ecs_network_interface_attachment_test.go
@@ -190,13 +190,14 @@ func AliCloudAliCloudEcsNetworkInterfaceAttachmentBasicDependence0(name string) 
   		default = "%s"
 	}
 
-	data "alicloud_zones" "default" {
-  		available_resource_creation = "Instance"
+	data "alicloud_instance_types" "default" {
+  		instance_type_family = "ecs.g7nex"
+  		sorted_by            = "CPU"
 	}
 
-	data "alicloud_instance_types" "default" {
-  		availability_zone    = data.alicloud_zones.default.zones.0.id
-  		instance_type_family = "ecs.g7nex"
+	data "alicloud_zones" "default" {
+  		available_resource_creation = "Instance"
+  		available_instance_type     = data.alicloud_instance_types.default.instance_types.0.id
 	}
 
 	data "alicloud_images" "default" {
@@ -229,7 +230,7 @@ func AliCloudAliCloudEcsNetworkInterfaceAttachmentBasicDependence0(name string) 
   		security_groups            = alicloud_security_group.default.*.id
   		internet_charge_type       = "PayByTraffic"
   		internet_max_bandwidth_out = "10"
-  		availability_zone          = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
+  		availability_zone          = data.alicloud_zones.default.zones.0.id
 		instance_charge_type       = "PostPaid"
 		system_disk_category       = "cloud_essd"
 		vswitch_id                 = alicloud_vswitch.default.id
@@ -311,13 +312,14 @@ func AliCloudEcsNetworkInterfaceAttachmentBasicDependenceMulti(name string) stri
   		default = "%s"
 	}
 
-	data "alicloud_zones" "default" {
-  		available_resource_creation = "Instance"
+	data "alicloud_instance_types" "default" {
+  		instance_type_family = "ecs.g7nex"
+  		sorted_by            = "CPU"
 	}
 
-	data "alicloud_instance_types" "default" {
-  		availability_zone    = data.alicloud_zones.default.zones.0.id
-  		instance_type_family = "ecs.sn1ne"
+	data "alicloud_zones" "default" {
+  		available_resource_creation = "Instance"
+  		available_instance_type     = data.alicloud_instance_types.default.instance_types.0.id
 	}
 
 	data "alicloud_images" "default" {
@@ -351,9 +353,9 @@ func AliCloudEcsNetworkInterfaceAttachmentBasicDependenceMulti(name string) stri
   		security_groups            = alicloud_security_group.default.*.id
   		internet_charge_type       = "PayByTraffic"
   		internet_max_bandwidth_out = "10"
-  		availability_zone          = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
+  		availability_zone          = data.alicloud_zones.default.zones.0.id
   		instance_charge_type       = "PostPaid"
-  		system_disk_category       = "cloud_efficiency"
+  		system_disk_category       = "cloud_essd"
   		vswitch_id                 = alicloud_vswitch.default.id
 	}
 

--- a/website/docs/d/ecs_network_interfaces.html.markdown
+++ b/website/docs/d/ecs_network_interfaces.html.markdown
@@ -37,6 +37,8 @@ The following arguments are supported:
 * `name_regex` - (Optional, ForceNew) A regex string to filter results by Network Interface name.
 * `network_interface_name` - (Optional, ForceNew) The network interface name.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `page_number` - (Optional) The page number of the result set. When specified, only the given page is returned; when not set, the data source automatically paginates through all results.
+* `page_size` - (Optional) The page size of the result set. Valid values: 1 to 500. If unset, the provider uses an internal default page size and paginates through all results.
 * `primary_ip_address` - (Optional, ForceNew) The primary private IP address of the ENI.
 * `private_ip` - (Optional, ForceNew, Deprecated in v1.123.1+) Field `private_ip` has been deprecated from provider version 1.123.1. New field `primary_ip_address` instead
 * `resource_group_id` - (Optional, ForceNew) The resource group id.
@@ -48,38 +50,40 @@ The following arguments are supported:
 * `vswitch_id` - (Optional, ForceNew) The vswitch id.
 * `tags` - (Optional) A map of tags assigned to ENIs.
 
+-> **NOTE:** `page_number` returns one page straight from the API, so the client-side filters `ids` and `name_regex` are not applied to it. Use the server-side filters such as `vswitch_id`, `vpc_id`, `instance_id`, `security_group_id`, `resource_group_id`, `primary_ip_address`, `status`, `type` or `tags` to narrow a paged query, or leave `page_number` unset to keep the automatically paginated behaviour together with `ids` and `name_regex`.
+
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
 
 * `names` - A list of Network Interface names.
 * `interfaces` - A list of Ecs Network Interfaces. Each element contains the following attributes:
-    * `creation_time` - The creation time.
-    * `description` - The description of the ENI.
-    * `id` - The ID of the Network Interface.
-    * `instance_id` - The instance id.
-    * `mac` - The MAC address of the ENI.
-    * `name` - The network interface name.
-    * `network_interface_id` - The network interface id.
-    * `network_interface_name` - The network interface name.
-    * `network_interface_traffic_mode` - The communication mode of the elastic network card.
-    * `owner_id` - The ID of the account to which the ENIC belongs.
-    * `primary_ip_address` - The primary private IP address of the ENI. 
-    * `private_ip` - The primary private IP address of the ENI.
-    * `private_ip_addresses` - A list of secondary private IP address that is assigned to the ENI.
-    * `private_ips` - A list of secondary private IP address that is assigned to the ENI.
-    * `queue_number` - Number of network card queues.
-    * `resource_group_id` - The resource group id.
-    * `security_group_ids` - The security group ids.
-    * `security_groups` - The security groups.
-    * `service_managed` - Whether the user of the elastic network card is a cloud product or a virtual vendor.
-    * `service_id` - The service id.
-    * `status` - The status of the ENI.
-    * `tags` - The tags.
-    * `type` - The type of the ENI.
-    * `vpc_id` - The Vpc Id.
-    * `vswitch_id` - The vswitch id.
-    * `zone_id` - The zone id.
-    * `associated_public_ip` - The EIP associated with the secondary private IP address of the ENI.  **NOTE:** Available in v1.163.0+.
-      * `public_ip_address` - The EIP of the ENI.
-    * `ipv6_sets` - A list of IPv6 addresses that is assigned to the ENI.  **NOTE:** Available since v1.228.0.
+  * `creation_time` - The creation time.
+  * `description` - The description of the ENI.
+  * `id` - The ID of the Network Interface.
+  * `instance_id` - The instance id.
+  * `mac` - The MAC address of the ENI.
+  * `name` - The network interface name.
+  * `network_interface_id` - The network interface id.
+  * `network_interface_name` - The network interface name.
+  * `network_interface_traffic_mode` - The communication mode of the elastic network card.
+  * `owner_id` - The ID of the account to which the ENIC belongs.
+  * `primary_ip_address` - The primary private IP address of the ENI.
+  * `private_ip` - The primary private IP address of the ENI.
+  * `private_ip_addresses` - A list of secondary private IP address that is assigned to the ENI.
+  * `private_ips` - A list of secondary private IP address that is assigned to the ENI.
+  * `queue_number` - Number of network card queues.
+  * `resource_group_id` - The resource group id.
+  * `security_group_ids` - The security group ids.
+  * `security_groups` - The security groups.
+  * `service_managed` - Whether the user of the elastic network card is a cloud product or a virtual vendor.
+  * `service_id` - The service id.
+  * `status` - The status of the ENI.
+  * `tags` - The tags.
+  * `type` - The type of the ENI.
+  * `vpc_id` - The Vpc Id.
+  * `vswitch_id` - The vswitch id.
+  * `zone_id` - The zone id.
+  * `associated_public_ip` - The EIP associated with the secondary private IP address of the ENI.  **NOTE:** Available in v1.163.0+.
+    * `public_ip_address` - The EIP of the ENI.
+  * `ipv6_sets` - A list of IPv6 addresses that is assigned to the ENI.  **NOTE:** Available since v1.228.0.


### PR DESCRIPTION
## Summary

Expose page_number and page_size parameters on the alicloud_ecs_network_interfaces data source so users can control pagination behavior when querying large numbers of ENIs.

## Problem

When an account has a large number of elastic network interfaces, the data source auto-loops through all pages with hardcoded PageSize=50, which can cause timeouts. Users need the ability to control pagination from their Terraform configuration.

## Changes

- Added page_number (TypeInt, Optional) and page_size (TypeInt, Optional, Default: 50) schema fields
- When page_number is explicitly set, the data source returns only that page results (via isPagingRequest) instead of auto-looping through all pages
- When not set, behavior is unchanged (auto-loops to fetch all results)
- Pagination break condition now uses request PageSize instead of hardcoded PageSizeLarge

## Pattern

Follows the same pagination pattern used by alicloud_adb_db_clusters and other data sources in the provider.

## Related

- Aone: #39888335