### PR TITLE
ci: fix document check workflow

### DIFF
--- a/.github/workflows/document-check.yml
+++ b/.github/workflows/document-check.yml
@@ -32,8 +32,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: avto-dev/markdown-lint@v1
+      - uses: actions/checkout@v7.0.1
+      - uses: avto-dev/markdown-lint@v1.5.0
 
   misspell:
     runs-on: ubuntu-latest
@@ -41,15 +41,16 @@ jobs:
       contents: read
     steps:
       - name: Check out code.
-        uses: actions/checkout@v1
+        uses: actions/checkout@v7.0.1
       - name: misspell
-        uses: reviewdog/action-misspell@v1.11.1
+        uses: reviewdog/action-misspell@v1.27.0
         with:
           github_token: ${{secrets.github_token}}
           fail_on_error: true
           filter_mode: file
           locale: "US"
           path: ./website/docs
+          ignore: 'analyses'
 
   terrafmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI tool updagte
- Bump reviewdog/action-misspell to v1.27.0 and ignore the word "analyses" so the documentation misspell lint stops reporting false positives.
- Bump actions/checkout from v1 to v7.0.1.