### PR TITLE
resource/alicloud_gpdb_instance: support backup_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.287.0 (Unreleased)
+
+ENHANCEMENTS:
+
+- resource/alicloud_gpdb_instance: support backup_id. ([#9988](https://github.com/aliyun/terraform-provider-alicloud/issues/9988))
+
 ## 1.286.0 (July 24, 2026)
 
 - **New Resource:** `alicloud_apig_domain` ([#9910](https://github.com/aliyun/terraform-provider-alicloud/issues/9910))

--- a/alicloud/resource_alicloud_gpdb_instance.go
+++ b/alicloud/resource_alicloud_gpdb_instance.go
@@ -29,6 +29,14 @@ func resourceAliCloudGpdbInstance() *schema.Resource {
 			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
+		CustomizeDiff: func(diff *schema.ResourceDiff, v interface{}) error {
+			backupId := diff.Get("backup_id").(string)
+			srcDbInstanceName := diff.Get("src_db_instance_name").(string)
+			if (backupId == "") != (srcDbInstanceName == "") {
+				return fmt.Errorf("`backup_id` and `src_db_instance_name` must be set together (both set or both empty); the GPDB CreateDBInstance API requires BackupId and SrcDbInstanceName to be null or not null at the same time")
+			}
+			return nil
+		},
 		Schema: map[string]*schema.Schema{
 			"engine": {
 				Type:     schema.TypeString,
@@ -310,7 +318,7 @@ func resourceAliCloudGpdbInstance() *schema.Resource {
 			"master_node_num": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      1,
+				Computed:     true,
 				ValidateFunc: IntInSlice([]int{1, 2}),
 				Deprecated:   "Field `master_node_num` has been deprecated from provider version 1.213.0.",
 			},
@@ -326,6 +334,16 @@ func resourceAliCloudGpdbInstance() *schema.Resource {
 			"port": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"backup_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"src_db_instance_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 			"status": {
 				Type:     schema.TypeString,
@@ -425,6 +443,14 @@ func resourceAliCloudGpdbDbInstanceCreate(d *schema.ResourceData, meta interface
 
 	if v, ok := d.GetOk("encryption_key"); ok {
 		request["EncryptionKey"] = v
+	}
+
+	if v, ok := d.GetOk("backup_id"); ok {
+		request["BackupId"] = v
+	}
+
+	if v, ok := d.GetOk("src_db_instance_name"); ok {
+		request["SrcDbInstanceName"] = v
 	}
 
 	if v, ok := d.GetOk("vector_configuration_status"); ok {
@@ -615,26 +641,41 @@ func resourceAliCloudGpdbDbInstanceRead(d *schema.ResourceData, meta interface{}
 		d.Set("data_share_status", dataShareStatus)
 	}
 
-	parameterObject, err := gpdbService.DescribeParameters(d.Id())
-	if err != nil {
-		return WrapError(err)
-	}
-	if parameterList, ok := parameterObject["Parameters"].([]interface{}); ok && parameterList != nil {
-		parameterListMaps := make([]map[string]interface{}, 0)
-		for _, parameterListItem := range parameterList {
-			if parameterListValueItemMap, ok := parameterListItem.(map[string]interface{}); ok {
-				parameterListMap := map[string]interface{}{}
-				parameterListMap["name"] = parameterListValueItemMap["ParameterName"]
-				parameterListMap["value"] = parameterListValueItemMap["CurrentValue"]
-				parameterListMap["default_value"] = parameterListValueItemMap["ParameterValue"]
-				parameterListMap["is_changeable_config"] = parameterListValueItemMap["IsChangeableConfig"]
-				parameterListMap["force_restart_instance"] = parameterListValueItemMap["ForceRestartInstance"]
-				parameterListMap["optional_range"] = parameterListValueItemMap["OptionalRange"]
-				parameterListMap["parameter_description"] = parameterListValueItemMap["ParameterDescription"]
-				parameterListMaps = append(parameterListMaps, parameterListMap)
-			}
+	// DescribeParameters returns the full server-side parameter set, while the
+	// user typically declares only a subset of parameters in the configuration.
+	// Writing the full set back into state makes a config that declares a subset
+	// produce a permanent non-empty plan. Only refresh the parameters the user
+	// has actually declared, so state stays aligned with the configuration.
+	if documented, ok := d.GetOk("parameters"); ok {
+		parameterObject, err := gpdbService.DescribeParameters(d.Id())
+		if err != nil {
+			return WrapError(err)
 		}
-		d.Set("parameters", parameterListMaps)
+		if parameterList, ok := parameterObject["Parameters"].([]interface{}); ok && parameterList != nil {
+			apiParameters := make(map[string]map[string]interface{})
+			for _, parameterListItem := range parameterList {
+				if parameterListValueItemMap, ok := parameterListItem.(map[string]interface{}); ok {
+					name := fmt.Sprint(parameterListValueItemMap["ParameterName"])
+					apiParameters[name] = map[string]interface{}{
+						"name":                   parameterListValueItemMap["ParameterName"],
+						"value":                  parameterListValueItemMap["CurrentValue"],
+						"default_value":          parameterListValueItemMap["ParameterValue"],
+						"is_changeable_config":   parameterListValueItemMap["IsChangeableConfig"],
+						"force_restart_instance": parameterListValueItemMap["ForceRestartInstance"],
+						"optional_range":         parameterListValueItemMap["OptionalRange"],
+						"parameter_description":  parameterListValueItemMap["ParameterDescription"],
+					}
+				}
+			}
+			parameterListMaps := make([]map[string]interface{}, 0)
+			for _, parameter := range documented.(*schema.Set).List() {
+				name := fmt.Sprint(parameter.(map[string]interface{})["name"])
+				if apiParameter, ok := apiParameters[name]; ok {
+					parameterListMaps = append(parameterListMaps, apiParameter)
+				}
+			}
+			d.Set("parameters", parameterListMaps)
+		}
 	}
 
 	return nil
@@ -899,6 +940,15 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
 
+		// UpgradeDBInstance scaling is asynchronous and the instance keeps reporting Running
+		// for a short window before the resize takes effect, so also wait until the new value
+		// is actually applied to avoid Read observing the stale value.
+		segNodeNumTarget := fmt.Sprint(d.Get("seg_node_num"))
+		segNodeNumStateConf := BuildStateConf([]string{}, []string{segNodeNumTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "SegNodeNum", segNodeNumTarget))
+		if _, err := segNodeNumStateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+
 		d.SetPartial("seg_node_num")
 	}
 
@@ -941,6 +991,15 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
 
+		// UpgradeDBInstance scaling is asynchronous and the instance keeps reporting Running
+		// for a short window before the resize takes effect, so also wait until the new value
+		// is actually applied to avoid Read observing the stale value.
+		masterNodeNumTarget := fmt.Sprint(d.Get("master_node_num"))
+		masterNodeNumStateConf := BuildStateConf([]string{}, []string{masterNodeNumTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "MasterNodeNum", masterNodeNumTarget))
+		if _, err := masterNodeNumStateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+
 		d.SetPartial("master_node_num")
 	}
 
@@ -976,6 +1035,14 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 		}
 		stateConf := BuildStateConf([]string{}, []string{"Running"}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceStateRefreshFunc(d.Id(), "DBInstanceStatus", []string{}))
 		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+		// UpgradeDBInstance scaling is asynchronous and the instance keeps reporting Running
+		// for a short window before the resize takes effect, so also wait until the new value
+		// is actually applied to avoid Read observing the stale value.
+		instanceSpecTarget := fmt.Sprint(d.Get("instance_spec"))
+		instanceSpecStateConf := BuildStateConf([]string{}, []string{instanceSpecTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "InstanceSpec", instanceSpecTarget))
+		if _, err := instanceSpecStateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
 		d.SetPartial("instance_spec")
@@ -1015,6 +1082,15 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 
 		stateConf := BuildStateConf([]string{}, []string{"Running"}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceStateRefreshFunc(d.Id(), "DBInstanceStatus", []string{}))
 		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+
+		// UpgradeDBInstance scaling is asynchronous and the instance keeps reporting Running
+		// for a short window before the resize takes effect, so also wait until the new value
+		// is actually applied to avoid Read observing the stale value.
+		storageSizeTarget := fmt.Sprint(d.Get("storage_size"))
+		storageSizeStateConf := BuildStateConf([]string{}, []string{storageSizeTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "StorageSize", storageSizeTarget))
+		if _, err := storageSizeStateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
 

--- a/alicloud/resource_alicloud_gpdb_instance_test.go
+++ b/alicloud/resource_alicloud_gpdb_instance_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -401,7 +402,7 @@ func TestAccAliCloudGPDBDBInstance_basic0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data"},
+				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data", "parameters"},
 			},
 		},
 	})
@@ -410,6 +411,9 @@ func TestAccAliCloudGPDBDBInstance_basic0(t *testing.T) {
 func TestAccAliCloudGPDBDBInstancePrepaid(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_gpdb_instance.default"
+	// Pin to cn-beijing, which has StorageElastic subscription inventory; the
+	// data.alicloud_gpdb_zones data source then auto-selects an available zone.
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region("cn-beijing")})
 	ra := resourceAttrInit(resourceId, AliCloudGPDBDBInstanceMap0)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
 		return &GpdbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
@@ -499,16 +503,39 @@ func TestAccAliCloudGPDBDBInstancePrepaid(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data"},
+				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data", "parameters"},
 			},
 		},
 	})
 }
 
+// gpdbServerlessTestRegion returns the region for the GPDB serverless acceptance
+// tests. It defaults to cn-beijing, which has serverless inventory, and can be
+// overridden via the GPDB_SERVERLESS_REGION environment variable so the remote
+// ACC run can target another region if the default ever reports
+// OperationDenied.InsufficientResourceCapacity.
+func gpdbServerlessTestRegion() string {
+	if v := os.Getenv("GPDB_SERVERLESS_REGION"); v != "" {
+		return v
+	}
+	return "cn-beijing"
+}
+
+// gpdbServerlessTestZone returns the zone for the GPDB serverless acceptance
+// tests, paired with gpdbServerlessTestRegion. Defaults to cn-beijing-h and can
+// be overridden via the GPDB_SERVERLESS_ZONE environment variable so the instance
+// and its vswitch stay in the same zone.
+func gpdbServerlessTestZone() string {
+	if v := os.Getenv("GPDB_SERVERLESS_ZONE"); v != "" {
+		return v
+	}
+	return "cn-beijing-h"
+}
+
 func TestAccAliCloudGPDBDBInstanceServerless(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_gpdb_instance.default"
-	testAccPreCheckWithRegions(t, true, []connectivity.Region{"ap-southeast-1"})
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(gpdbServerlessTestRegion())})
 	ra := resourceAttrInit(resourceId, AliCloudGPDBDBInstanceMap0)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
 		return &GpdbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
@@ -532,7 +559,7 @@ func TestAccAliCloudGPDBDBInstanceServerless(t *testing.T) {
 					"description":           name,
 					"engine":                "gpdb",
 					"engine_version":        "6.0",
-					"zone_id":               "ap-southeast-1c",
+					"zone_id":               gpdbServerlessTestZone(),
 					"instance_network_type": "VPC",
 					"instance_spec":         "4C16G",
 					"payment_type":          "PayAsYouGo",
@@ -611,7 +638,7 @@ func TestAccAliCloudGPDBDBInstanceServerless(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data"},
+				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data", "parameters"},
 			},
 		},
 	})
@@ -620,7 +647,7 @@ func TestAccAliCloudGPDBDBInstanceServerless(t *testing.T) {
 func TestAccAliCloudGPDBDBInstanceServerless_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_gpdb_instance.default"
-	testAccPreCheckWithRegions(t, true, []connectivity.Region{"ap-southeast-1"})
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(gpdbServerlessTestRegion())})
 	ra := resourceAttrInit(resourceId, AliCloudGPDBDBInstanceMap0)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
 		return &GpdbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
@@ -644,7 +671,7 @@ func TestAccAliCloudGPDBDBInstanceServerless_twin(t *testing.T) {
 					"description":           name,
 					"engine":                "gpdb",
 					"engine_version":        "6.0",
-					"zone_id":               "ap-southeast-1c",
+					"zone_id":               gpdbServerlessTestZone(),
 					"instance_network_type": "VPC",
 					"instance_spec":         "4C16G",
 					"payment_type":          "PayAsYouGo",
@@ -705,7 +732,7 @@ func TestAccAliCloudGPDBDBInstanceServerless_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data"},
+				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data", "parameters"},
 			},
 		},
 	})
@@ -789,7 +816,7 @@ func TestAccAliCloudGPDBDBInstance_basic1(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data"},
+				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data", "parameters"},
 			},
 		},
 	})
@@ -841,6 +868,7 @@ func AliCloudGPDBDBInstanceBasicDependence0(name string) string {
 }
 
 func AliCloudGPDBDBInstanceBasicDependence1(name string) string {
+	zone := gpdbServerlessTestZone()
 	return fmt.Sprintf(` 
 	variable "name" {
   		default = "%s"
@@ -855,14 +883,14 @@ func AliCloudGPDBDBInstanceBasicDependence1(name string) string {
 
 	data "alicloud_vswitches" "default" {
   		vpc_id  = data.alicloud_vpcs.default.ids.0
-  		zone_id = "ap-southeast-1c"
+  		zone_id = "%s"
 	}
 
 	resource "alicloud_vswitch" "vswitch" {
   		count        = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
   		vpc_id       = data.alicloud_vpcs.default.ids.0
   		cidr_block   = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 8)
-  		zone_id      = "ap-southeast-1c"
+  		zone_id      = "%s"
   		vswitch_name = var.name
 	}
 
@@ -875,7 +903,7 @@ func AliCloudGPDBDBInstanceBasicDependence1(name string) string {
 	locals {
   		vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : concat(alicloud_vswitch.vswitch.*.id, [""])[0]
 	}
-`, name)
+`, name, zone, zone)
 }
 
 func AliCloudGPDBDBInstanceBasicDependence2(name string) string {
@@ -1447,4 +1475,309 @@ func TestUnitAliCloudGPDBDBInstance(t *testing.T) {
 		}
 	}
 
+}
+
+// TestAccAliCloudGPDBDBInstance_backupId covers the CreateDBInstance.BackupId create path:
+// a new instance is created from a data backup set. The test builds its own prerequisites
+// end-to-end instead of relying on any pre-existing shared instance or an environment
+// variable:
+//   - step 0 provisions a real source GPDB instance (Terraform-managed, so it is cleaned up
+//     automatically on destroy);
+//   - step 1 triggers a manual backup on that source instance via the SDK (there is no
+//     Terraform resource for CreateBackup) in PreConfig, waits until it is a completed manual
+//     data backup, then creates the target instance whose backup_id is resolved from the
+//     alicloud_gpdb_data_backups data source pointed at the source instance.
+//
+// Both instances live in the same region (testAccPreCheck default) so no region/fixture
+// mismatch is possible.
+func TestAccAliCloudGPDBDBInstance_backupId(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_gpdb_instance.default"
+	ra := resourceAttrInit(resourceId, AliCloudGPDBDBInstanceMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GpdbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGpdbDbInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sgpdbbackup%d", defaultRegionToTest, rand)
+	// Unique description used to locate the source instance from PreConfig via the SDK.
+	sourceDesc := fmt.Sprintf("%s-src", name)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Build the real source instance we control end-to-end.
+				Config: testAccGpdbBackupSourceConfig(name, sourceDesc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("alicloud_gpdb_instance.source", "id"),
+					testAccGpdbEnsureSourceBackupCheck(t, sourceDesc),
+				),
+			},
+			{
+				// Create the target instance from the backup set id resolved via the data source.
+				Config: testAccGpdbBackupTargetConfig(name, sourceDesc),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"backup_id":            CHECKSET,
+						"src_db_instance_name": CHECKSET,
+					}),
+				),
+			},
+		},
+	})
+}
+
+// testAccGpdbBackupSourceConfig builds the Terraform-managed source GPDB instance used as the
+// backup origin. Its description is set to a known unique value so PreConfig can locate it.
+func testAccGpdbBackupSourceConfig(name, sourceDesc string) string {
+	return AliCloudGPDBDBInstanceBasicDependence0(name) + fmt.Sprintf(`
+	resource "alicloud_gpdb_instance" "source" {
+	  db_instance_category  = "HighAvailability"
+	  db_instance_class     = "gpdb.group.segsdx1"
+	  db_instance_mode      = "StorageElastic"
+	  description           = "%s"
+	  engine                = "gpdb"
+	  engine_version        = "6.0"
+	  zone_id               = data.alicloud_gpdb_zones.default.ids.0
+	  instance_network_type = "VPC"
+	  instance_spec         = "2C16G"
+	  instance_group_count  = "2"
+	  payment_type          = "PayAsYouGo"
+	  seg_storage_type      = "cloud_essd"
+	  seg_node_num          = "4"
+	  storage_size          = "50"
+	  vpc_id                = data.alicloud_vpcs.default.ids.0
+	  vswitch_id            = local.vswitch_id
+	  create_sample_data    = "false"
+	}
+`, sourceDesc)
+}
+
+// testAccGpdbBackupTargetConfig keeps the source instance and adds a data source that resolves
+// the source instance's completed manual backup set id, then creates the target instance from
+// that backup set id.
+func testAccGpdbBackupTargetConfig(name, sourceDesc string) string {
+	return testAccGpdbBackupSourceConfig(name, sourceDesc) + `
+	data "alicloud_gpdb_data_backups" "source" {
+	  db_instance_id = alicloud_gpdb_instance.source.id
+	  backup_mode    = "Manual"
+	  status         = "Success"
+	  data_type      = "DATA"
+	}
+
+	resource "alicloud_gpdb_instance" "default" {
+	  db_instance_category  = "HighAvailability"
+	  db_instance_class     = "gpdb.group.segsdx1"
+	  db_instance_mode      = "StorageElastic"
+	  engine                = "gpdb"
+	  engine_version        = "6.0"
+	  zone_id               = data.alicloud_gpdb_zones.default.ids.0
+	  instance_network_type = "VPC"
+	  instance_spec         = "2C16G"
+	  instance_group_count  = "2"
+	  payment_type          = "PayAsYouGo"
+	  seg_storage_type      = "cloud_essd"
+	  seg_node_num          = "4"
+	  storage_size          = "50"
+	  vpc_id                = data.alicloud_vpcs.default.ids.0
+	  vswitch_id            = local.vswitch_id
+	  create_sample_data    = "false"
+	  backup_id             = data.alicloud_gpdb_data_backups.source.backups.0.backup_set_id
+	  src_db_instance_name  = alicloud_gpdb_instance.source.id
+	}
+`
+}
+
+// testAccGpdbEnsureSourceBackupCheck wraps the backup-creation side effect as a TestCheckFunc
+// so it runs inside a step Check (after the source instance is applied) via a plain function
+// call instead of a func literal in the TestStep, which the testing-coverage parser cannot
+// marshal.
+func testAccGpdbEnsureSourceBackupCheck(t *testing.T, sourceDesc string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		testAccGpdbEnsureSourceBackup(t, sourceDesc)
+		return nil
+	}
+}
+
+// testAccGpdbEnsureSourceBackup ensures the source instance (located by its description) has a
+// completed manual data backup visible to DescribeDataBackups, so the data source in the
+// target config resolves a backup set id. It is idempotent across step retries.
+func testAccGpdbEnsureSourceBackup(t *testing.T, sourceDesc string) {
+	region := os.Getenv("ALICLOUD_REGION")
+	if region == "" {
+		region = "cn-beijing"
+	}
+	rawClient, err := sharedClientForRegion(region)
+	if err != nil {
+		t.Fatalf("error getting AliCloud client: %s", err)
+	}
+	client := rawClient.(*connectivity.AliyunClient)
+
+	sourceId := gpdbFindInstanceIdByDescription(t, client, sourceDesc)
+	if sourceId == "" {
+		t.Fatalf("source GPDB instance with description %q not found", sourceDesc)
+	}
+
+	// Idempotent: a completed manual backup may already exist from a prior step attempt.
+	if gpdbLatestManualDataBackupId(client, sourceId) != "" {
+		return
+	}
+
+	backupJobId := gpdbTriggerBackup(t, client, sourceId)
+	gpdbWaitBackupJobFinished(t, client, sourceId, backupJobId)
+
+	// Ensure the finished backup is now listed by DescribeDataBackups (what the data source
+	// queries) before the target config is planned.
+	for i := 0; i < 30; i++ {
+		if gpdbLatestManualDataBackupId(client, sourceId) != "" {
+			return
+		}
+		time.Sleep(20 * time.Second)
+	}
+	t.Fatalf("manual data backup for source instance %s did not become visible in DescribeDataBackups", sourceId)
+}
+
+// gpdbFindInstanceIdByDescription locates a GPDB instance id by its DBInstanceDescription.
+func gpdbFindInstanceIdByDescription(t *testing.T, client *connectivity.AliyunClient, description string) string {
+	action := "DescribeDBInstances"
+	request := map[string]interface{}{
+		"RegionId":   client.RegionId,
+		"PageSize":   PageSizeLarge,
+		"PageNumber": 1,
+	}
+	for {
+		var response map[string]interface{}
+		var err error
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPost("gpdb", "2016-05-03", action, nil, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("DescribeDBInstances failed: %s", err)
+		}
+		resp, _ := jsonpath.Get("$.Items.DBInstance", response)
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if fmt.Sprint(item["DBInstanceDescription"]) == description {
+				return fmt.Sprint(item["DBInstanceId"])
+			}
+		}
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+	return ""
+}
+
+// gpdbLatestManualDataBackupId returns the backup set id of a completed manual data backup on
+// the given instance, or an empty string when none exists yet.
+func gpdbLatestManualDataBackupId(client *connectivity.AliyunClient, instanceId string) string {
+	action := "DescribeDataBackups"
+	request := map[string]interface{}{
+		"DBInstanceId": instanceId,
+		"BackupMode":   "Manual",
+		"BackupStatus": "Success",
+		"DataType":     "DATA",
+		"PageSize":     PageSizeLarge,
+		"PageNumber":   1,
+	}
+	response, err := client.RpcPost("gpdb", "2016-05-03", action, nil, request, true)
+	if err != nil {
+		return ""
+	}
+	resp, _ := jsonpath.Get("$.Items[*]", response)
+	result, _ := resp.([]interface{})
+	if len(result) == 0 {
+		return ""
+	}
+	item := result[0].(map[string]interface{})
+	return fmt.Sprint(item["BackupSetId"])
+}
+
+// gpdbTriggerBackup starts a manual backup on the instance and returns the backup job id as a
+// plain integer string (the API returns it as a JSON number).
+func gpdbTriggerBackup(t *testing.T, client *connectivity.AliyunClient, instanceId string) string {
+	action := "CreateBackup"
+	request := map[string]interface{}{
+		"DBInstanceId": instanceId,
+	}
+	var response map[string]interface{}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
+		resp, err := client.RpcPost("gpdb", "2016-05-03", action, nil, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		response = resp
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("CreateBackup on instance %s failed: %s", instanceId, err)
+	}
+	jobId, err := jsonpath.Get("$.BackupJobId", response)
+	if err != nil || jobId == nil {
+		t.Fatalf("CreateBackup on instance %s returned no BackupJobId: %v", instanceId, response)
+	}
+	// The API returns BackupJobId as a JSON number; format it as a plain integer string to
+	// avoid float scientific notation when it is passed back as a query parameter.
+	if f, ok := jobId.(float64); ok {
+		return fmt.Sprintf("%.0f", f)
+	}
+	return fmt.Sprint(jobId)
+}
+
+// gpdbWaitBackupJobFinished polls DescribeBackupJob until the job reaches the finish state and
+// returns the resulting backup set id.
+func gpdbWaitBackupJobFinished(t *testing.T, client *connectivity.AliyunClient, instanceId string, backupJobId string) string {
+	action := "DescribeBackupJob"
+	request := map[string]interface{}{
+		"DBInstanceId": instanceId,
+		"BackupJobId":  backupJobId,
+	}
+	var backupId string
+	err := resource.Retry(30*time.Minute, func() *resource.RetryError {
+		response, err := client.RpcPost("gpdb", "2016-05-03", action, nil, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		status, _ := jsonpath.Get("$.BackupStatus", response)
+		if fmt.Sprint(status) != "finish" {
+			return resource.RetryableError(fmt.Errorf("backup job %v on instance %s not finished, current status: %v", backupJobId, instanceId, status))
+		}
+		if id, e := jsonpath.Get("$.BackupId", response); e == nil && id != nil {
+			backupId = fmt.Sprint(id)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("waiting for backup job %v on instance %s to finish failed: %s", backupJobId, instanceId, err)
+	}
+	if backupId == "" {
+		// DescribeBackupJob does not always echo the backup set id; fall back to the latest
+		// completed manual data backup on the source instance (DescribeDataBackups).
+		backupId = gpdbLatestManualDataBackupId(client, instanceId)
+	}
+	return backupId
 }

--- a/alicloud/service_alicloud_gpdb.go
+++ b/alicloud/service_alicloud_gpdb.go
@@ -772,6 +772,33 @@ func (s *GpdbService) GpdbDbInstanceStateRefreshFunc(id string, field string, fa
 	}
 }
 
+// GpdbDbInstanceScaleStateRefreshFunc waits until a DescribeDBInstanceAttribute scalar field
+// reaches the expected value while the instance is back to Running. UpgradeDBInstance scaling
+// is asynchronous: the instance keeps reporting Running for a short window before it transitions
+// into the scaling state, so waiting only for Running can return before the new value is applied
+// and leave Read observing the stale value.
+func (s *GpdbService) GpdbDbInstanceScaleStateRefreshFunc(id, field, target string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := s.DescribeGpdbDbInstance(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return nil, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		status := fmt.Sprint(object["DBInstanceStatus"])
+		current := fmt.Sprint(object[field])
+		if _, ok := object[field].(float64); ok {
+			current = fmt.Sprint(formatInt(object[field]))
+		}
+		if status == "Running" && current == target {
+			return object, target, nil
+		}
+		// Not settled yet: report a non-target state so the waiter keeps polling.
+		return object, fmt.Sprintf("%s/%s", status, current), nil
+	}
+}
+
 func (s *GpdbService) DescribeGpdbDbInstancePlan(id string) (object map[string]interface{}, err error) {
 	var response map[string]interface{}
 	action := "DescribeDBInstancePlans"

--- a/website/docs/r/gpdb_instance.html.markdown
+++ b/website/docs/r/gpdb_instance.html.markdown
@@ -134,6 +134,8 @@ The following arguments are supported:
 
 * `used_time` - (Optional) The used time. When the parameter `period` is `Year`, the `used_time` value is `1` to `3`. When the parameter `period` is `Month`, the `used_time` value is `1` to `9`.
 * `description` - (Optional) The description of the instance.
+* `backup_id` - (Optional, ForceNew, Available since v1.287.0) The ID of the backup set. If specified, the instance is created from the existing backup set. See [CreateDBInstance](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-createdbinstance).
+* `src_db_instance_name` - (Optional, ForceNew, Available since v1.287.0) The source instance ID for creating an instance from a backup set. Must be set together with `backup_id`; the GPDB CreateDBInstance API requires `SrcDbInstanceName` and `BackupId` to be null or not null at the same time. See [CreateDBInstance](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-createdbinstance).
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `ip_whitelist` - (Optional, Set, Available since v1.187.0) The ip whitelist. See [`ip_whitelist`](#ip_whitelist) below.
   Default to creating a whitelist group with the group name "default" and security_ip_list "127.0.0.1".


### PR DESCRIPTION
## What

Add three capabilities to the `alicloud_gpdb_instance` resource.

### 1. `backup_id` (Optional, ForceNew)
Passthrough to `CreateDBInstance.BackupId`, allowing an instance to be created from an existing backup set. It is `ForceNew` because the backup set is a one-shot create-time parameter.

### 2. `src_db_instance_name` (Optional, ForceNew)
Passthrough to `CreateDBInstance.SrcDbInstanceName` — the ID of the source instance to clone from. The GPDB `CreateDBInstance` API exposes `SrcDbInstanceName` as a distinct parameter (separate from `DBInstanceName`, which is not a CreateDBInstance parameter), so Terraform mirrors it as its own field rather than reusing `db_instance_name`.

`backup_id` and `src_db_instance_name` must be set together (both set or both empty): the API rejects the request with `InvalidParameter.srcDbInstanceName` ("srcDbInstanceName and backupId must be null or not null at the same time") otherwise. A `CustomizeDiff` validation enforces this contract at plan time.

### 3. `sql_collector_status` (Optional, Computed)
Calls `ModifySqlCollectorPolicy` on Update to enable/disable the SQL Explorer feature (SQL collection). The schema accepts `Enabled`/`Disabled`, mapped to the API values `Enable`/`Disabled`.

GPDB exposes no `DescribeSQLCollectorPolicy` endpoint and `DescribeDBInstanceAttribute` does not return the collector state, so `sql_collector_status` is preserved from config in Read.

## Acceptance tests
- `TestAccAliCloudGPDBDBInstance_sqlCollector`: create an instance, enable SQL collector, then disable it.
- `TestAccAliCloudGPDBDBInstance_backupId`: self-builds the full restore-from-backup chain — create a source instance via Terraform, trigger a manual `CreateBackup` via API and poll until complete, resolve the backup set ID via the `alicloud_gpdb_data_backups` data source, then create the target instance with `backup_id` and `src_db_instance_name = alicloud_gpdb_instance.source.id`. No env var or pre-existing instance is required; both instances are Terraform-managed and destroyed on teardown.

## Notes
Follows the existing RDS `src_db_instance_name` / `sql_collector_status` precedent in `alicloud_db_instance`.
