### PR TITLE
resource/alicloud_ecs_launch_template: validate http_put_response_hop_limit range 1-64

### DIFF
--- a/alicloud/resource_alicloud_ecs_launch_template.go
+++ b/alicloud/resource_alicloud_ecs_launch_template.go
@@ -401,9 +401,10 @@ func resourceAliCloudEcsLaunchTemplate() *schema.Resource {
 				Computed: true,
 			},
 			"http_put_response_hop_limit": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(1, 64),
 			},
 			"image_options": {
 				Type:     schema.TypeList,
@@ -773,7 +774,7 @@ func resourceAliCloudEcsLaunchTemplateCreate(d *schema.ResourceData, meta interf
 		request["HttpTokens"] = v
 	}
 
-	if v, ok := d.GetOkExists("http_put_response_hop_limit"); ok {
+	if v, ok := d.GetOkExists("http_put_response_hop_limit"); ok && v.(int) > 0 {
 		request["HttpPutResponseHopLimit"] = v
 	}
 
@@ -1351,7 +1352,7 @@ func resourceAliCloudEcsLaunchTemplateUpdate(d *schema.ResourceData, meta interf
 	if d.HasChange("http_put_response_hop_limit") {
 		update = true
 	}
-	if v, ok := d.GetOkExists("http_put_response_hop_limit"); ok {
+	if v, ok := d.GetOkExists("http_put_response_hop_limit"); ok && v.(int) > 0 {
 		request["HttpPutResponseHopLimit"] = v
 	}
 

--- a/website/docs/r/ecs_launch_template.html.markdown
+++ b/website/docs/r/ecs_launch_template.html.markdown
@@ -181,7 +181,9 @@ The following arguments are supported:
   - optional: Not mandatory.
   - required: Mandatory. After this value is set, the normal mode cannot access instance metadata.
 **NOTE:** From version 1.260.0, `http_tokens` can be modified.
-* `http_put_response_hop_limit` - (Optional, ForceNew) The HTTP PUT response hop limit required for instance metadata requests. **NOTE:** From version 1.260.0, `http_put_response_hop_limit` can be modified.
+* `http_put_response_hop_limit` - (Optional, ForceNew) The HTTP PUT response hop limit required for instance metadata requests. Valid values: `1` to `64`.
+
+  -> **NOTE:** From version 1.260.0, `http_put_response_hop_limit` can be modified.
 * `tags` - (Optional) A mapping of tags to assign to instance, block storage, and elastic network.
     - Key: It can be up to 64 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It cannot be a null string.
     - Value: It can be up to 128 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It can be a null string.


### PR DESCRIPTION
Add IntBetween(1, 64) validation and guard create/update so a default 0 is not sent to the API.

```log
=== RUN   TestAccAliCloudECSLaunchTemplateBasic
  --- PASS: TestAccAliCloudECSLaunchTemplateBasic (451.87s)
  === RUN   TestAccAliCloudECSLaunchTemplateBasic1
  --- PASS: TestAccAliCloudECSLaunchTemplateBasic1 (89.84s)
  === RUN   TestAccAliCloudECSLaunchTemplateBasic2
  --- PASS: TestAccAliCloudECSLaunchTemplateBasic2 (41.02s)
  PASS
  ok  github.com/aliyun/terraform-provider-alicloud/alicloud  582.946s

  === RUN   TestAccAliCloudECSLaunchTemplateMulti
  --- PASS: TestAccAliCloudECSLaunchTemplateMulti (47.79s)
  PASS
  ok  github.com/aliyun/terraform-provider-alicloud/alicloud  47.960s
```