### PR TITLE
docs: use non-deprecated role_name/assume_role_policy_document in ram_role_policy_attachment example

### DIFF
--- a/website/docs/r/ram_role_policy_attachment.html.markdown
+++ b/website/docs/r/ram_role_policy_attachment.html.markdown
@@ -29,8 +29,8 @@ Basic Usage
 ```terraform
 # Create a RAM Role Policy attachment.
 resource "alicloud_ram_role" "role" {
-  name        = "roleName"
-  document    = <<EOF
+  role_name                   = "roleName"
+  assume_role_policy_document = <<EOF
     {
       "Statement": [
         {
@@ -47,7 +47,7 @@ resource "alicloud_ram_role" "role" {
       "Version": "1"
     }
     EOF
-  description = "this is a role test."
+  description                 = "this is a role test."
 }
 
 resource "random_integer" "default" {
@@ -81,7 +81,7 @@ resource "alicloud_ram_policy" "policy" {
 resource "alicloud_ram_role_policy_attachment" "attach" {
   policy_name = alicloud_ram_policy.policy.policy_name
   policy_type = alicloud_ram_policy.policy.type
-  role_name   = alicloud_ram_role.role.name
+  role_name   = alicloud_ram_role.role.role_name
 }
 ```
 


### PR DESCRIPTION
### Summary

The example in `website/docs/r/ram_role_policy_attachment.html.markdown` still declares the `alicloud_ram_role` block with the deprecated `name` / `document` arguments (deprecated since v1.252.0) and references `alicloud_ram_role.role.name`.

The `r/ram_role` doc example has already migrated to `role_name` / `assume_role_policy_document`, so the two pages contradict each other and copy-pasting the attachment example emits deprecation warnings.

### Change

Docs-only. Update the example to the non-deprecated arguments and reference:

- `name` → `role_name`
- `document` → `assume_role_policy_document`
- `alicloud_ram_role.role.name` → `alicloud_ram_role.role.role_name`

No resource code or schema change.
