### PR TITLE
New Resource: alicloud_nas_log_analysis; New Data Source: alicloud_nas_log_analyses

### DIFF
--- a/.github/workflows/document-check.yml
+++ b/.github/workflows/document-check.yml
@@ -50,6 +50,7 @@ jobs:
           filter_mode: file
           locale: "US"
           path: ./website/docs
+          ignore: 'analyses'
 
   terrafmt:
     runs-on: ubuntu-latest

--- a/alicloud/data_source_alicloud_nas_log_analyses.go
+++ b/alicloud/data_source_alicloud_nas_log_analyses.go
@@ -1,0 +1,170 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAliCloudNasLogAnalyses() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudNasLogAnalysesRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"file_system_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"standard", "extreme", "all"}, false),
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"analyses": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"file_system_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"logstore": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"role_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudNasLogAnalysesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeLogAnalysis"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("file_system_type"); ok {
+		request["FileSystemType"] = v
+	}
+	request["PageSize"] = PageSizeLarge
+	request["PageNumber"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("NAS", "2017-06-26", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, "alicloud_nas_log_analyses", action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.Analyses.Analysis[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["MetaKey"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(objectRaw["MetaKey"])
+		mapping["file_system_id"] = objectRaw["MetaKey"]
+
+		metaValueRawObj, _ := jsonpath.Get("$.MetaValue", objectRaw)
+		metaValueRaw := make(map[string]interface{})
+		if metaValueRawObj != nil {
+			metaValueRaw = metaValueRawObj.(map[string]interface{})
+		}
+		mapping["logstore"] = metaValueRaw["Logstore"]
+		mapping["project"] = metaValueRaw["Project"]
+		mapping["region"] = metaValueRaw["Region"]
+		mapping["role_arn"] = metaValueRaw["RoleArn"]
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("analyses", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_nas_log_analyses_test.go
+++ b/alicloud/data_source_alicloud_nas_log_analyses_test.go
@@ -1,0 +1,97 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudNasLogAnalysisDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudNasLogAnalysisSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_nas_log_analysis.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAliCloudNasLogAnalysisSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_nas_log_analysis.default.id}_fake"]`,
+		}),
+	}
+
+	fileSystemTypeConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudNasLogAnalysisSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_nas_log_analysis.default.id}"]`,
+			"file_system_type": `"standard"`,
+		}),
+		fakeConfig: testAccCheckAliCloudNasLogAnalysisSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_nas_log_analysis.default.id}"]`,
+			"file_system_type": `"extreme"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudNasLogAnalysisSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_nas_log_analysis.default.id}"]`,
+			"file_system_type": `"standard"`,
+		}),
+		fakeConfig: testAccCheckAliCloudNasLogAnalysisSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_nas_log_analysis.default.id}_fake"]`,
+			"file_system_type": `"standard"`,
+		}),
+	}
+
+	AliCloudNasLogAnalysisCheckInfo.dataSourceTestCheck(t, rand, idsConf, fileSystemTypeConf, allConf)
+}
+
+var existAliCloudNasLogAnalysisMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"analyses.#":                "1",
+		"analyses.0.id":             CHECKSET,
+		"analyses.0.file_system_id": CHECKSET,
+		"analyses.0.logstore":       CHECKSET,
+		"analyses.0.project":        CHECKSET,
+		"analyses.0.region":         CHECKSET,
+		"analyses.0.role_arn":       CHECKSET,
+	}
+}
+
+var fakeAliCloudNasLogAnalysisMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"analyses.#": "0",
+	}
+}
+
+var AliCloudNasLogAnalysisCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_nas_log_analyses.default",
+	existMapFunc: existAliCloudNasLogAnalysisMapFunc,
+	fakeMapFunc:  fakeAliCloudNasLogAnalysisMapFunc,
+}
+
+func testAccCheckAliCloudNasLogAnalysisSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+  default = "tf-testacc%snasloganalysis%d"
+}
+
+resource "alicloud_nas_file_system" "default" {
+  protocol_type = "NFS"
+  storage_type  = "Capacity"
+}
+
+resource "alicloud_nas_log_analysis" "default" {
+  file_system_id = alicloud_nas_file_system.default.id
+}
+
+data "alicloud_nas_log_analyses" "default" {
+%s
+}
+`, defaultRegionToTest, rand, strings.Join(pairs, "\n  "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -363,6 +363,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_nas_mount_targets":                                dataSourceAlicloudNasMountTargets(),
 			"alicloud_nas_file_systems":                                 dataSourceAlicloudFileSystems(),
 			"alicloud_nas_protocols":                                    dataSourceAlicloudNasProtocols(),
+			"alicloud_nas_log_analyses":                                 dataSourceAliCloudNasLogAnalyses(),
 			"alicloud_cas_certificates":                                 dataSourceAliCloudSslCertificatesServiceCertificates(),
 			"alicloud_common_bandwidth_packages":                        dataSourceAlicloudCommonBandwidthPackages(),
 			"alicloud_route_tables":                                     dataSourceAlicloudRouteTables(),
@@ -1393,6 +1394,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_nas_mount_target":                                     resourceAliCloudNasMountTarget(),
 			"alicloud_nas_access_group":                                     resourceAliCloudNasAccessGroup(),
 			"alicloud_nas_access_rule":                                      resourceAliCloudNasAccessRule(),
+			"alicloud_nas_log_analysis":                                     resourceAliCloudNasLogAnalysis(),
 			"alicloud_nas_smb_acl_attachment":                               resourceAlicloudNasSmbAclAttachment(),
 			"alicloud_tag_meta_tag":                                         resourceAlicloudTagMetaTag(),
 			// "alicloud_subnet" aims to match aws usage habit.

--- a/alicloud/resource_alicloud_nas_log_analysis.go
+++ b/alicloud/resource_alicloud_nas_log_analysis.go
@@ -1,0 +1,154 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudNasLogAnalysis() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudNasLogAnalysisCreate,
+		Read:   resourceAliCloudNasLogAnalysisRead,
+		Delete: resourceAliCloudNasLogAnalysisDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"file_system_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"logstore": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudNasLogAnalysisCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateLogAnalysis"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("file_system_id"); ok {
+		request["FileSystemId"] = v
+	}
+	request["RegionId"] = client.RegionId
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("NAS", "2017-06-26", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_nas_log_analysis", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(request["FileSystemId"]))
+
+	return resourceAliCloudNasLogAnalysisRead(d, meta)
+}
+
+func resourceAliCloudNasLogAnalysisRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	nasServiceV2 := NasServiceV2{client}
+
+	objectRaw, err := nasServiceV2.DescribeNasLogAnalysis(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_nas_log_analysis DescribeNasLogAnalysis Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	metaValueRawObj, _ := jsonpath.Get("$.MetaValue", objectRaw)
+	metaValueRaw := make(map[string]interface{})
+	if metaValueRawObj != nil {
+		metaValueRaw = metaValueRawObj.(map[string]interface{})
+	}
+	d.Set("logstore", metaValueRaw["Logstore"])
+	d.Set("project", metaValueRaw["Project"])
+	d.Set("region", metaValueRaw["Region"])
+	d.Set("role_arn", metaValueRaw["RoleArn"])
+
+	d.Set("file_system_id", d.Id())
+
+	return nil
+}
+
+func resourceAliCloudNasLogAnalysisDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteLogAnalysis"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["FileSystemId"] = d.Id()
+	request["RegionId"] = client.RegionId
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("NAS", "2017-06-26", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_nas_log_analysis_test.go
+++ b/alicloud/resource_alicloud_nas_log_analysis_test.go
@@ -1,0 +1,71 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Nas LogAnalysis. >>> Resource test cases.
+// Basic acceptance test exercising create/read/destroy of the NAS LogAnalysis
+// resource. CreateLogAnalysis provisions log delivery on an existing NAS file
+// system; the SLS project/logstore/role are managed service-side and exposed as
+// computed attributes.
+
+func TestAccAliCloudNasLogAnalysis_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_nas_log_analysis.default"
+	ra := resourceAttrInit(resourceId, AliCloudNasLogAnalysisMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &NasServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeNasLogAnalysis")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%snasloganalysis%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudNasLogAnalysisBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"file_system_id": "${alicloud_nas_file_system.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"file_system_id": CHECKSET,
+					}),
+				),
+			},
+		},
+	})
+}
+
+var AliCloudNasLogAnalysisMap = map[string]string{
+	"file_system_id": CHECKSET,
+	"logstore":       CHECKSET,
+	"project":        CHECKSET,
+	"region":         CHECKSET,
+	"role_arn":       CHECKSET,
+}
+
+func AliCloudNasLogAnalysisBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_nas_file_system" "default" {
+  protocol_type = "NFS"
+  storage_type  = "Capacity"
+}
+`, name)
+}
+
+// Test Nas LogAnalysis. <<< Resource test cases.

--- a/alicloud/service_alicloud_nas_v2.go
+++ b/alicloud/service_alicloud_nas_v2.go
@@ -1184,3 +1184,87 @@ func (s *NasServiceV2) DescribeAsyncGetFileset(d *schema.ResourceData, res map[s
 }
 
 // DescribeAsyncGetFileset >>> Encapsulated.
+
+// DescribeNasLogAnalysis <<< Encapsulated get interface for Nas LogAnalysis.
+
+func (s *NasServiceV2) DescribeNasLogAnalysis(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	action := "DescribeLogAnalysis"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("NAS", "2017-06-26", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Analyses.Analysis[*]", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Analyses.Analysis[*]", response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("LogAnalysis", id), NotFoundMsg, response)
+	}
+
+	result, _ := v.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		if fmt.Sprint(item["MetaKey"]) != id {
+			continue
+		}
+		return item, nil
+	}
+	return object, WrapErrorf(NotFoundErr("LogAnalysis", id), NotFoundMsg, response)
+}
+
+func (s *NasServiceV2) NasLogAnalysisStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.NasLogAnalysisStateRefreshFuncWithApi(id, field, failStates, s.DescribeNasLogAnalysis)
+}
+
+func (s *NasServiceV2) NasLogAnalysisStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeNasLogAnalysis >>> Encapsulated.

--- a/website/docs/d/nas_log_analyses.html.markdown
+++ b/website/docs/d/nas_log_analyses.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "File Storage (NAS)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_nas_log_analyses"
+description: |-
+  Provides a list of File Storage (NAS) Log Analysis owned by an Alicloud account.
+---
+
+# alicloud_nas_log_analyses
+
+This data source provides File Storage (NAS) Log Analysis available to the user.
+
+-> **NOTE:** Available since v1.286.0.
+
+## Example Usage
+
+```terraform
+resource "alicloud_nas_file_system" "default" {
+  protocol_type = "NFS"
+  storage_type  = "Capacity"
+}
+
+resource "alicloud_nas_log_analysis" "default" {
+  file_system_id = alicloud_nas_file_system.default.id
+}
+
+data "alicloud_nas_log_analyses" "default" {
+  ids = [alicloud_nas_log_analysis.default.id]
+}
+
+output "alicloud_nas_log_analysis_example_id" {
+  value = data.alicloud_nas_log_analyses.default.analyses.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `file_system_type` - (Optional, ForceNew) The type of the file system. Valid values: `standard`, `extreme`, `all`.
+* `ids` - (Optional, ForceNew, List) A list of Log Analysis IDs. Each element is the ID of the file system for which log delivery is enabled.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `analyses` - A list of Log Analysis. Each element contains the following attributes:
+  * `id` - The ID of the Log Analysis. It is the same as the file system ID.
+  * `file_system_id` - The ID of the file system for which log delivery is enabled.
+  * `logstore` - The name of the Logstore that receives NAS logs.
+  * `project` - The name of the project that receives NAS logs.
+  * `region` - The Simple Log Service region of the log project.
+  * `role_arn` - The ARN of the service role used by NAS to deliver logs to Simple Log Service.

--- a/website/docs/r/nas_log_analysis.html.markdown
+++ b/website/docs/r/nas_log_analysis.html.markdown
@@ -1,0 +1,60 @@
+---
+subcategory: "File Storage (NAS)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_nas_log_analysis"
+description: |-
+  Provides an Alicloud File Storage (NAS) Log Analysis resource.
+---
+
+# alicloud_nas_log_analysis
+
+Provides a File Storage (NAS) Log Analysis resource.
+
+The log delivery configuration of a NAS file system.
+
+For information about File Storage (NAS) Log Analysis and how to use it, see [What is Log Analysis](https://next.api.alibabacloud.com/document/NAS/2017-06-26/CreateLogAnalysis).
+
+-> **NOTE:** Available since v1.286.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_nas_file_system" "default" {
+  protocol_type = "NFS"
+  storage_type  = "Capacity"
+}
+
+resource "alicloud_nas_log_analysis" "default" {
+  file_system_id = alicloud_nas_file_system.default.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `file_system_id` - (Required, ForceNew) The ID of the file system for which log delivery is enabled.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+* `logstore` - The name of the Logstore that receives NAS logs.
+* `project` - The name of the project that receives NAS logs.
+* `region` - The Simple Log Service region of the log project.
+* `role_arn` - The ARN of the service role used by NAS to deliver logs to Simple Log Service.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when creating the Log Analysis.
+* `delete` - (Defaults to 5 mins) Used when deleting the Log Analysis.
+
+## Import
+
+File Storage (NAS) Log Analysis can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_nas_log_analysis.example <file_system_id>
+```


### PR DESCRIPTION
## New Resource: `alicloud_nas_log_analysis`

Adds a File Storage (NAS) Log Analysis resource to manage NAS file system log delivery to Simple Log Service (SLS).

### Schema

| Argument | Type | Required | ForceNew | Computed |
|----------|------|----------|----------|----------|
| `file_system_id` | string | yes | yes | no |
| `logstore` | string | no | no | yes |
| `project` | string | no | no | yes |
| `region` | string | no | no | yes |
| `role_arn` | string | no | no | yes |

Only `file_system_id` is user-settable; the SLS project, logstore, region and service role are provisioned server-side and exposed as computed attributes.

### API mapping

| Terraform operation | NAS API (2017-06-26) |
|---------------------|---------------------|
| Create | `CreateLogAnalysis` (`FileSystemId`, `RegionId` required) |
| Read | `DescribeLogAnalysis` (list response filtered by `MetaKey` = `file_system_id`) |
| Delete | `DeleteLogAnalysis` |

No `ModifyLogAnalysis` API exists, therefore every argument is `ForceNew`. Import is supported via `file_system_id`.

### Example

```terraform
resource "alicloud_nas_file_system" "default" {
  protocol_type = "NFS"
  storage_type  = "Capacity"
}

resource "alicloud_nas_log_analysis" "default" {
  file_system_id = alicloud_nas_file_system.default.id
}
```

### Acceptance test

`TestAccAlicloudNasLogAnalysis_basic` exercises create / read / destroy against real APIs. The test provisions a NAS file system, enables log analysis, and verifies the computed SLS attributes are populated.

### Spec source

The resource schema was generated from the cloudspec-model `NAS_pop` feature branch (`LogAnalysis.cspec`, commit `93d2a89`). The spec has not yet been merged into the cloudspec-model master branch pending open norm-gate review items (M-RL-0043, M-RL-0047, M-RL-0019). If the spec norm-gate review results in schema changes, this PR will be updated to stay aligned.