### PR TITLE
resource/alicloud_ram_policy: validate policy_document structure at plan time

### DIFF
--- a/alicloud/resource_alicloud_ram_policy.go
+++ b/alicloud/resource_alicloud_ram_policy.go
@@ -40,7 +40,7 @@ func resourceAliCloudRamPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringIsJSON,
+				ValidateFunc: validation.All(validation.StringIsJSON, validateRamPolicyDocumentStructure),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					equal, _ := compareJsonTemplateAreEquivalent(old, new)
 					return equal
@@ -101,7 +101,7 @@ func resourceAliCloudRamPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringIsJSON,
+				ValidateFunc: validation.All(validation.StringIsJSON, validateRamPolicyDocumentStructure),
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					equal, _ := compareJsonTemplateAreEquivalent(old, new)
 					return equal

--- a/alicloud/service_alicloud_ram.go
+++ b/alicloud/service_alicloud_ram.go
@@ -82,6 +82,72 @@ type RamService struct {
 type PolicyDocumentStatementPrincipalSet []PolicyDocumentStatementPrincipal
 type PolicyDocumentStatementConditionSet []PolicyDocumentStatementCondition
 
+// validateRamPolicyDocumentStructure performs a conservative, structural
+// pre-flight check on a RAM policy document string, on top of the JSON-syntax
+// check done by validation.StringIsJSON. It only rejects the two invariants
+// that the RAM API always rejects with MalformedPolicyDocument, so that such
+// policies fail at plan time instead of apply time:
+//  1. a statement whose "Effect" is a string other than "Allow"/"Deny";
+//  2. a statement carrying neither "Action" nor "NotAction".
+//
+// It stays lenient about everything else (Version, Resource, Principal,
+// Condition, statement shape) to avoid rejecting policies the API accepts.
+func validateRamPolicyDocumentStructure(v interface{}, k string) (ws []string, errors []error) {
+	value, ok := v.(string)
+	if !ok {
+		return
+	}
+
+	var raw interface{}
+	if err := json.Unmarshal([]byte(value), &raw); err != nil {
+		// Not valid JSON; leave the syntax error to validation.StringIsJSON.
+		return
+	}
+
+	doc, ok := raw.(map[string]interface{})
+	if !ok {
+		// Not a JSON object; leave it to the API.
+		return
+	}
+
+	rawStatement, ok := doc["Statement"]
+	if !ok {
+		return
+	}
+
+	var statements []interface{}
+	switch s := rawStatement.(type) {
+	case []interface{}:
+		statements = s
+	case map[string]interface{}:
+		statements = []interface{}{s}
+	default:
+		// Unexpected shape; do not risk a false positive.
+		return
+	}
+
+	for i, rawStmt := range statements {
+		stmt, ok := rawStmt.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if effect, ok := stmt["Effect"]; ok {
+			if es, ok := effect.(string); ok && es != "Allow" && es != "Deny" {
+				errors = append(errors, fmt.Errorf("%q statement %d has invalid \"Effect\" %q: must be \"Allow\" or \"Deny\"", k, i, es))
+			}
+		}
+
+		_, hasAction := stmt["Action"]
+		_, hasNotAction := stmt["NotAction"]
+		if !hasAction && !hasNotAction {
+			errors = append(errors, fmt.Errorf("%q statement %d must contain either \"Action\" or \"NotAction\"", k, i))
+		}
+	}
+
+	return
+}
+
 func (s *RamService) ParseRolePolicyDocument(policyDocument string) (RolePolicy, error) {
 	var policy RolePolicy
 	err := json.Unmarshal([]byte(policyDocument), &policy)

--- a/alicloud/service_alicloud_ram_test.go
+++ b/alicloud/service_alicloud_ram_test.go
@@ -1,0 +1,68 @@
+package alicloud
+
+import (
+	"testing"
+)
+
+func TestValidateRamPolicyDocumentStructure(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr int
+	}{
+		{
+			name:    "valid single statement array with Action string and Effect Allow",
+			input:   `{"Version":"1","Statement":[{"Effect":"Allow","Action":"ecs:Describe*","Resource":"*"}]}`,
+			wantErr: 0,
+		},
+		{
+			name:    "valid array with Action slice Deny plus NotAction-only statement",
+			input:   `{"Version":"1","Statement":[{"Effect":"Deny","Action":["ecs:Describe*","oss:Get*"],"Resource":"*"},{"Effect":"Allow","NotAction":"ram:*","Resource":"*"}]}`,
+			wantErr: 0,
+		},
+		{
+			name:    "valid single statement object (not array)",
+			input:   `{"Version":"1","Statement":{"Effect":"Allow","Action":"ecs:Describe*","Resource":"*"}}`,
+			wantErr: 0,
+		},
+		{
+			name:    "top-level JSON array is not an object",
+			input:   `[]`,
+			wantErr: 0,
+		},
+		{
+			name:    "top-level JSON string is not an object",
+			input:   `"foo"`,
+			wantErr: 0,
+		},
+		{
+			name:    "invalid JSON syntax left to StringIsJSON",
+			input:   `{`,
+			wantErr: 0,
+		},
+		{
+			name:    "statement with no Effect key but with Action",
+			input:   `{"Version":"1","Statement":[{"Action":"ecs:Describe*","Resource":"*"}]}`,
+			wantErr: 0,
+		},
+		{
+			name:    "statement missing both Action and NotAction",
+			input:   `{"Version":"1","Statement":[{"Effect":"Allow","Resource":"*"}]}`,
+			wantErr: 1,
+		},
+		{
+			name:    "Effect typo Alow",
+			input:   `{"Version":"1","Statement":[{"Effect":"Alow","Action":"ecs:Describe*","Resource":"*"}]}`,
+			wantErr: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, errs := validateRamPolicyDocumentStructure(tc.input, "policy_document")
+			if len(errs) != tc.wantErr {
+				t.Fatalf("case %q: expected %d error(s), got %d: %v", tc.name, tc.wantErr, len(errs), errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Why

`alicloud_ram_policy.policy_document` (and the deprecated `document`) only used `validation.StringIsJSON`, i.e. a pure JSON-syntax check. A policy that is valid JSON but semantically invalid — for example a `Statement` element missing `Action`/`NotAction`, or `Effect` mistyped as `"Alow"` — passes `terraform validate`/`terraform plan` and is only rejected at `apply` time by the API:

```
Error: CreatePolicy Failed!!! SDKError: StatusCode: 400, Code: MalformedPolicyDocument
Message: Add an Action or NotAction element to the policy statement.
```

This breaks the "a green plan ≈ apply will succeed" expectation that plan-gate / CI pipelines rely on, and in batch-creation runs the failure only surfaces partway through apply. Note the deprecated `statement` block already validates `effect` via `StringInSlice({"Allow","Deny"})`, so the recommended path (`policy_document`) had weaker client-side validation than the deprecated one.

### What

Add a conservative structural check on top of the JSON-syntax check:
`ValidateFunc: validation.All(validation.StringIsJSON, validateRamPolicyDocumentStructure)` for both `policy_document` and `document`.

The new validator rejects **only** the two invariants the RAM API always rejects with `MalformedPolicyDocument`:

1. a statement whose `Effect` is a string other than `"Allow"` / `"Deny"`;
2. a statement carrying neither `Action` nor `NotAction`.

It is deliberately lenient about everything else — it accepts `Statement` as a single object or an array, `Action` as a string or a list, and does not touch `Version`, `Resource`, `Principal`, or `Condition` — so it will not reject any document the API would accept. Anything it does not recognize is left to the API.

### Test

- Unit test `TestValidateRamPolicyDocumentStructure` covers valid inputs (array statement, single-object statement, `Action` as string/list, `NotAction`-only, non-object JSON, `Effect`-less statement) with zero errors, and the two invalid cases (missing `Action`/`NotAction`, bad `Effect`) with one error each.
- Existing `TestAccAliCloudRamPolicy_*` acceptance tests all use valid policy documents (Effect `Allow`/`Deny` with `Action`), so they are unaffected by the new plan-time check.
