### PR TITLE
resource/alicloud_cs_kubernetes: resource/alicloud_cs_kubernetes_node_pool: replace unreachable len(config) < 0 with len(config) == 0

### DIFF
--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -2034,9 +2034,6 @@ func fetchWorkerNodes(d *schema.ResourceData, meta interface{}) []map[string]int
 
 func flattenTags(config []*roacs.Tag) map[string]string {
 	m := make(map[string]string, len(config))
-	if len(config) < 0 {
-		return m
-	}
 
 	for _, tag := range config {
 		key := tea.StringValue(tag.Key)

--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -2063,7 +2063,7 @@ func fetchWorkerNodes(d *schema.ResourceData, meta interface{}) []map[string]int
 
 func flattenTags(config []*roacs.Tag) map[string]string {
 	m := make(map[string]string, len(config))
-	if len(config) < 0 {
+	if len(config) == 0 {
 		return m
 	}
 

--- a/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
@@ -3559,9 +3559,6 @@ func ConvertCsTags(d *schema.ResourceData) ([]cs.Tag, error) {
 
 func flattenTagsConfig(config []cs.Tag) map[string]string {
 	m := make(map[string]string, len(config))
-	if len(config) < 0 {
-		return m
-	}
 
 	for _, tag := range config {
 		if tag.Key != DefaultClusterTag {

--- a/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
@@ -3661,7 +3661,7 @@ func ConvertCsTags(d *schema.ResourceData) ([]cs.Tag, error) {
 
 func flattenTagsConfig(config []cs.Tag) map[string]string {
 	m := make(map[string]string, len(config))
-	if len(config) < 0 {
+	if len(config) == 0 {
 		return m
 	}
 


### PR DESCRIPTION
## What

The `len(config) < 0` guards in `flattenTags` (`resource_alicloud_cs_kubernetes.go`) and `flattenTagsConfig` (`resource_alicloud_cs_kubernetes_node_pool.go`) are unreachable because a Go slice length is always non-negative. Replace the comparison with `len(config) == 0` so the early-return branch is reachable for empty input while preserving the existing empty-collection shortcut.

## Why

- `len(config)` returns an `int` that is never negative, so `< 0` is always false and the early return is dead code.
- `== 0` makes the branch reachable for an empty `config`, returning the pre-allocated empty map (`make(map[string]string, 0)`) without entering the no-op `for` loop.
- Behavior is unchanged for non-empty input; for empty input the returned map is still empty, now via an explicit early return instead of falling through the loop.

## Verification

- `gofmt` on the changed files is clean.
- `go vet -p=1 ./alicloud` reports no issues on the changed files (the two `fmt.Sprintln` findings in `alicloud/common.go` are pre-existing on the base commit and outside this change).
- These flatten helpers have no dedicated unit tests; behavior equivalence confirmed by reading the surrounding logic.

## Changes

- `alicloud/resource_alicloud_cs_kubernetes.go`: `flattenTags` guard `< 0` -> `== 0` (line 2066).
- `alicloud/resource_alicloud_cs_kubernetes_node_pool.go`: `flattenTagsConfig` guard `< 0` -> `== 0` (line 3664).

## CI Notes

Two checks are red; both are pre-existing on the base branch and are not introduced by this change (the change only touches the `if` condition in two flatten helpers — no schema, test case, or `.tf` file is modified):

- `TestingCoverageRate`: `alicloud_cs_kubernetes` (92.45%) and `alicloud_cs_kubernetes_node_pool` (92.43%) have pre-existing missing coverage for attributes such as `kms_encrypted_password`, `kms_encryption_context`, `master_disk_performance_level`, `retain_resources`, `addons.*`, `auto_mode.enabled`, `eflo_node_group.*`, `instance_metadata_options.http_tokens`, `data_disks.*`, `instance_patterns.*`. This change does not add or modify any schema attribute, so it does not regress coverage.
- `tflint` S022: `resource_alicloud_cs_kubernetes.go:484/564/589` "schema of TypeMap should not use Elem of *schema.Resource" — pre-existing schema design unrelated to the `flattenTags` guard at line 2066. tflint scans the whole changed file and surfaces these pre-existing findings.

These are tracked separately and should be addressed in dedicated follow-up PRs (attribute coverage and schema lint), not mixed into this dead-branch fix.
