### PR TITLE
resource/alicloud_redis_backup: expose cluster_backup_id and fan out shard-level delete for cluster-architecture instances

### DIFF
--- a/alicloud/resource_alicloud_redis_backup.go
+++ b/alicloud/resource_alicloud_redis_backup.go
@@ -31,6 +31,10 @@ func resourceAliCloudRedisBackup() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"cluster_backup_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"backup_retention_period": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -110,6 +114,23 @@ func resourceAliCloudRedisBackupCreate(d *schema.ResourceData, meta interface{})
 					if backupID, ok := backup["BackupId"]; ok {
 						// Update ID with the actual BackupId
 						d.SetId(fmt.Sprintf("%v:%v", instanceID, backupID))
+
+						// Resolve the owning cluster backup set id (cb-*) for cluster-architecture
+						// instances. Standalone instances are signalled either by an empty result
+						// or by InvalidClusterInstance.NotFound; both are non-fatal. Any other API
+						// error must surface — a silent empty cluster_backup_id would break
+						// downstream clone resources with an unactionable InvalidParameter.Missing.
+						clusterBackupID, cbErr := redisServiceV2.DescribeRedisClusterBackupId(instanceID, fmt.Sprint(backupID))
+						if cbErr != nil {
+							if !IsExpectedErrors(cbErr, []string{"InvalidClusterInstance.NotFound"}) {
+								return WrapErrorf(cbErr, DefaultErrorMsg, d.Id(), "DescribeClusterBackupList", AlibabaCloudSdkGoERROR)
+							}
+							log.Printf("[DEBUG] alicloud_redis_backup: no cluster backup set for %s (standalone instance)", d.Id())
+						} else if clusterBackupID != "" {
+							d.Set("cluster_backup_id", clusterBackupID)
+						} else {
+							log.Printf("[DEBUG] alicloud_redis_backup: no cluster backup set for %s (standalone instance)", d.Id())
+						}
 					}
 				}
 			}
@@ -150,36 +171,61 @@ func resourceAliCloudRedisBackupUpdate(d *schema.ResourceData, meta interface{})
 func resourceAliCloudRedisBackupDelete(d *schema.ResourceData, meta interface{}) error {
 
 	client := meta.(*connectivity.AliyunClient)
+	redisServiceV2 := RedisServiceV2{client}
 	parts := strings.Split(d.Id(), ":")
-	action := "DeleteBackup"
-	var request map[string]interface{}
-	var response map[string]interface{}
-	query := make(map[string]interface{})
-	var err error
-	request = make(map[string]interface{})
-	request["BackupId"] = parts[1]
-	request["InstanceId"] = parts[0]
-	request["RegionId"] = client.RegionId
+	instanceID := parts[0]
 
-	wait := incrementalWait(3*time.Second, 5*time.Second)
-	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
-		if err != nil {
-			if NeedRetry(err) {
-				wait()
-				return resource.RetryableError(err)
+	// Cluster-architecture instances hold one BackupId per shard under a single cluster
+	// backup set id (cb-*). R-kvstore has no cluster-level DeleteClusterBackup API, so we
+	// have to fan out shard-level DeleteBackup calls; otherwise only the state-recorded
+	// shard is removed and the rest linger. Standalone instances (cluster_backup_id empty
+	// or unset — including pre-fix state that never populated the field) take the single
+	// shard path unchanged.
+	backupIDs := []string{parts[1]}
+	if clusterBackupID, ok := d.Get("cluster_backup_id").(string); ok && clusterBackupID != "" {
+		shardIDs, listErr := redisServiceV2.ListClusterBackupShardIds(instanceID, clusterBackupID)
+		if listErr != nil {
+			// The cluster instance may already be gone (destroy order or manual cleanup);
+			// treat that as no fan-out needed and fall back to the state-recorded shard.
+			if !IsExpectedErrors(listErr, []string{"InvalidClusterInstance.NotFound"}) {
+				return WrapErrorf(listErr, DefaultErrorMsg, d.Id(), "DescribeClusterBackupList", AlibabaCloudSdkGoERROR)
 			}
-			return resource.NonRetryableError(err)
+		} else if len(shardIDs) > 0 {
+			backupIDs = shardIDs
 		}
-		return nil
-	})
-	addDebug(action, response, request)
+	}
 
-	if err != nil {
-		if NotFoundError(err) {
-			return nil
+	action := "DeleteBackup"
+	query := make(map[string]interface{})
+	for _, backupID := range backupIDs {
+		request := map[string]interface{}{
+			"BackupId":   backupID,
+			"InstanceId": instanceID,
+			"RegionId":   client.RegionId,
 		}
-		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+
+		var response map[string]interface{}
+		var err error
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+			response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_redis_backup_test.go
+++ b/alicloud/resource_alicloud_redis_backup_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 // Test Redis Backup. >>> Resource test cases, automatically generated.
@@ -48,7 +49,7 @@ func TestAccAliCloudRedisBackup_basic11970(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"backup_retention_period"},
+				ImportStateVerifyIgnore: []string{"backup_retention_period", "cluster_backup_id"},
 			},
 		},
 	})
@@ -104,6 +105,145 @@ resource "alicloud_kvstore_instance" "default" {
 
 
 `, name)
+}
+
+// Case cluster-delete: guards the fan-out Delete on cluster-architecture instances.
+// Before the fix Delete only removed the state-recorded shard backup and left the other
+// shards behind; the standard checkResourceDestroy would still pass because it only
+// re-queries that one shard. This case captures instance_id + cluster_backup_id during
+// Check, then in a custom CheckDestroy queries DescribeClusterBackupList for the captured
+// cluster set and fails if any shard backup survives.
+var AlicloudRedisBackupClusterDeleteMap = map[string]string{
+	"status":    CHECKSET,
+	"backup_id": CHECKSET,
+}
+
+func AlicloudRedisBackupClusterDeleteDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "zone_id" {
+  default = "cn-hangzhou-h"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  zone_id = var.zone_id
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_vswitch" "vswitch" {
+  count        = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
+  vpc_id       = data.alicloud_vpcs.default.ids.0
+  cidr_block   = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 8)
+  zone_id      = var.zone_id
+  vswitch_name = var.name
+}
+
+locals {
+  vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : concat(alicloud_vswitch.vswitch.*.id, [""])[0]
+}
+
+# Cloud-native cluster (shard_count >= 2) so the backup yields a cluster backup set (cb-*)
+# with per-shard BackupIds.
+resource "alicloud_redis_tair_instance" "cluster" {
+  payment_type       = "PayAsYouGo"
+  instance_type      = "tair_rdb"
+  zone_id            = var.zone_id
+  instance_class     = "tair.rdb.2g"
+  shard_count        = 2
+  tair_instance_name = var.name
+  vswitch_id         = local.vswitch_id
+  vpc_id             = data.alicloud_vpcs.default.ids.0
+  resource_group_id  = data.alicloud_resource_manager_resource_groups.default.ids.0
+  password           = "123456Tf"
+  engine_version     = "5.0"
+  port               = "6379"
+}
+
+
+`, name)
+}
+
+func TestAccAliCloudRedisBackup_clusterDelete(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_redis_backup.default"
+	ra := resourceAttrInit(resourceId, AlicloudRedisBackupClusterDeleteMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RedisServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRedisBackup")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccredisclusterdel%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRedisBackupClusterDeleteDependence)
+
+	// Captured during Check so CheckDestroy can re-verify all shard backups are gone.
+	// State-scoped access is not available at CheckDestroy time (the resource is already
+	// removed from state), so we stash the two ids in the closure.
+	var capturedInstanceID, capturedClusterBackupID string
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy: func(s *terraform.State) error {
+			if err := rac.checkResourceDestroy()(s); err != nil {
+				return err
+			}
+			if capturedInstanceID == "" || capturedClusterBackupID == "" {
+				// Cluster set never materialized; skip the extra assertion.
+				return nil
+			}
+			client := testAccProvider.Meta().(*connectivity.AliyunClient)
+			redisServiceV2 := &RedisServiceV2{client: client}
+			shardIds, err := redisServiceV2.ListClusterBackupShardIds(capturedInstanceID, capturedClusterBackupID)
+			if err != nil {
+				if NotFoundError(err) {
+					return nil
+				}
+				return fmt.Errorf("verify cluster backup fan-out delete for %s/%s: %v", capturedInstanceID, capturedClusterBackupID, err)
+			}
+			if len(shardIds) != 0 {
+				return fmt.Errorf("cluster_backup_id %s still has %d shard backups after destroy: %v", capturedClusterBackupID, len(shardIds), shardIds)
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"backup_retention_period": "7",
+					"instance_id":             "${alicloud_redis_tair_instance.cluster.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"backup_retention_period": "7",
+						"instance_id":             CHECKSET,
+					}),
+					resource.TestCheckResourceAttrSet(resourceId, "cluster_backup_id"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[resourceId]
+						if !ok {
+							return fmt.Errorf("resource %s not in state", resourceId)
+						}
+						capturedInstanceID = rs.Primary.Attributes["instance_id"]
+						capturedClusterBackupID = rs.Primary.Attributes["cluster_backup_id"]
+						return nil
+					},
+				),
+			},
+		},
+	})
 }
 
 // Test Redis Backup. <<< Resource test cases, automatically generated.

--- a/alicloud/resource_alicloud_redis_tair_instance_test.go
+++ b/alicloud/resource_alicloud_redis_tair_instance_test.go
@@ -2411,6 +2411,150 @@ func TestAccAliCloudRedisTairInstance_multiSecurityGroup(t *testing.T) {
 	})
 }
 
+// Case Tair 克隆实例_集群备份集恢复 clone-from-cluster-backup: covers cluster_backup_id
+var AlicloudRedisTairInstanceCloneFromClusterBackupMap = map[string]string{
+	"port":           CHECKSET,
+	"status":         CHECKSET,
+	"engine_version": CHECKSET,
+	"payment_type":   "PayAsYouGo",
+	"create_time":    CHECKSET,
+}
+
+func AlicloudRedisTairInstanceCloneFromClusterBackupDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "zone_id" {
+  default = "cn-hangzhou-h"
+}
+
+variable "region_id" {
+  default = "cn-hangzhou"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  zone_id = var.zone_id
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_vswitch" "vswitch" {
+  count        = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
+  vpc_id       = data.alicloud_vpcs.default.ids.0
+  cidr_block   = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 8)
+  zone_id      = var.zone_id
+  vswitch_name = var.name
+}
+
+locals {
+  vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : concat(alicloud_vswitch.vswitch.*.id, [""])[0]
+}
+
+# Cloud-native cluster source instance (shard_count >= 2) whose backup yields a cluster
+# backup set id (cb-*); all references are dynamic.
+resource "alicloud_redis_tair_instance" "source" {
+  payment_type       = "PayAsYouGo"
+  instance_type      = "tair_rdb"
+  zone_id            = var.zone_id
+  instance_class     = "tair.rdb.2g"
+  shard_count        = 2
+  tair_instance_name = "${var.name}Src"
+  vswitch_id         = local.vswitch_id
+  vpc_id             = data.alicloud_vpcs.default.ids.0
+  resource_group_id  = data.alicloud_resource_manager_resource_groups.default.ids.0
+  password           = "123456Tf"
+  engine_version     = "5.0"
+  port               = "6379"
+}
+
+# Backup of the cluster source instance, exposing cluster_backup_id (cb-*).
+resource "alicloud_redis_backup" "default" {
+  instance_id             = alicloud_redis_tair_instance.source.id
+  backup_retention_period = "7"
+}
+
+
+`, name)
+}
+
+func TestAccAliCloudRedisTairInstance_cloneFromClusterBackup(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_redis_tair_instance.default"
+	ra := resourceAttrInit(resourceId, AlicloudRedisTairInstanceCloneFromClusterBackupMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RedisServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRedisTairInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sredistairinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRedisTairInstanceCloneFromClusterBackupDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Clone a cloud-native cluster instance from a cluster backup set.
+				// cluster_backup_id is wired to the dynamically created cluster source
+				// instance's alicloud_redis_backup.cluster_backup_id (cb-*), with no hardcoded
+				// id. Per CreateTairInstance semantics ClusterBackupId is used on its own (it
+				// already identifies the source), so src_db_instance_id / backup_id are omitted.
+				// It is create-only, so it lives in the create step and is asserted with CHECKSET.
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type":       "PayAsYouGo",
+					"instance_type":      "tair_rdb",
+					"zone_id":            "${var.zone_id}",
+					"instance_class":     "tair.rdb.2g",
+					"shard_count":        "2",
+					"tair_instance_name": name,
+					"vswitch_id":         "${local.vswitch_id}",
+					"vpc_id":             "${data.alicloud_vpcs.default.ids.0}",
+					"resource_group_id":  "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"password":           "123456Tf",
+					"engine_version":     "5.0",
+					"port":               "6379",
+					"cluster_backup_id":  "${alicloud_redis_backup.default.cluster_backup_id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"payment_type":       "PayAsYouGo",
+						"instance_type":      "tair_rdb",
+						"zone_id":            CHECKSET,
+						"instance_class":     "tair.rdb.2g",
+						"shard_count":        "2",
+						"tair_instance_name": name,
+						"vswitch_id":         CHECKSET,
+						"vpc_id":             CHECKSET,
+						"resource_group_id":  CHECKSET,
+						"password":           "123456Tf",
+						"engine_version":     "5.0",
+						"port":               "6379",
+						"cluster_backup_id":  CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auto_renew", "auto_renew_period", "backup_id", "cluster_backup_id", "effective_time", "force_upgrade", "global_instance_id", "password", "period", "read_only_count", "recover_config_mode", "slave_read_only_count", "src_db_instance_id"},
+			},
+		},
+	})
+}
+
 // Test Redis TairInstance. <<< Resource test cases, automatically generated.
 
 func TestUnitRedisTairInstanceCreateRetryLogic(t *testing.T) {

--- a/alicloud/service_alicloud_redis_v2.go
+++ b/alicloud/service_alicloud_redis_v2.go
@@ -753,3 +753,130 @@ func (s *RedisServiceV2) DescribeAsyncDescribeBackups(d *schema.ResourceData, re
 }
 
 // DescribeAsyncDescribeBackups >>> Encapsulated.
+
+// DescribeRedisClusterBackupId <<< Resolve the cluster backup set id for a backup.
+
+// DescribeRedisClusterBackupId returns the cluster backup set id (cb-*) that owns the
+// given per-shard BackupId. Standalone instances legitimately have no cluster backup set;
+// an empty result with a nil error means "not a cluster backup", not a failure.
+func (s *RedisServiceV2) DescribeRedisClusterBackupId(instanceId string, backupId string) (string, error) {
+	response, err := s.describeClusterBackupList(instanceId, "")
+	if err != nil {
+		return "", err
+	}
+
+	for _, item := range redisRpcList(response["ClusterBackups"], "ClusterBackup") {
+		clusterBackup, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		clusterBackupId := fmt.Sprint(clusterBackup["ClusterBackupId"])
+		if clusterBackupId == "" || clusterBackupId == "<nil>" {
+			continue
+		}
+		for _, shard := range redisRpcList(clusterBackup["Backups"], "Backup") {
+			shardBackup, ok := shard.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if fmt.Sprint(shardBackup["BackupId"]) == backupId {
+				return clusterBackupId, nil
+			}
+		}
+	}
+
+	return "", nil
+}
+
+// ListClusterBackupShardIds returns every shard BackupId that belongs to the given
+// cluster backup set. Used by resource_alicloud_redis_backup Delete to fan out shard-level
+// DeleteBackup calls (R-kvstore exposes no cluster-level delete API). An empty slice with
+// nil error means the cluster set is gone or has no shard backups — both are non-fatal.
+func (s *RedisServiceV2) ListClusterBackupShardIds(instanceId string, clusterBackupId string) ([]string, error) {
+	response, err := s.describeClusterBackupList(instanceId, clusterBackupId)
+	if err != nil {
+		return nil, err
+	}
+
+	shardIds := make([]string, 0)
+	for _, item := range redisRpcList(response["ClusterBackups"], "ClusterBackup") {
+		clusterBackup, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if clusterBackupId != "" && fmt.Sprint(clusterBackup["ClusterBackupId"]) != clusterBackupId {
+			continue
+		}
+		for _, shard := range redisRpcList(clusterBackup["Backups"], "Backup") {
+			shardBackup, ok := shard.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if id := fmt.Sprint(shardBackup["BackupId"]); id != "" && id != "<nil>" {
+				shardIds = append(shardIds, id)
+			}
+		}
+	}
+	return shardIds, nil
+}
+
+// describeClusterBackupList calls R-kvstore DescribeClusterBackupList with a wide UTC time
+// window that covers any live backup set. StartTime / EndTime are Required by the API even
+// when ClusterBackupId is supplied; a 30-day-back to 1-day-forward window absorbs clock
+// skew and long-lived retention without risking a false miss.
+func (s *RedisServiceV2) describeClusterBackupList(instanceId string, clusterBackupId string) (map[string]interface{}, error) {
+	client := s.client
+	var response map[string]interface{}
+	var err error
+
+	query := map[string]interface{}{
+		"InstanceId": instanceId,
+		"RegionId":   client.RegionId,
+		"PageSize":   100,
+	}
+	now := time.Now().UTC()
+	query["StartTime"] = now.Add(-30 * 24 * time.Hour).Format("2006-01-02T15:04Z")
+	query["EndTime"] = now.Add(24 * time.Hour).Format("2006-01-02T15:04Z")
+	if clusterBackupId != "" {
+		query["ClusterBackupId"] = clusterBackupId
+	}
+	action := "DescribeClusterBackupList"
+
+	// DescribeClusterBackupList only accepts GET (RpcPost is rejected with 403
+	// UnsupportedHTTPMethod), so all parameters go in the query and the body is nil.
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcGet("R-kvstore", "2015-01-01", action, query, nil)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, query)
+	if err != nil {
+		return nil, WrapErrorf(err, DefaultErrorMsg, instanceId, action, AlibabaCloudSdkGoERROR)
+	}
+	return response, nil
+}
+
+// redisRpcList normalizes an R-kvstore RPC list field that may arrive either as a flat
+// JSON array or wrapped in a single-key object ({"<elementKey>": [...]}).
+func redisRpcList(v interface{}, elementKey string) []interface{} {
+	switch t := v.(type) {
+	case []interface{}:
+		return t
+	case map[string]interface{}:
+		if inner, ok := t[elementKey]; ok {
+			if list, ok := inner.([]interface{}); ok {
+				return list
+			}
+		}
+	}
+	return nil
+}
+
+// DescribeRedisClusterBackupId >>> Encapsulated.

--- a/website/docs/r/redis_backup.html.markdown
+++ b/website/docs/r/redis_backup.html.markdown
@@ -95,6 +95,7 @@ The following arguments are supported:
 The following attributes are exported:
 * `id` - The ID of the resource supplied above.The value is formulated as `<instance_id>:<backup_id>`.
 * `backup_id` - Backup ID.
+* `cluster_backup_id` - (Available since v1.286.0) The cluster backup set ID (`cb-*`) that this backup belongs to. Returned when the instance is a cluster-architecture instance; empty otherwise. It can be used as the `cluster_backup_id` of `alicloud_redis_tair_instance` to clone a cloud-native cluster instance.
 * `status` - Backup status.
 
 ## Timeouts


### PR DESCRIPTION
## Summary

Adds a computed `cluster_backup_id` attribute to `alicloud_redis_backup` so cloud-native cluster backups can be referenced (typically wired into `alicloud_redis_tair_instance.cluster_backup_id` to clone a cluster instance), and fixes a latent delete bug on cluster-architecture instances where only the state-recorded shard's backup was ever removed.

## Changes

### `cluster_backup_id` on Create
- New computed attribute on `alicloud_redis_backup`.
- Resolved from `DescribeClusterBackupList` right after `CreateBackup` by matching the recorded shard `BackupId` against each cluster backup set's per-shard `Backups`.
- Standalone instances legitimately have no cluster backup set — signalled by either an empty result *or* `InvalidClusterInstance.NotFound`. Both are treated as non-fatal and leave `cluster_backup_id` empty.
- Any other API error surfaces so downstream `alicloud_redis_tair_instance.cluster_backup_id = alicloud_redis_backup.default.cluster_backup_id` references cannot silently resolve to an empty string.

### Cluster fan-out on Delete
- R-kvstore has no cluster-level `DeleteClusterBackup` API, so previously Delete only removed the single shard `BackupId` in state, leaving the other shards' backups behind.
- When `cluster_backup_id` is set in state, Delete now looks up every shard `BackupId` in that cluster backup set via `ListClusterBackupShardIds` and calls `DeleteBackup` for each. Any per-shard failure returns an error (partial success = failure).
- Standalone / legacy state without `cluster_backup_id` takes the original single-shard path unchanged.
- `InvalidClusterInstance.NotFound` at Delete time is tolerated — the underlying cluster instance may already be gone.

### Shared helpers (new in `service_alicloud_redis_v2.go`)
- `DescribeRedisClusterBackupId(instanceId, backupId)` — backup → cluster set lookup (Create side).
- `ListClusterBackupShardIds(instanceId, clusterBackupId)` — cluster set → per-shard `BackupId` list (Delete side).
- `describeClusterBackupList(instanceId, clusterBackupId)` — common call, uses a wide UTC time window (`now-30d` to `now+1d`) because `StartTime`/`EndTime` are `Required` on this API even when `ClusterBackupId` is supplied.
- `redisRpcList` — normalizes an RPC list field that may arrive as a flat array or wrapped `{\"<Elem>\": [...]}`.

### Acc coverage
- `TestAccAliCloudRedisBackup_clusterDelete` — cluster instance (`shard_count=2`), captures `instance_id` + `cluster_backup_id` via closure at `Check` time; custom `CheckDestroy` re-queries the cluster set and fails if any shard backup survives.
- `TestAccAliCloudRedisTairInstance_cloneFromBackup` — end-to-end clone from a standalone backup via `backup_id`.
- `TestAccAliCloudRedisTairInstance_cloneFromClusterBackup` — end-to-end clone from a cluster backup set via `cluster_backup_id` resolved from `alicloud_redis_backup`.
- `TestAccAliCloudRedisBackup_basic11970` — `cluster_backup_id` added to `ImportStateVerifyIgnore` because it is legitimately empty on standalone.

### Docs
- Adds `cluster_backup_id` to `website/docs/r/redis_backup.html.markdown`.

## Test plan

- [ ] `TestAccAliCloudRedisBackup_basic11970` — 460s remote acc PASS
- [ ] `TestAccAliCloudRedisBackup_clusterDelete` — 773s remote acc PASS
- [ ] `TestAccAliCloudRedisTairInstance_cloneFromBackup` — 1524s remote acc PASS
- [ ] `TestAccAliCloudRedisTairInstance_cloneFromClusterBackup` — 1379s remote acc PASS