### PR TITLE
alicloud/service_alicloud_elasticsearch: fix unsafe error handling in kibana PVL network functions

### DIFF
--- a/alicloud/service_alicloud_elasticsearch.go
+++ b/alicloud/service_alicloud_elasticsearch.go
@@ -3,7 +3,6 @@ package alicloud
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -167,9 +166,16 @@ func (s *ElasticsearchService) getKibanaPvlNetworkInfo(id string) (interface{}, 
 		return nil
 	})
 
-	instanceMap := jsonToMap(listKibanaPvlNetworkResp.GetHttpContentString())
+	if err != nil {
+		return nil, err
+	}
+
+	instanceMap, err := jsonToMap(listKibanaPvlNetworkResp.GetHttpContentString())
+	if err != nil {
+		return nil, WrapErrorf(err, "parse kibana pvl network response error for instance %s", id)
+	}
 	resultMap := instanceMap["Result"]
-	return resultMap, err
+	return resultMap, nil
 }
 
 func (s *ElasticsearchService) updateKibanaPrivatePvlNetwork(d *schema.ResourceData, content map[string]interface{}, meta interface{}) error {
@@ -190,14 +196,23 @@ func (s *ElasticsearchService) updateKibanaPrivatePvlNetwork(d *schema.ResourceD
 		return WrapErrorf(err, "get kibana pvl info error %s", d.Id())
 	}
 
-	pvlInfoArr := pvlInfoInterface.([]interface{})
-
-	if len(pvlInfoArr) == 0 {
-		return WrapErrorf(err, "get kibana pvl info empty %s", d.Id())
+	pvlInfoArr, ok := pvlInfoInterface.([]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected type for kibana pvl network info of instance %s", d.Id())
 	}
 
-	pvlInfo := pvlInfoArr[0]
-	pvlId := pvlInfo.(map[string]interface{})["pvlId"].(string)
+	if len(pvlInfoArr) == 0 {
+		return fmt.Errorf("get kibana pvl info empty for instance %s", d.Id())
+	}
+
+	pvlInfoMap, ok := pvlInfoArr[0].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected pvl info element type for instance %s", d.Id())
+	}
+	pvlId, ok := pvlInfoMap["pvlId"].(string)
+	if !ok {
+		return fmt.Errorf("pvlId not found or invalid type in kibana pvl info for instance %s", d.Id())
+	}
 	updateKibanaPvlNetworkReq.QueryParams["pvlId"] = pvlId
 
 	// retry
@@ -1077,13 +1092,13 @@ func closeHttps(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func jsonToMap(content string) map[string]interface{} {
+func jsonToMap(content string) (map[string]interface{}, error) {
 	var dataMap map[string]interface{}
 
 	err := json.Unmarshal([]byte(content), &dataMap)
 	if err != nil {
-		log.Fatalf("parse json to map error: %v", err)
+		return nil, fmt.Errorf("parse json to map error: %v", err)
 	}
 
-	return dataMap
+	return dataMap, nil
 }


### PR DESCRIPTION
## Summary

Fix three error handling bugs in `alicloud/service_alicloud_elasticsearch.go` that could cause provider crashes or panics.

## Changes

### 1. `jsonToMap` — replace `log.Fatalf` with error return

`log.Fatalf` calls `os.Exit(1)`, which terminates the entire provider process when a malformed JSON response is received. Changed the function signature to return `(map[string]interface{}, error)` so callers can handle parse failures gracefully.

### 2. `getKibanaPvlNetworkInfo` — early return on `invoker.Run` error

After `invoker.Run` returned an error, execution continued to parse the (potentially empty or invalid) response body. Added an early `return nil, err` guard before response parsing.

### 3. `updateKibanaPrivatePvlNetwork` — safe type assertions

Three unsafe type assertions (`x.(Type)`) would panic if the API response structure did not match expectations. Converted all three to the comma-ok pattern (`v, ok := x.(Type)`) with descriptive error returns.

## Verification

- `gofmt -l alicloud/` — clean (no formatting issues)
- `go vet ./alicloud` — clean (no new warnings; pre-existing warnings in `common.go` are unrelated)
- `go build ./alicloud` — compiles successfully