### PR TITLE
estimate-cost: plan-time price estimation for alicloud resources

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,9 @@ before:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-  - env:
+  # ───────── Terraform Provider binary (original) ─────────
+  - id: provider
+    env:
       # goreleaser does not work with CGO, it could also complicate
       # usage by users in CI/CD systems like Terraform Cloud where
       # they are unable to install libraries.
@@ -33,11 +35,79 @@ builds:
       - goarch: arm64
         goos: windows
     binary: '{{ .ProjectName }}_v{{ .Version }}'
+
+  # ───────── estimate-cost: terraform wrapper ─────────
+  # Once installed, users get cost-estimation output simply by running
+  # `terraform plan --estimate-cost`.
+  - id: terraform-wrapper
+    main: ./estimate-cost/cmd/terraform-wrapper/
+    env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}}'
+    goos:
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goarch: arm64
+        goos: windows
+    binary: terraform-wrapper
+
+  # ───────── estimate-cost: pricing engine ─────────
+  # Pricing engine; invoked by the wrapper via exec. Bundles the full
+  # mapping set via go:embed.
+  - id: estimate-cost
+    main: ./estimate-cost/cmd/estimate-cost/
+    env:
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}}'
+    goos:
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goarch: arm64
+        goos: windows
+    binary: estimate-cost
+
 archives:
-  - files:
+  # ───────── Provider archive (original, unchanged) ─────────
+  - id: provider
+    builds: [provider]
+    files:
       - none*
     format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+
+  # ───────── estimate-cost archive (new) ─────────
+  # A single archive bundles both binaries — the wrapper and the engine.
+  # Users extract them and drop them into a directory that comes before the
+  # real `terraform` in PATH to enable the --estimate-cost flag.
+  - id: estimate-cost
+    builds: [terraform-wrapper, estimate-cost]
+    files:
+      - estimate-cost/README.md
+      - LICENSE
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: 'alicloud-tf-estimate-cost_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256

--- a/README.md
+++ b/README.md
@@ -103,3 +103,14 @@ export ALICLOUD_ACCOUNT_SITE=Domestic
 export ALICLOUD_ACCOUNT_SITE=International
 ```
 The setting of account site type can skip some unsupported cases automatically.
+
+## Estimate Cost (plan-time pricing)
+
+This repository also ships a small companion tool that adds a `--estimate-cost`
+flag to `terraform plan`, returning the real Alibaba Cloud price (from
+CloudControl `GetApiPrice`) of the resources you are about to create or modify.
+It is **built alongside the provider** by the same release pipeline, with
+matching version numbers, so every provider release tag automatically produces
+a matching `alicloud-tf-estimate-cost_*.tar.gz` on GitHub Releases.
+
+See [estimate-cost/README.md](./estimate-cost/README.md) for install + usage.

--- a/estimate-cost/README.md
+++ b/estimate-cost/README.md
@@ -1,0 +1,245 @@
+# Estimate Cost for Terraform Provider for Alibaba Cloud
+
+> Bring **plan-time price estimation** to your `terraform plan` workflow, with
+> zero changes to the provider itself.
+>
+> ```
+> $ terraform plan --estimate-cost -out=tfplan
+> [normal terraform plan output ...]
+>
+> ─────────────────────────────────────────────────────────────
+>                        Cost Estimate
+> ─────────────────────────────────────────────────────────────
+> RESOURCE                       AMOUNT     CURRENCY  MODE        NOTE
+> alicloud_instance.demo         235.70     CNY       create      create
+> ── TOTAL ──                    235.70     CNY
+> ```
+
+## What this is
+
+A pair of small Go binaries that **wrap Terraform** to add a `--estimate-cost`
+flag to `terraform plan`. When enabled, the tool reads the plan JSON, translates
+each resource change into an Alibaba Cloud OpenAPI call via [CloudControl's
+`GetApiPrice`](https://help.aliyun.com/document_detail/cloudcontrol-getapiprice),
+and renders a cost table at the end of the plan output.
+
+Provider code is **not modified** in any way. The wrapper transparently
+forwards every other Terraform subcommand to the real `terraform` binary
+(`init`, `apply`, `state`, `destroy`, etc.).
+
+## How it ships
+
+Built and released **alongside** the provider via `goreleaser`. Every
+provider tag (`v1.282.0`, etc.) automatically produces a matching estimate-cost
+archive on the same GitHub Release:
+
+```
+alicloud-tf-estimate-cost_1.282.0_darwin_arm64.tar.gz
+alicloud-tf-estimate-cost_1.282.0_darwin_amd64.tar.gz
+alicloud-tf-estimate-cost_1.282.0_linux_amd64.tar.gz
+alicloud-tf-estimate-cost_1.282.0_linux_arm64.tar.gz
+alicloud-tf-estimate-cost_1.282.0_windows_amd64.zip
+```
+
+The mapping files (schema ↔ OpenAPI translation rules) are **embedded inside
+the `estimate-cost` binary** via `go:embed`. Users do **not** need to download
+or configure any additional files.
+
+## Install
+
+### Manual
+
+1. Download the archive matching your platform from the GitHub Release page.
+2. Extract `terraform-wrapper` and `estimate-cost` into a directory on your PATH
+   that comes **before** the real `terraform`'s directory (e.g. `~/bin/` if
+   that is first in your PATH).
+3. Rename `terraform-wrapper` → `terraform`. Keep `estimate-cost` as a sibling
+   file (the wrapper looks for it next to itself).
+
+```bash
+tar -xzf alicloud-tf-estimate-cost_1.282.0_darwin_arm64.tar.gz
+mv terraform-wrapper ~/bin/terraform
+mv estimate-cost     ~/bin/estimate-cost
+chmod +x ~/bin/terraform ~/bin/estimate-cost
+```
+
+Verify:
+```bash
+which terraform                 # should be ~/bin/terraform
+terraform plan --estimate-cost  # if this triggers cost output, install succeeded
+```
+
+### Uninstall
+
+```bash
+rm ~/bin/terraform ~/bin/estimate-cost
+# Real terraform (e.g. /opt/homebrew/bin/terraform) becomes active again.
+```
+
+## Usage
+
+The wrapper is **fully transparent** for every Terraform command:
+
+```bash
+terraform init                     # forwarded to real terraform
+terraform plan                     # forwarded to real terraform
+terraform apply tfplan             # forwarded to real terraform
+terraform plan --estimate-cost     # ← intercepted, adds cost table
+```
+
+`--estimate-cost` works on both create and update plans:
+
+```bash
+# Cost of creating a new resource
+terraform plan --estimate-cost -out=tfplan
+
+# Cost delta for a modification (refresh skipped for speed)
+terraform plan --estimate-cost -refresh=false -out=tfplan
+```
+
+For `update` actions the tool calls the appropriate Modify-style OpenAPI
+(`ModifyPrepayInstanceSpec` for PrePaid spec changes, `ResizeDisk` for disk
+expansion, etc.) and CC API returns the **real delta amount** — the same number
+the actual upgrade order will show.
+
+## Authentication
+
+The tool uses the same Alibaba Cloud credentials as your Terraform provider.
+It signs requests with POP v3 (`ACS3-HMAC-SHA256`) **locally**; your AK/SK
+never leaves your machine.
+
+Set one of these env var pairs (checked in order):
+
+| Var pair | Notes |
+|---|---|
+| `ALIBABA_CLOUD_ACCESS_KEY_ID` / `ALIBABA_CLOUD_ACCESS_KEY_SECRET` | preferred (matches `aliyun` CLI) |
+| `ALICLOUD_ACCESS_KEY` / `ALICLOUD_SECRET_KEY` | fallback (matches Terraform provider) |
+
+### Endpoint
+
+By default, requests go to the CloudControl endpoint
+`cloudcontrol.aliyuncs.com`. Two env vars let you redirect them to a
+different endpoint when needed (e.g. for testing):
+
+| Var | Default | Notes |
+|---|---|---|
+| `ALICLOUD_CC_API_ENDPOINT` | `cloudcontrol.aliyuncs.com` | Override the request hostname. |
+| `ALICLOUD_CC_API_HOST` | `cloudcontrol.aliyuncs.com` | Override the HTTP Host header. Rarely needed — only when a custom gateway requires it. |
+
+## Architecture
+
+```
+                          ┌──────────────────────┐
+                          │   internal/embed-    │
+                          │   mappings/data/     │
+                          │   alicloud_*.json    │  ← single source of truth
+                          └──────────┬───────────┘
+                                     │ go:embed
+                                     ▼
+$ terraform plan --estimate-cost     ┌──────────────────────────────────┐
+                  │                  │  estimate-cost binary             │
+                  ▼                  │   - reads embedded mappings       │
+        ┌─────────────────────┐ exec │   - parses plan.json              │
+        │ terraform-wrapper   │─────►│   - builds OpenAPI params         │
+        │   - intercept       │      │   - calls CC API GetApiPrice      │
+        │   - run real plan   │      │   - aggregates result             │
+        │   - show -json      │      └──────────────────────────────────┘
+        │   - call estimate-cost                  │
+        │   - render output   │                   │ HTTPS + POP v3 sig
+        └─────────────────────┘                   ▼
+                                       Alibaba Cloud CloudControl
+                                       (GetApiPrice → BSS)
+```
+
+### `plan.json` stays local
+
+The wrapper extracts only the **billing-relevant fields** from `plan.json` and
+sends them as standard OpenAPI parameters. Sensitive content (`user_data`,
+`password`, `tags`, internal endpoints) is never transmitted.
+
+## Updating mappings
+
+The `internal/embedmappings/data/*.json` files describe how each provider
+schema attribute maps to an OpenAPI parameter. They are **the single source
+of truth** for the price-mapping layer and live in this same repository so
+they evolve with the provider's schema in lockstep.
+
+To add cost coverage for a new resource:
+
+1. Add `internal/embedmappings/data/alicloud_<resource>.json` following the
+   format of `alicloud_instance.json`.
+2. The binary will pick it up on the next build (`go:embed all:data`).
+3. Add a brief test plan if possible.
+
+Target-level matching fields:
+
+| Field | Meaning |
+|---|---|
+| `actions` | Match against the plan's `change.actions` (`create` / `update` / ...). |
+| `when` | All `{path: value}` pairs must hold. `$.x` reads `change.after`, `$before.x` reads `change.before` — the latter enables "changed from A to B" dispatch (e.g. a PostPaid → PrePaid switch). |
+| `whenChanged` | At least one listed field must differ between before and after. Prevents a target from firing when its driving field didn't change. |
+
+Param-level extras beyond `from`/`const`/`default`:
+
+| Field | Meaning |
+|---|---|
+| `wrapArray` | Wrap the resolved value in a single-element list (for list-typed inputs like `InstanceIds`). |
+| `PricingContext.*` keys | Dotted `PricingContext.` param names are automatically nested into a structured `PricingContext` JSON object — GetApiPrice requires that form for pricing hints such as `CurrentDisk` (unlike POP params like `SystemDisk.Size`, which stay flat). |
+
+## Development
+
+```bash
+# Build both binaries to the repo's bin/ for local testing
+go build -o bin/estimate-cost ./estimate-cost/cmd/estimate-cost/
+go build -o bin/terraform     ./estimate-cost/cmd/terraform-wrapper/
+
+# Override embedded mapping with a local directory (dev / debug only)
+TF_COST_MAPPINGS=$(pwd)/estimate-cost/internal/embedmappings/data \
+  terraform plan --estimate-cost -out=tfplan
+```
+
+## What's covered today
+
+### `alicloud_instance`
+
+| Plan change | OpenAPI called | Pricing mode |
+|---|---|---|
+| Create (PrePaid or PostPaid) | `RunInstances` | single |
+| PrePaid: change `instance_type` | `ModifyPrepayInstanceSpec` | delta |
+| PrePaid: increase `system_disk_size` | `ResizeDisk` | delta |
+| PostPaid: change `instance_type` | `ModifyInstanceSpec` | delta |
+| Switch to `PayByBandwidth` / raise `internet_max_bandwidth_out` | `ModifyInstanceNetworkSpec` | single (new-bandwidth order) |
+| PostPaid → PrePaid `instance_charge_type` switch | `ModifyInstanceChargeType` | single (first period) |
+| Change `image_id` | `ReplaceSystemDisk` | delta |
+| Change `system_disk_performance_level` / `system_disk_provisioned_iops` | `ModifyDiskSpec` | delta |
+| Any update not matched above | `RunInstances` × 2 | diff (after − before) |
+
+A single update may match more than one delta target — e.g. PrePaid
+changing both `instance_type` and `system_disk_size` returns two orders
+(`ModifyPrepayInstanceSpec` + `ResizeDisk`) summed into one total.
+
+### Intentionally not covered
+
+| Case | Why |
+|---|---|
+| `ResizeDisk` on PostPaid disks | GetApiPrice's rule requires `DiskChargeType='PrePaid'`; pay-as-you-go disks have no upfront order to quote. Falls back to the create-target diff. |
+| PrePaid → PostPaid charge-type switch | A refund, not a purchase — GetApiPrice returns `PRICING_PLAN_RESULT_NOT_FOUND`. Falls back to diff. |
+| `AllocatePublicIpAddress` | Priceable by GetApiPrice, but deliberately skipped: the bandwidth cost is already captured by the `ModifyInstanceNetworkSpec` target and a separate target would double-count. |
+| Bandwidth changes while staying on `PayByTraffic` | Pricing needs an estimated traffic volume (`PricingContext.EstimatedInternetTrafficOutGB`) which a Terraform plan cannot provide. |
+
+More resources will be added in subsequent provider releases.
+
+## Limitations
+
+- **Unknown fields**: if a pricing input depends on a `(known after apply)` value
+  (e.g. `region = other_resource.id`), the tool prints `known after apply`
+  rather than fabricating a price.
+- **No stock check**: a plan that would fail at `apply` time with
+  `OperationDenied.NoStock` is still priced. Stock is an orthogonal concern.
+- **Endpoint override**: by default the tool targets the CloudControl endpoint
+  `cloudcontrol.aliyuncs.com`. To target a different endpoint, set
+  `ALICLOUD_CC_API_ENDPOINT` and, if needed, `ALICLOUD_CC_API_HOST`.
+
+## License
+
+Same as the parent provider repository (see `LICENSE` at the repo root).

--- a/estimate-cost/cmd/estimate-cost/main.go
+++ b/estimate-cost/cmd/estimate-cost/main.go
@@ -1,0 +1,451 @@
+// estimate-cost turns a Terraform plan JSON into one or more CC API
+// GetApiPrice calls and prints an estimated cost table.
+//
+// Usage:
+//
+//	estimate-cost [--mappings <dir>] [--dry-run] <plan.json>
+//
+// Authentication: AK/SK is read from ALIBABA_CLOUD_ACCESS_KEY_ID/SECRET or
+// from ALICLOUD_ACCESS_KEY/SECRET (see internal/ccapi.NewFromEnv).
+//
+// Strategy:
+//
+//	create resources: call the matching create target once.
+//	update resources:
+//	  · If the mapping has a matching update target (e.g. ModifyPrepayInstance-
+//	    Spec for PrePaid), call it directly. CC API returns delta mode with
+//	    calculatedAmount = the actual upgrade-order amount.
+//	  · Otherwise (typically PostPaid spec changes), call the create target
+//	    twice — once against plan.before, once against plan.after — and take
+//	    the difference. CC API has no native delta mode for these APIs, so
+//	    the tool does the subtraction itself.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/aliyun/terraform-provider-alicloud/estimate-cost/internal/ccapi"
+	"github.com/aliyun/terraform-provider-alicloud/estimate-cost/internal/embedmappings"
+	"github.com/aliyun/terraform-provider-alicloud/estimate-cost/internal/mapping"
+)
+
+type planJSON struct {
+	ResourceChanges []resourceChange `json:"resource_changes"`
+	Configuration   struct {
+		ProviderConfig map[string]struct {
+			Expressions map[string]struct {
+				ConstantValue interface{} `json:"constant_value"`
+			} `json:"expressions"`
+		} `json:"provider_config"`
+	} `json:"configuration"`
+}
+
+type resourceChange struct {
+	Address      string `json:"address"`
+	Type         string `json:"type"`
+	ProviderName string `json:"provider_name"`
+	Change       struct {
+		Actions      []string               `json:"actions"`
+		Before       map[string]interface{} `json:"before"`
+		After        map[string]interface{} `json:"after"`
+		AfterUnknown map[string]interface{} `json:"after_unknown"`
+	} `json:"change"`
+}
+
+// row is a single output row. amount already reflects one of three semantics:
+// "create price", "delta price" or "diff price".
+type row struct {
+	addr     string
+	amount   float64
+	currency string
+	mode     string // "create" | "delta" | "diff(after-before)"
+	note     string
+	skip     bool   // when true, amount is not added to the total
+	skipNote string // displayed reason when skip=true
+}
+
+const headerFmt = "%-44s %-10s %-9s %-22s %s\n"
+const rowFmt = "%-44s %-10.2f %-9s %-22s %s\n"
+const skipFmt = "%-44s %-10s %-9s %-22s %s\n"
+
+func main() {
+	mappingDir := flag.String("mappings", "", "(dev only) override embedded mappings with a local directory")
+	dryRun := flag.Bool("dry-run", false, "build request bodies but do not call CC API")
+	flag.Parse()
+	if flag.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "Usage: estimate-cost [--mappings dir] [--dry-run] <plan.json>")
+		os.Exit(2)
+	}
+
+	plan, err := loadPlan(flag.Arg(0))
+	if err != nil {
+		fail("load plan: %v", err)
+	}
+	// Default to the embedded mappings; --mappings is for development only.
+	var mappings map[string]*mapping.File
+	if *mappingDir != "" {
+		mappings, err = mapping.Load(*mappingDir)
+	} else {
+		mappings, err = mapping.LoadFS(embedmappings.FS, embedmappings.Dir)
+	}
+	if err != nil {
+		fail("load mappings: %v", err)
+	}
+	providerCtx := extractProviderContext(plan)
+
+	var client *ccapi.Client
+	if !*dryRun {
+		if client, err = ccapi.NewFromEnv(); err != nil {
+			fail("init CC API client: %v", err)
+		}
+	}
+
+	fmt.Printf(headerFmt, "RESOURCE", "AMOUNT", "CURRENCY", "MODE", "NOTE")
+	var total float64
+	var currency string
+
+	for _, rc := range plan.ResourceChanges {
+		if !hasAny(rc.Change.Actions, "create", "update") {
+			continue
+		}
+		r := priceResource(rc, mappings, providerCtx, client, *dryRun)
+		if r.skip {
+			fmt.Printf(skipFmt, rc.Address, "-", "-", "-", r.skipNote)
+			continue
+		}
+		fmt.Printf(rowFmt, rc.Address, r.amount, r.currency, r.mode, r.note)
+		total += r.amount
+		if r.currency != "" {
+			currency = r.currency
+		}
+	}
+	fmt.Printf(rowFmt, "── TOTAL ──", total, currency, "", "")
+}
+
+// priceResource is the per-resource pricing routine. It returns a row to
+// print; skip=true means the resource could not be priced.
+func priceResource(
+	rc resourceChange,
+	mappings map[string]*mapping.File,
+	providerCtx map[string]map[string]interface{},
+	client *ccapi.Client,
+	dryRun bool,
+) row {
+	m, ok := mappings[rc.Type]
+	if !ok {
+		return skipRow("no mapping, skipped")
+	}
+	if !m.Billable {
+		return skipRow("marked non-billable")
+	}
+
+	ctx := providerCtx[shortProviderName(rc.ProviderName)]
+	afterCfg := mergeContext(ctx, rc.Change.After)
+	beforeCfg := mergeContext(ctx, rc.Change.Before)
+	isUpdate := hasAny(rc.Change.Actions, "update")
+
+	if isUpdate {
+		// ① A single update may trigger several OpenAPI calls — e.g. a
+		//    PrePaid update that changes both instance_type and
+		//    system_disk_size will call ModifyPrepayInstanceSpec and
+		//    ResizeDisk separately, producing two billing orders. Price
+		//    every matching update target and aggregate.
+		if ts := m.PickTargets(rc.Change.Actions, afterCfg, beforeCfg); len(ts) > 0 {
+			return quoteAndAggregate(ts, afterCfg, rc.Change.Before, rc.Change.AfterUnknown, client, dryRun)
+		}
+		// ② No update target matched → fall back to the create target and
+		//    call it twice (before / after) for a diff (typical for
+		//    PostPaid spec changes that CC API does not yet model as delta).
+		ct := m.PickTargetByAction("create", afterCfg, beforeCfg)
+		if ct == nil {
+			return skipRow("update: no modify target and no create-target fallback")
+		}
+		return quoteDiff(ct, beforeCfg, afterCfg, rc.Change.Before, rc.Change.AfterUnknown, client, dryRun)
+	}
+
+	// create path
+	t := m.PickTarget(rc.Change.Actions, afterCfg, beforeCfg)
+	if t == nil {
+		return skipRow("no target matched the action")
+	}
+	return quoteOnce(t, afterCfg, rc.Change.Before, rc.Change.AfterUnknown, client, dryRun, "create", "create")
+}
+
+// quoteAndAggregate prices every update target and sums them. Used for
+// "one update triggers several independent OpenAPI calls → several billing
+// orders" — e.g. PrePaid changing both instance_type and system_disk_size
+// at once. For each target, CC API returns that change's real delta amount;
+// summing them yields the total delta.
+//
+// A single failed or zero target is not fatal — we record the reason in the
+// note column and continue.
+func quoteAndAggregate(
+	targets []*mapping.PricingTarget,
+	after, before, afterUnknown map[string]interface{},
+	client *ccapi.Client,
+	dryRun bool,
+) row {
+	var total float64
+	var currency string
+	var notes []string
+
+	for _, t := range targets {
+		// Skip targets whose required inputs are unknown (e.g. disk resize
+		// when system_disk_id is missing from the plan).
+		if u := requiredUnknown(t, afterUnknown); u != "" {
+			notes = append(notes, fmt.Sprintf("%s:skipped(unknown %s)", t.Name, u))
+			continue
+		}
+		params, err := mapping.Build(t, after, before)
+		if err != nil {
+			// Required field missing (e.g. disk resize but disk_id not in
+			// plan) — skip this target only; other targets continue.
+			notes = append(notes, fmt.Sprintf("%s:skipped(%v)", t.Name, err))
+			continue
+		}
+		req := &ccapi.Request{
+			PopCode: t.OpenAPI.PopCode, PopVersion: t.OpenAPI.PopVersion,
+			APIName: t.OpenAPI.APIName, Parameters: params,
+		}
+		if dryRun {
+			body, _ := json.MarshalIndent(req, "", "  ")
+			fmt.Printf("---- dry-run %s request body ----\n", t.Name)
+			fmt.Println(string(body))
+			continue
+		}
+		resp, err := client.Quote(req)
+		if err != nil {
+			notes = append(notes, fmt.Sprintf("%s:failed(%v)", t.Name, err))
+			continue
+		}
+		if resp.Price == nil || !resp.Price.Success {
+			ec, em := "", ""
+			if resp.Price != nil {
+				ec, em = resp.Price.ErrorCode, resp.Price.ErrorMessage
+			}
+			notes = append(notes, fmt.Sprintf("%s:%s %s", t.Name, ec, em))
+			continue
+		}
+		amount, cur := resp.Price.FinalAmount()
+		total += amount
+		if cur != "" {
+			currency = cur
+		}
+		notes = append(notes, fmt.Sprintf("%s=%.2f", t.Name, amount))
+	}
+
+	if dryRun {
+		return skipRow("dry-run")
+	}
+	return row{
+		amount:   total,
+		currency: currency,
+		mode:     "delta×N",
+		note:     strings.Join(notes, ", "),
+	}
+}
+
+// quoteOnce makes a single CC API call and parses the amount. mode is the
+// label shown in the MODE column.
+func quoteOnce(
+	t *mapping.PricingTarget,
+	after, before, afterUnknown map[string]interface{},
+	client *ccapi.Client,
+	dryRun bool,
+	mode, note string,
+) row {
+	if u := requiredUnknown(t, afterUnknown); u != "" {
+		return skipRow("input " + u + " unknown, priced after apply")
+	}
+	params, err := mapping.Build(t, after, before)
+	if err != nil {
+		return skipRow("mapping failed: " + err.Error())
+	}
+	req := &ccapi.Request{
+		PopCode:    t.OpenAPI.PopCode,
+		PopVersion: t.OpenAPI.PopVersion,
+		APIName:    t.OpenAPI.APIName,
+		Parameters: params,
+	}
+	if dryRun {
+		body, _ := json.MarshalIndent(req, "", "  ")
+		fmt.Println("---- dry-run request body ----")
+		fmt.Println(string(body))
+		return skipRow("dry-run")
+	}
+	resp, err := client.Quote(req)
+	if err != nil {
+		return skipRow("CC API call failed: " + err.Error())
+	}
+	if resp.Price == nil || !resp.Price.Success {
+		msg := "upstream business error"
+		if resp.Price != nil {
+			msg = resp.Price.ErrorCode + ": " + resp.Price.ErrorMessage
+		}
+		return skipRow(msg)
+	}
+	amount, cur := resp.Price.FinalAmount()
+	// If CC API's pricingMode disagrees with our caller's mode label, prefer
+	// CC API's — it carries a more precise semantics (for example a PrePaid
+	// update naturally returns "delta", which we want to surface as-is).
+	actualMode := resp.Price.PricingMode
+	if mode == "delta" && actualMode != "" {
+		mode = actualMode
+	}
+	return row{amount: amount, currency: cur, mode: mode, note: note}
+}
+
+// quoteDiff prices the create target once against `before` and once against
+// `after` and returns the difference. Typically used for PostPaid spec
+// changes, where CC API does not (yet) expose a delta mode, so the tool
+// performs the subtraction.
+func quoteDiff(
+	ct *mapping.PricingTarget,
+	beforeCfg, afterCfg map[string]interface{},
+	beforeRaw, afterUnknown map[string]interface{},
+	client *ccapi.Client,
+	dryRun bool,
+) row {
+	if u := requiredUnknown(ct, afterUnknown); u != "" {
+		return skipRow("input " + u + " unknown, priced after apply")
+	}
+	// quote with "before" config
+	beforeAmount, currency, err := quoteFor(ct, beforeCfg, beforeRaw, client, dryRun, "before")
+	if err != "" {
+		return skipRow("before quote failed: " + err)
+	}
+	// quote with "after" config
+	afterAmount, cur2, err := quoteFor(ct, afterCfg, beforeRaw, client, dryRun, "after")
+	if err != "" {
+		return skipRow("after quote failed: " + err)
+	}
+	if cur2 != "" {
+		currency = cur2
+	}
+	return row{
+		amount:   afterAmount - beforeAmount,
+		currency: currency,
+		mode:     "diff(after-before)",
+		note:     fmt.Sprintf("before=%.2f after=%.2f", beforeAmount, afterAmount),
+	}
+}
+
+// quoteFor is an internal helper for quoteDiff: it runs the create target
+// once against a given config. Returns (amount, currency, errMsg); a
+// non-empty errMsg signals failure.
+func quoteFor(
+	ct *mapping.PricingTarget,
+	cfg, before map[string]interface{},
+	client *ccapi.Client,
+	dryRun bool,
+	tag string,
+) (float64, string, string) {
+	params, err := mapping.Build(ct, cfg, before)
+	if err != nil {
+		return 0, "", err.Error()
+	}
+	req := &ccapi.Request{
+		PopCode:    ct.OpenAPI.PopCode,
+		PopVersion: ct.OpenAPI.PopVersion,
+		APIName:    ct.OpenAPI.APIName,
+		Parameters: params,
+	}
+	if dryRun {
+		body, _ := json.MarshalIndent(req, "", "  ")
+		fmt.Printf("---- dry-run %s request body ----\n", tag)
+		fmt.Println(string(body))
+		return 0, "", ""
+	}
+	resp, err := client.Quote(req)
+	if err != nil {
+		return 0, "", err.Error()
+	}
+	if resp.Price == nil || !resp.Price.Success {
+		if resp.Price != nil {
+			return 0, "", resp.Price.ErrorCode + ": " + resp.Price.ErrorMessage
+		}
+		return 0, "", "upstream business error"
+	}
+	amount, cur := resp.Price.FinalAmount()
+	return amount, cur, ""
+}
+
+func skipRow(note string) row {
+	return row{skip: true, skipNote: note}
+}
+
+func loadPlan(path string) (*planJSON, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var p planJSON
+	return &p, json.Unmarshal(raw, &p)
+}
+
+func extractProviderContext(plan *planJSON) map[string]map[string]interface{} {
+	out := map[string]map[string]interface{}{}
+	for name, pc := range plan.Configuration.ProviderConfig {
+		ctx := map[string]interface{}{}
+		for k, v := range pc.Expressions {
+			if v.ConstantValue != nil {
+				ctx[k] = v.ConstantValue
+			}
+		}
+		out[name] = ctx
+	}
+	return out
+}
+
+func mergeContext(ctx, m map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+	for k, v := range ctx {
+		out[k] = v
+	}
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func requiredUnknown(t *mapping.PricingTarget, au map[string]interface{}) string {
+	for name, def := range t.Params {
+		if !def.Required || def.From == "" || len(def.From) < 3 {
+			continue
+		}
+		key := def.From[2:]
+		if v, ok := au[key]; ok {
+			if b, _ := v.(bool); b {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+func hasAny(actions []string, want ...string) bool {
+	for _, a := range actions {
+		for _, w := range want {
+			if a == w {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func shortProviderName(full string) string {
+	if i := strings.LastIndex(full, "/"); i >= 0 {
+		return full[i+1:]
+	}
+	return full
+}
+
+func fail(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/estimate-cost/cmd/terraform-wrapper/main.go
+++ b/estimate-cost/cmd/terraform-wrapper/main.go
@@ -1,0 +1,300 @@
+// terraform-wrapper is a transparent wrapper around the real `terraform`
+// binary:
+//
+//	terraform plan --estimate-cost   →  runs the real plan and appends a cost report
+//	terraform <any other subcommand> →  syscall.Exec passthrough to the real terraform
+//
+// The real terraform binary is discovered by scanning $PATH and skipping the
+// wrapper's own absolute path — no environment variable configuration needed.
+// Cost estimation is delegated to a sibling `estimate-cost` binary; the
+// mapping JSON files are embedded inside that binary. For development you
+// can set TF_COST_MAPPINGS to a local mapping directory to override the
+// embedded copy.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"syscall"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) >= 1 && args[0] == "plan" && hasFlag(args, "--estimate-cost") {
+		runPlanWithCost(args)
+		return
+	}
+	passthrough(args)
+}
+
+// passthrough exec's the real terraform with the original args, unchanged.
+// We use syscall.Exec to replace the current process so signal handling,
+// TTY behaviour and exit codes are inherited transparently.
+func passthrough(args []string) {
+	real := findRealTerraform()
+	if real == "" {
+		die("terraform-wrapper: real terraform binary not found in PATH")
+	}
+	if err := syscall.Exec(real, append([]string{real}, args...), os.Environ()); err != nil {
+		die("exec %s: %v", real, err)
+	}
+}
+
+// runPlanWithCost implements the `plan --estimate-cost` branch.
+func runPlanWithCost(args []string) {
+	real := findRealTerraform()
+	if real == "" {
+		die("terraform-wrapper: real terraform binary not found in PATH")
+	}
+
+	// Strip --estimate-cost and ensure -out= is present (use a temp file when
+	// the user did not specify one).
+	planArgs := []string{}
+	hasOut := false
+	outPath := ""
+	for _, a := range args {
+		if a == "--estimate-cost" {
+			continue
+		}
+		if strings.HasPrefix(a, "-out=") {
+			hasOut = true
+			outPath = strings.TrimPrefix(a, "-out=")
+		}
+		planArgs = append(planArgs, a)
+	}
+	cleanup := func() {}
+	// suppressTempPath is non-empty when we injected a temp -out= ourselves.
+	// In that case we will filter terraform's "Saved the plan to: <tempPath>"
+	// and "terraform apply <tempPath>" hint block out of stdout — that file is
+	// about to be deleted, so the hint would mislead the user.
+	suppressTempPath := ""
+	if !hasOut {
+		tmp, err := os.CreateTemp("", "wrap-tfplan-*.tfplan")
+		if err != nil {
+			die("failed to create temp plan file: %v", err)
+		}
+		outPath = tmp.Name()
+		tmp.Close()
+		cleanup = func() { os.Remove(outPath) }
+		planArgs = append(planArgs, "-out="+outPath)
+		suppressTempPath = outPath
+	}
+	defer cleanup()
+
+	// Run the real `terraform plan` and stream stdout/stderr to the user.
+	planCmd := exec.Command(real, planArgs...)
+	planCmd.Stdin = os.Stdin
+	planCmd.Stderr = os.Stderr
+
+	// Stdout wiring: pass-through when the user supplied -out=, otherwise
+	// pipe through filterApplyHint to rewrite the misleading apply-hint block.
+	var pipeW io.Closer
+	var filterDone chan struct{}
+	if suppressTempPath == "" {
+		planCmd.Stdout = os.Stdout
+	} else {
+		pr, pw := io.Pipe()
+		planCmd.Stdout = pw
+		pipeW = pw
+		filterDone = make(chan struct{})
+		go func() {
+			defer close(filterDone)
+			filterApplyHint(pr, os.Stdout, suppressTempPath)
+		}()
+	}
+
+	runErr := planCmd.Run()
+	if pipeW != nil {
+		_ = pipeW.Close() // signal EOF to the filter goroutine
+		<-filterDone      // wait for it to drain
+	}
+	if runErr != nil {
+		os.Exit(exitCode(planCmd))
+	}
+
+	// Convert the saved plan to JSON via `terraform show -json`.
+	showCmd := exec.Command(real, "show", "-json", outPath)
+	planJSON, err := showCmd.Output()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "\n[--estimate-cost] terraform show -json failed:", err)
+		return // The plan itself succeeded; do not let a pricing failure derail it.
+	}
+
+	// Stash the JSON in a temp file and pass it to the estimate-cost engine.
+	tmpJSON, err := os.CreateTemp("", "wrap-plan-*.json")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "\n[--estimate-cost] writing temp JSON failed:", err)
+		return
+	}
+	defer os.Remove(tmpJSON.Name())
+	tmpJSON.Write(planJSON)
+	tmpJSON.Close()
+
+	costPath := findEstimateCost()
+	if costPath == "" {
+		fmt.Fprintln(os.Stderr, "\n[--estimate-cost] estimate-cost binary not found (expected alongside the wrapper)")
+		return
+	}
+
+	fmt.Println()
+	fmt.Println("─────────────────────────────────────────────────────────────")
+	fmt.Println("                       Cost Estimate")
+	fmt.Println("─────────────────────────────────────────────────────────────")
+	// estimate-cost ships with embedded mappings, so we normally do not need
+	// to pass --mappings. For development, the user can set TF_COST_MAPPINGS
+	// to a local directory; we forward it to the child.
+	costArgs := []string{}
+	if dir := os.Getenv("TF_COST_MAPPINGS"); dir != "" {
+		costArgs = append(costArgs, "--mappings", dir)
+	}
+	costArgs = append(costArgs, tmpJSON.Name())
+	costCmd := exec.Command(costPath, costArgs...)
+	costCmd.Stdout = os.Stdout
+	costCmd.Stderr = os.Stderr
+	costCmd.Run()
+}
+
+// ansiRE matches CSI-style ANSI escape codes (e.g. \x1b[31m, \x1b[1;32m).
+// terraform normally disables color when stdout is a pipe, but env vars
+// like CLICOLOR_FORCE=1 or FORCE_COLOR=1 can override that. We strip them
+// before pattern-matching so the filter is robust to either case.
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	if !strings.ContainsRune(s, '\x1b') {
+		return s
+	}
+	return ansiRE.ReplaceAllString(s, "")
+}
+
+// filterApplyHint reads terraform's stdout from r and writes it to w,
+// removing the apply-hint block that points at the temporary plan file we
+// injected (which is about to be deleted). The block looks like:
+//
+//	Saved the plan to: <tempPath>
+//
+//	To perform exactly these actions, run the following command to apply:
+//	    terraform apply "<tempPath>"
+//
+// All lines from the first match up to and including the `terraform apply
+// <tempPath>` line are removed; a friendly hint is printed in their place.
+// All other terraform output is forwarded verbatim, line-by-line.
+func filterApplyHint(r io.Reader, w io.Writer, tempPath string) {
+	scanner := bufio.NewScanner(r)
+	// Bump the scanner's max line size from the 64 KiB default to 1 MiB.
+	// terraform plan output is usually small, but a single resource diff
+	// containing a large blob would otherwise trigger ErrTooLong and we'd
+	// drop output silently. 1 MiB is well beyond anything realistic.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	suppressing := false
+	inserted := false
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Match against the ANSI-stripped form so coloured terraform output
+		// (CLICOLOR_FORCE / FORCE_COLOR) still triggers correctly. We
+		// always write the original line back unchanged so any colours
+		// passing through are preserved.
+		plain := stripANSI(line)
+
+		// Detect the start of the apply-hint block. We trigger on the
+		// "Saved the plan to:" prefix alone — terraform wraps long temp
+		// paths to the next line when stdout is a pipe, so we cannot rely
+		// on tempPath appearing on the same line.
+		if !inserted && !suppressing && strings.HasPrefix(plain, "Saved the plan to:") {
+			suppressing = true
+			continue
+		}
+
+		if suppressing {
+			// The block ends at the line `    terraform apply "<tempPath>"`.
+			// Emit our friendly hint in its place, then resume pass-through.
+			if strings.HasPrefix(strings.TrimSpace(plain), "terraform apply") {
+				fmt.Fprintln(w, "[--estimate-cost] Plan was processed locally for cost estimation and not saved to disk.")
+				fmt.Fprintln(w, "                  To apply, either:")
+				fmt.Fprintln(w, "                    · re-run `terraform apply` to plan + apply interactively, or")
+				fmt.Fprintln(w, "                    · re-run `terraform plan --estimate-cost -out=<path>` to save")
+				fmt.Fprintln(w, "                      the plan, then `terraform apply <path>`.")
+				suppressing = false
+				inserted = true
+			}
+			continue
+		}
+
+		fmt.Fprintln(w, line)
+	}
+	// Surface scanner read errors instead of dropping them silently. An
+	// over-long line (>1 MiB) would land here as bufio.ErrTooLong.
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(w, "\n[--estimate-cost] warning: stdout read incomplete: %v\n", err)
+	}
+}
+
+// findRealTerraform scans $PATH for a terraform binary that is not the
+// wrapper itself.
+func findRealTerraform() string {
+	self, _ := os.Executable()
+	self, _ = filepath.EvalSymlinks(self)
+	for _, dir := range strings.Split(os.Getenv("PATH"), string(os.PathListSeparator)) {
+		if dir == "" {
+			continue
+		}
+		c := filepath.Join(dir, "terraform")
+		info, err := os.Stat(c)
+		if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+			continue
+		}
+		resolved, _ := filepath.EvalSymlinks(c)
+		if resolved != self {
+			return c
+		}
+	}
+	return ""
+}
+
+// findEstimateCost looks for an `estimate-cost` binary alongside the wrapper
+// first, then falls back to scanning $PATH.
+func findEstimateCost() string {
+	self, err := os.Executable()
+	if err == nil {
+		cand := filepath.Join(filepath.Dir(self), "estimate-cost")
+		if info, err := os.Stat(cand); err == nil && !info.IsDir() {
+			return cand
+		}
+	}
+	if p, err := exec.LookPath("estimate-cost"); err == nil {
+		return p
+	}
+	return ""
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+func die(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}
+
+func exitCode(cmd *exec.Cmd) int {
+	if cmd.ProcessState == nil {
+		return 1
+	}
+	if ws, ok := cmd.ProcessState.Sys().(syscall.WaitStatus); ok {
+		return ws.ExitStatus()
+	}
+	return cmd.ProcessState.ExitCode()
+}

--- a/estimate-cost/internal/ccapi/client.go
+++ b/estimate-cost/internal/ccapi/client.go
@@ -1,0 +1,274 @@
+// Package ccapi is a client for the CloudControl GetApiPrice endpoint.
+//
+// Requests are signed with POP v3 (ACS3-HMAC-SHA256). The AK/SK pair is read
+// from the user's environment — see NewFromEnv for the variable name
+// precedence.
+package ccapi
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// Default CloudControl endpoint. The HTTP Host header is the same
+	// hostname. To target a different endpoint, set ALICLOUD_CC_API_ENDPOINT
+	// (and optionally ALICLOUD_CC_API_HOST) — see NewFromEnv.
+	defaultEndpoint = "cloudcontrol.aliyuncs.com"
+	defaultHost     = "cloudcontrol.aliyuncs.com"
+	apiVersion      = "2022-08-30"
+	apiAction       = "GetApiPrice"
+	apiPath         = "/api/v1/price/quote"
+)
+
+// Request is the GetApiPrice request body: the (popCode, popVersion, apiName,
+// parameters) four-tuple that names an Alibaba Cloud OpenAPI operation and
+// the parameters to price.
+type Request struct {
+	PopCode    string                 `json:"popCode"`
+	PopVersion string                 `json:"popVersion"`
+	APIName    string                 `json:"apiName"`
+	Parameters map[string]interface{} `json:"parameters"`
+}
+
+// Response decodes a GetApiPrice response. The endpoint returns one of three
+// shapes: success, upstream business failure, or a system-level error.
+type Response struct {
+	RequestID string `json:"requestId"`
+	Price     *Price `json:"price"`
+
+	// System errors (HTTP 4xx) use CamelCase keys at the top level.
+	Code    string `json:"Code,omitempty"`
+	Message string `json:"Message,omitempty"`
+	HostID  string `json:"HostId,omitempty"`
+}
+
+// Price mirrors the response's `price.*` section.
+type Price struct {
+	PricingMode       string                  `json:"pricingMode"` // single / composite / delta
+	Success           bool                    `json:"success"`
+	Currency          string                  `json:"currency"`
+	CalculatedAmount  *float64                `json:"calculatedAmount"` // composite/delta total
+	PriceSummary      *PriceSummary           `json:"priceSummary"`     // single-mode total
+	Components        map[string]PriceSummary `json:"components"`       // composite/delta per-component breakdown
+	UpstreamRequestID string                  `json:"upstreamRequestId"`
+	ErrorCode         string                  `json:"errorCode"`
+	ErrorMessage      string                  `json:"errorMessage"`
+}
+
+// PriceSummary is the core amount structure. priceSummary and each entry of
+// components[*] use the same shape.
+type PriceSummary struct {
+	Currency           string  `json:"currency"`
+	TradePrice         float64 `json:"tradePrice"`
+	OriginalPrice      float64 `json:"originalPrice"`
+	ModuleSum          float64 `json:"moduleSum"`          // per-unit subtotal
+	Quantity           float64 `json:"quantity"`
+	EffectiveModuleSum float64 `json:"effectiveModuleSum"` // ★ final user-paid amount (includes quantity)
+	Modules            []struct {
+		ModuleCode        string  `json:"moduleCode"`
+		CostAfterDiscount float64 `json:"costAfterDiscount"`
+		OriginalCost      float64 `json:"originalCost"`
+	} `json:"modules"`
+}
+
+// FinalAmount flattens the single / composite / delta variants and returns
+// the unified final amount. Per the GetApiPrice spec, single mode reads
+// priceSummary.effectiveModuleSum and composite/delta read calculatedAmount.
+func (p *Price) FinalAmount() (float64, string) {
+	if p == nil {
+		return 0, ""
+	}
+	if p.PricingMode == "composite" || p.PricingMode == "delta" {
+		if p.CalculatedAmount != nil {
+			return *p.CalculatedAmount, p.Currency
+		}
+	}
+	if p.PriceSummary != nil {
+		return p.PriceSummary.EffectiveModuleSum, p.PriceSummary.Currency
+	}
+	return 0, p.Currency
+}
+
+// Client is the GetApiPrice HTTP client.
+type Client struct {
+	AK       string
+	SK       string
+	Endpoint string // default: cloudcontrol.aliyuncs.com (production)
+	Host     string // default: cloudcontrol.aliyuncs.com (production)
+	HTTP     *http.Client
+}
+
+// NewFromEnv builds a Client from environment variables.
+//
+// Credentials. The ALIBABA_CLOUD_ACCESS_KEY_ID / ALIBABA_CLOUD_ACCESS_KEY_SECRET
+// pair (matching the aliyun CLI) takes precedence; it falls back to ALICLOUD_*
+// (matching the Terraform alicloud provider) when the canonical pair is unset.
+//
+// Endpoint. By default the client targets the CloudControl endpoint
+// cloudcontrol.aliyuncs.com. To target a different endpoint, override with:
+//
+//	ALICLOUD_CC_API_ENDPOINT  alternate request hostname
+//	ALICLOUD_CC_API_HOST      alternate HTTP Host header (rarely needed)
+//
+// Setting ENDPOINT alone is enough for most cases; HOST is only needed when
+// a custom gateway expects a Host header different from the endpoint
+// hostname.
+func NewFromEnv() (*Client, error) {
+	ak := firstEnv("ALIBABA_CLOUD_ACCESS_KEY_ID", "ALICLOUD_ACCESS_KEY")
+	sk := firstEnv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", "ALICLOUD_SECRET_KEY")
+	if ak == "" || sk == "" {
+		return nil, fmt.Errorf("env vars ALIBABA_CLOUD_ACCESS_KEY_ID/SECRET (or ALICLOUD_*) not set")
+	}
+	endpoint := defaultEndpoint
+	if v := os.Getenv("ALICLOUD_CC_API_ENDPOINT"); v != "" {
+		endpoint = v
+	}
+	host := defaultHost
+	if v := os.Getenv("ALICLOUD_CC_API_HOST"); v != "" {
+		host = v
+	}
+	return &Client{
+		AK:       ak,
+		SK:       sk,
+		Endpoint: endpoint,
+		Host:     host,
+		HTTP:     &http.Client{Timeout: 15 * time.Second},
+	}, nil
+}
+
+func firstEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// Quote performs a single GetApiPrice call.
+func (c *Client) Quote(req *Request) (*Response, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	httpReq, err := c.signedRequest(body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.HTTP.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("CC API HTTP call failed: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		// System-level error (PricingNotSupported / InvalidParameter / ...).
+		var sysErr Response
+		_ = json.Unmarshal(raw, &sysErr)
+		return &sysErr, fmt.Errorf("CC API system error HTTP %d %s: %s", resp.StatusCode, sysErr.Code, sysErr.Message)
+	}
+	var out Response
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("parse response failed: %w raw: %s", err, raw)
+	}
+	return &out, nil
+}
+
+// signedRequest builds the HTTP request signed with POP v3 (ACS3-HMAC-SHA256).
+//
+// Signing rules in brief:
+//   - signed headers include only: host, content-type, and every x-acs-* header
+//   - canonical headers are sorted by lowercase name and joined as "name:value\n"
+//   - StringToSign = "ACS3-HMAC-SHA256\n" + sha256(canonicalRequest) hex
+//   - signature = hmacsha256(SK, StringToSign) hex
+func (c *Client) signedRequest(body []byte) (*http.Request, error) {
+	bodyHash := sha256Hex(body)
+	nonce, _ := randomNonce()
+	date := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	headers := map[string]string{
+		"host":                  c.Host,
+		"content-type":          "application/json",
+		"x-acs-action":          apiAction,
+		"x-acs-version":         apiVersion,
+		"x-acs-date":            date,
+		"x-acs-signature-nonce": nonce,
+		"x-acs-content-sha256":  bodyHash,
+	}
+
+	signedHeaderNames := make([]string, 0, len(headers))
+	for k := range headers {
+		signedHeaderNames = append(signedHeaderNames, k)
+	}
+	sort.Strings(signedHeaderNames)
+
+	var canonicalHeaders strings.Builder
+	for _, k := range signedHeaderNames {
+		canonicalHeaders.WriteString(k)
+		canonicalHeaders.WriteByte(':')
+		canonicalHeaders.WriteString(strings.TrimSpace(headers[k]))
+		canonicalHeaders.WriteByte('\n')
+	}
+	signedHeaders := strings.Join(signedHeaderNames, ";")
+
+	canonicalRequest := strings.Join([]string{
+		"POST",
+		apiPath,
+		"", // no query string
+		canonicalHeaders.String(),
+		signedHeaders,
+		bodyHash,
+	}, "\n")
+
+	stringToSign := "ACS3-HMAC-SHA256\n" + sha256Hex([]byte(canonicalRequest))
+	signature := hmacSha256Hex(c.SK, stringToSign)
+
+	auth := fmt.Sprintf("ACS3-HMAC-SHA256 Credential=%s,SignedHeaders=%s,Signature=%s",
+		c.AK, signedHeaders, signature)
+
+	u := url.URL{Scheme: "https", Host: c.Endpoint, Path: apiPath}
+	httpReq, err := http.NewRequest("POST", u.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
+	// Host needs special handling: in Go the value lives on Request.Host,
+	// not in the Header map.
+	httpReq.Host = c.Host
+	httpReq.Header.Set("Authorization", auth)
+	return httpReq, nil
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func hmacSha256Hex(key, msg string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(msg))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func randomNonce() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/estimate-cost/internal/embedmappings/data/alicloud_instance.json
+++ b/estimate-cost/internal/embedmappings/data/alicloud_instance.json
@@ -1,0 +1,176 @@
+{
+  "resource": "alicloud_instance",
+  "billable": true,
+  "pricingTargets": [
+    {
+      "name": "create",
+      "actions": ["create"],
+      "openapi": {
+        "popCode": "Ecs",
+        "popVersion": "2014-05-26",
+        "apiName": "RunInstances"
+      },
+      "params": {
+        "RegionId":               {"from": "$.region",                          "fallbackEnv": "ALICLOUD_REGION", "required": true},
+        "ZoneId":                 {"from": "$.availability_zone"},
+        "InstanceType":           {"from": "$.instance_type",                   "required": true},
+        "ImageId":                {"from": "$.image_id",                        "required": true},
+        "InstanceChargeType":     {"from": "$.instance_charge_type",            "default": "PostPaid"},
+        "Period":                 {"from": "$.period",                          "when": {"$.instance_charge_type": "PrePaid"}},
+        "PeriodUnit":             {"from": "$.period_unit",                     "default": "Month", "when": {"$.instance_charge_type": "PrePaid"}},
+        "SpotStrategy":           {"from": "$.spot_strategy",                   "when": {"$.instance_charge_type": "PostPaid"}},
+        "SpotPriceLimit":         {"from": "$.spot_price_limit",                "when": {"$.instance_charge_type": "PostPaid"}},
+        "SpotDuration":           {"from": "$.spot_duration",                   "when": {"$.instance_charge_type": "PostPaid"}},
+        "InternetChargeType":     {"from": "$.internet_charge_type"},
+        "InternetMaxBandwidthOut":{"from": "$.internet_max_bandwidth_out"},
+        "SystemDisk.Category":         {"from": "$.system_disk_category",         "default": "cloud_efficiency"},
+        "SystemDisk.Size":             {"from": "$.system_disk_size"},
+        "SystemDisk.PerformanceLevel": {"from": "$.system_disk_performance_level"},
+        "SystemDisk.ProvisionedIops":  {"from": "$.system_disk_provisioned_iops"},
+        "SystemDisk.BurstingEnabled":  {"from": "$.system_disk_bursting_enabled"},
+        "DataDisk": {
+          "from":   "$.data_disks",
+          "expand": "indexed",
+          "fields": {
+            "Category":         {"from": "$item.category", "default": "cloud_efficiency"},
+            "Size":             {"from": "$item.size",     "required": true},
+            "PerformanceLevel": {"from": "$item.performance_level"},
+            "ProvisionedIops":  {"from": "$item.provisioned_iops"},
+            "BurstingEnabled":  {"from": "$item.bursting_enabled"}
+          }
+        },
+        "DedicatedHostId":        {"from": "$.dedicated_host_id"}
+      }
+    },
+
+    {
+      "name": "update_spec_prepaid",
+      "actions": ["update"],
+      "when": {"$.instance_charge_type": "PrePaid"},
+      "whenChanged": ["instance_type"],
+      "openapi": {
+        "popCode": "Ecs",
+        "popVersion": "2014-05-26",
+        "apiName": "ModifyPrepayInstanceSpec"
+      },
+      "params": {
+        "RegionId":     {"from": "$.region",            "fallbackEnv": "ALICLOUD_REGION", "required": true},
+        "InstanceId":   {"from": "$before.id",          "required": true},
+        "InstanceType": {"from": "$.instance_type",     "required": true},
+        "OperatorType": {"const": "upgrade"}
+      }
+    },
+
+    {
+      "name": "update_disk_resize_prepaid",
+      "actions": ["update"],
+      "when": {"$.instance_charge_type": "PrePaid"},
+      "whenChanged": ["system_disk_size"],
+      "openapi": {
+        "popCode": "Ecs",
+        "popVersion": "2014-05-26",
+        "apiName": "ResizeDisk"
+      },
+      "params": {
+        "RegionId": {"from": "$.region",                "fallbackEnv": "ALICLOUD_REGION", "required": true},
+        "DiskId":   {"from": "$before.system_disk_id",  "required": true},
+        "NewSize":  {"from": "$.system_disk_size",      "required": true},
+        "Type":     {"const": "online"}
+      }
+    },
+
+    {
+      "name": "update_spec_postpaid",
+      "actions": ["update"],
+      "when": {"$.instance_charge_type": "PostPaid"},
+      "whenChanged": ["instance_type"],
+      "openapi": {
+        "popCode": "Ecs",
+        "popVersion": "2014-05-26",
+        "apiName": "ModifyInstanceSpec"
+      },
+      "params": {
+        "RegionId":     {"from": "$.region",        "fallbackEnv": "ALICLOUD_REGION", "required": true},
+        "InstanceId":   {"from": "$before.id",      "required": true},
+        "InstanceType": {"from": "$.instance_type", "required": true}
+      }
+    },
+
+    {
+      "name": "update_network_spec_bandwidth",
+      "actions": ["update"],
+      "when": {"$.internet_charge_type": "PayByBandwidth"},
+      "whenChanged": ["internet_max_bandwidth_out", "internet_charge_type"],
+      "openapi": {
+        "popCode": "Ecs",
+        "popVersion": "2014-05-26",
+        "apiName": "ModifyInstanceNetworkSpec"
+      },
+      "params": {
+        "RegionId":                {"from": "$.region",                     "fallbackEnv": "ALICLOUD_REGION", "required": true},
+        "InstanceId":              {"from": "$before.id",                   "required": true},
+        "InternetMaxBandwidthOut": {"from": "$.internet_max_bandwidth_out", "required": true},
+        "NetworkChargeType":       {"from": "$.internet_charge_type",       "required": true},
+        "AutoPay":                 {"const": true}
+      }
+    },
+
+    {
+      "name": "update_charge_type_to_prepaid",
+      "actions": ["update"],
+      "when": {"$.instance_charge_type": "PrePaid", "$before.instance_charge_type": "PostPaid"},
+      "openapi": {
+        "popCode": "Ecs",
+        "popVersion": "2014-05-26",
+        "apiName": "ModifyInstanceChargeType"
+      },
+      "params": {
+        "RegionId":           {"from": "$.region",      "fallbackEnv": "ALICLOUD_REGION", "required": true},
+        "InstanceIds":        {"from": "$before.id",    "required": true, "wrapArray": true},
+        "InstanceChargeType": {"const": "PrePaid"},
+        "Period":             {"from": "$.period",      "default": 1},
+        "PeriodUnit":         {"from": "$.period_unit", "default": "Month"},
+        "AutoPay":            {"const": false}
+      }
+    },
+
+    {
+      "name": "update_image_replace_system_disk",
+      "actions": ["update"],
+      "whenChanged": ["image_id"],
+      "openapi": {
+        "popCode": "Ecs",
+        "popVersion": "2014-05-26",
+        "apiName": "ReplaceSystemDisk"
+      },
+      "params": {
+        "RegionId":        {"from": "$.region",           "fallbackEnv": "ALICLOUD_REGION", "required": true},
+        "InstanceId":      {"from": "$before.id",         "required": true},
+        "ImageId":         {"from": "$.image_id",         "required": true},
+        "SystemDisk.Size": {"from": "$.system_disk_size"}
+      }
+    },
+
+    {
+      "name": "update_system_disk_spec",
+      "actions": ["update"],
+      "whenChanged": ["system_disk_performance_level", "system_disk_provisioned_iops"],
+      "openapi": {
+        "popCode": "Ecs",
+        "popVersion": "2014-05-26",
+        "apiName": "ModifyDiskSpec"
+      },
+      "params": {
+        "RegionId":         {"from": "$.region",                        "fallbackEnv": "ALICLOUD_REGION", "required": true},
+        "DiskId":           {"from": "$before.system_disk_id",          "required": true},
+        "PerformanceLevel": {"from": "$.system_disk_performance_level"},
+        "ProvisionedIops":  {"from": "$.system_disk_provisioned_iops"},
+        "PricingContext.CurrentDisk.Size":           {"from": "$before.system_disk_size",     "required": true},
+        "PricingContext.CurrentDisk.Category":       {"from": "$before.system_disk_category", "required": true},
+        "PricingContext.CurrentDisk.Type":           {"const": "system"},
+        "PricingContext.CurrentDisk.DiskChargeType": {"from": "$before.instance_charge_type", "required": true},
+        "PricingContext.CurrentDisk.InstanceId":     {"from": "$before.id",                   "required": true}
+      }
+    }
+  ]
+}

--- a/estimate-cost/internal/embedmappings/embedmappings.go
+++ b/estimate-cost/internal/embedmappings/embedmappings.go
@@ -1,0 +1,12 @@
+// Package embedmappings ships the mapping JSON files inside the binary so
+// users do not need to download or configure anything separately. The
+// mapping files in data/ are the single source of truth for the project.
+package embedmappings
+
+import "embed"
+
+//go:embed all:data
+var FS embed.FS
+
+// Dir is the directory name inside the embedded FS where mapping JSON files live.
+const Dir = "data"

--- a/estimate-cost/internal/mapping/engine.go
+++ b/estimate-cost/internal/mapping/engine.go
@@ -1,0 +1,236 @@
+package mapping
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// MissingField means a required field could not be resolved from the plan,
+// has no FallbackEnv, and no Default. Callers should treat the resource as
+// unknown/incomplete and skip pricing for it.
+type MissingField struct {
+	Param string
+	Path  string
+}
+
+func (e MissingField) Error() string {
+	return fmt.Sprintf("required param %q (from %s) could not be resolved", e.Param, e.Path)
+}
+
+// Build applies a PricingTarget's rules to the plan's change.after / change.before
+// maps and returns the corresponding CC API parameters.
+//
+// A rule using "$.x" reads from after; "$before.x" reads from before (which
+// holds the refreshed prior values on an update plan). before may be nil
+// (e.g. on a create plan).
+func Build(t *PricingTarget, after, before map[string]interface{}) (map[string]interface{}, error) {
+	out := map[string]interface{}{}
+	for name, def := range t.Params {
+		// Evaluate the per-param When predicate: every {path: value} pair must hold.
+		if !matchWhen(def.When, after, before) {
+			continue
+		}
+
+		switch {
+		case def.Expand == "indexed":
+			if err := expandIndexed(out, name, def, after, before); err != nil {
+				return nil, err
+			}
+		default:
+			val, ok := resolveScalar(def, after, before)
+			if !ok {
+				if def.Required {
+					return nil, MissingField{Param: name, Path: def.From}
+				}
+				continue
+			}
+			if def.WrapArray {
+				// Some pricing inputs are list-typed even for a single value
+				// (e.g. ModifyInstanceChargeType's InstanceIds).
+				val = []interface{}{val}
+			}
+			out[name] = val
+		}
+	}
+	nestPricingContext(out)
+	return out, nil
+}
+
+// nestPricingContext converts flat "PricingContext.a.b" keys into a nested
+// object under the "PricingContext" key. GetApiPrice's PricingContext is a
+// structured JSON object (unlike POP parameters such as "SystemDisk.Size",
+// which stay flat) — CC API rejects the dotted-flat form for it. Mapping
+// files write dotted keys for readability; this rewrites them on the way out.
+func nestPricingContext(params map[string]interface{}) {
+	const prefix = "PricingContext."
+	var nested map[string]interface{}
+	for k, v := range params {
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		if nested == nil {
+			nested = map[string]interface{}{}
+		}
+		cur := nested
+		segs := strings.Split(k[len(prefix):], ".")
+		for i, seg := range segs {
+			if i == len(segs)-1 {
+				cur[seg] = v
+				break
+			}
+			next, ok := cur[seg].(map[string]interface{})
+			if !ok {
+				next = map[string]interface{}{}
+				cur[seg] = next
+			}
+			cur = next
+		}
+		delete(params, k)
+	}
+	if nested != nil {
+		params["PricingContext"] = nested
+	}
+}
+
+// resolveScalar resolves a scalar field, in priority order:
+//
+//	const → from → fallbackEnv → default
+//
+// "$.x" reads from after, "$before.x" reads from before (before may be nil).
+// Returns (value, true) on success, (nil, false) when nothing matched.
+func resolveScalar(def ParamDef, after, before map[string]interface{}) (interface{}, bool) {
+	if def.Const != nil {
+		return def.Const, true
+	}
+	if def.From != "" {
+		source, path := after, def.From
+		if strings.HasPrefix(path, "$before.") {
+			source = before
+			path = "$." + path[len("$before."):]
+		}
+		if source != nil {
+			if v, ok := getByPath(source, path); ok && !isEmpty(v) {
+				return v, true
+			}
+		}
+	}
+	if def.FallbackEnv != "" {
+		if v := os.Getenv(def.FallbackEnv); v != "" {
+			return v, true
+		}
+	}
+	if def.Default != nil {
+		return def.Default, true
+	}
+	return nil, false
+}
+
+// expandIndexed flattens a list field into indexed parameters X.1.A, X.1.B,
+// X.2.A, ... def.From must point to a list field in after; def.Fields gives
+// the per-element sub-field mapping.
+func expandIndexed(out map[string]interface{}, prefix string, def ParamDef, after, before map[string]interface{}) error {
+	if def.From == "" || def.Fields == nil {
+		return nil
+	}
+	raw, ok := getByPath(after, def.From)
+	if !ok {
+		return nil
+	}
+	list, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	for i, item := range list {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// Build a synthetic "after" for sub-fields: "$item.foo" resolves to itemMap[foo].
+		ctx := map[string]interface{}{"item": itemMap}
+		for subName, subDef := range def.Fields {
+			// Rewrite "$item.x" → "$.item.x" so the same getByPath works.
+			rewritten := subDef
+			rewritten.From = strings.Replace(subDef.From, "$item.", "$.item.", 1)
+			val, ok := resolveScalar(rewritten, ctx, before)
+			if !ok {
+				if subDef.Required {
+					return MissingField{Param: fmt.Sprintf("%s.%d.%s", prefix, i+1, subName), Path: subDef.From}
+				}
+				continue
+			}
+			out[fmt.Sprintf("%s.%d.%s", prefix, i+1, subName)] = val
+		}
+	}
+	return nil
+}
+
+// matchWhen evaluates the When predicate: every {path: expected} pair must
+// hold. An empty/nil When map is treated as true.
+//
+// Paths starting with "$." read from after; paths starting with "$before."
+// read from before — useful for "field X changed from A to B" branching
+// (e.g. detecting a PostPaid → PrePaid charge-type switch). before may be
+// nil on create plans, in which case $before.* paths fail to resolve and
+// the predicate returns false.
+func matchWhen(when map[string]string, after, before map[string]interface{}) bool {
+	if len(when) == 0 {
+		return true
+	}
+	for path, expected := range when {
+		source := after
+		lookupPath := path
+		if strings.HasPrefix(path, "$before.") {
+			source = before
+			lookupPath = "$." + path[len("$before."):]
+		}
+		if source == nil {
+			return false
+		}
+		v, ok := getByPath(source, lookupPath)
+		if !ok {
+			// The When path is not present in the plan: we treat that as a
+			// non-match (the simpler, more conservative behaviour, e.g. for
+			// instance_charge_type-style discriminators).
+			return false
+		}
+		if fmt.Sprint(v) != expected {
+			return false
+		}
+	}
+	return true
+}
+
+// getByPath is an intentionally minimal JSONPath implementation: only
+// "$.a.b.c" style pure-dot paths are supported.
+func getByPath(root map[string]interface{}, path string) (interface{}, bool) {
+	if !strings.HasPrefix(path, "$.") {
+		return nil, false
+	}
+	cur := interface{}(root)
+	for _, seg := range strings.Split(path[2:], ".") {
+		m, ok := cur.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		cur, ok = m[seg]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+// isEmpty classifies "unset in plan" values. In Terraform plan JSON, numbers
+// default to 0 and strings default to "". We only filter obviously empty
+// strings and nil; zero-valued numbers are left for per-param Default to
+// handle (avoiding false negatives on legitimate zeros).
+func isEmpty(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	if s, ok := v.(string); ok && s == "" {
+		return true
+	}
+	return false
+}

--- a/estimate-cost/internal/mapping/mapping.go
+++ b/estimate-cost/internal/mapping/mapping.go
@@ -1,0 +1,187 @@
+// Package mapping translates a resource's `change.after` block in a Terraform
+// plan JSON into the (popCode, popVersion, apiName, parameters) tuple required
+// by CC API GetApiPrice.
+//
+// Mapping rules come from mappings/*.json — one file per resource type. The
+// supported fields in a rule are:
+//
+//	from / fallbackEnv / required / default / const / when / expand+fields
+//
+// See the estimate-cost README for the full field semantics.
+package mapping
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// File is the decoded representation of a mapping JSON file.
+type File struct {
+	Resource       string           `json:"resource"`
+	Billable       bool             `json:"billable"`
+	PricingTargets []*PricingTarget `json:"pricingTargets"`
+}
+
+// PricingTarget describes "when these plan actions are matched, call this
+// OpenAPI with these parameter mappings". When is evaluated at the target
+// level to support conditional dispatch — e.g. for the same `update` action,
+// route to ModifyInstanceSpec for PostPaid and ModifyPrepayInstanceSpec for
+// PrePaid based on `instance_charge_type`.
+//
+// WhenChanged narrows the match further by requiring at least one of the
+// listed schema fields to differ between change.before and change.after.
+// This prevents false-positive triggers like "user updated only the disk
+// size, but the spec-change target also fired because instance_charge_type
+// matched". The strings are bare field names (no "$." prefix). When the
+// list is empty/nil the constraint is treated as satisfied.
+type PricingTarget struct {
+	Name        string              `json:"name"`
+	Actions     []string            `json:"actions"`
+	When        map[string]string   `json:"when,omitempty"`
+	WhenChanged []string            `json:"whenChanged,omitempty"`
+	OpenAPI     OpenAPIRef          `json:"openapi"`
+	Params      map[string]ParamDef `json:"params"`
+}
+
+// OpenAPIRef is the triple required to address a single OpenAPI operation
+// inside CC API GetApiPrice.
+type OpenAPIRef struct {
+	PopCode    string `json:"popCode"`
+	PopVersion string `json:"popVersion"`
+	APIName    string `json:"apiName"`
+}
+
+// ParamDef describes how to resolve a single OpenAPI parameter. All JSON
+// fields are omitempty; a single definition typically uses only a few of them.
+type ParamDef struct {
+	From        string              `json:"from,omitempty"`        // JSONPath like "$.field"
+	FallbackEnv string              `json:"fallbackEnv,omitempty"` // env var to fall back to when From is unresolvable
+	Default     interface{}         `json:"default,omitempty"`     // value to use when both From and FallbackEnv fail
+	Const       interface{}         `json:"const,omitempty"`       // hard-coded value (overrides From)
+	Required    bool                `json:"required,omitempty"`    // fail if unresolved
+	When        map[string]string   `json:"when,omitempty"`        // include only when {"$.x": "V"} (i.e. x==V) holds
+	Expand      string              `json:"expand,omitempty"`      // "indexed" expands a list to X.1.A, X.1.B …
+	Fields      map[string]ParamDef `json:"fields,omitempty"`      // per-element field map used together with Expand=indexed
+	WrapArray   bool                `json:"wrapArray,omitempty"`   // wrap the resolved scalar in a single-element list
+}
+
+// Load reads every *.json mapping file in dir and returns a resource-type
+// index. It is a thin wrapper over LoadFS — production builds use LoadFS
+// directly against the embedded FS.
+func Load(dir string) (map[string]*File, error) {
+	return LoadFS(os.DirFS(dir), ".")
+}
+
+// LoadFS reads mapping files from an arbitrary fs.FS (e.g. an embed.FS for the
+// production build, or os.DirFS for development). Production and development
+// share the same parsing logic this way.
+func LoadFS(fsys fs.FS, dir string) (map[string]*File, error) {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return nil, fmt.Errorf("read mapping dir %s: %w", dir, err)
+	}
+	out := map[string]*File{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		raw, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		var f File
+		if err := json.Unmarshal(raw, &f); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		if f.Resource == "" {
+			return nil, fmt.Errorf("%s: missing 'resource' field", path)
+		}
+		out[f.Resource] = &f
+	}
+	return out, nil
+}
+
+// PickTargetByAction is a convenience wrapper over PickTarget. It is mainly
+// used by the fallback path where an update is not matched by any modify
+// target and must fall back to the create target for a double-call diff.
+func (f *File) PickTargetByAction(action string, after, before map[string]interface{}) *PricingTarget {
+	return f.PickTarget([]string{action}, after, before)
+}
+
+// PickTarget returns the first PricingTarget whose actions intersect with the
+// requested actions and whose target-level When predicate holds. Used for
+// "one action → one OpenAPI call" cases such as create.
+//
+// before may be nil on create plans; targets whose When references $before.*
+// will not match in that case.
+func (f *File) PickTarget(actions []string, after, before map[string]interface{}) *PricingTarget {
+	for _, t := range f.PricingTargets {
+		if !actionsMatch(t.Actions, actions) {
+			continue
+		}
+		if !matchWhen(t.When, after, before) {
+			continue
+		}
+		if !matchWhenChanged(t.WhenChanged, after, before) {
+			continue
+		}
+		return t
+	}
+	return nil
+}
+
+// PickTargets returns every matching target. Used for "one action may trigger
+// multiple OpenAPI calls" cases — e.g. a PrePaid update that changes both
+// instance_type and system_disk_size will call ModifyPrepayInstanceSpec and
+// ResizeDisk separately, producing two separate billing orders.
+func (f *File) PickTargets(actions []string, after, before map[string]interface{}) []*PricingTarget {
+	var out []*PricingTarget
+	for _, t := range f.PricingTargets {
+		if !actionsMatch(t.Actions, actions) {
+			continue
+		}
+		if !matchWhen(t.When, after, before) {
+			continue
+		}
+		if !matchWhenChanged(t.WhenChanged, after, before) {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// matchWhenChanged returns true when at least one of the listed schema field
+// names has a different value in after vs before. Used to gate "update_*"
+// targets so that, e.g., a disk-only resize doesn't also fire the spec-
+// change target. Empty/nil list passes through (no constraint).
+func matchWhenChanged(fields []string, after, before map[string]interface{}) bool {
+	if len(fields) == 0 {
+		return true
+	}
+	if before == nil {
+		return false
+	}
+	for _, f := range fields {
+		if fmt.Sprint(after[f]) != fmt.Sprint(before[f]) {
+			return true
+		}
+	}
+	return false
+}
+
+func actionsMatch(target, actual []string) bool {
+	for _, a := range actual {
+		for _, ta := range target {
+			if a == ta {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

Adds **`estimate-cost`**, a small companion tool that brings **plan-time price
estimation** to `terraform plan` for Alibaba Cloud resources — with **zero
changes to the provider itself**.

```
$ terraform plan --estimate-cost
[normal terraform plan output ...]

─────────────────────────────────────────────────────────────
                       Cost Estimate
─────────────────────────────────────────────────────────────
RESOURCE                       AMOUNT     CURRENCY  MODE        NOTE
alicloud_instance.demo         235.70     CNY       create      create
── TOTAL ──                    235.70     CNY
```

## How it works

Two tiny Go binaries wrap Terraform:

- `terraform-wrapper` — installed ahead of the real `terraform` on `PATH`,
  transparently forwards every subcommand. When it sees `plan --estimate-cost`
  it runs the real plan, converts it to JSON (`terraform show -json`), then
  invokes the pricing engine.
- `estimate-cost` — reads the plan JSON, translates each resource change into
  an Alibaba Cloud OpenAPI call via CloudControl's `GetApiPrice`, and renders a
  cost table. Schema→OpenAPI mapping rules are embedded via `go:embed`, so no
  extra files to download.

Provider resource code is **not modified**. All new code lives under
`estimate-cost/`; the only integration points are `.goreleaser.yml`
(builds/archives the two binaries alongside the provider) and a short section
in the root `README.md`.

## Coverage (`alicloud_instance`)

| Plan change | OpenAPI | Mode |
|---|---|---|
| Create (PrePaid / PostPaid) | `RunInstances` | single |
| PrePaid: change `instance_type` | `ModifyPrepayInstanceSpec` | delta |
| PostPaid: change `instance_type` | `ModifyInstanceSpec` | delta |
| Increase `system_disk_size` | `ResizeDisk` | delta |
| Raise / switch bandwidth (`PayByBandwidth`) | `ModifyInstanceNetworkSpec` | single |
| PostPaid → PrePaid charge-type switch | `ModifyInstanceChargeType` | single |
| Change `image_id` | `ReplaceSystemDisk` | delta |
| Change disk performance level / IOPS | `ModifyDiskSpec` | delta |
| Anything else | `RunInstances` × 2 | diff (after − before) |

Every target above was verified end-to-end against the production CloudControl
endpoint (`cloudcontrol.aliyuncs.com`) returning real prices.

## Authentication & privacy

- Uses the same credentials as the provider:
  `ALIBABA_CLOUD_ACCESS_KEY_ID/SECRET` (preferred) → `ALICLOUD_ACCESS_KEY/SECRET`
  (fallback). Read from the environment only — nothing hard-coded.
- Requests are signed locally with POP v3 (`ACS3-HMAC-SHA256`); the AK/SK never
  leaves the machine.
- Only billing-relevant fields are sent to `GetApiPrice`; sensitive plan content
  (`user_data`, `password`, tags, …) is never transmitted.

## How it ships

Built and released alongside the provider by the same `goreleaser` pipeline, so
every provider tag automatically produces a matching
`alicloud-tf-estimate-cost_<version>_<os>_<arch>.tar.gz` on the same GitHub
Release. Users drop the two binaries into a `PATH` dir ahead of `terraform` to
enable the flag.

See `estimate-cost/README.md` for install, usage, and how to add mappings for
more resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
