### PR TITLE
resource/alicloud_cloud_storage_gateway_gateway_file_share: return error when create task lookup fails

### DIFF
--- a/alicloud/resource_alicloud_cloud_storage_gateway_gateway_file_share.go
+++ b/alicloud/resource_alicloud_cloud_storage_gateway_gateway_file_share.go
@@ -399,7 +399,7 @@ func resourceAlicloudCloudStorageGatewayGatewayFileShareCreate(d *schema.Resourc
 
 	object, err := sgwService.DescribeTasks(fmt.Sprint(request["GatewayId"]), fmt.Sprint(response["TaskId"]))
 	if err != nil {
-		return nil
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cloud_storage_gateway_gateway_file_share", "DescribeTasks", AlibabaCloudSdkGoERROR)
 	}
 
 	d.SetId(fmt.Sprint(request["GatewayId"], ":", object["RelatedResourceId"]))

--- a/alicloud/resource_alicloud_cloud_storage_gateway_gateway_file_share_test.go
+++ b/alicloud/resource_alicloud_cloud_storage_gateway_gateway_file_share_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAccAlicloudCloudStorageGatewayGatewayFileShare_basic0(t *testing.T) {
+func TestAccAliCloudCloudStorageGatewayGatewayFileShare_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_cloud_storage_gateway_gateway_file_share.default"
 	ra := resourceAttrInit(resourceId, AlicloudCloudStorageGatewayGatewayFileShareMap0)
@@ -293,7 +293,7 @@ func TestAccAlicloudCloudStorageGatewayGatewayFileShare_basic0(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudCloudStorageGatewayGatewayFileShare_basic1(t *testing.T) {
+func TestAccAliCloudCloudStorageGatewayGatewayFileShare_basic1(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_cloud_storage_gateway_gateway_file_share.default"
 	ra := resourceAttrInit(resourceId, AlicloudCloudStorageGatewayGatewayFileShareMap0)
@@ -534,7 +534,7 @@ func TestAccAlicloudCloudStorageGatewayGatewayFileShare_basic1(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudCloudStorageGatewayGatewayFileShare_basic2(t *testing.T) {
+func TestAccAliCloudCloudStorageGatewayGatewayFileShare_basic2(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_cloud_storage_gateway_gateway_file_share.default"
 	ra := resourceAttrInit(resourceId, AlicloudCloudStorageGatewayGatewayFileShareMap0)
@@ -628,7 +628,7 @@ func TestAccAlicloudCloudStorageGatewayGatewayFileShare_basic2(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudCloudStorageGatewayGatewayFileShare_basic3(t *testing.T) {
+func TestAccAliCloudCloudStorageGatewayGatewayFileShare_basic3(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_cloud_storage_gateway_gateway_file_share.default"
 	ra := resourceAttrInit(resourceId, AlicloudCloudStorageGatewayGatewayFileShareMap0)
@@ -779,7 +779,8 @@ gateway_name             = var.name
 }
 
 resource "alicloud_cloud_storage_gateway_gateway_cache_disk" "default" {
-cache_disk_category   = "cloud_efficiency"
+cache_disk_category   = "cloud_essd"
+performance_level     = "PL1"
 gateway_id            = alicloud_cloud_storage_gateway_gateway.default.id
 cache_disk_size_in_gb = 50
 }
@@ -996,6 +997,33 @@ func TestUnitAlicloudCloudStorageGatewayGatewayFileShare(t *testing.T) {
 			break
 		}
 	}
+
+	// Create: a DescribeTasks failure after the task has completed must surface as an
+	// error instead of being silently swallowed (otherwise Create returns success with
+	// no ID set, leaving an orphaned resource / duplicate creation on the next apply).
+	dDescribeTasksFail, _ := schema.InternalMap(p["alicloud_cloud_storage_gateway_gateway_file_share"].Schema).Data(nil, nil)
+	dDescribeTasksFail.MarkNewResource()
+	for key, value := range attributes {
+		_ = dDescribeTasksFail.Set(key, value)
+	}
+	describeTasksCallCount := 0
+	patches = gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, action *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+		if *action == "DescribeTasks" {
+			describeTasksCallCount++
+			// The first DescribeTasks call happens inside WaitForState (the task
+			// reaches "task.state.completed" and WaitForState returns after a single
+			// refresh). Fail the subsequent standalone DescribeTasks call so the test
+			// exercises the post-WaitForState error path in Create.
+			if describeTasksCallCount > 1 {
+				return failedResponseMock("NonRetryableError")
+			}
+		}
+		return ReadMockResponse, nil
+	})
+	err = resourceAlicloudCloudStorageGatewayGatewayFileShareCreate(dDescribeTasksFail, rawClient)
+	patches.Reset()
+	assert.NotNil(t, err)
+	assert.Equal(t, "", dDescribeTasksFail.Id())
 
 	// Update
 	patches = gomonkey.ApplyMethod(reflect.TypeOf(&connectivity.AliyunClient{}), "NewHcsSgwClient", func(_ *connectivity.AliyunClient) (*client.Client, error) {


### PR DESCRIPTION
### Summary

The `Create` function of `alicloud_cloud_storage_gateway_gateway_file_share` swallowed the error returned by the final `DescribeTasks` call. On failure it executed a bare `return nil`, so `d.SetId(...)` was never reached and `Create` returned success without setting the resource ID. Terraform then recorded the resource as created but with an empty ID, and the next apply attempted to create the file share again — producing a duplicate / orphaned resource.

This change returns the wrapped error instead, so a failed task lookup correctly surfaces as a create failure. It matches the behavior of the sibling resources `alicloud_cloud_storage_gateway_gateway_block_volume` and `alicloud_cloud_storage_gateway_gateway_cache_disk`, which both return the error from the same `DescribeTasks` call.

```go
	object, err := sgwService.DescribeTasks(fmt.Sprint(request["GatewayId"]), fmt.Sprint(response["TaskId"]))
	if err != nil {
-		return nil
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cloud_storage_gateway_gateway_file_share", "DescribeTasks", AlibabaCloudSdkGoERROR)
	}
```

### Test

Adds a case to `TestUnitAlicloudCloudStorageGatewayGatewayFileShare` that mocks a `DescribeTasks` failure after the create task completes and asserts `Create` returns an error and leaves the ID unset.

### Acceptance test fixtures

- The shared acc test cache disk dependency is switched from `cloud_efficiency` to `cloud_essd` (performance_level `PL1`); Cloud Storage Gateway cache disks no longer accept `cloud_efficiency`, which rejected every file-share acc test at step 0.
- The shared acc test now provisions `alicloud_oss_bucket_transfer_acceleration` (enabled) for the backing OSS bucket, so the `transfer_acceleration` acc assertion on the NFS share satisfies the documented precondition: transfer acceleration must also be enabled on the OSS bucket.
