### PR TITLE
resource/alicloud_alidns_cloud_gtm_address_pool: accept non_preemptive for sequence_lb_strategy_mode; resource/alicloud_alidns_cloud_gtm_instance_config: accept non_preemptive for sequence_lb_strategy_mode

### DIFF
--- a/alicloud/resource_alicloud_alidns_cloud_gtm_address_pool.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_address_pool.go
@@ -62,7 +62,7 @@ func resourceAliCloudAlidnsCloudGtmAddressPool() *schema.Resource {
 			"sequence_lb_strategy_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: StringInSlice([]string{"preemptive", "nonPreemptive"}, false),
+				ValidateFunc: StringInSlice([]string{"preemptive", "non_preemptive", "nonPreemptive"}, false),
 			},
 		},
 	}

--- a/alicloud/resource_alicloud_alidns_cloud_gtm_address_pool_test.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_address_pool_test.go
@@ -72,6 +72,16 @@ func TestAccAliCloudAlidnsCloudGtmAddressPool_basic12688(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"sequence_lb_strategy_mode": "non_preemptive",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"sequence_lb_strategy_mode": "non_preemptive",
+					}),
+				),
+			},
+			{
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/alicloud/resource_alicloud_alidns_cloud_gtm_instance_config.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_instance_config.go
@@ -72,7 +72,7 @@ func resourceAliCloudAlidnsCloudGtmInstanceConfig() *schema.Resource {
 			"sequence_lb_strategy_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: StringInSlice([]string{"preemptive", "nonPreemptive"}, false),
+				ValidateFunc: StringInSlice([]string{"preemptive", "non_preemptive", "nonPreemptive"}, false),
 			},
 			"ttl": {
 				Type:     schema.TypeInt,

--- a/alicloud/resource_alicloud_alidns_cloud_gtm_instance_config_test.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_instance_config_test.go
@@ -78,6 +78,16 @@ func TestAccAliCloudAlidnsCloudGtmInstanceConfig_basic12689(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"sequence_lb_strategy_mode": "non_preemptive",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"sequence_lb_strategy_mode": "non_preemptive",
+					}),
+				),
+			},
+			{
 				ResourceName:      resourceId,
 				ImportState:       true,
 				ImportStateVerify: true,


### PR DESCRIPTION
## Description

The `sequence_lb_strategy_mode` field on `alicloud_alidns_cloud_gtm_address_pool` and `alicloud_alidns_cloud_gtm_instance_config` only accepted the camelCase value `nonPreemptive` via `StringInSlice`. The upstream OpenAPI (`UpdateCloudGtmAddressPoolLbStrategy` / `UpdateCloudGtmInstanceConfigLbStrategy`) and the Terraform documentation both document the snake_case value `non_preemptive`, so configurations following the documented value were rejected at plan time.

## Changes

- Add `non_preemptive` to the `sequence_lb_strategy_mode` enum on both resources, alongside the existing `nonPreemptive` so existing state is not broken. The validator stays case-sensitive (no `Non_Preemptive` etc.).
- Extend the basic acc tests with a step that switches the field to the documented `non_preemptive` value to cover plan/apply on both resources.

## Motivation

Documented values should pass the provider's plan-time validator. Existing state that already stores the camelCase form keeps working because both spellings are now accepted.

## Testing

- `go build ./alicloud/` clean.
- `go vet ./alicloud/` clean (only pre-existing `fmt.Sprintln` warnings in `common.go`).
- Acc tests require real credentials; run remotely.
