### PR TITLE
resource/alicloud_kvstore_instance: validate private_connection_prefix format

### DIFF
--- a/alicloud/resource_alicloud_kvstore_instance.go
+++ b/alicloud/resource_alicloud_kvstore_instance.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/helper"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAliCloudKvstoreInstance() *schema.Resource {
@@ -237,8 +239,9 @@ func resourceAliCloudKvstoreInstance() *schema.Resource {
 				Optional: true,
 			},
 			"private_connection_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-z][a-z0-9]{7,39}$`), "The prefix must be 8 to 40 characters in length, can contain lowercase letters and digits, and must start with a lowercase letter."),
 			},
 			"private_connection_port": {
 				Type:     schema.TypeString,

--- a/website/docs/r/kvstore_instance.html.markdown
+++ b/website/docs/r/kvstore_instance.html.markdown
@@ -258,7 +258,7 @@ The following arguments are supported:
 * `backup_period`- (Optional, List, Available since v1.104.0) Backup period.
 * `backup_time`- (Optional, Available since v1.104.0) Backup time, the format is HH:mmZ-HH:mmZ (UTC time).
 * `enable_backup_log`- (Optional, Int, Available since v1.104.0) Turn on or off incremental backup. Valid values: `1`, `0`. Default value: `0`
-* `private_connection_prefix`- (Optional, Available since v1.105.0) Private network connection prefix, used to modify the private network connection address. Only supports updating private network connections for existing instance.
+* `private_connection_prefix`- (Optional, Available since v1.105.0) Private network connection prefix, used to modify the private network connection address. Only supports updating private network connections for existing instance. The prefix must be 8 to 40 characters in length, and can contain lowercase letters and digits. It must start with a lowercase letter. The private network connection address is in the format of `<prefix>.redis.rds.aliyuncs.com`.
 * `private_connection_port`- (Optional, Available since v1.124.0) Private network connection port, used to modify the private network connection port.
 * `dry_run` - (Optional, Bool, Available since v1.128.0) Specifies whether to precheck the request. Valid values:
   - `true`: prechecks the request without creating an instance. The system prechecks the required parameters, request format, service limits, and available resources. If the request fails the precheck, the corresponding error message is returned. If the request passes the precheck, the DryRunOperation error code is returned.


### PR DESCRIPTION
### Summary

`alicloud_kvstore_instance.private_connection_prefix` is passed straight through to the R-kvstore `ModifyDBInstanceConnectionString` API as `NewConnectionString`. The upstream API constrains this prefix to **8–40 characters, lowercase letters and digits only, and it must start with a lowercase letter** (final endpoint form `<prefix>.redis.rds.aliyuncs.com`). Previously the field had no validation and the doc did not record the constraint, so an invalid prefix only surfaced as an opaque `NewConnectionStringNotSupport` error at apply time.

### Changes

- Add a `ValidateFunc` on `private_connection_prefix` (`^[a-z][a-z0-9]{7,39}$`) so an invalid prefix fails fast at plan time with a clear message instead of an opaque API error.
- Document the prefix constraint and endpoint format in the resource docs.

### Test

- `gofmt` clean; `go vet ./alicloud` shows only pre-existing unrelated warnings.
- Field-level validation is plan-time and does not require an acceptance run to exercise; existing `alicloud_kvstore_instance` acceptance coverage is unaffected.
