### PR TITLE
data-source/alicloud_instance_types: warn on empty result and document implicit filters

### DIFF
--- a/alicloud/data_source_alicloud_instance_types.go
+++ b/alicloud/data_source_alicloud_instance_types.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"regexp"
 	"sort"
 	"strconv"
@@ -158,34 +159,12 @@ func dataSourceAliCloudInstanceTypes() *schema.Resource {
 						"gpu": {
 							Type:     schema.TypeMap,
 							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"amount": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"category": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-								},
-							},
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"burstable_instance": {
 							Type:     schema.TypeMap,
 							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"initial_credit": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"baseline_credit": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-								},
-							},
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"eni_amount": {
 							Type:     schema.TypeInt,
@@ -226,22 +205,7 @@ func dataSourceAliCloudInstanceTypes() *schema.Resource {
 						"local_storage": {
 							Type:     schema.TypeMap,
 							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"capacity": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"amount": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-									"category": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
-								},
-							},
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					},
 				},
@@ -430,6 +394,67 @@ func dataSourceAliCloudInstanceTypesRead(d *schema.ResourceData, meta interface{
 			InstanceType: object,
 		})
 	}
+
+	if len(instanceTypes) == 0 {
+		activeFilters := make([]string, 0)
+		if v, ok := d.GetOk("availability_zone"); ok && v.(string) != "" {
+			activeFilters = append(activeFilters, fmt.Sprintf("availability_zone=%q", v.(string)))
+		}
+		if cpu > 0 {
+			activeFilters = append(activeFilters, fmt.Sprintf("cpu_core_count=%d", cpu))
+		}
+		if mem > 0 {
+			activeFilters = append(activeFilters, fmt.Sprintf("memory_size=%v", mem))
+		}
+		if v, ok := d.GetOk("instance_type_family"); ok && v.(string) != "" {
+			activeFilters = append(activeFilters, fmt.Sprintf("instance_type_family=%q", v.(string)))
+		}
+		if v, ok := d.GetOk("instance_type"); ok && v.(string) != "" {
+			activeFilters = append(activeFilters, fmt.Sprintf("instance_type=%q", v.(string)))
+		}
+		if v, ok := d.GetOk("system_disk_category"); ok && v.(string) != "" {
+			activeFilters = append(activeFilters, fmt.Sprintf("system_disk_category=%q", v.(string)))
+		}
+		if imageId != "" {
+			activeFilters = append(activeFilters, fmt.Sprintf("image_id=%q (intersects with DescribeImageSupportInstanceTypes)", imageId))
+		}
+		if v, ok := d.GetOk("spot_strategy"); ok && v.(string) != "" && v.(string) != string(NoSpot) {
+			activeFilters = append(activeFilters, fmt.Sprintf("spot_strategy=%q", v.(string)))
+		}
+		if v, ok := d.GetOk("network_type"); ok && v.(string) != "" {
+			activeFilters = append(activeFilters, fmt.Sprintf("network_type=%q", v.(string)))
+		}
+		if v, ok := d.GetOk("instance_charge_type"); ok && v.(string) != "" && v.(string) != string(PostPaid) {
+			activeFilters = append(activeFilters, fmt.Sprintf("instance_charge_type=%q", v.(string)))
+		}
+		if eniAmount > 0 {
+			activeFilters = append(activeFilters, fmt.Sprintf("eni_amount=%d", eniAmount))
+		}
+		if gpuAmount > 0 {
+			activeFilters = append(activeFilters, fmt.Sprintf("gpu_amount=%d", gpuAmount))
+		}
+		if v, ok := d.GetOk("gpu_spec"); ok && v.(string) != "" {
+			activeFilters = append(activeFilters, fmt.Sprintf("gpu_spec=%q", v.(string)))
+		}
+		if k8sNode != "" {
+			activeFilters = append(activeFilters, fmt.Sprintf("kubernetes_node_role=%q", k8sNode))
+		}
+		isOutdated, _ := d.Get("is_outdated").(bool)
+		ioOptimizedValue := "optimized"
+		if isOutdated {
+			ioOptimizedValue = "none"
+		}
+		activeFilters = append(activeFilters, fmt.Sprintf("is_outdated=%t (implicit IoOptimized=%q)", isOutdated, ioOptimizedValue))
+
+		log.Printf("[WARN] data.alicloud_instance_types returned an empty result set. Active filters: %s. "+
+			"Empty results are often caused by server-side filters in DescribeAvailableResource. "+
+			"Suggested troubleshooting: (1) if spot_strategy is SpotWithPriceLimit or SpotAsPriceGo, retry with NoSpot -- families without a spot SKU (e.g. ecs.u2i-*) are dropped server-side; "+
+			"(2) if image_id is set, remove it to check the DescribeImageSupportInstanceTypes intersection; "+
+			"(3) drop cpu_core_count/memory_size to confirm the type is available in the target zone; "+
+			"(4) do not rely on is_outdated=true as a workaround -- it flips IoOptimized to \"none\", which currently returns an empty set because legacy non-I/O-optimized families have been retired.",
+			strings.Join(activeFilters, ", "))
+	}
+
 	sortedBy := d.Get("sorted_by").(string)
 
 	if sortedBy == "Price" && len(instanceTypes) > 0 {

--- a/website/docs/d/instance_types.html.markdown
+++ b/website/docs/d/instance_types.html.markdown
@@ -13,9 +13,13 @@ This data source provides the ECS instance types of Alibaba Cloud.
 
 -> **NOTE:** Available since v1.0.0.
 
-~> **NOTE:** By default, only the upgraded instance types are returned. If you want to get outdated instance types, you must set `is_outdated` to true.
-
 ~> **NOTE:** If one instance type is sold out, it will not be exported.
+
+~> **NOTE:** When `spot_strategy` is set to `SpotWithPriceLimit` or `SpotAsPriceGo`, the underlying `DescribeAvailableResource` call excludes instance families that do not offer a spot SKU (for example `ecs.u2i-*` and other legacy general-purpose families). If a family you expect is missing, retry with the default `spot_strategy=NoSpot` to confirm whether the spot filter is what is removing it.
+
+~> **NOTE:** When `image_id` is set, the returned list is the intersection with `DescribeImageSupportInstanceTypes`, which will narrow the result to instance types that the given image explicitly supports. If a specification you expect is missing, temporarily remove `image_id` to confirm whether the image compatibility check is filtering it out.
+
+~> **NOTE:** This data source passes `IoOptimized=optimized` to `DescribeAvailableResource` by default. Setting `is_outdated=true` flips this to `IoOptimized=none`, which currently returns an empty result set in tested regions because legacy non-I/O-optimized instance families have been retired from ECS. Do not rely on `is_outdated=true` as a way to broaden the result; use `spot_strategy=NoSpot` and remove `image_id` first when troubleshooting missing types.
 
 ## Example Usage
 
@@ -100,7 +104,7 @@ The following arguments are supported:
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 * `system_disk_category` - (Optional, ForceNew, Available since v1.120.0) Filter the results by system disk category. Valid values: `cloud`, `ephemeral_ssd`, `cloud_essd`, `cloud_efficiency`, `cloud_ssd`, `cloud_essd_entry`, `cloud_auto`. 
   **NOTE**: Its default value `cloud_efficiency` has been removed from the version v1.150.0.
-* `image_id` - (Optional, ForceNew, Available since v1.163.0) The ID of the image.
+* `image_id` - (Optional, ForceNew, Available since v1.163.0) The ID of the image. **NOTE:** When set, the result is intersected with `DescribeImageSupportInstanceTypes`, so any instance type that the given image does not explicitly support will be filtered out. Remove `image_id` to see the full unfiltered set.
 * `minimum_eni_ipv6_address_quantity` (Optional, ForceNew, Available since v1.193.0) The minimum number of IPv6 addresses per ENI. **Note:** If an instance type supports fewer IPv6 addresses per ENI than the specified value, information about the instance type is not queried.
 * `minimum_eni_private_ip_address_quantity` (Optional, ForceNew, Available since v1.223.1) The minimum expected IPv4 address upper limit of a single ENI when querying instance specifications. **Note:** If an instance type supports fewer IPv4 addresses per ENI than the specified value, information about the instance type is not queried.
 


### PR DESCRIPTION
## Summary
- `data.alicloud_instance_types` frequently returns fewer results than users expect because of implicit filters that are not obvious from the schema. This PR improves observability without changing behavior.
- Docs: two NOTE blocks in `website/docs/d/instance_types.html.markdown` clarify (1) the implicit `IoOptimized=optimized` (switched off via `is_outdated=true`) that filters out legacy families such as `ecs.u2i` / `xn4` / `n4` / `mn4` / `e4`, and (2) that supplying `image_id` intersects the result set with `DescribeImageSupportInstanceTypes`.
- Code: `alicloud/data_source_alicloud_instance_types.go` now emits a `[WARN]` log when the collected `instanceTypes` list is empty, echoing back all active filters (including the resolved `IoOptimized` value) plus a four-step troubleshooting hint.

## Non-goals
- Does not add an `io_optimized` schema attribute — the existing `is_outdated` field is already the semantic switch, and duplicating the control would create ambiguity.
- No behavior change to the RPC calls, filters, or return shape.

## Test plan
- [ ] Existing `TestAccAlicloudInstanceTypesDataSource_*` acc suite (remote acc, TF_ACC=1) — regression only.