### PR TITLE
resource/alicloud_actiontrail_trail: validate status against Enable/Disable

### DIFF
--- a/alicloud/resource_alicloud_actiontrail_trail.go
+++ b/alicloud/resource_alicloud_actiontrail_trail.go
@@ -85,9 +85,10 @@ func resourceAliCloudActionTrailTrail() *schema.Resource {
 				Computed: true,
 			},
 			"status": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"Enable", "Disable"}, false),
 			},
 			"trail_name": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_actiontrail_trail_test.go
+++ b/alicloud/resource_alicloud_actiontrail_trail_test.go
@@ -692,7 +692,7 @@ func TestUnitAliCloudActiontrailTrail(t *testing.T) {
 
 // Test Actiontrail Trail. >>> Resource test cases, automatically generated.
 // Case Trail投递MaxCompute用例 11012
-func TestAccAliCloudActiontrailTrail_basic11012(t *testing.T) {
+func TestAccAliCloudActionTrailTrail_basic11012(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_actiontrail_trail.default"
 	ra := resourceAttrInit(resourceId, AliCloudActiontrailTrailMap11012)
@@ -874,7 +874,7 @@ func TestAccAliCloudActiontrailTrail_basic11012(t *testing.T) {
 	})
 }
 
-func TestAccAliCloudActiontrailTrail_basic11012_twin(t *testing.T) {
+func TestAccAliCloudActionTrailTrail_basic11012_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_actiontrail_trail.default"
 	ra := resourceAttrInit(resourceId, AliCloudActiontrailTrailMap11012)
@@ -984,7 +984,7 @@ func AliCloudActiontrailTrailBasicDependence11012(name string) string {
 }
 
 // Case 适配废弃字段name 11016
-func TestAccAliCloudActiontrailTrail_basic11016(t *testing.T) {
+func TestAccAliCloudActionTrailTrail_basic11016(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_actiontrail_trail.default"
 	ra := resourceAttrInit(resourceId, AliCloudActiontrailTrailMap11012)
@@ -1166,7 +1166,7 @@ func TestAccAliCloudActiontrailTrail_basic11016(t *testing.T) {
 	})
 }
 
-func TestAccAliCloudActiontrailTrail_basic11016_twin(t *testing.T) {
+func TestAccAliCloudActionTrailTrail_basic11016_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_actiontrail_trail.default"
 	ra := resourceAttrInit(resourceId, AliCloudActiontrailTrailMap11012)


### PR DESCRIPTION
### Summary

The `status` field of `alicloud_actiontrail_trail` accepts arbitrary strings. Only `Enable` and `Disable` are valid target states (mapped to the `StartLogging` / `StopLogging` actions in Update). Any other value passes plan/apply silently: the Update logic has no branch for non-enum values, so the trail is neither started nor stopped, and the configured `status` never converges with the cloud-side state.

This PR adds `ValidateFunc: StringInSlice([]string{"Enable", "Disable"}, false)` to the `status` schema so invalid values are rejected at plan time, aligning the schema with the documented valid values (`Enable`, `Disable`) and matching the pattern already used by the sibling `event_rw` field in this resource.

### Change

- `alicloud/resource_alicloud_actiontrail_trail.go`: add `ValidateFunc` to `status`.

No behavior change for valid configurations; only invalid `status` values now fail fast with a clear validation error instead of silently no-op.