### PR TITLE
docs: fix type annotation typo Intl to Int for escalations.warn.times

### DIFF
--- a/website/docs/r/cms_group_metric_rule.html.markdown
+++ b/website/docs/r/cms_group_metric_rule.html.markdown
@@ -136,7 +136,7 @@ The warn supports the following:
 * `comparison_operator` - (Optional) The comparison operator of the threshold for warn-level alerts.
 * `statistics` - (Optional) The statistical aggregation method for warn-level alerts.
 * `threshold` - (Optional) The threshold for warn-level alerts.
-* `times` - (Optional, Intl) The consecutive number of times for which the metric value is measured before a warn-level alert is triggered.
+* `times` - (Optional, Int) The consecutive number of times for which the metric value is measured before a warn-level alert is triggered.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## What this PR does

Fixes a documentation typo in the `alicloud_cms_group_metric_rule` resource page: the `times` field under `escalations.warn` was annotated as `(Optional, Intl)` instead of `(Optional, Int)`.

## Why

`Intl` (internationalization) is not a valid Terraform type annotation. The same `times` field under `escalations.critical` and `escalations.info` is already annotated as `(Optional, Int)`. This PR aligns the `warn` variant with the other two.

## Scope

- Single-character documentation change in `website/docs/r/cms_group_metric_rule.html.markdown`.
- No schema or Go source code modified.
