### PR TITLE
resource/alicloud_drds_instance: fix panic on empty VIP list in Read

### DIFF
--- a/alicloud/resource_alicloud_drds_instance.go
+++ b/alicloud/resource_alicloud_drds_instance.go
@@ -215,19 +215,30 @@ func resourceAliCloudDRDSInstanceRead(d *schema.ResourceData, meta interface{}) 
 	//other attribute not set,because these attribute from `data` can't  get
 	d.Set("zone_id", data.ZoneId)
 	d.Set("description", data.Description)
-	d.Set("vpc_id", data.Vips.Vip[0].VpcId)
-	var connectionString, port string
-	for _, vip := range data.Vips.Vip {
+	vpcId, connectionString, port := flattenDrdsInstanceVips(data.Vips.Vip)
+	d.Set("vpc_id", vpcId)
+	d.Set("connection_string", connectionString)
+	d.Set("port", port)
+	d.Set("mysql_version", data.MysqlVersion)
+	return nil
+}
+
+// flattenDrdsInstanceVips extracts the vpc_id, connection_string and port from the
+// DescribeDrdsInstance VIP list. A valid instance can transiently report an empty
+// VIP list, so the first-element access is length-guarded to avoid an out-of-range
+// panic; an empty list yields zero values.
+func flattenDrdsInstanceVips(vips []drds.Vip) (vpcId, connectionString, port string) {
+	if len(vips) > 0 {
+		vpcId = vips[0].VpcId
+	}
+	for _, vip := range vips {
 		if vip.Type == "intranet" {
 			connectionString = vip.Dns
 			port = vip.Port
 			break
 		}
 	}
-	d.Set("connection_string", connectionString)
-	d.Set("port", port)
-	d.Set("mysql_version", data.MysqlVersion)
-	return nil
+	return vpcId, connectionString, port
 }
 
 func resourceAliCloudDRDSInstanceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_drds_instance_test.go
+++ b/alicloud/resource_alicloud_drds_instance_test.go
@@ -93,7 +93,7 @@ func testSweepDRDSInstances(region string) error {
 	return nil
 }
 
-func TestAccAlicloudDRDSInstance_Vpc(t *testing.T) {
+func TestAccAliCloudDRDSInstance_Vpc(t *testing.T) {
 	var v *drds.DescribeDrdsInstanceResponse
 
 	resourceId := "alicloud_drds_instance.default"
@@ -166,7 +166,7 @@ func TestAccAlicloudDRDSInstance_Vpc(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudDRDSInstance_Multi(t *testing.T) {
+func TestAccAliCloudDRDSInstance_Multi(t *testing.T) {
 	var v *drds.DescribeDrdsInstanceResponse
 
 	resourceId := "alicloud_drds_instance.default.2"
@@ -216,7 +216,7 @@ func TestAccAlicloudDRDSInstance_Multi(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudDRDSInstance_VpcId(t *testing.T) {
+func TestAccAliCloudDRDSInstance_VpcId(t *testing.T) {
 	var v *drds.DescribeDrdsInstanceResponse
 
 	resourceId := "alicloud_drds_instance.default"
@@ -271,7 +271,7 @@ func TestAccAlicloudDRDSInstance_VpcId(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudDRDSInstance_MySQLVersion(t *testing.T) {
+func TestAccAliCloudDRDSInstance_MySQLVersion(t *testing.T) {
 	var v *drds.DescribeDrdsInstanceResponse
 
 	resourceId := "alicloud_drds_instance.default"
@@ -355,4 +355,39 @@ var drdsInstancebasicMap = map[string]string{
 	"specification":        "drds.sn1.4c8g.8C16G",
 	"connection_string":    CHECKSET,
 	"port":                 CHECKSET,
+}
+
+// TestUnitAliCloudDRDSInstanceFlattenVips guards the DRDS instance Read against a
+// panic when the DescribeDrdsInstance response returns an empty VIP list. A valid
+// instance can transiently report no VIPs, and indexing Vip[0] directly used to
+// crash the provider. The empty case must return zero values; the populated case
+// must surface the first VIP's VpcId plus the intranet connection string/port.
+func TestUnitAliCloudDRDSInstanceFlattenVips(t *testing.T) {
+	// Empty VIP list: must not panic and must yield zero values.
+	vpcId, connectionString, port := flattenDrdsInstanceVips([]drds.Vip{})
+	if vpcId != "" || connectionString != "" || port != "" {
+		t.Fatalf("empty VIP list should yield zero values, got vpcId=%q connectionString=%q port=%q", vpcId, connectionString, port)
+	}
+
+	// Nil VIP list: same guarantee.
+	vpcId, connectionString, port = flattenDrdsInstanceVips(nil)
+	if vpcId != "" || connectionString != "" || port != "" {
+		t.Fatalf("nil VIP list should yield zero values, got vpcId=%q connectionString=%q port=%q", vpcId, connectionString, port)
+	}
+
+	// Populated VIP list: vpc_id from the first VIP, connection_string/port from the intranet VIP.
+	vips := []drds.Vip{
+		{Type: "internet", VpcId: "vpc-external", Dns: "public.example.com", Port: "3306"},
+		{Type: "intranet", VpcId: "vpc-internal", Dns: "intranet.example.com", Port: "3307"},
+	}
+	vpcId, connectionString, port = flattenDrdsInstanceVips(vips)
+	if vpcId != "vpc-external" {
+		t.Fatalf("vpcId should come from the first VIP, got %q", vpcId)
+	}
+	if connectionString != "intranet.example.com" {
+		t.Fatalf("connectionString should come from the intranet VIP, got %q", connectionString)
+	}
+	if port != "3307" {
+		t.Fatalf("port should come from the intranet VIP, got %q", port)
+	}
 }

--- a/website/docs/r/drds_instance.html.markdown
+++ b/website/docs/r/drds_instance.html.markdown
@@ -84,16 +84,6 @@ The following arguments are supported:
 * `vpc_id` - (Optional, ForceNew, Available since v1.185.0) The id of the VPC.
 * `mysql_version` - (Optional, ForceNew, Available since v1.201.0) The MySQL version supported by the instance, with the following range of values. `5`: Fully compatible with MySQL 5.x (default) `8`: Fully compatible with MySQL 8.0. This parameter takes effect when the primary instance is created, and the read-only instance has the same MySQL version as the primary instance by default.
        
-## Timeouts
-
--> **NOTE:** Available since v1.49.0.
-
-The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
-
-* `create` - (Defaults to 10 mins) Used when creating the drds instance (until it reaches running status). 
-* `delete` - (Defaults to 10 mins) Used when terminating the drds instance. 
-       
-       
 ## Attributes Reference
 
 The following attributes are exported:
@@ -102,6 +92,14 @@ The following attributes are exported:
 * `connection_string` - (Available since v1.196.0) The connection string of the DRDS instance.
 * `port` - (Available since v1.196.0) The connection port of the DRDS instance.
 
+## Timeouts
+
+-> **NOTE:** Available since v1.49.0.
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 10 mins) Used when creating the drds instance (until it reaches running status).
+* `delete` - (Defaults to 10 mins) Used when terminating the drds instance.
 
 ## Import
 


### PR DESCRIPTION
### Summary

`resourceAliCloudDRDSInstanceRead` indexed `data.Vips.Vip[0].VpcId` directly. `DescribeDrdsInstance` can return a valid instance whose `Data.Vips.Vip` is an empty slice, which caused an index-out-of-range panic that crashed the provider during refresh.

### Change

- Extract the VIP flattening (`vpc_id`, `connection_string`, `port`) into a length-guarded helper `flattenDrdsInstanceVips`. An empty/nil VIP list now yields zero values instead of panicking; behavior is unchanged when VIPs are present (`vpc_id` from the first VIP, `connection_string`/`port` from the intranet VIP).
- Add unit test `TestUnitAliCloudDRDSInstanceFlattenVips` covering empty, nil and populated VIP lists.

### Test

```
=== RUN   TestUnitAliCloudDRDSInstanceFlattenVips
--- PASS: TestUnitAliCloudDRDSInstanceFlattenVips
```