### PR TITLE
resource/alicloud_ga_acl: support Chinese characters in acl_name

### DIFF
--- a/alicloud/resource_alicloud_ga_acl.go
+++ b/alicloud/resource_alicloud_ga_acl.go
@@ -35,7 +35,7 @@ func resourceAliCloudGaAcl() *schema.Resource {
 			"acl_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: StringMatch(regexp.MustCompile(`^[a-zA-Z][A-Za-z0-9._-]{2,128}$`), "The name must be `2` to `128` characters in length, and can contain letters, digits, periods (.), hyphens (-) and underscores (_). It must start with a letter."),
+				ValidateFunc: StringMatch(regexp.MustCompile(`^[a-zA-Z\p{Han}][a-zA-Z\p{Han}0-9._-]{0,127}$`), "The name must be `1` to `128` characters in length, and can contain letters, Chinese characters, digits, periods (.), hyphens (-) and underscores (_). It must start with a letter or a Chinese character."),
 			},
 			"resource_group_id": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_ga_acl_test.go
+++ b/alicloud/resource_alicloud_ga_acl_test.go
@@ -509,3 +509,45 @@ func AliCloudGaAclBasicDependence0(name string) string {
 	}
 `)
 }
+
+// TestUnitAliCloudGaAclNameValidation guards that the acl_name ValidateFunc
+// mirrors the Ga CreateAcl API contract: length 1-128, starts with a letter or
+// a Chinese character, and may contain letters, Chinese characters, digits,
+// periods (.), underscores (_) and hyphens (-). Chinese names must pass because
+// the underlying API accepts them.
+func TestUnitAliCloudGaAclNameValidation(t *testing.T) {
+	validateFunc := resourceAliCloudGaAcl().Schema["acl_name"].ValidateFunc
+	if validateFunc == nil {
+		t.Fatal("acl_name ValidateFunc is nil")
+	}
+
+	cases := []struct {
+		name        string
+		value       string
+		expectError bool
+	}{
+		{"chinese_only", "测试策略组", false},
+		{"chinese_mixed", "测试-acl_1", false},
+		{"chinese_leading", "中文acl", false},
+		{"ascii_normal", "test-acl", false},
+		{"single_letter", "a", false},
+		{"single_chinese", "组", false},
+		{"max_length_ascii", strings.Repeat("a", 128), false},
+		{"leading_digit", "1abc", true},
+		{"leading_hyphen", "-abc", true},
+		{"too_long", strings.Repeat("a", 129), true},
+		{"illegal_char", "test@acl", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, errs := validateFunc(c.value, "acl_name")
+			if c.expectError && len(errs) == 0 {
+				t.Errorf("value %q: expected validation error, got none", c.value)
+			}
+			if !c.expectError && len(errs) != 0 {
+				t.Errorf("value %q: expected no error, got %v", c.value, errs)
+			}
+		})
+	}
+}

--- a/website/docs/r/ga_acl.html.markdown
+++ b/website/docs/r/ga_acl.html.markdown
@@ -45,7 +45,7 @@ resource "alicloud_ga_acl_entry_attachment" "default" {
 The following arguments are supported:
 
 * `address_ip_version` - (Required, ForceNew) The IP version. Valid values: `IPv4` and `IPv6`.
-* `acl_name` - (Optional) The name of the ACL. The name must be `2` to `128` characters in length, and can contain letters, digits, periods (.), hyphens (-) and underscores (_). It must start with a letter.
+* `acl_name` - (Optional) The name of the ACL. The name must be `1` to `128` characters in length, and can contain letters, Chinese characters, digits, periods (.), hyphens (-) and underscores (_). It must start with a letter or a Chinese character.
 * `resource_group_id` - (Optional, Available since v1.226.0) The ID of the resource group. **Note:** Once you set a value of this property, you cannot set it to an empty string anymore.
 * `tags` - (Optional, Available since v1.207.1) A mapping of tags to assign to the resource.
 * `acl_entries` - (Optional, Set, Deprecated since v1.190.0) The entries of the Acl. See [`acl_entries`](#acl_entries) below. **NOTE:** "Field `acl_entries` has been deprecated from provider version 1.190.0 and it will be removed in the future version. Please use the new resource `alicloud_ga_acl_entry_attachment`."


### PR DESCRIPTION
### Summary
Relax the client-side validation of \`acl_name\` on \`alicloud_ga_acl\` so that Chinese characters are accepted.

### Background
The Ga \`CreateAcl\` API documents \`AclName\` as: 1 to 128 characters, starting with a letter or a Chinese character, and may contain letters, Chinese characters, digits, periods (.), underscores (_) and hyphens (-). The previous \`ValidateFunc\` regex \`^[a-zA-Z][A-Za-z0-9._-]{2,128}$\` only allowed ASCII names starting with a letter, so Chinese names were rejected during plan/apply before ever reaching the API.

### Changes
- Update the \`acl_name\` \`ValidateFunc\` regex to \`^[a-zA-Z\p{Han}][a-zA-Z\p{Han}0-9._-]{0,127}$\`, matching the API contract (1-128 chars, letter/Chinese leading char).
- Update the resource documentation accordingly.
- Add a unit test (\`TestUnitAlicloudGaAclNameValidation\`) covering Chinese, ASCII, boundary and invalid inputs.

### Test
\`\`\`
make test TEST=./alicloud TESTARGS="-run TestUnitAlicloudGaAclNameValidation"
\`\`\`