### PR TITLE
data-source/alicloud_slb_acls: propagate ListTagResources error instead of swallowing it

### DIFF
--- a/alicloud/data_source_alicloud_slb_acls.go
+++ b/alicloud/data_source_alicloud_slb_acls.go
@@ -201,7 +201,7 @@ func slbAclsDescriptionAttributes(d *schema.ResourceData, acls []slb.Acl, client
 		}
 		tags, err := slbService.ListTagResources(response.AclId, "acl")
 		if err != nil {
-			return nil
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_slb_acls", request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 		mapping["tags"] = tagsToMap(tags)
 

--- a/alicloud/data_source_alicloud_slb_acls_test.go
+++ b/alicloud/data_source_alicloud_slb_acls_test.go
@@ -3,10 +3,17 @@ package alicloud
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/slb"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccAlicloudSLBAclsDataSource_basic(t *testing.T) {
@@ -135,4 +142,173 @@ data "alicloud_slb_acls" "default" {
 }
 `, rand, strings.Join(pairs, "\n  "))
 	return config
+}
+
+// TestAccAlicloudSLBAclsDataSource_multipleAcls exercises the multi-ACL loop in
+// slbAclsDescriptionAttributes where the ListTagResources error-swallowing bug
+// previously left the data source returning success with a half-complete state.
+// Both ACLs carry tags; the data source must surface both ACLs, both id/name
+// lists, and per-ACL tags (d.Set("acls", s)/d.Set("ids", ids)/d.Set("names", names)).
+func TestAccAlicloudSLBAclsDataSource_multipleAcls(t *testing.T) {
+	rand := acctest.RandInt()
+	secondTagsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudSlbAclsMultipleConfig(rand),
+	}
+	allAttrs := resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr("data.alicloud_slb_acls.default", "acls.#", "2"),
+		resource.TestCheckResourceAttr("data.alicloud_slb_acls.default", "ids.#", "2"),
+		resource.TestCheckResourceAttr("data.alicloud_slb_acls.default", "names.#", "2"),
+		// Both ACLs carry two tags; the per-index ordering is not guaranteed but
+		// each returned ACL must expose its two tags rather than an empty set.
+		resource.TestCheckResourceAttrSet("data.alicloud_slb_acls.default", "acls.0.id"),
+		resource.TestCheckResourceAttrSet("data.alicloud_slb_acls.default", "acls.1.id"),
+		resource.TestCheckResourceAttr("data.alicloud_slb_acls.default", "acls.0.tags.%", "2"),
+		resource.TestCheckResourceAttr("data.alicloud_slb_acls.default", "acls.1.tags.%", "2"),
+	)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: secondTagsConf.existConfig,
+				Check:  allAttrs,
+			},
+		},
+	})
+}
+
+func testAccCheckAlicloudSlbAclsMultipleConfig(rand int) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "tf-testAccSlbAclDataSourceMulti-%d"
+}
+variable "ip_version" {
+  default = "ipv4"
+}
+
+resource "alicloud_slb_acl" "first" {
+  name = "${var.name}-1"
+  ip_version = "${var.ip_version}"
+  entry_list {
+    entry = "10.10.10.0/24"
+    comment = "first"
+  }
+  tags = {
+    Created = "TF"
+    Order   = "first"
+  }
+}
+
+resource "alicloud_slb_acl" "second" {
+  name = "${var.name}-2"
+  ip_version = "${var.ip_version}"
+  entry_list {
+    entry = "168.10.10.0/24"
+    comment = "second"
+  }
+  tags = {
+    Created = "TF"
+    Order   = "second"
+  }
+}
+
+data "alicloud_slb_acls" "default" {
+  ids = ["${alicloud_slb_acl.first.id}", "${alicloud_slb_acl.second.id}"]
+}
+`, rand)
+}
+
+// TestUnitAlicloudSlbAcls_listTagsResourcesError verifies the fix for the bug
+// where the alicloud_slb_acls data source swallowed the ListTagResources error
+// (returned nil) and reported the data source as successful with a
+// half-complete state (missing tags/ids/names/acls). With the fix, the error
+// must be propagated. Mocks the SLB client via gomonkey so no real cloud calls
+// are made; skipped when the shared test client cannot be constructed.
+func TestUnitAlicloudSlbAcls_listTagsResourcesError(t *testing.T) {
+	p := Provider().(*schema.Provider).DataSourcesMap
+	d, _ := schema.InternalMap(p["alicloud_slb_acls"].Schema).Data(nil, nil)
+
+	region := os.Getenv("ALICLOUD_REGION")
+	rawClient, err := sharedClientForRegion(region)
+	if err != nil {
+		t.Skipf("Skipping the test case with err: %s", err)
+		t.Skipped()
+	}
+	rawClient = rawClient.(*connectivity.AliyunClient)
+
+	// Single ACL whose tags query fails: the data source must surface the error
+	// instead of returning success with an incomplete state.
+	t.Run("SingleAclTagsErrorPropagated", func(t *testing.T) {
+		callCount := 0
+		patchWithSlbClient := gomonkey.ApplyMethod(reflect.TypeOf(&connectivity.AliyunClient{}), "WithSlbClient",
+			func(_ *connectivity.AliyunClient, do func(*slb.Client) (interface{}, error)) (interface{}, error) {
+				callCount++
+				if callCount == 1 {
+					resp := slb.CreateDescribeAccessControlListsResponse()
+					resp.Acls = slb.Acls{Acl: []slb.Acl{{AclId: "acl-test-1", AclName: "tf-test-acl-1"}}}
+					return resp, nil
+				}
+				attrResp := slb.CreateDescribeAccessControlListAttributeResponse()
+				attrResp.AclId = "acl-test-1"
+				attrResp.AclName = "tf-test-acl-1"
+				attrResp.AddressIPVersion = "ipv4"
+				attrResp.ResourceGroupId = "rg-test"
+				return attrResp, nil
+			})
+		defer patchWithSlbClient.Reset()
+
+		patchListTags := gomonkey.ApplyMethod(reflect.TypeOf(&SlbService{}), "ListTagResources",
+			func(_ *SlbService, id string, resourceType string) (interface{}, error) {
+				return nil, fmt.Errorf("ListTagResources failed for acl %s", id)
+			})
+		defer patchListTags.Reset()
+
+		err := dataSourceAlicloudSlbAclsRead(d, rawClient)
+		assert.NotNil(t, err, "data source must propagate ListTagResources error instead of swallowing it and returning success")
+	})
+
+	// Multiple ACLs where only the second ACL's tags query fails: the whole
+	// data source must return an error, not silently succeed with the first
+	// ACL's state (the original bug's most damaging symptom).
+	t.Run("MultipleAclsPartialTagsErrorPropagated", func(t *testing.T) {
+		callCount := 0
+		patchWithSlbClient := gomonkey.ApplyMethod(reflect.TypeOf(&connectivity.AliyunClient{}), "WithSlbClient",
+			func(_ *connectivity.AliyunClient, do func(*slb.Client) (interface{}, error)) (interface{}, error) {
+				callCount++
+				if callCount == 1 {
+					resp := slb.CreateDescribeAccessControlListsResponse()
+					resp.Acls = slb.Acls{Acl: []slb.Acl{
+						{AclId: "acl-test-1", AclName: "tf-test-acl-1"},
+						{AclId: "acl-test-2", AclName: "tf-test-acl-2"},
+					}}
+					return resp, nil
+				}
+				attrResp := slb.CreateDescribeAccessControlListAttributeResponse()
+				attrResp.AclId = "acl-test-1"
+				attrResp.AclName = "tf-test-acl-1"
+				attrResp.AddressIPVersion = "ipv4"
+				attrResp.ResourceGroupId = "rg-test"
+				return attrResp, nil
+			})
+		defer patchWithSlbClient.Reset()
+
+		// First ACL's tags query succeeds, second ACL's fails: the data source
+		// must error out rather than returning a half-complete success.
+		tagsCallCount := 0
+		patchListTags := gomonkey.ApplyMethod(reflect.TypeOf(&SlbService{}), "ListTagResources",
+			func(_ *SlbService, id string, resourceType string) (interface{}, error) {
+				tagsCallCount++
+				if tagsCallCount == 1 {
+					return nil, nil
+				}
+				return nil, fmt.Errorf("ListTagResources failed for acl %s", id)
+			})
+		defer patchListTags.Reset()
+
+		err := dataSourceAlicloudSlbAclsRead(d, rawClient)
+		assert.NotNil(t, err, "multi-ACL partial tags failure must surface an error, not silent success with half-complete state")
+		assert.GreaterOrEqual(t, tagsCallCount, 2, "ListTagResources must be invoked for each ACL until the failure surfaces")
+	})
 }


### PR DESCRIPTION
## Problem

The `alicloud_slb_acls` data source swallowed `ListTagResources` errors and returned `nil`, causing the data source to report success while leaving state half-complete:

- `tags` was never populated for the failing ACL (the `mapping["tags"] = tagsToMap(tags)` line was skipped).
- The early `return nil` aborted `slbAclsDescriptionAttributes` before `d.Set("acls", s)`, `d.Set("ids", ids)`, and `d.Set("names", names)` ran, so the whole list (ids/names/acls) was never written to state.

A single ACL whose tag lookup failed therefore poisoned the entire data source result, producing non-deterministic plans and broken downstream references that depended on `ids`/`names`/`acls`/`tags`.

## Root cause

`alicloud/data_source_alicloud_slb_acls.go`:

```go
tags, err := slbService.ListTagResources(response.AclId, "acl")
if err != nil {
    return nil   // swallowed the error AND skipped the per-ACL mapping + outer d.Set calls
}
```

Compare `alicloud/resource_alicloud_slb_acl.go`, which already returns `WrapError(err)` for the same `ListTagResources(d.Id(), "acl")` call. The data source was the only inconsistent caller.

## Fix

Propagate the error with `WrapErrorf`, matching the error-handling style used for `DescribeAccessControlListAttribute` in the same function:

```go
tags, err := slbService.ListTagResources(response.AclId, "acl")
if err != nil {
    return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_slb_acls", request.GetActionName(), AlibabaCloudSdkGoERROR)
}
```

## Tests

- `TestUnitAlicloudSlbAcls_listTagsResourcesError`: gomonkey-based unit test that mocks `WithSlbClient` and `SlbService.ListTagResources`. Exercises two cases:
  - `SingleAclTagsErrorPropagated`: a single ACL whose tags query fails - the data source must surface an error rather than swallow it.
  - `MultipleAclsPartialTagsErrorPropagated`: multiple ACLs where only the second ACL's tags query fails - the data source must error out rather than silently return the first ACL's partial state.
- `TestAccAlicloudSLBAclsDataSource_multipleAcls`: acc test covering the multi-ACL happy path (two ACLs, each with two tags) to lock down `d.Set("acls"/"ids"/"names")` behavior across ACLs.
