### PR TITLE
New Resource: alicloud_gpdb_api_key. New Data Source: alicloud_gpdb_api_keys.

### DIFF
--- a/alicloud/data_source_alicloud_gpdb_api_keys.go
+++ b/alicloud/data_source_alicloud_gpdb_api_keys.go
@@ -1,0 +1,159 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudGpdbApiKeys() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudGpdbApiKeyRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"keys": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"key_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"key_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"key_prefix": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudGpdbApiKeyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListApiKeys"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("workspace_id"); ok {
+		request["WorkspaceId"] = v
+	}
+	request["WorkspaceId"] = d.Get("workspace_id")
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+		response, err = client.RpcPost("gpdb", "2016-05-03", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	resp, _ := jsonpath.Get("$.Items[*]", response)
+
+	result, _ := resp.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		if len(idsMap) > 0 {
+			if _, ok := idsMap[fmt.Sprint(item["KeyId"])]; !ok {
+				continue
+			}
+		}
+		objects = append(objects, item)
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["KeyId"]
+
+		mapping["description"] = objectRaw["Description"]
+		mapping["key_name"] = objectRaw["KeyName"]
+		mapping["create_time"] = objectRaw["CreateTime"]
+		mapping["key_id"] = objectRaw["KeyId"]
+		mapping["key_prefix"] = objectRaw["KeyPrefix"]
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("keys", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_gpdb_api_keys_test.go
+++ b/alicloud/data_source_alicloud_gpdb_api_keys_test.go
@@ -1,0 +1,138 @@
+package alicloud
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// TestAccAlicloudGPDBApiKeysDataSource covers the alicloud_gpdb_api_keys data
+// source. A GPDB ApiKey requires a pre-existing GPDB workspace which has no
+// Terraform resource, so the workspace is provisioned out of band (reusing the
+// helpers shared with the resource test) and the returned id is interpolated
+// into the config.
+//
+// Each scenario is split into two TestSteps:
+//
+//	Step 1 — create the resource only (populates state).
+//	Step 2 — add the data source config (resource already in state, so the
+//	         data source can be read during plan without depends_on).
+//
+// This avoids the Terraform SDK v1 quirk where depends_on on a data source
+// defers its Read to the apply phase, leaving all attributes as <computed>
+// after refresh and causing plan-non-empty failures.
+func TestAccAlicloudGPDBApiKeysDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+
+	var workspaceId string
+	var wsClient *connectivity.AliyunClient
+	if os.Getenv("TF_ACC") != "" {
+		wsClient, workspaceId = gpdbApiKeyTestCreateWorkspace(t, rand)
+		defer gpdbApiKeyTestDeleteWorkspace(wsClient, workspaceId)
+	}
+
+	preCheck := func() {
+		testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+		testAccPreCheck(t)
+	}
+
+	name := fmt.Sprintf("tfaccgpdbapikey%d", rand)
+
+	// Resource-only config — used as Step 1 to populate state.
+	resourceConf := fmt.Sprintf(`
+resource "alicloud_gpdb_api_key" "default" {
+  workspace_id = "%s"
+  key_name     = "%s"
+  description  = "terraform test"
+}
+`, workspaceId, name)
+
+	// Data-source-only configs — used as Step 2. The resource already
+	// exists in state from Step 1, so the data source can reference it
+	// via interpolation (implicit dependency) without depends_on.
+	dsBasicConf := fmt.Sprintf(`
+resource "alicloud_gpdb_api_key" "default" {
+  workspace_id = "%s"
+  key_name     = "%s"
+  description  = "terraform test"
+}
+
+data "alicloud_gpdb_api_keys" "default" {
+  workspace_id = "%s"
+}
+`, workspaceId, name, workspaceId)
+
+	dsIdsExistConf := fmt.Sprintf(`
+resource "alicloud_gpdb_api_key" "default" {
+  workspace_id = "%s"
+  key_name     = "%s"
+  description  = "terraform test"
+}
+
+data "alicloud_gpdb_api_keys" "default" {
+  workspace_id = "%s"
+  ids          = ["${alicloud_gpdb_api_key.default.key_id}"]
+}
+`, workspaceId, name, workspaceId)
+
+	dsIdsFakeConf := fmt.Sprintf(`
+resource "alicloud_gpdb_api_key" "default" {
+  workspace_id = "%s"
+  key_name     = "%s"
+  description  = "terraform test"
+}
+
+data "alicloud_gpdb_api_keys" "default" {
+  workspace_id = "%s"
+  ids          = ["${alicloud_gpdb_api_key.default.key_id}_fake"]
+}
+`, workspaceId, name, workspaceId)
+
+	dsOutputFileConf := fmt.Sprintf(`
+resource "alicloud_gpdb_api_key" "default" {
+  workspace_id = "%s"
+  key_name     = "%s"
+  description  = "terraform test"
+}
+
+data "alicloud_gpdb_api_keys" "default" {
+  workspace_id = "%s"
+  output_file  = "./test_output_file"
+}
+`, workspaceId, name, workspaceId)
+
+	// Expected attributes when data source finds one key.
+	existCheck := resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr("data.alicloud_gpdb_api_keys.default", "ids.#", "1"),
+		resource.TestCheckResourceAttr("data.alicloud_gpdb_api_keys.default", "keys.#", "1"),
+		resource.TestCheckResourceAttrSet("data.alicloud_gpdb_api_keys.default", "keys.0.id"),
+		resource.TestCheckResourceAttrSet("data.alicloud_gpdb_api_keys.default", "keys.0.key_id"),
+		resource.TestCheckResourceAttr("data.alicloud_gpdb_api_keys.default", "keys.0.key_name", name),
+	)
+	// Expected attributes when data source finds no keys.
+	emptyCheck := resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr("data.alicloud_gpdb_api_keys.default", "ids.#", "0"),
+		resource.TestCheckResourceAttr("data.alicloud_gpdb_api_keys.default", "keys.#", "0"),
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  preCheck,
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Case 1: basic list — Step 1 creates resource, Step 2 reads data source.
+			{Config: resourceConf},
+			{Config: dsBasicConf, Check: existCheck},
+			// Case 2: ids filter (exist) — resource persists in state from
+			// Case 1, so we only need the data-source step.
+			{Config: dsIdsExistConf, Check: existCheck},
+			// Case 3: ids filter (fake) — non-matching id yields empty set.
+			{Config: dsIdsFakeConf, Check: emptyCheck},
+			// Case 4: output_file — results are written to a file.
+			{Config: dsOutputFileConf, Check: existCheck},
+		},
+	})
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -683,6 +683,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ecd_users":                                        dataSourceAlicloudEcdUsers(),
 			"alicloud_vpc_traffic_mirror_sessions":                      dataSourceAlicloudVpcTrafficMirrorSessions(),
 			"alicloud_gpdb_accounts":                                    dataSourceAlicloudGpdbAccounts(),
+			"alicloud_gpdb_api_keys":                                    dataSourceAliCloudGpdbApiKeys(),
 			"alicloud_vpc_ipv6_gateways":                                dataSourceAlicloudVpcIpv6Gateways(),
 			"alicloud_vpc_ipv6_egress_rules":                            dataSourceAlicloudVpcIpv6EgressRules(),
 			"alicloud_vpc_ipv6_addresses":                               dataSourceAlicloudVpcIpv6Addresses(),
@@ -939,6 +940,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_gpdb_api_key":                                         resourceAliCloudGpdbApiKey(),
 			"alicloud_apig_plugin":                                          resourceAliCloudApigPlugin(),
 			"alicloud_apig_plugin_class":                                    resourceAliCloudApigPluginClass(),
 			"alicloud_apig_domain":                                          resourceAliCloudApigDomain(),

--- a/alicloud/resource_alicloud_gpdb_api_key.go
+++ b/alicloud/resource_alicloud_gpdb_api_key.go
@@ -1,0 +1,178 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudGpdbApiKey() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudGpdbApiKeyCreate,
+		Read:   resourceAliCloudGpdbApiKeyRead,
+		Delete: resourceAliCloudGpdbApiKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"service_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudGpdbApiKeyCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateApiKey"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("workspace_id"); ok {
+		request["WorkspaceId"] = v
+	}
+	request["RegionId"] = client.RegionId
+
+	request["KeyName"] = d.Get("key_name")
+	if v, ok := d.GetOk("description"); ok {
+		request["Description"] = v
+	}
+	if v, ok := d.GetOk("service_ids"); ok {
+		serviceIdsJsonPath, err := jsonpath.Get("$", v)
+		if err == nil && serviceIdsJsonPath != "" {
+			request["ServiceIds"] = convertListToJsonString(convertToInterfaceArray(serviceIdsJsonPath))
+		}
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("gpdb", "2016-05-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_gpdb_api_key", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", request["WorkspaceId"], response["KeyId"]))
+
+	return resourceAliCloudGpdbApiKeyRead(d, meta)
+}
+
+func resourceAliCloudGpdbApiKeyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	gpdbServiceV2 := GpdbServiceV2{client}
+
+	objectRaw, err := gpdbServiceV2.DescribeGpdbApiKey(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_gpdb_api_key DescribeGpdbApiKey Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("key_id", objectRaw["KeyId"])
+	d.Set("key_name", objectRaw["KeyName"])
+	d.Set("description", objectRaw["Description"])
+
+	if v, ok := objectRaw["AuthServices"]; ok && v != nil {
+		authServices, _ := v.([]interface{})
+		serviceIds := make([]string, 0, len(authServices))
+		for _, item := range authServices {
+			if m, ok := item.(map[string]interface{}); ok {
+				if sid, ok := m["ServiceId"]; ok {
+					serviceIds = append(serviceIds, fmt.Sprint(sid))
+				}
+			}
+		}
+		d.Set("service_ids", serviceIds)
+	}
+
+	parts := strings.Split(d.Id(), ":")
+	d.Set("workspace_id", parts[0])
+
+	return nil
+}
+
+func resourceAliCloudGpdbApiKeyDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := "DeleteApiKey"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["KeyId"] = parts[1]
+	request["RegionId"] = client.RegionId
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("gpdb", "2016-05-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_gpdb_api_key_test.go
+++ b/alicloud/resource_alicloud_gpdb_api_key_test.go
@@ -1,0 +1,177 @@
+package alicloud
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// A GPDB ApiKey requires a pre-existing GPDB workspace, but there is no
+// Terraform resource for a GPDB workspace, so it must be provisioned out of
+// band before the test case is built. It cannot be created inside a step's
+// PreConfig: the SDK configures the provider lazily on the first apply, so
+// testAccProvider.Meta() is still nil when the first step's PreConfig runs,
+// and the step Config string is rendered eagerly (before any PreConfig), so a
+// workspace id captured in PreConfig would never reach the config. We therefore
+// build a client from the acceptance credentials (sharedClientForRegion) and
+// create the workspace up front, guarded by TF_ACC so non-acceptance runs
+// (plain `go test`, vet, CI compile) never touch the API.
+func gpdbApiKeyTestCreateWorkspace(t *testing.T, rand int) (*connectivity.AliyunClient, string) {
+	region := os.Getenv("ALICLOUD_REGION")
+	if region == "" {
+		region = "cn-beijing"
+	}
+	rawClient, err := sharedClientForRegion(region)
+	if err != nil {
+		t.Fatalf("failed to get AliCloud client for gpdb workspace: %s", err)
+	}
+	client := rawClient.(*connectivity.AliyunClient)
+	request := map[string]interface{}{
+		"WorkspaceName": fmt.Sprintf("tfacc-gpdb-ws-%d", rand),
+		"RegionId":      client.RegionId,
+	}
+	response, err := client.RpcPost("gpdb", "2016-05-03", "CreateWorkspace", nil, request, true)
+	if err != nil {
+		t.Fatalf("failed to create gpdb workspace: %s", err)
+	}
+	return client, fmt.Sprint(response["WorkspaceId"])
+}
+
+func gpdbApiKeyTestDeleteWorkspace(client *connectivity.AliyunClient, workspaceId string) {
+	if client == nil || workspaceId == "" {
+		return
+	}
+	request := map[string]interface{}{
+		"WorkspaceId": workspaceId,
+		"RegionId":    client.RegionId,
+	}
+	_, _ = client.RpcPost("gpdb", "2016-05-03", "DeleteWorkspace", nil, request, true)
+}
+
+// Test Gpdb ApiKey. >>> Resource test cases, automatically generated.
+// Case: basic test
+func TestAccAliCloudGpdbApiKey_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_gpdb_api_key.default"
+	ra := resourceAttrInit(resourceId, AliCloudGpdbApiKeyMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GpdbServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGpdbApiKey")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccgpdbapikey%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudGpdbApiKeyBasicDependence)
+
+	var workspaceId string
+	var wsClient *connectivity.AliyunClient
+	if os.Getenv("TF_ACC") != "" {
+		wsClient, workspaceId = gpdbApiKeyTestCreateWorkspace(t, rand)
+		defer gpdbApiKeyTestDeleteWorkspace(wsClient, workspaceId)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"workspace_id": workspaceId,
+					"key_name":     name,
+					"description":  "terraform test",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"workspace_id": workspaceId,
+						"key_name":     name,
+						"description":  "terraform test",
+						"key_id":       CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case: twin test with service_ids
+func TestAccAliCloudGpdbApiKey_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_gpdb_api_key.default"
+	ra := resourceAttrInit(resourceId, AliCloudGpdbApiKeyMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GpdbServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGpdbApiKey")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccgpdbapikey%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudGpdbApiKeyBasicDependence)
+
+	var workspaceId string
+	var wsClient *connectivity.AliyunClient
+	if os.Getenv("TF_ACC") != "" {
+		wsClient, workspaceId = gpdbApiKeyTestCreateWorkspace(t, rand)
+		defer gpdbApiKeyTestDeleteWorkspace(wsClient, workspaceId)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"workspace_id": workspaceId,
+					"key_name":     name,
+					"description":  "terraform test twin",
+					"service_ids":  []string{},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"workspace_id":  workspaceId,
+						"key_name":      name,
+						"description":   "terraform test twin",
+						"key_id":        CHECKSET,
+						"service_ids.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AliCloudGpdbApiKeyMap = map[string]string{
+	"key_id":       CHECKSET,
+	"key_name":     CHECKSET,
+	"description":  CHECKSET,
+	"workspace_id": CHECKSET,
+}
+
+func AliCloudGpdbApiKeyBasicDependence(name string) string {
+	return ""
+}
+
+// Test Gpdb ApiKey. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_gpdb_v2.go
+++ b/alicloud/service_alicloud_gpdb_v2.go
@@ -1001,3 +1001,78 @@ func (s *GpdbServiceV2) GpdbSupabaseProjectStateRefreshFuncWithApi(id string, fi
 }
 
 // DescribeGpdbSupabaseProject >>> Encapsulated.
+// DescribeGpdbApiKey <<< Encapsulated get interface for Gpdb ApiKey.
+
+func (s *GpdbServiceV2) DescribeGpdbApiKey(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["KeyId"] = parts[1]
+	request["RegionId"] = client.RegionId
+	action := "GetApiKey"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("gpdb", "2016-05-03", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"MetaDBApiCalled.Failed"}) {
+			return object, WrapErrorf(NotFoundErr("ApiKey", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *GpdbServiceV2) GpdbApiKeyStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.GpdbApiKeyStateRefreshFuncWithApi(id, field, failStates, s.DescribeGpdbApiKey)
+}
+
+func (s *GpdbServiceV2) GpdbApiKeyStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeGpdbApiKey >>> Encapsulated.

--- a/website/docs/d/gpdb_api_keys.html.markdown
+++ b/website/docs/d/gpdb_api_keys.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "AnalyticDB for PostgreSQL (GPDB)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_gpdb_api_keys"
+sidebar_current: "docs-alicloud-datasource-gpdb-api-keys"
+description: |-
+  Provides a list of Gpdb Api Key owned by an Alibaba Cloud account.
+---
+
+# alicloud_gpdb_api_keys
+
+This data source provides Gpdb Api Key available to the user.[What is Api Key](https://next.api.alibabacloud.com/document/gpdb/2016-05-03/CreateApiKey)
+
+-> **NOTE:** Available since v1.286.0.
+
+## Example Usage
+
+```terraform
+variable "workspace_id" {
+  default = "ws-xxxxxxx"
+}
+
+data "alicloud_gpdb_api_keys" "default" {
+  workspace_id = var.workspace_id
+}
+
+output "gpdb_api_key_id" {
+  value = data.alicloud_gpdb_api_keys.default.keys[0].key_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `workspace_id` - (Required) The ID of the workspace.
+* `ids` - (Optional, Computed) A list of Api Key IDs. The value is formulated as `<workspace_id>:<key_id>`.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Api Key IDs.
+* `keys` - A list of Api Key Entries. Each element contains the following attributes:
+    * `create_time` - The creation time of the resource.
+    * `description` - The description of the API key.
+    * `key_id` - The ID of the API key.
+    * `key_name` - The name of the API key.
+    * `key_prefix` - The prefix of the API key.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/gpdb_api_key.html.markdown
+++ b/website/docs/r/gpdb_api_key.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "AnalyticDB for PostgreSQL (GPDB)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_gpdb_api_key"
+description: |-
+  Provides a Alicloud AnalyticDB for PostgreSQL (GPDB) Api Key resource.
+---
+
+# alicloud_gpdb_api_key
+
+Provides a AnalyticDB for PostgreSQL (GPDB) Api Key resource.
+
+The API key under a GPDB SaaS workspace.
+
+For information about AnalyticDB for PostgreSQL (GPDB) Api Key and how to use it, see [What is Api Key](https://next.api.alibabacloud.com/document/gpdb/2016-05-03/CreateApiKey).
+
+-> **NOTE:** Available since v1.286.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+variable "workspace_id" {
+  default = "ws-xxxxxxx"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_gpdb_api_key" "default" {
+  workspace_id = var.workspace_id
+  key_name     = var.name
+  description  = "terraform example"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `description` - (Optional, ForceNew) The description of the API key.
+* `key_name` - (Required, ForceNew) The name of the API key.
+* `service_ids` - (Optional, ForceNew) The list of SaaS service IDs that the API key is authorized to access.
+* `workspace_id` - (Required, ForceNew) The ID of the workspace.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<workspace_id>:<key_id>`.
+* `key_id` - The ID of the API key.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Api Key.
+* `delete` - (Defaults to 5 mins) Used when delete the Api Key.
+
+## Import
+
+AnalyticDB for PostgreSQL (GPDB) Api Key can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_gpdb_api_key.example <workspace_id>:<key_id>
+```


### PR DESCRIPTION
## Summary

Add `alicloud_gpdb_api_key` resource and `alicloud_gpdb_api_keys` data source for managing API keys under GPDB SaaS workspaces.

## New Resource: alicloud_gpdb_api_key

Manages an API key for an AnalyticDB for PostgreSQL (GPDB) SaaS workspace.

### Supported Arguments
- `workspace_id` - (Required, ForceNew) The ID of the GPDB workspace.
- `key_name` - (Required, ForceNew) The name of the API key.
- `description` - (Optional, ForceNew) The description of the API key.
- `service_ids` - (Optional, ForceNew) The list of SaaS service IDs that the API key is authorized to access.

### Exported Attributes
- `key_id` - The ID of the API key.

## New Data Source: alicloud_gpdb_api_keys

Lists API keys under a GPDB SaaS workspace.

## API Reference

- [CreateApiKey](https://next.api.alibabacloud.com/document/gpdb/2016-05-03/CreateApiKey)
- [GetApiKey](https://next.api.alibabacloud.com/document/gpdb/2016-05-03/GetApiKey)
- [DeleteApiKey](https://next.api.alibabacloud.com/document/gpdb/2016-05-03/DeleteApiKey)
- [ListApiKeys](https://next.api.alibabacloud.com/document/gpdb/2016-05-03/ListApiKeys)