### PR TITLE
ci: add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Enable weekly Dependabot updates for the github-actions ecosystem so action versions across .github/workflows are kept current automatically.

Configured conservatively so it cannot break CI by accident:
- Group all action updates into a single PR.
- Ignore major-version bumps (handled manually) since majors carry the breaking changes. Dependabot only opens PRs and every PR runs full CI, so a bad bump fails in the PR rather than on the default branch.