### PR TITLE
New Resource: alicloud_apig_ai_model_provider; New Data Source: alicloud_apig_ai_model_providers

### DIFF
--- a/alicloud/data_source_alicloud_apig_ai_model_providers.go
+++ b/alicloud/data_source_alicloud_apig_ai_model_providers.go
@@ -1,0 +1,249 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudApigAiModelProviders() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudApigAiModelProviderRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"providers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"display_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"model_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"model_provider": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"model_provider_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"bound_services": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"express_type":       {Type: schema.TypeString, Computed: true},
+									"group_name":         {Type: schema.TypeString, Computed: true},
+									"name":               {Type: schema.TypeString, Computed: true},
+									"namespace":          {Type: schema.TypeString, Computed: true},
+									"pai_workspace_id":   {Type: schema.TypeString, Computed: true},
+									"pai_workspace_name": {Type: schema.TypeString, Computed: true},
+									"qualifier":          {Type: schema.TypeString, Computed: true},
+									"service_id":         {Type: schema.TypeString, Computed: true},
+									"source_type":        {Type: schema.TypeString, Computed: true},
+									"status":             {Type: schema.TypeString, Computed: true},
+								},
+							},
+						},
+						"model_cards": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"gateway_id":     {Type: schema.TypeString, Computed: true},
+									"model_card_id":  {Type: schema.TypeString, Computed: true},
+									"model_name":     {Type: schema.TypeString, Computed: true},
+									"model_provider": {Type: schema.TypeString, Computed: true},
+									"source":         {Type: schema.TypeString, Computed: true},
+									"update_time":    {Type: schema.TypeString, Computed: true},
+								},
+							},
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudApigAiModelProviderRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListAiModelProviders
+	action := fmt.Sprintf("/v1/ai-model-providers")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	if v, ok := d.GetOk("gateway_id"); ok {
+		query["gatewayId"] = StringPointer(v.(string))
+	}
+
+	query["pageSize"] = StringPointer(strconv.Itoa(PageSizeLarge))
+	query["pageNumber"] = StringPointer("1")
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaGet("APIG", "2024-03-27", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.data.items[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["modelProviderId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		pageNum, _ := strconv.Atoi(*query["pageNumber"])
+		query["pageNumber"] = StringPointer(strconv.Itoa(pageNum + 1))
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["modelProviderId"]
+
+		mapping["model_count"] = objectRaw["modelCount"]
+		mapping["source"] = objectRaw["source"]
+		mapping["update_time"] = objectRaw["updateTime"]
+		mapping["display_name"] = objectRaw["displayName"]
+		mapping["gateway_id"] = objectRaw["gatewayId"]
+		mapping["model_provider"] = objectRaw["provider"]
+		mapping["model_provider_id"] = objectRaw["modelProviderId"]
+
+		boundServicesRaw := objectRaw["boundServices"]
+		boundServicesMaps := make([]map[string]interface{}, 0)
+		if boundServicesRaw != nil {
+			for _, boundServicesChildRaw := range convertToInterfaceArray(boundServicesRaw) {
+				boundServicesMap := make(map[string]interface{})
+				boundServicesChildRaw := boundServicesChildRaw.(map[string]interface{})
+				boundServicesMap["express_type"] = boundServicesChildRaw["expressType"]
+				boundServicesMap["group_name"] = boundServicesChildRaw["groupName"]
+				boundServicesMap["name"] = boundServicesChildRaw["name"]
+				boundServicesMap["namespace"] = boundServicesChildRaw["namespace"]
+				boundServicesMap["pai_workspace_id"] = boundServicesChildRaw["paiWorkspaceId"]
+				boundServicesMap["pai_workspace_name"] = boundServicesChildRaw["paiWorkspaceName"]
+				boundServicesMap["qualifier"] = boundServicesChildRaw["qualifier"]
+				boundServicesMap["service_id"] = boundServicesChildRaw["serviceId"]
+				boundServicesMap["source_type"] = boundServicesChildRaw["sourceType"]
+				boundServicesMap["status"] = boundServicesChildRaw["status"]
+
+				boundServicesMaps = append(boundServicesMaps, boundServicesMap)
+			}
+		}
+		mapping["bound_services"] = boundServicesMaps
+		modelCardsRaw := objectRaw["modelCards"]
+		modelCardsMaps := make([]map[string]interface{}, 0)
+		if modelCardsRaw != nil {
+			for _, modelCardsChildRaw := range convertToInterfaceArray(modelCardsRaw) {
+				modelCardsMap := make(map[string]interface{})
+				modelCardsChildRaw := modelCardsChildRaw.(map[string]interface{})
+				modelCardsMap["gateway_id"] = modelCardsChildRaw["gatewayId"]
+				modelCardsMap["model_card_id"] = modelCardsChildRaw["modelCardId"]
+				modelCardsMap["model_name"] = modelCardsChildRaw["modelName"]
+				modelCardsMap["model_provider"] = modelCardsChildRaw["modelProvider"]
+				modelCardsMap["source"] = modelCardsChildRaw["source"]
+				modelCardsMap["update_time"] = modelCardsChildRaw["updateTime"]
+
+				modelCardsMaps = append(modelCardsMaps, modelCardsMap)
+			}
+		}
+		mapping["model_cards"] = modelCardsMaps
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("providers", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_apig_ai_model_providers_test.go
+++ b/alicloud/data_source_alicloud_apig_ai_model_providers_test.go
@@ -1,0 +1,74 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudApigAiModelProvidersDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(10000, 99999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudApigAiModelProvidersSourceConfig(rand, map[string]string{
+			"gateway_id": `"${alicloud_apig_ai_model_provider.default.gateway_id}"`,
+			"ids":        `["${alicloud_apig_ai_model_provider.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAliCloudApigAiModelProvidersSourceConfig(rand, map[string]string{
+			"gateway_id": `"${alicloud_apig_ai_model_provider.default.gateway_id}"`,
+			"ids":        `["${alicloud_apig_ai_model_provider.default.id}_fake"]`,
+		}),
+	}
+
+	ApigAiModelProvidersCheckInfo.dataSourceTestCheck(t, rand, idsConf)
+}
+
+var existApigAiModelProvidersMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"ids.#":                          "1",
+		"providers.#":                    "1",
+		"providers.0.id":                 CHECKSET,
+		"providers.0.model_provider_id":  CHECKSET,
+		"providers.0.gateway_id":         CHECKSET,
+		"providers.0.model_provider":     "openai",
+		"providers.0.display_name":       fmt.Sprintf("tfaccapigaimp%d", rand),
+		"providers.0.source":             CHECKSET,
+		"providers.0.update_time":        CHECKSET,
+	}
+}
+
+var fakeApigAiModelProvidersMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"ids.#":       "0",
+		"providers.#": "0",
+	}
+}
+
+var ApigAiModelProvidersCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_apig_ai_model_providers.default",
+	existMapFunc: existApigAiModelProvidersMapFunc,
+	fakeMapFunc:  fakeApigAiModelProvidersMapFunc,
+}
+
+func testAccCheckAliCloudApigAiModelProvidersSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	name := fmt.Sprintf("tfaccapigaimp%d", rand)
+	return AlicloudApigAiModelProviderBasicDependence(name) + fmt.Sprintf(`
+resource "alicloud_apig_ai_model_provider" "default" {
+  gateway_id     = alicloud_apig_gateway.default.id
+  model_provider = "openai"
+  display_name   = "%s"
+}
+
+data "alicloud_apig_ai_model_providers" "default" {
+  %s
+}
+`, name, strings.Join(pairs, "\n  "))
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -170,6 +170,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_apig_ai_model_providers":                    dataSourceAliCloudApigAiModelProviders(),
 			"alicloud_apig_services":                              dataSourceAliCloudApigServices(),
 			"alicloud_apig_gateways":                              dataSourceAliCloudApigGateways(),
 			"alicloud_apig_plugins":                               dataSourceAliCloudApigPlugins(),
@@ -943,6 +944,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_apig_ai_model_provider":                               resourceAliCloudApigAiModelProvider(),
 			"alicloud_apig_service":                                         resourceAliCloudApigService(),
 			"alicloud_gpdb_api_key":                                         resourceAliCloudGpdbApiKey(),
 			"alicloud_apig_plugin":                                          resourceAliCloudApigPlugin(),

--- a/alicloud/resource_alicloud_apig_ai_model_provider.go
+++ b/alicloud/resource_alicloud_apig_ai_model_provider.go
@@ -1,0 +1,231 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudApigAiModelProvider() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudApigAiModelProviderCreate,
+		Read:   resourceAliCloudApigAiModelProviderRead,
+		Update: resourceAliCloudApigAiModelProviderUpdate,
+		Delete: resourceAliCloudApigAiModelProviderDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"model_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"model_provider": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"service_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"source": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudApigAiModelProviderCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/v1/ai-model-providers")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["provider"] = d.Get("model_provider")
+	request["gatewayId"] = d.Get("gateway_id")
+	request["displayName"] = d.Get("display_name")
+	if v, ok := d.GetOk("service_ids"); ok {
+		serviceIdsMapsArray := convertToInterfaceArray(v)
+
+		request["serviceIds"] = serviceIdsMapsArray
+	}
+
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("APIG", "2024-03-27", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_apig_ai_model_provider", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.data.modelProviderId", response)
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudApigAiModelProviderRead(d, meta)
+}
+
+func resourceAliCloudApigAiModelProviderRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	apigServiceV2 := ApigServiceV2{client}
+
+	objectRaw, err := apigServiceV2.DescribeApigAiModelProvider(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_apig_ai_model_provider DescribeApigAiModelProvider Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("model_count", objectRaw["modelCount"])
+	d.Set("source", objectRaw["source"])
+	d.Set("update_time", objectRaw["updateTime"])
+	d.Set("display_name", objectRaw["displayName"])
+	d.Set("gateway_id", objectRaw["gatewayId"])
+	d.Set("model_provider", objectRaw["provider"])
+
+	serviceIds := make([]string, 0)
+	if boundServicesRaw, ok := objectRaw["boundServices"].([]interface{}); ok {
+		for _, item := range boundServicesRaw {
+			if svc, ok := item.(map[string]interface{}); ok {
+				if id, ok := svc["serviceId"].(string); ok && id != "" {
+					serviceIds = append(serviceIds, id)
+				}
+			}
+		}
+	}
+	d.Set("service_ids", serviceIds)
+
+	return nil
+}
+
+func resourceAliCloudApigAiModelProviderUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var body map[string]interface{}
+	update := false
+
+	var err error
+	modelProviderId := d.Id()
+	action := fmt.Sprintf("/v1/ai-model-providers/%s", modelProviderId)
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+
+	request["displayName"] = d.Get("display_name")
+	if d.HasChange("display_name") {
+		update = true
+	}
+	if d.HasChange("service_ids") {
+		update = true
+		if v, ok := d.GetOk("service_ids"); ok || d.HasChange("service_ids") {
+			serviceIdsMapsArray := convertToInterfaceArray(v)
+
+			request["serviceIds"] = serviceIdsMapsArray
+		}
+	}
+
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPut("APIG", "2024-03-27", action, query, nil, body, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudApigAiModelProviderRead(d, meta)
+}
+
+func resourceAliCloudApigAiModelProviderDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	modelProviderId := d.Id()
+	action := fmt.Sprintf("/v1/ai-model-providers/%s", modelProviderId)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("APIG", "2024-03-27", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_apig_ai_model_provider_test.go
+++ b/alicloud/resource_alicloud_apig_ai_model_provider_test.go
@@ -1,0 +1,137 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Apig AiModelProvider. >>> Resource test cases, hand-written.
+func TestAccAliCloudApigAiModelProvider_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_apig_ai_model_provider.default"
+	ra := resourceAttrInit(resourceId, AlicloudApigAiModelProviderMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ApigServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeApigAiModelProvider")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccapigaimp%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudApigAiModelProviderBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"gateway_id":     "${alicloud_apig_gateway.default.id}",
+					"model_provider": "openai",
+					"display_name":   name,
+					"service_ids":    []string{},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"gateway_id":     CHECKSET,
+						"model_provider": "openai",
+						"display_name":   name,
+						"service_ids.#":  "0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"display_name": name + "_update",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"display_name": name + "_update",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"service_ids"},
+			},
+		},
+	})
+}
+
+var AlicloudApigAiModelProviderMap = map[string]string{
+	"model_count": CHECKSET,
+	"source":      CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudApigAiModelProviderBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "j" {
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+  zone_id = "cn-hangzhou-j"
+}
+
+data "alicloud_vswitches" "k" {
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+  zone_id = "cn-hangzhou-k"
+}
+
+# AI gateway auto-creates a security group whose cleanup lags gateway Delete;
+# using the shared NODELETING VPC avoids the framework attempting to delete
+# the VPC and hitting DependencyViolation.SecurityGroup during test teardown.
+resource "alicloud_apig_gateway" "default" {
+  gateway_name = var.name
+  spec         = "aigw.small.x1"
+  gateway_type = "AI"
+  payment_type = "PayAsYouGo"
+  vpc {
+    vpc_id = data.alicloud_vpcs.default.ids.0
+  }
+  network_access_config {
+    type = "Intranet"
+  }
+  zone_config {
+    select_option = "Manual"
+  }
+  vswitch {
+    vswitch_id = data.alicloud_vswitches.j.ids.0
+  }
+  log_config {
+    sls {
+      enable = false
+    }
+  }
+  zones {
+    vswitch_id = data.alicloud_vswitches.j.ids.0
+    zone_id    = "cn-hangzhou-j"
+  }
+  zones {
+    vswitch_id = data.alicloud_vswitches.k.ids.0
+    zone_id    = "cn-hangzhou-k"
+  }
+  resource_group_id = data.alicloud_resource_manager_resource_groups.default.ids.0
+}
+
+`, name)
+}
+
+// Test Apig AiModelProvider. <<< Resource test cases, hand-written.

--- a/alicloud/service_alicloud_apig_v2.go
+++ b/alicloud/service_alicloud_apig_v2.go
@@ -906,3 +906,79 @@ func (s *ApigServiceV2) ApigRouteStateRefreshFunc(id string, field string, failS
 }
 
 // DescribeApigRoute >>> Encapsulated.
+
+// DescribeApigAiModelProvider <<< Encapsulated get interface for Apig AiModelProvider.
+
+func (s *ApigServiceV2) DescribeApigAiModelProvider(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	modelProviderId := id
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	action := fmt.Sprintf("/v1/ai-model-providers/%s", modelProviderId)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RoaGet("APIG", "2024-03-27", action, query, nil, nil)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if response == nil {
+		return object, WrapErrorf(NotFoundErr("AiModelProvider", id), NotFoundMsg, response)
+	}
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.data", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.data", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *ApigServiceV2) ApigAiModelProviderStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ApigAiModelProviderStateRefreshFuncWithApi(id, field, failStates, s.DescribeApigAiModelProvider)
+}
+
+func (s *ApigServiceV2) ApigAiModelProviderStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeApigAiModelProvider >>> Encapsulated.

--- a/website/docs/d/apig_ai_model_providers.html.markdown
+++ b/website/docs/d/apig_ai_model_providers.html.markdown
@@ -1,0 +1,71 @@
+---
+subcategory: "Cloud Native API Gateway (APIG)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_apig_ai_model_providers"
+sidebar_current: "docs-alicloud-datasource-apig-ai-model-providers"
+description: |-
+  Provides a list of Apig Ai Model Provider owned by an Alibaba Cloud account.
+---
+
+# alicloud_apig_ai_model_providers
+
+This data source provides Apig Ai Model Provider available to the user.[What is Ai Model Provider](https://next.api.alibabacloud.com/document/APIG/2024-03-27/CreateAiModelProvider)
+
+-> **NOTE:** Available since v1.286.0.
+
+## Example Usage
+
+```terraform
+variable "gateway_id" {
+  description = "The ID of an existing AI-type APIG gateway"
+  type        = string
+}
+
+data "alicloud_apig_ai_model_providers" "default" {
+  gateway_id = var.gateway_id
+}
+
+output "first_provider_id" {
+  value = data.alicloud_apig_ai_model_providers.default.providers[0].model_provider_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `gateway_id` - (Required, ForceNew) The ID of the AI gateway instance. The target instance must exist, belong to the current account, and be of the AI gateway type.
+* `ids` - (Optional, Computed) A list of Ai Model Provider IDs. 
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Ai Model Provider IDs.
+* `providers` - A list of Ai Model Provider Entries. Each element contains the following attributes:
+    * `display_name` - Model supplier presentation name.
+    * `gateway_id` - The ID of the AI gateway instance.
+    * `model_count` - The number of model cards currently associated with the model supplier.
+    * `model_provider` - Stable model vendor ID, no more than 128 characters in length.
+    * `model_provider_id` - The first ID of the resource.
+    * `source` - Model supplier source.
+    * `update_time` - The last update time of the model vendor, in the format of yyyy-MM-dd HH:mm:ss.
+    * `id` - The ID of the resource supplied above.
+    * `bound_services` - A list of AI service summaries currently bound to this model vendor. Each element contains the following attributes:
+        * `service_id` - The ID of the AI service.
+        * `name` - The name of the AI service.
+        * `namespace` - The namespace of the AI service.
+        * `source_type` - The source type of the AI service.
+        * `group_name` - The group name of the AI service.
+        * `qualifier` - The qualifier of the AI service.
+        * `express_type` - The express type of the AI service.
+        * `pai_workspace_id` - The PAI workspace ID.
+        * `pai_workspace_name` - The PAI workspace name.
+        * `status` - The status of the AI service.
+    * `model_cards` - A list of model cards currently associated with the model supplier. Each element contains the following attributes:
+        * `model_card_id` - The ID of the model card.
+        * `gateway_id` - The gateway ID of the model card.
+        * `model_provider` - The model provider identifier.
+        * `model_name` - The model name.
+        * `source` - The model source.
+        * `update_time` - The last update time of the model card.

--- a/website/docs/r/apig_ai_model_provider.html.markdown
+++ b/website/docs/r/apig_ai_model_provider.html.markdown
@@ -1,0 +1,79 @@
+---
+subcategory: "Cloud Native API Gateway (APIG)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_apig_ai_model_provider"
+description: |-
+  Provides a Alicloud APIG Ai Model Provider resource.
+---
+
+# alicloud_apig_ai_model_provider
+
+Provides a APIG Ai Model Provider resource.
+
+AI Model Provider.
+
+For information about APIG Ai Model Provider and how to use it, see [What is Ai Model Provider](https://next.api.alibabacloud.com/document/APIG/2024-03-27/CreateAiModelProvider).
+
+-> **NOTE:** Available since v1.286.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+# AiModelProvider must be bound to an existing AI-type APIG gateway.
+# Set the gateway_id variable to your own AI gateway.
+variable "gateway_id" {
+  description = "The ID of an existing AI-type APIG gateway"
+  type        = string
+}
+
+resource "alicloud_apig_ai_model_provider" "default" {
+  gateway_id     = var.gateway_id
+  model_provider = "openai"
+  display_name   = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `display_name` - (Required) Model supplier presentation name. Required, no more than 128 characters in length.
+
+* `gateway_id` - (Required, ForceNew) The ID of the AI gateway instance. The target instance must exist, belong to the current account, and be of the AI gateway type.
+
+* `model_provider` - (Required, ForceNew) Stable model vendor ID, no more than 128 characters in length.
+
+* `service_ids` - (Optional, List) The full collection of AI service IDs to bind to the model vendor. If not passed, existing bindings are retained; if empty array, all bindings are cleared.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+* `model_count` - The number of model cards currently associated with the model supplier.
+* `source` - Model supplier source.
+* `update_time` - The last update time of the model vendor, in the format of yyyy-MM-dd HH:mm:ss.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Ai Model Provider.
+* `delete` - (Defaults to 5 mins) Used when delete the Ai Model Provider.
+* `update` - (Defaults to 5 mins) Used when update the Ai Model Provider.
+
+## Import
+
+APIG Ai Model Provider can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_apig_ai_model_provider.example <model_provider_id>
+```


### PR DESCRIPTION
## Summary
- New `alicloud_apig_ai_model_provider` resource for managing AI model provider bindings on an APIG AI-type gateway.
- New `alicloud_apig_ai_model_providers` data source for listing AI model providers under a gateway.

## Test plan
- [x] `TestAccAliCloudApigAiModelProvider_basic` PASS in cn-hangzhou (291s): create → update display_name → import → destroy.