### PR TITLE
resource/alicloud_arms_prometheus: support duration, archive_duration and payment_type

### DIFF
--- a/alicloud/resource_alicloud_arms_prometheus.go
+++ b/alicloud/resource_alicloud_arms_prometheus.go
@@ -71,6 +71,22 @@ func resourceAlicloudArmsPrometheus() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"duration": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"archive_duration": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"payment_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"POSTPAY", "POSTPAY_GB"}, false),
+			},
 			"tags": tagsSchema(),
 		},
 	}
@@ -114,6 +130,18 @@ func resourceAliCloudArmsPrometheusCreate(d *schema.ResourceData, meta interface
 
 	if v, ok := d.GetOk("resource_group_id"); ok {
 		request["ResourceGroupId"] = v
+	}
+
+	if v, ok := d.GetOkExists("duration"); ok {
+		request["Duration"] = v
+	}
+
+	if v, ok := d.GetOkExists("archive_duration"); ok {
+		request["ArchiveDuration"] = v
+	}
+
+	if v, ok := d.GetOk("payment_type"); ok {
+		request["PaymentType"] = v
 	}
 
 	wait := incrementalWait(3*time.Second, 3*time.Second)
@@ -161,6 +189,9 @@ func resourceAliCloudArmsPrometheusRead(d *schema.ResourceData, meta interface{}
 	d.Set("cluster_name", object["ClusterName"])
 	d.Set("sub_clusters_json", object["SubClustersJson"])
 	d.Set("resource_group_id", object["ResourceGroupId"])
+	d.Set("duration", formatInt(object["StorageDuration"]))
+	d.Set("archive_duration", formatInt(object["ArchiveDuration"]))
+	d.Set("payment_type", object["PaymentType"])
 
 	listTagResourcesObject, err := armsService.ListTagResources(d.Id(), "PROMETHEUS")
 	if err != nil {
@@ -292,6 +323,58 @@ func resourceAliCloudArmsPrometheusUpdate(d *schema.ResourceData, meta interface
 		}
 
 		d.SetPartial("resource_group_id")
+	}
+
+	update = false
+	updatePrometheusInstanceReq := map[string]interface{}{
+		"RegionId":  client.RegionId,
+		"ClusterId": d.Id(),
+	}
+
+	if !d.IsNewResource() && d.HasChange("duration") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("duration"); ok {
+		updatePrometheusInstanceReq["StorageDuration"] = v
+	}
+
+	if !d.IsNewResource() && d.HasChange("archive_duration") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("archive_duration"); ok {
+		updatePrometheusInstanceReq["ArchiveDuration"] = v
+	}
+
+	if !d.IsNewResource() && d.HasChange("payment_type") {
+		update = true
+	}
+	if v, ok := d.GetOk("payment_type"); ok {
+		updatePrometheusInstanceReq["PaymentType"] = v
+	}
+
+	if update {
+		action := "UpdatePrometheusInstance"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
+			response, err = client.RpcPost("ARMS", "2019-08-08", action, nil, updatePrometheusInstanceReq, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, updatePrometheusInstanceReq)
+
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		d.SetPartial("duration")
+		d.SetPartial("archive_duration")
+		d.SetPartial("payment_type")
 	}
 
 	d.Partial(false)

--- a/alicloud/resource_alicloud_arms_prometheus_test.go
+++ b/alicloud/resource_alicloud_arms_prometheus_test.go
@@ -35,6 +35,9 @@ func TestAccAliCloudArmsPrometheus_basic0(t *testing.T) {
 					"grafana_instance_id": "free",
 					"cluster_name":        name,
 					"resource_group_id":   "${data.alicloud_resource_manager_resource_groups.default.groups.0.id}",
+					"payment_type":        "POSTPAY",
+					"duration":            "90",
+					"archive_duration":    "60",
 					"tags": map[string]string{
 						"Created": "TF",
 						"For":     "Prometheus",
@@ -46,9 +49,26 @@ func TestAccAliCloudArmsPrometheus_basic0(t *testing.T) {
 						"grafana_instance_id": "free",
 						"cluster_name":        name,
 						"resource_group_id":   CHECKSET,
+						"payment_type":        "POSTPAY",
+						"duration":            "90",
+						"archive_duration":    "60",
 						"tags.%":              "2",
 						"tags.Created":        "TF",
 						"tags.For":            "Prometheus",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"duration":         "180",
+					"archive_duration": "90",
+					"payment_type":     "POSTPAY_GB",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"duration":         "180",
+						"archive_duration": "90",
+						"payment_type":     "POSTPAY_GB",
 					}),
 				),
 			},

--- a/website/docs/r/arms_prometheus.html.markdown
+++ b/website/docs/r/arms_prometheus.html.markdown
@@ -82,6 +82,9 @@ The following arguments are supported:
 * `cluster_name` - (Optional, ForceNew) The name of the created cluster. This parameter is required, if you set `cluster_type` to `remote-write`, `ecs` or `global-view`.
 * `sub_clusters_json` - (Optional) The child instance json string of the globalView instance.
 * `resource_group_id` - (Optional) The ID of the resource group.
+* `duration` - (Optional, Computed, Available since v1.286.0) The data storage duration, in days.
+* `archive_duration` - (Optional, Computed, Available since v1.286.0) The number of days for which data is automatically archived after the storage duration expires. Valid values: `60`, `90`, `180`, `365`. `0` indicates that data is not archived.
+* `payment_type` - (Optional, Computed, Available since v1.286.0) The billing method. Valid values: `POSTPAY` (pay-as-you-go based on the amount of reported metrics), `POSTPAY_GB` (pay-as-you-go based on the amount of written metrics).
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
### Description

This PR adds three new arguments to `resource/alicloud_arms_prometheus`:

- `duration` (Optional, Computed) — the data storage duration, in days.
- `archive_duration` (Optional, Computed) — the number of days for which data is automatically archived after the storage duration expires.
- `payment_type` (Optional, Computed) — the billing method, one of `POSTPAY` or `POSTPAY_GB`.

Full CRUD coverage:

- **Create** — passes `Duration`, `ArchiveDuration` and `PaymentType` to `CreatePrometheusInstance`.
- **Read** — refreshes state from the API response fields `StorageDuration`, `ArchiveDuration` and `PaymentType`.
- **Update** — supports in-place update via `UpdatePrometheusInstance` (storage duration maps to the `StorageDuration` parameter).

### API references

- CreatePrometheusInstance: https://www.alibabacloud.com/help/en/arms/developer-reference/api-arms-2019-08-08-createprometheusinstance
- UpdatePrometheusInstance: https://www.alibabacloud.com/help/en/arms/developer-reference/api-arms-2019-08-08-updateprometheusinstance

### Acceptance tests

Verified with `TestAccAliCloudArmsPrometheus_basic0` and `TestAccAliCloudArmsPrometheus_basic1`, covering create with the new fields, in-place update, and re-import — all passing.
