### PR TITLE
docs: add length and prefix constraints for vswitch_name

### DIFF
--- a/website/docs/r/vswitch.html.markdown
+++ b/website/docs/r/vswitch.html.markdown
@@ -133,7 +133,7 @@ The following arguments are supported:
   - When the VPC IPv6 address mask is `56`: `0` to `255`.
   - When the VPC IPv6 address mask is `60`: `0` to `15`.
 * `tags` - (Optional, Map, Available since v1.55.3) The tags of VSwitch.
-* `vswitch_name` - (Optional, Available since v1.119.0) The name of the VSwitch.
+* `vswitch_name` - (Optional, Available since v1.119.0) The name of the VSwitch. The name must be `1` to `128` characters in length, and cannot start with `http://` or `https://`.
 * `vpc_id` - (Optional, ForceNew) The VPC ID. **NOTE:** From version 1.233.0, if you do not set `is_default`, or set `is_default` to `false`, `vpc_id` is required.
 * `is_default` - (Optional, Computed, ForceNew, Bool, Available since v1.233.0) Specifies whether to create the default VSwitch. Default value: `false`. Valid values:
   - `true`: Creates a default vSwitch.


### PR DESCRIPTION
### What this PR does

Documents the length and prefix constraints for `vswitch_name` in the `alicloud_vswitch` resource argument reference, aligning the wording with the existing `description` field on the same page.

- `vswitch_name` must be `1` to `128` characters in length.
- `vswitch_name` cannot start with `http://` or `https://`.

These match the upstream VPC OpenAPI contract for `CreateVSwitch.VSwitchName` and `ModifyVSwitchAttribute.VSwitchName`.

### Change scope

- Doc-only: `website/docs/r/vswitch.html.markdown` (Argument Reference entry for `vswitch_name`).
- No schema/`ValidateFunc` changes — kept consistent with the convention already used by `vpc_name` and `security_group_name`.

### Verification

- Doc-only; no ACC tests touched.
- Wording mirrors the existing `description` constraint sentence on the same page.
