### PR TITLE
resource/alicloud_db_instance: fix panic when DescribeParameters has no ParamGroupInfo

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -2122,6 +2122,20 @@ func resourceAliCloudDBInstanceUpdate(d *schema.ResourceData, meta interface{}) 
 	return resourceAliCloudDBInstanceRead(d, meta)
 }
 
+// parseDBInstanceParamGroupId extracts the parameter group id from a
+// DescribeParameters response. The "ParamGroupInfo" object (and its
+// "ParamGroupId") is not always present - e.g. right after an instance is
+// created, before its parameter group is populated - so both lookups are
+// guarded to avoid a nil interface conversion panic in Read.
+func parseDBInstanceParamGroupId(response map[string]interface{}) (string, bool) {
+	dbParamGroupInfo, ok := response["ParamGroupInfo"].(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	paramGroupId, ok := dbParamGroupInfo["ParamGroupId"].(string)
+	return paramGroupId, ok
+}
+
 func resourceAliCloudDBInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	rdsService := RdsService{client}
@@ -2437,11 +2451,12 @@ func resourceAliCloudDBInstanceRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("tcp_connection_type", res["TcpConnectionType"])
 
 	response, err := rdsService.DescribeParameters(d.Id())
-	dbParamGroupInfo := response["ParamGroupInfo"].(map[string]interface{})
 	if err != nil {
 		return WrapError(err)
 	}
-	d.Set("db_param_group_id", dbParamGroupInfo["ParamGroupId"].(string))
+	if paramGroupId, ok := parseDBInstanceParamGroupId(response); ok {
+		d.Set("db_param_group_id", paramGroupId)
+	}
 
 	WhitelistTemplate, err := rdsService.DescribeInstanceLinkedWhitelistTemplate(d.Id())
 	if err != nil {

--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -4684,3 +4684,63 @@ var instanceBasicMap9 = map[string]string{
 	"status":               CHECKSET,
 	"create_time":          CHECKSET,
 }
+
+// TestUnitParseDBInstanceParamGroupId is a regression test for the provider
+// panic reported when creating alicloud_db_instance.
+//
+// resourceAliCloudDBInstanceRead used to run, without a comma-ok guard:
+//
+//	dbParamGroupInfo := response["ParamGroupInfo"].(map[string]interface{})
+//	...
+//	d.Set("db_param_group_id", dbParamGroupInfo["ParamGroupId"].(string))
+//
+// A freshly created instance whose DescribeParameters response does not yet
+// contain "ParamGroupInfo" therefore crashed the plugin with:
+//
+//	interface conversion: interface {} is nil, not map[string]interface {}
+//
+// The parsing is now isolated in parseDBInstanceParamGroupId, which must never
+// panic and must report presence via its second return value. The first two
+// cases below are the crash inputs (they panic against the old inline code).
+func TestUnitParseDBInstanceParamGroupId(t *testing.T) {
+	cases := []struct {
+		name      string
+		response  map[string]interface{}
+		wantID    string
+		wantFound bool
+	}{
+		{
+			name:     "ParamGroupInfo absent (freshly created instance)",
+			response: map[string]interface{}{},
+		},
+		{
+			name:     "ParamGroupInfo present but nil",
+			response: map[string]interface{}{"ParamGroupInfo": nil},
+		},
+		{
+			name:     "ParamGroupInfo present but ParamGroupId missing",
+			response: map[string]interface{}{"ParamGroupInfo": map[string]interface{}{}},
+		},
+		{
+			name:     "ParamGroupId present but not a string",
+			response: map[string]interface{}{"ParamGroupInfo": map[string]interface{}{"ParamGroupId": 123}},
+		},
+		{
+			name:      "ParamGroupInfo and ParamGroupId both present",
+			response:  map[string]interface{}{"ParamGroupInfo": map[string]interface{}{"ParamGroupId": "rpg-test123"}},
+			wantID:    "rpg-test123",
+			wantFound: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			id, ok := parseDBInstanceParamGroupId(c.response)
+			if ok != c.wantFound {
+				t.Fatalf("parseDBInstanceParamGroupId(%v) found = %v, want %v", c.response, ok, c.wantFound)
+			}
+			if id != c.wantID {
+				t.Fatalf("parseDBInstanceParamGroupId(%v) id = %q, want %q", c.response, id, c.wantID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary

`resourceAliCloudDBInstanceRead` could panic while creating an `alicloud_db_instance` (the crash surfaces via `Create` -> `Update` -> `Read`):

```
panic: interface conversion: interface {} is nil, not map[string]interface {}
```

The Read function asserted the `DescribeParameters` response without a comma-ok guard, and did so *before* checking the returned error:

```go
response, err := rdsService.DescribeParameters(d.Id())
dbParamGroupInfo := response["ParamGroupInfo"].(map[string]interface{}) // panics here
if err != nil {
    return WrapError(err)
}
d.Set("db_param_group_id", dbParamGroupInfo["ParamGroupId"].(string))
```

When an instance has just been created, the `DescribeParameters` response does not always contain `ParamGroupInfo` yet, so `response["ParamGroupInfo"]` is `nil` and the unguarded type assertion crashes the plugin. The same happens if `DescribeParameters` returns an error, because `response` is then `nil` but is dereferenced before the error is ever checked.

### Fix

- Check the returned error before touching `response`.
- Guard the `ParamGroupInfo` / `ParamGroupId` lookups with comma-ok, isolated in a small helper `parseDBInstanceParamGroupId`, so a missing or absent field no longer panics (`db_param_group_id` is simply left unset when the API has not populated it yet).

### Test

Added `TestUnitParseDBInstanceParamGroupId`, a table-driven unit test covering the crash inputs (missing `ParamGroupInfo`, nil `ParamGroupInfo`, missing/non-string `ParamGroupId`) plus the happy path. The first cases panic against the previous inline code and pass after the fix.
