### PR TITLE
fix(provider): guard SDK v2 unknown-value sentinel in credential config

### DIFF
--- a/alicloud/connectivity/config.go
+++ b/alicloud/connectivity/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
 	credential "github.com/aliyun/credentials-go/credentials"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/errs"
 )
 
 var securityCredURL = "http://100.100.100.200/latest/meta-data/ram/security-credentials/"
@@ -285,7 +286,7 @@ func (c *Config) setAuthByAssumeRole() (err error) {
 	c.Credential = provider
 	credential, err := provider.GetCredential()
 	if err != nil || credential == nil {
-		return fmt.Errorf("refresh Ram Role Arn credential failed. Error: %v", err)
+		return errs.WrapErrorf(err, "refresh Ram Role Arn credential failed")
 	}
 	c.AccessKey, c.SecretKey, c.SecurityToken = *credential.AccessKeyId, *credential.AccessKeySecret, *credential.SecurityToken
 	return nil
@@ -308,7 +309,7 @@ func (c *Config) setAuthCredentialByEcsRoleName() (err error) {
 	c.Credential = provider
 	credential, err := provider.GetCredential()
 	if err != nil || credential == nil {
-		return fmt.Errorf("refresh Ecs Ram Role credential failed. Error: %v", err)
+		return errs.WrapErrorf(err, "refresh Ecs Ram Role credential failed")
 	}
 
 	c.AccessKey, c.SecretKey, c.SecurityToken = *credential.AccessKeyId, *credential.AccessKeySecret, *credential.SecurityToken
@@ -365,7 +366,7 @@ func (c *Config) setAuthCredentialByOidc() (err error) {
 		conf.GlobalParameters = param
 		stsClient, err := sts20150401.NewClient(conf)
 		if err != nil {
-			return fmt.Errorf("refreshing credential failed when building sts client. Error: %v", err)
+			return errs.WrapErrorf(err, "refreshing credential failed when building sts client")
 		}
 
 		request := &sts20150401.AssumeRoleWithOIDCRequest{
@@ -390,7 +391,7 @@ func (c *Config) setAuthCredentialByOidc() (err error) {
 					time.Sleep(time.Duration(i))
 					continue
 				}
-				return fmt.Errorf("refreshing credential failed by AssumeRoleWithOIDC. Error: %v", err)
+				return errs.WrapErrorf(err, "refreshing credential failed by AssumeRoleWithOIDC")
 			}
 			break
 		}
@@ -406,7 +407,7 @@ func (c *Config) setAuthCredentialByOidc() (err error) {
 	c.Credential = provider
 	credential, err := provider.GetCredential()
 	if err != nil || credential == nil {
-		return fmt.Errorf("refresh OIDC credential failed. Error: %v", err)
+		return errs.WrapErrorf(err, "refresh OIDC credential failed")
 	}
 
 	c.AccessKey, c.SecretKey, c.SecurityToken = *credential.AccessKeyId, *credential.AccessKeySecret, *credential.SecurityToken

--- a/alicloud/errs/errors.go
+++ b/alicloud/errs/errors.go
@@ -1,0 +1,82 @@
+// Package errs is reused verbatim from alicloud/errors.go
+// TODO refactor to alicloud.errors, currently is tmp workaround
+package errs
+
+import (
+	"fmt"
+	"log"
+	"runtime"
+	"strings"
+)
+
+const ResourceNotfound = "ResourceNotfound"
+const RequestIdMsg = "RequestId: %s"
+const NotFoundMsg = ResourceNotfound + "!!! %s"
+
+type ComplexError struct {
+	Cause error
+	Err   error
+	Path  string
+	Line  int
+}
+
+func (e ComplexError) Error() string {
+	if e.Cause == nil {
+		e.Cause = Error("<nil cause>")
+	}
+	if e.Err == nil {
+		return fmt.Sprintf("[31m[ERROR][0m %s:%d:\n%s", e.Path, e.Line, e.Cause.Error())
+	}
+	return fmt.Sprintf("[31m[ERROR][0m %s:%d: %s:\n%s", e.Path, e.Line, e.Err.Error(), e.Cause.Error())
+}
+
+func Error(format string, args ...interface{}) error {
+	return fmt.Errorf(format, args...)
+}
+
+// Return a ComplexError which including error occurred file and path
+func WrapError(cause error) error {
+	if cause == nil {
+		return nil
+	}
+	_, filepath, line, ok := runtime.Caller(1)
+	if !ok {
+		log.Printf("[31m[ERROR][0m runtime.Caller error in WrapError.")
+		return WrapComplexError(cause, nil, "", -1)
+	}
+	parts := strings.Split(filepath, "/")
+	if len(parts) > 3 {
+		filepath = strings.Join(parts[len(parts)-3:], "/")
+	}
+	return WrapComplexError(cause, nil, filepath, line)
+}
+
+// Return a ComplexError which including extra error message, error occurred file and path
+func WrapErrorf(cause error, msg string, args ...interface{}) error {
+	if cause == nil && strings.TrimSpace(msg) == "" {
+		return nil
+	}
+	_, filepath, line, ok := runtime.Caller(1)
+	if !ok {
+		log.Printf("[31m[ERROR][0m runtime.Caller error in WrapErrorf.")
+		return WrapComplexError(cause, Error("%s", msg), "", -1)
+	}
+	parts := strings.Split(filepath, "/")
+	if len(parts) > 3 {
+		filepath = strings.Join(parts[len(parts)-3:], "/")
+	}
+	// The second parameter of args is requestId, if the error message is NotFoundMsg the requestId need to be returned.
+	if msg == NotFoundMsg && len(args) == 2 {
+		msg += RequestIdMsg
+	}
+	return WrapComplexError(cause, fmt.Errorf(msg, args...), filepath, line)
+}
+
+func WrapComplexError(cause, err error, filepath string, fileline int) error {
+	return &ComplexError{
+		Cause: cause,
+		Err:   err,
+		Path:  filepath,
+		Line:  fileline,
+	}
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -2122,12 +2122,53 @@ func Provider() *schema.Provider {
 
 var providerConfig map[string]interface{}
 
+// hcl2shimUnknownValue mirrors terraform-plugin-sdk's internal
+// hcl2shim.UnknownVariableValue. Under SDK v2 the shim hands this sentinel string
+// to d.Get/d.GetOk for any provider-config attribute whose value is unknown until
+// apply (for example a role_arn that interpolates an attribute of a resource
+// created in the same apply). The package is internal and cannot be imported, so
+// the constant is mirrored here. Under SDK v1 such attributes read back as empty
+// and eager credential resolution was deferred to apply; forwarding the sentinel
+// into the AssumeRole call instead fails with "Invalid role arn format:74D93920-...".
+// Treating it as unset restores the SDK v1 deferred behavior.
+const hcl2shimUnknownValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
+
+// cfgString reads a string provider-config attribute, treating the SDK v2
+// plan-unknown sentinel (hcl2shimUnknownValue) as "not set". Route any config
+// value that drives an eager configure-time side effect (HTTP/file/credential
+// call) through this so an unknown-until-apply value is deferred to apply rather
+// than fed as a garbage literal. Returns ("", false) when unset or unknown.
+func cfgString(d *schema.ResourceData, key string) (string, bool) {
+	v, ok := d.GetOk(key)
+	if !ok {
+		return "", false
+	}
+	s, _ := v.(string)
+	if s == "" || s == hcl2shimUnknownValue {
+		return "", false
+	}
+	return s, true
+}
+
+// mapString is the map-read counterpart of cfgString for values read out of a
+// schema block/set element (e.g. an assume_role or assume_role_with_oidc map),
+// applying the identical unknown-sentinel handling. Returns ("", false) when the
+// key is absent, empty, or the plan-unknown sentinel. Route every credential
+// string read from such a map through this so no field is left unguarded.
+func mapString(m map[string]interface{}, key string) (string, bool) {
+	s, ok := m[key].(string)
+	if !ok || s == "" || s == hcl2shimUnknownValue {
+		return "", false
+	}
+	return s, true
+}
+
 func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Provider) (interface{}, diag.Diagnostics) {
 	log.Println("using terraform version:", p.TerraformVersion)
 	var getProviderConfig = func(schemaKey string, profileKey string) string {
 		if schemaKey != "" {
-			if v, ok := d.GetOk(schemaKey); ok && v != nil && v.(string) != "" {
-				return v.(string)
+			if v, ok := cfgString(d, schemaKey); ok {
+				return v
 			}
 		}
 		if v, err := getConfigFromProfile(d, profileKey); err == nil && v != nil {
@@ -2147,8 +2188,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	ecsRoleName := getProviderConfig("ecs_role_name", "ram_role_name")
 	var profileName string
 	var credential credentials.Credential
-	if v, ok := d.GetOk("profile"); ok && v != nil {
-		profileName = v.(string)
+	if v, ok := cfgString(d, "profile"); ok {
+		profileName = v
 	}
 
 	// TODO: supports all of profile modes after credentials supporting setting timeout
@@ -2158,8 +2199,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 		(profileMode == "ChainableRamRoleArn" || profileMode == "CloudSSO" ||
 			profileMode == "External" || profileMode == "OAuth") {
 		var profileFile string
-		if v, ok := d.GetOk("shared_credentials_file"); ok && v.(string) != "" {
-			profileFile = absPath(v.(string))
+		if v, ok := cfgString(d, "shared_credentials_file"); ok {
+			profileFile = absPath(v)
 		}
 		provider, err := providers.NewCLIProfileCredentialsProviderBuilder().WithProfileName(profileName).WithProfileFile(profileFile).Build()
 		if err != nil {
@@ -2174,8 +2215,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	}
 
 	if accessKey == "" || secretKey == "" {
-		if v, ok := d.GetOk("credentials_uri"); ok && v.(string) != "" {
-			credentialsURIResp, err := getClientByCredentialsURI(v.(string))
+		if v, ok := cfgString(d, "credentials_uri"); ok {
+			credentialsURIResp, err := getClientByCredentialsURI(v)
 			if err != nil {
 				return nil, diag.FromErr(err)
 			}
@@ -2248,16 +2289,18 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	assumeRoleList := d.Get("assume_role").(*schema.Set).List()
 	if len(assumeRoleList) == 1 {
 		assumeRole := assumeRoleList[0].(map[string]interface{})
-		if assumeRole["role_arn"].(string) != "" {
-			config.RamRoleArn = assumeRole["role_arn"].(string)
+		if v, ok := mapString(assumeRole, "role_arn"); ok {
+			config.RamRoleArn = v
 		}
-		if assumeRole["session_name"].(string) != "" {
-			config.RamRoleSessionName = assumeRole["session_name"].(string)
+		if v, ok := mapString(assumeRole, "session_name"); ok {
+			config.RamRoleSessionName = v
 		}
 		if config.RamRoleSessionName == "" {
 			config.RamRoleSessionName = "terraform"
 		}
-		config.RamRolePolicy = assumeRole["policy"].(string)
+		if v, ok := mapString(assumeRole, "policy"); ok {
+			config.RamRolePolicy = v
+		}
 		if assumeRole["session_expiration"].(int) == 0 {
 			if v := os.Getenv("ALICLOUD_ASSUME_ROLE_SESSION_EXPIRATION"); v != "" {
 				if expiredSeconds, err := strconv.Atoi(v); err == nil {
@@ -2270,7 +2313,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 		} else {
 			config.RamRoleSessionExpiration = assumeRole["session_expiration"].(int)
 		}
-		if v := assumeRole["external_id"].(string); v != "" {
+		if v, ok := mapString(assumeRole, "external_id"); ok {
 			config.RamRoleExternalId = v
 		}
 
@@ -4247,32 +4290,32 @@ func getAssumeRoleWithOIDCConfig(tfMap map[string]interface{}) (*connectivity.As
 		assumeRole.DurationSeconds = v
 	}
 
-	if v, ok := tfMap["policy"].(string); ok && v != "" {
+	if v, ok := mapString(tfMap, "policy"); ok {
 		assumeRole.Policy = v
 	}
 
-	if v, ok := tfMap["role_arn"].(string); ok && v != "" {
+	if v, ok := mapString(tfMap, "role_arn"); ok {
 		assumeRole.RoleARN = v
 	}
 
-	if v, ok := tfMap["role_session_name"].(string); ok && v != "" {
+	if v, ok := mapString(tfMap, "role_session_name"); ok {
 		assumeRole.RoleSessionName = v
 	}
 	if assumeRole.RoleSessionName == "" {
 		assumeRole.RoleSessionName = "terraform"
 	}
 
-	if v, ok := tfMap["oidc_provider_arn"].(string); ok && v != "" {
+	if v, ok := mapString(tfMap, "oidc_provider_arn"); ok {
 		assumeRole.OIDCProviderArn = v
 	}
 
 	missingOidcToken := true
-	if v, ok := tfMap["oidc_token"]; ok && v.(string) != "" {
-		assumeRole.OIDCToken = v.(string)
+	if v, ok := mapString(tfMap, "oidc_token"); ok {
+		assumeRole.OIDCToken = v
 		missingOidcToken = false
 	}
 
-	if v, ok := tfMap["oidc_token_file"].(string); ok && v != "" {
+	if v, ok := mapString(tfMap, "oidc_token_file"); ok {
 		assumeRole.OIDCTokenFile = v
 		if assumeRole.OIDCToken == "" {
 			token, err := os.ReadFile(v)


### PR DESCRIPTION
Enhance the check for unknow values.

Migrating terraform-plugin-sdk v1 -> v2 changed how unknown-at-plan provider-config values reach d.Get/d.GetOk: v1 returned an empty string (eager auth short-circuited, deferred to apply) whereas v2 returns the literal hcl2shim sentinel "74D93920-ED26-11E3-AC10-0800200C9A66". That non-empty sentinel was forwarded to STS AssumeRole, producing "Invalid role arn format:74D93920-..." when e.g. assume_role.role_arn interpolated a resource created in the same apply.

Add cfgString/mapString helpers that treat the sentinel (and empty string) as unset, and route all credential string reads through them: access_key/secret_key/security_token/region/ecs_role_name, profile, shared_credentials_file, credentials_uri, the assume_role block, and assume_role_with_oidc. This restores v1's defer-eager-auth-to-apply behavior.

Introduce alicloud/errs, a stdlib-only leaf package holding the ComplexError/WrapErrorf stack copied from alicloud/errors.go, so connectivity can wrap credential-refresh errors without an import cycle.

The real fix (lazy credential/client loading, which deletes these guards) is deferred to a future refactor.