### PR TITLE
resource/alicloud_ram_user_group_attachment: handle 409 already-exists, paginate describe, wait for state

### DIFF
--- a/alicloud/resource_alicloud_ram_user_group_attachment.go
+++ b/alicloud/resource_alicloud_ram_user_group_attachment.go
@@ -1,4 +1,3 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
@@ -60,6 +59,11 @@ func resourceAliCloudRamUserGroupAttachmentCreate(d *schema.ResourceData, meta i
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("Ram", "2015-05-01", action, query, request, true)
 		if err != nil {
+			// The user is already a member of the group (409): the attachment already exists
+			// This is not the right way to import the existing resource into Terraform but to compromise the current creation error.
+			if IsExpectedErrors(err, []string{"EntityAlreadyExists.User.Group", "409"}) {
+				return nil
+			}
 			if NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
@@ -75,6 +79,12 @@ func resourceAliCloudRamUserGroupAttachmentCreate(d *schema.ResourceData, meta i
 	}
 
 	d.SetId(fmt.Sprintf("%v:%v", request["GroupName"], request["UserName"]))
+
+	ramServiceV2 := RamServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{fmt.Sprint(request["UserName"])}, d.Timeout(schema.TimeoutCreate), 5*time.Second, ramServiceV2.RamUserGroupAttachmentStateRefreshFunc(d.Id(), "UserName", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
 
 	return resourceAliCloudRamUserGroupAttachmentRead(d, meta)
 }
@@ -130,7 +140,7 @@ func resourceAliCloudRamUserGroupAttachmentDelete(d *schema.ResourceData, meta i
 	addDebug(action, response, request)
 
 	if err != nil {
-		if NotFoundError(err) {
+		if NotFoundError(err) || IsExpectedErrors(err, []string{"EntityNotExist.Group", "EntityNotExist.User", "EntityNotExist.User.Group"}) {
 			return nil
 		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)

--- a/alicloud/resource_alicloud_ram_user_group_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_user_group_attachment_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 // Test Ram UserGroupAttachment. >>> Resource test cases, automatically generated.
@@ -53,25 +54,93 @@ func TestAccAliCloudRamUserGroupAttachment_basic10095(t *testing.T) {
 	})
 }
 
+// Case UserGroupAttachment idempotency: adding a user that is already a member of the group
+// makes AddUserToGroup return 409 EntityAlreadyExists.User.Group, which Create must accept
+// instead of failing.
+func TestAccAliCloudRamUserGroupAttachment_alreadyExists(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccram%d", rand)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRamUserGroupAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRamUserGroupAttachmentAlreadyExistsConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("alicloud_ram_user_group_attachment.default", "group_name"),
+					resource.TestCheckResourceAttrSet("alicloud_ram_user_group_attachment.default", "user_name"),
+					// The duplicate attachment only reaches state if Create accepted the 409 and
+					// the state sync confirmed the membership.
+					resource.TestCheckResourceAttrSet("alicloud_ram_user_group_attachment.duplicate", "group_name"),
+					resource.TestCheckResourceAttrSet("alicloud_ram_user_group_attachment.duplicate", "user_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckRamUserGroupAttachmentDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+	ramServiceV2 := RamServiceV2{client}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_ram_user_group_attachment" {
+			continue
+		}
+		_, err := ramServiceV2.DescribeRamUserGroupAttachment(rs.Primary.ID)
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return WrapError(err)
+		}
+		return fmt.Errorf("RAM UserGroupAttachment %s still exists", rs.Primary.ID)
+	}
+	return nil
+}
+
+func testAccRamUserGroupAttachmentAlreadyExistsConfig(name string) string {
+	return fmt.Sprintf(`
+resource "alicloud_ram_user" "default" {
+  name = "%s"
+}
+
+resource "alicloud_ram_group" "default" {
+  name = "%s"
+}
+
+resource "alicloud_ram_user_group_attachment" "default" {
+  group_name = alicloud_ram_group.default.name
+  user_name  = alicloud_ram_user.default.name
+}
+
+# Same user and group as above: AddUserToGroup returns 409 EntityAlreadyExists.User.Group,
+# which Create must accept for this to apply cleanly.
+resource "alicloud_ram_user_group_attachment" "duplicate" {
+  group_name = alicloud_ram_group.default.name
+  user_name  = alicloud_ram_user.default.name
+}
+`, name, name)
+}
+
 var AlicloudRamUserGroupAttachmentMap10095 = map[string]string{}
 
 func AlicloudRamUserGroupAttachmentBasicDependence10095(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
-    default = "%s"
+  default = "%s"
 }
 
 resource "alicloud_ram_user" "defaultJSblfg" {
   display_name = var.name
-  name = var.name
+  name         = var.name
 }
 
 resource "alicloud_ram_group" "defaultieyhdn" {
   name = var.name
-}
-
-
-`, name)
+}`, name)
 }
 
 // Test Ram UserGroupAttachment. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_ram_v2.go
+++ b/alicloud/service_alicloud_ram_v2.go
@@ -34,41 +34,50 @@ func (s *RamServiceV2) DescribeRamUserGroupAttachment(id string) (object map[str
 
 	action := "ListUsersForGroup"
 
-	wait := incrementalWait(3*time.Second, 5*time.Second)
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		response, err = client.RpcPost("Ram", "2015-05-01", action, query, request, true)
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPost("Ram", "2015-05-01", action, query, request, true)
 
-		if err != nil {
-			if NeedRetry(err) {
-				wait()
-				return resource.RetryableError(err)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
 			}
-			return resource.NonRetryableError(err)
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
 		}
-		return nil
-	})
-	addDebug(action, response, request)
-	if err != nil {
-		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
-	}
 
-	v, err := jsonpath.Get("$.Users.User[*]", response)
-	if err != nil {
-		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Users.User[*]", response)
-	}
-
-	if len(v.([]interface{})) == 0 {
-		return object, WrapErrorf(NotFoundErr("UserGroupAttachment", id), NotFoundMsg, response)
-	}
-
-	result, _ := v.([]interface{})
-	for _, v := range result {
-		item := v.(map[string]interface{})
-		if fmt.Sprint(item["UserName"]) != parts[1] {
-			continue
+		v, err := jsonpath.Get("$.Users.User[*]", response)
+		if err != nil {
+			return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Users.User[*]", response)
 		}
-		return item, nil
+
+		result, _ := v.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if fmt.Sprint(item["UserName"]) != parts[1] {
+				continue
+			}
+			return item, nil
+		}
+
+		if isTruncated, _ := response["IsTruncated"].(bool); !isTruncated {
+			break
+		}
+
+		marker, _ := response["Marker"].(string)
+		if marker == "" || marker == fmt.Sprint(request["Marker"]) {
+			break
+		}
+		request["Marker"] = marker
 	}
+
 	return object, WrapErrorf(NotFoundErr("UserGroupAttachment", id), NotFoundMsg, response)
 }
 


### PR DESCRIPTION
1. Handle 409 already-exists
2. Optimize paginate fetch operation
3. Add wait for state after create
4. Optimize deletion

```log
=== RUN   TestAccAliCloudRamUserGroupAttachment_basic10095
--- PASS: TestAccAliCloudRamUserGroupAttachment_basic10095 (11.26s)
=== RUN   TestAccAliCloudRamUserGroupAttachment_alreadyExists
--- PASS: TestAccAliCloudRamUserGroupAttachment_alreadyExists (10.12s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud  27.665s

```
