### PR TITLE
resource/alicloud_cloud_firewall_address_book: Supported group_type set to asset, assetIpv6; Added the field asset_member_uids, asset_region_resource_types, address_list_count, reference_count; data-source/alicloud_cloud_firewall_address_books: Added the field asset_member_uids, asset_region_resource_types, address_list_count, reference_count

### DIFF
--- a/alicloud/data_source_alicloud_cloud_firewall_address_books.go
+++ b/alicloud/data_source_alicloud_cloud_firewall_address_books.go
@@ -30,7 +30,7 @@ func dataSourceAliCloudCloudFirewallAddressBooks() *schema.Resource {
 			"group_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: StringInSlice([]string{"ip", "ipv6", "domain", "port", "tag"}, false),
+				ValidateFunc: StringInSlice([]string{"ip", "ipv6", "domain", "port", "tag", "asset", "assetIpv6"}, false),
 			},
 			"output_file": {
 				Type:     schema.TypeString,
@@ -94,6 +94,155 @@ func dataSourceAliCloudCloudFirewallAddressBooks() *schema.Resource {
 									},
 								},
 							},
+						},
+						"asset_member_uids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+						},
+						"asset_region_resource_types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"asset_region_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"resource_type": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"ipv4": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"eip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"ecs_eip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"ecs_public_ip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"slb_eip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"slb_public_ip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"nlb_eip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"alb_eip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"nat_eip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"nat_public_ip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"eni_eip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"ga_eip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"api_gateway_eip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"ai_gateway_eip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"bastion_host_ip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"bastion_host_ingress_ip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"bastion_host_egress_ip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"havip": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"ipv6": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"ecs_ipv6": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"slb_ipv6": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"nlb_ipv6": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"alb_ipv6": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"eni_eipv6": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"ga_eipv6": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"api_gateway_eipv6": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"ai_gateway_eipv6": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"address_list_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"reference_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
 						},
 					},
 				},
@@ -213,6 +362,24 @@ func dataSourceAliCloudCloudFirewallAddressBooksRead(d *schema.ResourceData, met
 		}
 
 		mapping["ecs_tags"] = ecsTags
+
+		assetMemberUids := make([]int, 0)
+		if v, ok := object["AssetMemberUids"].([]interface{}); ok {
+			for _, assetMemberUid := range v {
+				assetMemberUids = append(assetMemberUids, formatInt(assetMemberUid))
+			}
+		}
+
+		mapping["asset_member_uids"] = assetMemberUids
+		mapping["asset_region_resource_types"] = flattenCloudFirewallAddressBookAssetRegionResourceTypes(object["AssetRegionResourceTypes"])
+
+		if v, ok := object["AddressListCount"]; ok {
+			mapping["address_list_count"] = formatInt(v)
+		}
+
+		if v, ok := object["ReferenceCount"]; ok {
+			mapping["reference_count"] = formatInt(v)
+		}
 
 		ids = append(ids, fmt.Sprint(mapping["id"]))
 		names = append(names, object["GroupName"])

--- a/alicloud/data_source_alicloud_cloud_firewall_address_books_test.go
+++ b/alicloud/data_source_alicloud_cloud_firewall_address_books_test.go
@@ -83,6 +83,118 @@ func TestAccAliCloudCloudFirewallAddressBooksDataSource(t *testing.T) {
 	alicloudCloudFirewallAddressBooksCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, idsConf, nameRegexConf, groupTypePortConf, allConf)
 }
 
+func TestAccAliCloudCloudFirewallAddressBooksDataSource_assetType(t *testing.T) {
+	rand := acctest.RandInt()
+	checkoutSupportedRegions(t, true, connectivity.CloudFirewallSupportRegions)
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudCloudFirewallAddressBooksDataSourceAssetType(rand, map[string]string{
+			"ids":        `["${alicloud_cloud_firewall_address_book.default.id}"]`,
+			"group_type": `"asset"`,
+		}),
+		fakeConfig: testAccCheckAliCloudCloudFirewallAddressBooksDataSourceAssetType(rand, map[string]string{
+			"ids":        `["${alicloud_cloud_firewall_address_book.default.id}_fake"]`,
+			"group_type": `"asset"`,
+		}),
+	}
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudCloudFirewallAddressBooksDataSourceAssetType(rand, map[string]string{
+			"ids":        `["${alicloud_cloud_firewall_address_book.default.id}"]`,
+			"name_regex": `"${alicloud_cloud_firewall_address_book.default.group_name}"`,
+			"group_type": `"asset"`,
+		}),
+		fakeConfig: testAccCheckAliCloudCloudFirewallAddressBooksDataSourceAssetType(rand, map[string]string{
+			"ids":        `["${alicloud_cloud_firewall_address_book.default.id}_fake"]`,
+			"name_regex": `"${alicloud_cloud_firewall_address_book.default.group_name}_fake"`,
+			"group_type": `"asset"`,
+		}),
+	}
+	var existAliCloudCloudFirewallAddressBooksDataSourceNameMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":                                 "1",
+			"names.#":                               "1",
+			"books.#":                               "1",
+			"books.0.id":                            CHECKSET,
+			"books.0.group_uuid":                    CHECKSET,
+			"books.0.group_name":                    CHECKSET,
+			"books.0.group_type":                    "asset",
+			"books.0.description":                   CHECKSET,
+			"books.0.address_list_count":            CHECKSET,
+			"books.0.reference_count":               CHECKSET,
+			"books.0.asset_region_resource_types.#": "1",
+			"books.0.asset_region_resource_types.0.asset_region_id":                        "all",
+			"books.0.asset_region_resource_types.0.resource_type.#":                        "1",
+			"books.0.asset_region_resource_types.0.resource_type.0.ipv4.#":                 "1",
+			"books.0.asset_region_resource_types.0.resource_type.0.ipv4.0.bastion_host_ip": "true",
+			"books.0.asset_region_resource_types.0.resource_type.0.ipv4.0.havip":           "true",
+			"books.0.asset_region_resource_types.0.resource_type.0.ipv4.0.eip":             "false",
+		}
+	}
+	var fakeAliCloudCloudFirewallAddressBooksDataSourceNameMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":   "0",
+			"names.#": "0",
+			"books.#": "0",
+		}
+	}
+	var alicloudCloudFirewallAddressBooksCheckInfo = dataSourceAttr{
+		resourceId:   "data.alicloud_cloud_firewall_address_books.default",
+		existMapFunc: existAliCloudCloudFirewallAddressBooksDataSourceNameMapFunc,
+		fakeMapFunc:  fakeAliCloudCloudFirewallAddressBooksDataSourceNameMapFunc,
+	}
+	preCheck := func() {
+		testAccPreCheck(t)
+	}
+	alicloudCloudFirewallAddressBooksCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, idsConf, allConf)
+}
+
+func testAccCheckAliCloudCloudFirewallAddressBooksDataSourceAssetType(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+
+	config := fmt.Sprintf(`
+	variable "name" {
+  		default = "tf-testAccAddressBookAsset-%d"
+	}
+
+	resource "alicloud_cloud_firewall_address_book" "default" {
+  		group_name  = var.name
+  		group_type  = "asset"
+  		description = "tf-testAccAddressBookAsset"
+  		asset_region_resource_types {
+    		asset_region_id = "all"
+    		resource_type {
+      		ipv4 {
+        		eip                     = false
+        		ecs_eip                 = false
+        		ecs_public_ip           = false
+        		slb_eip                 = false
+        		slb_public_ip           = false
+        		nlb_eip                 = false
+        		alb_eip                 = false
+        		nat_eip                 = false
+        		nat_public_ip           = false
+        		eni_eip                 = false
+        		ga_eip                  = false
+        		api_gateway_eip         = false
+        		ai_gateway_eip          = false
+        		bastion_host_ip         = true
+        		bastion_host_ingress_ip = false
+        		bastion_host_egress_ip  = false
+        		havip                   = true
+      		}
+    		}
+  		}
+	}
+
+	data "alicloud_cloud_firewall_address_books" "default" {
+		%s
+	}
+`, rand, strings.Join(pairs, " \n "))
+	return config
+}
+
 func testAccCheckAliCloudCloudFirewallAddressBooksDataSource(rand int, attrMap map[string]string) string {
 	var pairs []string
 	for k, v := range attrMap {

--- a/alicloud/resource_alicloud_cloud_firewall_address_book.go
+++ b/alicloud/resource_alicloud_cloud_firewall_address_book.go
@@ -29,7 +29,7 @@ func resourceAliCloudCloudFirewallAddressBook() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: StringInSlice([]string{"ip", "ipv6", "domain", "port", "tag"}, false),
+				ValidateFunc: StringInSlice([]string{"ip", "ipv6", "domain", "port", "tag", "asset", "assetIpv6"}, false),
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -54,6 +54,7 @@ func resourceAliCloudCloudFirewallAddressBook() *schema.Resource {
 			"address_list": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"ecs_tags": {
@@ -72,8 +73,306 @@ func resourceAliCloudCloudFirewallAddressBook() *schema.Resource {
 					},
 				},
 			},
+			"asset_member_uids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"asset_region_resource_types": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"asset_region_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"resource_type": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ipv4": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"eip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"ecs_eip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"ecs_public_ip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"slb_eip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"slb_public_ip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"nlb_eip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"alb_eip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"nat_eip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"nat_public_ip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"eni_eip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"ga_eip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"api_gateway_eip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"ai_gateway_eip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"bastion_host_ip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"bastion_host_ingress_ip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"bastion_host_egress_ip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"havip": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"ipv6": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"ecs_ipv6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"slb_ipv6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"nlb_ipv6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"alb_ipv6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"eni_eipv6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"ga_eipv6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"api_gateway_eipv6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"ai_gateway_eipv6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"address_list_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"reference_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
+}
+
+var cloudFirewallAddressBookIpv4AssetTypesMap = map[string]string{
+	"eip":                     "EIP",
+	"ecs_eip":                 "EcsEIP",
+	"ecs_public_ip":           "EcsPublicIP",
+	"slb_eip":                 "SlbEIP",
+	"slb_public_ip":           "SlbPublicIP",
+	"nlb_eip":                 "NlbEIP",
+	"alb_eip":                 "AlbEIP",
+	"nat_eip":                 "NatEIP",
+	"nat_public_ip":           "NatPublicIP",
+	"eni_eip":                 "EniEIP",
+	"ga_eip":                  "GaEIP",
+	"api_gateway_eip":         "ApiGatewayEIP",
+	"ai_gateway_eip":          "AiGatewayEIP",
+	"bastion_host_ip":         "BastionHostIP",
+	"bastion_host_ingress_ip": "BastionHostIngressIP",
+	"bastion_host_egress_ip":  "BastionHostEgressIP",
+	"havip":                   "HAVIP",
+}
+
+var cloudFirewallAddressBookIpv6AssetTypesMap = map[string]string{
+	"ecs_ipv6":          "EcsIPv6",
+	"slb_ipv6":          "SlbIPv6",
+	"nlb_ipv6":          "NlbIPv6",
+	"alb_ipv6":          "AlbIPv6",
+	"eni_eipv6":         "EniEIPv6",
+	"ga_eipv6":          "GaEIPv6",
+	"api_gateway_eipv6": "ApiGatewayEIPv6",
+	"ai_gateway_eipv6":  "AiGatewayEIPv6",
+}
+
+func expandCloudFirewallAddressBookAssetRegionResourceTypes(configured []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	for _, item := range configured {
+		if item == nil {
+			continue
+		}
+
+		itemArg := item.(map[string]interface{})
+		itemMap := make(map[string]interface{})
+
+		if v, ok := itemArg["asset_region_id"].(string); ok && v != "" {
+			itemMap["AssetRegionId"] = v
+		}
+
+		if resourceTypeList, ok := itemArg["resource_type"].([]interface{}); ok && len(resourceTypeList) > 0 && resourceTypeList[0] != nil {
+			resourceTypeArg := resourceTypeList[0].(map[string]interface{})
+			resourceTypeMap := make(map[string]interface{})
+
+			if ipv4List, ok := resourceTypeArg["ipv4"].([]interface{}); ok && len(ipv4List) > 0 && ipv4List[0] != nil {
+				ipv4Arg := ipv4List[0].(map[string]interface{})
+				ipv4Map := make(map[string]interface{})
+				for schemaKey, apiKey := range cloudFirewallAddressBookIpv4AssetTypesMap {
+					if v, ok := ipv4Arg[schemaKey].(bool); ok {
+						ipv4Map[apiKey] = v
+					}
+				}
+
+				resourceTypeMap["Ipv4"] = ipv4Map
+			}
+
+			if ipv6List, ok := resourceTypeArg["ipv6"].([]interface{}); ok && len(ipv6List) > 0 && ipv6List[0] != nil {
+				ipv6Arg := ipv6List[0].(map[string]interface{})
+				ipv6Map := make(map[string]interface{})
+				for schemaKey, apiKey := range cloudFirewallAddressBookIpv6AssetTypesMap {
+					if v, ok := ipv6Arg[schemaKey].(bool); ok {
+						ipv6Map[apiKey] = v
+					}
+				}
+
+				resourceTypeMap["Ipv6"] = ipv6Map
+			}
+
+			itemMap["ResourceType"] = resourceTypeMap
+		}
+
+		result = append(result, itemMap)
+	}
+
+	return result
+}
+
+func flattenCloudFirewallAddressBookAssetRegionResourceTypes(src interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	srcList, ok := src.([]interface{})
+	if !ok {
+		return result
+	}
+
+	for _, item := range srcList {
+		itemArg, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		itemMap := make(map[string]interface{})
+		itemMap["asset_region_id"] = itemArg["AssetRegionId"]
+
+		if resourceTypeArg, ok := itemArg["ResourceType"].(map[string]interface{}); ok {
+			resourceTypeMap := make(map[string]interface{})
+
+			// The service always returns both Ipv4 and Ipv6 maps with explicit booleans,
+			// so a sub-block is exposed only when at least one asset type is enabled.
+			if ipv4Arg, ok := resourceTypeArg["Ipv4"].(map[string]interface{}); ok {
+				ipv4Map := make(map[string]interface{})
+				ipv4Enabled := false
+				for schemaKey, apiKey := range cloudFirewallAddressBookIpv4AssetTypesMap {
+					if v, ok := ipv4Arg[apiKey]; ok {
+						ipv4Map[schemaKey] = v
+						if enabled, ok := v.(bool); ok && enabled {
+							ipv4Enabled = true
+						}
+					}
+				}
+
+				if ipv4Enabled {
+					resourceTypeMap["ipv4"] = []map[string]interface{}{ipv4Map}
+				}
+			}
+
+			if ipv6Arg, ok := resourceTypeArg["Ipv6"].(map[string]interface{}); ok {
+				ipv6Map := make(map[string]interface{})
+				ipv6Enabled := false
+				for schemaKey, apiKey := range cloudFirewallAddressBookIpv6AssetTypesMap {
+					if v, ok := ipv6Arg[apiKey]; ok {
+						ipv6Map[schemaKey] = v
+						if enabled, ok := v.(bool); ok && enabled {
+							ipv6Enabled = true
+						}
+					}
+				}
+
+				if ipv6Enabled {
+					resourceTypeMap["ipv6"] = []map[string]interface{}{ipv6Map}
+				}
+			}
+
+			itemMap["resource_type"] = []map[string]interface{}{resourceTypeMap}
+		}
+
+		result = append(result, itemMap)
+	}
+
+	return result
 }
 
 func resourceAliCloudCloudFirewallAddressBookCreate(d *schema.ResourceData, meta interface{}) error {
@@ -110,6 +409,24 @@ func resourceAliCloudCloudFirewallAddressBookCreate(d *schema.ResourceData, meta
 			request[fmt.Sprintf("TagList.%d.TagValue", i+1)] = tagItemArg["tag_value"]
 			request[fmt.Sprintf("TagList.%d.TagKey", i+1)] = tagItemArg["tag_key"]
 		}
+	}
+
+	if v, ok := d.GetOk("asset_member_uids"); ok {
+		assetMemberUidsJson, err := convertArrayObjectToJsonString(v.([]interface{}))
+		if err != nil {
+			return WrapError(err)
+		}
+
+		request["AssetMemberUids"] = assetMemberUidsJson
+	}
+
+	if v, ok := d.GetOk("asset_region_resource_types"); ok {
+		assetRegionResourceTypesJson, err := convertArrayObjectToJsonString(expandCloudFirewallAddressBookAssetRegionResourceTypes(v.([]interface{})))
+		if err != nil {
+			return WrapError(err)
+		}
+
+		request["AssetRegionResourceTypes"] = assetRegionResourceTypesJson
 	}
 
 	wait := incrementalWait(3*time.Second, 3*time.Second)
@@ -178,6 +495,27 @@ func resourceAliCloudCloudFirewallAddressBookRead(d *schema.ResourceData, meta i
 
 	d.Set("ecs_tags", ecsTags)
 
+	if v, ok := object["AssetMemberUids"].([]interface{}); ok {
+		assetMemberUids := make([]int, 0)
+		for _, assetMemberUid := range v {
+			assetMemberUids = append(assetMemberUids, formatInt(assetMemberUid))
+		}
+
+		d.Set("asset_member_uids", assetMemberUids)
+	}
+
+	if v, ok := object["AssetRegionResourceTypes"]; ok {
+		d.Set("asset_region_resource_types", flattenCloudFirewallAddressBookAssetRegionResourceTypes(v))
+	}
+
+	if v, ok := object["AddressListCount"]; ok {
+		d.Set("address_list_count", formatInt(v))
+	}
+
+	if v, ok := object["ReferenceCount"]; ok {
+		d.Set("reference_count", formatInt(v))
+	}
+
 	return nil
 }
 
@@ -232,6 +570,32 @@ func resourceAliCloudCloudFirewallAddressBookUpdate(d *schema.ResourceData, meta
 				request[fmt.Sprintf("TagList.%d.TagValue", i+1)] = tagItemArg["tag_value"]
 				request[fmt.Sprintf("TagList.%d.TagKey", i+1)] = tagItemArg["tag_key"]
 			}
+		}
+	}
+
+	if d.HasChange("asset_member_uids") {
+		update = true
+
+		if v, ok := d.GetOk("asset_member_uids"); ok {
+			assetMemberUidsJson, err := convertArrayObjectToJsonString(v.([]interface{}))
+			if err != nil {
+				return WrapError(err)
+			}
+
+			request["AssetMemberUids"] = assetMemberUidsJson
+		}
+	}
+
+	if d.HasChange("asset_region_resource_types") {
+		update = true
+
+		if v, ok := d.GetOk("asset_region_resource_types"); ok {
+			assetRegionResourceTypesJson, err := convertArrayObjectToJsonString(expandCloudFirewallAddressBookAssetRegionResourceTypes(v.([]interface{})))
+			if err != nil {
+				return WrapError(err)
+			}
+
+			request["AssetRegionResourceTypes"] = assetRegionResourceTypesJson
 		}
 	}
 

--- a/alicloud/resource_alicloud_cloud_firewall_address_book_test.go
+++ b/alicloud/resource_alicloud_cloud_firewall_address_book_test.go
@@ -613,12 +613,278 @@ func TestAccAliCloudCloudFirewallAddressBook_basic5(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudCloudFirewallAddressBook_basic6(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_firewall_address_book.default"
+	checkoutSupportedRegions(t, true, connectivity.CloudFirewallSupportRegions)
+	ra := resourceAttrInit(resourceId, AliCloudCloudFirewallAddressBookMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudfwService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudFirewallAddressBook")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%scloudfirewalladdressbook%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudFirewallAddressBookBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group_name":  name,
+					"group_type":  "asset",
+					"description": name,
+					"asset_region_resource_types": []map[string]interface{}{
+						{
+							"asset_region_id": "all",
+							"resource_type": []map[string]interface{}{
+								{
+									"ipv4": []map[string]interface{}{
+										{
+											"eip":                     "false",
+											"ecs_eip":                 "false",
+											"ecs_public_ip":           "false",
+											"slb_eip":                 "false",
+											"slb_public_ip":           "false",
+											"nlb_eip":                 "false",
+											"alb_eip":                 "false",
+											"nat_eip":                 "false",
+											"nat_public_ip":           "false",
+											"eni_eip":                 "false",
+											"ga_eip":                  "true",
+											"api_gateway_eip":         "false",
+											"ai_gateway_eip":          "false",
+											"bastion_host_ip":         "true",
+											"bastion_host_ingress_ip": "true",
+											"bastion_host_egress_ip":  "true",
+											"havip":                   "true",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group_name":                    name,
+						"group_type":                    "asset",
+						"description":                   name,
+						"asset_region_resource_types.#": "1",
+						"asset_region_resource_types.0.asset_region_id":                        "all",
+						"asset_region_resource_types.0.resource_type.#":                        "1",
+						"asset_region_resource_types.0.resource_type.0.ipv4.#":                 "1",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.ga_eip":          "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.bastion_host_ip": "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.havip":           "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.eip":             "false",
+						"address_list_count": CHECKSET,
+						"reference_count":    CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group_name": name + "update",
+					"asset_region_resource_types": []map[string]interface{}{
+						{
+							"asset_region_id": "all",
+							"resource_type": []map[string]interface{}{
+								{
+									"ipv4": []map[string]interface{}{
+										{
+											"eip":                     "true",
+											"ecs_eip":                 "true",
+											"ecs_public_ip":           "true",
+											"slb_eip":                 "true",
+											"slb_public_ip":           "true",
+											"nlb_eip":                 "true",
+											"alb_eip":                 "true",
+											"nat_eip":                 "true",
+											"nat_public_ip":           "true",
+											"eni_eip":                 "true",
+											"ga_eip":                  "false",
+											"api_gateway_eip":         "true",
+											"ai_gateway_eip":          "true",
+											"bastion_host_ip":         "false",
+											"bastion_host_ingress_ip": "false",
+											"bastion_host_egress_ip":  "false",
+											"havip":                   "false",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group_name": name + "update",
+						"asset_region_resource_types.0.asset_region_id":                        "all",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.eip":             "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.ecs_eip":         "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.ecs_public_ip":   "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.slb_eip":         "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.slb_public_ip":   "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.nlb_eip":         "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.alb_eip":         "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.nat_eip":         "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.nat_public_ip":   "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.eni_eip":         "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.ga_eip":          "false",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.api_gateway_eip": "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.ai_gateway_eip":  "true",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.bastion_host_ip": "false",
+						"asset_region_resource_types.0.resource_type.0.ipv4.0.havip":           "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"asset_member_uids": []string{"${data.alicloud_account.default.id}"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"asset_member_uids.#": "1",
+						"asset_member_uids.0": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"lang", "asset_region_resource_types.asset_region_id"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudCloudFirewallAddressBook_basic7(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_firewall_address_book.default"
+	checkoutSupportedRegions(t, true, connectivity.CloudFirewallSupportRegions)
+	ra := resourceAttrInit(resourceId, AliCloudCloudFirewallAddressBookMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudfwService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudFirewallAddressBook")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%scloudfirewalladdressbook%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudFirewallAddressBookBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group_name":  name,
+					"group_type":  "assetIpv6",
+					"description": name,
+					"asset_region_resource_types": []map[string]interface{}{
+						{
+							"asset_region_id": "all",
+							"resource_type": []map[string]interface{}{
+								{
+									"ipv6": []map[string]interface{}{
+										{
+											"ecs_ipv6":          "false",
+											"slb_ipv6":          "false",
+											"nlb_ipv6":          "false",
+											"alb_ipv6":          "false",
+											"eni_eipv6":         "false",
+											"ga_eipv6":          "true",
+											"api_gateway_eipv6": "false",
+											"ai_gateway_eipv6":  "false",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group_name":                    name,
+						"group_type":                    "assetIpv6",
+						"description":                   name,
+						"asset_region_resource_types.#": "1",
+						"asset_region_resource_types.0.asset_region_id":                 "all",
+						"asset_region_resource_types.0.resource_type.#":                 "1",
+						"asset_region_resource_types.0.resource_type.0.ipv6.#":          "1",
+						"asset_region_resource_types.0.resource_type.0.ipv6.0.ga_eipv6": "true",
+						"asset_region_resource_types.0.resource_type.0.ipv6.0.ecs_ipv6": "false",
+						"address_list_count": CHECKSET,
+						"reference_count":    CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"asset_region_resource_types": []map[string]interface{}{
+						{
+							"asset_region_id": "all",
+							"resource_type": []map[string]interface{}{
+								{
+									"ipv6": []map[string]interface{}{
+										{
+											"ecs_ipv6":          "true",
+											"slb_ipv6":          "true",
+											"nlb_ipv6":          "true",
+											"alb_ipv6":          "true",
+											"eni_eipv6":         "true",
+											"ga_eipv6":          "false",
+											"api_gateway_eipv6": "true",
+											"ai_gateway_eipv6":  "true",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"asset_region_resource_types.0.resource_type.0.ipv6.0.ecs_ipv6":          "true",
+						"asset_region_resource_types.0.resource_type.0.ipv6.0.slb_ipv6":          "true",
+						"asset_region_resource_types.0.resource_type.0.ipv6.0.nlb_ipv6":          "true",
+						"asset_region_resource_types.0.resource_type.0.ipv6.0.alb_ipv6":          "true",
+						"asset_region_resource_types.0.resource_type.0.ipv6.0.eni_eipv6":         "true",
+						"asset_region_resource_types.0.resource_type.0.ipv6.0.ga_eipv6":          "false",
+						"asset_region_resource_types.0.resource_type.0.ipv6.0.api_gateway_eipv6": "true",
+						"asset_region_resource_types.0.resource_type.0.ipv6.0.ai_gateway_eipv6":  "true",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"lang"},
+			},
+		},
+	})
+}
+
 var AliCloudCloudFirewallAddressBookMap0 = map[string]string{}
 
 func AliCloudCloudFirewallAddressBookBasicDependence0(name string) string {
-	return fmt.Sprintf(` 
+	return fmt.Sprintf(`
 	variable "name" {
   		default = "%s"
+	}
+
+	data "alicloud_account" "default" {
 	}
 `, name)
 }

--- a/website/docs/d/cloud_firewall_address_books.html.markdown
+++ b/website/docs/d/cloud_firewall_address_books.html.markdown
@@ -45,8 +45,8 @@ The following arguments are supported:
 
 * `ids` - (Optional, ForceNew, List) A list of Address Book IDs.
 * `name_regex` - (Optional, ForceNew) A regex string to filter results Address Book name.
-* `group_type` - (Optional, ForceNew) The type of the Address Book. Valid values: `ip`, `ipv6`, `domain`, `port`, `tag`.
-  **NOTE:** From version 1.213.1, `group_type` can be set to `ipv6`, `domain`, `port`.
+* `group_type` - (Optional, ForceNew) The type of the Address Book. Valid values: `ip`, `ipv6`, `domain`, `port`, `tag`, `asset`, `assetIpv6`.
+  **NOTE:** From version 1.213.1, `group_type` can be set to `ipv6`, `domain`, `port`. From version 1.286.0, `group_type` can be set to `asset`, `assetIpv6`.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
 ## Attributes Reference
@@ -63,6 +63,39 @@ The following attributes are exported in addition to the arguments listed above:
   * `auto_add_tag_ecs` - Whether you want to automatically add new matching tags of the ECS IP address to the Address Book.
   * `tag_relation` - One or more tags for the relationship between.
   * `address_list` - The addresses in the Address Book.
-  * `ecs_tags` - The logical relation among the ECS tags that to be matchedh.
+  * `address_list_count` - (Available since v1.286.0) The number of addresses in the Address Book.
+  * `reference_count` - (Available since v1.286.0) The number of times that the Address Book is referenced.
+  * `asset_member_uids` - (Available since v1.286.0) The list of member account UIDs of the asset Address Book.
+  * `asset_region_resource_types` - (Available since v1.286.0) The list of regions and asset types of the asset Address Book.
+      * `asset_region_id` - The region ID of the assets.
+      * `resource_type` - The types of the assets.
+          * `ipv4` - The IPv4 asset types.
+              * `eip` - Whether the assets of the type EIP are included.
+              * `ecs_eip` - Whether the assets of the type EcsEIP are included.
+              * `ecs_public_ip` - Whether the assets of the type EcsPublicIP are included.
+              * `slb_eip` - Whether the assets of the type SlbEIP are included.
+              * `slb_public_ip` - Whether the assets of the type SlbPublicIP are included.
+              * `nlb_eip` - Whether the assets of the type NlbEIP are included.
+              * `alb_eip` - Whether the assets of the type AlbEIP are included.
+              * `nat_eip` - Whether the assets of the type NatEIP are included.
+              * `nat_public_ip` - Whether the assets of the type NatPublicIP are included.
+              * `eni_eip` - Whether the assets of the type EniEIP are included.
+              * `ga_eip` - Whether the assets of the type GaEIP are included.
+              * `api_gateway_eip` - Whether the assets of the type ApiGatewayEIP are included.
+              * `ai_gateway_eip` - Whether the assets of the type AiGatewayEIP are included.
+              * `bastion_host_ip` - Whether the assets of the type BastionHostIP are included.
+              * `bastion_host_ingress_ip` - Whether the assets of the type BastionHostIngressIP are included.
+              * `bastion_host_egress_ip` - Whether the assets of the type BastionHostEgressIP are included.
+              * `havip` - Whether the assets of the type HAVIP are included.
+          * `ipv6` - The IPv6 asset types.
+              * `ecs_ipv6` - Whether the assets of the type EcsIPv6 are included.
+              * `slb_ipv6` - Whether the assets of the type SlbIPv6 are included.
+              * `nlb_ipv6` - Whether the assets of the type NlbIPv6 are included.
+              * `alb_ipv6` - Whether the assets of the type AlbIPv6 are included.
+              * `eni_eipv6` - Whether the assets of the type EniEIPv6 are included.
+              * `ga_eipv6` - Whether the assets of the type GaEIPv6 are included.
+              * `api_gateway_eipv6` - Whether the assets of the type ApiGatewayEIPv6 are included.
+              * `ai_gateway_eipv6` - Whether the assets of the type AiGatewayEIPv6 are included.
+  * `ecs_tags` - The logical relation among the ECS tags that to be matched.
     * `tag_key` - The key of ECS tag that to be matched.
     * `tag_value` - The value of ECS tag that to be matched.

--- a/website/docs/r/cloud_firewall_address_book.html.markdown
+++ b/website/docs/r/cloud_firewall_address_book.html.markdown
@@ -45,8 +45,8 @@ resource "alicloud_cloud_firewall_address_book" "example" {
 
 The following arguments are supported:
 * `group_name` - (Required) The name of the Address Book.
-* `group_type` - (Required, ForceNew) The type of the Address Book. Valid values: `ip`, `ipv6`, `domain`, `port`, `tag`.
-**NOTE:** From version 1.213.1, `group_type` can be set to `ipv6`, `domain`, `port`.
+* `group_type` - (Required, ForceNew) The type of the Address Book. Valid values: `ip`, `ipv6`, `domain`, `port`, `tag`, `asset`, `assetIpv6`.
+**NOTE:** From version 1.213.1, `group_type` can be set to `ipv6`, `domain`, `port`. From version 1.286.0, `group_type` can be set to `asset`, `assetIpv6`.
 * `description` - (Required) The description of the Address Book.
 * `auto_add_tag_ecs` - (Optional, Int) Whether you want to automatically add new matching tags of the ECS IP address to the Address Book. Valid values: `0`, `1`.
 * `tag_relation` - (Optional) The logical relation among the ECS tags that to be matched. Default value: `and`. Valid values:
@@ -55,6 +55,8 @@ The following arguments are supported:
 * `lang` - (Optional) The language of the content within the request and response. Valid values: `zh`, `en`.
 * `address_list` - (Optional, List) The list of addresses.
 * `ecs_tags` - (Optional, Set) A list of ECS tags. See [`ecs_tags`](#ecs_tags) below.
+* `asset_member_uids` - (Optional, List, Available since v1.286.0) The list of member account UIDs of the asset Address Book.
+* `asset_region_resource_types` - (Optional, List, Available since v1.286.0) The list of regions and asset types of the asset Address Book. See [`asset_region_resource_types`](#asset_region_resource_types) below.
 
 ### `ecs_tags`
 
@@ -63,11 +65,62 @@ The ecs_tags supports the following:
 * `tag_key` - (Optional) The key of ECS tag that to be matched.
 * `tag_value` - (Optional) The value of ECS tag that to be matched.
 
+### `asset_region_resource_types`
+
+The asset_region_resource_types supports the following:
+
+* `asset_region_id` - (Optional) The region ID of the assets. Set the value to `all` to specify all the regions. **NOTE:** `asset_region_id` cannot be modified after the Address Book is created.
+* `resource_type` - (Optional, List) The types of the assets. See [`resource_type`](#asset_region_resource_types-resource_type) below.
+
+### `asset_region_resource_types-resource_type`
+
+The resource_type supports the following:
+
+* `ipv4` - (Optional, List) The IPv4 asset types. See [`ipv4`](#asset_region_resource_types-resource_type-ipv4) below.
+* `ipv6` - (Optional, List) The IPv6 asset types. See [`ipv6`](#asset_region_resource_types-resource_type-ipv6) below.
+
+### `asset_region_resource_types-resource_type-ipv4`
+
+The ipv4 supports the following:
+
+* `eip` - (Optional, Bool) Whether to include the assets of the type EIP.
+* `ecs_eip` - (Optional, Bool) Whether to include the assets of the type EcsEIP.
+* `ecs_public_ip` - (Optional, Bool) Whether to include the assets of the type EcsPublicIP.
+* `slb_eip` - (Optional, Bool) Whether to include the assets of the type SlbEIP.
+* `slb_public_ip` - (Optional, Bool) Whether to include the assets of the type SlbPublicIP.
+* `nlb_eip` - (Optional, Bool) Whether to include the assets of the type NlbEIP.
+* `alb_eip` - (Optional, Bool) Whether to include the assets of the type AlbEIP.
+* `nat_eip` - (Optional, Bool) Whether to include the assets of the type NatEIP.
+* `nat_public_ip` - (Optional, Bool) Whether to include the assets of the type NatPublicIP.
+* `eni_eip` - (Optional, Bool) Whether to include the assets of the type EniEIP.
+* `ga_eip` - (Optional, Bool) Whether to include the assets of the type GaEIP.
+* `api_gateway_eip` - (Optional, Bool) Whether to include the assets of the type ApiGatewayEIP.
+* `ai_gateway_eip` - (Optional, Bool) Whether to include the assets of the type AiGatewayEIP.
+* `bastion_host_ip` - (Optional, Bool) Whether to include the assets of the type BastionHostIP.
+* `bastion_host_ingress_ip` - (Optional, Bool) Whether to include the assets of the type BastionHostIngressIP.
+* `bastion_host_egress_ip` - (Optional, Bool) Whether to include the assets of the type BastionHostEgressIP.
+* `havip` - (Optional, Bool) Whether to include the assets of the type HAVIP.
+
+### `asset_region_resource_types-resource_type-ipv6`
+
+The ipv6 supports the following:
+
+* `ecs_ipv6` - (Optional, Bool) Whether to include the assets of the type EcsIPv6.
+* `slb_ipv6` - (Optional, Bool) Whether to include the assets of the type SlbIPv6.
+* `nlb_ipv6` - (Optional, Bool) Whether to include the assets of the type NlbIPv6.
+* `alb_ipv6` - (Optional, Bool) Whether to include the assets of the type AlbIPv6.
+* `eni_eipv6` - (Optional, Bool) Whether to include the assets of the type EniEIPv6.
+* `ga_eipv6` - (Optional, Bool) Whether to include the assets of the type GaEIPv6.
+* `api_gateway_eipv6` - (Optional, Bool) Whether to include the assets of the type ApiGatewayEIPv6.
+* `ai_gateway_eipv6` - (Optional, Bool) Whether to include the assets of the type AiGatewayEIPv6.
+
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The resource ID in terraform of Address Book.
+* `address_list_count` - (Available since v1.286.0) The number of addresses in the Address Book.
+* `reference_count` - (Available since v1.286.0) The number of times that the Address Book is referenced.
 
 ## Import
 


### PR DESCRIPTION
### What this PR does

Adds asset address book support to `alicloud_cloud_firewall_address_book` and `alicloud_cloud_firewall_address_books`:

- `group_type` now supports `asset` (IPv4 public asset address book) and `assetIpv6` (IPv6 public asset address book).
- New argument `asset_member_uids` — member account UID list of the asset address book.
- New argument `asset_region_resource_types` — region and asset type selection (`asset_region_id` + `resource_type.ipv4` / `resource_type.ipv6` boolean flags).
- New exported attributes `address_list_count` and `reference_count`.
- `address_list` is now also `Computed`, because the service automatically populates the address list for tag/asset type address books.
- The data source `books` block exports the new fields as well.

### Notes

- `AssetMemberUids` and `AssetRegionResourceTypes` are JSON-style API parameters and are serialized as JSON strings in the requests.
- `DescribeAddressBook` always returns both `Ipv4` and `Ipv6` maps with explicit booleans; the provider only stores a sub-block when at least one asset type in it is enabled, keeping the plan stable for both `asset` and `assetIpv6` books.
- `ModifyAddressBook` rejects any change of `AssetRegionId` with `ErrorParameters`, so the docs note that `asset_region_id` cannot be modified after creation.

### Acceptance tests

```
=== RUN TestAccAliCloudCloudFirewallAddressBook_basic0
--- PASS: TestAccAliCloudCloudFirewallAddressBook_basic0 (21.97s)

=== RUN TestAccAliCloudCloudFirewallAddressBook_basic4
--- PASS: TestAccAliCloudCloudFirewallAddressBook_basic4 (30.96s)

=== RUN TestAccAliCloudCloudFirewallAddressBook_basic6
--- PASS: TestAccAliCloudCloudFirewallAddressBook_basic6 (23.73s)

=== RUN TestAccAliCloudCloudFirewallAddressBook_basic7
--- PASS: TestAccAliCloudCloudFirewallAddressBook_basic7 (17.29s)

=== RUN TestAccAliCloudCloudFirewallAddressBooksDataSource
--- PASS: TestAccAliCloudCloudFirewallAddressBooksDataSource (27.35s)

=== RUN TestAccAliCloudCloudFirewallAddressBooksDataSource_assetType
--- PASS: TestAccAliCloudCloudFirewallAddressBooksDataSource_assetType (19.53s)
```