### PR TITLE
docs: correct invalid event_rw enum value in alicloud_actiontrail example

### DIFF
--- a/website/docs/r/actiontrail.html.markdown
+++ b/website/docs/r/actiontrail.html.markdown
@@ -21,7 +21,7 @@ Provides a new resource to manage [Action Trail](https://www.alibabacloud.com/he
 # Create a new action trail.
 resource "alicloud_actiontrail" "foo" {
   name            = "action-trail"
-  event_rw        = "Write-test"
+  event_rw        = "Write"
   oss_bucket_name = alicloud_oss_bucket.bucket.id
   role_name       = alicloud_ram_role_policy_attachment.attach.role_name
   oss_key_prefix  = "at-product-account-audit-B"


### PR DESCRIPTION
### Summary

The `alicloud_actiontrail` resource documentation's **Example Usage** sets `event_rw = "Write-test"`, which is not a valid value. The schema's `ValidateFunc` accepts only `{Read, Write, All}` (`StringInSlice([]string{"Write", "Read", "All"}, false)`), and the same page's Argument Reference documents the same set. A user copying this example verbatim hits an error on the first `terraform validate`.

Note: `alicloud_actiontrail` is deprecated and now backed by the same implementation as `alicloud_actiontrail_trail`, so the ValidateFunc applies here too.

### Change

Docs-only: change the example's `event_rw` from `"Write-test"` to the valid value `"Write"`.

```diff
-  event_rw        = "Write-test"
+  event_rw        = "Write"
```

No code or behavior change.
