### PR TITLE
data-source/alicloud_alikafka_sasl_acls: Added the field id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.285.0 (Unreleased)
+
+ENHANCEMENTS:
+
+- data-source/alicloud_alikafka_sasl_acls: Added the field id.
+
 ## 1.284.0 (July 2, 2026)
 
 - **New Resource:** `alicloud_resource_manager_handshake_acceptance` ([#9907](https://github.com/aliyun/terraform-provider-alicloud/issues/9907))

--- a/alicloud/data_source_alicloud_alikafka_sasl_acls.go
+++ b/alicloud/data_source_alicloud_alikafka_sasl_acls.go
@@ -42,6 +42,10 @@ func dataSourceAlicloudAlikafkaSaslAcls() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"username": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -106,8 +110,11 @@ func alikafkaSaslAclsDecriptionAttributes(d *schema.ResourceData, kafkaAclsInfo 
 	var names []string
 	var s []map[string]interface{}
 
+	instanceId := d.Get("instance_id").(string)
+
 	for _, item := range kafkaAclsInfo {
 		mapping := map[string]interface{}{
+			"id":                        fmt.Sprintf("%s:%s:%s:%s:%s:%s", instanceId, item.Username, item.AclResourceType, item.AclResourceName, item.AclResourcePatternType, item.AclOperationType),
 			"username":                  item.Username,
 			"acl_resource_type":         item.AclResourceType,
 			"acl_resource_name":         item.AclResourceName,

--- a/alicloud/data_source_alicloud_alikafka_sasl_acls_test.go
+++ b/alicloud/data_source_alicloud_alikafka_sasl_acls_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
@@ -33,12 +34,13 @@ func TestAccAlicloudAlikafkaSaslAclsDataSource(t *testing.T) {
 	var existAlikafkaSaslAclsMapFunc = func(rand int) map[string]string {
 		return map[string]string{
 			"acls.#":                           "1",
+			"acls.0.id":                        CHECKSET,
 			"acls.0.username":                  fmt.Sprintf("tf-testacc-alikafkasaslacl%v", rand),
-			"acls.0.acl_resource_type":         "Topic",
+			"acls.0.acl_resource_type":         "TOPIC",
 			"acls.0.acl_resource_name":         fmt.Sprintf("tf-testacc-alikafkasaslacl%v", rand),
 			"acls.0.acl_resource_pattern_type": "LITERAL",
 			"acls.0.host":                      "*",
-			"acls.0.acl_operation_type":        "Write",
+			"acls.0.acl_operation_type":        "WRITE",
 		}
 	}
 
@@ -54,7 +56,8 @@ func TestAccAlicloudAlikafkaSaslAclsDataSource(t *testing.T) {
 		fakeMapFunc:  fakeAlikafkaSaslAclsMapFunc,
 	}
 	preCheck := func() {
-		testAccPreCheckWithAlikafkaAclEnable(t)
+		testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		testAccPreCheck(t)
 	}
 	alikafkaSaslAclsCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, nameRegexConf)
 }
@@ -62,51 +65,56 @@ func TestAccAlicloudAlikafkaSaslAclsDataSource(t *testing.T) {
 func dataSourceAlikafkaSaslAclsConfigDependence(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
- default = "%v"
+  default = "%v"
 }
 
-data "alicloud_vpcs" "default" {
-    name_regex = "^default-NODELETING$"
+data "alicloud_zones" "default" {
+  available_resource_creation = "VSwitch"
 }
+
 data "alicloud_vswitches" "default" {
-  vpc_id = data.alicloud_vpcs.default.ids.0
+  zone_id = data.alicloud_zones.default.zones.0.id
 }
 
 resource "alicloud_security_group" "default" {
-  name   = var.name
-  vpc_id = data.alicloud_vpcs.default.ids.0
+  vpc_id = data.alicloud_vswitches.default.vswitches.0.vpc_id
 }
 
 resource "alicloud_alikafka_instance" "default" {
-  name = "${var.name}"
-  partition_num = "50"
-  disk_type = "1"
-  disk_size = "500"
-  deploy_type = "5"
-  io_max = "20"
-  vswitch_id = "${data.alicloud_vswitches.default.ids.0}"
-  security_group = alicloud_security_group.default.id
+  name            = var.name
+  deploy_type     = "4"
+  instance_type   = "alikafka_serverless"
+  vswitch_id      = data.alicloud_vswitches.default.vswitches.0.id
+  spec_type       = "normal"
+  service_version = "3.3.1"
+  security_group  = alicloud_security_group.default.id
+  config          = "{\"enable.acl\":\"true\"}"
+  serverless_config {
+    reserved_publish_capacity   = 60
+    reserved_subscribe_capacity = 60
+  }
 }
 
 resource "alicloud_alikafka_topic" "default" {
-  instance_id = "${alicloud_alikafka_instance.default.id}"
-  topic = "${var.name}"
-  remark = "topic-remark"
+  instance_id = alicloud_alikafka_instance.default.id
+  topic       = var.name
+  remark      = "topic-remark"
 }
 
 resource "alicloud_alikafka_sasl_user" "default" {
-  instance_id = "${alicloud_alikafka_instance.default.id}"
-  username = "${var.name}"
-  password = "password"
+  instance_id = alicloud_alikafka_instance.default.id
+  username    = var.name
+  type        = "scram"
+  password    = "YourPassword1234!"
 }
 
 resource "alicloud_alikafka_sasl_acl" "default" {
-  instance_id = "${alicloud_alikafka_instance.default.id}"
-  username = "${alicloud_alikafka_sasl_user.default.username}"
-  acl_resource_type = "Topic"
-  acl_resource_name = "${alicloud_alikafka_topic.default.topic}"
+  instance_id               = alicloud_alikafka_instance.default.id
+  username                  = alicloud_alikafka_sasl_user.default.username
+  acl_resource_type         = "Topic"
+  acl_resource_name         = alicloud_alikafka_topic.default.topic
   acl_resource_pattern_type = "LITERAL"
-  acl_operation_type = "Write"
+  acl_operation_type        = "Write"
 }
 `, name)
 }

--- a/website/docs/d/alikafka_sasl_acls.html.markdown
+++ b/website/docs/d/alikafka_sasl_acls.html.markdown
@@ -7,25 +7,25 @@ description: |-
     Provides a list of alikafka sasl acls available to the user.
 ---
 
-# alicloud\_alikafka\_sasl\_acls
+# alicloud_alikafka_sasl_acls
 
 This data source provides a list of ALIKAFKA Sasl acls in an Alibaba Cloud account according to the specified filters.
 
--> **NOTE:** Available in 1.66.0+
+-> **NOTE:** Available since v1.66.0.
 
 ## Example Usage
 
-```
+```terraform
 data "alicloud_alikafka_sasl_acls" "sasl_acls_ds" {
-  instance_id = "xxx"
-  username = "username"
+  instance_id       = "xxx"
+  username          = "username"
   acl_resource_type = "Topic"
-  acl_resource_name = "testTopic"
-  output_file = "saslAcls.txt"
+  acl_resource_name = "yourTopic"
+  output_file       = "saslAcls.txt"
 }
 
 output "first_sasl_acl_username" {
-  value = "${data.alicloud_alikafka_sasl_acls.sasl_acls_ds.acls.0.username}"
+  value = data.alicloud_alikafka_sasl_acls.sasl_acls_ds.acls.0.username
 }
 ```
 
@@ -44,6 +44,7 @@ The following arguments are supported:
 The following attributes are exported in addition to the arguments listed above:
 
 * `acls` - A list of sasl acls. Each element contains the following attributes:
+  * `id` - (Available since v1.285.0) The resource ID in terraform of Sasl Acl. It formats as `<instance_id>:<username>:<acl_resource_type>:<acl_resource_name>:<acl_resource_pattern_type>:<acl_operation_type>`.
   * `username` - The username of the sasl acl.
   * `acl_resource_type` - The resource type of the sasl acl.
   * `acl_resource_name` - The resource name of the sasl acl.


### PR DESCRIPTION
## Summary
- data-source/alicloud_alikafka_sasl_acls: add `id` field for each acl item; composite `<instance_id>:<username>:<acl_resource_type>:<acl_resource_name>:<acl_resource_pattern_type>:<acl_operation_type>` aligned with the resource-side `SetId`.
- Doc updated with the new field, plus pre-existing lint fixes (backslash escapes on the H1, version tag format, code fence language, avoid `test` in example, terrafmt alignment).
- Acc test now runs standalone: switched to a serverless kafka instance with `config = "{\"enable.acl\":\"true\"}"` (pinned pre-check to cn-hangzhou to mirror the sibling resource test), so the old `testAccPreCheckWithAlikafkaAclEnable` gate is no longer invoked. Assertions updated to the uppercase enum values returned by `DescribeAcls` on serverless kafka.
- Acc test map extended with `acls.0.id: CHECKSET`.

## Test plan
- [x] `TestAccAlicloudAlikafkaSaslAclsDataSource` — remote acc verified end-to-end (create serverless instance -> sasl_user -> sasl_acl -> query datasource -> destroy), PASS in 680.63s.