### PR TITLE
feat: add static check for panic() calls and fix existing panics

### DIFF
--- a/.github/workflows/acctest-terraform-basic.yml
+++ b/.github/workflows/acctest-terraform-basic.yml
@@ -44,6 +44,22 @@ jobs:
           git diff HEAD^ HEAD > diff.out
           go run scripts/consistency/consistency_check.go -fileNames="diff.out"
 
+  PanicCheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24.x'
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Panic Static Check
+        run: |
+          sh scripts/paniccheck.sh
+
   Formatter:
     runs-on: ubuntu-latest
     permissions:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -131,6 +131,9 @@ test-resource-debug:
 vet:
 	"$(CURDIR)/scripts/vetcheck.sh"
 
+panic-check:
+	@sh scripts/paniccheck.sh
+
 fmt:
 	gofmt -w $(GOFMT_FILES)
 	goimports -w $(GOFMT_FILES)
@@ -252,7 +255,7 @@ sweep:
 		TF_ACC=1 go test ./alicloud -v -sweep=$(REGION) -sweep-run=$(RESOURCE); \
 	fi
 
-.PHONY: build test testacc test-resource test-resource-debug vet fmt fmtcheck errcheck test-compile website website-test commit ci-check ci-check-quick minimal-test-set sweep
+.PHONY: build test testacc test-resource test-resource-debug vet panic-check fmt fmtcheck errcheck test-compile website website-test commit ci-check ci-check-quick minimal-test-set sweep
 
 all: mac windows linux
 

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -345,8 +345,9 @@ func convertListToJsonString(configured []interface{}) string {
 }
 
 func convertJsonStringToStringList(src interface{}) (result []interface{}) {
-	if err, ok := src.([]interface{}); !ok {
-		panic(err)
+	if _, ok := src.([]interface{}); !ok {
+		log.Printf("[WARN] convertJsonStringToStringList: expected []interface{} but got %T, returning nil", src)
+		return nil
 	}
 	for _, v := range src.([]interface{}) {
 		result = append(result, fmt.Sprint(formatInt(v)))
@@ -1160,17 +1161,20 @@ func formatInt(src interface{}) int {
 		}
 		v, err := strconv.Atoi(vv)
 		if err != nil {
-			panic(err)
+			log.Printf("[WARN] formatInt: failed to parse string %q: %v, returning 0", vv, err)
+			return 0
 		}
 		return v
 	case "json.Number":
 		v, err := strconv.Atoi(src.(json.Number).String())
 		if err != nil {
-			panic(err)
+			log.Printf("[WARN] formatInt: failed to parse json.Number %q: %v, returning 0", src.(json.Number).String(), err)
+			return 0
 		}
 		return v
 	default:
-		panic(fmt.Sprintf("Not support type %s", attrType.String()))
+		log.Printf("[WARN] formatInt: unsupported type %s, returning 0", attrType.String())
+		return 0
 	}
 }
 
@@ -1189,11 +1193,13 @@ func formatBool(src interface{}) bool {
 		}
 		v, err := strconv.ParseBool(vv)
 		if err != nil {
-			panic(err)
+			log.Printf("[WARN] formatBool: failed to parse string %q: %v, returning false", vv, err)
+			return false
 		}
 		return v
 	default:
-		panic(fmt.Sprintf("Not support type %s", attrType.String()))
+		log.Printf("[WARN] formatBool: unsupported type %s, returning false", attrType.String())
+		return false
 	}
 }
 
@@ -1220,17 +1226,20 @@ func formatFloat64(src interface{}) float64 {
 		}
 		v, err := strconv.ParseFloat(vv, 64)
 		if err != nil {
-			panic(err)
+			log.Printf("[WARN] formatFloat64: failed to parse string %q: %v, returning 0", vv, err)
+			return 0
 		}
 		return v
 	case "json.Number":
 		v, err := src.(json.Number).Float64()
 		if err != nil {
-			panic(err)
+			log.Printf("[WARN] formatFloat64: failed to parse json.Number %q: %v, returning 0", src.(json.Number).String(), err)
+			return 0
 		}
 		return v
 	default:
-		panic(fmt.Sprintf("Not support type %s", attrType.String()))
+		log.Printf("[WARN] formatFloat64: unsupported type %s, returning 0", attrType.String())
+		return 0
 	}
 }
 

--- a/scripts/local-ci-check.sh
+++ b/scripts/local-ci-check.sh
@@ -299,6 +299,13 @@ if echo "$CHANGED_FILES" | grep -q "\.go$\|website/docs"; then
     || true
 fi
 
+# 1.6 Panic Check (static check for panic() calls)
+if echo "$CHANGED_FILES" | grep -q "\.go$"; then
+  run_check "Panic Check (no panic() in changed files)" \
+    "sh \"$SCRIPT_DIR/paniccheck.sh\"" \
+    || true
+fi
+
 # ============================================================================
 # 2. Testing Coverage Rate Check
 # ============================================================================

--- a/scripts/panic_check/panic_check.go
+++ b/scripts/panic_check/panic_check.go
@@ -1,0 +1,160 @@
+//nolint:all
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	fileNames    = flag.String("fileNames", "", "path to a file containing a list of Go files to check (one per line); if empty, scans all .go files under alicloud/")
+	includeTests = flag.Bool("includeTests", false, "include _test.go files in the check")
+	exclude      = flag.String("exclude", "", "comma-separated list of file path substrings to exclude (e.g., common.go)")
+)
+
+func main() {
+	flag.Parse()
+
+	var files []string
+
+	if fileNames != nil && len(*fileNames) > 0 {
+		// Read file list from the given file
+		data, err := os.ReadFile(*fileNames)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error reading file list %s: %v\n", *fileNames, err)
+			os.Exit(2)
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" && strings.HasSuffix(line, ".go") {
+				files = append(files, line)
+			}
+		}
+	} else {
+		// Scan all .go files under alicloud/
+		var err error
+		files, err = findGoFiles("alicloud")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error scanning alicloud/: %v\n", err)
+			os.Exit(2)
+		}
+	}
+
+	// Build exclude list
+	var excludePatterns []string
+	if exclude != nil && len(*exclude) > 0 {
+		excludePatterns = strings.Split(*exclude, ",")
+		for i := range excludePatterns {
+			excludePatterns[i] = strings.TrimSpace(excludePatterns[i])
+		}
+	}
+
+	exitCode := 0
+	checkedCount := 0
+	panicCount := 0
+
+	for _, file := range files {
+		// Skip test files unless -includeTests is set
+		if !*includeTests && strings.HasSuffix(file, "_test.go") {
+			continue
+		}
+
+		// Skip excluded files
+		if isExcluded(file, excludePatterns) {
+			continue
+		}
+
+		// Skip files that don't exist (e.g., deleted in diff)
+		if _, err := os.Stat(file); os.IsNotExist(err) {
+			continue
+		}
+
+		checkedCount++
+		panics := checkFileForPanics(file)
+		for _, p := range panics {
+			fmt.Printf("%s:%d:%d: panic() call in function %s\n", p.file, p.line, p.col, p.funcName)
+			panicCount++
+			exitCode = 1
+		}
+	}
+
+	if exitCode == 0 {
+		fmt.Printf("panic-check: OK (checked %d files, 0 panic calls found)\n", checkedCount)
+	} else {
+		fmt.Printf("panic-check: FAIL (checked %d files, %d panic call(s) found)\n", checkedCount, panicCount)
+	}
+
+	os.Exit(exitCode)
+}
+
+type panicLocation struct {
+	file     string
+	line     int
+	col      int
+	funcName string
+}
+
+func checkFileForPanics(filename string) []panicLocation {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filename, nil, 0)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not parse %s: %v\n", filename, err)
+		return nil
+	}
+
+	var panics []panicLocation
+	currentFunc := "<package-level>"
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.FuncDecl:
+			// Track the enclosing function name
+			currentFunc = node.Name.Name
+			// Continue inspecting the function body
+			return true
+		case *ast.CallExpr:
+			if ident, ok := node.Fun.(*ast.Ident); ok && ident.Name == "panic" {
+				pos := fset.Position(node.Pos())
+				panics = append(panics, panicLocation{
+					file:     filename,
+					line:     pos.Line,
+					col:      pos.Column,
+					funcName: currentFunc,
+				})
+			}
+			return true
+		}
+		return true
+	})
+
+	return panics
+}
+
+func findGoFiles(dir string) ([]string, error) {
+	var files []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(path, ".go") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	return files, err
+}
+
+func isExcluded(file string, patterns []string) bool {
+	for _, p := range patterns {
+		if p != "" && strings.Contains(file, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/panic_check/panic_check_test.go
+++ b/scripts/panic_check/panic_check_test.go
@@ -1,0 +1,206 @@
+//nolint:all
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPanicCheckDetectsPanic(t *testing.T) {
+	// Create a temporary directory for the test file
+	tmpDir := t.TempDir()
+
+	// Write a Go file that contains a panic() call
+	panicFile := filepath.Join(tmpDir, "has_panic.go")
+	panicCode := `package main
+
+import "fmt"
+
+func doSomething() {
+	fmt.Println("hello")
+	panic("something went wrong")
+}
+
+func main() {
+	doSomething()
+}
+`
+	if err := os.WriteFile(panicFile, []byte(panicCode), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	// Build the panic checker binary
+	checkerBin := filepath.Join(tmpDir, "panic_check")
+	buildCmd := exec.Command("go", "build", "-o", checkerBin, ".")
+	buildCmd.Dir = "." // build from the panic_check directory
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build panic checker: %v\n%s", err, out)
+	}
+
+	// Run the checker against the test file
+	runCmd := exec.Command(checkerBin, "-fileNames="+panicFile)
+	output, err := runCmd.CombinedOutput()
+
+	// Should exit with code 1 (panics found)
+	if err == nil {
+		t.Fatalf("expected panic checker to exit non-zero, but it exited 0.\nOutput: %s", output)
+	}
+
+	outStr := string(output)
+
+	// Should report the panic in doSomething
+	if !strings.Contains(outStr, "panic() call in function doSomething") {
+		t.Errorf("expected output to contain 'panic() call in function doSomething', got:\n%s", outStr)
+	}
+
+	// Should report the file path
+	if !strings.Contains(outStr, "has_panic.go") {
+		t.Errorf("expected output to contain 'has_panic.go', got:\n%s", outStr)
+	}
+
+	// Should report FAIL
+	if !strings.Contains(outStr, "FAIL") {
+		t.Errorf("expected output to contain 'FAIL', got:\n%s", outStr)
+	}
+}
+
+func TestPanicCheckCleanFile(t *testing.T) {
+	// Create a temporary directory for the test file
+	tmpDir := t.TempDir()
+
+	// Write a Go file that does NOT contain a panic() call
+	cleanFile := filepath.Join(tmpDir, "clean.go")
+	cleanCode := `package main
+
+import (
+	"fmt"
+	"log"
+)
+
+func doSomething() {
+	fmt.Println("hello")
+	log.Println("safe operation")
+}
+
+func main() {
+	doSomething()
+}
+`
+	if err := os.WriteFile(cleanFile, []byte(cleanCode), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	// Build the panic checker binary
+	checkerBin := filepath.Join(tmpDir, "panic_check")
+	buildCmd := exec.Command("go", "build", "-o", checkerBin, ".")
+	buildCmd.Dir = "." // build from the panic_check directory
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build panic checker: %v\n%s", err, out)
+	}
+
+	// Run the checker against the clean file
+	runCmd := exec.Command(checkerBin, "-fileNames="+cleanFile)
+	output, err := runCmd.CombinedOutput()
+
+	// Should exit with code 0 (no panics)
+	if err != nil {
+		t.Fatalf("expected panic checker to exit 0, but it failed.\nOutput: %s", output)
+	}
+
+	outStr := string(output)
+
+	// Should report OK
+	if !strings.Contains(outStr, "OK") {
+		t.Errorf("expected output to contain 'OK', got:\n%s", outStr)
+	}
+
+	// Should report 0 panic calls
+	if !strings.Contains(outStr, "0 panic calls found") {
+		t.Errorf("expected output to contain '0 panic calls found', got:\n%s", outStr)
+	}
+}
+
+func TestPanicCheckSkipsTestFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a test file that contains a panic() call
+	testFile := filepath.Join(tmpDir, "has_panic_test.go")
+	testCode := `package main
+
+func TestSomething(t *testing.T) {
+	panic("this should be skipped")
+}
+`
+	if err := os.WriteFile(testFile, []byte(testCode), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	// Write file list
+	fileList := filepath.Join(tmpDir, "files.txt")
+	if err := os.WriteFile(fileList, []byte(testFile+"\n"), 0644); err != nil {
+		t.Fatalf("failed to write file list: %v", err)
+	}
+
+	// Build the panic checker binary
+	checkerBin := filepath.Join(tmpDir, "panic_check")
+	buildCmd := exec.Command("go", "build", "-o", checkerBin, ".")
+	buildCmd.Dir = "."
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build panic checker: %v\n%s", err, out)
+	}
+
+	// Run without -includeTests — should skip the test file and exit 0
+	runCmd := exec.Command(checkerBin, "-fileNames="+fileList)
+	output, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected panic checker to exit 0 (test files skipped), but it failed.\nOutput: %s", output)
+	}
+
+	if !strings.Contains(string(output), "OK") {
+		t.Errorf("expected OK output when test files are skipped, got:\n%s", output)
+	}
+}
+
+func TestPanicCheckExclude(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Write a Go file with panic
+	panicFile := filepath.Join(tmpDir, "common.go")
+	panicCode := `package main
+
+func helper() {
+	panic("should be excluded")
+}
+`
+	if err := os.WriteFile(panicFile, []byte(panicCode), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	// Write file list
+	fileList := filepath.Join(tmpDir, "files.txt")
+	if err := os.WriteFile(fileList, []byte(panicFile+"\n"), 0644); err != nil {
+		t.Fatalf("failed to write file list: %v", err)
+	}
+
+	// Build the panic checker binary
+	checkerBin := filepath.Join(tmpDir, "panic_check")
+	buildCmd := exec.Command("go", "build", "-o", checkerBin, ".")
+	buildCmd.Dir = "."
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build panic checker: %v\n%s", err, out)
+	}
+
+	// Run with -exclude common.go — should skip and exit 0
+	runCmd := exec.Command(checkerBin, "-fileNames="+fileList, "-exclude=common.go")
+	output, err := runCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected panic checker to exit 0 (excluded), but it failed.\nOutput: %s", output)
+	}
+
+	if !strings.Contains(string(output), "OK") {
+		t.Errorf("expected OK output when file is excluded, got:\n%s", output)
+	}
+}

--- a/scripts/paniccheck.sh
+++ b/scripts/paniccheck.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Panic static check for alicloud/ Go files
+# Modelled after scripts/vetcheck.sh:
+#   - Diffs current branch against origin/master to get changed files
+#   - Filters to .go files under alicloud/
+#   - Runs the Go panic checker on changed files
+#   - Exits non-zero if panics found in changed files
+
+echo "==> Checking for panic() calls in changed Go files..."
+
+base_branch="origin/master"
+
+# If running inside a GitHub Actions pull request check, use the PR target branch
+if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+  base_branch="origin/$GITHUB_BASE_REF"
+fi
+
+# Get changed Go files under alicloud/ (exclude test files by default in the checker)
+target_files=$(git diff --name-only "${base_branch}" --diff-filter=MA 2>/dev/null | grep "^alicloud/.*\.go$" || true)
+
+if [[ -z "$target_files" ]]; then
+  echo "No Go files under alicloud/ have changed relative to ${base_branch}, nothing to check!"
+  exit 0
+fi
+
+# Write file list to a temp file for the checker
+TEMP_FILELIST=$(mktemp)
+echo "$target_files" > "$TEMP_FILELIST"
+
+echo "Changed files to check:"
+echo "$target_files" | sed 's/^/  /'
+echo ""
+
+# Run the panic checker on the changed files
+exitCode=0
+if go run scripts/panic_check/panic_check.go -fileNames="$TEMP_FILELIST"; then
+  echo "==> PASS: No panic() calls found in changed files."
+else
+  echo ""
+  echo "==> FAIL: panic() calls found in changed files."
+  echo "Please replace panic() with proper error handling (log + return zero value)."
+  exitCode=1
+fi
+
+rm -f "$TEMP_FILELIST"
+exit $exitCode


### PR DESCRIPTION
## Summary

Add a Go AST-based static checker that detects `panic()` calls in `alicloud/` Go files, and fix all 9 existing panics.

### New files
- `scripts/panic_check/panic_check.go` — AST-based checker (follows `breaking_change_check.go` pattern)
- `scripts/panic_check/panic_check_test.go` — 4 regression tests
- `scripts/paniccheck.sh` — shell wrapper (diffs against origin/master, like vetcheck.sh)

### Changes
- `alicloud/common.go` — replace all 9 `panic()` calls with `log.Printf("[WARN]...")` + safe zero-value returns
- `GNUmakefile` — add `make panic-check` target
- `scripts/local-ci-check.sh` — wire panic check into local CI
- `.github/workflows/acctest-terraform-basic.yml` — add `PanicCheck` CI job

### Why
`panic()` in a Terraform provider is catastrophic — it crashes the entire terraform process during plan/apply. All 9 panics were in type-conversion helpers (`formatInt`, `formatBool`, `formatFloat64`, `convertJsonStringToStringList`) in `common.go`. Replacing them with log+return ensures graceful degradation instead of crashes.

Closes Aone #44777692