### PR TITLE
resource/alicloud_cen_bandwidth_package_attachment: guard against empty CenId list to prevent index panic

### DIFF
--- a/alicloud/resource_alicloud_cen_bandwidth_package_attachment.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_package_attachment.go
@@ -87,6 +87,13 @@ func resourceAlicloudCenBandwidthPackageAttachmentRead(d *schema.ResourceData, m
 		return WrapError(err)
 	}
 
+	// The attachment has no associated CEN when the id list is empty; treat it as
+	// removed and avoid indexing into an empty slice.
+	if len(object.CenIds.CenId) < 1 {
+		d.SetId("")
+		return nil
+	}
+
 	d.Set("instance_id", object.CenIds.CenId[0])
 	d.Set("bandwidth_package_id", object.CenBandwidthPackageId)
 


### PR DESCRIPTION
### Summary

`resourceAlicloudCenBandwidthPackageAttachmentRead` reads the associated CEN
id list and immediately indexes `object.CenIds.CenId[0]` to set `instance_id`.
This change adds a length check before the index access: when the id list is
empty, the attachment is treated as removed (`d.SetId("")`) and the read
returns gracefully, mirroring the existing not-found handling a few lines
above.

### Rationale

The read path relies on an invariant enforced in a separate service helper
(`DescribeCenBandwidthPackageAttachment`), which only returns an object when
`len(CenIds.CenId) == 1` and otherwise surfaces not-found. The local length
guard makes the read self-contained and robust against any future change to
that helper, avoiding a potential index-out-of-range panic.

### Behavior

No behavior change for existing resources: an empty association list is already
surfaced as not-found today, so the resource state and the graceful `SetId("")`
exit are preserved. This is a defensive hardening, not a functional change.
