### PR TITLE
resource/alicloud_db_instance: support force_delete for Prepaid instances

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -538,6 +538,13 @@ func resourceAliCloudDBInstance() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: StringInSlice([]string{"None", "Lastest", "All"}, false),
 			},
+			"force_delete": {
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          false,
+				Description:      "A behavior mark used to delete 'Prepaid' RDS instance forcibly.",
+				DiffSuppressFunc: PostPaidDiffSuppressFunc,
+			},
 			"fresh_white_list_readins": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -2534,8 +2541,40 @@ func resourceAliCloudDBInstanceDelete(d *schema.ResourceData, meta interface{}) 
 		return WrapError(err)
 	}
 	if PayType(instance["PayType"].(string)) == Prepaid {
-		log.Printf("[WARN] Cannot destroy Subscription resource: alicloud_db_instance. Terraform will remove this resource from the state file, however resources may remain.")
-		return nil
+		if !d.Get("force_delete").(bool) {
+			log.Printf("[WARN] Cannot destroy Subscription resource: alicloud_db_instance. Terraform will remove this resource from the state file, however resources may remain.")
+			return nil
+		}
+		// force_delete: transform the 'Prepaid' instance to 'Postpaid' before releasing it,
+		// consistent with the force_delete behavior of alicloud_instance.
+		transformAction := "TransformDBInstancePayType"
+		transformRequest := map[string]interface{}{
+			"RegionId":     client.RegionId,
+			"DBInstanceId": d.Id(),
+			"PayType":      Postpaid,
+			"SourceIp":     client.SourceIp,
+		}
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+			response, err := client.RpcPost("Rds", "2014-08-15", transformAction, nil, transformRequest, false)
+			if err != nil {
+				if NeedRetry(err) || IsExpectedErrors(err, []string{"OperationDenied.DBInstanceStatus", "OperationDenied.ReadDBInstanceStatus", "IncorrectDBInstanceState"}) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(transformAction, response, transformRequest)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), transformAction, AlibabaCloudSdkGoERROR)
+		}
+		// wait until the charge type has converged to 'Postpaid' and the instance is running again
+		stateConf := BuildStateConf([]string{}, []string{"Running"}, d.Timeout(schema.TimeoutDelete), 5*time.Second, rdsService.RdsDBInstanceStateRefreshFunc(d.Id(), []string{"Deleting"}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
 	}
 	action := "DeleteDBInstance"
 	request := map[string]interface{}{

--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -4754,3 +4754,97 @@ func TestUnitParseDBInstanceParamGroupId(t *testing.T) {
 		})
 	}
 }
+
+// TestAccAliCloudRdsDBInstance_Mysql_ForceDelete verifies that a 'Prepaid' (Subscription)
+// RDS instance created with force_delete = true is converted to 'Postpaid' and then really
+// released on destroy (CheckDestroy asserts the instance no longer exists on the cloud).
+func TestAccAliCloudRdsDBInstance_Mysql_ForceDelete(t *testing.T) {
+	var instance map[string]interface{}
+
+	resourceId := "alicloud_db_instance.default"
+	ra := resourceAttrInit(resourceId, instanceBasicMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &instance, func() interface{} {
+		return &RdsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeDBInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAccDBInstanceForceDelete%d", rand.Intn(1000))
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceDBInstanceConfigDependencePrePaid)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"engine":                   "MySQL",
+					"engine_version":           "8.0",
+					"instance_type":            "mysql.n1e.small.1",
+					"instance_storage":         "20",
+					"instance_charge_type":     "Prepaid",
+					"period":                   "1",
+					"force_delete":             "true",
+					"instance_name":            "${var.name}",
+					"vswitch_id":               "${local.vswitch_id}",
+					"db_instance_storage_type": "cloud_essd",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"engine":               "MySQL",
+						"engine_version":       "8.0",
+						"instance_charge_type": "Prepaid",
+						"force_delete":         "true",
+						"instance_name":        name,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func resourceDBInstanceConfigDependencePrePaid(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "%s"
+}
+data "alicloud_db_zones" "default"{
+	engine = "MySQL"
+	engine_version = "8.0"
+	instance_charge_type = "PrePaid"
+	category = "Basic"
+	db_instance_storage_type = "cloud_essd"
+}
+
+data "alicloud_db_instance_classes" "default" {
+	zone_id = data.alicloud_db_zones.default.zones.0.id
+	engine = "MySQL"
+	engine_version = "8.0"
+	category = "Basic"
+	db_instance_storage_type = "cloud_essd"
+	instance_charge_type = "PrePaid"
+}
+
+data "alicloud_vpcs" "default" {
+	name_regex = "^default-NODELETING$"
+}
+data "alicloud_vswitches" "default" {
+	vpc_id = data.alicloud_vpcs.default.ids.0
+	zone_id = data.alicloud_db_zones.default.zones.0.id
+}
+
+resource "alicloud_vswitch" "this" {
+	count = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
+	vswitch_name = var.name
+	vpc_id = data.alicloud_vpcs.default.ids.0
+	zone_id = data.alicloud_db_zones.default.ids.0
+	cidr_block = cidrsubnet(data.alicloud_vpcs.default.vpcs.0.cidr_block, 8, 4)
+}
+locals {
+	vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids.0 : concat(alicloud_vswitch.this.*.id, [""])[0]
+}
+`, name)
+}

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -780,6 +780,10 @@ The following arguments are supported:
   - All: All the archived backup files are retained.
 
 -> **NOTE:** This parameter is supported only when the instance runs the MySQL database engine.
+* `force_delete` - (Optional, Available since v1.287.0) A behavior mark used to delete a `Prepaid` (Subscription) instance forcibly. Defaults to `false`. When set to `true`, deleting the resource will first convert the `Prepaid` instance to `Postpaid` (Pay-As-You-Go) and then release it.
+
+-> **NOTE:** Setting `force_delete` to `true` on a `Prepaid` instance triggers a subscription-to-pay-as-you-go conversion followed by a real release on destroy. This has financial consequences (refund/settlement of the subscription) and permanently removes the instance and its data. Use with caution.
+
 * `storage_auto_scale` - (Optional, Available since v1.129.0)Automatic storage space expansion switch. Valid values:
   - Enable
   - Disable


### PR DESCRIPTION
### Summary

Add a `force_delete` argument to `alicloud_db_instance`, consistent with the existing `force_delete` behavior of `alicloud_instance`.

By default a `Prepaid` (Subscription) RDS instance cannot be released; the provider only removes it from state and leaves the instance on the cloud. When `force_delete = true`, destroying the resource first converts the `Prepaid` instance to `Postpaid` (Pay-As-You-Go) via `TransformDBInstancePayType`, waits for the instance to converge back to `Running`, and then performs a real `DeleteDBInstance`.

### Behavior

- New schema field `force_delete` (bool, optional, default `false`).
- `DiffSuppressFunc: PostPaidDiffSuppressFunc` — no plan diff; the field only affects the delete lifecycle.
- Delete flow:
  - `Postpaid` instance: unchanged.
  - `Prepaid` instance + `force_delete = false`: unchanged (soft removal from state, as before).
  - `Prepaid` instance + `force_delete = true`: convert to `Postpaid`, wait for `Running`, then release.

### Documentation

`website/docs/r/db_instance.html.markdown` documents the new argument and calls out the financial/data consequences of forcibly releasing a subscription instance.

### Test

Added `TestAccAliCloudRdsDBInstance_Mysql_ForceDelete`: creates a `Prepaid` MySQL instance with `force_delete = true` and relies on `CheckDestroy` to assert the instance is actually released on destroy.