### PR TITLE
New Resource: alicloud_ssl_certificates_service_company; New Data Source: alicloud_ssl_certificates_service_companies

### DIFF
--- a/alicloud/data_source_alicloud_ssl_certificates_service_companies.go
+++ b/alicloud/data_source_alicloud_ssl_certificates_service_companies.go
@@ -1,0 +1,254 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudSslCertificatesServiceCompanies() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudSslCertificatesServiceCompanyRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"company_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"keyword": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"companies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"city": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"company_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"company_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"company_email": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"company_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"company_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"company_phone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"company_type": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"country_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"department": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"lang": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"post_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"province": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudSslCertificatesServiceCompanyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListCompanies"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if v := d.Get("company_id").(int); v != 0 {
+		request["CompanyId"] = v
+	}
+	if v, ok := d.GetOk("keyword"); ok {
+		request["Keyword"] = v
+	}
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	request["ShowSize"] = PageSizeLarge
+	request["CurrentPage"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("cas", "2020-04-07", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.CompanyList[*]", response)
+
+		result, ok := resp.([]interface{})
+		if !ok {
+			return WrapError(fmt.Errorf("CompanyList is not a list, got %T", resp))
+		}
+		for _, v := range result {
+			item, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["CompanyName"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["CompanyId"])]; !ok {
+					continue
+				}
+			}
+			// API ListCompanies does not honor CompanyId server-side (returns full
+			// list even when CompanyId is set on the request), so filter client-side
+			// to make the company_id argument functional.
+			if cid := d.Get("company_id").(int); cid != 0 {
+				if fmt.Sprint(item["CompanyId"]) != fmt.Sprint(cid) {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["CurrentPage"] = request["CurrentPage"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["CompanyId"]
+
+		mapping["city"] = objectRaw["City"]
+		mapping["company_address"] = objectRaw["CompanyAddress"]
+		mapping["company_code"] = objectRaw["CompanyCode"]
+		mapping["company_email"] = objectRaw["CompanyEmail"]
+		mapping["company_name"] = objectRaw["CompanyName"]
+		mapping["company_phone"] = objectRaw["CompanyPhone"]
+		mapping["company_type"] = objectRaw["CompanyType"]
+		mapping["country_code"] = objectRaw["CountryCode"]
+		mapping["department"] = objectRaw["Department"]
+		mapping["lang"] = objectRaw["Lang"]
+		mapping["post_code"] = objectRaw["PostCode"]
+		mapping["province"] = objectRaw["Province"]
+		mapping["company_id"] = objectRaw["CompanyId"]
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["CompanyName"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("companies", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_ssl_certificates_service_companies_test.go
+++ b/alicloud/data_source_alicloud_ssl_certificates_service_companies_test.go
@@ -1,0 +1,122 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudSslCertificatesServiceCompanyDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudSslCertificatesServiceCompanySourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ssl_certificates_service_company.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudSslCertificatesServiceCompanySourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ssl_certificates_service_company.default.id}_fake"]`,
+		}),
+	}
+
+	companyIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudSslCertificatesServiceCompanySourceConfig(rand, map[string]string{
+			"company_id": `"${alicloud_ssl_certificates_service_company.default.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudSslCertificatesServiceCompanySourceConfig(rand, map[string]string{
+			"company_id": "999999999",
+		}),
+	}
+
+	keywordConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudSslCertificatesServiceCompanySourceConfig(rand, map[string]string{
+			"keyword": `"测试公司"`,
+		}),
+		fakeConfig: testAccCheckAlicloudSslCertificatesServiceCompanySourceConfig(rand, map[string]string{
+			"keyword": `"nonexistent_keyword_xyz"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudSslCertificatesServiceCompanySourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_ssl_certificates_service_company.default.id}"]`,
+			"company_id": `"${alicloud_ssl_certificates_service_company.default.id}"`,
+			"keyword":    `"测试公司"`,
+		}),
+		fakeConfig: testAccCheckAlicloudSslCertificatesServiceCompanySourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_ssl_certificates_service_company.default.id}_fake"]`,
+			"company_id": "999999999",
+			"keyword":    `"nonexistent_keyword_xyz"`,
+		}),
+	}
+
+	SslCertificatesServiceCompanyCheckInfo.dataSourceTestCheck(t, rand, idsConf, companyIdConf, keywordConf, allConf)
+}
+
+var existSslCertificatesServiceCompanyMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"companies.#":                 "1",
+		"companies.0.company_id":      CHECKSET,
+		"companies.0.company_email":   CHECKSET,
+		"companies.0.lang":            CHECKSET,
+		"companies.0.city":            CHECKSET,
+		"companies.0.company_type":    CHECKSET,
+		"companies.0.province":        CHECKSET,
+		"companies.0.company_address": CHECKSET,
+		"companies.0.company_name":    CHECKSET,
+		"companies.0.department":      CHECKSET,
+		"companies.0.country_code":    CHECKSET,
+		"companies.0.post_code":       CHECKSET,
+		"companies.0.company_code":    CHECKSET,
+		"companies.0.company_phone":   CHECKSET,
+	}
+}
+
+var fakeSslCertificatesServiceCompanyMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"companies.#": "0",
+	}
+}
+
+var SslCertificatesServiceCompanyCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_ssl_certificates_service_companies.default",
+	existMapFunc: existSslCertificatesServiceCompanyMapFunc,
+	fakeMapFunc:  fakeSslCertificatesServiceCompanyMapFunc,
+}
+
+func testAccCheckAlicloudSslCertificatesServiceCompanySourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccSslCertificatesServiceCompany%d"
+}
+
+
+resource "alicloud_ssl_certificates_service_company" "default" {
+        company_address = "西安市"
+        company_name = "测试公司1"
+        department = "测试部门1"
+        city = "西安"
+        company_type = "1"
+        country_code = "111122"
+        post_code = "11112233"
+        company_code = "12312311"
+        company_phone = "15101081174"
+        province = "陕西"
+        lang = "zh"
+        company_email = "test@example.com"
+}
+
+data "alicloud_ssl_certificates_service_companies" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -174,6 +174,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugins":                               dataSourceAliCloudApigPlugins(),
 			"alicloud_apig_domains":                               dataSourceAliCloudApigDomains(),
 			"alicloud_express_connect_router_vpc_associations":    dataSourceAliCloudExpressConnectRouterVpcAssociations(),
+			"alicloud_ssl_certificates_service_companies":         dataSourceAliCloudSslCertificatesServiceCompanies(),
 			"alicloud_express_connect_router_tr_associations":     dataSourceAliCloudExpressConnectRouterTrAssociations(),
 			"alicloud_express_connect_router_vbr_child_instances": dataSourceAliCloudExpressConnectRouterVbrChildInstances(),
 			"alicloud_cr_artifact_lifecycle_rules":                dataSourceAliCloudCrArtifactLifecycleRules(),
@@ -943,6 +944,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_gpdb_api_key":                                         resourceAliCloudGpdbApiKey(),
 			"alicloud_apig_plugin":                                          resourceAliCloudApigPlugin(),
+			"alicloud_ssl_certificates_service_company":                     resourceAliCloudSslCertificatesServiceCompany(),
 			"alicloud_apig_plugin_class":                                    resourceAliCloudApigPluginClass(),
 			"alicloud_apig_domain":                                          resourceAliCloudApigDomain(),
 			"alicloud_cr_artifact_lifecycle_rule":                           resourceAliCloudCrArtifactLifecycleRule(),

--- a/alicloud/resource_alicloud_ssl_certificates_service_company.go
+++ b/alicloud/resource_alicloud_ssl_certificates_service_company.go
@@ -1,0 +1,283 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudSslCertificatesServiceCompany() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudSslCertificatesServiceCompanyCreate,
+		Read:   resourceAliCloudSslCertificatesServiceCompanyRead,
+		Update: resourceAliCloudSslCertificatesServiceCompanyUpdate,
+		Delete: resourceAliCloudSslCertificatesServiceCompanyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"city": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"company_address": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"company_code": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"company_email": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"company_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"company_phone": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"company_type": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"country_code": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"department": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"lang": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"post_code": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"province": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudSslCertificatesServiceCompanyCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateCompany"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["ClientToken"] = buildClientToken(action)
+
+	request["CountryCode"] = d.Get("country_code")
+	request["Lang"] = d.Get("lang")
+	request["City"] = d.Get("city")
+	request["Province"] = d.Get("province")
+	request["PostCode"] = d.Get("post_code")
+	request["CompanyCode"] = d.Get("company_code")
+	request["CompanyName"] = d.Get("company_name")
+	if v, ok := d.GetOk("department"); ok {
+		request["Department"] = v
+	}
+	request["CompanyPhone"] = d.Get("company_phone")
+	request["CompanyAddress"] = d.Get("company_address")
+	request["CompanyType"] = d.Get("company_type")
+	if v, ok := d.GetOk("company_email"); ok {
+		request["CompanyEmail"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("cas", "2020-04-07", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ssl_certificates_service_company", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["CompanyId"]))
+
+	return resourceAliCloudSslCertificatesServiceCompanyRead(d, meta)
+}
+
+func resourceAliCloudSslCertificatesServiceCompanyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	sslCertificatesServiceServiceV2 := SslCertificatesServiceServiceV2{client}
+
+	objectRaw, err := sslCertificatesServiceServiceV2.DescribeSslCertificatesServiceCompany(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ssl_certificates_service_company DescribeSslCertificatesServiceCompany Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("city", objectRaw["City"])
+	d.Set("company_address", objectRaw["CompanyAddress"])
+	d.Set("company_code", objectRaw["CompanyCode"])
+	d.Set("company_email", objectRaw["CompanyEmail"])
+	d.Set("company_name", objectRaw["CompanyName"])
+	d.Set("company_phone", objectRaw["CompanyPhone"])
+	d.Set("company_type", objectRaw["CompanyType"])
+	d.Set("country_code", objectRaw["CountryCode"])
+	d.Set("department", objectRaw["Department"])
+	d.Set("lang", objectRaw["Lang"])
+	d.Set("post_code", objectRaw["PostCode"])
+	d.Set("province", objectRaw["Province"])
+
+	return nil
+}
+
+func resourceAliCloudSslCertificatesServiceCompanyUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "UpdateCompany"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["CompanyId"] = d.Id()
+
+	request["ClientToken"] = buildClientToken(action)
+	if d.HasChange("country_code") {
+		update = true
+	}
+	request["CountryCode"] = d.Get("country_code")
+	if d.HasChange("lang") {
+		update = true
+	}
+	request["Lang"] = d.Get("lang")
+
+	if d.HasChange("city") {
+		update = true
+	}
+	request["City"] = d.Get("city")
+	if d.HasChange("province") {
+		update = true
+	}
+	request["Province"] = d.Get("province")
+	if d.HasChange("post_code") {
+		update = true
+	}
+	request["PostCode"] = d.Get("post_code")
+	if d.HasChange("company_code") {
+		update = true
+	}
+	request["CompanyCode"] = d.Get("company_code")
+	if d.HasChange("company_name") {
+		update = true
+	}
+	request["CompanyName"] = d.Get("company_name")
+	if d.HasChange("department") {
+		update = true
+		request["Department"] = d.Get("department")
+	}
+
+	if d.HasChange("company_phone") {
+		update = true
+	}
+	request["CompanyPhone"] = d.Get("company_phone")
+	if d.HasChange("company_address") {
+		update = true
+	}
+	request["CompanyAddress"] = d.Get("company_address")
+	if d.HasChange("company_type") {
+		update = true
+	}
+	request["CompanyType"] = d.Get("company_type")
+	if d.HasChange("company_email") {
+		update = true
+		request["CompanyEmail"] = d.Get("company_email")
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("cas", "2020-04-07", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudSslCertificatesServiceCompanyRead(d, meta)
+}
+
+func resourceAliCloudSslCertificatesServiceCompanyDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteCompany"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["CompanyId"] = d.Id()
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("cas", "2020-04-07", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ssl_certificates_service_company_test.go
+++ b/alicloud/resource_alicloud_ssl_certificates_service_company_test.go
@@ -1,0 +1,120 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test SslCertificatesService Company. >>> Resource test cases, automatically generated.
+// Case Company资源用例 12894
+func TestAccAliCloudSslCertificatesServiceCompany_basic12894(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ssl_certificates_service_company.default"
+	ra := resourceAttrInit(resourceId, AlicloudSslCertificatesServiceCompanyMap12894)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &SslCertificatesServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeSslCertificatesServiceCompany")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccsslcertificatesservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudSslCertificatesServiceCompanyBasicDependence12894)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"company_address": "西安市",
+					"company_name":    name,
+					"department":      "测试部门1",
+					"city":            "西安",
+					"company_type":    "1",
+					"country_code":    "111122",
+					"post_code":       "11112233",
+					"company_code":    "12312311",
+					"company_phone":   "15101081174",
+					"province":        "陕西",
+					"lang":            "zh",
+					"company_email":   "test@example.com",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"company_address": "西安市",
+						"company_name":    name,
+						"department":      "测试部门1",
+						"city":            "西安",
+						"company_type":    "1",
+						"country_code":    CHECKSET,
+						"post_code":       CHECKSET,
+						"company_code":    CHECKSET,
+						"company_phone":   CHECKSET,
+						"province":        "陕西",
+						"lang":            CHECKSET,
+						"company_email":   CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"company_address": "西安市12333",
+					"company_name":    name + "_update",
+					"department":      "测试部门2",
+					"city":            "北京",
+					"company_type":    "2",
+					"country_code":    "222211",
+					"post_code":       "22221111",
+					"company_code":    "111122",
+					"company_phone":   "15201081174",
+					"province":        "西安市111",
+					"lang":            "en",
+					"company_email":   "update@example.com",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"company_address": "西安市12333",
+						"company_name":    name + "_update",
+						"department":      "测试部门2",
+						"city":            "北京",
+						"company_type":    "2",
+						"country_code":    CHECKSET,
+						"post_code":       CHECKSET,
+						"company_code":    CHECKSET,
+						"company_phone":   CHECKSET,
+						"province":        "西安市111",
+						"lang":            CHECKSET,
+						"company_email":   CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudSslCertificatesServiceCompanyMap12894 = map[string]string{}
+
+func AlicloudSslCertificatesServiceCompanyBasicDependence12894(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Test SslCertificatesService Company. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_ssl_certificates_service_v2.go
+++ b/alicloud/service_alicloud_ssl_certificates_service_v2.go
@@ -319,3 +319,74 @@ func (s *SslCertificatesServiceServiceV2) SslCertificatesServicePcaCertStateRefr
 }
 
 // DescribeSslCertificatesServicePcaCert >>> Encapsulated.
+
+// DescribeSslCertificatesServiceCompany <<< Encapsulated get interface for SslCertificatesService Company.
+
+func (s *SslCertificatesServiceServiceV2) DescribeSslCertificatesServiceCompany(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["CompanyId"] = id
+
+	action := "GetCompany"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("cas", "2020-04-07", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NotFound"}) {
+			return object, WrapErrorf(NotFoundErr("Company", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *SslCertificatesServiceServiceV2) SslCertificatesServiceCompanyStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.SslCertificatesServiceCompanyStateRefreshFuncWithApi(id, field, failStates, s.DescribeSslCertificatesServiceCompany)
+}
+
+func (s *SslCertificatesServiceServiceV2) SslCertificatesServiceCompanyStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeSslCertificatesServiceCompany >>> Encapsulated.

--- a/website/docs/d/ssl_certificates_service_companies.html.markdown
+++ b/website/docs/d/ssl_certificates_service_companies.html.markdown
@@ -1,0 +1,80 @@
+---
+subcategory: "Certificate Management Service (Original SSL Certificate)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ssl_certificates_service_companies"
+sidebar_current: "docs-alicloud-datasource-ssl-certificates-service-companies"
+description: |-
+  Provides a list of SSL Certificate Service Companies owned by an Alibaba Cloud account.
+---
+
+# alicloud_ssl_certificates_service_companies
+
+This data source provides SSL Certificate Service Companies available to the user.[What is Company](https://next.api.alibabacloud.com/document/cas/2020-04-07/CreateCompany)
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_ssl_certificates_service_company" "default" {
+  company_address = "西安市"
+  company_name    = "example公司1"
+  department      = "example部门1"
+  city            = "西安"
+  company_type    = "1"
+  country_code    = "111122"
+  post_code       = "11112233"
+  company_code    = "12312311"
+  company_phone   = "15101081174"
+  province        = "陕西"
+  lang            = "zh"
+}
+
+data "alicloud_ssl_certificates_service_companies" "default" {
+  ids        = ["${alicloud_ssl_certificates_service_company.default.id}"]
+  name_regex = "${alicloud_ssl_certificates_service_company.default.company_name}"
+}
+
+output "alicloud_ssl_certificates_service_company_example_id" {
+  value = "${data.alicloud_ssl_certificates_service_companies.default.companies.0.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `company_id` - (Optional, Int) The ID of the company used to filter the results.
+* `keyword` - (Optional) The keyword used to filter the companies.
+* `ids` - (Optional, Computed) A list of Company IDs.
+* `name_regex` - (Optional) A regex string to filter results by Company name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Company IDs.
+* `names` - A list of name of Companies.
+* `companies` - A list of Company Entries. Each element contains the following attributes:
+    * `city` - The city where the company is located.
+    * `company_address` - The address of the company.
+    * `company_code` - The code of the company.
+    * `company_email` - The email address of the company.
+    * `company_id` - The ID of the company.
+    * `company_name` - The name of the company.
+    * `company_phone` - The contact phone number of the company.
+    * `company_type` - The type of the company.
+    * `country_code` - The country code of the company.
+    * `department` - The department of the company.
+    * `lang` - The natural language of the content within the request and response.
+    * `post_code` - The postal code of the company.
+    * `province` - The province where the company is located.
+    * `id` - The ID of the Company.

--- a/website/docs/r/ssl_certificates_service_company.html.markdown
+++ b/website/docs/r/ssl_certificates_service_company.html.markdown
@@ -1,0 +1,82 @@
+---
+subcategory: "Certificate Management Service (Original SSL Certificate)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ssl_certificates_service_company"
+description: |-
+  Provides an Alicloud Certificate Management Service (Original SSL Certificate) Company resource.
+---
+
+# alicloud_ssl_certificates_service_company
+
+Provides a Certificate Management Service (Original SSL Certificate) Company resource.
+
+
+
+For information about Certificate Management Service (Original SSL Certificate) Company and how to use it, see [What is Company](https://next.api.alibabacloud.com/document/cas/2020-04-07/CreateCompany).
+
+-> **NOTE:** Available since v1.285.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_ssl_certificates_service_company" "default" {
+  company_address = "西安市"
+  company_name    = "example公司1"
+  department      = "example部门1"
+  city            = "西安"
+  company_type    = "1"
+  country_code    = "111122"
+  post_code       = "11112233"
+  company_code    = "12312311"
+  company_phone   = "15101081174"
+  province        = "陕西"
+  lang            = "zh"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `city` - (Required) The city where the company is located.
+* `company_address` - (Required) The address of the company.
+* `company_code` - (Required) The code of the company.
+* `company_email` - (Optional) The email address of the company.
+* `company_name` - (Required) The name of the company.
+* `company_phone` - (Required) The contact phone number of the company.
+* `company_type` - (Required, Int) The type of the company.
+* `country_code` - (Required) The country code of the company.
+* `department` - (Optional) The department of the company.
+* `lang` - (Required) The natural language of the content within the request and response.
+* `post_code` - (Required) The postal code of the company.
+* `province` - (Required) The province where the company is located.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Company.
+* `delete` - (Defaults to 5 mins) Used when delete the Company.
+* `update` - (Defaults to 5 mins) Used when update the Company.
+
+## Import
+
+Certificate Management Service (Original SSL Certificate) Company can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ssl_certificates_service_company.example <company_id>
+```


### PR DESCRIPTION
Add a new resource `alicloud_ssl_certificates_service_company` and its data source `alicloud_ssl_certificates_service_companies` for SSL Certificates Service (cas), covering certificate company information management.

### Resource

`alicloud_ssl_certificates_service_company` — full CRUD for certificate company information, backed by the cas Company APIs (CreateCompany / GetCompany / UpdateCompany / DeleteCompany).

Supported arguments: `company_name`, `city`, `lang`, `company_address`, `company_code`, `company_email`, `company_phone`, `company_type`, `country_code`, `department`, `post_code`, `province`.

### Data Source

`alicloud_ssl_certificates_service_companies` — query certificate company records (backed by ListCompanies), with `keyword` filter and full attribute export.

### Acceptance Tests

```
=== RUN   TestAccAliCloudSslCertificatesServiceCompany_basic12894
--- PASS: TestAccAliCloudSslCertificatesServiceCompany_basic12894 (5.49s)

=== RUN   TestAccAlicloudSslCertificatesServiceCompanyDataSource
--- PASS: TestAccAlicloudSslCertificatesServiceCompanyDataSource (10.21s)
```
