### PR TITLE
docs: fix vpc_route_entry example / cdn_real_time_log_delivery import / hbr_cross_account API links

### DIFF
--- a/website/docs/r/cdn_real_time_log_delivery.html.markdown
+++ b/website/docs/r/cdn_real_time_log_delivery.html.markdown
@@ -103,8 +103,8 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-CDN Real Time Log Delivery can be imported using the id, e.g.
+CDN Real Time Log Delivery can be imported using the id (the accelerated `domain`), e.g.
 
 ```shell
-$ terraform import alicloud_cdn_real_time_log_delivery.example <id>
+$ terraform import alicloud_cdn_real_time_log_delivery.example <domain>
 ```

--- a/website/docs/r/hbr_cross_account.html.markdown
+++ b/website/docs/r/hbr_cross_account.html.markdown
@@ -12,7 +12,7 @@ Provides a Hybrid Backup Recovery (HBR) Cross Account resource.
 
 The cross account is used for the cross-account backup in the Cloud Backup. The management account can back up the resources under the cross account.
 
-For information about Hybrid Backup Recovery (HBR) Cross Account and how to use it, see [What is Cross Account](https://www.alibabacloud.com/help/en/).
+For information about Hybrid Backup Recovery (HBR) Cross Account and how to use it, see [AddCrossAccount](https://www.alibabacloud.com/help/en/cloud-backup/developer-reference/api-hbr-2017-09-08-addcrossaccount) and [DeleteCrossAccount](https://www.alibabacloud.com/help/en/cloud-backup/developer-reference/api-hbr-2017-09-08-deletecrossaccount).
 
 -> **NOTE:** Available since v1.241.0.
 

--- a/website/docs/r/vpc_route_entry.html.markdown
+++ b/website/docs/r/vpc_route_entry.html.markdown
@@ -42,11 +42,11 @@ resource "alicloud_vpc_ipv4_gateway" "default" {
   enabled           = true
 }
 
-resource "alicloud_route_entry" "default" {
-  route_table_id        = alicloud_vpc.default.route_table_id
-  destination_cidrblock = "172.11.1.1/32"
-  nexthop_type          = "Ipv4Gateway"
-  nexthop_id            = alicloud_vpc_ipv4_gateway.default.id
+resource "alicloud_vpc_route_entry" "default" {
+  route_table_id         = alicloud_vpc.default.route_table_id
+  destination_cidr_block = "172.11.1.1/32"
+  nexthop_type           = "Ipv4Gateway"
+  nexthop_id             = alicloud_vpc_ipv4_gateway.default.id
 }
 ```
 


### PR DESCRIPTION
Fix 3 documentation issues reported by customers:

- **`website/docs/r/vpc_route_entry.html.markdown`** — the example used the legacy `alicloud_route_entry` resource name and `destination_cidrblock` field; align with the current `alicloud_vpc_route_entry` schema (`destination_cidr_block`). Reported in Aone #78504233.

- **`website/docs/r/cdn_real_time_log_delivery.html.markdown`** — the Import section used a generic `<id>`; clarify the id is the accelerated `domain` (per `alicloud/resource_alicloud_cdn_real_time_log_delivery.go:99` `d.SetId(fmt.Sprint(query["Domain"]))`). Reported in Aone #78523353.

- **`website/docs/r/hbr_cross_account.html.markdown`** — replace the placeholder Cross Account link with the actual `AddCrossAccount` and `DeleteCrossAccount` API references (as provided by customer). Reported in Aone #78554774.

No provider code changed; docs only.