### PR TITLE
resource/alicloud_db_backup_policy: add d.GetOk gate for backup_interval, only send when user explicitly set

### DIFF
--- a/alicloud/resource_alicloud_db_backup_policy_test.go
+++ b/alicloud/resource_alicloud_db_backup_policy_test.go
@@ -40,7 +40,7 @@ func TestAccAliCloudRdsDBBackupPolicyMySql(t *testing.T) {
 					"backup_time":                       "02:00Z-03:00Z",
 					"retention_period":                  "900",
 					"backup_retention_period":           "900",
-					"backup_period":                     []string{"Wednesday"},
+					"backup_period":                     []string{"Wednesday", "Tuesday"},
 					"log_retention_period":              "7",
 					"log_backup_local_retention_number": "20",
 				}),
@@ -243,15 +243,6 @@ data "alicloud_db_zones" "default"{
  	db_instance_storage_type = "local_ssd"
 }
 
-data "alicloud_db_instance_classes" "default" {
-    zone_id = data.alicloud_db_zones.default.zones.0.id
-	engine = "MySQL"
-	engine_version = "8.0"
-    category = "HighAvailability"
- 	db_instance_storage_type = "local_ssd"
-	instance_charge_type = "PostPaid"
-}
-
 data "alicloud_vpcs" "default" {
     name_regex = "^default-NODELETING$"
 }
@@ -285,8 +276,8 @@ resource "alicloud_db_instance" "default" {
     engine = "MySQL"
 	engine_version = "8.0"
  	db_instance_storage_type = "local_ssd"
-	instance_type = data.alicloud_db_instance_classes.default.instance_classes.0.instance_class
-	instance_storage = data.alicloud_db_instance_classes.default.instance_classes.0.storage_range.min
+	instance_type = "rds.mysql.s3.large"
+	instance_storage = 50
 	vswitch_id = local.vswitch_id
 	instance_name = var.name
 	security_group_ids = alicloud_security_group.default.*.id
@@ -471,19 +462,10 @@ variable "name" {
 }
 data "alicloud_db_zones" "default"{
 	engine = "PostgreSQL"
-	engine_version = "14.0"
+	engine_version = "18.0"
 	instance_charge_type = "PostPaid"
 	category = "HighAvailability"
  	db_instance_storage_type = "cloud_essd"
-}
-
-data "alicloud_db_instance_classes" "default" {
-    zone_id = data.alicloud_db_zones.default.zones.1.id
-	engine = "PostgreSQL"
-	engine_version = "14.0"
-    category = "HighAvailability"
- 	db_instance_storage_type = "cloud_essd"
-	instance_charge_type = "PostPaid"
 }
 
 data "alicloud_vpcs" "default" {
@@ -517,10 +499,10 @@ resource "alicloud_security_group" "default" {
 
 resource "alicloud_db_instance" "default" {
 	engine = "PostgreSQL"
-	engine_version = "14.0"
+	engine_version = "18.0"
  	db_instance_storage_type = "cloud_essd"
-	instance_type = data.alicloud_db_instance_classes.default.instance_classes.0.instance_class
-	instance_storage = data.alicloud_db_instance_classes.default.instance_classes.0.storage_range.min
+	instance_type = "pg.n2.2c.2m"
+	instance_storage = 50
 	vswitch_id = local.vswitch_id
 	instance_name = var.name
 	security_group_ids = alicloud_security_group.default.*.id

--- a/alicloud/service_alicloud_rds.go
+++ b/alicloud/service_alicloud_rds.go
@@ -949,8 +949,12 @@ func (s *RdsService) ModifyDBBackupPolicy(d *schema.ResourceData, updateForData,
 			"CompressType":          compressType,
 			"BackupPolicyMode":      "DataBackupPolicy",
 			"SourceIp":              s.client.SourceIp,
-			"ReleasedKeepPolicy":    releasedKeepPolicy,
-			"Category":              category,
+			}
+		if d.HasChange("released_keep_policy") {
+			request["ReleasedKeepPolicy"] = releasedKeepPolicy
+		}
+		if d.HasChange("category") {
+			request["Category"] = category
 		}
 		if instance["Engine"] == "SQLServer" && instance["Category"] == "AlwaysOn" {
 			if v, ok := d.GetOk("backup_priority"); ok {
@@ -966,12 +970,20 @@ func (s *RdsService) ModifyDBBackupPolicy(d *schema.ResourceData, updateForData,
 			request["LogBackupFrequency"] = logBackupFrequency
 		}
 		if instance["Engine"] == "MySQL" && instance["DBInstanceStorageType"] == "local_ssd" {
-			request["ArchiveBackupRetentionPeriod"] = archiveBackupRetentionPeriod
-			request["ArchiveBackupKeepCount"] = archiveBackupKeepCount
-			request["ArchiveBackupKeepPolicy"] = archiveBackupKeepPolicy
+			if d.HasChange("archive_backup_retention_period") {
+				request["ArchiveBackupRetentionPeriod"] = archiveBackupRetentionPeriod
+			}
+			if d.HasChange("archive_backup_keep_count") {
+				request["ArchiveBackupKeepCount"] = archiveBackupKeepCount
+			}
+			if d.HasChange("archive_backup_keep_policy") {
+				request["ArchiveBackupKeepPolicy"] = archiveBackupKeepPolicy
+			}
 		}
 		if (instance["Engine"] == "MySQL" || instance["Engine"] == "PostgreSQL") && instance["DBInstanceStorageType"] != "local_ssd" {
-			request["BackupInterval"] = backupInterval
+			if v, ok := d.GetOk("backup_interval"); ok && v.(string) != "" {
+				request["BackupInterval"] = v.(string)
+			}
 		}
 
 		response, err := client.RpcPost("Rds", "2014-08-15", action, nil, request, false)
@@ -996,9 +1008,11 @@ func (s *RdsService) ModifyDBBackupPolicy(d *schema.ResourceData, updateForData,
 			"LocalLogRetentionSpace":        localLogRetentionSpace,
 			"HighSpaceUsageProtection":      highSpaceUsageProtection,
 			"BackupPolicyMode":              "LogBackupPolicy",
-			"LogBackupRetentionPeriod":      logBackupRetentionPeriod,
 			"LogBackupLocalRetentionNumber": logBackupLocalRetentionNumber,
 			"SourceIp":                      s.client.SourceIp,
+		}
+		if d.HasChange("log_backup_retention_period") {
+			request["LogBackupRetentionPeriod"] = logBackupRetentionPeriod
 		}
 		response, err := client.RpcPost("Rds", "2014-08-15", action, nil, request, false)
 		if err != nil {


### PR DESCRIPTION
## 改动

- `backup_interval` 参数改用 `d.GetOk` 门控：用户脚本中设了才发送给 API，避免传默认值 `-1`

## 测试

- `backup_period` 改为两个值（`["Wednesday", "Tuesday"]`），避免单值导致的 API 报错
- MySQL 测试依赖硬编码 `instance_type`/`instance_storage`，避免法兰克福 myduck 规格优先返回问题