### PR TITLE
resource/alicloud_cs_kubernetes: remove dead len(config) < 0 branches (resource/alicloud_cs_kubernetes_node_pool: same fix)

### DIFF
--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -2034,9 +2034,6 @@ func fetchWorkerNodes(d *schema.ResourceData, meta interface{}) []map[string]int
 
 func flattenTags(config []*roacs.Tag) map[string]string {
 	m := make(map[string]string, len(config))
-	if len(config) < 0 {
-		return m
-	}
 
 	for _, tag := range config {
 		key := tea.StringValue(tag.Key)

--- a/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
@@ -3559,9 +3559,6 @@ func ConvertCsTags(d *schema.ResourceData) ([]cs.Tag, error) {
 
 func flattenTagsConfig(config []cs.Tag) map[string]string {
 	m := make(map[string]string, len(config))
-	if len(config) < 0 {
-		return m
-	}
 
 	for _, tag := range config {
 		if tag.Key != DefaultClusterTag {


### PR DESCRIPTION
## What
Removes the dead `if len(config) < 0 { return m }` branches from two CS Kubernetes (ACK) flatten helpers:

- `flattenTags` in `alicloud/resource_alicloud_cs_kubernetes.go`
- `flattenTagsConfig` in `alicloud/resource_alicloud_cs_kubernetes_node_pool.go`

## Why
A slice length is always non-negative, so `len(config) < 0` is always false and the branch is unreachable dead code. Removing it has no behavioral effect: when `config` is empty, the `for` loop body never executes and the function returns the empty map produced by `make(map[string]string, len(config))` — exactly what the dead branch would have returned.

## Verification
- `go build ./alicloud/...` passes
- `go vet ./alicloud/...` reports no new issues (pre-existing `fmt.Sprintln` warnings in `common.go` are untouched)
