### PR TITLE
resource/alicloud_elasticsearch_instance: fix provider crash on Kibana private network response parsing; testcase: add unit tests

### DIFF
--- a/alicloud/service_alicloud_elasticsearch.go
+++ b/alicloud/service_alicloud_elasticsearch.go
@@ -3,7 +3,6 @@ package alicloud
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -167,9 +166,15 @@ func (s *ElasticsearchService) getKibanaPvlNetworkInfo(id string) (interface{}, 
 		return nil
 	})
 
-	instanceMap := jsonToMap(listKibanaPvlNetworkResp.GetHttpContentString())
-	resultMap := instanceMap["Result"]
-	return resultMap, err
+	if err != nil {
+		return nil, err
+	}
+
+	instanceMap, err := jsonToMap(listKibanaPvlNetworkResp.GetHttpContentString())
+	if err != nil {
+		return nil, WrapError(err)
+	}
+	return instanceMap["Result"], nil
 }
 
 func (s *ElasticsearchService) updateKibanaPrivatePvlNetwork(d *schema.ResourceData, content map[string]interface{}, meta interface{}) error {
@@ -190,14 +195,10 @@ func (s *ElasticsearchService) updateKibanaPrivatePvlNetwork(d *schema.ResourceD
 		return WrapErrorf(err, "get kibana pvl info error %s", d.Id())
 	}
 
-	pvlInfoArr := pvlInfoInterface.([]interface{})
-
-	if len(pvlInfoArr) == 0 {
-		return WrapErrorf(err, "get kibana pvl info empty %s", d.Id())
+	pvlId, err := parseKibanaPvlId(pvlInfoInterface)
+	if err != nil {
+		return WrapErrorf(err, "get kibana pvl info error %s", d.Id())
 	}
-
-	pvlInfo := pvlInfoArr[0]
-	pvlId := pvlInfo.(map[string]interface{})["pvlId"].(string)
 	updateKibanaPvlNetworkReq.QueryParams["pvlId"] = pvlId
 
 	// retry
@@ -1077,13 +1078,38 @@ func closeHttps(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func jsonToMap(content string) map[string]interface{} {
+func jsonToMap(content string) (map[string]interface{}, error) {
 	var dataMap map[string]interface{}
 
-	err := json.Unmarshal([]byte(content), &dataMap)
-	if err != nil {
-		log.Fatalf("parse json to map error: %v", err)
+	if err := json.Unmarshal([]byte(content), &dataMap); err != nil {
+		return nil, WrapError(err)
 	}
 
-	return dataMap
+	return dataMap, nil
+}
+
+// parseKibanaPvlId safely extracts the pvlId from the ListKibanaPvlNetwork response
+// Result. It returns an error instead of panicking when the response shape is
+// unexpected (nil/non-array Result, empty array, non-object item, or missing/non-string pvlId).
+func parseKibanaPvlId(result interface{}) (string, error) {
+	pvlInfoArr, ok := result.([]interface{})
+	if !ok {
+		return "", WrapError(fmt.Errorf("unexpected kibana pvl network response: Result is not a list, got %T", result))
+	}
+
+	if len(pvlInfoArr) == 0 {
+		return "", WrapError(fmt.Errorf("kibana pvl network info is empty"))
+	}
+
+	pvlInfoMap, ok := pvlInfoArr[0].(map[string]interface{})
+	if !ok {
+		return "", WrapError(fmt.Errorf("unexpected kibana pvl network response: item is not an object, got %T", pvlInfoArr[0]))
+	}
+
+	pvlId, ok := pvlInfoMap["pvlId"].(string)
+	if !ok {
+		return "", WrapError(fmt.Errorf("unexpected kibana pvl network response: pvlId is missing or not a string"))
+	}
+
+	return pvlId, nil
 }

--- a/alicloud/service_alicloud_elasticsearch_test.go
+++ b/alicloud/service_alicloud_elasticsearch_test.go
@@ -1,0 +1,87 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUnitElasticsearchJsonToMap verifies jsonToMap returns an error (instead of
+// terminating the whole provider process via log.Fatalf/os.Exit) when the content
+// is empty or not valid JSON.
+func TestUnitElasticsearchJsonToMap(t *testing.T) {
+	t.Run("valid json", func(t *testing.T) {
+		m, err := jsonToMap(`{"Result":[{"pvlId":"pvl-123"}]}`)
+		assert.NoError(t, err)
+		assert.NotNil(t, m)
+		assert.Contains(t, m, "Result")
+	})
+
+	t.Run("empty content", func(t *testing.T) {
+		m, err := jsonToMap("")
+		assert.Error(t, err)
+		assert.Nil(t, m)
+	})
+
+	t.Run("illegal json", func(t *testing.T) {
+		m, err := jsonToMap("not-a-json")
+		assert.Error(t, err)
+		assert.Nil(t, m)
+	})
+}
+
+// TestUnitElasticsearchParseKibanaPvlId verifies parseKibanaPvlId returns an error
+// (instead of panicking on an unchecked type assertion) for every malformed shape
+// of the ListKibanaPvlNetwork response Result.
+func TestUnitElasticsearchParseKibanaPvlId(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		result := []interface{}{
+			map[string]interface{}{"pvlId": "pvl-123"},
+		}
+		pvlId, err := parseKibanaPvlId(result)
+		assert.NoError(t, err)
+		assert.Equal(t, "pvl-123", pvlId)
+	})
+
+	t.Run("result is nil", func(t *testing.T) {
+		pvlId, err := parseKibanaPvlId(nil)
+		assert.Error(t, err)
+		assert.Empty(t, pvlId)
+	})
+
+	t.Run("result is not a list", func(t *testing.T) {
+		pvlId, err := parseKibanaPvlId(map[string]interface{}{"pvlId": "pvl-123"})
+		assert.Error(t, err)
+		assert.Empty(t, pvlId)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		pvlId, err := parseKibanaPvlId([]interface{}{})
+		assert.Error(t, err)
+		assert.Empty(t, pvlId)
+	})
+
+	t.Run("item is not an object", func(t *testing.T) {
+		pvlId, err := parseKibanaPvlId([]interface{}{"pvl-123"})
+		assert.Error(t, err)
+		assert.Empty(t, pvlId)
+	})
+
+	t.Run("pvlId missing", func(t *testing.T) {
+		result := []interface{}{
+			map[string]interface{}{"otherField": "x"},
+		}
+		pvlId, err := parseKibanaPvlId(result)
+		assert.Error(t, err)
+		assert.Empty(t, pvlId)
+	})
+
+	t.Run("pvlId not a string", func(t *testing.T) {
+		result := []interface{}{
+			map[string]interface{}{"pvlId": 123},
+		}
+		pvlId, err := parseKibanaPvlId(result)
+		assert.Error(t, err)
+		assert.Empty(t, pvlId)
+	})
+}


### PR DESCRIPTION
### Summary

`ListKibanaPvlNetwork` responses for the Kibana private network (`alicloud_elasticsearch_instance`) were parsed unsafely, which could crash the entire provider process on an unexpected or failed API response:

- `jsonToMap` called `log.Fatalf` on invalid JSON, which triggers `os.Exit` and terminates the whole provider plugin process instead of returning an error.
- `updateKibanaPrivatePvlNetwork` parsed the response body before checking the API error, feeding a failed/empty/invalid response into the parser.
- `pvlId` was extracted with unchecked type assertions (`Result.([]interface{})`, `item.(map[string]interface{})["pvlId"].(string)`), causing a panic when `Result` is nil / not an array, the first element is not an object, or `pvlId` is missing / not a string.

A single transient API error during a Kibana private network create/update could therefore take down the provider.

### Changes

- `jsonToMap` now returns `(map[string]interface{}, error)` and no longer calls `log.Fatalf`.
- `getKibanaPvlNetworkInfo` checks the API error before parsing the response body.
- `pvlId` extraction moved to `parseKibanaPvlId`, which uses safe (comma-ok) type assertions and returns a diagnostic error instead of panicking.
- Added unit tests covering empty content, invalid JSON, and malformed `Result` shapes (non-array, empty array, non-object item, missing / non-string `pvlId`).

### Test

```
$ go test ./alicloud -run 'TestUnitElasticsearch(JsonToMap|ParseKibanaPvlId)' -v
--- PASS: TestUnitElasticsearchJsonToMap
--- PASS: TestUnitElasticsearchParseKibanaPvlId
```
