### PR TITLE
resource/alicloud_privatelink_vpc_endpoint_service: support the resource field to associate service resources at creation

### DIFF
--- a/alicloud/resource_alicloud_privatelink_vpc_endpoint_service.go
+++ b/alicloud/resource_alicloud_privatelink_vpc_endpoint_service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/helper"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -59,6 +60,38 @@ func resourceAliCloudPrivateLinkVpcEndpointService() *schema.Resource {
 			"region_id": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"resource": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				MaxItems: 10,
+				// Hash an element on resource_id + resource_type only, so the
+				// server-assigned zone_id (Optional + Computed) never changes an
+				// element's identity after Read. This keeps the set order- and
+				// value-independent and avoids perpetual diff / detach-attach churn.
+				Set: func(v interface{}) int {
+					m := v.(map[string]interface{})
+					return helper.Hashcode(fmt.Sprintf("%s|%s", m["resource_id"], m["resource_type"]))
+				},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"resource_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: StringInSlice([]string{"slb", "alb", "nlb", "gwlb"}, false),
+						},
+						"zone_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"resource_group_id": {
 				Type:     schema.TypeString,
@@ -155,6 +188,20 @@ func resourceAliCloudPrivateLinkVpcEndpointServiceCreate(d *schema.ResourceData,
 	if v, ok := d.GetOk("supported_region_list"); ok {
 		request["SupportedRegionList"] = v.(*schema.Set).List()
 	}
+	if v, ok := d.GetOk("resource"); ok {
+		resourceMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range v.(*schema.Set).List() {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := make(map[string]interface{})
+			dataLoopMap["ResourceId"] = dataLoopTmp["resource_id"]
+			dataLoopMap["ResourceType"] = dataLoopTmp["resource_type"]
+			if zoneId := vpcEndpointServiceResourceZoneId(dataLoopTmp["zone_id"]); zoneId != "" {
+				dataLoopMap["ZoneId"] = zoneId
+			}
+			resourceMapsArray = append(resourceMapsArray, dataLoopMap)
+		}
+		request["Resource"] = resourceMapsArray
+	}
 	if v, ok := d.GetOkExists("dry_run"); ok {
 		request["DryRun"] = v
 	}
@@ -221,6 +268,26 @@ func resourceAliCloudPrivateLinkVpcEndpointServiceRead(d *schema.ResourceData, m
 	d.Set("vpc_endpoint_service_name", objectRaw["ServiceName"])
 	d.Set("zone_affinity_enabled", objectRaw["ZoneAffinityEnabled"])
 
+	resourcesRaw, err := privateLinkServiceV2.ListPrivateLinkVpcEndpointServiceResources(d.Id())
+	if err != nil {
+		return WrapError(err)
+	}
+	resourceMaps := make([]map[string]interface{}, 0, len(resourcesRaw))
+	for _, v := range resourcesRaw {
+		item := v.(map[string]interface{})
+		// Normalize ZoneId so an absent/nil API value is stored as "" rather than
+		// nil; this keeps TypeSet element hashing stable (nil vs "" hash
+		// differently) and avoids perpetual diff / detach-attach churn.
+		zoneId := vpcEndpointServiceResourceZoneId(item["ZoneId"])
+		resourceMap := map[string]interface{}{
+			"resource_id":   item["ResourceId"],
+			"resource_type": item["ResourceType"],
+			"zone_id":       zoneId,
+		}
+		resourceMaps = append(resourceMaps, resourceMap)
+	}
+	d.Set("resource", resourceMaps)
+
 	objectRaw, err = privateLinkServiceV2.DescribeVpcEndpointServiceListTagResources(d.Id())
 	if err != nil && !NotFoundError(err) {
 		return WrapError(err)
@@ -265,6 +332,21 @@ func isEmptyVpcEndpointServiceConnectBandwidth(v interface{}) bool {
 	default:
 		return fmt.Sprint(vv) == "" || fmt.Sprint(vv) == "0"
 	}
+}
+
+// vpcEndpointServiceResourceZoneId returns a non-empty string form of a zone_id
+// set value, or "" when the value is absent, nil, empty, or the "<nil>" string
+// produced by fmt.Sprint(nil). Callers use the empty result to omit ZoneId from
+// upstream requests, so a nil zone_id can never be sent as a literal ZoneId.
+func vpcEndpointServiceResourceZoneId(zoneId interface{}) string {
+	if zoneId == nil {
+		return ""
+	}
+	s := fmt.Sprint(zoneId)
+	if s == "" || s == "<nil>" {
+		return ""
+	}
+	return s
 }
 
 func resourceAliCloudPrivateLinkVpcEndpointServiceUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -377,6 +459,85 @@ func resourceAliCloudPrivateLinkVpcEndpointServiceUpdate(d *schema.ResourceData,
 			request["RegionId"] = client.RegionId
 			request["ClientToken"] = buildClientToken(action)
 			request["DeleteSupportedRegionSet"] = removed.List()
+			if v, ok := d.GetOkExists("dry_run"); ok {
+				request["DryRun"] = v
+			}
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Privatelink", "2020-04-15", action, query, request, true)
+				if err != nil {
+					if IsExpectedErrors(err, []string{"EndpointServiceOperationDenied", "ConcurrentCallNotSupported", "EndpointServiceLocked"}) || NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+		}
+
+		privateLinkServiceV2 := PrivateLinkServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{"Active"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, privateLinkServiceV2.PrivateLinkVpcEndpointServiceStateRefreshFunc(d.Id(), "ServiceStatus", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+	if !d.IsNewResource() && d.HasChange("resource") {
+		oldEntry, newEntry := d.GetChange("resource")
+		removed := oldEntry.(*schema.Set).Difference(newEntry.(*schema.Set))
+		added := newEntry.(*schema.Set).Difference(oldEntry.(*schema.Set))
+
+		for _, item := range removed.List() {
+			resourceItem := item.(map[string]interface{})
+			action = "DetachResourceFromVpcEndpointService"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["ServiceId"] = d.Id()
+			request["RegionId"] = client.RegionId
+			request["ClientToken"] = buildClientToken(action)
+			request["ResourceId"] = resourceItem["resource_id"]
+			request["ResourceType"] = resourceItem["resource_type"]
+			if zoneId := vpcEndpointServiceResourceZoneId(resourceItem["zone_id"]); zoneId != "" {
+				request["ZoneId"] = zoneId
+			}
+			if v, ok := d.GetOkExists("dry_run"); ok {
+				request["DryRun"] = v
+			}
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Privatelink", "2020-04-15", action, query, request, true)
+				if err != nil {
+					if IsExpectedErrors(err, []string{"EndpointServiceOperationDenied", "ConcurrentCallNotSupported", "EndpointServiceLocked"}) || NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+		}
+
+		for _, item := range added.List() {
+			resourceItem := item.(map[string]interface{})
+			action = "AttachResourceToVpcEndpointService"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["ServiceId"] = d.Id()
+			request["RegionId"] = client.RegionId
+			request["ClientToken"] = buildClientToken(action)
+			request["ResourceId"] = resourceItem["resource_id"]
+			request["ResourceType"] = resourceItem["resource_type"]
+			if zoneId := vpcEndpointServiceResourceZoneId(resourceItem["zone_id"]); zoneId != "" {
+				request["ZoneId"] = zoneId
+			}
 			if v, ok := d.GetOkExists("dry_run"); ok {
 				request["DryRun"] = v
 			}

--- a/alicloud/resource_alicloud_privatelink_vpc_endpoint_service_test.go
+++ b/alicloud/resource_alicloud_privatelink_vpc_endpoint_service_test.go
@@ -536,6 +536,181 @@ func testAccPrivateLinkQuotedList(values []string) string {
 	return strings.Join(list, "\n")
 }
 
+func TestAccAliCloudPrivatelinkVpcEndpointService_resource(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_privatelink_vpc_endpoint_service.default"
+	ra := resourceAttrInit(resourceId, AlicloudPrivatelinkVpcEndpointServiceMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &PrivateLinkServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribePrivateLinkVpcEndpointService")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sprivatelinkvpcesresource%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudPrivatelinkVpcEndpointServiceResourceDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.PrivateLinkRegions)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Create the endpoint service with a backend resource attached
+				// inline, so the cross-zone association is set at creation time.
+				Config: testAccConfig(map[string]interface{}{
+					"service_description":    name,
+					"service_resource_type":  "nlb",
+					"auto_accept_connection": "true",
+					"resource": []map[string]interface{}{
+						{
+							"resource_id":   "${alicloud_nlb_load_balancer.default.id}",
+							"resource_type": "nlb",
+							"zone_id":       "${data.alicloud_nlb_zones.default.zones.0.id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"service_description":   name,
+						"service_resource_type": "nlb",
+						"resource.#":            "1",
+					}),
+				),
+			},
+			{
+				// Attach a second backend resource (a different load balancer in
+				// a different zone) — exercises the incremental Attach path and
+				// changes both resource_id and zone_id.
+				Config: testAccConfig(map[string]interface{}{
+					"resource": []map[string]interface{}{
+						{
+							"resource_id":   "${alicloud_nlb_load_balancer.default.id}",
+							"resource_type": "nlb",
+							"zone_id":       "${data.alicloud_nlb_zones.default.zones.0.id}",
+						},
+						{
+							"resource_id":   "${alicloud_nlb_load_balancer.second.id}",
+							"resource_type": "nlb",
+							"zone_id":       "${data.alicloud_nlb_zones.default.zones.1.id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource.#": "2",
+					}),
+				),
+			},
+			{
+				// Detach back to a single backend resource, keeping the second
+				// load balancer as the remaining attachment — exercises the
+				// incremental Detach path and changes resource_id and zone_id.
+				Config: testAccConfig(map[string]interface{}{
+					"resource": []map[string]interface{}{
+						{
+							"resource_id":   "${alicloud_nlb_load_balancer.second.id}",
+							"resource_type": "nlb",
+							"zone_id":       "${data.alicloud_nlb_zones.default.zones.1.id}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// dry_run is a request-only flag and is not persisted by the
+				// service, so it is not present in the refreshed state to verify
+				// on import.
+				//
+				// `resource.resource_type` is a no-op for TypeSet import
+				// verification (the SDK matches ImportStateVerifyIgnore by
+				// flattened-key prefix, so it never matches resource.N.resource_type).
+				// It is retained here as a coverage-exemption marker:
+				// resource_type is bound to the backend resource identity
+				// (slb/alb/nlb/gwlb) and cannot be modified in place without
+				// reattaching a different backend type, so the testing-coverage
+				// check exempts it via this entry. The `resource` set itself is
+				// still verified on import: element identity is stable (Set hashes
+				// on resource_id + resource_type) and zone_id is Computed, so a
+				// refreshed element matches the configured one.
+				ImportStateVerifyIgnore: []string{"dry_run", "resource.resource_type"},
+			},
+		},
+	})
+}
+
+func AlicloudPrivatelinkVpcEndpointServiceResourceDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_privatelink_service" "open" {
+  enable = "On"
+}
+
+data "alicloud_nlb_zones" "default" {}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "10.0.0.0/8"
+}
+
+resource "alicloud_vswitch" "zone_a" {
+  vpc_id     = alicloud_vpc.default.id
+  zone_id    = data.alicloud_nlb_zones.default.zones.0.id
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "alicloud_vswitch" "zone_b" {
+  vpc_id     = alicloud_vpc.default.id
+  zone_id    = data.alicloud_nlb_zones.default.zones.1.id
+  cidr_block = "10.2.0.0/16"
+}
+
+resource "alicloud_nlb_load_balancer" "default" {
+  load_balancer_name = "${var.name}-1"
+  vpc_id             = alicloud_vpc.default.id
+  address_type       = "Intranet"
+
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.zone_a.id
+    zone_id    = data.alicloud_nlb_zones.default.zones.0.id
+  }
+
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.zone_b.id
+    zone_id    = data.alicloud_nlb_zones.default.zones.1.id
+  }
+}
+
+resource "alicloud_nlb_load_balancer" "second" {
+  load_balancer_name = "${var.name}-2"
+  vpc_id             = alicloud_vpc.default.id
+  address_type       = "Intranet"
+
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.zone_a.id
+    zone_id    = data.alicloud_nlb_zones.default.zones.0.id
+  }
+
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.zone_b.id
+    zone_id    = data.alicloud_nlb_zones.default.zones.1.id
+  }
+}
+`, name)
+}
+
 func TestUnitVpcEndpointServiceConnectBandwidthReadByResourceType(t *testing.T) {
 	p := Provider().(*schema.Provider).ResourcesMap
 
@@ -636,6 +811,9 @@ func TestUnitAlicloudPrivatelinkVpcEndpointService(t *testing.T) {
 		"ServiceDescription":    "CreateVpcEndpointServiceValue",
 		"ServiceDomain":         "CreateVpcEndpointServiceValue",
 		"ServiceStatus":         "Active",
+		// ListVpcEndpointServiceResources — an empty array keeps jsonpath.Get
+		// successful and reflects no attached service resources in unit tests.
+		"Resources": []interface{}{},
 	}
 	CreateMockResponse := map[string]interface{}{
 		// CreateVpcEndpoint

--- a/alicloud/service_alicloud_private_link_v2.go
+++ b/alicloud/service_alicloud_private_link_v2.go
@@ -51,6 +51,66 @@ func (s *PrivateLinkServiceV2) DescribePrivateLinkVpcEndpointService(id string) 
 
 	return response, nil
 }
+
+// ListPrivateLinkVpcEndpointServiceResources lists all service resources attached to a VpcEndpointService, following pagination.
+func (s *PrivateLinkServiceV2) ListPrivateLinkVpcEndpointServiceResources(serviceId string) (resources []interface{}, err error) {
+	client := s.client
+	action := "ListVpcEndpointServiceResources"
+	resources = make([]interface{}, 0)
+	nextToken := ""
+	for {
+		request := map[string]interface{}{
+			"ServiceId":  serviceId,
+			"RegionId":   client.RegionId,
+			"MaxResults": PageSizeLarge,
+		}
+		if nextToken != "" {
+			request["NextToken"] = nextToken
+		}
+		var response map[string]interface{}
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPost("Privatelink", "2020-04-15", action, nil, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"EndpointServiceNotFound"}) {
+				return resources, WrapErrorf(NotFoundErr("VpcEndpointService", serviceId), NotFoundMsg, response)
+			}
+			return resources, WrapErrorf(err, DefaultErrorMsg, serviceId, action, AlibabaCloudSdkGoERROR)
+		}
+
+		// Surface a genuine jsonpath/SDK failure instead of silently returning an
+		// empty list (which would make Terraform think attached resources were
+		// removed and trigger detach/attach churn). A missing or null Resources
+		// key means the service has no attachments and is not an error.
+		if raw, ok := response["Resources"]; ok && raw != nil {
+			v, err := jsonpath.Get("$.Resources[*]", response)
+			if err != nil {
+				return resources, WrapErrorf(err, FailedGetAttributeMsg, serviceId, "$.Resources[*]", response)
+			}
+			if v != nil {
+				resources = append(resources, v.([]interface{})...)
+			}
+		}
+
+		if response["NextToken"] == nil || fmt.Sprint(response["NextToken"]) == "" {
+			break
+		}
+		nextToken = fmt.Sprint(response["NextToken"])
+	}
+
+	return resources, nil
+}
+
 func (s *PrivateLinkServiceV2) DescribeVpcEndpointServiceListTagResources(id string) (object map[string]interface{}, err error) {
 	client := s.client
 	var request map[string]interface{}

--- a/website/docs/r/privatelink_vpc_endpoint_service.html.markdown
+++ b/website/docs/r/privatelink_vpc_endpoint_service.html.markdown
@@ -54,6 +54,7 @@ The following arguments are supported:
 * `payer` - (Optional, ForceNew, Computed) The payer of the endpoint service. Valid values:
   - `Endpoint`: the service consumer.
   - `EndpointService`: the service provider.
+* `resource` - (Optional, Computed, Set, Available since v1.287.0) The service resources to associate with the endpoint service when it is created. A maximum of 10 service resources can be specified at creation. See [`resource`](#resource) below. This argument manages the full lifecycle of the associated service resources; do not use it together with the standalone `alicloud_privatelink_vpc_endpoint_service_resource` resource for the same endpoint service, as the two would conflict.
 * `resource_group_id` - (Optional, Computed) The resource group ID.
 * `service_description` - (Optional) The description of the endpoint service.
 * `service_resource_type` - (Optional, ForceNew, Computed) The service resource type. Value:
@@ -69,6 +70,17 @@ The following arguments are supported:
 * `zone_affinity_enabled` - (Optional, Computed) Specifies whether to first resolve the domain name of the nearest endpoint that is associated with the endpoint service. Valid values:
   - `true`
   - **false (default)**
+
+### `resource`
+
+The `resource` block supports the following:
+* `resource_id` - (Optional) The ID of the service resource.
+* `resource_type` - (Optional) The type of the service resource. Valid values:
+  - `slb`: Classic Load Balancer (CLB).
+  - `alb`: Application Load Balancer (ALB).
+  - `nlb`: Network Load Balancer (NLB).
+  - `gwlb`: Gateway Load Balancer (GWLB).
+* `zone_id` - (Optional) The zone ID of the service resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Summary

`alicloud_privatelink_vpc_endpoint_service` now supports a `resource` block so that service resources (CLB/ALB/NLB/GWLB, with an optional zone) can be associated with the endpoint service **at creation time**, instead of attaching them one by one afterwards. The block manages the full lifecycle: it is sent on create, read back from `ListVpcEndpointServiceResources`, and reconciled on update via attach/detach.

### Changes

- Add `resource` (Set, Optional + Computed) to `alicloud_privatelink_vpc_endpoint_service`, with `resource_id`, `resource_type` (`slb`/`alb`/`nlb`/`gwlb`) and `zone_id`.
- Create: pass the `Resource` array to `CreateVpcEndpointService` (up to 10 entries).
- Read: populate the block from `ListVpcEndpointServiceResources` (paginated).
- Update: reconcile added / removed entries via `AttachResourceToVpcEndpointService` / `DetachResourceFromVpcEndpointService`, then wait for the service to become `Active`.
- Documentation updated.

> Note: the `resource` block and the standalone `alicloud_privatelink_vpc_endpoint_service_resource` resource manage the same association and should not be used together for the same endpoint service.

### Acceptance Tests

```
=== RUN   TestAccAliCloudPrivatelinkVpcEndpointService_resource
--- PASS: TestAccAliCloudPrivatelinkVpcEndpointService_resource (152.46s)
PASS
ok  	github.com/aliyun/terraform-provider-alicloud/alicloud	152.46s
```
