### PR TITLE
New Data Source: alicloud_cms_alert_rules_v2 (rename of alicloud_cms_alert_rule_v2s)

### DIFF
--- a/alicloud/data_source_alicloud_cms_alert_rules_v2.go
+++ b/alicloud/data_source_alicloud_cms_alert_rules_v2.go
@@ -14,9 +14,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
-func dataSourceAliCloudCmsAlertRuleV2s() *schema.Resource {
+func dataSourceAliCloudCmsAlertRulesV2() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAliCloudCmsAlertRuleV2Read,
+		Read: dataSourceAliCloudCmsAlertRulesV2Read,
 		Schema: map[string]*schema.Schema{
 			"ids": {
 				Type:     schema.TypeList,
@@ -100,7 +100,7 @@ func dataSourceAliCloudCmsAlertRuleV2s() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"v2s": {
+			"rules": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -729,7 +729,7 @@ func dataSourceAliCloudCmsAlertRuleV2s() *schema.Resource {
 	}
 }
 
-func dataSourceAliCloudCmsAlertRuleV2Read(d *schema.ResourceData, meta interface{}) error {
+func dataSourceAliCloudCmsAlertRulesV2Read(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 
 	var objects []map[string]interface{}
@@ -1341,7 +1341,7 @@ func dataSourceAliCloudCmsAlertRuleV2Read(d *schema.ResourceData, meta interface
 		return WrapError(err)
 	}
 
-	if err := d.Set("v2s", s); err != nil {
+	if err := d.Set("rules", s); err != nil {
 		return WrapError(err)
 	}
 

--- a/alicloud/data_source_alicloud_cms_alert_rules_v2_test.go
+++ b/alicloud/data_source_alicloud_cms_alert_rules_v2_test.go
@@ -10,82 +10,82 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-func TestAccAlicloudCmsAlertRuleV2DataSource(t *testing.T) {
+func TestAccAlicloudCmsAlertRulesV2DataSource(t *testing.T) {
 	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 	rand := acctest.RandIntRange(1000000, 9999999)
 
 	idsConf := dataSourceTestAccConfig{
-		existConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+		existConfig: testAccCheckAlicloudCmsAlertRulesV2SourceConfig(rand, map[string]string{
 			"ids": `["${alicloud_cms_alert_rule_v2.default.id}"]`,
 		}),
-		fakeConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+		fakeConfig: testAccCheckAlicloudCmsAlertRulesV2SourceConfig(rand, map[string]string{
 			"ids": `["${alicloud_cms_alert_rule_v2.default.id}_fake"]`,
 		}),
 	}
 
 	WorkspaceConf := dataSourceTestAccConfig{
-		existConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+		existConfig: testAccCheckAlicloudCmsAlertRulesV2SourceConfig(rand, map[string]string{
 			"ids":       `["${alicloud_cms_alert_rule_v2.default.id}"]`,
 			"workspace": `"default-cms-1511928242963727-cn-hangzhou"`,
 		}),
-		fakeConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+		fakeConfig: testAccCheckAlicloudCmsAlertRulesV2SourceConfig(rand, map[string]string{
 			"ids":       `["${alicloud_cms_alert_rule_v2.default.id}_fake"]`,
 			"workspace": `"default-cms-1511928242963727-cn-hangzhou"`,
 		}),
 	}
 
 	allConf := dataSourceTestAccConfig{
-		existConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+		existConfig: testAccCheckAlicloudCmsAlertRulesV2SourceConfig(rand, map[string]string{
 			"ids":       `["${alicloud_cms_alert_rule_v2.default.id}"]`,
 			"workspace": `"default-cms-1511928242963727-cn-hangzhou"`,
 		}),
-		fakeConfig: testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand, map[string]string{
+		fakeConfig: testAccCheckAlicloudCmsAlertRulesV2SourceConfig(rand, map[string]string{
 			"ids":       `["${alicloud_cms_alert_rule_v2.default.id}_fake"]`,
 			"workspace": `"default-cms-1511928242963727-cn-hangzhou"`,
 		}),
 	}
 
-	CmsAlertRuleV2CheckInfo.dataSourceTestCheck(t, rand, idsConf, WorkspaceConf, allConf)
+	CmsAlertRulesV2CheckInfo.dataSourceTestCheck(t, rand, idsConf, WorkspaceConf, allConf)
 }
 
-var existCmsAlertRuleV2MapFunc = func(rand int) map[string]string {
+var existCmsAlertRulesV2MapFunc = func(rand int) map[string]string {
 	return map[string]string{
-		"v2s.#":                               "1",
-		"v2s.0.created_at":                    CHECKSET,
-		"v2s.0.observe_resource_type":         CHECKSET,
-		"v2s.0.datasource_type":               CHECKSET,
-		"v2s.0.datasource_config.#":           CHECKSET,
-		"v2s.0.display_name":                  CHECKSET,
-		"v2s.0.notify_config.#":               CHECKSET,
-		"v2s.0.status":                        CHECKSET,
-		"v2s.0.observe_resource_global_scope": CHECKSET,
-		"v2s.0.action_integration_config.#":   CHECKSET,
-		"v2s.0.severity_levels":               CHECKSET,
-		"v2s.0.query_config.#":                CHECKSET,
-		"v2s.0.enabled":                       CHECKSET,
-		"v2s.0.alert_rule_v2_id":              CHECKSET,
-		"v2s.0.updated_at":                    CHECKSET,
-		"v2s.0.content_template":              CHECKSET,
-		"v2s.0.schedule_config.#":             CHECKSET,
-		"v2s.0.arms_integration_config.#":     CHECKSET,
-		"v2s.0.condition_config.#":            CHECKSET,
-		"v2s.0.workspace":                     CHECKSET,
+		"rules.#":                               "1",
+		"rules.0.created_at":                    CHECKSET,
+		"rules.0.observe_resource_type":         CHECKSET,
+		"rules.0.datasource_type":               CHECKSET,
+		"rules.0.datasource_config.#":           CHECKSET,
+		"rules.0.display_name":                  CHECKSET,
+		"rules.0.notify_config.#":               CHECKSET,
+		"rules.0.status":                        CHECKSET,
+		"rules.0.observe_resource_global_scope": CHECKSET,
+		"rules.0.action_integration_config.#":   CHECKSET,
+		"rules.0.severity_levels":               CHECKSET,
+		"rules.0.query_config.#":                CHECKSET,
+		"rules.0.enabled":                       CHECKSET,
+		"rules.0.alert_rule_v2_id":              CHECKSET,
+		"rules.0.updated_at":                    CHECKSET,
+		"rules.0.content_template":              CHECKSET,
+		"rules.0.schedule_config.#":             CHECKSET,
+		"rules.0.arms_integration_config.#":     CHECKSET,
+		"rules.0.condition_config.#":            CHECKSET,
+		"rules.0.workspace":                     CHECKSET,
 	}
 }
 
-var fakeCmsAlertRuleV2MapFunc = func(rand int) map[string]string {
+var fakeCmsAlertRulesV2MapFunc = func(rand int) map[string]string {
 	return map[string]string{
-		"v2s.#": "0",
+		"rules.#": "0",
 	}
 }
 
-var CmsAlertRuleV2CheckInfo = dataSourceAttr{
-	resourceId:   "data.alicloud_cms_alert_rule_v2s.default",
-	existMapFunc: existCmsAlertRuleV2MapFunc,
-	fakeMapFunc:  fakeCmsAlertRuleV2MapFunc,
+var CmsAlertRulesV2CheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_cms_alert_rules_v2.default",
+	existMapFunc: existCmsAlertRulesV2MapFunc,
+	fakeMapFunc:  fakeCmsAlertRulesV2MapFunc,
 }
 
-func testAccCheckAlicloudCmsAlertRuleV2SourceConfig(rand int, attrMap map[string]string) string {
+func testAccCheckAlicloudCmsAlertRulesV2SourceConfig(rand int, attrMap map[string]string) string {
 	var pairs []string
 	for k, v := range attrMap {
 		pairs = append(pairs, k+" = "+v)
@@ -147,7 +147,7 @@ resource "alicloud_cms_alert_rule_v2" "default" {
   workspace = "default-cms-1511928242963727-cn-hangzhou"
 }
 
-data "alicloud_cms_alert_rule_v2s" "default" {
+data "alicloud_cms_alert_rules_v2" "default" {
 %s
 }
 `, rand, strings.Join(pairs, "\n   "))

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -175,7 +175,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_express_connect_router_tr_associations":     dataSourceAliCloudExpressConnectRouterTrAssociations(),
 			"alicloud_express_connect_router_vbr_child_instances": dataSourceAliCloudExpressConnectRouterVbrChildInstances(),
 			"alicloud_cr_artifact_lifecycle_rules":                dataSourceAliCloudCrArtifactLifecycleRules(),
-			"alicloud_cms_alert_rule_v2s":                         dataSourceAliCloudCmsAlertRuleV2s(),
+			"alicloud_cms_alert_rules_v2":                         dataSourceAliCloudCmsAlertRulesV2(),
 			"alicloud_oss_bucket_inventories":                     dataSourceAliCloudOssBucketInventories(),
 			"alicloud_wafv3_address_books":                        dataSourceAliCloudWafv3AddressBooks(),
 			"alicloud_wafv3_defense_rules":                        dataSourceAliCloudWafv3DefenseRules(),

--- a/website/docs/d/cms_alert_rules_v2.html.markdown
+++ b/website/docs/d/cms_alert_rules_v2.html.markdown
@@ -1,13 +1,13 @@
 ---
 subcategory: "Cms"
 layout: "alicloud"
-page_title: "Alicloud: alicloud_cms_alert_rule_v2s"
-sidebar_current: "docs-alicloud-datasource-cms-alert-rule-v2s"
+page_title: "Alicloud: alicloud_cms_alert_rules_v2"
+sidebar_current: "docs-alicloud-datasource-cms-alert-rules-v2"
 description: |-
   Provides a list of Cms Alert Rule V2 owned by an Alibaba Cloud account.
 ---
 
-# alicloud_cms_alert_rule_v2s
+# alicloud_cms_alert_rules_v2
 
 This data source provides Cms Alert Rule V2 available to the user.[What is Alert Rule V2](https://next.api.alibabacloud.com/document/Cms/2024-03-30/ManageAlertRules)
 
@@ -75,12 +75,12 @@ resource "alicloud_cms_alert_rule_v2" "default" {
   }
 }
 
-data "alicloud_cms_alert_rule_v2s" "default" {
+data "alicloud_cms_alert_rules_v2" "default" {
   ids = ["${alicloud_cms_alert_rule_v2.default.id}"]
 }
 
 output "alicloud_cms_alert_rule_v2_example_id" {
-  value = data.alicloud_cms_alert_rule_v2s.default.v2s.0.id
+  value = data.alicloud_cms_alert_rules_v2.default.rules.0.id
 }
 ```
 
@@ -114,7 +114,7 @@ The following arguments are supported:
 
 The following attributes are exported in addition to the arguments listed above:
 * `ids` - A list of Alert Rule V2 IDs.
-* `v2s` - A list of Alert Rule V2 Entries. Each element contains the following attributes:
+* `rules` - A list of Alert Rule V2 Entries. Each element contains the following attributes:
     * `action_integration_config` - Action integration configuration.
         * `actions` - List of actions.
         * `enabled` - Indicates whether action integration is enabled.


### PR DESCRIPTION
Rename the recently added, not-yet-released data source `alicloud_cms_alert_rule_v2s` to `alicloud_cms_alert_rules_v2`, and rename its collection attribute from `v2s` to `rules`.

The previous names pluralized the version suffix (`rule_v2s` / `v2s`), which reads awkwardly. The new names align with the singular resource `alicloud_cms_alert_rule_v2` and with the provider's data source conventions (`alert_rules_v2` + a `rules` list).

No behavior change: the schema structure, filters, and API mappings are identical — only the data source type name and the output collection attribute are renamed.

Acceptance test result:

```
=== RUN   TestAccAlicloudCmsAlertRulesV2DataSource
--- PASS: TestAccAlicloudCmsAlertRulesV2DataSource (15.48s)
PASS
```
