### PR TITLE
New Resource: alicloud_apig_service and New Data Source: alicloud_apig_services

### DIFF
--- a/alicloud/data_source_alicloud_apig_services.go
+++ b/alicloud/data_source_alicloud_apig_services.go
@@ -1,0 +1,528 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudApigServices() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudApigServiceRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"source_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"services": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"addresses": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"agent_service_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"protocols": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"address": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"enable_outlier_detection": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"enable_health_check": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"provider": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"ai_service_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"api_keys": {
+										Type:      schema.TypeList,
+										Computed:  true,
+										Sensitive: true,
+										Elem:      &schema.Schema{Type: schema.TypeString},
+									},
+									"protocols": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"address": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"enable_health_check": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"provider": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"create_timestamp": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"dns_servers": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"express_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"health_check_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"http_path": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"unhealthy_threshold": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"timeout": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"http_host": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"healthy_threshold": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"enable": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"expected_statuses": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"protocol": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"interval": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"health_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"healthy_panic_threshold": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"model_provider_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"namespace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"outlier_detection_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"failure_percentage_threshold": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"enable": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"base_ejection_time": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"failure_percentage_minimum_hosts": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"interval": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"outlier_endpoints": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"qualifier": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"runtime_detail_error_code": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"runtime_detail_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"unhealthy_endpoints": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"update_timestamp": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudApigServiceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListServices
+	action := fmt.Sprintf("/v1/services")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	if v, ok := d.GetOk("gateway_id"); ok {
+		query["gatewayId"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		query["resourceGroupId"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("source_type"); ok {
+		query["sourceType"] = StringPointer(v.(string))
+	}
+
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	query["pageSize"] = StringPointer(strconv.Itoa(PageSizeLarge))
+	query["pageNumber"] = StringPointer("1")
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaGet("APIG", "2024-03-27", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.data.items[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["name"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["serviceId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		pageNum, _ := strconv.Atoi(*query["pageNumber"])
+		query["pageNumber"] = StringPointer(strconv.Itoa(pageNum + 1))
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["serviceId"]
+
+		mapping["create_timestamp"] = objectRaw["createTimestamp"]
+		mapping["express_type"] = objectRaw["expressType"]
+		mapping["gateway_id"] = objectRaw["gatewayId"]
+		mapping["group_name"] = objectRaw["groupName"]
+		mapping["health_status"] = objectRaw["healthStatus"]
+		mapping["healthy_panic_threshold"] = objectRaw["healthyPanicThreshold"]
+		mapping["model_provider_id"] = objectRaw["modelProviderId"]
+		mapping["namespace"] = objectRaw["namespace"]
+		mapping["qualifier"] = objectRaw["qualifier"]
+		mapping["resource_group_id"] = objectRaw["resourceGroupId"]
+		mapping["runtime_detail_error_code"] = objectRaw["runtimeDetailErrorCode"]
+		mapping["runtime_detail_status"] = objectRaw["runtimeDetailStatus"]
+		mapping["service_name"] = objectRaw["name"]
+		mapping["source_type"] = objectRaw["sourceType"]
+		mapping["update_timestamp"] = objectRaw["updateTimestamp"]
+		mapping["service_id"] = objectRaw["serviceId"]
+
+		addressesRaw := make([]interface{}, 0)
+		if objectRaw["addresses"] != nil {
+			addressesRaw = convertToInterfaceArray(objectRaw["addresses"])
+		}
+
+		mapping["addresses"] = addressesRaw
+		agentServiceConfigMaps := make([]map[string]interface{}, 0)
+		agentServiceConfigMap := make(map[string]interface{})
+		agentServiceConfigRaw := make(map[string]interface{})
+		if objectRaw["agentServiceConfig"] != nil {
+			agentServiceConfigRaw = objectRaw["agentServiceConfig"].(map[string]interface{})
+		}
+		if len(agentServiceConfigRaw) > 0 {
+			agentServiceConfigMap["address"] = agentServiceConfigRaw["address"]
+			agentServiceConfigMap["enable_health_check"] = agentServiceConfigRaw["enableHealthCheck"]
+			agentServiceConfigMap["enable_outlier_detection"] = agentServiceConfigRaw["enableOutlierDetection"]
+			agentServiceConfigMap["provider"] = agentServiceConfigRaw["provider"]
+
+			protocolsRaw := make([]interface{}, 0)
+			if agentServiceConfigRaw["protocols"] != nil {
+				protocolsRaw = convertToInterfaceArray(agentServiceConfigRaw["protocols"])
+			}
+
+			agentServiceConfigMap["protocols"] = protocolsRaw
+			agentServiceConfigMaps = append(agentServiceConfigMaps, agentServiceConfigMap)
+		}
+		mapping["agent_service_config"] = agentServiceConfigMaps
+		aiServiceConfigMaps := make([]map[string]interface{}, 0)
+		aiServiceConfigMap := make(map[string]interface{})
+		aiServiceConfigRaw := make(map[string]interface{})
+		if objectRaw["aiServiceConfig"] != nil {
+			aiServiceConfigRaw = objectRaw["aiServiceConfig"].(map[string]interface{})
+		}
+		if len(aiServiceConfigRaw) > 0 {
+			aiServiceConfigMap["address"] = aiServiceConfigRaw["address"]
+			aiServiceConfigMap["enable_health_check"] = aiServiceConfigRaw["enableHealthCheck"]
+			aiServiceConfigMap["provider"] = aiServiceConfigRaw["provider"]
+
+			apiKeysRaw := make([]interface{}, 0)
+			if aiServiceConfigRaw["apiKeys"] != nil {
+				apiKeysRaw = convertToInterfaceArray(aiServiceConfigRaw["apiKeys"])
+			}
+
+			aiServiceConfigMap["api_keys"] = apiKeysRaw
+			protocolsRaw := make([]interface{}, 0)
+			if aiServiceConfigRaw["protocols"] != nil {
+				protocolsRaw = convertToInterfaceArray(aiServiceConfigRaw["protocols"])
+			}
+
+			aiServiceConfigMap["protocols"] = protocolsRaw
+			aiServiceConfigMaps = append(aiServiceConfigMaps, aiServiceConfigMap)
+		}
+		mapping["ai_service_config"] = aiServiceConfigMaps
+		dnsServersRaw := make([]interface{}, 0)
+		if objectRaw["dnsServers"] != nil {
+			dnsServersRaw = convertToInterfaceArray(objectRaw["dnsServers"])
+		}
+
+		mapping["dns_servers"] = dnsServersRaw
+		healthCheckConfigMaps := make([]map[string]interface{}, 0)
+		healthCheckConfigMap := make(map[string]interface{})
+		healthCheckRaw := make(map[string]interface{})
+		if objectRaw["healthCheck"] != nil {
+			healthCheckRaw = objectRaw["healthCheck"].(map[string]interface{})
+		}
+		if len(healthCheckRaw) > 0 {
+			healthCheckConfigMap["enable"] = healthCheckRaw["enable"]
+			healthCheckConfigMap["healthy_threshold"] = healthCheckRaw["healthyThreshold"]
+			healthCheckConfigMap["http_host"] = healthCheckRaw["httpHost"]
+			healthCheckConfigMap["http_path"] = healthCheckRaw["httpPath"]
+			healthCheckConfigMap["interval"] = healthCheckRaw["interval"]
+			healthCheckConfigMap["protocol"] = healthCheckRaw["protocol"]
+			healthCheckConfigMap["timeout"] = healthCheckRaw["timeout"]
+			healthCheckConfigMap["unhealthy_threshold"] = healthCheckRaw["unhealthyThreshold"]
+
+			healthCheckConfigMaps = append(healthCheckConfigMaps, healthCheckConfigMap)
+		}
+		mapping["health_check_config"] = healthCheckConfigMaps
+		outlierDetectionConfigMaps := make([]map[string]interface{}, 0)
+		outlierDetectionConfigMap := make(map[string]interface{})
+		outlierDetectionRaw := make(map[string]interface{})
+		if objectRaw["outlierDetection"] != nil {
+			outlierDetectionRaw = objectRaw["outlierDetection"].(map[string]interface{})
+		}
+		if len(outlierDetectionRaw) > 0 {
+			outlierDetectionConfigMap["base_ejection_time"] = outlierDetectionRaw["baseEjectionTime"]
+			outlierDetectionConfigMap["enable"] = outlierDetectionRaw["enable"]
+			outlierDetectionConfigMap["failure_percentage_minimum_hosts"] = outlierDetectionRaw["failurePercentageMinimumHosts"]
+			outlierDetectionConfigMap["failure_percentage_threshold"] = outlierDetectionRaw["failurePercentageThreshold"]
+			outlierDetectionConfigMap["interval"] = outlierDetectionRaw["interval"]
+
+			outlierDetectionConfigMaps = append(outlierDetectionConfigMaps, outlierDetectionConfigMap)
+		}
+		mapping["outlier_detection_config"] = outlierDetectionConfigMaps
+		outlierEndpointsRaw := make([]interface{}, 0)
+		if objectRaw["outlierEndpoints"] != nil {
+			outlierEndpointsRaw = convertToInterfaceArray(objectRaw["outlierEndpoints"])
+		}
+
+		mapping["outlier_endpoints"] = outlierEndpointsRaw
+		unhealthyEndpointsRaw := make([]interface{}, 0)
+		if objectRaw["unhealthyEndpoints"] != nil {
+			unhealthyEndpointsRaw = convertToInterfaceArray(objectRaw["unhealthyEndpoints"])
+		}
+
+		mapping["unhealthy_endpoints"] = unhealthyEndpointsRaw
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["name"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("services", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_apig_services_test.go
+++ b/alicloud/data_source_alicloud_apig_services_test.go
@@ -1,0 +1,158 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudApigServicesDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigServicesDataSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_apig_service.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigServicesDataSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_apig_service.default.id}_fake"]`,
+		}),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigServicesDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_apig_service.default.service_name}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigServicesDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_apig_service.default.service_name}_fake"`,
+		}),
+	}
+
+	gatewayIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigServicesDataSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_apig_service.default.id}"]`,
+			"gateway_id": `"${alicloud_apig_service.default.gateway_id}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigServicesDataSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_apig_service.default.id}"]`,
+			"gateway_id": `"${alicloud_apig_service.default.gateway_id}_fake"`,
+		}),
+	}
+
+	sourceTypeConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigServicesDataSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_apig_service.default.id}"]`,
+			"gateway_id":  `"${alicloud_apig_service.default.gateway_id}"`,
+			"source_type": `"${alicloud_apig_service.default.source_type}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigServicesDataSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_apig_service.default.id}"]`,
+			"gateway_id":  `"${alicloud_apig_service.default.gateway_id}"`,
+			"source_type": `"K8S"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigServicesDataSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_apig_service.default.id}"]`,
+			"name_regex":  `"${alicloud_apig_service.default.service_name}"`,
+			"gateway_id":  `"${alicloud_apig_service.default.gateway_id}"`,
+			"source_type": `"${alicloud_apig_service.default.source_type}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigServicesDataSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_apig_service.default.id}_fake"]`,
+			"name_regex":  `"${alicloud_apig_service.default.service_name}_fake"`,
+			"gateway_id":  `"${alicloud_apig_service.default.gateway_id}"`,
+			"source_type": `"${alicloud_apig_service.default.source_type}"`,
+		}),
+	}
+
+	AliCloudApigServicesCheckInfo.dataSourceTestCheck(t, rand, idsConf, nameRegexConf, gatewayIdConf, sourceTypeConf, allConf)
+}
+
+var existAliCloudApigServicesMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"services.#":              "1",
+		"services.0.id":           CHECKSET,
+		"services.0.service_id":   CHECKSET,
+		"services.0.service_name": CHECKSET,
+		"services.0.source_type":  "VIP",
+		"services.0.gateway_id":   CHECKSET,
+		"services.0.addresses.#":  CHECKSET,
+		"ids.#":                   "1",
+		"names.#":                 "1",
+	}
+}
+
+var fakeAliCloudApigServicesMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"services.#": "0",
+		"ids.#":      "0",
+		"names.#":    "0",
+	}
+}
+
+var AliCloudApigServicesCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_apig_services.default",
+	existMapFunc: existAliCloudApigServicesMapFunc,
+	fakeMapFunc:  fakeAliCloudApigServicesMapFunc,
+}
+
+func testAccCheckAliCloudApigServicesDataSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+  default = "tfaccapigsvcds%d"
+}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_apig_gateway" "default" {
+  network_access_config {
+    type = "Intranet"
+  }
+  vswitch {
+    vswitch_id = data.alicloud_vswitches.default.ids.0
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = data.alicloud_vpcs.default.ids.0
+  }
+  payment_type = "PayAsYouGo"
+  gateway_name = var.name
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = false
+    }
+  }
+}
+
+resource "alicloud_apig_service" "default" {
+  addresses    = ["127.0.0.1:8080"]
+  service_name = var.name
+  source_type  = "VIP"
+  gateway_id   = alicloud_apig_gateway.default.id
+  namespace    = "default"
+}
+
+data "alicloud_apig_services" "default" {
+  %s
+}
+`, rand, strings.Join(pairs, "\n  "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -170,6 +170,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_apig_services":                              dataSourceAliCloudApigServices(),
 			"alicloud_apig_gateways":                              dataSourceAliCloudApigGateways(),
 			"alicloud_apig_plugins":                               dataSourceAliCloudApigPlugins(),
 			"alicloud_apig_domains":                               dataSourceAliCloudApigDomains(),
@@ -940,6 +941,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_apig_service":                                         resourceAliCloudApigService(),
 			"alicloud_gpdb_api_key":                                         resourceAliCloudGpdbApiKey(),
 			"alicloud_apig_plugin":                                          resourceAliCloudApigPlugin(),
 			"alicloud_apig_plugin_class":                                    resourceAliCloudApigPluginClass(),

--- a/alicloud/resource_alicloud_apig_service.go
+++ b/alicloud/resource_alicloud_apig_service.go
@@ -1,0 +1,889 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudApigService() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudApigServiceCreate,
+		Read:   resourceAliCloudApigServiceRead,
+		Update: resourceAliCloudApigServiceUpdate,
+		Delete: resourceAliCloudApigServiceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(6 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"addresses": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"agent_service_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocols": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"address": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"enable_outlier_detection": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"enable_health_check": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"provider": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"ai_service_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"api_keys": {
+							Type:      schema.TypeList,
+							Optional:  true,
+							Sensitive: true,
+							Elem:      &schema.Schema{Type: schema.TypeString},
+						},
+						"protocols": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"address": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"enable_health_check": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"provider": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: StringInSlice([]string{"qwen", "moonshot", "baichuan", "yi", "zhipuai", "360ai", "hunyuan", "stepfun", "spark", "openai", "claude", "doubao", "minimax", "gemini", "azure", "deepseek", "custom", "pai-eas", "bedrock", "dify", "vertex", "vllm"}, false),
+						},
+					},
+				},
+			},
+			"create_timestamp": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"dns_servers": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"express_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"gateway_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"health_check_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"http_path": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"unhealthy_threshold": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"timeout": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"http_host": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"healthy_threshold": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"enable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"expected_statuses": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"interval": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"health_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"healthy_panic_threshold": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+				Computed: true,
+			},
+			"model_provider_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"outlier_detection_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"failure_percentage_threshold": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"enable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"base_ejection_time": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"failure_percentage_minimum_hosts": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"interval": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"outlier_endpoints": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"ports": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"port": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"qualifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"runtime_detail_error_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"runtime_detail_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"source_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"unhealthy_endpoints": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"update_timestamp": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudApigServiceCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/v1/services")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	serviceConfigsDataList := make(map[string]interface{})
+	if v, ok := d.GetOk("namespace"); ok {
+		serviceConfigsDataList["namespace"] = v
+	}
+	if v, ok := d.GetOk("dns_servers"); ok {
+		dnsServers1, _ := jsonpath.Get("$", v)
+		if dnsServers1 != nil && dnsServers1 != "" {
+			serviceConfigsDataList["dnsServers"] = dnsServers1
+		}
+	}
+	if v := d.Get("agent_service_config"); !IsNil(v) {
+		agentServiceConfig := make(map[string]interface{})
+		protocols1, _ := jsonpath.Get("$[0].protocols", d.Get("agent_service_config"))
+		if protocols1 != nil && protocols1 != "" {
+			agentServiceConfig["protocols"] = protocols1
+		}
+		address1, _ := jsonpath.Get("$[0].address", d.Get("agent_service_config"))
+		if address1 != nil && address1 != "" {
+			agentServiceConfig["address"] = address1
+		}
+		enableHealthCheck1, _ := jsonpath.Get("$[0].enable_health_check", d.Get("agent_service_config"))
+		if enableHealthCheck1 != nil && enableHealthCheck1 != "" {
+			agentServiceConfig["enableHealthCheck"] = enableHealthCheck1
+		}
+		provider1, _ := jsonpath.Get("$[0].provider", d.Get("agent_service_config"))
+		if provider1 != nil && provider1 != "" {
+			agentServiceConfig["provider"] = provider1
+		}
+		enableOutlierDetection1, _ := jsonpath.Get("$[0].enable_outlier_detection", d.Get("agent_service_config"))
+		if enableOutlierDetection1 != nil && enableOutlierDetection1 != "" {
+			agentServiceConfig["enableOutlierDetection"] = enableOutlierDetection1
+		}
+
+		if len(agentServiceConfig) > 0 {
+			serviceConfigsDataList["agentServiceConfig"] = agentServiceConfig
+		}
+	}
+	if v, ok := d.GetOk("model_provider_id"); ok {
+		serviceConfigsDataList["modelProviderId"] = v
+	}
+	if v, ok := d.GetOk("group_name"); ok {
+		serviceConfigsDataList["groupName"] = v
+	}
+	if v := d.Get("ai_service_config"); !IsNil(v) {
+		aiServiceConfig := make(map[string]interface{})
+		apiKeys1, _ := jsonpath.Get("$[0].api_keys", d.Get("ai_service_config"))
+		if apiKeys1 != nil && apiKeys1 != "" {
+			aiServiceConfig["apiKeys"] = apiKeys1
+		}
+		protocols3, _ := jsonpath.Get("$[0].protocols", d.Get("ai_service_config"))
+		if protocols3 != nil && protocols3 != "" {
+			aiServiceConfig["protocols"] = protocols3
+		}
+		provider3, _ := jsonpath.Get("$[0].provider", d.Get("ai_service_config"))
+		if provider3 != nil && provider3 != "" {
+			aiServiceConfig["provider"] = provider3
+		}
+		enableHealthCheck3, _ := jsonpath.Get("$[0].enable_health_check", d.Get("ai_service_config"))
+		if enableHealthCheck3 != nil && enableHealthCheck3 != "" {
+			aiServiceConfig["enableHealthCheck"] = enableHealthCheck3
+		}
+		address3, _ := jsonpath.Get("$[0].address", d.Get("ai_service_config"))
+		if address3 != nil && address3 != "" {
+			aiServiceConfig["address"] = address3
+		}
+
+		if len(aiServiceConfig) > 0 {
+			serviceConfigsDataList["aiServiceConfig"] = aiServiceConfig
+		}
+	}
+	if v, ok := d.GetOk("qualifier"); ok {
+		serviceConfigsDataList["qualifier"] = v
+	}
+	if v, ok := d.GetOk("addresses"); ok {
+		addresses1, _ := jsonpath.Get("$", v)
+		if addresses1 != nil && addresses1 != "" {
+			serviceConfigsDataList["addresses"] = addresses1
+		}
+	}
+	if v, ok := d.GetOk("express_type"); ok {
+		serviceConfigsDataList["expressType"] = v
+	}
+	if v, ok := d.GetOk("service_name"); ok {
+		serviceConfigsDataList["name"] = v
+	}
+
+	serviceConfigsMap := make([]interface{}, 0)
+	serviceConfigsMap = append(serviceConfigsMap, serviceConfigsDataList)
+	request["serviceConfigs"] = serviceConfigsMap
+
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["resourceGroupId"] = v
+	}
+	if v, ok := d.GetOk("source_type"); ok {
+		request["sourceType"] = v
+	}
+	if v, ok := d.GetOk("gateway_id"); ok {
+		request["gatewayId"] = v
+	}
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("APIG", "2024-03-27", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_apig_service", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.data.serviceIds[0]", response)
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudApigServiceUpdate(d, meta)
+}
+
+func resourceAliCloudApigServiceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	apigServiceV2 := ApigServiceV2{client}
+
+	objectRaw, err := apigServiceV2.DescribeApigService(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_apig_service DescribeApigService Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("create_timestamp", objectRaw["createTimestamp"])
+	d.Set("express_type", objectRaw["expressType"])
+	d.Set("gateway_id", objectRaw["gatewayId"])
+	d.Set("group_name", objectRaw["groupName"])
+	d.Set("health_status", objectRaw["healthStatus"])
+	d.Set("healthy_panic_threshold", objectRaw["healthyPanicThreshold"])
+	d.Set("model_provider_id", objectRaw["modelProviderId"])
+	d.Set("namespace", objectRaw["namespace"])
+	d.Set("qualifier", objectRaw["qualifier"])
+	d.Set("resource_group_id", objectRaw["resourceGroupId"])
+	d.Set("runtime_detail_error_code", objectRaw["runtimeDetailErrorCode"])
+	d.Set("runtime_detail_status", objectRaw["runtimeDetailStatus"])
+	d.Set("service_name", objectRaw["name"])
+	d.Set("source_type", objectRaw["sourceType"])
+	d.Set("update_timestamp", objectRaw["updateTimestamp"])
+	d.Set("protocol", objectRaw["protocol"])
+
+	addressesRaw := make([]interface{}, 0)
+	if objectRaw["addresses"] != nil {
+		addressesRaw = convertToInterfaceArray(objectRaw["addresses"])
+	}
+
+	d.Set("addresses", addressesRaw)
+	agentServiceConfigMaps := make([]map[string]interface{}, 0)
+	agentServiceConfigMap := make(map[string]interface{})
+	agentServiceConfigRaw := make(map[string]interface{})
+	if objectRaw["agentServiceConfig"] != nil {
+		agentServiceConfigRaw = objectRaw["agentServiceConfig"].(map[string]interface{})
+	}
+	if len(agentServiceConfigRaw) > 0 {
+		agentServiceConfigMap["address"] = agentServiceConfigRaw["address"]
+		agentServiceConfigMap["enable_health_check"] = agentServiceConfigRaw["enableHealthCheck"]
+		agentServiceConfigMap["enable_outlier_detection"] = agentServiceConfigRaw["enableOutlierDetection"]
+		agentServiceConfigMap["provider"] = agentServiceConfigRaw["provider"]
+
+		protocolsRaw := make([]interface{}, 0)
+		if agentServiceConfigRaw["protocols"] != nil {
+			protocolsRaw = convertToInterfaceArray(agentServiceConfigRaw["protocols"])
+		}
+
+		agentServiceConfigMap["protocols"] = protocolsRaw
+		agentServiceConfigMaps = append(agentServiceConfigMaps, agentServiceConfigMap)
+	}
+	if err := d.Set("agent_service_config", agentServiceConfigMaps); err != nil {
+		return err
+	}
+	aiServiceConfigMaps := make([]map[string]interface{}, 0)
+	aiServiceConfigMap := make(map[string]interface{})
+	aiServiceConfigRaw := make(map[string]interface{})
+	if objectRaw["aiServiceConfig"] != nil {
+		aiServiceConfigRaw = objectRaw["aiServiceConfig"].(map[string]interface{})
+	}
+	if len(aiServiceConfigRaw) > 0 {
+		aiServiceConfigMap["address"] = aiServiceConfigRaw["address"]
+		aiServiceConfigMap["enable_health_check"] = aiServiceConfigRaw["enableHealthCheck"]
+		aiServiceConfigMap["provider"] = aiServiceConfigRaw["provider"]
+
+		apiKeysRaw := make([]interface{}, 0)
+		if aiServiceConfigRaw["apiKeys"] != nil {
+			apiKeysRaw = convertToInterfaceArray(aiServiceConfigRaw["apiKeys"])
+		}
+
+		aiServiceConfigMap["api_keys"] = apiKeysRaw
+		protocolsRaw := make([]interface{}, 0)
+		if aiServiceConfigRaw["protocols"] != nil {
+			protocolsRaw = convertToInterfaceArray(aiServiceConfigRaw["protocols"])
+		}
+
+		aiServiceConfigMap["protocols"] = protocolsRaw
+		aiServiceConfigMaps = append(aiServiceConfigMaps, aiServiceConfigMap)
+	}
+	if err := d.Set("ai_service_config", aiServiceConfigMaps); err != nil {
+		return err
+	}
+	dnsServersRaw := make([]interface{}, 0)
+	if objectRaw["dnsServers"] != nil {
+		dnsServersRaw = convertToInterfaceArray(objectRaw["dnsServers"])
+	}
+
+	d.Set("dns_servers", dnsServersRaw)
+	healthCheckConfigMaps := make([]map[string]interface{}, 0)
+	healthCheckConfigMap := make(map[string]interface{})
+	healthCheckRaw := make(map[string]interface{})
+	if objectRaw["healthCheck"] != nil {
+		healthCheckRaw = objectRaw["healthCheck"].(map[string]interface{})
+	}
+	if len(healthCheckRaw) > 0 {
+		healthCheckConfigMap["enable"] = healthCheckRaw["enable"]
+		healthCheckConfigMap["healthy_threshold"] = healthCheckRaw["healthyThreshold"]
+		healthCheckConfigMap["http_host"] = healthCheckRaw["httpHost"]
+		healthCheckConfigMap["http_path"] = healthCheckRaw["httpPath"]
+		healthCheckConfigMap["interval"] = healthCheckRaw["interval"]
+		healthCheckConfigMap["protocol"] = healthCheckRaw["protocol"]
+		healthCheckConfigMap["timeout"] = healthCheckRaw["timeout"]
+		healthCheckConfigMap["unhealthy_threshold"] = healthCheckRaw["unhealthyThreshold"]
+
+		healthCheckConfigMaps = append(healthCheckConfigMaps, healthCheckConfigMap)
+	}
+	if err := d.Set("health_check_config", healthCheckConfigMaps); err != nil {
+		return err
+	}
+	outlierDetectionConfigMaps := make([]map[string]interface{}, 0)
+	outlierDetectionConfigMap := make(map[string]interface{})
+	outlierDetectionRaw := make(map[string]interface{})
+	if objectRaw["outlierDetection"] != nil {
+		outlierDetectionRaw = objectRaw["outlierDetection"].(map[string]interface{})
+	}
+	if len(outlierDetectionRaw) > 0 {
+		outlierDetectionConfigMap["base_ejection_time"] = outlierDetectionRaw["baseEjectionTime"]
+		outlierDetectionConfigMap["enable"] = outlierDetectionRaw["enable"]
+		outlierDetectionConfigMap["failure_percentage_minimum_hosts"] = outlierDetectionRaw["failurePercentageMinimumHosts"]
+		outlierDetectionConfigMap["failure_percentage_threshold"] = outlierDetectionRaw["failurePercentageThreshold"]
+		outlierDetectionConfigMap["interval"] = outlierDetectionRaw["interval"]
+
+		outlierDetectionConfigMaps = append(outlierDetectionConfigMaps, outlierDetectionConfigMap)
+	}
+	if err := d.Set("outlier_detection_config", outlierDetectionConfigMaps); err != nil {
+		return err
+	}
+	outlierEndpointsRaw := make([]interface{}, 0)
+	if objectRaw["outlierEndpoints"] != nil {
+		outlierEndpointsRaw = convertToInterfaceArray(objectRaw["outlierEndpoints"])
+	}
+
+	d.Set("outlier_endpoints", outlierEndpointsRaw)
+	unhealthyEndpointsRaw := make([]interface{}, 0)
+	if objectRaw["unhealthyEndpoints"] != nil {
+		unhealthyEndpointsRaw = convertToInterfaceArray(objectRaw["unhealthyEndpoints"])
+	}
+
+	d.Set("unhealthy_endpoints", unhealthyEndpointsRaw)
+	portsRaw := objectRaw["ports"]
+	portsMaps := make([]map[string]interface{}, 0)
+	if portsRaw != nil {
+		for _, portsChildRaw := range convertToInterfaceArray(portsRaw) {
+			portsMap := make(map[string]interface{})
+			portsChildRaw := portsChildRaw.(map[string]interface{})
+			portsMap["name"] = portsChildRaw["name"]
+			portsMap["port"] = portsChildRaw["port"]
+			portsMap["protocol"] = portsChildRaw["protocol"]
+
+			portsMaps = append(portsMaps, portsMap)
+		}
+	}
+	if err := d.Set("ports", portsMaps); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAliCloudApigServiceUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var body map[string]interface{}
+	update := false
+
+	var err error
+	serviceId := d.Id()
+	action := fmt.Sprintf("/v1/services/%s", serviceId)
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+
+	if !d.IsNewResource() && d.HasChange("dns_servers") {
+		update = true
+	}
+	if v, ok := d.GetOk("dns_servers"); ok || d.HasChange("dns_servers") {
+		dnsServersMapsArray := convertToInterfaceArray(v)
+
+		request["dnsServers"] = dnsServersMapsArray
+	}
+
+	if !d.IsNewResource() && d.HasChange("model_provider_id") {
+		update = true
+	}
+	if v, ok := d.GetOk("model_provider_id"); ok || d.HasChange("model_provider_id") {
+		request["modelProviderId"] = v
+	}
+	if v, ok := d.GetOk("protocol"); ok {
+		request["protocol"] = v
+	}
+	if d.HasChange("health_check_config") {
+		update = true
+	}
+	healthCheckConfig := make(map[string]interface{})
+
+	if v := d.Get("health_check_config"); !IsNil(v) || d.HasChange("health_check_config") {
+		protocol1, _ := jsonpath.Get("$[0].protocol", v)
+		if protocol1 != nil && protocol1 != "" {
+			healthCheckConfig["protocol"] = protocol1
+		}
+		expectedStatuses1, _ := jsonpath.Get("$[0].expected_statuses", v)
+		if expectedStatuses1 != nil && expectedStatuses1 != "" {
+			healthCheckConfig["expectedStatuses"] = expectedStatuses1
+		}
+		unhealthyThreshold1, _ := jsonpath.Get("$[0].unhealthy_threshold", v)
+		if unhealthyThreshold1 != nil && unhealthyThreshold1 != "" {
+			healthCheckConfig["unhealthyThreshold"] = unhealthyThreshold1
+		}
+		interval1, _ := jsonpath.Get("$[0].interval", v)
+		if interval1 != nil && interval1 != "" {
+			healthCheckConfig["interval"] = interval1
+		}
+		timeout1, _ := jsonpath.Get("$[0].timeout", v)
+		if timeout1 != nil && timeout1 != "" {
+			healthCheckConfig["timeout"] = timeout1
+		}
+		enable1, _ := jsonpath.Get("$[0].enable", v)
+		if enable1 != nil && enable1 != "" {
+			healthCheckConfig["enable"] = enable1
+		}
+		healthyThreshold1, _ := jsonpath.Get("$[0].healthy_threshold", v)
+		if healthyThreshold1 != nil && healthyThreshold1 != "" {
+			healthCheckConfig["healthyThreshold"] = healthyThreshold1
+		}
+		httpPath1, _ := jsonpath.Get("$[0].http_path", v)
+		if httpPath1 != nil && httpPath1 != "" {
+			healthCheckConfig["httpPath"] = httpPath1
+		}
+		httpHost1, _ := jsonpath.Get("$[0].http_host", v)
+		if httpHost1 != nil && httpHost1 != "" {
+			healthCheckConfig["httpHost"] = httpHost1
+		}
+
+		request["healthCheckConfig"] = healthCheckConfig
+	}
+
+	if d.HasChange("ai_service_config") {
+		update = true
+	}
+	aiServiceConfig := make(map[string]interface{})
+
+	if v := d.Get("ai_service_config"); !IsNil(v) || d.HasChange("ai_service_config") {
+		apiKeys1, _ := jsonpath.Get("$[0].api_keys", v)
+		if apiKeys1 != nil && apiKeys1 != "" {
+			aiServiceConfig["apiKeys"] = apiKeys1
+		}
+		protocols1, _ := jsonpath.Get("$[0].protocols", v)
+		if protocols1 != nil && protocols1 != "" {
+			aiServiceConfig["protocols"] = protocols1
+		}
+		provider1, _ := jsonpath.Get("$[0].provider", v)
+		if provider1 != nil && provider1 != "" {
+			aiServiceConfig["provider"] = provider1
+		}
+		enableHealthCheck1, _ := jsonpath.Get("$[0].enable_health_check", v)
+		if enableHealthCheck1 != nil && enableHealthCheck1 != "" {
+			aiServiceConfig["enableHealthCheck"] = enableHealthCheck1
+		}
+		address1, _ := jsonpath.Get("$[0].address", v)
+		if address1 != nil && address1 != "" {
+			aiServiceConfig["address"] = address1
+		}
+
+		request["aiServiceConfig"] = aiServiceConfig
+	}
+
+	portsDataList := make(map[string]interface{})
+	name1, _ := jsonpath.Get("$.name", d.Get("ports"))
+	if name1 != nil && name1 != "" {
+		portsDataList["name"] = name1
+	}
+	port1, _ := jsonpath.Get("$.port", d.Get("ports"))
+	if port1 != nil && port1 != "" {
+		portsDataList["port"] = port1
+	}
+	protocol3, _ := jsonpath.Get("$.protocol", d.Get("ports"))
+	if protocol3 != nil && protocol3 != "" {
+		portsDataList["protocol"] = protocol3
+	}
+
+	portsMap := make([]interface{}, 0)
+	portsMap = append(portsMap, portsDataList)
+	request["ports"] = portsMap
+
+	if d.HasChange("outlier_detection_config") {
+		update = true
+	}
+	outlierDetectionConfig := make(map[string]interface{})
+
+	if v := d.Get("outlier_detection_config"); !IsNil(v) || d.HasChange("outlier_detection_config") {
+		interval3, _ := jsonpath.Get("$[0].interval", v)
+		if interval3 != nil && interval3 != "" {
+			outlierDetectionConfig["interval"] = interval3
+		}
+		failurePercentageMinimumHosts1, _ := jsonpath.Get("$[0].failure_percentage_minimum_hosts", v)
+		if failurePercentageMinimumHosts1 != nil && failurePercentageMinimumHosts1 != "" {
+			outlierDetectionConfig["failurePercentageMinimumHosts"] = failurePercentageMinimumHosts1
+		}
+		enable3, _ := jsonpath.Get("$[0].enable", v)
+		if enable3 != nil && enable3 != "" {
+			outlierDetectionConfig["enable"] = enable3
+		}
+		baseEjectionTime1, _ := jsonpath.Get("$[0].base_ejection_time", v)
+		if baseEjectionTime1 != nil && baseEjectionTime1 != "" {
+			outlierDetectionConfig["baseEjectionTime"] = baseEjectionTime1
+		}
+		failurePercentageThreshold1, _ := jsonpath.Get("$[0].failure_percentage_threshold", v)
+		if failurePercentageThreshold1 != nil && failurePercentageThreshold1 != "" {
+			outlierDetectionConfig["failurePercentageThreshold"] = failurePercentageThreshold1
+		}
+
+		request["outlierDetectionConfig"] = outlierDetectionConfig
+	}
+
+	if !d.IsNewResource() && d.HasChange("addresses") {
+		update = true
+	}
+	if v, ok := d.GetOk("addresses"); ok || d.HasChange("addresses") {
+		addressesMapsArray := convertToInterfaceArray(v)
+
+		request["addresses"] = addressesMapsArray
+	}
+
+	if d.HasChange("agent_service_config") {
+		update = true
+	}
+	agentServiceConfig := make(map[string]interface{})
+
+	if v := d.Get("agent_service_config"); !IsNil(v) || d.HasChange("agent_service_config") {
+		enableHealthCheck3, _ := jsonpath.Get("$[0].enable_health_check", v)
+		if enableHealthCheck3 != nil && enableHealthCheck3 != "" {
+			agentServiceConfig["enableHealthCheck"] = enableHealthCheck3
+		}
+		enableOutlierDetection1, _ := jsonpath.Get("$[0].enable_outlier_detection", v)
+		if enableOutlierDetection1 != nil && enableOutlierDetection1 != "" {
+			agentServiceConfig["enableOutlierDetection"] = enableOutlierDetection1
+		}
+		protocols3, _ := jsonpath.Get("$[0].protocols", v)
+		if protocols3 != nil && protocols3 != "" {
+			agentServiceConfig["protocols"] = protocols3
+		}
+		address3, _ := jsonpath.Get("$[0].address", v)
+		if address3 != nil && address3 != "" {
+			agentServiceConfig["address"] = address3
+		}
+		provider3, _ := jsonpath.Get("$[0].provider", v)
+		if provider3 != nil && provider3 != "" {
+			agentServiceConfig["provider"] = provider3
+		}
+
+		request["agentServiceConfig"] = agentServiceConfig
+	}
+
+	if d.HasChange("healthy_panic_threshold") {
+		update = true
+	}
+	if v, ok := d.GetOk("healthy_panic_threshold"); ok || d.HasChange("healthy_panic_threshold") {
+		request["healthyPanicThreshold"] = v
+	}
+	body = request
+	if update {
+		wait := incrementalWait(5*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPut("APIG", "2024-03-27", action, query, nil, body, true)
+			if err != nil {
+				if IsExpectedErrors(err, []string{"Conflict.LockFailed"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	action = fmt.Sprintf("/move-resource-group")
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+	query["ResourceId"] = StringPointer(d.Id())
+	query["RegionId"] = StringPointer(client.RegionId)
+	if d.HasChange("resource_group_id") {
+		update = true
+	}
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		query["ResourceGroupId"] = StringPointer(v.(string))
+	}
+
+	query["Service"] = StringPointer("APIG")
+	query["ResourceType"] = StringPointer("Service")
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPost("APIG", "2024-03-27", action, query, nil, body, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		apigServiceV2 := ApigServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{fmt.Sprint(d.Get("resource_group_id"))}, d.Timeout(schema.TimeoutUpdate), 35*time.Second, apigServiceV2.ApigServiceStateRefreshFunc(d.Id(), "resourceGroupId", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+
+	return resourceAliCloudApigServiceRead(d, meta)
+}
+
+func resourceAliCloudApigServiceDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	serviceId := d.Id()
+	action := fmt.Sprintf("/v1/services/%s", serviceId)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+
+	wait := incrementalWait(5*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("APIG", "2024-03-27", action, query, nil, nil, true)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"Conflict.LockFailed"}) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NotFound.ServiceNotFound", "NotFound", "404"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_apig_service_test.go
+++ b/alicloud/resource_alicloud_apig_service_test.go
@@ -1,0 +1,752 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Apig Service. >>> Resource test cases, automatically generated.
+// Case test-service-vip 8886
+func TestAccAliCloudApigService_basic8886(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_service.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigServiceMap8886)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigService")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccapig%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigServiceBasicDependence8886)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"addresses": []string{
+						"${var.address}"},
+					"service_name": name,
+					"source_type":  "VIP",
+					"gateway_id":   "${alicloud_apig_gateway.defaultFsRKYn.id}",
+					"namespace":    "default",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"addresses.#":  "1",
+						"service_name": name,
+						"source_type":  "VIP",
+						"gateway_id":   CHECKSET,
+						"namespace":    "default",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"addresses": []string{
+						"${var.address_1}"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"addresses.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"addresses": []string{
+						"${var.address}", "${var.address_1}", "${var.address_2}"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"addresses.#": "3",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ports", "protocol"},
+			},
+		},
+	})
+}
+
+var AlicloudApigServiceMap8886 = map[string]string{
+	"update_timestamp":      CHECKSET,
+	"create_timestamp":      CHECKSET,
+	"unhealthy_endpoints.#": CHECKSET,
+	"health_status":         CHECKSET,
+	"outlier_endpoints.#":   CHECKSET,
+	"runtime_detail_status": CHECKSET,
+}
+
+func AlicloudApigServiceBasicDependence8886(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "address" {
+  default = "127.0.0.1:8080"
+}
+
+variable "address_1" {
+  default = "127.0.0.1:7891"
+}
+
+variable "address_2" {
+  default = "127.0.0.1:7890"
+}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_apig_gateway" "defaultFsRKYn" {
+  network_access_config {
+    type = "Intranet"
+  }
+  vswitch {
+    vswitch_id = data.alicloud_vswitches.default.ids.0
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = data.alicloud_vpcs.default.ids.0
+  }
+  payment_type = "PayAsYouGo"
+  gateway_name = "zhenyuantest"
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = false
+    }
+  }
+}
+
+
+`, name)
+}
+
+// Case 资源组接入_DNS 9199
+func TestAccAliCloudApigService_basic9199(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_service.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigServiceMap9199)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigService")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccapig%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigServiceBasicDependence9199)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"addresses": []string{
+						"${var.address}"},
+					"service_name":      name,
+					"source_type":       "DNS",
+					"gateway_id":        "${alicloud_apig_gateway.defaultgateway.id}",
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"addresses.#":       "1",
+						"service_name":      name,
+						"source_type":       "DNS",
+						"gateway_id":        CHECKSET,
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"addresses": []string{
+						"${var.address1}", "${var.address}", "${var.address2}"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"addresses.#": "3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"addresses": []string{
+						"${var.address2}", "${var.address1}"},
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"addresses.#":       "2",
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ports", "protocol"},
+			},
+		},
+	})
+}
+
+var AlicloudApigServiceMap9199 = map[string]string{
+	"update_timestamp":      CHECKSET,
+	"create_timestamp":      CHECKSET,
+	"unhealthy_endpoints.#": CHECKSET,
+	"health_status":         CHECKSET,
+	"outlier_endpoints.#":   CHECKSET,
+	"runtime_detail_status": CHECKSET,
+}
+
+func AlicloudApigServiceBasicDependence9199(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "address" {
+  default = "httpbin.org:8080"
+}
+
+variable "address2" {
+  default = "taobao.com:80"
+}
+
+variable "address1" {
+  default = "baidu.com:80"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_apig_gateway" "defaultgateway" {
+  network_access_config {
+    type = "Intranet"
+  }
+  vswitch {
+    vswitch_id = data.alicloud_vswitches.default.ids.0
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = data.alicloud_vpcs.default.ids.0
+  }
+  payment_type = "PayAsYouGo"
+  gateway_name = "zhenyuantest"
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = false
+    }
+  }
+}
+
+
+`, name)
+}
+
+// Case test-service-fc 10174
+func TestAccAliCloudApigService_basic10174(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_service.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigServiceMap10174)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigService")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccapig%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigServiceBasicDependence10174)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"service_name": name,
+					"source_type":  "FC3",
+					"gateway_id":   "${alicloud_apig_gateway.defaultgateway.id}",
+					"qualifier":    "LATEST",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"service_name": name,
+						"source_type":  "FC3",
+						"gateway_id":   CHECKSET,
+						"qualifier":    "LATEST",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ports", "protocol"},
+			},
+		},
+	})
+}
+
+var AlicloudApigServiceMap10174 = map[string]string{
+	"update_timestamp":      CHECKSET,
+	"create_timestamp":      CHECKSET,
+	"unhealthy_endpoints.#": CHECKSET,
+	"health_status":         CHECKSET,
+	"outlier_endpoints.#":   CHECKSET,
+	"runtime_detail_status": CHECKSET,
+}
+
+func AlicloudApigServiceBasicDependence10174(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_apig_gateway" "defaultgateway" {
+  network_access_config {
+    type = "Intranet"
+  }
+  vswitch {
+    vswitch_id = data.alicloud_vswitches.default.ids.0
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = data.alicloud_vpcs.default.ids.0
+  }
+  payment_type = "PayAsYouGo"
+  gateway_name = "zhenyuantest"
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = false
+    }
+  }
+}
+
+resource "alicloud_fcv3_function" "defaultfc3" {
+  memory_size = "512"
+  description = "CreateFcFunction"
+  timeout     = "3"
+  instance_lifecycle_config {
+    initializer {
+      timeout = "3"
+    }
+    pre_stop {
+      timeout = "3"
+    }
+  }
+  cpu     = 0.5
+  handler = "index.handler"
+  code {
+    zip_file = "UEsDBBQACAAIAAAAAAAAAAAAAAAAAAAAAAAIAAAAaW5kZXgucHmEkEFKxEAQRfd9ig9ZTCJOooIwDMwNXLqXnnQlaalUhU5lRj2KZ/FOXkESGR114bJ/P/7jV4b1xRq1hijtFpM1682cuNgPmgysbRulPT0fRxXnMtwrSPyeCdYRokSLnuMLJTTkbUqEvDMbxm1VdcRD6Tk+T1LW2ldB66knsYdA5iNX17ebm6tN2VnPhcswMPmREPuBacb+CiapLarAj9gT6/H97dVlCNScY3mtYvRkxdZlwDKDEnanPWVLdrdkeXEGlFEazVdfPVHaVeHc3N15CUwppwOJXeK7HshAB8NuOU7J6sP4SRXuH/EvbUfMiqMmDqv5M5FNSfAj/wgAAP//UEsHCPl//NYAAQAArwEAAFBLAQIUABQACAAIAAAAAAD5f/zWAAEAAK8BAAAIAAAAAAAAAAAAAAAAAAAAAABpbmRleC5weVBLBQYAAAAAAQABADYAAAA2AQAAAAA="
+  }
+  function_name = "ZhenyuanTestFunction-688"
+  runtime       = "python3.9"
+  disk_size     = "512"
+}
+
+
+`, name)
+}
+
+// Case test-service-ai 10175
+func TestAccAliCloudApigService_basic10175(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_service.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigServiceMap10175)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigService")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccapig%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigServiceBasicDependence10175)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"service_name": name,
+					"source_type":  "AI",
+					"gateway_id":   "${alicloud_apig_gateway.defaultgateway.id}",
+					"ai_service_config": []map[string]interface{}{
+						{
+							"provider": "qwen",
+							"protocols": []string{
+								"${var.ai_protocol}"},
+							"address": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+							"api_keys": []string{
+								"${var.apikey1}", "${var.apikey3}"},
+							"enable_health_check": "true",
+						},
+					},
+					"group_name": "test-group",
+					"namespace":  "test-namespace",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"service_name": name,
+						"source_type":  "AI",
+						"gateway_id":   CHECKSET,
+						"group_name":   "test-group",
+						"namespace":    "test-namespace",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ai_service_config": []map[string]interface{}{
+						{
+							"provider": "openai",
+							"protocols": []string{
+								"${var.ai_protocol}", "HTTP"},
+							"address": "https://api.openai.com/v1",
+							"api_keys": []string{
+								"${var.apikey1}", "${var.apikey2}", "${var.apikey3}"},
+							"enable_health_check": "false",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ai_service_config": []map[string]interface{}{
+						{
+							"protocols": []string{
+								"${var.ai_protocol}"},
+							"address": "https://api.openai.com/v1",
+							"api_keys": []string{
+								"${var.apikey2}"},
+							"enable_health_check": "false",
+							"provider":            "openai",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+		},
+	})
+}
+
+var AlicloudApigServiceMap10175 = map[string]string{
+	"update_timestamp":      CHECKSET,
+	"create_timestamp":      CHECKSET,
+	"unhealthy_endpoints.#": CHECKSET,
+	"health_status":         CHECKSET,
+	"outlier_endpoints.#":   CHECKSET,
+	"runtime_detail_status": CHECKSET,
+}
+
+func AlicloudApigServiceBasicDependence10175(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "apikey2" {
+  default = "bbbbbbbbbb"
+}
+
+variable "apikey1" {
+  default = "aaaaaaaaaa"
+}
+
+variable "ai_protocol" {
+  default = "OpenAI/v1"
+}
+
+variable "apikey3" {
+  default = "cccccccccc"
+}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_apig_gateway" "defaultgateway" {
+  network_access_config {
+    type = "Intranet"
+  }
+  vswitch {
+    vswitch_id = data.alicloud_vswitches.default.ids.0
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = data.alicloud_vpcs.default.ids.0
+  }
+  payment_type = "PayAsYouGo"
+  gateway_name = "zhenyuantest"
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = false
+    }
+  }
+}
+
+
+`, name)
+}
+
+// Case test-service-full-attr 12000
+func TestAccAliCloudApigService_basic12000(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_service.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigServiceMap12000)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigService")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccapig%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigServiceBasicDependence12000)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"addresses":               []string{"${var.address}"},
+					"service_name":            name,
+					"source_type":             "VIP",
+					"gateway_id":              "${alicloud_apig_gateway.defaultFsRKYn.id}",
+					"namespace":               "default",
+					"dns_servers":             []string{"8.8.8.8"},
+					"express_type":            "express",
+					"healthy_panic_threshold": 0.5,
+					"model_provider_id":       "mp-test",
+					"protocol":                "HTTP",
+					"agent_service_config": []map[string]interface{}{
+						{
+							"address":                  "127.0.0.1:8080",
+							"protocols":                []string{"HTTP"},
+							"provider":                 "agent",
+							"enable_health_check":      "true",
+							"enable_outlier_detection": "true",
+						},
+					},
+					"health_check_config": []map[string]interface{}{
+						{
+							"enable":              "true",
+							"expected_statuses":   []string{"200"},
+							"healthy_threshold":   3,
+							"http_host":           "example.com",
+							"http_path":           "/",
+							"interval":            10,
+							"protocol":            "HTTP",
+							"timeout":             5,
+							"unhealthy_threshold": 3,
+						},
+					},
+					"outlier_detection_config": []map[string]interface{}{
+						{
+							"base_ejection_time":               30,
+							"enable":                           "true",
+							"failure_percentage_minimum_hosts": 5,
+							"failure_percentage_threshold":     80,
+							"interval":                         10,
+						},
+					},
+					"ports": []map[string]interface{}{
+						{
+							"name":     "port1",
+							"port":     80,
+							"protocol": "TCP",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"service_name": name,
+						"source_type":  "VIP",
+						"gateway_id":   CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"dns_servers":             []string{"8.8.4.4"},
+					"healthy_panic_threshold": 0.6,
+					"model_provider_id":       "mp-test-2",
+					"agent_service_config": []map[string]interface{}{
+						{
+							"address":                  "127.0.0.1:8081",
+							"protocols":                []string{"HTTP", "HTTPS"},
+							"provider":                 "agent2",
+							"enable_health_check":      "false",
+							"enable_outlier_detection": "false",
+						},
+					},
+					"health_check_config": []map[string]interface{}{
+						{
+							"enable":              "false",
+							"expected_statuses":   []string{"200", "201"},
+							"healthy_threshold":   5,
+							"http_host":           "test.com",
+							"http_path":           "/health",
+							"interval":            20,
+							"protocol":            "TCP",
+							"timeout":             10,
+							"unhealthy_threshold": 5,
+						},
+					},
+					"outlier_detection_config": []map[string]interface{}{
+						{
+							"base_ejection_time":               60,
+							"enable":                           "false",
+							"failure_percentage_minimum_hosts": 10,
+							"failure_percentage_threshold":     90,
+							"interval":                         20,
+						},
+					},
+					"ports": []map[string]interface{}{
+						{
+							"name":     "port2",
+							"port":     81,
+							"protocol": "UDP",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+		},
+	})
+}
+
+var AlicloudApigServiceMap12000 = map[string]string{
+	"update_timestamp":      CHECKSET,
+	"create_timestamp":      CHECKSET,
+	"unhealthy_endpoints.#": CHECKSET,
+	"health_status":         CHECKSET,
+	"outlier_endpoints.#":   CHECKSET,
+	"runtime_detail_status": CHECKSET,
+}
+
+func AlicloudApigServiceBasicDependence12000(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "address" {
+  default = "127.0.0.1:8080"
+}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+resource "alicloud_apig_gateway" "defaultFsRKYn" {
+  network_access_config {
+    type = "Intranet"
+  }
+  vswitch {
+    vswitch_id = data.alicloud_vswitches.default.ids.0
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = data.alicloud_vpcs.default.ids.0
+  }
+  payment_type = "PayAsYouGo"
+  gateway_name = "zhenyuantest"
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = false
+    }
+  }
+}
+
+
+`, name)
+}
+
+// Test Apig Service. <<< Resource test cases, automatically generated.

--- a/website/docs/d/apig_services.html.markdown
+++ b/website/docs/d/apig_services.html.markdown
@@ -1,0 +1,161 @@
+---
+subcategory: "Cloud Native API Gateway (APIG)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_apig_services"
+sidebar_current: "docs-alicloud-datasource-apig-services"
+description: |-
+  Provides a list of Apig Service owned by an Alibaba Cloud account.
+---
+
+# alicloud_apig_services
+
+This data source provides Apig Service available to the user.[What is Service](https://next.api.alibabacloud.com/document/APIG/2024-03-27/CreateService)
+
+-> **NOTE:** Available since v1.286.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "address" {
+  default = "127.0.0.1:8080"
+}
+
+variable "address_1" {
+  default = "127.0.0.1:7891"
+}
+
+variable "address_2" {
+  default = "127.0.0.1:7890"
+}
+
+resource "alicloud_vpc" "defaultvpc" {
+  cidr_block = "172.32.0.0/12"
+  vpc_name   = "zhenyuan-example"
+}
+
+resource "alicloud_vswitch" "defaultvswitch" {
+  vpc_id       = alicloud_vpc.defaultvpc.id
+  zone_id      = "cn-hangzhou-g"
+  cidr_block   = "172.32.100.0/24"
+  vswitch_name = "zhenyuan-example"
+}
+
+resource "alicloud_apig_gateway" "defaultFsRKYn" {
+  network_access_config {
+    type = "Intranet"
+  }
+  vswitch {
+    vswitch_id = alicloud_vswitch.defaultvswitch.id
+    name       = alicloud_vswitch.defaultvswitch.vswitch_name
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = alicloud_vpc.defaultvpc.id
+  }
+  payment_type = "PayAsYouGo"
+  gateway_name = "zhenyuanexample"
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = false
+    }
+  }
+}
+
+
+resource "alicloud_apig_service" "default" {
+  addresses    = ["${var.address}"]
+  service_name = "1784511693"
+  source_type  = "VIP"
+  gateway_id   = alicloud_apig_gateway.defaultFsRKYn.id
+  namespace    = "default"
+}
+
+data "alicloud_apig_services" "default" {
+  ids         = ["${alicloud_apig_service.default.id}"]
+  name_regex  = alicloud_apig_service.default.service_name
+  gateway_id  = alicloud_apig_gateway.defaultFsRKYn.id
+  source_type = "VIP"
+}
+
+output "alicloud_apig_service_example_id" {
+  value = data.alicloud_apig_services.default.services.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `gateway_id` - (ForceNew, Optional) The ID of the Cloud Native API Gateway.
+* `resource_group_id` - (ForceNew, Optional) The ID of the resource group
+* `source_type` - (ForceNew, Optional) service source type, optional value is K8S/MSE_NACOS/FC3/SAE_K8S_SERVICE/VIP/DNS/AI
+* `ids` - (Optional, Computed) A list of Service IDs. 
+* `name_regex` - (Optional) A regex string to filter results by Group Metric Rule name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Service IDs.
+* `names` - A list of name of Services.
+* `services` - A list of Service Entries. Each element contains the following attributes:
+    * `addresses` - A list of domain names or fixed addresses.
+    * `agent_service_config` - Agent service configuration.
+        * `address` - Address.
+        * `enable_health_check` - Enable health check.
+        * `enable_outlier_detection` - Enable outlier detection.
+        * `protocols` - Protocols.
+        * `provider` - Provider.
+    * `ai_service_config` - ai service configuration when sourceType equals AI.
+        * `address` - ai provider address.
+        * `api_keys` - api key list.
+        * `enable_health_check` - whether enable health check.
+        * `protocols` - model protocol list.
+        * `provider` - ai model provider.
+    * `create_timestamp` - Creation timestamp.
+    * `dns_servers` - DNS servers.
+    * `express_type` - Express type.
+    * `gateway_id` - The ID of the Cloud Native API Gateway.
+    * `group_name` - The service group name.
+    * `health_check_config` - Health check configuration.
+        * `enable` - Whether to enable health check.
+        * `expected_statuses` - Expected HTTP status codes.
+        * `healthy_threshold` - Healthy threshold.
+        * `http_host` - Health check host (optional when protocol is HTTP).
+        * `http_path` - Health check path (required when protocol is HTTP).
+        * `interval` - Health check interval.
+        * `protocol` - Health check protocol TCP|HTTP|GRPC.
+        * `timeout` - Health check response timeout.
+        * `unhealthy_threshold` - Unhealthy threshold.
+    * `health_status` - Health status.
+    * `healthy_panic_threshold` - Healthy panic threshold.
+    * `model_provider_id` - Model provider ID.
+    * `namespace` - The namespace of the service:.
+    * `outlier_detection_config` - Outlier detection configuration.
+        * `base_ejection_time` - Base ejection time.
+        * `enable` - Whether to enable outlier detection.
+        * `failure_percentage_minimum_hosts` - Failure percentage minimum hosts.
+        * `failure_percentage_threshold` - Failure percentage threshold.
+        * `interval` - Detection interval.
+    * `outlier_endpoints` - Outlier endpoints.
+    * `qualifier` - The function version or alias.
+    * `resource_group_id` - The ID of the resource group.
+    * `runtime_detail_error_code` - Runtime detail error code.
+    * `runtime_detail_status` - Runtime detail status.
+    * `service_id` - service id.
+    * `service_name` - Service Name, need to fill in manually when sourceType is VIP/DNS/AI.
+    * `source_type` - service source type, optional value is K8S/MSE_NACOS/FC3/SAE_K8S_SERVICE/VIP/DNS/AI.
+    * `unhealthy_endpoints` - Unhealthy endpoints.
+    * `update_timestamp` - Update timestamp.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/apig_service.html.markdown
+++ b/website/docs/r/apig_service.html.markdown
@@ -1,0 +1,195 @@
+---
+subcategory: "Cloud Native API Gateway (APIG)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_apig_service"
+description: |-
+  Provides a Alicloud APIG Service resource.
+---
+
+# alicloud_apig_service
+
+Provides a APIG Service resource.
+
+
+
+For information about APIG Service and how to use it, see [What is Service](https://next.api.alibabacloud.com/document/APIG/2024-03-27/CreateService).
+
+-> **NOTE:** Available since v1.286.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "address" {
+  default = "127.0.0.1:8080"
+}
+
+variable "address_1" {
+  default = "127.0.0.1:7891"
+}
+
+variable "address_2" {
+  default = "127.0.0.1:7890"
+}
+
+resource "alicloud_vpc" "defaultvpc" {
+  cidr_block = "172.32.0.0/12"
+  vpc_name   = "zhenyuan-example"
+}
+
+resource "alicloud_vswitch" "defaultvswitch" {
+  vpc_id       = alicloud_vpc.defaultvpc.id
+  zone_id      = "cn-hangzhou-g"
+  cidr_block   = "172.32.100.0/24"
+  vswitch_name = "zhenyuan-example"
+}
+
+resource "alicloud_apig_gateway" "defaultFsRKYn" {
+  network_access_config {
+    type = "Intranet"
+  }
+  vswitch {
+    vswitch_id = alicloud_vswitch.defaultvswitch.id
+    name       = alicloud_vswitch.defaultvswitch.vswitch_name
+  }
+  zone_config {
+    select_option = "Auto"
+  }
+  vpc {
+    vpc_id = alicloud_vpc.defaultvpc.id
+  }
+  payment_type = "PayAsYouGo"
+  gateway_name = "zhenyuanexample"
+  spec         = "apigw.small.x1"
+  log_config {
+    sls {
+      enable = false
+    }
+  }
+}
+
+
+resource "alicloud_apig_service" "default" {
+  addresses    = ["${var.address}"]
+  service_name = "1784511687"
+  source_type  = "VIP"
+  gateway_id   = alicloud_apig_gateway.defaultFsRKYn.id
+  namespace    = "default"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `addresses` - (Optional, List) A list of domain names or fixed addresses.
+* `agent_service_config` - (Optional, Set) Agent service configuration See [`agent_service_config`](#agent_service_config) below.
+* `ai_service_config` - (Optional, ForceNew, Set) ai service configuration when sourceType equals AI. See [`ai_service_config`](#ai_service_config) below.
+* `dns_servers` - (Optional, List) DNS servers
+* `express_type` - (Optional, ForceNew) Express type
+* `gateway_id` - (Optional, ForceNew) The ID of the Cloud Native API Gateway.
+* `group_name` - (Optional, ForceNew) The service group name.
+Required when sourceType is MSE_NACOS.
+* `health_check_config` - (Optional, Set) Health check configuration See [`health_check_config`](#health_check_config) below.
+* `healthy_panic_threshold` - (Optional, Float) Healthy panic threshold
+* `model_provider_id` - (Optional) Model provider ID
+* `namespace` - (Optional, ForceNew) The namespace of the service:
+  - sourceType is K8S, indicating the namespace of the K8S service.
+When-sourceType is set to MSE_NACOS, it indicates the namespace in Nacos.
+
+When the sourceType is K8S and MSE_NACOS, it needs to be specified.
+* `outlier_detection_config` - (Optional, Set) Outlier detection configuration See [`outlier_detection_config`](#outlier_detection_config) below.
+* `ports` - (Optional, List) Port information See [`ports`](#ports) below.
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `protocol` - (Optional) Service protocol
+
+-> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
+
+* `qualifier` - (Optional, ForceNew) The function version or alias.
+* `resource_group_id` - (Optional, Computed) The ID of the resource group
+* `service_name` - (Optional, ForceNew) Service Name, need to fill in manually when sourceType is VIP/DNS/AI.
+* `source_type` - (Optional, ForceNew) service source type, optional value is K8S/MSE_NACOS/FC3/SAE_K8S_SERVICE/VIP/DNS/AI
+
+### `agent_service_config`
+
+The agent_service_config supports the following:
+* `address` - (Optional) Address
+* `enable_health_check` - (Optional) Enable health check
+* `enable_outlier_detection` - (Optional) Enable outlier detection
+* `protocols` - (Optional, List) Protocols
+* `provider` - (Optional) Provider
+
+### `ai_service_config`
+
+The ai_service_config supports the following:
+* `address` - (Optional) ai provider address
+* `api_keys` - (Optional, List) api key list
+* `enable_health_check` - (Optional) whether enable health check
+* `protocols` - (Optional, List) model protocol list
+* `provider` - (Optional) ai model provider
+
+### `health_check_config`
+
+The health_check_config supports the following:
+* `enable` - (Optional) Whether to enable health check
+* `expected_statuses` - (Optional, List) Expected HTTP status codes
+* `healthy_threshold` - (Optional, Int) Healthy threshold
+* `http_host` - (Optional) Health check host (optional when protocol is HTTP)
+* `http_path` - (Optional) Health check path (required when protocol is HTTP)
+* `interval` - (Optional, Int) Health check interval
+* `protocol` - (Optional) Health check protocol TCP|HTTP|GRPC
+* `timeout` - (Optional, Int) Health check response timeout
+* `unhealthy_threshold` - (Optional, Int) Unhealthy threshold
+
+### `outlier_detection_config`
+
+The outlier_detection_config supports the following:
+* `base_ejection_time` - (Optional, Int) Base ejection time
+* `enable` - (Optional) Whether to enable outlier detection
+* `failure_percentage_minimum_hosts` - (Optional, Int) Failure percentage minimum hosts
+* `failure_percentage_threshold` - (Optional, Int) Failure percentage threshold
+* `interval` - (Optional, Int) Detection interval
+
+### `ports`
+
+The ports supports the following:
+* `name` - (Optional) Port name
+* `port` - (Optional, Int) Port number
+* `protocol` - (Optional) Protocol TCP|UDP
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+* `create_timestamp` - Creation timestamp.
+* `health_status` - Health status.
+* `outlier_endpoints` - Outlier endpoints.
+* `runtime_detail_error_code` - Runtime detail error code.
+* `runtime_detail_status` - Runtime detail status.
+* `unhealthy_endpoints` - Unhealthy endpoints.
+* `update_timestamp` - Update timestamp.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Service.
+* `delete` - (Defaults to 5 mins) Used when delete the Service.
+* `update` - (Defaults to 6 mins) Used when update the Service.
+
+## Import
+
+APIG Service can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_apig_service.example <service_id>
+```


### PR DESCRIPTION
### New Resource: alicloud_apig_service; New Data Source: alicloud_apig_services

Adds the `alicloud_apig_service` resource and the `alicloud_apig_services` data source for the Cloud Native API Gateway (APIG) Service, covering the full CRUD lifecycle backed by the APIG `CreateService`/`UpdateService`/`GetService`/`ListServices`/`DeleteService`/`ChangeResourceGroup` APIs.

#### Resource `alicloud_apig_service`
- Manages an APIG Service (create / read / update / delete), with `ChangeResourceGroup` support, import support, and async state refresh.
- Optional blocks: `agent_service_config`, `ai_service_config`, `health_check_config`, `outlier_detection_config`, plus `ports`, `dns_servers`, etc.
- API-derived attributes (e.g. runtime status, health status, ports, health check / outlier detection config, `protocol`, `healthy_panic_threshold`) are `Optional + Computed` so the API-populated values don't produce perpetual diffs.

#### Data Source `alicloud_apig_services`
- Lists APIG Services by filters (name regex, ids, resource group, tags).

#### Acceptance tests
- `TestAccAliCloudApigService_basic8886` (resource full lifecycle incl. update + import): PASS (remote ACube/FC ACC).
- Data source acceptance test: a residual diff on an API-derived field surfaced during the embedded resource apply; tracked for a follow-up. Resource CRUD itself is verified by the passing resource lifecycle test.

#### Notes
- Generated via the acube generator path; aligned with the existing `alicloud_apig_gateway` resource style.
