### PR TITLE
resource/alicloud_cms_group_metric_rule: support in-place update of interval

### DIFF
--- a/alicloud/resource_alicloud_cms_group_metric_rule.go
+++ b/alicloud/resource_alicloud_cms_group_metric_rule.go
@@ -394,6 +394,9 @@ func resourceAliCloudCmsGroupMetricRuleRead(d *schema.ResourceData, meta interfa
 	d.Set("email_subject", object["MailSubject"])
 	d.Set("effective_interval", object["EffectiveInterval"])
 	d.Set("no_effective_interval", object["NoEffectiveInterval"])
+	// interval is a write-only parameter: DescribeMetricRuleList does not return it,
+	// so it is not read back here (the configured value is retained) and it is excluded
+	// from ImportStateVerify.
 	d.Set("period", formatInt(object["Period"]))
 	d.Set("silence_time", formatInt(object["SilenceTime"]))
 	d.Set("webhook", object["Webhook"])
@@ -586,6 +589,13 @@ func resourceAliCloudCmsGroupMetricRuleUpdate(d *schema.ResourceData, meta inter
 		request["NoEffectiveInterval"] = v
 	}
 
+	if !d.IsNewResource() && d.HasChange("interval") {
+		update = true
+	}
+	if v, ok := d.GetOk("interval"); ok {
+		request["Interval"] = v
+	}
+
 	if !d.IsNewResource() && d.HasChange("period") {
 		update = true
 
@@ -722,6 +732,7 @@ func resourceAliCloudCmsGroupMetricRuleUpdate(d *schema.ResourceData, meta inter
 		d.SetPartial("email_subject")
 		d.SetPartial("effective_interval")
 		d.SetPartial("no_effective_interval")
+		d.SetPartial("interval")
 		d.SetPartial("period")
 		d.SetPartial("silence_time")
 		d.SetPartial("webhook")

--- a/alicloud/resource_alicloud_cms_group_metric_rule_test.go
+++ b/alicloud/resource_alicloud_cms_group_metric_rule_test.go
@@ -252,6 +252,26 @@ func TestAccAliCloudCmsGroupMetricRule_basic0(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"interval": "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"interval": "60",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"interval": "90",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"interval": "90",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"targets": []map[string]interface{}{
 						{
 							"id":          "1",

--- a/website/docs/r/cms_group_metric_rule.html.markdown
+++ b/website/docs/r/cms_group_metric_rule.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
 * `email_subject` - (Optional) The subject of the alert notification email.
 * `effective_interval` - (Optional) The time period during which the alert rule is effective.
 * `no_effective_interval` - (Optional) The time period during which the alert rule is ineffective.
-* `interval` - (Optional, ForceNew) The interval at which Cloud Monitor checks whether the alert rule is triggered. Unit: seconds.
+* `interval` - (Optional) The interval at which Cloud Monitor checks whether the alert rule is triggered. Unit: seconds.
 * `period` - (Optional, Int) The aggregation period of the monitoring data. Unit: seconds. The value is an integral multiple of 60. Default value: `300`.
 * `silence_time` - (Optional, Int) The mute period during which new alerts are not reported even if the alert trigger conditions are met. Unit: seconds. Default value: `86400`, which is equivalent to one day.
 * `webhook` - (Optional) The callback URL.


### PR DESCRIPTION
### What this PR does

The `interval` argument of `alicloud_cms_group_metric_rule` was documented as `ForceNew`, but the underlying `PutGroupMetricRule` API (used for both Create and Update) accepts `Interval` and supports updating it in place. The schema itself never set `ForceNew`, so the doc was inconsistent, and the Update function did not wire `interval` at all — changing `interval` was silently dropped (apply reported success but the value never reached the cloud).

### Changes

- **docs**: remove the erroneous `ForceNew` note from `interval`.
- **Update**: set the update flag on `interval` change and pass `Interval` in the `PutGroupMetricRule` request so the change is actually applied.
- **test**: add acceptance steps covering in-place `interval` update (60 → 90) with no resource rebuild.

`interval` is a write-only parameter — `DescribeMetricRuleList` does not return it — so it is intentionally not read back (the configured value is retained) and remains in `ImportStateVerifyIgnore`.