### PR TITLE
resource/alicloud_cen_bandwidth_package_attachment: guard empty CenId list in Read

### DIFF
--- a/alicloud/resource_alicloud_cen_bandwidth_package_attachment.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_package_attachment.go
@@ -87,6 +87,12 @@ func resourceAlicloudCenBandwidthPackageAttachmentRead(d *schema.ResourceData, m
 		return WrapError(err)
 	}
 
+	if len(object.CenIds.CenId) < 1 {
+		// The attachment is no longer associated with any CEN; treat it as gone.
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("instance_id", object.CenIds.CenId[0])
 	d.Set("bandwidth_package_id", object.CenBandwidthPackageId)
 

--- a/alicloud/resource_alicloud_cen_bandwidth_package_attachment_test.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_package_attachment_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAlicloudCenBandwidthPackageAttachment_basic(t *testing.T) {
+func TestAccAliCloudCenBandwidthPackageAttachment_basic(t *testing.T) {
 	var cenBwp cbn.CenBandwidthPackage
 
 	resourceId := "alicloud_cen_bandwidth_package_attachment.default"


### PR DESCRIPTION
### Summary

`resourceAlicloudCenBandwidthPackageAttachmentRead` reads the associated CEN ID via `object.CenIds.CenId[0]` without first checking that the slice is non-empty, which can index an empty list.

Add a defensive guard: when the returned bandwidth package has no associated CEN, treat the attachment as gone and clear it from state (`d.SetId("")`). This is consistent with the service-layer lookup `DescribeCenBandwidthPackageAttachment`, which already treats a non-single `CenId` list as not-found, and keeps the resource lifecycle semantics consistent while making the Read path robust against an empty `CenId` list.

### Test

No behavioral change on the reachable path; static checks only (`gofmt -l`, `go vet ./alicloud`) — the guarded index access is now safe.
