### PR TITLE
testcase: add CloudMonitor 2.0 (CMS2) endpoint, client, and unit tests

### DIFF
--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -15,6 +15,7 @@ import (
 
 	ossclient "github.com/alibabacloud-go/alibabacloud-gateway-oss/client"
 	gatewayclient "github.com/alibabacloud-go/alibabacloud-gateway-sls/client"
+	cms2 "github.com/alibabacloud-go/cms-20240330/v10/client"
 	roaCS "github.com/alibabacloud-go/cs-20151215/v7/client"
 	openapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
 	roa "github.com/alibabacloud-go/tea-roa/client"
@@ -113,6 +114,7 @@ type AliyunClient struct {
 	cdnconn                      *cdn.CdnClient
 	otsconn                      *ots.Client
 	cmsconn                      *cms.Client
+	cms2conn                     *cms2.Client
 	logconn                      *sls.Client
 	fcconn                       *fc.Client
 	cenconn                      *cbn.Client
@@ -1039,6 +1041,44 @@ func (client *AliyunClient) WithCmsClient(do func(*cms.Client) (interface{}, err
 	client.cmsconn = cmsconn
 
 	return do(client.cmsconn)
+}
+
+// WithCms2Client invokes the do callback with a CloudMonitor 2.0 (CMS2, API version
+// 2024-03-30) client. The endpoint is resolved from the provider "cms2" endpoint
+// override and falls back to the regional default cms.%s.aliyuncs.com, so that CMS2
+// resources route to the dedicated CMS 2.0 domain instead of the legacy CMS 1.0 one.
+func (client *AliyunClient) WithCms2Client(do func(*cms2.Client) (interface{}, error)) (interface{}, error) {
+	if client.cms2conn != nil && !client.config.needRefreshCredential() {
+		return do(client.cms2conn)
+	}
+	product := "cms2"
+	endpoint, err := client.loadApiEndpoint(product)
+	if err != nil {
+		return nil, err
+	}
+	accessKey, secretKey, stsToken := client.config.AccessKey, client.config.SecretKey, client.config.SecurityToken
+	credential, err := client.config.Credential.GetCredential()
+	if err != nil || credential == nil {
+		log.Printf("[WARN] get credential failed. Error: %#v", err)
+	} else {
+		accessKey, secretKey, stsToken = *credential.AccessKeyId, *credential.AccessKeySecret, *credential.SecurityToken
+	}
+	cms2conn, err := cms2.NewClient(&openapi.Config{
+		AccessKeyId:     tea.String(accessKey),
+		AccessKeySecret: tea.String(secretKey),
+		SecurityToken:   tea.String(stsToken),
+		RegionId:        tea.String(client.config.RegionId),
+		UserAgent:       tea.String(client.config.getUserAgent()),
+		Endpoint:        tea.String(endpoint),
+		ReadTimeout:     tea.Int(client.config.ClientReadTimeout),
+		ConnectTimeout:  tea.Int(client.config.ClientConnectTimeout),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize the CMS2 client: %#v", err)
+	}
+	client.cms2conn = cms2conn
+
+	return do(client.cms2conn)
 }
 
 func (client *AliyunClient) WithLogPopClient(do func(*slsPop.Client) (interface{}, error)) (interface{}, error) {

--- a/alicloud/connectivity/cms2_endpoint_test.go
+++ b/alicloud/connectivity/cms2_endpoint_test.go
@@ -1,0 +1,52 @@
+package connectivity
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUnitCms2EndpointTableEntry verifies that the CloudMonitor 2.0 (CMS2, API
+// version 2024-03-30) product code is registered in the regularProductEndpoint
+// table with the dedicated CMS 2.0 regional domain `cms.%s.aliyuncs.com` rather
+// than the legacy CMS 1.0 `metrics.%s.aliyuncs.com` domain.
+func TestUnitCms2EndpointTableEntry(t *testing.T) {
+	endpointFmt, ok := regularProductEndpoint["cms2"]
+	assert.True(t, ok, "cms2 product code must be registered in regularProductEndpoint")
+	assert.Equal(t, "cms.%s.aliyuncs.com", endpointFmt)
+
+	assert.Equal(t, "cms.cn-hangzhou.aliyuncs.com", fmt.Sprintf(endpointFmt, "cn-hangzhou"))
+	assert.Equal(t, "cms.us-east-1.aliyuncs.com", fmt.Sprintf(endpointFmt, "us-east-1"))
+}
+
+// TestUnitCms2EndpointDomainDistinctFromCms1 guards against the regression where
+// CMS 2.0 requests route to the CMS 1.0 domain: cms and cms2 must resolve to
+// different regional domains so the dedicated 2.0 endpoint is reachable.
+func TestUnitCms2EndpointDomainDistinctFromCms1(t *testing.T) {
+	region := "cn-hangzhou"
+	cms1 := fmt.Sprintf(regularProductEndpoint["cms"], region)
+	cms2 := fmt.Sprintf(regularProductEndpoint["cms2"], region)
+	assert.NotEqual(t, cms1, cms2)
+	assert.Equal(t, "metrics.cn-hangzhou.aliyuncs.com", cms1)
+	assert.Equal(t, "cms.cn-hangzhou.aliyuncs.com", cms2)
+}
+
+// TestUnitCms2EndpointOverrideFromConfig verifies that the provider `cms2` endpoint
+// override (stored in config.Endpoints by the provider endpoints loop) takes
+// precedence over the regional default, so users can point CMS2 resources at a
+// custom CloudMonitor 2.0 endpoint.
+func TestUnitCms2EndpointOverrideFromConfig(t *testing.T) {
+	client := &AliyunClient{
+		config: &Config{
+			Endpoints: new(sync.Map),
+			RegionId:  "cn-hangzhou",
+		},
+	}
+	client.config.Endpoints.Store("cms2", "https://cms2.custom.example.com")
+
+	endpoint, err := client.loadApiEndpoint("cms2")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://cms2.custom.example.com", endpoint)
+}

--- a/alicloud/connectivity/config.go
+++ b/alicloud/connectivity/config.go
@@ -66,6 +66,7 @@ type Config struct {
 	KmsEndpoint              string
 	OtsEndpoint              string
 	CmsEndpoint              string
+	Cms2Endpoint             string
 	PvtzEndpoint             string
 	StsEndpoint              string
 	LogEndpoint              string

--- a/alicloud/connectivity/endpoint.go
+++ b/alicloud/connectivity/endpoint.go
@@ -400,6 +400,7 @@ var regularProductEndpoint = map[string]string{
 	"oss":                  "oss-%s.aliyuncs.com",
 	"cr":                   "cr.%s.aliyuncs.com",
 	"cms":                  "metrics.%s.aliyuncs.com",
+	"cms2":                 "cms.%s.aliyuncs.com",
 	"sls":                  "%s.log.aliyuncs.com",
 	"drds":                 "drds.%s.aliyuncs.com",
 	"polardbx":             "polardbx.%s.aliyuncs.com",

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -2313,6 +2313,7 @@ func providerConfigure(d *schema.ResourceData, p *schema.Provider) (interface{},
 		config.KmsEndpoint = strings.TrimSpace(endpoints["kms"].(string))
 		config.OtsEndpoint = strings.TrimSpace(endpoints["ots"].(string))
 		config.CmsEndpoint = strings.TrimSpace(endpoints["cms"].(string))
+		config.Cms2Endpoint = strings.TrimSpace(endpoints["cms2"].(string))
 		config.PvtzEndpoint = strings.TrimSpace(endpoints["pvtz"].(string))
 		config.StsEndpoint = strings.TrimSpace(endpoints["sts"].(string))
 		config.LogEndpoint = strings.TrimSpace(endpoints["log"].(string))
@@ -2575,6 +2576,8 @@ func init() {
 		"ots_endpoint": "Use this to override the default endpoint URL constructed from the `region`. It's typically used to connect to custom Table Store endpoints.",
 
 		"cms_endpoint": "Use this to override the default endpoint URL constructed from the `region`. It's typically used to connect to custom Cloud Monitor endpoints.",
+
+		"cms2_endpoint": "Use this to override the default endpoint URL constructed from the `region` for CloudMonitor 2.0 (CMS2, API version 2024-03-30). It's typically used to connect to custom Cloud Monitor 2.0 endpoints.",
 
 		"pvtz_endpoint": "Use this to override the default endpoint URL constructed from the `region`. It's typically used to connect to custom Private Zone endpoints.",
 
@@ -3748,6 +3751,13 @@ func endpointsSchema() *schema.Schema {
 					Optional:    true,
 					Default:     "",
 					Description: descriptions["cms_endpoint"],
+				},
+
+				"cms2": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Default:     "",
+					Description: descriptions["cms2_endpoint"],
 				},
 
 				"pvtz": {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aliyun/terraform-provider-alicloud
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/agiledragon/gomonkey/v2 v2.3.1
-	github.com/alibabacloud-go/tea v1.3.13
+	github.com/alibabacloud-go/tea v1.5.1
 	github.com/alibabacloud-go/tea-roa v1.3.4
 	github.com/alibabacloud-go/tea-rpc v1.2.0
 	github.com/alibabacloud-go/tea-utils v1.4.5
@@ -37,11 +37,12 @@ require (
 require (
 	github.com/alibabacloud-go/alibabacloud-gateway-oss v0.0.26
 	github.com/alibabacloud-go/alibabacloud-gateway-sls v0.3.0
+	github.com/alibabacloud-go/cms-20240330/v10 v10.2.0
 	github.com/alibabacloud-go/cs-20151215/v7 v7.6.0
-	github.com/alibabacloud-go/darabonba-openapi/v2 v2.1.14
+	github.com/alibabacloud-go/darabonba-openapi/v2 v2.2.2
 	github.com/alibabacloud-go/fc-open-20210406/v2 v2.0.7
 	github.com/alibabacloud-go/sts-20150401/v2 v2.0.2
-	github.com/alibabacloud-go/tea-utils/v2 v2.0.7
+	github.com/alibabacloud-go/tea-utils/v2 v2.0.9
 	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.5.0
 	github.com/blues/jsonata-go v1.5.4
 	github.com/hashicorp/errwrap v1.1.0
@@ -119,7 +120,7 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.3 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-getter v1.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ github.com/alibabacloud-go/alibabacloud-gateway-sls-util v0.3.0/go.mod h1:o4e70j
 github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.4/go.mod h1:sCavSAvdzOjul4cEqeVtvlSaSScfNsTQ+46HwlTL1hc=
 github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5 h1:zE8vH9C7JiZLNJJQ5OwjU9mSi4T9ef9u3BURT6LCLC8=
 github.com/alibabacloud-go/alibabacloud-gateway-spi v0.0.5/go.mod h1:tWnyE9AjF8J8qqLk645oUmVUnFybApTQWklQmi5tY6g=
+github.com/alibabacloud-go/cms-20240330/v10 v10.2.0 h1:VBOpy7mAqfheePbqZ25QjgMDDf4JXo/1bCoSaopH4Wo=
+github.com/alibabacloud-go/cms-20240330/v10 v10.2.0/go.mod h1:DJDRUYZP8CL63BaWkpFagnG5boBqdulaUJfDSNIvZhc=
 github.com/alibabacloud-go/cs-20151215/v7 v7.6.0 h1:AH/oobA+Qd3B7SATH/6uvo22T57jbVAYegr30G55HUc=
 github.com/alibabacloud-go/cs-20151215/v7 v7.6.0/go.mod h1:pCqw5KF+WTtCxe7IuOdSdRlNmz8h+karbK7N7Ulz4Ow=
 github.com/alibabacloud-go/darabonba-array v0.1.0 h1:vR8s7b1fWAQIjEjWnuF0JiKsCvclSRTfDzZHTYqfufY=
@@ -249,8 +251,9 @@ github.com/alibabacloud-go/darabonba-encode-util v0.0.2/go.mod h1:JiW9higWHYXm7F
 github.com/alibabacloud-go/darabonba-map v0.0.2 h1:qvPnGB4+dJbJIxOOfawxzF3hzMnIpjmafa0qOTp6udc=
 github.com/alibabacloud-go/darabonba-map v0.0.2/go.mod h1:28AJaX8FOE/ym8OUFWga+MtEzBunJwQGceGQlvaPGPc=
 github.com/alibabacloud-go/darabonba-openapi/v2 v2.0.2/go.mod h1:5JHVmnHvGzR2wNdgaW1zDLQG8kOC4Uec8ubkMogW7OQ=
-github.com/alibabacloud-go/darabonba-openapi/v2 v2.1.14 h1:iIamPRvehxQvVnTOvz77rZR+/YME1lR7X8kHonQSU6Y=
 github.com/alibabacloud-go/darabonba-openapi/v2 v2.1.14/go.mod h1:lxFGfobinVsQ49ntjpgWghXmIF0/Sm4+wvBJ1h5RtaE=
+github.com/alibabacloud-go/darabonba-openapi/v2 v2.2.2 h1:xu7UZuLUQsgCPJA02c2DEvIWjIZVh44KlDvPwuzqolo=
+github.com/alibabacloud-go/darabonba-openapi/v2 v2.2.2/go.mod h1:CsqHkHPpAKL64jl/fChR249EL0abYEIDWmlwFYgo7/E=
 github.com/alibabacloud-go/darabonba-signature-util v0.0.7 h1:UzCnKvsjPFzApvODDNEYqBHMFt1w98wC7FOo0InLyxg=
 github.com/alibabacloud-go/darabonba-signature-util v0.0.7/go.mod h1:oUzCYV2fcCH797xKdL6BDH8ADIHlzrtKVjeRtunBNTQ=
 github.com/alibabacloud-go/darabonba-string v1.0.2 h1:E714wms5ibdzCqGeYJ9JCFywE5nDyvIXIIQbZVFkkqo=
@@ -279,8 +282,9 @@ github.com/alibabacloud-go/tea v1.1.20/go.mod h1:nXxjm6CIFkBhwW4FQkNrolwbfon8Svy
 github.com/alibabacloud-go/tea v1.2.2/go.mod h1:CF3vOzEMAG+bR4WOql8gc2G9H3EkH3ZLAQdpmpXMgwk=
 github.com/alibabacloud-go/tea v1.2.3-0.20240605082020-e6e537a31150/go.mod h1:SP/4ugxOFdctgZvPRC0Anqbq1Q1VmuPXoUVyncO5azs=
 github.com/alibabacloud-go/tea v1.3.8/go.mod h1:A560v/JTQ1n5zklt2BEpurJzZTI8TUT+Psg2drWlxRg=
-github.com/alibabacloud-go/tea v1.3.13 h1:WhGy6LIXaMbBM6VBYcsDCz6K/TPsT1Ri2hPmmZffZ94=
 github.com/alibabacloud-go/tea v1.3.13/go.mod h1:A560v/JTQ1n5zklt2BEpurJzZTI8TUT+Psg2drWlxRg=
+github.com/alibabacloud-go/tea v1.5.1 h1:V519mvow9s6XdbrrLvZ+oR2HiaeY4KIN4yBfURbxlwc=
+github.com/alibabacloud-go/tea v1.5.1/go.mod h1:hgSs82CkOiehSQMoiFN79dL6zsGX7pVGvnn9SIEs8/0=
 github.com/alibabacloud-go/tea-oss-utils v1.1.0 h1:y65crjjcZ2Pbb6UZtC2deuIZHDVTS3IaDWE7M9nVLRc=
 github.com/alibabacloud-go/tea-oss-utils v1.1.0/go.mod h1:PFCF12e9yEKyBUIn7X1IrF/pNjvxgkHy0CgxX4+xRuY=
 github.com/alibabacloud-go/tea-roa v1.3.4 h1:afc1MrB9d5euBR5cxQTZ5Erswshguf1KSZmyttxJSTU=
@@ -302,8 +306,9 @@ github.com/alibabacloud-go/tea-utils/v2 v2.0.1/go.mod h1:U5MTY10WwlquGPS34DOeomU
 github.com/alibabacloud-go/tea-utils/v2 v2.0.4/go.mod h1:sj1PbjPodAVTqGTA3olprfeeqqmwD0A5OQz94o9EuXQ=
 github.com/alibabacloud-go/tea-utils/v2 v2.0.5/go.mod h1:dL6vbUT35E4F4bFTHL845eUloqaerYBYPsdWR2/jhe4=
 github.com/alibabacloud-go/tea-utils/v2 v2.0.6/go.mod h1:qxn986l+q33J5VkialKMqT/TTs3E+U9MJpd001iWQ9I=
-github.com/alibabacloud-go/tea-utils/v2 v2.0.7 h1:WDx5qW3Xa5ZgJ1c8NfqJkF6w+AU5wB8835UdhPr6Ax0=
 github.com/alibabacloud-go/tea-utils/v2 v2.0.7/go.mod h1:qxn986l+q33J5VkialKMqT/TTs3E+U9MJpd001iWQ9I=
+github.com/alibabacloud-go/tea-utils/v2 v2.0.9 h1:y6pUIlhjxbZl9ObDAcmA1H3c21eaAxADHTDQmBnAIgA=
+github.com/alibabacloud-go/tea-utils/v2 v2.0.9/go.mod h1:qxn986l+q33J5VkialKMqT/TTs3E+U9MJpd001iWQ9I=
 github.com/alibabacloud-go/tea-xml v1.1.2/go.mod h1:Rq08vgCcCAjHyRi/M7xlHKUykZCEtyBy9+DPF6GgEu8=
 github.com/alibabacloud-go/tea-xml v1.1.3 h1:7LYnm+JbOq2B+T/B0fHC4Ies4/FofC4zHzYtqw7dgt0=
 github.com/alibabacloud-go/tea-xml v1.1.3/go.mod h1:Rq08vgCcCAjHyRi/M7xlHKUykZCEtyBy9+DPF6GgEu8=
@@ -606,8 +611,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 h1:l5lAOZEym3oK3SQ2HBHWsJUfbNBiTXJDeW2QDxw9AQ0=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
-github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 h1:A3dhViTeFDSQcGOXuUi6ukCQSMyDtDISBp2z6OOo2YM=
 github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6/go.mod h1:M5qHK+eWfAv8VR/265dIuEpL3fNfeC21tXXp9itM24A=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=


### PR DESCRIPTION
## What this PR does

Adds provider-level support for CloudMonitor 2.0 (CMS2, API version 2024-03-30) so that CMS2 resources can route to the dedicated CMS 2.0 regional domain `cms.<region>.aliyuncs.com` instead of falling back to the legacy CMS 1.0 `metrics.<region>.aliyuncs.com` domain.

## Changes

- `alicloud/connectivity/endpoint.go`: register `cms2` in `regularProductEndpoint` with the default `cms.%s.aliyuncs.com` regional domain.
- `alicloud/connectivity/config.go`: add a `Cms2Endpoint` config field.
- `alicloud/connectivity/client.go`: add a `cms2conn` client and `WithCms2Client`, backed by `github.com/alibabacloud-go/cms-20240330/v10`. The endpoint is resolved via `loadApiEndpoint("cms2")`, honoring the provider `cms2` endpoint override and falling back to the regional default.
- `alicloud/provider.go`: expose a `cms2` field on the `endpoints` schema so users can override the CMS 2.0 endpoint, and wire the override into the config.
- `go.mod` / `go.sum`: add the `github.com/alibabacloud-go/cms-20240330/v10` dependency.

## Why

CMS2 (API 2024-03-30) is a separate POP product line (Integration Center, Prometheus Service, Alert Center, Event Center) that uses a different regional domain from CMS 1.0 (`cms.*` vs `metrics.*`). Today the provider has no `cms2` endpoint, so any CMS2 resource defaults to the CMS 1.0 `metrics.*` domain and fails. This wires up the endpoint override path and a default `cms.*` domain, mirroring the existing `cms` (1.0) wiring.

This is the provider-layer prerequisite for CMS2 resource support; the corresponding resource generation is tracked separately.

## Testing

- `gofmt -l` clean.
- `go vet ./alicloud/connectivity/` clean.
- `go build ./alicloud/` compiles.
- New unit tests in `alicloud/connectivity/cms2_endpoint_test.go`:
  - `TestUnitCms2EndpointTableEntry` — the `cms2` entry exists with the `cms.%s.aliyuncs.com` default.
  - `TestUnitCms2EndpointDomainDistinctFromCms1` — CMS 1.0 and 2.0 resolve to different domains.
  - `TestUnitCms2EndpointOverrideFromConfig` — the provider `cms2` override takes precedence over the default.
- Existing endpoint tests still pass (no regression).
