### PR TITLE
New Resource: alicloud_apig_plugin; New Data Source: alicloud_apig_plugins

### DIFF
--- a/alicloud/data_source_alicloud_apig_plugins.go
+++ b/alicloud/data_source_alicloud_apig_plugins.go
@@ -1,0 +1,199 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudApigPlugins() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudApigPluginRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"plugin_class_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"plugin_class_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"plugins": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"plugin_class_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"plugin_class_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"plugin_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudApigPluginRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListPlugins
+	action := fmt.Sprintf("/v1/plugins")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	if v, ok := d.GetOk("gateway_id"); ok {
+		query["gatewayId"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("plugin_class_id"); ok {
+		query["pluginClassId"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("plugin_class_name"); ok {
+		query["pluginClassName"] = StringPointer(v.(string))
+	}
+
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	query["pageSize"] = StringPointer(strconv.Itoa(PageSizeLarge))
+	query["pageNumber"] = StringPointer("1")
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaGet("APIG", "2024-03-27", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.data.items[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["pluginId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		pageNum, _ := strconv.Atoi(*query["pageNumber"])
+		query["pageNumber"] = StringPointer(strconv.Itoa(pageNum + 1))
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["pluginId"]
+
+		mapping["plugin_id"] = objectRaw["pluginId"]
+
+		gatewayInfoRawObj, _ := jsonpath.Get("$.gatewayInfo", objectRaw)
+		gatewayInfoRaw := make(map[string]interface{})
+		if gatewayInfoRawObj != nil {
+			gatewayInfoRaw = gatewayInfoRawObj.(map[string]interface{})
+		}
+		mapping["gateway_name"] = gatewayInfoRaw["name"]
+		mapping["gateway_id"] = gatewayInfoRaw["gatewayId"]
+
+		pluginClassInfoRawObj, _ := jsonpath.Get("$.pluginClassInfo", objectRaw)
+		pluginClassInfoRaw := make(map[string]interface{})
+		if pluginClassInfoRawObj != nil {
+			pluginClassInfoRaw = pluginClassInfoRawObj.(map[string]interface{})
+		}
+		mapping["plugin_class_name"] = pluginClassInfoRaw["name"]
+		mapping["plugin_class_id"] = pluginClassInfoRaw["pluginClassId"]
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("plugins", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_apig_plugins_test.go
+++ b/alicloud/data_source_alicloud_apig_plugins_test.go
@@ -1,0 +1,139 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudApigPluginDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudApigPluginSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_apig_plugin.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudApigPluginSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_apig_plugin.default.id}_fake"]`,
+		}),
+	}
+
+	PluginClassIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudApigPluginSourceConfig(rand, map[string]string{
+			"ids":             `["${alicloud_apig_plugin.default.id}"]`,
+			"plugin_class_id": `"pls-crpqb35lhtgo800k2m86"`,
+		}),
+		fakeConfig: testAccCheckAlicloudApigPluginSourceConfig(rand, map[string]string{
+			"ids":             `["${alicloud_apig_plugin.default.id}_fake"]`,
+			"plugin_class_id": `"pls-crpqb35lhtgo800k2m86_fake"`,
+		}),
+	}
+	GatewayIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudApigPluginSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_apig_plugin.default.id}"]`,
+			"gateway_id": `"${alicloud_apig_gateway.plugin_gateway_pre.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudApigPluginSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_apig_plugin.default.id}_fake"]`,
+			"gateway_id": `"${alicloud_apig_gateway.plugin_gateway_pre.id}_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudApigPluginSourceConfig(rand, map[string]string{
+			"ids":             `["${alicloud_apig_plugin.default.id}"]`,
+			"plugin_class_id": `"pls-crpqb35lhtgo800k2m86"`,
+
+			"gateway_id": `"${alicloud_apig_gateway.plugin_gateway_pre.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudApigPluginSourceConfig(rand, map[string]string{
+			"ids":             `["${alicloud_apig_plugin.default.id}_fake"]`,
+			"plugin_class_id": `"pls-crpqb35lhtgo800k2m86_fake"`,
+
+			"gateway_id": `"${alicloud_apig_gateway.plugin_gateway_pre.id}_fake"`,
+		}),
+	}
+
+	ApigPluginCheckInfo.dataSourceTestCheck(t, rand, idsConf, PluginClassIdConf, GatewayIdConf, allConf)
+}
+
+var existApigPluginMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"plugins.#":                   "1",
+		"plugins.0.plugin_class_name": CHECKSET,
+		"plugins.0.gateway_name":      CHECKSET,
+		"plugins.0.plugin_id":         CHECKSET,
+	}
+}
+
+var fakeApigPluginMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"plugins.#": "0",
+	}
+}
+
+var ApigPluginCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_apig_plugins.default",
+	existMapFunc: existApigPluginMapFunc,
+	fakeMapFunc:  fakeApigPluginMapFunc,
+}
+
+func testAccCheckAlicloudApigPluginSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccApigPlugin%d"
+}
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_apig_gateway" "plugin_gateway_pre" {
+  network_access_config {
+    type = "Internet"
+  }
+  vswitch {
+    vswitch_id = data.alicloud_vswitches.default.ids.0
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = data.alicloud_vpcs.default.ids.0
+  }
+  gateway_type = "API"
+  payment_type = "PayAsYouGo"
+  gateway_name = var.name
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = true
+    }
+  }
+}
+
+
+
+resource "alicloud_apig_plugin" "default" {
+  plugin_class_id = "pls-crpqb35lhtgo800k2m86"
+  gateway_id      = alicloud_apig_gateway.plugin_gateway_pre.id
+}
+
+data "alicloud_apig_plugins" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"alicloud_apig_gateways":                              dataSourceAliCloudApigGateways(),
+			"alicloud_apig_plugins":                               dataSourceAliCloudApigPlugins(),
 			"alicloud_express_connect_router_vpc_associations":    dataSourceAliCloudExpressConnectRouterVpcAssociations(),
 			"alicloud_express_connect_router_tr_associations":     dataSourceAliCloudExpressConnectRouterTrAssociations(),
 			"alicloud_express_connect_router_vbr_child_instances": dataSourceAliCloudExpressConnectRouterVbrChildInstances(),
@@ -937,6 +938,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_apig_plugin":                                          resourceAliCloudApigPlugin(),
 			"alicloud_apig_plugin_class":                                    resourceAliCloudApigPluginClass(),
 			"alicloud_cr_artifact_lifecycle_rule":                           resourceAliCloudCrArtifactLifecycleRule(),
 			"alicloud_das_sql_log_config":                                   resourceAliCloudDasSqlLogConfig(),

--- a/alicloud/resource_alicloud_apig_plugin.go
+++ b/alicloud/resource_alicloud_apig_plugin.go
@@ -1,0 +1,161 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudApigPlugin() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudApigPluginCreate,
+		Read:   resourceAliCloudApigPluginRead,
+		Delete: resourceAliCloudApigPluginDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"gateway_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"plugin_class_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"plugin_class_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudApigPluginCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/v1/plugins/")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["pluginClassId"] = d.Get("plugin_class_id")
+	if v, ok := d.GetOk("gateway_id"); ok {
+		localData, _ := jsonpath.Get("$", v)
+		gatewayIdsMapsArray := convertToInterfaceArray(localData)
+
+		request["gatewayIds"] = gatewayIdsMapsArray
+	}
+
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("APIG", "2024-03-27", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_apig_plugin", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.data.installPluginResults[0].pluginId", response)
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudApigPluginRead(d, meta)
+}
+
+func resourceAliCloudApigPluginRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	apigServiceV2 := ApigServiceV2{client}
+
+	objectRaw, err := apigServiceV2.DescribeApigPlugin(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_apig_plugin DescribeApigPlugin Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	gatewayInfoRawObj, _ := jsonpath.Get("$.gatewayInfo", objectRaw)
+	gatewayInfoRaw := make(map[string]interface{})
+	if gatewayInfoRawObj != nil {
+		gatewayInfoRaw = gatewayInfoRawObj.(map[string]interface{})
+	}
+	d.Set("gateway_name", gatewayInfoRaw["name"])
+	d.Set("gateway_id", gatewayInfoRaw["gatewayId"])
+
+	pluginClassInfoRawObj, _ := jsonpath.Get("$.pluginClassInfo", objectRaw)
+	pluginClassInfoRaw := make(map[string]interface{})
+	if pluginClassInfoRawObj != nil {
+		pluginClassInfoRaw = pluginClassInfoRawObj.(map[string]interface{})
+	}
+	d.Set("plugin_class_name", pluginClassInfoRaw["name"])
+	d.Set("plugin_class_id", pluginClassInfoRaw["pluginClassId"])
+
+	return nil
+}
+
+func resourceAliCloudApigPluginDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	pluginId := d.Id()
+	action := fmt.Sprintf("/v1/plugins/%s", pluginId)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("APIG", "2024-03-27", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_apig_plugin_test.go
+++ b/alicloud/resource_alicloud_apig_plugin_test.go
@@ -1,0 +1,104 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Apig Plugin. >>> Resource test cases, automatically generated.
+// Case plugin_basic_test 12943
+func TestAccAliCloudApigPlugin_basic12943(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_plugin.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigPluginMap12943)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigPlugin")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccapig%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigPluginBasicDependence12943)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"plugin_class_id": "pls-crpqb35lhtgo800k2m86",
+					"gateway_id":      "${alicloud_apig_gateway.plugin_gateway_pre.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"plugin_class_id": "pls-crpqb35lhtgo800k2m86",
+						"gateway_id":      CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudApigPluginMap12943 = map[string]string{
+	"plugin_class_name": CHECKSET,
+	"gateway_name":      CHECKSET,
+}
+
+func AlicloudApigPluginBasicDependence12943(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_apig_gateway" "plugin_gateway_pre" {
+  network_access_config {
+    type = "Internet"
+  }
+  vswitch {
+    vswitch_id = data.alicloud_vswitches.default.ids.0
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = data.alicloud_vpcs.default.ids.0
+  }
+  gateway_type = "API"
+  payment_type = "PayAsYouGo"
+  gateway_name = var.name
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = true
+    }
+  }
+}
+
+
+`, name)
+}
+
+// Test Apig Plugin. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_apig_v2.go
+++ b/alicloud/service_alicloud_apig_v2.go
@@ -495,61 +495,77 @@ func (s *ApigServiceV2) DescribeApigPlugin(id string) (object map[string]interfa
 	var request map[string]interface{}
 	var response map[string]interface{}
 	var query map[string]*string
-	action := fmt.Sprintf("/v1/plugins")
 	request = make(map[string]interface{})
 	query = make(map[string]*string)
 
-	wait := incrementalWait(3*time.Second, 5*time.Second)
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		response, err = client.RoaGet("APIG", "2024-03-27", action, query, nil, nil)
+	action := fmt.Sprintf("/v1/plugins")
 
-		if err != nil {
-			if NeedRetry(err) {
-				wait()
-				return resource.RetryableError(err)
+	pageNumber := 1
+	query["pageSize"] = StringPointer(fmt.Sprintf("%d", PageSizeLarge))
+	query["pageNumber"] = StringPointer(fmt.Sprintf("%d", pageNumber))
+
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			response, err = client.RoaGet("APIG", "2024-03-27", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
 			}
-			return resource.NonRetryableError(err)
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
 		}
-		return nil
-	})
-	addDebug(action, response, request)
-	if err != nil {
-		if IsExpectedErrors(err, []string{"DatabaseError.RecordNotFound"}) {
-			return object, WrapErrorf(NotFoundErr("Plugin", id), NotFoundMsg, err)
+		if response == nil {
+			return object, WrapErrorf(NotFoundErr("Plugin", id), NotFoundMsg, response)
 		}
-		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+		code, _ := jsonpath.Get("$.code", response)
+		if InArray(fmt.Sprint(code), []string{"DatabaseError.RecordNotFound"}) {
+			return object, WrapErrorf(NotFoundErr("Plugin", id), NotFoundMsg, response)
+		}
+
+		v, err := jsonpath.Get("$.data.items[*]", response)
+		if err != nil {
+			return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.data.items[*]", response)
+		}
+
+		result, _ := v.([]interface{})
+		for _, vv := range result {
+			item := vv.(map[string]interface{})
+			if fmt.Sprint(item["pluginId"]) == id {
+				return item, nil
+			}
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		pageNumber += 1
+		query["pageNumber"] = StringPointer(fmt.Sprintf("%d", pageNumber))
 	}
 
-	v, err := jsonpath.Get("$.data.items[*]", response)
-	if err != nil {
-		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.data.items[*]", response)
-	}
-
-	if len(v.([]interface{})) == 0 {
-		return object, WrapErrorf(NotFoundErr("Plugin", id), NotFoundMsg, response)
-	}
-
-	result, _ := v.([]interface{})
-	for _, v := range result {
-		item := v.(map[string]interface{})
-		if fmt.Sprint(item["pluginId"]) != id {
-			continue
-		}
-		return item, nil
-	}
 	return object, WrapErrorf(NotFoundErr("Plugin", id), NotFoundMsg, response)
 }
 
 func (s *ApigServiceV2) ApigPluginStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ApigPluginStateRefreshFuncWithApi(id, field, failStates, s.DescribeApigPlugin)
+}
+
+func (s *ApigServiceV2) ApigPluginStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		object, err := s.DescribeApigPlugin(id)
+		object, err := call(id)
 		if err != nil {
 			if NotFoundError(err) {
 				return object, "", nil
 			}
 			return nil, "", WrapError(err)
 		}
-
 		v, err := jsonpath.Get(field, object)
 		currentStatus := fmt.Sprint(v)
 

--- a/website/docs/d/apig_plugins.html.markdown
+++ b/website/docs/d/apig_plugins.html.markdown
@@ -1,0 +1,102 @@
+---
+subcategory: "Cloud Native API Gateway (APIG)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_apig_plugins"
+sidebar_current: "docs-alicloud-datasource-apig-plugins"
+description: |-
+  Provides a list of Apig Plugin owned by an Alibaba Cloud account.
+---
+
+# alicloud_apig_plugins
+
+This data source provides Apig Plugin available to the user.[What is Plugin](https://next.api.alibabacloud.com/document/APIG/2024-03-27/InstallPlugin)
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_vpc" "plugin_vpc_pre" {
+  is_default = false
+  cidr_block = "10.0.0.0/8"
+  vpc_name   = "plugin-example-vpc"
+}
+
+resource "alicloud_vswitch" "plugin_vswitch_pre" {
+  is_default   = false
+  vpc_id       = alicloud_vpc.plugin_vpc_pre.id
+  zone_id      = "cn-hangzhou-i"
+  cidr_block   = "10.0.0.0/24"
+  vswitch_name = "plugin-example-vswitch"
+}
+
+resource "alicloud_apig_gateway" "plugin_gateway_pre" {
+  network_access_config {
+    type = "Internet"
+  }
+  vswitch {
+    vswitch_id = alicloud_vswitch.plugin_vswitch_pre.id
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = alicloud_vpc.plugin_vpc_pre.id
+  }
+  gateway_type = "API"
+  payment_type = "PayAsYouGo"
+  gateway_name = "plugin-example-gateway"
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = true
+    }
+  }
+}
+
+
+resource "alicloud_apig_plugin" "default" {
+  plugin_class_id = "pls-crpqb35lhtgo800k2m86"
+  gateway_id      = alicloud_apig_gateway.plugin_gateway_pre.id
+}
+
+data "alicloud_apig_plugins" "default" {
+  ids             = ["${alicloud_apig_plugin.default.id}"]
+  gateway_id      = alicloud_apig_gateway.plugin_gateway_pre.id
+  plugin_class_id = "pls-crpqb35lhtgo800k2m86"
+}
+
+output "alicloud_apig_plugin_example_id" {
+  value = data.alicloud_apig_plugins.default.plugins.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `gateway_id` - (ForceNew, Optional) The filter parameter for the gateway instance ID.
+* `plugin_class_id` - (ForceNew, Optional) The plugin class ID.
+* `plugin_class_name` - (ForceNew, Optional) The filter parameter for the plugin class name.
+* `ids` - (Optional, Computed) A list of Plugin IDs. 
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Plugin IDs.
+* `plugins` - A list of Plugin Entries. Each element contains the following attributes:
+    * `gateway_id` - The filter parameter for the gateway instance ID.
+    * `gateway_name` - The gateway name.
+    * `plugin_class_id` - The plugin class ID.
+    * `plugin_class_name` - The filter parameter for the plugin class name.
+    * `plugin_id` - The plugin ID.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/apig_plugin.html.markdown
+++ b/website/docs/r/apig_plugin.html.markdown
@@ -1,0 +1,108 @@
+---
+subcategory: "Cloud Native API Gateway (APIG)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_apig_plugin"
+description: |-
+  Provides a Alicloud APIG Plugin resource.
+---
+
+# alicloud_apig_plugin
+
+Provides a APIG Plugin resource.
+
+
+
+For information about APIG Plugin and how to use it, see [What is Plugin](https://next.api.alibabacloud.com/document/APIG/2024-03-27/InstallPlugin).
+
+-> **NOTE:** Available since v1.286.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_vpc" "plugin_vpc_pre" {
+  is_default = false
+  cidr_block = "10.0.0.0/8"
+  vpc_name   = "plugin-example-vpc"
+}
+
+resource "alicloud_vswitch" "plugin_vswitch_pre" {
+  is_default   = false
+  vpc_id       = alicloud_vpc.plugin_vpc_pre.id
+  zone_id      = "cn-hangzhou-i"
+  cidr_block   = "10.0.0.0/24"
+  vswitch_name = "plugin-example-vswitch"
+}
+
+resource "alicloud_apig_gateway" "plugin_gateway_pre" {
+  network_access_config {
+    type = "Internet"
+  }
+  vswitch {
+    vswitch_id = alicloud_vswitch.plugin_vswitch_pre.id
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = alicloud_vpc.plugin_vpc_pre.id
+  }
+  gateway_type = "API"
+  payment_type = "PayAsYouGo"
+  gateway_name = "plugin-example-gateway"
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = true
+    }
+  }
+}
+
+
+resource "alicloud_apig_plugin" "default" {
+  plugin_class_id = "pls-crpqb35lhtgo800k2m86"
+  gateway_id      = alicloud_apig_gateway.plugin_gateway_pre.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `gateway_id` - (Required, ForceNew) The filter parameter for the gateway instance ID.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `plugin_class_id` - (Required, ForceNew) The plugin class ID.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+* `gateway_name` - The gateway name.
+* `plugin_class_name` - The filter parameter for the plugin class name.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Plugin.
+* `delete` - (Defaults to 5 mins) Used when delete the Plugin.
+
+## Import
+
+APIG Plugin can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_apig_plugin.example <plugin_id>
+```


### PR DESCRIPTION
Add a new resource `alicloud_apig_plugin` and data source `alicloud_apig_plugins` for Cloud Native API Gateway (APIG). The resource installs a plugin (identified by `plugin_class_id`) onto an APIG gateway; the data source lists installed plugins with filtering by gateway and plugin class.

Acceptance tests (cn-hangzhou):

```
=== RUN   TestAccAliCloudApigPlugin_basic12943
--- PASS: TestAccAliCloudApigPlugin_basic12943 (266.83s)

=== RUN   TestAccAlicloudApigPluginDataSource
--- PASS: TestAccAlicloudApigPluginDataSource (370.02s)
```
