### PR TITLE
testcase: tolerate externally deleted role user in alicloud_max_compute_role_user_attachment Read

### DIFF
--- a/alicloud/service_alicloud_max_compute_v2.go
+++ b/alicloud/service_alicloud_max_compute_v2.go
@@ -440,7 +440,16 @@ func (s *MaxComputeServiceV2) MaxComputeQuotaScheduleStateRefreshFunc(id string,
 // DescribeMaxComputeRoleUserAttachment <<< Encapsulated get interface for MaxCompute RoleUserAttachment.
 
 func (s *MaxComputeServiceV2) DescribeMaxComputeRoleUserAttachment(id string) (object map[string]interface{}, err error) {
-	client := s.client
+	return s.describeMaxComputeRoleUserAttachmentWithRoaGet(id, s.client.RoaGet)
+}
+
+// describeMaxComputeRoleUserAttachmentWithRoaGet is the testable core of
+// DescribeMaxComputeRoleUserAttachment. It accepts a roaGet func so the
+// externally-deleted-member error branch (and the rest of the Read path)
+// can be exercised by unit tests without a real AliyunClient; production
+// wires in s.client.RoaGet via the thin wrapper above. This mirrors the
+// WithApi injection pattern used by MaxComputeTenantRoleUserAttachmentStateRefreshFuncWithApi.
+func (s *MaxComputeServiceV2) describeMaxComputeRoleUserAttachmentWithRoaGet(id string, roaGet func(apiProductCode string, apiVersion string, pathName string, query map[string]*string, headers map[string]*string, body interface{}) (map[string]interface{}, error)) (object map[string]interface{}, err error) {
 	var request map[string]interface{}
 	var response map[string]interface{}
 	var query map[string]*string
@@ -457,7 +466,7 @@ func (s *MaxComputeServiceV2) DescribeMaxComputeRoleUserAttachment(id string) (o
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		response, err = client.RoaGet("MaxCompute", "2022-01-04", action, query, nil, nil)
+		response, err = roaGet("MaxCompute", "2022-01-04", action, query, nil, nil)
 
 		if err != nil {
 			if NeedRetry(err) {
@@ -470,6 +479,16 @@ func (s *MaxComputeServiceV2) DescribeMaxComputeRoleUserAttachment(id string) (o
 	})
 	addDebug(action, response, request)
 	if err != nil {
+		// When the linked RAM/ALIYUN user referenced by a role is deleted
+		// externally, the project role user list API returns a non-404 error
+		// whose message contains "baseId and tenantId do not match" instead
+		// of an empty user list. Treat that case as NotFound so the resource
+		// Read drops the attachment from state instead of failing refresh/apply.
+		// String match is a stop-gap until MaxCompute exposes a stable error
+		// code for the externally-deleted member case.
+		if strings.Contains(err.Error(), "baseId and tenantId do not match") {
+			return object, WrapErrorf(NotFoundErr("RoleUserAttachment", id), NotFoundMsg, err)
+		}
 		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
 	}
 

--- a/alicloud/service_alicloud_max_compute_v2_test.go
+++ b/alicloud/service_alicloud_max_compute_v2_test.go
@@ -1,0 +1,127 @@
+package alicloud
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alibabacloud-go/tea/tea"
+)
+
+// TestDescribeMaxComputeRoleUserAttachment_ExternallyDeletedMember verifies
+// that when MaxCompute returns a non-404 error whose message indicates the
+// linked RAM/ALIYUN user referenced by a role has been deleted externally
+// ("baseId and tenantId do not match"), the service-layer Read path in
+// DescribeMaxComputeRoleUserAttachment surfaces a NotFoundError so the
+// resource Read drops the attachment from state instead of failing
+// refresh/apply.
+//
+// The test exercises the production describeMaxComputeRoleUserAttachmentWithRoaGet
+// method (the testable core of DescribeMaxComputeRoleUserAttachment) by
+// injecting a fake roaGet func, so it covers the real error-conversion
+// branch including the resource.Retry loop and the NeedRetry guard, instead
+// of copy-pasting the matching logic into the test.
+//
+// The fake roaGet signature matches connectivity.AliyunClient.RoaGet so the
+// injected func stands in for the real SDK call without a live AliyunClient.
+func TestDescribeMaxComputeRoleUserAttachment_ExternallyDeletedMember(t *testing.T) {
+	const (
+		ramID    = "default_project&role_project_admin&RAM$openapiautomation@test.aliyunid.com:tf-example"
+		aliyunID = "default_project&role_project_admin&ALIYUN$openapiautomation@test.aliyunid.com"
+	)
+
+	roaGetFunc := func(err error) func(apiProductCode string, apiVersion string, pathName string, query map[string]*string, headers map[string]*string, body interface{}) (map[string]interface{}, error) {
+		return func(string, string, string, map[string]*string, map[string]*string, interface{}) (map[string]interface{}, error) {
+			return nil, err
+		}
+	}
+
+	cases := []struct {
+		name         string
+		id           string
+		roaGet       func(string, string, string, map[string]*string, map[string]*string, interface{}) (map[string]interface{}, error)
+		wantNotFound bool
+		wantErr      bool
+	}{
+		{
+			name: "externally_deleted_ram_member_message_in_message_field",
+			id:   ramID,
+			roaGet: roaGetFunc(&tea.SDKError{
+				StatusCode: tea.Int(400),
+				Code:       tea.String("ODPS-0000001"),
+				Message:    tea.String("baseId and tenantId do not match"),
+			}),
+			wantNotFound: true,
+			wantErr:      true,
+		},
+		{
+			name: "externally_deleted_aliyun_member_message_in_data_field",
+			id:   aliyunID,
+			roaGet: roaGetFunc(&tea.SDKError{
+				StatusCode: tea.Int(400),
+				Code:       tea.String("InternalError.Project.User.BaseIdNotMatch"),
+				Message:    tea.String("ODPS request failed"),
+				Data:       tea.String(`{"message":"baseId and tenantId do not match"}`),
+			}),
+			wantNotFound: true,
+			wantErr:      true,
+		},
+		{
+			name: "unrelated_auth_error_does_not_match",
+			id:   ramID,
+			roaGet: roaGetFunc(&tea.SDKError{
+				StatusCode: tea.Int(403),
+				Code:       tea.String("Forbidden.Access"),
+				Message:    tea.String("Access denied"),
+			}),
+			wantNotFound: false,
+			wantErr:      true,
+		},
+		{
+			name: "empty_users_response_is_notfound",
+			id:   ramID,
+			roaGet: func(string, string, string, map[string]*string, map[string]*string, interface{}) (map[string]interface{}, error) {
+				return map[string]interface{}{
+					"data": map[string]interface{}{
+						"users": []interface{}{},
+					},
+				}, nil
+			},
+			wantNotFound: true,
+			wantErr:      true,
+		},
+		{
+			name: "matching_aliyun_user_response_succeeds",
+			id:   aliyunID,
+			roaGet: func(string, string, string, map[string]*string, map[string]*string, interface{}) (map[string]interface{}, error) {
+				return map[string]interface{}{
+					"data": map[string]interface{}{
+						"users": []interface{}{
+							map[string]interface{}{
+								"name": "ALIYUN$openapiautomation@test.aliyunid.com",
+							},
+						},
+					},
+				}, nil
+			},
+			wantNotFound: false,
+			wantErr:      false,
+		},
+	}
+
+	s := &MaxComputeServiceV2{}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := s.describeMaxComputeRoleUserAttachmentWithRoaGet(c.id, c.roaGet)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("expected err != nil = %v, got err = %v", c.wantErr, err)
+			}
+			if NotFoundError(err) != c.wantNotFound {
+				t.Fatalf("expected NotFoundError = %v, got %v. err: %v", c.wantNotFound, NotFoundError(err), err)
+			}
+			if c.wantNotFound && !strings.Contains(err.Error(), c.id) {
+				t.Fatalf("expected NotFoundError to contain resource ID %q, got %v", c.id, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When a RAM or ALIYUN user referenced by a MaxCompute project role is deleted outside of Terraform, the project role user list API (`/api/v1/projects/{p}/roles/{r}/users`) can return a non-404 error whose message contains `"baseId and tenantId do not match"` instead of an empty user list. The `alicloud_max_compute_role_user_attachment` Read path did not recognize this case, so refresh, plan, or apply failed even though the attachment was already gone.

## Fix

In `DescribeMaxComputeRoleUserAttachment`, treat an API error containing `"baseId and tenantId do not match"` as NotFound. This lets the resource Read remove the attachment from state while retaining the original API error in the diagnostic.

The message match is a stop-gap until MaxCompute exposes a stable error code for this condition.

## Tests

`TestDescribeMaxComputeRoleUserAttachment_ExternallyDeletedMember` exercises the production describe core with a per-case resource ID and injected `RoaGet` response. The matrix covers:

- A RAM role-user ID with the target signal in `tea.SDKError.Message`.
- An ALIYUN role-user ID with the target signal in `tea.SDKError.Data`.
- An unrelated authorization error that must remain a non-NotFound error.
- An empty user list that must remain NotFound.
- A matching ALIYUN user response that must succeed.

Each NotFound case also asserts that the returned diagnostic contains the exact resource ID supplied by that case, so RAM and ALIYUN inputs cannot accidentally share one fixed test ID.

Validation:

```text
go test ./alicloud -run '^TestDescribeMaxComputeRoleUserAttachment_ExternallyDeletedMember$' -count=1
PASS

go test ./alicloud -run '^$'
PASS
```

Existing acceptance cases for `alicloud_max_compute_role_user_attachment` are unchanged.

## Notes

- No schema changes or breaking changes.
- Existing empty-list and name-mismatch NotFound behavior is unchanged.
