### PR TITLE
resource/alicloud_rocketmq_instance: tolerate renewal query failure in Read

### DIFF
--- a/alicloud/resource_alicloud_rocketmq_instance.go
+++ b/alicloud/resource_alicloud_rocketmq_instance.go
@@ -652,13 +652,20 @@ func resourceAliCloudRocketmqInstanceRead(d *schema.ResourceData, meta interface
 	bssOpenApiService := BssOpenApiService{client}
 	queryAvailableInstancesObject, err := bssOpenApiService.QueryAvailableInstancesWithoutProductType(d.Id(), client.RegionId, "ons", "ons")
 	if err != nil {
-		return WrapError(err)
+		// The renewal info is fetched from the BSS billing API and only feeds three
+		// non-critical attributes (auto_renew/auto_renew_period/auto_renew_period_unit).
+		// For some account and region combinations the billing endpoint is not
+		// applicable and returns an error even though the instance itself is healthy,
+		// which must not fail the whole read. Treat it as best-effort: log and skip
+		// these attributes instead of returning an error.
+		log.Printf("[WARN] querying renewal info for RocketMQ instance %s failed, skip setting auto_renew attributes: %v", d.Id(), err)
+	} else {
+		d.Set("auto_renew", queryAvailableInstancesObject["RenewStatus"] == "AutoRenewal")
+		if v, ok := queryAvailableInstancesObject["RenewalDuration"]; ok && fmt.Sprint(v) != "0" {
+			d.Set("auto_renew_period", formatInt(v))
+		}
+		d.Set("auto_renew_period_unit", convertAmqpInstanceRenewalDurationUnitResponse(queryAvailableInstancesObject["RenewalDurationUnit"]))
 	}
-	d.Set("auto_renew", queryAvailableInstancesObject["RenewStatus"] == "AutoRenewal")
-	if v, ok := queryAvailableInstancesObject["RenewalDuration"]; ok && fmt.Sprint(v) != "0" {
-		d.Set("auto_renew_period", formatInt(v))
-	}
-	d.Set("auto_renew_period_unit", convertAmqpInstanceRenewalDurationUnitResponse(queryAvailableInstancesObject["RenewalDurationUnit"]))
 
 	objectRaw, err = rocketmqServiceV2.DescribeInstanceGetInstanceIpWhitelist(d.Id())
 	if err != nil && !NotFoundError(err) {

--- a/alicloud/resource_alicloud_rocketmq_instance_test.go
+++ b/alicloud/resource_alicloud_rocketmq_instance_test.go
@@ -44,8 +44,9 @@ func TestAccAliCloudRocketmqInstance_SendReceiveRatioValidation(t *testing.T) {
 					"instance_name": name,
 					"product_info": []map[string]interface{}{
 						{
-							"msg_process_spec":       "rmq.p2.4xlarge",
-							"send_receive_ratio":     "0.03", // This should be out of range [0.05, 0.5] to test validation
+							"msg_process_spec": "rmq.p2.4xlarge",
+							// send_receive_ratio 0.03 is intentionally out of range [0.05, 0.5] to trigger the expected validation error
+							"send_receive_ratio":     "0.03",
 							"message_retention_time": "70",
 						},
 					},


### PR DESCRIPTION
### Summary

`resourceAliCloudRocketmqInstanceRead` queries renewal information from the BSS billing API (`QueryAvailableInstances`) to populate three non-critical attributes: `auto_renew`, `auto_renew_period` and `auto_renew_period_unit`.

Previously any error from that billing query was returned as a fatal error, which aborted the whole Read. As a result, an instance that was created successfully and is `RUNNING` could still fail `terraform apply` during the refresh/read step whenever the billing endpoint is not applicable for a given account-and-region combination (for example a domestic-station account operating in an international region, where the international billing system has no record of the account and returns an error).

### Fix

Degrade the renewal query to best-effort: on failure, log a warning and skip setting the three `auto_renew*` attributes instead of failing Read. This matches the tolerant handling already used by `alicloud_amqp_instance`, whose Read guards its equivalent billing query rather than treating it as fatal. Instance provisioning and all primary attributes are unaffected.

### Test / verification

This failure only manifests with a specific account-type by region combination against the live BSS billing endpoint, so it cannot be reproduced in a standalone unit test without mocking the BSS RPC layer (the resource has no such test seam). Verification is done via remote acceptance tests: running the existing `TestAccAliCloudRocketmqInstance_*` cases in an international region with a domestic-station account fails at the Read step before this change and passes after it. The change is otherwise a no-op for the common case, where the billing query succeeds and the attributes are set exactly as before.
