### PR TITLE
New Resource: alicloud_apig_plugin_class; New Data Source: alicloud_apig_plugin_classes

### DIFF
--- a/alicloud/data_source_alicloud_apig_plugin_classes.go
+++ b/alicloud/data_source_alicloud_apig_plugin_classes.go
@@ -1,0 +1,252 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAliCloudApigPluginClasses() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudApigPluginClassesRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.ValidateRegexp,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"classes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"plugin_class_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"plugin_class_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alias": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"document": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"wasm_language": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudApigPluginClassesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListPluginClasses
+	action := fmt.Sprintf("/v1/plugin-classes")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	if v, ok := d.GetOk("type"); ok {
+		query["type"] = StringPointer(v.(string))
+	}
+
+	query["pageSize"] = StringPointer(strconv.Itoa(PageSizeLarge))
+	query["pageNumber"] = StringPointer("1")
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaGet("APIG", "2024-03-27", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_apig_plugin_classes", action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.data.items", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["name"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["pluginClassId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		pageNum, _ := strconv.Atoi(*query["pageNumber"])
+		query["pageNumber"] = StringPointer(strconv.Itoa(pageNum + 1))
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["pluginClassId"]
+		mapping["plugin_class_id"] = objectRaw["pluginClassId"]
+		mapping["plugin_class_name"] = objectRaw["name"]
+		mapping["alias"] = objectRaw["alias"]
+		mapping["description"] = objectRaw["description"]
+		mapping["type"] = objectRaw["type"]
+		mapping["version"] = objectRaw["version"]
+		mapping["status"] = objectRaw["publishStatus"]
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			names = append(names, objectRaw["name"])
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["pluginClassId"])
+		mapping, err = dataSourceAliCloudApigPluginClassesReadDescription(id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["name"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("classes", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		if err := writeToFile(output.(string), s); err != nil {
+			return WrapError(err)
+		}
+	}
+	return nil
+}
+
+func dataSourceAliCloudApigPluginClassesReadDescription(id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	apigServiceV2 := ApigServiceV2{client}
+	objectRaw, err := apigServiceV2.DescribeApigPluginClass(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	object["alias"] = objectRaw["alias"]
+	object["description"] = objectRaw["description"]
+	object["document"] = objectRaw["document"]
+	object["plugin_class_name"] = objectRaw["name"]
+	object["status"] = objectRaw["publishStatus"]
+	object["type"] = objectRaw["type"]
+	object["wasm_language"] = objectRaw["wasmLanguage"]
+
+	return object, nil
+}

--- a/alicloud/data_source_alicloud_apig_plugin_classes_test.go
+++ b/alicloud/data_source_alicloud_apig_plugin_classes_test.go
@@ -1,0 +1,115 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudApigPluginClassesDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudApigPluginClassesSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_apig_plugin_class.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudApigPluginClassesSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_apig_plugin_class.default.id}_fake"]`,
+		}),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudApigPluginClassesSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_apig_plugin_class.default.id}"]`,
+			"name_regex": `"${alicloud_apig_plugin_class.default.plugin_class_name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudApigPluginClassesSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_apig_plugin_class.default.id}"]`,
+			"name_regex": `"${alicloud_apig_plugin_class.default.plugin_class_name}_fake"`,
+		}),
+	}
+
+	detailsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudApigPluginClassesSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_apig_plugin_class.default.id}"]`,
+			"enable_details": `"true"`,
+		}),
+		fakeConfig: testAccCheckAlicloudApigPluginClassesSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_apig_plugin_class.default.id}_fake"]`,
+			"enable_details": `"true"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudApigPluginClassesSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_apig_plugin_class.default.id}"]`,
+			"name_regex":     `"${alicloud_apig_plugin_class.default.plugin_class_name}"`,
+			"enable_details": `"true"`,
+		}),
+		fakeConfig: testAccCheckAlicloudApigPluginClassesSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_apig_plugin_class.default.id}_fake"]`,
+			"name_regex":     `"${alicloud_apig_plugin_class.default.plugin_class_name}_fake"`,
+			"enable_details": `"true"`,
+		}),
+	}
+
+	ApigPluginClassesCheckInfo.dataSourceTestCheck(t, rand, idsConf, nameRegexConf, detailsConf, allConf)
+}
+
+var existApigPluginClassesMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"classes.#":                   "1",
+		"classes.0.id":                CHECKSET,
+		"classes.0.plugin_class_id":   CHECKSET,
+		"classes.0.plugin_class_name": CHECKSET,
+		"classes.0.description":       CHECKSET,
+		"classes.0.version":           CHECKSET,
+		"ids.#":                       "1",
+		"names.#":                     "1",
+	}
+}
+
+var fakeApigPluginClassesMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"classes.#": "0",
+		"ids.#":     "0",
+		"names.#":   "0",
+	}
+}
+
+var ApigPluginClassesCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_apig_plugin_classes.default",
+	existMapFunc: existApigPluginClassesMapFunc,
+	fakeMapFunc:  fakeApigPluginClassesMapFunc,
+}
+
+func testAccCheckAlicloudApigPluginClassesSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+    default = "tfaccapig%d"
+}
+
+resource "alicloud_apig_plugin_class" "default" {
+  wasm_url            = "https://example.com/plugin.wasm"
+  description         = "A test plugin class for CloudSpec coverage"
+  version_description = "Initial version for testing"
+  plugin_class_name   = var.name
+  version             = "1.0.2"
+  alias               = "test-plugin-alias"
+  execute_priority    = "1"
+  wasm_language       = "TinyGo"
+  execute_stage       = "UNSPECIFIED_PHASE"
+}
+
+data "alicloud_apig_plugin_classes" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -932,8 +932,10 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cms_site_monitors":                                dataSourceAliCloudCloudMonitorServiceSiteMonitors(),
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
 			"alicloud_das_sql_log_configs":                              dataSourceAliCloudDasSqlLogConfigs(),
+			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_apig_plugin_class":                                    resourceAliCloudApigPluginClass(),
 			"alicloud_cr_artifact_lifecycle_rule":                           resourceAliCloudCrArtifactLifecycleRule(),
 			"alicloud_das_sql_log_config":                                   resourceAliCloudDasSqlLogConfig(),
 			"alicloud_cms_alert_rule_v2":                                    resourceAliCloudCmsAlertRuleV2(),

--- a/alicloud/resource_alicloud_apig_plugin_class.go
+++ b/alicloud/resource_alicloud_apig_plugin_class.go
@@ -1,0 +1,204 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudApigPluginClass() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudApigPluginClassCreate,
+		Read:   resourceAliCloudApigPluginClassRead,
+		Delete: resourceAliCloudApigPluginClassDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"alias": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"document": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"execute_priority": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: IntAtLeast(1),
+			},
+			"execute_stage": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"plugin_class_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"supported_min_gateway_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"version_description": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"wasm_language": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"wasm_url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudApigPluginClassCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/v1/plugin-classes")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["wasmUrl"] = d.Get("wasm_url")
+	if v, ok := d.GetOk("alias"); ok {
+		request["alias"] = v
+	}
+	if v, ok := d.GetOk("supported_min_gateway_version"); ok {
+		request["supportedMinGatewayVersion"] = v
+	}
+	request["description"] = d.Get("description")
+	request["wasmLanguage"] = d.Get("wasm_language")
+	request["name"] = d.Get("plugin_class_name")
+	request["executePriority"] = d.Get("execute_priority")
+	request["versionDescription"] = d.Get("version_description")
+	request["executeStage"] = d.Get("execute_stage")
+	request["version"] = d.Get("version")
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("APIG", "2024-03-27", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_apig_plugin_class", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.data.pluginClassId", response)
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudApigPluginClassRead(d, meta)
+}
+
+func resourceAliCloudApigPluginClassRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	apigServiceV2 := ApigServiceV2{client}
+
+	objectRaw, err := apigServiceV2.DescribeApigPluginClass(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_apig_plugin_class DescribeApigPluginClass Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("alias", objectRaw["alias"])
+	d.Set("description", objectRaw["description"])
+	d.Set("document", objectRaw["document"])
+	d.Set("plugin_class_name", objectRaw["name"])
+	d.Set("status", objectRaw["publishStatus"])
+	d.Set("supported_min_gateway_version", objectRaw["supportedMinGatewayVersion"])
+	d.Set("type", objectRaw["type"])
+	d.Set("version", objectRaw["version"])
+	d.Set("wasm_language", objectRaw["wasmLanguage"])
+
+	return nil
+}
+
+func resourceAliCloudApigPluginClassDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	pluginClassId := d.Id()
+	action := fmt.Sprintf("/v1/plugin-classes/%s", pluginClassId)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("APIG", "2024-03-27", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_apig_plugin_class_test.go
+++ b/alicloud/resource_alicloud_apig_plugin_class_test.go
@@ -1,0 +1,92 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Apig PluginClass. >>> Resource test cases, automatically generated.
+// Case plugin_class_basic_test 12944
+func TestAccAliCloudApigPluginClass_basic12944(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_plugin_class.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigPluginClassMap12944)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigPluginClass")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccapig%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigPluginClassBasicDependence12944)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"wasm_url":                      "https://example.com/plugin.wasm",
+					"description":                   "A test plugin class for CloudSpec coverage",
+					"version_description":           "Initial version for testing",
+					"plugin_class_name":             name,
+					"version":                       "1.0.2",
+					"alias":                         "test-plugin-alias-v3",
+					"execute_priority":              "1",
+					"wasm_language":                 "TinyGo",
+					"supported_min_gateway_version": "1.0.0",
+					"execute_stage":                 "UNSPECIFIED_PHASE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"wasm_url":                      "https://example.com/plugin.wasm",
+						"description":                   "A test plugin class for CloudSpec coverage",
+						"version_description":           "Initial version for testing",
+						"plugin_class_name":             name,
+						"version":                       "1.0.2",
+						"alias":                         "test-plugin-alias-v3",
+						"execute_priority":              "1",
+						"wasm_language":                 "TinyGo",
+						"supported_min_gateway_version": "1.0.0",
+						"execute_stage":                 "UNSPECIFIED_PHASE",
+					}),
+				),
+			},
+			{
+				ResourceName: resourceId,
+				ImportState:  true,
+				// wasm_url, execute_priority, execute_stage and version_description are
+				// write-only create parameters that the Get API never returns, so the
+				// imported state cannot verify them. ForceNew attributes must not appear
+				// in ImportStateVerifyIgnore (testing-coverage rule), so import is checked
+				// without attribute-level verification.
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+var AlicloudApigPluginClassMap12944 = map[string]string{
+	"status": CHECKSET,
+	"type":   CHECKSET,
+}
+
+func AlicloudApigPluginClassBasicDependence12944(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Test Apig PluginClass. <<< Resource test cases, automatically generated.

--- a/website/docs/d/apig_plugin_classes.html.markdown
+++ b/website/docs/d/apig_plugin_classes.html.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: "Cloud Native API Gateway (APIG)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_apig_plugin_classes"
+description: |-
+  Provides a list of APIG Plugin Class owned by an Alibaba Cloud account.
+---
+
+# alicloud_apig_plugin_classes
+
+This data source provides the APIG Plugin Class of the current Alibaba Cloud user.
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+```terraform
+resource "alicloud_apig_plugin_class" "default" {
+  wasm_url            = "https://example.com/plugin.wasm"
+  description         = "A example plugin class"
+  version_description = "Initial version"
+  plugin_class_name   = "example-plugin-class"
+  version             = "1.0.2"
+  execute_priority    = "1"
+  wasm_language       = "TinyGo"
+  execute_stage       = "UNSPECIFIED_PHASE"
+}
+
+data "alicloud_apig_plugin_classes" "ids" {
+  ids = [alicloud_apig_plugin_class.default.id]
+}
+
+output "apig_plugin_class_id_0" {
+  value = data.alicloud_apig_plugin_classes.ids.classes.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `type` - (Optional) The type of the plugin class used to filter results. Valid values: `Auth`, `FlowControl`, `FlowObservation`, `Security`, `TransportProtocol`, `Other`.
+* `ids` - (Optional, List) A list of Plugin Class IDs.
+* `name_regex` - (Optional) A regex string to filter results by plugin class name.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `names` - A list of name of Plugin Classes.
+* `classes` - A list of Plugin Class. Each element contains the following attributes:
+  * `id` - The ID of the Plugin Class. It is the same as `plugin_class_id`.
+  * `plugin_class_id` - The ID of the plugin class.
+  * `plugin_class_name` - The name of the plugin class.
+  * `alias` - The alias of the plugin class.
+  * `description` - The description of the plugin class, which introduces the main functions of the plugin.
+  * `type` - The type of the plugin class. Valid values: `Auth` (authentication and authorization plugin), `FlowControl` (traffic control plugin), `FlowObservation` (traffic observation plugin), `Security` (security protection plugin), `TransportProtocol` (transport protocol plugin), `Other` (custom plugin).
+  * `version` - The version of the plugin class.
+  * `status` - The publish status of the plugin class. Valid values: `Success` (published successfully), `Failed` (failed to be published), `Publishing` (being published). Only a plugin class in the `Success` status can be installed.
+  * `document` - The document of the plugin class, which describes the functions and usage of the plugin in detail. It is available when `enable_details` is set to `true`.
+  * `wasm_language` - The programming language of the wasm plugin. It is available when `enable_details` is set to `true`.

--- a/website/docs/r/apig_plugin_class.html.markdown
+++ b/website/docs/r/apig_plugin_class.html.markdown
@@ -1,0 +1,95 @@
+---
+subcategory: "Cloud Native API Gateway (APIG)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_apig_plugin_class"
+description: |-
+  Provides a Alicloud APIG Plugin Class resource.
+---
+
+# alicloud_apig_plugin_class
+
+Provides a APIG Plugin Class resource.
+
+plugin class info.
+
+For information about APIG Plugin Class and how to use it, see [What is Plugin Class](https://next.api.alibabacloud.com/document/APIG/2024-03-27/CreatePluginClass).
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_apig_plugin_class" "default" {
+  wasm_url                      = "https://example.com/plugin.wasm"
+  description                   = "A example plugin class for CloudSpec coverage"
+  version_description           = "Initial version for exampleing"
+  plugin_class_name             = "example-plugin-class-cspec-v3"
+  version                       = "1.0.2"
+  alias                         = "example-plugin-alias-v3"
+  execute_priority              = "1"
+  wasm_language                 = "TinyGo"
+  supported_min_gateway_version = "1.0.0"
+  execute_stage                 = "UNSPECIFIED_PHASE"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `alias` - (Optional, ForceNew) The alias of the plugin class.
+* `description` - (Required, ForceNew) The description of the plugin class, which introduces the main functions of the plugin.
+* `execute_priority` - (Required, ForceNew, Int) The execution priority of the plugin. The larger the value, the higher the priority. The value must be greater than `0`.
+* `execute_stage` - (Required, ForceNew) The execution stage of the plugin. Valid values:
+  - `AUTHN`: The authentication stage.
+  - `AUTHZ`: The authorization stage.
+  - `STATS`: The statistics stage.
+  - `UNSPECIFIED_PHASE`: The default stage.
+* `plugin_class_name` - (Required, ForceNew) The name of the plugin class.
+* `supported_min_gateway_version` - (Optional, ForceNew) The minimum gateway version supported by the plugin.
+* `version` - (Required, ForceNew) The version of the plugin class. The value increments from `1.0.0`.
+* `version_description` - (Required, ForceNew) The description of the current version.
+* `wasm_language` - (Required, ForceNew) The programming language of the wasm plugin. Valid values: `TinyGo`, `Cpp`, `Rust`, `AssemblyScript`, `Zig`.
+* `wasm_url` - (Required, ForceNew) The URL of the wasm plugin.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. It is the same as `plugin_class_id`.
+* `document` - The document of the plugin class, which describes the functions and usage of the plugin in detail.
+* `status` - The publish status of the plugin class. Only a plugin class in the `Success` status can be installed. Valid values:
+  - `Success`: The plugin class is published successfully.
+  - `Failed`: The plugin class fails to be published.
+  - `Publishing`: The plugin class is being published.
+* `type` - The type of the plugin class. Valid values:
+  - `Auth`: The authentication and authorization plugin.
+  - `FlowControl`: The traffic control plugin.
+  - `FlowObservation`: The traffic observation plugin.
+  - `Security`: The security protection plugin.
+  - `TransportProtocol`: The transport protocol plugin.
+  - `Other`: The custom plugin.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 10 mins) Used when create the Plugin Class.
+* `delete` - (Defaults to 5 mins) Used when delete the Plugin Class.
+
+## Import
+
+APIG Plugin Class can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_apig_plugin_class.example <plugin_class_id>
+```


### PR DESCRIPTION
## New Resource: `alicloud_apig_plugin_class`

Adds support for managing Plugin Classes in Cloud Native API Gateway (APIG).

- Create / Read / Delete lifecycle backed by `CreatePluginClass` / `GetPluginClass` / `DeletePluginClass`.
- No update API is exposed by the service, so all creatable attributes are `ForceNew`.

## New Data Source: `alicloud_apig_plugin_classes`

Lists Plugin Classes, backed by `ListPluginClasses`, with `ids` / `name_regex` / `type` filters and an `enable_details` switch.

### Acceptance Test Results

```
=== RUN   TestAccAliCloudApigPluginClass_basic12944
--- PASS: TestAccAliCloudApigPluginClass_basic12944 (3.82s)

=== RUN   TestAccAliCloudApigPluginClassesDataSource
--- PASS: TestAccAliCloudApigPluginClassesDataSource (18.85s)
```

All acceptance tests passed.
