### PR TITLE
docs: annotate composite import ID composition (pilot batch of 10 resources)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.285.0 (Unreleased)
+
+ENHANCEMENTS:
+
+- docs: annotate composite import ID composition for 10 resources (pilot batch).
+
 ## 1.284.0 (July 2, 2026)
 
 - **New Resource:** `alicloud_resource_manager_handshake_acceptance` ([#9907](https://github.com/aliyun/terraform-provider-alicloud/issues/9907))

--- a/website/docs/r/alb_load_balancer_zone_shifted_attachment.html.markdown
+++ b/website/docs/r/alb_load_balancer_zone_shifted_attachment.html.markdown
@@ -114,7 +114,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Application Load Balancer (ALB) Load Balancer Zone Shifted Attachment can be imported using the id, e.g.
+Application Load Balancer (ALB) Load Balancer Zone Shifted Attachment can be imported using the id, which consists of load_balancer_id, vswitch_id and zone_id, e.g.
 
 ```shell
 $ terraform import alicloud_alb_load_balancer_zone_shifted_attachment.example <load_balancer_id>:<vswitch_id>:<zone_id>

--- a/website/docs/r/alikafka_instance_allowed_ip_attachment.html.markdown
+++ b/website/docs/r/alikafka_instance_allowed_ip_attachment.html.markdown
@@ -107,7 +107,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-AliKafka Instance Allowed Ip Attachment can be imported using the id, e.g.
+AliKafka Instance Allowed Ip Attachment can be imported using the id, which consists of instance_id, allowed_type, port_range and allowed_ip, e.g.
 
 ```shell
 $ terraform import alicloud_alikafka_instance_allowed_ip_attachment.example <instance_id>:<allowed_type>:<port_range>:<allowed_ip>

--- a/website/docs/r/alikafka_sasl_acl.html.markdown
+++ b/website/docs/r/alikafka_sasl_acl.html.markdown
@@ -147,7 +147,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Alikafka Sasl Acl can be imported using the id, e.g.
+Alikafka Sasl Acl can be imported using the id, which consists of instance_id, username, acl_resource_type, acl_resource_name, acl_resource_pattern_type and acl_operation_type, e.g.
 
 ```shell
 $ terraform import alicloud_alikafka_sasl_acl.example <instance_id>:<username>:<acl_resource_type>:<acl_resource_name>:<acl_resource_pattern_type>:<acl_operation_type>

--- a/website/docs/r/amqp_binding.html.markdown
+++ b/website/docs/r/amqp_binding.html.markdown
@@ -101,7 +101,7 @@ The following attributes are exported:
 
 ## Import
 
-RabbitMQ (AMQP) Binding can be imported using the id, e.g.
+RabbitMQ (AMQP) Binding can be imported using the id, which consists of instance_id, virtual_host_name, source_exchange and destination_name, e.g.
 
 ```shell
 $ terraform import alicloud_amqp_binding.example <instance_id>:<virtual_host_name>:<source_exchange>:<destination_name>

--- a/website/docs/r/amqp_exchange.html.markdown
+++ b/website/docs/r/amqp_exchange.html.markdown
@@ -113,7 +113,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RabbitMQ (AMQP) Exchange can be imported using the id, e.g.
+RabbitMQ (AMQP) Exchange can be imported using the id, which consists of instance_id, virtual_host_name and exchange_name, e.g.
 
 ```shell
 $ terraform import alicloud_amqp_exchange.example <instance_id>:<virtual_host_name>:<exchange_name>

--- a/website/docs/r/amqp_queue.html.markdown
+++ b/website/docs/r/amqp_queue.html.markdown
@@ -88,7 +88,7 @@ The following attributes are exported:
 
 ## Import
 
-RabbitMQ (AMQP) Queue can be imported using the id, e.g.
+RabbitMQ (AMQP) Queue can be imported using the id, which consists of instance_id, virtual_host_name and queue_name, e.g.
 
 ```shell
 $ terraform import alicloud_amqp_queue.example <instance_id>:<virtual_host_name>:<queue_name>

--- a/website/docs/r/api_gateway_instance_acl_attachment.html.markdown
+++ b/website/docs/r/api_gateway_instance_acl_attachment.html.markdown
@@ -84,7 +84,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Api Gateway Instance Acl Attachment can be imported using the id, e.g.
+Api Gateway Instance Acl Attachment can be imported using the id, which consists of instance_id, acl_id and acl_type, e.g.
 
 ```shell
 $ terraform import alicloud_api_gateway_instance_acl_attachment.example <instance_id>:<acl_id>:<acl_type>

--- a/website/docs/r/api_gateway_vpc_access.html.markdown
+++ b/website/docs/r/api_gateway_vpc_access.html.markdown
@@ -111,7 +111,7 @@ The following attributes are exported:
 
 ## Import
 
-Api Gateway Vpc Access can be imported using the id, e.g.
+Api Gateway Vpc Access can be imported using the id, which consists of name, vpc_id, instance_id and port, e.g.
 
 ```shell
 $ terraform import alicloud_api_gateway_vpc_access.example <name>:<vpc_id>:<instance_id>:<port>

--- a/website/docs/r/arms_env_pod_monitor.html.markdown
+++ b/website/docs/r/arms_env_pod_monitor.html.markdown
@@ -163,7 +163,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ARMS Env Pod Monitor can be imported using the id, e.g.
+ARMS Env Pod Monitor can be imported using the id, which consists of environment_id, namespace and env_pod_monitor_name, e.g.
 
 ```shell
 $ terraform import alicloud_arms_env_pod_monitor.example <environment_id>:<namespace>:<env_pod_monitor_name>

--- a/website/docs/r/bastionhost_host_account_user_attachment.html.markdown
+++ b/website/docs/r/bastionhost_host_account_user_attachment.html.markdown
@@ -109,7 +109,7 @@ The following attributes are exported:
 
 ## Import
 
-Bastion Host Host Account can be imported using the id, e.g.
+Bastion Host Host Account can be imported using the id, which consists of instance_id, user_id and host_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_host_account.example <instance_id>:<user_id>:<host_id>


### PR DESCRIPTION
## Summary
- Pilot batch: for 10 resources whose `## Import` section shows a composite ID like `<a>:<b>:...` but doesn't say what those tokens are, add a `which consists of <a>, <b>, ...` clause to the leading sentence.
- Shell import example is left untouched — only the descriptive sentence changes.
- Composition order matches the order shown in the existing shell import example (which reflects the authoritative `Importer.State` layout).

## Scope of this batch
`alb_load_balancer_zone_shifted_attachment`, `alikafka_instance_allowed_ip_attachment`, `alikafka_sasl_acl`, `amqp_binding`, `amqp_exchange`, `amqp_queue`, `api_gateway_instance_acl_attachment`, `api_gateway_vpc_access`, `arms_env_pod_monitor`, `bastionhost_host_account_user_attachment`.

## Motivation
Import composition is currently opaque to users — the shell example is the only hint. This unified phrasing (matching the existing sample in `ack_one_membership_attachment.html.markdown` etc.) makes it explicit.

## Follow-up
- ~109 more resources under `website/docs/r/` have composite import IDs whose sentence still lacks the `which consists of ...` clause. Plan: mechanical batches of ~15, each keyed on the exact literal `can be imported using the id, e.g.` → `... using the id, which consists of <tokens>, e.g.`; verify with `go build ./alicloud/...` (docs-only, no impact expected).
- Single-attribute IDs (~1000 resources) are intentionally excluded — they are just the primary key.

## Test plan
- [x] `go build ./alicloud/...` — docs-only diff, clean.
- Docs preview should still render correctly (no syntax touched).