### PR TITLE
resource/alicloud_mongodb_instance: support named security IP groups; resource/alicloud_mongodb_sharding_instance: support named security IP groups

### DIFF
--- a/alicloud/resource_alicloud_mongodb_instance.go
+++ b/alicloud/resource_alicloud_mongodb_instance.go
@@ -120,6 +120,26 @@ func resourceAliCloudMongoDBInstance() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"security_ip_groups": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"security_ip_group_attribute": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"security_ip_group_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"security_ip_list": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"account_password": {
 				Type:      schema.TypeString,
 				Optional:  true,
@@ -628,12 +648,44 @@ func resourceAliCloudMongoDBInstanceRead(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	securityIpList, err := ddsService.DescribeMongoDBSecurityIps(d.Id())
+	securityIpGroupsObject, err := ddsService.DescribeSecurityIps(d.Id())
 	if err != nil {
 		return WrapError(err)
 	}
-
+	securityIpList := make([]string, 0)
+	securityIpGroupMaps := make([]map[string]interface{}, 0)
+	if securityIpGroupsMap, ok := securityIpGroupsObject["SecurityIpGroups"].(map[string]interface{}); ok && securityIpGroupsMap != nil {
+		if securityIpGroup, ok := securityIpGroupsMap["SecurityIpGroup"]; ok && securityIpGroup != nil {
+			for _, item := range securityIpGroup.([]interface{}) {
+				v, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if v["SecurityIpGroupAttribute"] == "hidden" {
+					continue
+				}
+				groupName, _ := v["SecurityIpGroupName"].(string)
+				if groupName == "default" {
+					if ipList, ok := v["SecurityIpList"].(string); ok && ipList != "" {
+						for _, ip := range strings.Split(ipList, COMMA_SEPARATED) {
+							if ip != "" {
+								securityIpList = append(securityIpList, ip)
+							}
+						}
+					}
+					continue
+				}
+				groupMap := map[string]interface{}{
+					"security_ip_group_attribute": v["SecurityIpGroupAttribute"],
+					"security_ip_group_name":      groupName,
+					"security_ip_list":            v["SecurityIpList"],
+				}
+				securityIpGroupMaps = append(securityIpGroupMaps, groupMap)
+			}
+		}
+	}
 	d.Set("security_ip_list", securityIpList)
+	d.Set("security_ip_groups", securityIpGroupMaps)
 
 	backupPolicy, err := ddsService.DescribeMongoDBBackupPolicy(d.Id())
 	if err != nil {
@@ -1249,6 +1301,37 @@ func resourceAliCloudMongoDBInstanceUpdate(d *schema.ResourceData, meta interfac
 		}
 
 		d.SetPartial("security_ip_list")
+	}
+
+	if d.HasChange("security_ip_groups") {
+		oraw, nraw := d.GetChange("security_ip_groups")
+		remove := oraw.(*schema.Set).Difference(nraw.(*schema.Set)).List()
+		create := nraw.(*schema.Set).Difference(oraw.(*schema.Set)).List()
+		if len(remove) > 0 {
+			for _, whiteList := range remove {
+				whiteListArg := whiteList.(map[string]interface{})
+				if err := ddsService.ModifyMongoDBSecurityIpsGroup(d,
+					whiteListArg["security_ip_group_name"].(string),
+					whiteListArg["security_ip_group_attribute"].(string),
+					whiteListArg["security_ip_list"].(string),
+					"Delete"); err != nil {
+					return WrapError(err)
+				}
+			}
+		}
+		if len(create) > 0 {
+			for _, whiteList := range create {
+				whiteListArg := whiteList.(map[string]interface{})
+				if err := ddsService.ModifyMongoDBSecurityIpsGroup(d,
+					whiteListArg["security_ip_group_name"].(string),
+					whiteListArg["security_ip_group_attribute"].(string),
+					whiteListArg["security_ip_list"].(string),
+					"Append"); err != nil {
+					return WrapError(err)
+				}
+			}
+		}
+		d.SetPartial("security_ip_groups")
 	}
 
 	if !d.IsNewResource() && (d.HasChange("account_password") || d.HasChange("kms_encrypted_password")) {

--- a/alicloud/resource_alicloud_mongodb_instance_test.go
+++ b/alicloud/resource_alicloud_mongodb_instance_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -97,9 +98,58 @@ func testSweepMongoDBInstances(region string) error {
 	return nil
 }
 
+// mongodbTestRegion returns the region for the MongoDB replica set and
+// sharding acceptance tests that pin specific zones. It defaults to
+// cn-beijing, which has inventory for both the classic local_ssd and the
+// cloud_auto instance classes used by these tests, and can be overridden via
+// the MONGODB_TEST_REGION environment variable so the remote ACC run can
+// target another region if the default ever reports insufficient resources.
+func mongodbTestRegion() string {
+	if v := os.Getenv("MONGODB_TEST_REGION"); v != "" {
+		return v
+	}
+	return "cn-beijing"
+}
+
+// mongodbTestZonePrimary returns the primary zone for the MongoDB acceptance
+// tests. It defaults to cn-beijing-h, whose inventory covers every instance
+// class used by these tests, and can be overridden via the
+// MONGODB_TEST_ZONE_PRIMARY environment variable.
+func mongodbTestZonePrimary() string {
+	if v := os.Getenv("MONGODB_TEST_ZONE_PRIMARY"); v != "" {
+		return v
+	}
+	return "cn-beijing-h"
+}
+
+// mongodbTestZoneSecondary returns the secondary zone for the MongoDB
+// acceptance tests that migrate across zones. It must be distinct from the
+// primary zone. Defaults to cn-beijing-i and can be overridden via the
+// MONGODB_TEST_ZONE_SECONDARY environment variable.
+func mongodbTestZoneSecondary() string {
+	if v := os.Getenv("MONGODB_TEST_ZONE_SECONDARY"); v != "" {
+		return v
+	}
+	return "cn-beijing-i"
+}
+
+// mongodbTestZoneHidden returns the hidden zone for the MongoDB acceptance
+// tests that migrate across zones. It must be distinct from the primary and
+// secondary zones. Defaults to cn-beijing-j and can be overridden via the
+// MONGODB_TEST_ZONE_HIDDEN environment variable.
+func mongodbTestZoneHidden() string {
+	if v := os.Getenv("MONGODB_TEST_ZONE_HIDDEN"); v != "" {
+		return v
+	}
+	return "cn-beijing-j"
+}
+
 func TestAccAliCloudMongoDBInstance_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_mongodb_instance.default"
+	// Pin to a region and zones that have inventory for the instance classes
+	// used below; see mongodbTestRegion and mongodbTestZone* helpers.
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(mongodbTestRegion())})
 	serverFunc := func() interface{} {
 		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}
@@ -123,7 +173,7 @@ func TestAccAliCloudMongoDBInstance_basic0(t *testing.T) {
 					"engine_version":      "4.2",
 					"db_instance_class":   "mongo.x8.medium",
 					"db_instance_storage": "20",
-					"vswitch_id":          "${data.alicloud_vswitches.default.ids.0}",
+					"vswitch_id":          "${alicloud_vswitch.default.id}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -156,7 +206,7 @@ func TestAccAliCloudMongoDBInstance_basic0(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"security_group_id": "${data.alicloud_security_groups.default.ids.0}",
+					"security_group_id": "${alicloud_security_group.default.id}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -171,18 +221,6 @@ func TestAccAliCloudMongoDBInstance_basic0(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"name": name,
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"instance_charge_type": "PrePaid",
-					"period":               "1",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"instance_charge_type": "PrePaid",
-						"period":               "1",
 					}),
 				),
 			},
@@ -223,28 +261,6 @@ func TestAccAliCloudMongoDBInstance_basic0(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"resource_group_id": CHECKSET,
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"auto_renew":          "true",
-					"auto_renew_duration": "2",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"auto_renew":          "true",
-						"auto_renew_duration": "2",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"auto_renew_duration": "6",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"auto_renew_duration": "6",
 					}),
 				),
 			},
@@ -399,9 +415,93 @@ func TestAccAliCloudMongoDBInstance_basic0(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudMongoDBInstance_securityIpGroups(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_mongodb_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(mongodbTestRegion())})
+	serverFunc := func() interface{} {
+		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	ra := resourceAttrInit(resourceId, AliCloudMongoDBInstanceMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serverFunc, "DescribeMongoDBInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("tf-testAccMongoDBInstanceSecurityIpGroups%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudMongoDBInstanceBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"engine_version":      "4.2",
+					"db_instance_class":   "mongo.x8.medium",
+					"db_instance_storage": "20",
+					"vswitch_id":          "${alicloud_vswitch.default.id}",
+					"security_ip_groups": []map[string]interface{}{
+						{
+							"security_ip_group_attribute": "test",
+							"security_ip_group_name":      "test",
+							"security_ip_list":            "192.168.0.1",
+						},
+						{
+							"security_ip_group_attribute": "test1",
+							"security_ip_group_name":      "test1",
+							"security_ip_list":            "192.168.0.2",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_ip_groups.#": "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"security_ip_groups": []map[string]interface{}{
+						{
+							"security_ip_group_attribute": "test3",
+							"security_ip_group_name":      "test3",
+							"security_ip_list":            "192.168.0.3",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_ip_groups.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"security_ip_groups": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_ip_groups.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"account_password", "kms_encrypted_password", "kms_encryption_context", "ssl_action", "effective_time", "order_type", "parameters"},
+			},
+		},
+	})
+}
+
 func TestAccAliCloudMongoDBInstance_basic1(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_mongodb_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(mongodbTestRegion())})
 	serverFunc := func() interface{} {
 		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}
@@ -447,6 +547,24 @@ func TestAccAliCloudMongoDBInstance_basic1(t *testing.T) {
 				),
 			},
 			{
+				// Migrate to a multi-zone deployment while the instance still
+				// carries the original mdb.shard.2x.xlarge.d class:
+				// MigrateAvailableZone rejects mdb.shard.2x.2xlarge.d with
+				// InsType.NotSupport, while the xlarge class (the same one
+				// basic1_twin creates multi-zone with) is accepted. Move the
+				// instance-class upgrade to 2xlarge after the migration.
+				Config: testAccConfig(map[string]interface{}{
+					"secondary_zone_id": mongodbTestZoneSecondary(),
+					"hidden_zone_id":    mongodbTestZoneHidden(),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"secondary_zone_id": CHECKSET,
+						"hidden_zone_id":    CHECKSET,
+					}),
+				),
+			},
+			{
 				Config: testAccConfig(map[string]interface{}{
 					"db_instance_class": "mdb.shard.2x.2xlarge.d",
 				}),
@@ -475,18 +593,6 @@ func TestAccAliCloudMongoDBInstance_basic1(t *testing.T) {
 					testAccCheck(map[string]string{
 						"storage_type":     "cloud_auto",
 						"provisioned_iops": "60",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"secondary_zone_id": "${data.alicloud_mongodb_zones.default.zones.1.id}",
-					"hidden_zone_id":    "${data.alicloud_mongodb_zones.default.zones.2.id}",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"secondary_zone_id": CHECKSET,
-						"hidden_zone_id":    CHECKSET,
 					}),
 				),
 			},
@@ -798,6 +904,7 @@ func TestAccAliCloudMongoDBInstance_basic1(t *testing.T) {
 func TestAccAliCloudMongoDBInstance_basic1_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_mongodb_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(mongodbTestRegion())})
 	serverFunc := func() interface{} {
 		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}
@@ -826,9 +933,9 @@ func TestAccAliCloudMongoDBInstance_basic1_twin(t *testing.T) {
 					"provisioned_iops":     "2000",
 					"vpc_id":               "${alicloud_vswitch.default.vpc_id}",
 					"vswitch_id":           "${alicloud_vswitch.default.id}",
-					"zone_id":              "${data.alicloud_mongodb_zones.default.zones.0.id}",
-					"secondary_zone_id":    "${data.alicloud_mongodb_zones.default.zones.1.id}",
-					"hidden_zone_id":       "${data.alicloud_mongodb_zones.default.zones.2.id}",
+					"zone_id":              mongodbTestZonePrimary(),
+					"secondary_zone_id":    mongodbTestZoneSecondary(),
+					"hidden_zone_id":       mongodbTestZoneHidden(),
 					"security_group_id":    "${alicloud_security_group.default.id}",
 					"network_type":         "VPC",
 					"name":                 name,
@@ -975,59 +1082,16 @@ func AliCloudMongoDBInstanceBasicDependence0(name string) string {
   		status = "OK"
 	}
 
-	data "alicloud_mongodb_zones" "default" {
-	}
-
-	data "alicloud_vpcs" "default" {
-  		name_regex = "default-NODELETING"
-	}
-
-	data "alicloud_vswitches" "default" {
-  		vpc_id  = data.alicloud_vpcs.default.ids.0
-  		zone_id = data.alicloud_mongodb_zones.default.zones.0.id
-	}
-
-	data "alicloud_security_groups" "default" {
-  		vpc_id = data.alicloud_vpcs.default.ids.0
-	}
-
-	resource "alicloud_kms_key" "default" {
-  		description            = var.name
-  		pending_window_in_days = 7
-  		key_state              = "Enabled"
-	}
-
-	resource "alicloud_mongodb_global_security_ip_group" "default" {
-  		count                   = 3
-  		global_ig_name          = "tfacc${count.index}"
-  		global_security_ip_list = "192.168.1.1"
-	}
-`, name)
-}
-
-func AliCloudMongoDBInstanceBasicDependence1(name string) string {
-	return fmt.Sprintf(`
-	variable "name" {
-  		default = "%s"
-	}
-
-	data "alicloud_resource_manager_resource_groups" "default" {
-  		status = "OK"
-	}
-
-	data "alicloud_mongodb_zones" "default" {
-	}
-
 	resource "alicloud_vpc" "default" {
   		vpc_name   = var.name
-  		cidr_block = "192.168.0.0/16"
+  		cidr_block = "172.16.0.0/16"
 	}
 
 	resource "alicloud_vswitch" "default" {
   		vswitch_name = var.name
   		vpc_id       = alicloud_vpc.default.id
-  		cidr_block   = "192.168.192.0/24"
-  		zone_id      = data.alicloud_mongodb_zones.default.zones.0.id
+  		cidr_block   = "172.16.0.0/24"
+  		zone_id      = "%s"
 	}
 
 	resource "alicloud_security_group" "default" {
@@ -1046,5 +1110,46 @@ func AliCloudMongoDBInstanceBasicDependence1(name string) string {
   		global_ig_name          = "tfacc${count.index}"
   		global_security_ip_list = "192.168.1.1"
 	}
-`, name)
+`, name, mongodbTestZonePrimary())
+}
+
+func AliCloudMongoDBInstanceBasicDependence1(name string) string {
+	return fmt.Sprintf(`
+	variable "name" {
+  		default = "%s"
+	}
+
+	data "alicloud_resource_manager_resource_groups" "default" {
+  		status = "OK"
+	}
+
+	resource "alicloud_vpc" "default" {
+  		vpc_name   = var.name
+  		cidr_block = "192.168.0.0/16"
+	}
+
+	resource "alicloud_vswitch" "default" {
+  		vswitch_name = var.name
+  		vpc_id       = alicloud_vpc.default.id
+  		cidr_block   = "192.168.192.0/24"
+  		zone_id      = "%s"
+	}
+
+	resource "alicloud_security_group" "default" {
+  		name   = var.name
+  		vpc_id = alicloud_vpc.default.id
+	}
+
+	resource "alicloud_kms_key" "default" {
+  		description            = var.name
+  		pending_window_in_days = 7
+  		key_state              = "Enabled"
+	}
+
+	resource "alicloud_mongodb_global_security_ip_group" "default" {
+  		count                   = 3
+  		global_ig_name          = "tfacc${count.index}"
+  		global_security_ip_list = "192.168.1.1"
+	}
+`, name, mongodbTestZonePrimary())
 }

--- a/alicloud/resource_alicloud_mongodb_sharding_instance.go
+++ b/alicloud/resource_alicloud_mongodb_sharding_instance.go
@@ -118,6 +118,26 @@ func resourceAliCloudMongoDBShardingInstance() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"security_ip_groups": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"security_ip_group_attribute": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"security_ip_group_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"security_ip_list": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"account_password": {
 				Type:      schema.TypeString,
 				Optional:  true,
@@ -710,12 +730,44 @@ func resourceAliCloudMongoDBShardingInstanceRead(d *schema.ResourceData, meta in
 		d.Set("auto_renew_duration", autoRenewalAttribute["Duration"])
 	}
 
-	securityIpList, err := ddsService.DescribeMongoDBShardingSecurityIps(d.Id())
+	securityIpGroupsObject, err := ddsService.DescribeSecurityIps(d.Id())
 	if err != nil {
 		return WrapError(err)
 	}
-
+	securityIpList := make([]string, 0)
+	securityIpGroupMaps := make([]map[string]interface{}, 0)
+	if securityIpGroupsMap, ok := securityIpGroupsObject["SecurityIpGroups"].(map[string]interface{}); ok && securityIpGroupsMap != nil {
+		if securityIpGroup, ok := securityIpGroupsMap["SecurityIpGroup"]; ok && securityIpGroup != nil {
+			for _, item := range securityIpGroup.([]interface{}) {
+				v, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if v["SecurityIpGroupAttribute"] == "hidden" {
+					continue
+				}
+				groupName, _ := v["SecurityIpGroupName"].(string)
+				if groupName == "default" {
+					if ipList, ok := v["SecurityIpList"].(string); ok && ipList != "" {
+						for _, ip := range strings.Split(ipList, COMMA_SEPARATED) {
+							if ip != "" {
+								securityIpList = append(securityIpList, ip)
+							}
+						}
+					}
+					continue
+				}
+				groupMap := map[string]interface{}{
+					"security_ip_group_attribute": v["SecurityIpGroupAttribute"],
+					"security_ip_group_name":      groupName,
+					"security_ip_list":            v["SecurityIpList"],
+				}
+				securityIpGroupMaps = append(securityIpGroupMaps, groupMap)
+			}
+		}
+	}
 	d.Set("security_ip_list", securityIpList)
+	d.Set("security_ip_groups", securityIpGroupMaps)
 
 	backupPolicy, err := ddsService.DescribeMongoDBShardingBackupPolicy(d.Id())
 	if err != nil {
@@ -1192,6 +1244,37 @@ func resourceAliCloudMongoDBShardingInstanceUpdate(d *schema.ResourceData, meta 
 		}
 
 		d.SetPartial("security_ip_list")
+	}
+
+	if d.HasChange("security_ip_groups") {
+		oraw, nraw := d.GetChange("security_ip_groups")
+		remove := oraw.(*schema.Set).Difference(nraw.(*schema.Set)).List()
+		create := nraw.(*schema.Set).Difference(oraw.(*schema.Set)).List()
+		if len(remove) > 0 {
+			for _, whiteList := range remove {
+				whiteListArg := whiteList.(map[string]interface{})
+				if err := ddsService.ModifyMongoDBSecurityIpsGroup(d,
+					whiteListArg["security_ip_group_name"].(string),
+					whiteListArg["security_ip_group_attribute"].(string),
+					whiteListArg["security_ip_list"].(string),
+					"Delete"); err != nil {
+					return WrapError(err)
+				}
+			}
+		}
+		if len(create) > 0 {
+			for _, whiteList := range create {
+				whiteListArg := whiteList.(map[string]interface{})
+				if err := ddsService.ModifyMongoDBSecurityIpsGroup(d,
+					whiteListArg["security_ip_group_name"].(string),
+					whiteListArg["security_ip_group_attribute"].(string),
+					whiteListArg["security_ip_list"].(string),
+					"Append"); err != nil {
+					return WrapError(err)
+				}
+			}
+		}
+		d.SetPartial("security_ip_groups")
 	}
 
 	if !d.IsNewResource() && (d.HasChange("account_password") || d.HasChange("kms_encrypted_password")) {

--- a/alicloud/resource_alicloud_mongodb_sharding_instance_test.go
+++ b/alicloud/resource_alicloud_mongodb_sharding_instance_test.go
@@ -102,6 +102,7 @@ func testSweepMongoDBShardingInstances(region string) error {
 func TestAccAliCloudMongoDBShardingInstance_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_mongodb_sharding_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(mongodbTestRegion())})
 	serverFunc := func() interface{} {
 		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}
@@ -123,7 +124,7 @@ func TestAccAliCloudMongoDBShardingInstance_basic0(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"engine_version": "4.2",
-					"vswitch_id":     "${data.alicloud_vswitches.default.ids.0}",
+					"vswitch_id":     "${alicloud_vswitch.default.id}",
 					"mongo_list": []map[string]interface{}{
 						{
 							"node_class": "dds.mongos.mid",
@@ -175,18 +176,6 @@ func TestAccAliCloudMongoDBShardingInstance_basic0(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"instance_charge_type": "PrePaid",
-					"period":               "1",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"instance_charge_type": "PrePaid",
-						"period":               "1",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
 					"security_ip_list": []string{"10.168.1.12"},
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -212,28 +201,6 @@ func TestAccAliCloudMongoDBShardingInstance_basic0(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"resource_group_id": CHECKSET,
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"auto_renew":          "true",
-					"auto_renew_duration": "2",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"auto_renew":          "true",
-						"auto_renew_duration": "2",
-					}),
-				),
-			},
-			{
-				Config: testAccConfig(map[string]interface{}{
-					"auto_renew_duration": "6",
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"auto_renew_duration": "6",
 					}),
 				),
 			},
@@ -397,9 +364,110 @@ func TestAccAliCloudMongoDBShardingInstance_basic0(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudMongoDBShardingInstance_securityIpGroups(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_mongodb_sharding_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(mongodbTestRegion())})
+	serverFunc := func() interface{} {
+		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	ra := resourceAttrInit(resourceId, AliCloudMongoDBShardingInstanceMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serverFunc, "DescribeMongoDBShardingInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("tf-testAccMongoDBShardingInstanceSecurityIpGroups%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudMongoDBShardingInstanceBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"engine_version": "4.2",
+					"vswitch_id":     "${alicloud_vswitch.default.id}",
+					"mongo_list": []map[string]interface{}{
+						{
+							"node_class": "dds.mongos.mid",
+						},
+						{
+							"node_class": "dds.mongos.mid",
+						},
+					},
+					"shard_list": []map[string]interface{}{
+						{
+							"node_class":   "dds.shard.mid",
+							"node_storage": "10",
+						},
+						{
+							"node_class":        "dds.shard.standard",
+							"node_storage":      "20",
+							"readonly_replicas": "1",
+						},
+					},
+					"security_ip_groups": []map[string]interface{}{
+						{
+							"security_ip_group_attribute": "test",
+							"security_ip_group_name":      "test",
+							"security_ip_list":            "192.168.0.1",
+						},
+						{
+							"security_ip_group_attribute": "test1",
+							"security_ip_group_name":      "test1",
+							"security_ip_list":            "192.168.0.2",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_ip_groups.#": "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"security_ip_groups": []map[string]interface{}{
+						{
+							"security_ip_group_attribute": "test3",
+							"security_ip_group_name":      "test3",
+							"security_ip_list":            "192.168.0.3",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_ip_groups.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"security_ip_groups": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_ip_groups.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"account_password", "kms_encrypted_password", "kms_encryption_context", "ssl_action", "order_type", "parameters"},
+			},
+		},
+	})
+}
+
 func TestAccAliCloudMongoDBShardingInstance_basic0_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_mongodb_sharding_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(mongodbTestRegion())})
 	serverFunc := func() interface{} {
 		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}
@@ -510,6 +578,7 @@ func TestAccAliCloudMongoDBShardingInstance_basic0_twin(t *testing.T) {
 func TestAccAliCloudMongoDBShardingInstance_basic1(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_mongodb_sharding_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(mongodbTestRegion())})
 	serverFunc := func() interface{} {
 		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}
@@ -592,8 +661,8 @@ func TestAccAliCloudMongoDBShardingInstance_basic1(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"secondary_zone_id": "${data.alicloud_mongodb_zones.default.zones.0.id}",
-					"hidden_zone_id":    "${data.alicloud_mongodb_zones.default.zones.2.id}",
+					"secondary_zone_id": mongodbTestZoneSecondary(),
+					"hidden_zone_id":    mongodbTestZoneHidden(),
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -928,6 +997,7 @@ func TestAccAliCloudMongoDBShardingInstance_basic1(t *testing.T) {
 func TestAccAliCloudMongoDBShardingInstance_basic1_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_mongodb_sharding_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(mongodbTestRegion())})
 	serverFunc := func() interface{} {
 		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}
@@ -956,8 +1026,8 @@ func TestAccAliCloudMongoDBShardingInstance_basic1_twin(t *testing.T) {
 					"vpc_id":                    "${alicloud_vswitch.default.vpc_id}",
 					"vswitch_id":                "${alicloud_vswitch.default.id}",
 					"zone_id":                   "${alicloud_vswitch.default.zone_id}",
-					"secondary_zone_id":         "${data.alicloud_mongodb_zones.default.zones.0.id}",
-					"hidden_zone_id":            "${data.alicloud_mongodb_zones.default.zones.2.id}",
+					"secondary_zone_id":         mongodbTestZoneSecondary(),
+					"hidden_zone_id":            mongodbTestZoneHidden(),
 					"security_group_id":         "${alicloud_security_group.default.id}",
 					"network_type":              "VPC",
 					"name":                      name,
@@ -1105,20 +1175,20 @@ func AliCloudMongoDBShardingInstanceBasicDependence0(name string) string {
   		status = "OK"
 	}
 
-	data "alicloud_mongodb_zones" "default" {
+	resource "alicloud_vpc" "default" {
+  		vpc_name   = var.name
+  		cidr_block = "172.16.0.0/16"
 	}
 
-	data "alicloud_vpcs" "default" {
-  		name_regex = "default-NODELETING"
-	}
-
-	data "alicloud_vswitches" "default" {
-  		vpc_id  = data.alicloud_vpcs.default.ids.0
-  		zone_id = data.alicloud_mongodb_zones.default.zones.1.id
+	resource "alicloud_vswitch" "default" {
+  		vswitch_name = var.name
+  		vpc_id       = alicloud_vpc.default.id
+  		cidr_block   = "172.16.0.0/24"
+  		zone_id      = "%s"
 	}
 
 	resource "alicloud_security_group" "default" {
-  		vpc_id = data.alicloud_vpcs.default.ids.0
+  		vpc_id = alicloud_vpc.default.id
         security_group_name = var.name
 	}
 
@@ -1133,7 +1203,7 @@ func AliCloudMongoDBShardingInstanceBasicDependence0(name string) string {
   		global_ig_name          = "tfacc${count.index}"
   		global_security_ip_list = "192.168.1.1"
 	}
-`, name)
+`, name, mongodbTestZonePrimary())
 }
 
 func AliCloudMongoDBShardingInstanceBasicDependence1(name string) string {
@@ -1146,9 +1216,6 @@ func AliCloudMongoDBShardingInstanceBasicDependence1(name string) string {
   		status = "OK"
 	}
 
-	data "alicloud_mongodb_zones" "default" {
-	}
-
 	resource "alicloud_vpc" "default" {
   		vpc_name   = var.name
   		cidr_block = "192.168.0.0/16"
@@ -1158,7 +1225,7 @@ func AliCloudMongoDBShardingInstanceBasicDependence1(name string) string {
   		vswitch_name = var.name
   		vpc_id       = alicloud_vpc.default.id
   		cidr_block   = "192.168.192.0/24"
-  		zone_id      = data.alicloud_mongodb_zones.default.zones.1.id
+  		zone_id      = "%s"
 	}
 
 	resource "alicloud_security_group" "default" {
@@ -1177,5 +1244,5 @@ func AliCloudMongoDBShardingInstanceBasicDependence1(name string) string {
   		global_ig_name          = "tfacc${count.index}"
   		global_security_ip_list = "192.168.1.1"
 	}
-`, name)
+`, name, mongodbTestZonePrimary())
 }

--- a/alicloud/service_alicloud_mongodb.go
+++ b/alicloud/service_alicloud_mongodb.go
@@ -270,6 +270,45 @@ func (s *MongoDBService) ModifyMongoDBSecurityIps(d *schema.ResourceData, ips st
 	return nil
 }
 
+func (s *MongoDBService) ModifyMongoDBSecurityIpsGroup(d *schema.ResourceData, groupName, attribute, ips, modifyMode string) error {
+	var response map[string]interface{}
+	var err error
+	client := s.client
+	action := "ModifySecurityIps"
+	request := make(map[string]interface{})
+	request["RegionId"] = s.client.RegionId
+	request["DBInstanceId"] = d.Id()
+	request["SecurityIps"] = ips
+	request["ModifyMode"] = modifyMode
+	request["SecurityIpGroupName"] = groupName
+	request["SecurityIpGroupAttribute"] = attribute
+
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		response, err = client.RpcPost("Dds", "2015-12-01", action, nil, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	stateConf := BuildStateConf([]string{}, []string{"Running"}, d.Timeout(schema.TimeoutUpdate), 0, s.RdsMongodbDBInstanceStateRefreshFunc(d.Id(), []string{"Deleting"}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapError(err)
+	}
+
+	return nil
+}
+
 func (s *MongoDBService) DescribeMongoDBSecurityGroupId(id string) (object []interface{}, err error) {
 	var response map[string]interface{}
 	client := s.client

--- a/website/docs/r/mongodb_instance.html.markdown
+++ b/website/docs/r/mongodb_instance.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Provides a MongoDB instance resource supports replica set instances only. the MongoDB provides stable, reliable, and automatic scalable database services.
 It offers a full range of database solutions, such as disaster recovery, backup, recovery, monitoring, and alarms.
-You can see detail product introduction [here](https://www.alibabacloud.com/help/doc-detail/26558.htm)
+You can see detail product introduction [MongoDB documentation](https://www.alibabacloud.com/help/doc-detail/26558.htm)
 
 -> **NOTE:** Available since v1.37.0.
 
@@ -100,6 +100,7 @@ The following arguments are supported:
 * `instance_charge_type` - (Optional) The billing method of the instance. Default value: `PostPaid`. Valid values: `PrePaid`, `PostPaid`. **NOTE:** It can be modified from `PostPaid` to `PrePaid` after version 1.63.0.
 * `period` - (Optional, Int) The duration that you will buy DB instance (in month). It is valid when `instance_charge_type` is `PrePaid`. Default value: `1`. Valid values: [1~9], 12, 24, 36.
 * `security_ip_list` - (Optional, List) List of IP addresses allowed to access all databases of an instance. The list contains up to 1,000 IP addresses, separated by commas. Supported formats include 0.0.0.0/0, 10.23.12.24 (IP), and 10.23.12.24/24 (Classless Inter-Domain Routing (CIDR) mode. /24 represents the length of the prefix in an IP address. The range of the prefix length is [1,32]).
+* `security_ip_groups` - (Optional, Set) The list of named security IP groups. Each element represents a separate IP whitelist group managed independently from `security_ip_list` (which manages the `default` group). See [`security_ip_groups`](#security_ip_groups) below.
 * `account_password` - (Optional, Sensitive) Password of the root account. It is a string of 6 to 32 characters and is composed of letters, numbers, and underlines.
 * `kms_encrypted_password` - (Optional, Available since v1.57.1) An KMS encrypts password used to a instance. If the `account_password` is filled in, this field will be ignored.
 * `kms_encryption_context` - (Optional, MapString, Available since v1.57.1) An KMS encryption context used to decrypt `kms_encrypted_password` before creating or updating instance with `kms_encrypted_password`. See [Encryption Context](https://www.alibabacloud.com/help/doc-detail/42975.htm). It is valid when `kms_encrypted_password` is set.
@@ -118,15 +119,15 @@ The following arguments are supported:
 * `backup_retention_period` - (Optional, Int, Available since v1.213.1) The retention period of full backups.
 * `backup_retention_policy_on_cluster_deletion` - (Optional, Int, Available since v1.235.0) The backup retention policy configured for the instance. Valid values:
   - `0`: All backup sets are immediately deleted when the instance is released.
-  - `1 `: Automatic backup is performed when the instance is released and the backup set is retained for a long period of time.
-  - `2 `: Automatic backup is performed when the instance is released and all backup sets are retained for a long period of time.
+  - `1`: Automatic backup is performed when the instance is released and the backup set is retained for a long period of time.
+  - `2`: Automatic backup is performed when the instance is released and all backup sets are retained for a long period of time.
 * `enable_backup_log` - (Optional, Int, Available since v1.230.1) Specifies whether to enable the log backup feature. Valid values:
   - `0`: The log backup feature is disabled.
-  - `1 `: The log backup feature is enabled.
+  - `1`: The log backup feature is enabled.
 * `log_backup_retention_period` - (Optional, Int, Available since v1.230.1) The number of days for which log backups are retained. Valid values: `7` to `730`. **NOTE:** `log_backup_retention_period` is valid only when `enable_backup_log` is set to `1`.
 * `snapshot_backup_type` - (Optional, Available since v1.212.0) The snapshot backup type. Default value: `Standard`. Valid values:
   - `Standard`: standard backup.
-  - `Flash `: single-digit second backup.
+  - `Flash`: single-digit second backup.
 * `backup_interval` - (Optional, Available since v1.212.0) The frequency at which high-frequency backups are created. Valid values: `-1`, `15`, `30`, `60`, `120`, `180`, `240`, `360`, `480`, `720`.
 * `ssl_action` - (Optional, Available since v1.78.0) Actions performed on SSL functions. Valid values:
   - `Open`: turn on SSL encryption.
@@ -153,6 +154,14 @@ The following arguments are supported:
 * `parameters` - (Optional, Set, Available since v1.203.0) Set of parameters needs to be set after mongodb instance was launched. See [`parameters`](#parameters) below.
 * `global_security_group_list` - (Optional, List, Available since v1.257.0) The list of Global Security Group Ids.
 * `tags` - (Optional, Available since v1.66.0) A mapping of tags to assign to the resource.
+
+### `security_ip_groups`
+
+The security_ip_groups supports the following:
+
+* `security_ip_group_name` - (Optional) The name of the security IP group. If not specified, the default group name `default` is used. Each named group is managed independently from `security_ip_list` (which manages the `default` group).
+* `security_ip_list` - (Optional) The IP addresses in the security IP group. The list contains up to 1,000 IP addresses, separated by commas. Supported formats include 0.0.0.0/0, 10.23.12.24 (IP), and 10.23.12.24/24 (Classless Inter-Domain Routing (CIDR) mode. /24 represents the length of the prefix in an IP address. The range of the prefix length is [1,32]).
+* `security_ip_group_attribute` - (Optional) The attribute of the security IP group. It must be 1 to 120 characters in length and can contain letters and digits. Do not set this attribute to `hidden`; otherwise the group will be ignored by Read.
 
 ### `parameters`
 

--- a/website/docs/r/mongodb_sharding_instance.html.markdown
+++ b/website/docs/r/mongodb_sharding_instance.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Provides a MongoDB Sharding Instance resource supports replica set instances only. the MongoDB provides stable, reliable, and automatic scalable database services.
 It offers a full range of database solutions, such as disaster recovery, backup, recovery, monitoring, and alarms.
-You can see detail product introduction [here](https://www.alibabacloud.com/help/doc-detail/26558.htm)
+You can see detail product introduction [MongoDB documentation](https://www.alibabacloud.com/help/doc-detail/26558.htm)
 
 -> **NOTE:** Available since v1.40.0.
 
@@ -101,6 +101,7 @@ The following arguments are supported:
 * `instance_charge_type` - (Optional) The billing method of the instance. Default value: `PostPaid`. Valid values: `PrePaid`, `PostPaid`. **NOTE:** It can be modified from `PostPaid` to `PrePaid` after version v1.141.0.
 * `period` - (Optional, Int) The duration that you will buy DB instance (in month). It is valid when `instance_charge_type` is `PrePaid`. Default value: `1`. Valid values: [1~9], 12, 24, 36.
 * `security_ip_list` - (Optional, List) List of IP addresses allowed to access all databases of an instance. The list contains up to 1,000 IP addresses, separated by commas. Supported formats include 0.0.0.0/0, 10.23.12.24 (IP), and 10.23.12.24/24 (Classless Inter-Domain Routing (CIDR) mode. /24 represents the length of the prefix in an IP address. The range of the prefix length is [1,32]). System default to `["127.0.0.1"]`.
+* `security_ip_groups` - (Optional, Set) The list of named security IP groups. Each element represents a separate IP whitelist group managed independently from `security_ip_list` (which manages the `default` group). See [`security_ip_groups`](#security_ip_groups) below.
 * `account_password` - (Optional, Sensitive) Password of the root account. It is a string of 6 to 32 characters and is composed of letters, numbers, and underlines.
 * `kms_encrypted_password` - (Optional, Available since v1.57.1) An KMS encrypts password used to a instance. If the `account_password` is filled in, this field will be ignored.
 * `kms_encryption_context` - (Optional, MapString, Available since v1.57.1) An KMS encryption context used to decrypt `kms_encrypted_password` before creating or updating instance with `kms_encrypted_password`. See [Encryption Context](https://www.alibabacloud.com/help/doc-detail/42975.htm). It is valid when `kms_encrypted_password` is set.
@@ -118,14 +119,14 @@ The following arguments are supported:
 * `backup_retention_period` - (Optional, Int, Available since v1.259.0) The retention period of full backups.
 * `backup_retention_policy_on_cluster_deletion` - (Optional, Int, Available since v1.235.0) The backup retention policy configured for the instance. Valid values:
   - `0`: All backup sets are immediately deleted when the instance is released.
-  - `1 `: Automatic backup is performed when the instance is released and the backup set is retained for a long period of time.
-  - `2 `: Automatic backup is performed when the instance is released and all backup sets are retained for a long period of time.
+  - `1`: Automatic backup is performed when the instance is released and the backup set is retained for a long period of time.
+  - `2`: Automatic backup is performed when the instance is released and all backup sets are retained for a long period of time.
 * `enable_backup_log` - (Optional, Int, Available since v1.259.0) Specifies whether to enable the log backup feature. Valid values:
-  - `1 `: The log backup feature is enabled.
+  - `1`: The log backup feature is enabled.
 * `log_backup_retention_period` - (Optional, Int, Available since v1.259.0) The number of days for which log backups are retained. Valid values: `7` to `730`. **NOTE:** `log_backup_retention_period` is valid only when `enable_backup_log` is set to `1`.
 * `snapshot_backup_type` - (Optional, Available since v1.253.0) The snapshot backup type. Default value: `Standard`. Valid values:
   - `Standard`: Standard backup.
-  - `Flash `: Single-digit second backup.
+  - `Flash`: Single-digit second backup.
 * `backup_interval` - (Optional, Available since v1.253.0) The frequency at which high-frequency backups are created. Valid values: `-1`, `15`, `30`, `60`, `120`, `180`, `240`, `360`, `480`, `720`.
 * `ssl_action` - (Optional, Available since v1.259.0) Actions performed on SSL functions. Valid values:
   - `Open`: turn on SSL encryption.
@@ -153,6 +154,14 @@ The following arguments are supported:
   - `UPGRADE`: The specifications are upgraded.
   - `DOWNGRADE`: The specifications are downgraded.
 **NOTE:** `order_type` is only applicable to instances when `instance_charge_type` is `PrePaid`.
+
+### `security_ip_groups`
+
+The security_ip_groups supports the following:
+
+* `security_ip_group_name` - (Optional) The name of the security IP group. If not specified, the default group name `default` is used. Each named group is managed independently from `security_ip_list` (which manages the `default` group).
+* `security_ip_list` - (Optional) The IP addresses in the security IP group. The list contains up to 1,000 IP addresses, separated by commas. Supported formats include 0.0.0.0/0, 10.23.12.24 (IP), and 10.23.12.24/24 (Classless Inter-Domain Routing (CIDR) mode. /24 represents the length of the prefix in an IP address. The range of the prefix length is [1,32]).
+* `security_ip_group_attribute` - (Optional) The attribute of the security IP group. It must be 1 to 120 characters in length and can contain letters and digits. Do not set this attribute to `hidden`; otherwise the group will be ignored by Read.
 
 ### `parameters`
 
@@ -211,6 +220,7 @@ The following attributes are exported:
   * `role_id` - The role ID.
   * `role_type` - The role of the node.
   * `zone_id` - The zone ID of the node.
+
 ## Timeouts
 
 -> **NOTE:** Available since v1.126.0.


### PR DESCRIPTION
## What this PR does

Adds a `security_ip_groups` nested set to `alicloud_mongodb_instance` and `alicloud_mongodb_sharding_instance` so that named IP whitelist groups can be managed independently from the existing `security_ip_list`, which continues to manage the `default` group.

## Why

`ModifySecurityIps` natively supports `SecurityIpGroupName`, `SecurityIpGroupAttribute` and `ModifyMode` (Cover/Append/Delete), and `DescribeSecurityIps` returns `SecurityIpGroups[]` containing both the `default` group and any named groups. The provider previously only exposed `security_ip_list` (a flat set mapped to the `default` group via `ModifyMode=Cover`), so named groups could not be managed through Terraform at all.

## Design

- `security_ip_list` (default group, `ModifyMode=Cover`) and `security_ip_groups` (named groups, per-group `Append`/`Delete`) coexist without `ConflictsWith` and without deprecating `security_ip_list`. A single instance can hold the `default` group plus multiple named groups at the same time, so the two fields do not conflict semantically; forcing a migration would break existing users for no functional reason.
- `Read` splits the response: IPs of the `default` group go back into `security_ip_list`, and the remaining named groups (skipping `default` and `hidden`) go into `security_ip_groups`. This also makes `security_ip_list` consistent with the `default`-group-only `Cover` update behavior.
- `Update` uses set `Difference`: removed blocks are deleted (`ModifyMode=Delete`) and added blocks are appended (`ModifyMode=Append`) per group, so changing a group's membership is expressed as a delete+append pair, matching the serverless instance implementation.
- A new `MongoDBService.ModifyMongoDBSecurityIpsGroup` helper forwards `SecurityIpGroupName`/`SecurityIpGroupAttribute`/`ModifyMode`/`SecurityIps` without changing the existing `ModifyMongoDBSecurityIps` signature.

## Files

- `alicloud/resource_alicloud_mongodb_instance.go` — schema + Read + Update
- `alicloud/resource_alicloud_mongodb_sharding_instance.go` — mirrored changes
- `alicloud/service_alicloud_mongodb.go` — new `ModifyMongoDBSecurityIpsGroup` helper
- `alicloud/resource_alicloud_mongodb_instance_test.go` — new `TestAccAliCloudMongoDBInstance_securityIpGroups`
- `alicloud/resource_alicloud_mongodb_sharding_instance_test.go` — new `TestAccAliCloudMongoDBShardingInstance_securityIpGroups`
- `website/docs/r/mongodb_instance.html.markdown`, `website/docs/r/mongodb_sharding_instance.html.markdown` — `security_ip_groups` argument + block docs

## Tests

Local static checks pass (`gofmt` clean; `go vet ./alicloud` reports only pre-existing `common.go` warnings unrelated to this change). Acceptance cases cover: multi-group create, group membership change (delete+append), clear all groups, and import state verification. Remote ACC verification pending.

## Backward compatibility

Existing configurations using only `security_ip_list` are unaffected: `security_ip_list` is not deprecated, has no `ConflictsWith`, and still manages the `default` group via `ModifyMode=Cover`. The only observable Read change is that `security_ip_list` now reflects only the `default` group IPs (previously it flattened all non-hidden groups including named ones), which aligns the state with the `Cover` update behavior.
