### PR TITLE
resource/alicloud_ram_role: document role_name constraints and add schema validation

### DIFF
--- a/alicloud/resource_alicloud_ram_role.go
+++ b/alicloud/resource_alicloud_ram_role.go
@@ -4,6 +4,7 @@ package alicloud
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/PaesslerAG/jsonpath"
@@ -66,6 +67,7 @@ func resourceAliCloudRamRole() *schema.Resource {
 				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name"},
+				ValidateFunc:  validation.StringMatch(regexp.MustCompile(`^[A-Za-z0-9.-]{1,64}$`), "The name of the RAM role must be 1 to 64 characters in length and can contain letters, digits, periods (.), and hyphens (-)."),
 			},
 			"tags": tagsSchema(),
 			"name": {

--- a/alicloud/resource_alicloud_ram_role_test.go
+++ b/alicloud/resource_alicloud_ram_role_test.go
@@ -689,3 +689,47 @@ variable "name" {
 
 `, name)
 }
+
+// TestUnitRamRoleRoleNameValidation exercises the role_name schema
+// ValidateFunc without requiring acceptance test credentials. It mirrors the
+// OpenAPI CreateRole/UpdateRole RoleName constraint: 1 to 64 characters,
+// letters, digits, periods (.), and hyphens (-).
+func TestUnitRamRoleRoleNameValidation(t *testing.T) {
+	v := resourceAliCloudRamRole().Schema["role_name"].ValidateFunc
+	if v == nil {
+		t.Fatal("role_name schema is expected to register a ValidateFunc")
+	}
+
+	valid := []string{
+		"a", // 1 char, lower-bound
+		"Z", // 1 char, upper-case
+		"0", // 1 char, digit
+		"-", // single hyphen (OpenAPI has no leading-char restriction)
+		".", // single period (OpenAPI permits periods)
+		"tf-testAcc.Role-Name",
+		"role.name-1",
+		strings.Repeat("a", 64),            // 64 chars, upper-bound
+		strings.Repeat("a.b-c", 12) + "ab", // 62 chars mixing all allowed classes
+	}
+	for _, name := range valid {
+		if _, errs := v(name, "role_name"); len(errs) != 0 {
+			t.Errorf("role_name ValidateFunc should accept %q, got errors: %v", name, errs)
+		}
+	}
+
+	invalid := []string{
+		"",                      // empty, below 1
+		strings.Repeat("a", 65), // 65 chars, above 64
+		"role_name",             // underscore not allowed
+		"role name",             // space not allowed
+		"role@name",             // special char not allowed
+		"角色名",                   // non-ASCII not allowed
+		"role/name",             // slash not allowed
+		"role#name",             // hash not allowed
+	}
+	for _, name := range invalid {
+		if _, errs := v(name, "role_name"); len(errs) == 0 {
+			t.Errorf("role_name ValidateFunc should reject %q", name)
+		}
+	}
+}

--- a/website/docs/r/ram_role.html.markdown
+++ b/website/docs/r/ram_role.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 * `assume_role_policy_document` - (Optional, Available since v1.252.0) The trust policy that specifies one or more trusted entities to assume the RAM role. The trusted entities can be Alibaba Cloud accounts, Alibaba Cloud services, or identity providers (IdPs).
 * `description` - (Optional) The description of the RAM role. The description must be `1` to `1024` characters in length.
 * `max_session_duration` - (Optional, Int, Available since v1.105.0) The maximum session time of the RAM role. Default value: `3600`. Valid values: `3600` to `43200`.
-* `role_name` - (Optional, ForceNew, Available since v1.252.0) The name of the RAM role.
+* `role_name` - (Optional, ForceNew, Available since v1.252.0) The name of the RAM role. The name must be `1` to `64` characters in length, and can contain letters, digits, periods (.), and hyphens (-). Note: unlike `alicloud_ram_policy.policy_name`, `role_name` permits periods; `policy_name` only allows letters, digits, and hyphens.
 * `tags` - (Optional, Map, Available since v1.252.0) The list of tags for the role.
 * `force` - (Optional, Bool) Specifies whether to force delete the Role. Default value: `false`. Valid values:
   - `true`: Enable.


### PR DESCRIPTION
## What
- Document the `alicloud_ram_role.role_name` length (1-64) and charset (letters, digits, periods, hyphens) constraints in the argument reference.
- Add a `ValidateFunc` on `role_name` so invalid names fail at `terraform plan` instead of `terraform apply`.

## Why
The RAM CreateRole/UpdateRole APIs constrain `RoleName` to 1 to 64 characters allowing letters, digits, periods (.), and hyphens (-), but the provider schema and docs did not surface this. Users only discovered the limit on apply with an API error.

Notably, `role_name` permits periods, whereas `alicloud_ram_policy.policy_name` does not — this difference is called out in the docs.

## Changes
- `website/docs/r/ram_role.html.markdown`: describe the 1-64 length, allowed charset, and the `policy_name` difference.
- `alicloud/resource_alicloud_ram_role.go`: `validation.StringMatch(regexp.MustCompile("^[A-Za-z0-9.-]{1,64}$"), ...)` on `role_name`, matching existing precedents (`alicloud_cddc_dedicated_host.host_name`, `alicloud_vpc_ipv4_gateway.ipv4_gateway_name`). The field is `Computed` so `ValidateFunc` only validates user-supplied input and does not affect read-back values during import/refresh.
- `alicloud/resource_alicloud_ram_role_test.go`: add unit test `TestUnitRamRoleRoleNameValidation` (valid: 1/64 boundaries, single period, single hyphen, mixed; invalid: 65 chars, underscore, space, `@`, non-ASCII, slash, hash).

The deprecated `name` field is intentionally left without validation to avoid breaking existing configurations that still rely on it.

## Validation
- `gofmt -l` clean on changed files.
- `go vet ./alicloud` clean on changed files (pre-existing unrelated `fmt.Sprintln` warnings in `alicloud/common.go` are not touched).
- `go test ./alicloud -run TestUnitRamRoleRoleNameValidation` passes.

## Release Note
```release-note:enhancement
`alicloud_ram_role`: added `role_name` length and charset validation (1-64 characters; letters, digits, periods, hyphens) and documented the constraint.
```
