### PR TITLE
resource/cloud_sso: make access configuration and provisioning delete idempotent when the resource is already gone

### DIFF
--- a/alicloud/resource_alicloud_cloud_sso_access_configuration.go
+++ b/alicloud/resource_alicloud_cloud_sso_access_configuration.go
@@ -429,6 +429,9 @@ func resourceAliCloudCloudSsoAccessConfigurationDelete(d *schema.ResourceData, m
 				addDebug(action, response, removePermissionPolicyFromAccessConfigurationReq)
 
 				if err != nil {
+					if IsExpectedErrors(err, []string{"EntityNotExists.AccessConfiguration"}) || NotFoundError(err) {
+						return nil
+					}
 					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 				}
 			}

--- a/alicloud/resource_alicloud_cloud_sso_access_configuration_provisioning.go
+++ b/alicloud/resource_alicloud_cloud_sso_access_configuration_provisioning.go
@@ -143,7 +143,7 @@ func resourceAlicloudCloudSsoAccessConfigurationProvisioningDelete(d *schema.Res
 	})
 	addDebug(action, response, request)
 	if err != nil {
-		if IsExpectedErrors(err, []string{"EntityNotExists.AccessConfigurationProvisioning"}) {
+		if IsExpectedErrors(err, []string{"EntityNotExists.AccessConfigurationProvisioning", "EntityNotExists.AccessConfiguration"}) || NotFoundError(err) {
 			return nil
 		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)

--- a/alicloud/resource_alicloud_cloud_sso_access_configuration_provisioning_test.go
+++ b/alicloud/resource_alicloud_cloud_sso_access_configuration_provisioning_test.go
@@ -82,7 +82,7 @@ func testSweepCloudSsoDirectoryAccessConfigurationProvisioning(region, directory
 	return nil
 }
 
-func TestAccAlicloudCloudSSOAccessConfigurationProvisioning_basic0(t *testing.T) {
+func TestAccAliCloudCloudSSOAccessConfigurationProvisioning_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_cloud_sso_access_configuration_provisioning.default"
 	checkoutSupportedRegions(t, true, connectivity.CloudSsoSupportRegions)
@@ -116,6 +116,24 @@ func TestAccAlicloudCloudSSOAccessConfigurationProvisioning_basic0(t *testing.T)
 						"access_configuration_id": CHECKSET,
 						"target_type":             "RD-Account",
 						"target_id":               CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"directory_id":            "${local.directory_id}",
+					"access_configuration_id": "${alicloud_cloud_sso_access_configuration.default.access_configuration_id}",
+					"target_type":             "RD-Account",
+					"target_id":               "${data.alicloud_resource_manager_resource_directories.default.directories.0.master_account_id}",
+					"status":                  "Provisioned",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"directory_id":            CHECKSET,
+						"access_configuration_id": CHECKSET,
+						"target_type":             "RD-Account",
+						"target_id":               CHECKSET,
+						"status":                  "Provisioned",
 					}),
 				),
 			},


### PR DESCRIPTION
### Summary

Make the CloudSSO delete operations idempotent when the underlying resource has already been removed out of band (e.g. deleted directly via the console/API). Previously, deleting such a resource returned a `404 EntityNotExists` error instead of succeeding.

### Changes

- `alicloud_cloud_sso_access_configuration`: the delete flow first calls `RemovePermissionPolicyFromAccessConfiguration` for each permission policy. If the access configuration no longer exists, this step now short-circuits and returns `nil` instead of surfacing the not-found error. The final `DeleteAccessConfiguration` step already handled this case.
- `alicloud_cloud_sso_access_configuration_provisioning`: the delete flow now also treats a generic not-found error and a missing parent access configuration (`EntityNotExists.AccessConfiguration`) as a successful, idempotent delete, in addition to the existing `EntityNotExists.AccessConfigurationProvisioning` handling.

`alicloud_cloud_sso_access_assignment` already silences `EntityNotExists.AccessAssignment` / not-found on its delete path, so no change is required there.

### Test

Acceptance tests for the affected resources are being validated.
