### PR TITLE
resource/alicloud_cs_serverless_kubernetes: support secret encryption

### DIFF
--- a/alicloud/resource_alicloud_cs_serverless_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_serverless_kubernetes.go
@@ -26,6 +26,7 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
@@ -255,6 +256,17 @@ func resourceAlicloudCSServerlessKubernetes() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"encryption_provider_key": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: kmsEncryptionDiffSuppressFunc,
+				Description:      "The ID of the Key Management Service (KMS) key that is used to encrypt Kubernetes Secrets.",
+			},
+			"disable_encryption": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"delete_options": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -478,6 +490,10 @@ func resourceAlicloudCSServerlessKubernetesCreate(d *schema.ResourceData, meta i
 		request.CustomSan = tea.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("encryption_provider_key"); ok {
+		request.EncryptionProviderKey = tea.String(v.(string))
+	}
+
 	if v, ok := d.GetOk("maintenance_window"); ok {
 		request.MaintenanceWindow = expandMaintenanceWindowConfigRoa(v.([]interface{}))
 	}
@@ -590,6 +606,12 @@ func resourceAlicloudCSServerlessKubernetesRead(d *schema.ResourceData, meta int
 	if v, ok := capabilities["PublicSLB"]; ok {
 		d.Set("endpoint_public_access_enabled", Interface2Bool(v))
 	}
+	if v, ok := capabilities["DisableEncryption"]; ok {
+		d.Set("disable_encryption", Interface2Bool(v))
+	}
+	if kmsKeyId, ok := capabilities["EncryptionKMSKeyId"]; ok {
+		d.Set("encryption_provider_key", Interface2String(kmsKeyId))
+	}
 	metadata := fetchClusterMetaDataMap(tea.StringValue(object.MetaData))
 	if v, ok := metadata["ExtraCertSAN"]; ok && v != nil {
 		l := expandStringList(v.([]interface{}))
@@ -658,6 +680,13 @@ func resourceAlicloudCSServerlessKubernetesUpdate(d *schema.ResourceData, meta i
 		err := migrateCluster(d, meta)
 		if err != nil {
 			return WrapError(err)
+		}
+	}
+
+	// update kms encryption
+	if !d.IsNewResource() && (d.HasChange("encryption_provider_key") || d.HasChange("disable_encryption")) {
+		if err := updateClusterKMSEncryption(d, meta); err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "UpdateKMSEncryption", AlibabaCloudSdkGoERROR)
 		}
 	}
 

--- a/alicloud/resource_alicloud_cs_serverless_kubernetes_test.go
+++ b/alicloud/resource_alicloud_cs_serverless_kubernetes_test.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/denverdino/aliyungo/cs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func getTimezone(region string) string {
@@ -240,7 +242,21 @@ func TestAccAliCloudCSServerlessKubernetes_basic(t *testing.T) {
 				),
 			},
 			{
+				// retain_resources is a delete-time, write-only input: it is only
+				// sent in the Delete request and is never read back into state, so
+				// it is set here purely to exercise the config path without a
+				// read-back assertion. It is reset to empty in the next step so the
+				// final destroy is unaffected.
 				Config: testAccConfig(map[string]interface{}{
+					"retain_resources": []string{"${alicloud_vswitch.default.id}"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"retain_resources": []string{},
 					"delete_options": []map[string]interface{}{
 						{
 							"delete_mode":   "delete",
@@ -266,6 +282,91 @@ func TestAccAliCloudCSServerlessKubernetes_basic(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{})),
+			},
+		},
+	})
+}
+
+func TestAccAliCloudCSServerlessKubernetes_encryption(t *testing.T) {
+	var v *cs.ServerlessClusterResponse
+	resourceId := "alicloud_cs_serverless_kubernetes.default"
+	ra := resourceAttrInit(resourceId, csServerlessKubernetesBasicMap)
+
+	serviceFunc := func() interface{} {
+		return &CsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+
+	rac := resourceAttrCheckInit(rc, ra)
+
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testaccserverlesskubernetes-encryption-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceCSServerlessKubernetesConfigDependenceEncryption)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name":                           name,
+					"version":                        "${data.alicloud_cs_kubernetes_version.version-126.metadata.0.version}",
+					"vpc_id":                         "${alicloud_vpc.default.id}",
+					"vswitch_ids":                    []string{"${alicloud_vswitch.default.id}"},
+					"security_group_id":              "${alicloud_security_group.default.id}",
+					"new_nat_gateway":                "true",
+					"deletion_protection":            "false",
+					"endpoint_public_access_enabled": "true",
+					"load_balancer_spec":             "slb.s2.small",
+					"resource_group_id":              "${data.alicloud_resource_manager_resource_groups.default.groups.0.id}",
+					"service_cidr":                   "10.0.1.0/24",
+					"private_zone":                   "true",
+					"cluster_spec":                   "ack.pro.small",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":                           name,
+						"version":                        CHECKSET,
+						"deletion_protection":            "false",
+						"endpoint_public_access_enabled": "true",
+						"cluster_spec":                   "ack.pro.small",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"encryption_provider_key": "${data.alicloud_kms_keys.default.keys[0].key_id}",
+					"disable_encryption":      "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"encryption_provider_key": CHECKSET,
+						"disable_encryption":      "false",
+					}),
+				),
+			},
+			{
+				PreConfig: func() { time.Sleep(5 * time.Minute) },
+				Config: testAccConfig(map[string]interface{}{
+					"encryption_provider_key": "",
+					"disable_encryption":      "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"disable_encryption": "true",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"load_balancer_spec", "new_nat_gateway", "private_zone", "sls_project_name", "service_discovery_types", "logging_type", "time_zone", "addons", "cluster_ca_cert", "client_key", "client_cert"},
 			},
 		},
 	})
@@ -412,8 +513,7 @@ variable "name" {
 	default = "%s"
 }
 
-data "alicloud_zones" "default" {
-	available_resource_creation = "VSwitch"
+data "alicloud_enhanced_nat_available_zones" "enhanced" {
 }
 
 data "alicloud_resource_manager_resource_groups" "default" {}
@@ -438,13 +538,53 @@ resource "alicloud_vpc" "default" {
 resource "alicloud_vswitch" "default" {
 	vpc_id            = alicloud_vpc.default.id
 	cidr_block        = cidrsubnet(alicloud_vpc.default.cidr_block, 8, 8)
-	zone_id           = data.alicloud_zones.default.zones.0.id
+	zone_id           = data.alicloud_enhanced_nat_available_zones.enhanced.zones.0.zone_id
 	vswitch_name      = var.name
 }
 
 resource "alicloud_security_group" "default" {
   name   = var.name
   vpc_id = alicloud_vpc.default.id
+}
+`, name)
+}
+
+func resourceCSServerlessKubernetesConfigDependenceEncryption(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "%s"
+}
+
+data "alicloud_enhanced_nat_available_zones" "enhanced" {
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+data "alicloud_cs_kubernetes_version" "version-126" {
+  cluster_type       = "Kubernetes"
+  kubernetes_version = "1.26"
+  profile            = "Serverless"
+}
+
+resource "alicloud_vpc" "default" {
+	vpc_name   = var.name
+	cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "default" {
+	vpc_id            = alicloud_vpc.default.id
+	cidr_block        = cidrsubnet(alicloud_vpc.default.cidr_block, 8, 8)
+	zone_id           = data.alicloud_enhanced_nat_available_zones.enhanced.zones.0.zone_id
+	vswitch_name      = var.name
+}
+
+resource "alicloud_security_group" "default" {
+  name   = var.name
+  vpc_id = alicloud_vpc.default.id
+}
+
+data "alicloud_kms_keys" "default" {
+  filters = "[{\"Key\":\"KeyState\",\"Values\":[\"Enabled\"]},{\"Key\":\"KeySpec\",\"Values\":[\"Aliyun_AES_256\"]},{\"Key\":\"KeyUsage\",\"Values\":[\"ENCRYPT/DECRYPT\"]},{\"Key\":\"CreatorType\",\"Values\":[\"User\"]}]"
 }
 `, name)
 }
@@ -468,4 +608,53 @@ var csServerlessKubernetesBasicMap = map[string]string{
 	"new_nat_gateway":                "true",
 	"deletion_protection":            "false",
 	"endpoint_public_access_enabled": "true",
+}
+
+func TestUnitAliCloudCSServerlessKubernetesEncryptionSchema(t *testing.T) {
+	r := resourceAlicloudCSServerlessKubernetes()
+
+	keySchema, ok := r.Schema["encryption_provider_key"]
+	if !ok {
+		t.Fatal("expected schema to contain 'encryption_provider_key'")
+	}
+	if keySchema.Type != schema.TypeString {
+		t.Errorf("encryption_provider_key type = %v, want TypeString", keySchema.Type)
+	}
+	if !keySchema.Optional {
+		t.Error("encryption_provider_key should be Optional")
+	}
+	if keySchema.DiffSuppressFunc == nil {
+		t.Error("encryption_provider_key should set DiffSuppressFunc")
+	}
+
+	disableSchema, ok := r.Schema["disable_encryption"]
+	if !ok {
+		t.Fatal("expected schema to contain 'disable_encryption'")
+	}
+	if disableSchema.Type != schema.TypeBool {
+		t.Errorf("disable_encryption type = %v, want TypeBool", disableSchema.Type)
+	}
+	if !disableSchema.Optional || !disableSchema.Computed {
+		t.Error("disable_encryption should be Optional and Computed")
+	}
+}
+
+func TestUnitAliCloudCSServerlessKubernetesKmsEncryptionDiffSuppress(t *testing.T) {
+	r := resourceAlicloudCSServerlessKubernetes()
+
+	// When disable_encryption is true, a diff on encryption_provider_key is suppressed.
+	dDisabled := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
+		"disable_encryption": true,
+	})
+	if !kmsEncryptionDiffSuppressFunc("encryption_provider_key", "key-old", "", dDisabled) {
+		t.Error("expected diff to be suppressed when disable_encryption=true")
+	}
+
+	// When disable_encryption is false, the diff is not suppressed.
+	dEnabled := schema.TestResourceDataRaw(t, r.Schema, map[string]interface{}{
+		"disable_encryption": false,
+	})
+	if kmsEncryptionDiffSuppressFunc("encryption_provider_key", "", "key-new", dEnabled) {
+		t.Error("expected diff not to be suppressed when disable_encryption=false")
+	}
 }

--- a/website/docs/r/cs_serverless_kubernetes.html.markdown
+++ b/website/docs/r/cs_serverless_kubernetes.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 # alicloud_cs_serverless_kubernetes
 
--> **DEPRECATION NOTICE:** This resource has been deprecated since v1.276.0 and will be removed in a future release. Please use `alicloud_cs_managed_kubernetes` instead.
+-> **DEPRECATED:** This resource has been deprecated since v1.276.0 and will be removed in a future release. Please use `alicloud_cs_managed_kubernetes` instead.
 
 This resource will help you to manager a Serverless Kubernetes Cluster, see [What is serverless kubernetes](https://www.alibabacloud.com/help/en/ack/ack-managed-and-ack-dedicated/developer-reference/create-a-dedicated-kubernetes-cluster-that-supports-sandboxed-containers). The cluster is same as container service created by web console.
 
@@ -109,7 +109,7 @@ The following arguments are supported:
 * `security_group_id` - (Optional, ForceNew, Available since v1.91.0) The ID of the security group to which the ECS instances in the cluster belong. If it is not specified, a new Security group will be built.
 * `resource_group_id` - (Optional, Available since v1.101.0) The ID of the resource group,by default these cloud resources are automatically assigned to the default resource group.
 * `load_balancer_spec` - (Optional, Deprecated since v1.229.1) The cluster api server load balance instance specification, default `slb.s2.small`. For more information on how to select a LB instance specification, see [SLB instance overview](https://help.aliyun.com/document_detail/85931.html). Only works for **Create** Operation. 
-* `addons` - (Optional, Available since v1.91.0) You can specific network plugin, log component, ingress component and so on. See [`addons`](#addons) below. Only works for **Create** Operation, use [resource cs_kubernetes_addon](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cs_kubernetes_addon) to manage addons if cluster is created.
+* `addons` - (Optional, Available since v1.91.0) You can specific network plugin, log component, ingress component and so on. See [`addons`](#addons) below. Only works for **Create** Operation, use [resource cs_kubernetes_addon](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/cs_kubernetes_addon) to manage addons if cluster is created. **Note: The parameter is immutable after resource creation.**
 * `time_zone` - (Optional, Available since v1.123.1) The time zone of the cluster.
 * `zone_id` - (Optional, Available since v1.123.1) When creating a cluster using automatic VPC creation, you need to specify the zone where the VPC is located. Only works for **Create** Operation.  
 * `service_cidr` - (Optional, ForceNew, Available since v1.123.1) CIDR block of the service network. The specified CIDR block cannot overlap with that of the VPC or those of the ACK clusters that are deployed in the VPC. The CIDR block cannot be modified after the cluster is created.
@@ -122,6 +122,10 @@ The following arguments are supported:
     - ack.pro.small: Professional serverless clusters.
 * `custom_san` - (Optional, Available since v1.229.1) Customize the certificate SAN, multiple IP or domain names are separated by English commas (,).
 -> **NOTE:** Make sure you have specified all certificate SANs before updating. Updating this field will lead APIServer to restart.
+* `encryption_provider_key` - (Optional, Available since v1.286.0) The ID of the Key Management Service (KMS) key that is used to encrypt Kubernetes Secrets.
+  -> **Note:** To enable encryption, you must specify both `encryption_provider_key` and `disable_encryption = false`. When `disable_encryption` is set to `true`, changes to `encryption_provider_key` will be ignored.
+* `disable_encryption` - (Optional, Computed, Available since v1.286.0) Whether to disable encryption for Kubernetes Secrets. Default value is `false`. Set to `true` to disable encryption.
+  -> **Note:** When enabling encryption, you must explicitly set `disable_encryption = false` along with `encryption_provider_key`. When disabling encryption, you only need to set `disable_encryption = true`, and the `encryption_provider_key` will be ignored.
 * `maintenance_window` - (Optional, Available since v1.232.0) The cluster maintenance window，effective only in the professional managed cluster. Managed node pool will use it. See [`maintenance_window`](#maintenance_window) below.
 * `operation_policy` - (Optional, Available since v1.232.0) The cluster automatic operation policy. See [`operation_policy`](#operation_policy) below.
 


### PR DESCRIPTION
### Description

Add support for encrypting Kubernetes Secrets with a KMS key on ACK Serverless clusters (`alicloud_cs_serverless_kubernetes`), matching the capability already available on `alicloud_cs_managed_kubernetes`.

Two new arguments:

- `encryption_provider_key` - (Optional) The ID of the KMS key used to encrypt Kubernetes Secrets. Wired into cluster creation (`CreateCluster.EncryptionProviderKey`), read back from cluster capabilities, and updatable via `UpdateKMSEncryption`.
- `disable_encryption` - (Optional, Computed) Whether to disable Secret encryption. When `true`, changes to `encryption_provider_key` are diff-suppressed.

CRUD coverage:

- Create: sets `EncryptionProviderKey` on the create request.
- Read: reads `DisableEncryption` / `EncryptionKMSKeyId` from cluster capabilities and writes them back to state.
- Update: calls `UpdateKMSEncryption` when either attribute changes; waits for the cluster to return to the running state (new `Update` timeout added).

### Test

Added `TestAccAliCloudCSServerlessKubernetes_encryption` (create -> enable encryption -> disable encryption -> reimport) plus unit tests for the schema and the diff-suppress behavior.

Unit tests:

```
=== RUN   TestUnitAliCloudCSServerlessKubernetesEncryptionSchema
--- PASS: TestUnitAliCloudCSServerlessKubernetesEncryptionSchema (0.00s)
=== RUN   TestUnitAliCloudCSServerlessKubernetesKmsEncryptionDiffSuppress
--- PASS: TestUnitAliCloudCSServerlessKubernetesKmsEncryptionDiffSuppress (0.00s)
PASS
ok  	github.com/aliyun/terraform-provider-alicloud/alicloud
```

Remote acceptance test results will be added once completed.
