### PR TITLE
docs: document ALIBABA_CLOUD_SKIP_REGION_VALIDATION / ALICLOUD_SKIP_REGION_VALIDATION support for skip_region_validation

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -24,6 +24,29 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
+// skipRegionValidationDefaultFunc resolves the default value of
+// skip_region_validation from environment variables when the attribute is not
+// set explicitly in the configuration. ALIBABA_CLOUD_SKIP_REGION_VALIDATION
+// takes precedence over ALICLOUD_SKIP_REGION_VALIDATION, and an unset (or empty)
+// environment defaults to false. An invalid boolean value is reported as an
+// error rather than silently falling back to the default.
+func skipRegionValidationDefaultFunc() schema.SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		for _, key := range []string{"ALIBABA_CLOUD_SKIP_REGION_VALIDATION", "ALICLOUD_SKIP_REGION_VALIDATION"} {
+			v := os.Getenv(key)
+			if v == "" {
+				continue
+			}
+			parsed, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid boolean value %q for environment variable %s: %w", v, key, err)
+			}
+			return parsed, nil
+		}
+		return false, nil
+	}
+}
+
 // Provider returns a schema.Provider for alicloud
 func Provider() terraform.ResourceProvider {
 	provider := &schema.Provider{
@@ -109,7 +132,7 @@ func Provider() terraform.ResourceProvider {
 			"skip_region_validation": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				DefaultFunc: skipRegionValidationDefaultFunc(),
 				Description: descriptions["skip_region_validation"],
 			},
 			"configuration_source": {
@@ -2537,7 +2560,7 @@ func init() {
 
 		"assume_role_session_expiration": "The time after which the established session for assuming role expires. Valid value range: [900-3600] seconds. Default to 0 (in this case Alicloud use own default value).",
 
-		"skip_region_validation": "Skip static validation of region ID. Used by users of alternative AlibabaCloud-like APIs or users w/ access to regions that are not public (yet).",
+		"skip_region_validation": "Skip static validation of region ID. Used by users of alternative AlibabaCloud-like APIs or users w/ access to regions that are not public (yet). It can also be sourced from the `ALIBABA_CLOUD_SKIP_REGION_VALIDATION` (preferred) or `ALICLOUD_SKIP_REGION_VALIDATION` environment variable; an explicit value in the configuration takes precedence over the environment.",
 
 		"configuration_source": "Use this to mark a terraform configuration file source.",
 

--- a/alicloud/provider_skip_region_validation_test.go
+++ b/alicloud/provider_skip_region_validation_test.go
@@ -1,0 +1,66 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// skipRegionValidationTestSchema returns a single-field schema map containing
+// only the provider-level skip_region_validation attribute, so the SDK diff
+// machinery (which applies DefaultFunc) can be exercised in isolation.
+func skipRegionValidationTestSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"skip_region_validation": Provider().(*schema.Provider).Schema["skip_region_validation"],
+	}
+}
+
+func TestProviderSkipRegionValidation(t *testing.T) {
+	t.Run("env unset defaults to false", func(t *testing.T) {
+		t.Setenv("ALIBABA_CLOUD_SKIP_REGION_VALIDATION", "")
+		t.Setenv("ALICLOUD_SKIP_REGION_VALIDATION", "")
+		d := schema.TestResourceDataRaw(t, skipRegionValidationTestSchema(), map[string]interface{}{})
+		if got := d.Get("skip_region_validation").(bool); got != false {
+			t.Fatalf("expected false when no env is set, got %v", got)
+		}
+	})
+
+	t.Run("ALICLOUD env true enables skip", func(t *testing.T) {
+		t.Setenv("ALIBABA_CLOUD_SKIP_REGION_VALIDATION", "")
+		t.Setenv("ALICLOUD_SKIP_REGION_VALIDATION", "true")
+		d := schema.TestResourceDataRaw(t, skipRegionValidationTestSchema(), map[string]interface{}{})
+		if got := d.Get("skip_region_validation").(bool); got != true {
+			t.Fatalf("expected true from ALICLOUD_SKIP_REGION_VALIDATION, got %v", got)
+		}
+	})
+
+	t.Run("ALIBABA_CLOUD takes priority over ALICLOUD", func(t *testing.T) {
+		t.Setenv("ALIBABA_CLOUD_SKIP_REGION_VALIDATION", "true")
+		t.Setenv("ALICLOUD_SKIP_REGION_VALIDATION", "false")
+		d := schema.TestResourceDataRaw(t, skipRegionValidationTestSchema(), map[string]interface{}{})
+		if got := d.Get("skip_region_validation").(bool); got != true {
+			t.Fatalf("expected ALIBABA_CLOUD_SKIP_REGION_VALIDATION to win (true), got %v", got)
+		}
+	})
+
+	t.Run("explicit config value overrides env", func(t *testing.T) {
+		t.Setenv("ALIBABA_CLOUD_SKIP_REGION_VALIDATION", "true")
+		t.Setenv("ALICLOUD_SKIP_REGION_VALIDATION", "true")
+		d := schema.TestResourceDataRaw(t, skipRegionValidationTestSchema(), map[string]interface{}{"skip_region_validation": false})
+		if got := d.Get("skip_region_validation").(bool); got != false {
+			t.Fatalf("expected explicit config value false to override env, got %v", got)
+		}
+	})
+
+	t.Run("invalid boolean env value returns an error", func(t *testing.T) {
+		t.Setenv("ALIBABA_CLOUD_SKIP_REGION_VALIDATION", "")
+		t.Setenv("ALICLOUD_SKIP_REGION_VALIDATION", "notabool")
+		defaultFunc := Provider().(*schema.Provider).Schema["skip_region_validation"].DefaultFunc
+		if defaultFunc == nil {
+			t.Fatal("expected skip_region_validation to declare a DefaultFunc")
+		}
+		if _, err := defaultFunc(); err == nil {
+			t.Fatal("expected an error for an invalid boolean env value, got nil")
+		}
+	})
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -349,7 +349,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 
 * `sign_version` - (Optional, Available since v1.215.0) A [`sign_version`](#sign_version) block to specify the signature version used for the API requests of certain cloud products (currently `oss` and `sls`). Only one `sign_version` block may be in the configuration.
 
-* `skip_region_validation` - (Optional, Available since v1.52.0) Skip static validation of region ID. Used by users of alternative AlibabaCloud-like APIs or users w/ access to regions that are not public (yet).
+* `skip_region_validation` - (Optional, Available since v1.52.0) Skip static validation of region ID. Used by users of alternative AlibabaCloud-like APIs or users w/ access to regions that are not public (yet). It can also be sourced from the `ALIBABA_CLOUD_SKIP_REGION_VALIDATION` (preferred) or `ALICLOUD_SKIP_REGION_VALIDATION` environment variable. An explicit value in the configuration takes precedence over the environment variable.
 
 * `configuration_source` - (Optional, Available since v1.56.0) Use a string to mark a configuration file source, like `terraform-alicloud-modules/terraform-alicloud-ecs-instance` or `terraform-provider-alicloud/examples/vpc`.
 The length should not more than 1024(Before 1.283.0, it should not more than 128. Before 1.207.2, it should not more than 64). Since the version 1.145.0, it supports to be set by environment variable `TF_APPEND_USER_AGENT`. See `Custom User-Agent Information`.


### PR DESCRIPTION
### Summary

`skip_region_validation` can currently only be set through the provider configuration block. This change lets it also be sourced from an environment variable, consistent with how other provider-level attributes (`region`, `access_key`, `profile`, etc.) already support environment-based configuration.

### Behavior

A `DefaultFunc` now resolves the value in this order:

1. `ALIBABA_CLOUD_SKIP_REGION_VALIDATION` (preferred)
2. `ALICLOUD_SKIP_REGION_VALIDATION`
3. `false` when neither is set

Additional guarantees:

- An explicit value in the provider configuration always takes precedence over the environment variable.
- An invalid boolean value (not parseable by `strconv.ParseBool`) returns an error instead of being silently ignored.

### Tests

```
=== RUN   TestProviderSkipRegionValidation
=== RUN   TestProviderSkipRegionValidation/env_unset_defaults_to_false
=== RUN   TestProviderSkipRegionValidation/ALICLOUD_env_true_enables_skip
=== RUN   TestProviderSkipRegionValidation/ALIBABA_CLOUD_takes_priority_over_ALICLOUD
=== RUN   TestProviderSkipRegionValidation/explicit_config_value_overrides_env
=== RUN   TestProviderSkipRegionValidation/invalid_boolean_env_value_returns_an_error
--- PASS: TestProviderSkipRegionValidation (0.05s)
    --- PASS: TestProviderSkipRegionValidation/env_unset_defaults_to_false (0.02s)
    --- PASS: TestProviderSkipRegionValidation/ALICLOUD_env_true_enables_skip (0.01s)
    --- PASS: TestProviderSkipRegionValidation/ALIBABA_CLOUD_takes_priority_over_ALICLOUD (0.01s)
    --- PASS: TestProviderSkipRegionValidation/explicit_config_value_overrides_env (0.01s)
    --- PASS: TestProviderSkipRegionValidation/invalid_boolean_env_value_returns_an_error (0.01s)
PASS
ok  	github.com/aliyun/terraform-provider-alicloud/alicloud	4.571s
```

The provider documentation (`website/docs/index.html.markdown`) is updated to describe the new environment variables.