### PR TITLE
fix(cs): remove unsupported cluster_spec from cs_kubernetes

### DIFF
--- a/alicloud/resource_alicloud_cs_kubernetes.go
+++ b/alicloud/resource_alicloud_cs_kubernetes.go
@@ -259,11 +259,6 @@ func resourceAlicloudCSKubernetes() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"cluster_spec": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"proxy_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/website/docs/r/cs_kubernetes.html.markdown
+++ b/website/docs/r/cs_kubernetes.html.markdown
@@ -39,8 +39,6 @@ Please refer to the `Authorization management` and `Cluster management` sections
 
 -> **NOTE:** From version 1.75.0, Some parameters have been removed from resource,You can check them below and re-import the cluster if necessary.
 
--> **NOTE:** From version 1.101.0+, We supported the `professional managed clusters(ack-pro)`, You can create a pro cluster by setting the the value of `cluster_spec`.
-
 -> **NOTE:** From version 1.177.0+, `exclude_autoscaler_nodes`,`worker_number`,`worker_vswitch_ids`,`worker_instance_types`,`worker_instance_charge_type`,`worker_period`,`worker_period_unit`,`worker_auto_renew`,`worker_auto_renew_period`,`worker_disk_category`,`worker_disk_size`,`worker_data_disks`,`node_port_range`,`cpu_policy`,`user_data`,`taints`,`worker_disk_performance_level`,`worker_disk_snapshot_policy_id` are deprecated.
 We Suggest you using resource **`alicloud_cs_kubernetes_node_pool`** to manage your cluster worker nodes.
 


### PR DESCRIPTION
## What changed

- Remove the unsupported `cluster_spec` schema entry from `alicloud_cs_kubernetes`.
- Remove the stale documentation note that claimed ACK Pro could be configured through this resource.

## Why

`alicloud_cs_kubernetes` creates a dedicated Kubernetes cluster through `CreateDelicatedKubernetesCluster`. The reintroduced `cluster_spec` attribute was not connected to Create, Read, or Update, so Terraform accepted a configuration that had no effect. Managed-cluster specifications remain supported by `alicloud_cs_managed_kubernetes`.

## Impact

This removes a no-op argument and corrects the documentation. It does not change the API or state behavior of valid `alicloud_cs_kubernetes` configurations.

## Validation

Remote ACube ACC task `8548`:

- `TestAccAliCloudCSKubernetes_basic`: PASS (`4418.93s`)
- Summary: `PASS=1 FAIL=0 SKIP=0`
- Remote provider build: succeeded
