### PR TITLE
resource/alicloud_amqp_instance: support storage encryption

### DIFF
--- a/alicloud/resource_alicloud_amqp_instance.go
+++ b/alicloud/resource_alicloud_amqp_instance.go
@@ -44,6 +44,12 @@ func resourceAliCloudAmqpInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"encrypted_instance": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"instance_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -61,6 +67,11 @@ func resourceAliCloudAmqpInstance() *schema.Resource {
 				ForceNew:     true,
 				Computed:     true,
 				ValidateFunc: StringInSlice([]string{"tcp_and_ssl", "ssl_only"}, false),
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 			"max_connections": {
 				Type:     schema.TypeInt,
@@ -159,8 +170,9 @@ func resourceAliCloudAmqpInstance() *schema.Resource {
 				ForceNew: true,
 			},
 			"serverless_charge_type": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"onDemand", "provisioned"}, false),
 			},
 			"serverless_switch": {
 				Type:     schema.TypeBool,
@@ -238,6 +250,9 @@ func resourceAliCloudAmqpInstanceCreate(d *schema.ResourceData, meta interface{}
 	}
 	if v, ok := d.GetOk("edition"); ok {
 		request["Edition"] = v
+	}
+	if err := addAmqpInstanceEncryptionCreateRequest(d, request); err != nil {
+		return err
 	}
 	if v, ok := d.GetOk("instance_type"); ok {
 		request["InstanceType"] = v
@@ -348,9 +363,11 @@ func resourceAliCloudAmqpInstanceRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("create_time", objectRaw["OrderCreateTime"])
 	d.Set("edition", objectRaw["Edition"])
+	d.Set("encrypted_instance", objectRaw["EncryptedInstance"])
 	d.Set("instance_name", objectRaw["InstanceName"])
 	d.Set("instance_type", convertAmqpInstanceDataInstanceTypeResponse(objectRaw["InstanceType"]))
 	d.Set("listener_mode", objectRaw["ListenerMode"])
+	d.Set("kms_key_id", objectRaw["KmsKeyId"])
 	d.Set("max_connections", objectRaw["MaxConnections"])
 	d.Set("max_eip_tps", objectRaw["MaxEipTps"])
 	d.Set("max_tps", objectRaw["MaxTps"])
@@ -791,4 +808,29 @@ func convertAmqpInstanceModifyTypeRequest(source interface{}) interface{} {
 		return "UPGRADE"
 	}
 	return source
+}
+
+func addAmqpInstanceEncryptionCreateRequest(d *schema.ResourceData, request map[string]interface{}) error {
+	encryptedRaw, encryptedConfigured := d.GetOkExists("encrypted_instance")
+	kmsKeyIdRaw, kmsKeyConfigured := d.GetOk("kms_key_id")
+	encrypted, _ := encryptedRaw.(bool)
+	kmsKeyId := strings.TrimSpace(fmt.Sprint(kmsKeyIdRaw))
+
+	if kmsKeyConfigured && kmsKeyId == "" {
+		return fmt.Errorf("kms_key_id must be configured when encrypted_instance is true")
+	}
+	if kmsKeyConfigured && !encrypted {
+		return fmt.Errorf("encrypted_instance must be true when kms_key_id is configured")
+	}
+	if encrypted && !kmsKeyConfigured {
+		return fmt.Errorf("kms_key_id must be configured when encrypted_instance is true")
+	}
+
+	if encryptedConfigured {
+		request["EncryptedInstance"] = encrypted
+	}
+	if kmsKeyConfigured {
+		request["KmsKeyId"] = kmsKeyId
+	}
+	return nil
 }

--- a/alicloud/resource_alicloud_amqp_instance_test.go
+++ b/alicloud/resource_alicloud_amqp_instance_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/alibabacloud-go/tea-rpc/client"
@@ -94,11 +95,13 @@ func TestUnitAliCloudAmqpInstance(t *testing.T) {
 		"Data": map[string]interface{}{
 			"Instances": []interface{}{
 				map[string]interface{}{
-					"InstanceId":   "MockInstanceId",
-					"Status":       "SERVING",
-					"InstanceName": "instance_name",
-					"InstanceType": "PROFESSIONAL",
-					"SupportEIP":   false,
+					"InstanceId":        "MockInstanceId",
+					"Status":            "SERVING",
+					"InstanceName":      "instance_name",
+					"InstanceType":      "PROFESSIONAL",
+					"SupportEIP":        false,
+					"EncryptedInstance": true,
+					"KmsKeyId":          "MockKmsKeyId",
 				},
 			},
 			"InstanceList": []interface{}{
@@ -762,6 +765,149 @@ func TestUnitAliCloudAmqpInstance(t *testing.T) {
 	})
 }
 
+func TestUnitAliCloudAmqpInstanceEncryption(t *testing.T) {
+	resourceSchema := resourceAliCloudAmqpInstance()
+	assert.True(t, resourceSchema.Schema["encrypted_instance"].Optional)
+	assert.True(t, resourceSchema.Schema["encrypted_instance"].Computed)
+	assert.True(t, resourceSchema.Schema["encrypted_instance"].ForceNew)
+	assert.True(t, resourceSchema.Schema["kms_key_id"].Optional)
+	assert.False(t, resourceSchema.Schema["kms_key_id"].Computed)
+	assert.True(t, resourceSchema.Schema["kms_key_id"].ForceNew)
+	assert.False(t, resourceSchema.Schema["edition"].ForceNew)
+	serverlessChargeTypeValidate := resourceSchema.Schema["serverless_charge_type"].ValidateFunc
+	assert.NotNil(t, serverlessChargeTypeValidate)
+	_, validationErrors := serverlessChargeTypeValidate("onDemand", "serverless_charge_type")
+	assert.Empty(t, validationErrors)
+	_, validationErrors = serverlessChargeTypeValidate("provisioned", "serverless_charge_type")
+	assert.Empty(t, validationErrors)
+	_, validationErrors = serverlessChargeTypeValidate("invalid", "serverless_charge_type")
+	assert.NotEmpty(t, validationErrors)
+
+	newData := func(values map[string]interface{}) *schema.ResourceData {
+		return schema.TestResourceDataRaw(t, resourceSchema.Schema, values)
+	}
+
+	for name, values := range map[string]map[string]interface{}{
+		"vip": {
+			"payment_type":       "Subscription",
+			"instance_type":      "vip",
+			"encrypted_instance": true,
+			"kms_key_id":         "MockKmsKeyId",
+		},
+		"serverless provisioned dedicated": {
+			"payment_type":           "PayAsYouGo",
+			"serverless_charge_type": "provisioned",
+			"edition":                "dedicated",
+			"encrypted_instance":     true,
+			"kms_key_id":             "MockKmsKeyId",
+		},
+	} {
+		t.Run("valid "+name, func(t *testing.T) {
+			request := make(map[string]interface{})
+			assert.NoError(t, addAmqpInstanceEncryptionCreateRequest(newData(values), request))
+			assert.Equal(t, true, request["EncryptedInstance"])
+			assert.Equal(t, "MockKmsKeyId", request["KmsKeyId"])
+		})
+	}
+
+	t.Run("encryption arguments omitted", func(t *testing.T) {
+		request := make(map[string]interface{})
+		assert.NoError(t, addAmqpInstanceEncryptionCreateRequest(newData(map[string]interface{}{
+			"payment_type":  "PayAsYouGo",
+			"instance_type": "enterprise",
+			"edition":       "shared",
+		}), request))
+		assert.NotContains(t, request, "EncryptedInstance")
+		assert.NotContains(t, request, "KmsKeyId")
+	})
+
+	t.Run("encryption explicitly disabled", func(t *testing.T) {
+		request := make(map[string]interface{})
+		assert.NoError(t, addAmqpInstanceEncryptionCreateRequest(newData(map[string]interface{}{
+			"payment_type":       "PayAsYouGo",
+			"instance_type":      "enterprise",
+			"edition":            "shared",
+			"encrypted_instance": false,
+		}), request))
+		assert.Equal(t, false, request["EncryptedInstance"])
+		assert.NotContains(t, request, "KmsKeyId")
+	})
+
+	for name, testCase := range map[string]struct {
+		values map[string]interface{}
+		err    string
+	}{
+		"missing key": {
+			values: map[string]interface{}{
+				"payment_type":       "Subscription",
+				"instance_type":      "vip",
+				"encrypted_instance": true,
+			},
+			err: "kms_key_id must be configured when encrypted_instance is true",
+		},
+		"blank key": {
+			values: map[string]interface{}{
+				"payment_type":       "Subscription",
+				"instance_type":      "vip",
+				"encrypted_instance": true,
+				"kms_key_id":         "  ",
+			},
+			err: "kms_key_id must be configured when encrypted_instance is true",
+		},
+		"key without encryption": {
+			values: map[string]interface{}{
+				"payment_type":       "Subscription",
+				"instance_type":      "vip",
+				"encrypted_instance": false,
+				"kms_key_id":         "MockKmsKeyId",
+			},
+			err: "encrypted_instance must be true when kms_key_id is configured",
+		},
+	} {
+		t.Run("invalid "+name, func(t *testing.T) {
+			assert.EqualError(t, addAmqpInstanceEncryptionCreateRequest(newData(testCase.values), make(map[string]interface{})), testCase.err)
+		})
+	}
+
+	for name, values := range map[string]map[string]interface{}{
+		"subscription enterprise dedicated": {
+			"payment_type":       "Subscription",
+			"instance_type":      "enterprise",
+			"edition":            "dedicated",
+			"encrypted_instance": true,
+			"kms_key_id":         "MockKmsKeyId",
+		},
+		"pay as you go on demand dedicated": {
+			"payment_type":           "PayAsYouGo",
+			"serverless_charge_type": "onDemand",
+			"edition":                "dedicated",
+			"encrypted_instance":     true,
+			"kms_key_id":             "MockKmsKeyId",
+		},
+		"pay as you go provisioned shared": {
+			"payment_type":           "PayAsYouGo",
+			"serverless_charge_type": "provisioned",
+			"edition":                "shared",
+			"encrypted_instance":     true,
+			"kms_key_id":             "MockKmsKeyId",
+		},
+		"subscription provisioned dedicated": {
+			"payment_type":           "Subscription",
+			"serverless_charge_type": "provisioned",
+			"edition":                "dedicated",
+			"encrypted_instance":     true,
+			"kms_key_id":             "MockKmsKeyId",
+		},
+	} {
+		t.Run("passes through "+name, func(t *testing.T) {
+			request := make(map[string]interface{})
+			assert.NoError(t, addAmqpInstanceEncryptionCreateRequest(newData(values), request))
+			assert.Equal(t, true, request["EncryptedInstance"])
+			assert.Equal(t, "MockKmsKeyId", request["KmsKeyId"])
+		})
+	}
+}
+
 // Case 创建serverless实例 6128
 func TestAccAliCloudAmqpInstanceResource_basic6128(t *testing.T) {
 	var v map[string]interface{}
@@ -982,6 +1128,107 @@ func TestAccAliCloudAmqpInstanceResource_basic6128_twin(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudAmqpInstanceResource_encryptedServerlessDedicatedCreate(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_amqp_instance.default"
+	ra := resourceAttrInit(resourceId, AliCloudAmqpInstanceMap6128)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AmqpServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAmqpInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%samqpencrypted%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudAmqpInstanceEncryptedDependence6128)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+			testAccEnsureAmqpEncryptionServiceLinkedRole(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type":           "PayAsYouGo",
+					"vpc_id":                 "${data.alicloud_vswitches.default.vpc_id}",
+					"vswitch_ids":            []string{"${data.alicloud_vswitches.default.ids.0}", "${data.alicloud_vswitches.default.ids.1}"},
+					"security_group_id":      "${data.alicloud_security_groups.default.ids.0}",
+					"serverless_charge_type": "provisioned",
+					"provisioned_capacity":   "20000",
+					"edition":                "dedicated",
+					"instance_name":          name,
+					"encrypted_instance":     true,
+					"kms_key_id":             "${alicloud_kms_key.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"payment_type":           "PayAsYouGo",
+						"vpc_id":                 CHECKSET,
+						"vswitch_ids.#":          "2",
+						"security_group_id":      CHECKSET,
+						"serverless_charge_type": "provisioned",
+						"provisioned_capacity":   "20000",
+						"edition":                "dedicated",
+						"instance_name":          name,
+						"encrypted_instance":     "true",
+						"kms_key_id":             CHECKSET,
+					}),
+					resource.TestCheckResourceAttrPair(resourceId, "kms_key_id", "alicloud_kms_key.default", "id"),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auth_model", "auto_renew", "modify_type", "period", "period_cycle", "serverless_charge_type", "renewal_duration", "renewal_duration_unit", "renewal_status"},
+			},
+		},
+	})
+}
+
+func testAccEnsureAmqpEncryptionServiceLinkedRole(t *testing.T) {
+	t.Helper()
+
+	const (
+		serviceName = "encrypt.amqp.aliyuncs.com"
+		roleID      = serviceName + ":AliyunServiceRoleForAmqpEncrypt"
+	)
+
+	rawClient, err := sharedClientForRegion(defaultRegionToTest)
+	if err != nil {
+		t.Fatalf("failed to get Alibaba Cloud client: %s", err)
+	}
+	aliyunClient := rawClient.(*connectivity.AliyunClient)
+	ramService := RamService{aliyunClient}
+	if _, err = ramService.DescribeRamServiceLinkedRole(roleID); err == nil {
+		return
+	} else if !NotFoundError(err) && !IsExpectedErrors(err, []string{"EntityNotExist.Role"}) {
+		t.Fatalf("failed to describe AMQP encryption service-linked role: %s", err)
+	}
+
+	request := map[string]interface{}{"ServiceName": serviceName}
+	if _, err = aliyunClient.RpcPost("ResourceManager", "2020-03-31", "CreateServiceLinkedRole", nil, request, true); err != nil &&
+		!IsExpectedErrors(err, []string{"AlreadyExists", "EntityAlreadyExists"}) {
+		t.Fatalf("failed to create AMQP encryption service-linked role: %s", err)
+	}
+
+	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
+		if _, describeErr := ramService.DescribeRamServiceLinkedRole(roleID); describeErr != nil {
+			if NotFoundError(describeErr) || IsExpectedErrors(describeErr, []string{"EntityNotExist.Role"}) {
+				return resource.RetryableError(describeErr)
+			}
+			return resource.NonRetryableError(describeErr)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("AMQP encryption service-linked role did not become available: %s", err)
+	}
+}
+
 var AliCloudAmqpInstanceMap6128 = map[string]string{
 	"status":        CHECKSET,
 	"create_time":   CHECKSET,
@@ -1008,6 +1255,15 @@ func AliCloudAmqpInstanceBasicDependence6128(name string) string {
   		name_regex = "^sae"
 	}
 `, name)
+}
+
+func AliCloudAmqpInstanceEncryptedDependence6128(name string) string {
+	return AliCloudAmqpInstanceBasicDependence6128(name) + `
+	resource "alicloud_kms_key" "default" {
+		description            = "terraform-provider-alicloud AMQP acceptance test"
+		pending_window_in_days = 7
+	}
+`
 }
 
 // Test Amqp Instance. >>> Resource test cases, automatically generated.

--- a/website/docs/r/amqp_instance.html.markdown
+++ b/website/docs/r/amqp_instance.html.markdown
@@ -94,6 +94,7 @@ You can resume managing the subscription instance via the AlibabaCloud Console.
 ## Argument Reference
 
 The following arguments are supported:
+
 * `auth_model` - (Optional, Available since v1.285.0) The authentication mode of the instance. Default value: `ram`. Valid values:
   - `ram`: RAM authentication.
   - `openSource`: Open source authentication.
@@ -106,23 +107,30 @@ The following arguments are supported:
   - `dedicated`: Dedicated architecture, applicable to reserved + elastic (dedicated) editions.
 
 -> **NOTE:**  Modifying the Edition parameter triggers instance cluster migration. Before making this change, submit a ticket to the cloud service team. [Submit a Ticket](https://smartservice.console.aliyun.com/service/create-ticket?entrance=100&product=rabbitmq)
-    
+
+* `encrypted_instance` - (Optional, ForceNew, Computed) Whether to enable storage encryption when creating the instance. When set to `true`, `kms_key_id` must also be specified. AMQP currently supports storage encryption for the following SKU combinations:
+  - `instance_type = "vip"`.
+  - `payment_type = "PayAsYouGo"`, `serverless_charge_type = "provisioned"`, and `edition = "dedicated"`.
+
+-> **NOTE:** SKU eligibility is validated by the AMQP API when the instance is created, and unsupported combinations are rejected by the backend. Storage encryption cannot be enabled or modified after creation. Changing `encrypted_instance` replaces the instance.
+
 * `instance_name` - (Optional, Computed) The instance name.
 * `instance_type` - (Optional, Computed) Instance type. Valid values:
-  - professional: professional Edition 
-  - enterprise: enterprise Edition 
+  - professional: professional Edition
+  - enterprise: enterprise Edition
   - vip: Platinum Edition.
   - serverless: Serverless Edition.
-  -> **NOTE:** There should not set the `instance_type` parameter when creating a serverless instance. Only need to set `payment_type = "PayAsYouGo"` and `serverless_charge_type = "onDemand"`.
+  -> **NOTE:** Do not set `instance_type` when creating a serverless instance. Set `payment_type = "PayAsYouGo"` and choose `serverless_charge_type = "onDemand"` or `serverless_charge_type = "provisioned"`.
 * `listener_mode` - (Optional, ForceNew, Available since v1.274.0) The Listener mode. Valid values: `tcp_and_ssl`, `ssl_only`.
+* `kms_key_id` - (Optional, ForceNew) The ID of the KMS key used for storage encryption. The key must be in the same region as the instance, enabled, symmetric, and usable for encryption and decryption. This argument must be specified together with `encrypted_instance = true` when the instance is created. Changing `kms_key_id` replaces the instance.
 * `max_connections` - (Optional, Computed, Available since v1.129.0) The maximum number of connections, according to the value given on the purchase page of the cloud message queue RabbitMQ version console.
 * `max_eip_tps` - (Optional, Computed) Peak TPS traffic of the public network, which must be a multiple of 128, unit: times per second.
 * `max_tps` - (Optional, Computed) Configure the private network TPS traffic peak, please set the value according to the cloud message queue RabbitMQ version of the console purchase page given.
 * `modify_type` - (Optional) This parameter must be provided while you change the instance specification. Type of instance lifting and lowering:
   - Upgrade: Upgrade
   - Downgrade: Downgrading.
-* `payment_type` - (Required, ForceNew) The Payment type. Valid value: 
-  - Subscription: Pre-paid. 
+* `payment_type` - (Required, ForceNew) The Payment type. Valid value:
+  - Subscription: Pre-paid.
   - PayAsYouGo: Post-paid, and for serverless Edition.
 * `period` - (Optional) Prepayment cycle, unit: periodCycle. This parameter is valid when PaymentType is set to Subscription.
 * `period_cycle` - (Optional, Available since v1.129.0) Prepaid cycle units. Value: Month, Year.
@@ -131,7 +139,7 @@ The following arguments are supported:
 * `renewal_duration` - (Optional, Computed) The number of automatic renewal cycles.
 * `renewal_duration_unit` - (Optional, Computed) Auto-Renewal Cycle Unit Values Include: Month: Month. Year: Years.
 * `renewal_status` - (Optional, Computed) The renewal status. Value: AutoRenewal: automatic renewal. ManualRenewal: manual renewal. NotRenewal: no renewal.
-* `serverless_charge_type` - (Optional, Available since v1.129.0) The billing type of the serverless instance. Value: onDemand.
+* `serverless_charge_type` - (Optional, Available since v1.129.0) The billing type of the serverless instance. Valid values: `onDemand`, `provisioned`.
 * `serverless_switch` - (Optional, Computed, Available since v1.283.0) Whether to enable the Serverless elastic capability on the instance.
   - `true`: Enable. The instance's maximum TPS is increased to base TPS multiplied by an edition factor (1.5x for Professional Edition, 2x for Enterprise and Platinum Edition).
   - `false`: Disable. The instance's maximum TPS reverts to its original base TPS.
@@ -147,6 +155,7 @@ The following arguments are supported:
 ## Attributes Reference
 
 The following attributes are exported:
+
 * `id` - The ID of the resource supplied above.
 * `create_time` - OrderCreateTime.
 * `status` - The status of the resource.
@@ -154,6 +163,7 @@ The following attributes are exported:
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
 * `create` - (Defaults to 5 mins) Used when create the Instance.
 * `delete` - (Defaults to 5 mins) Used when delete the Instance.
 * `update` - (Defaults to 5 mins) Used when update the Instance.


### PR DESCRIPTION
### Summary

- Add `encrypted_instance` and `kms_key_id` to `alicloud_amqp_instance`.
- Send both arguments only when creating the instance and read them back into state.
- Validate only the dependency between the encryption flag and KMS key in the Provider; AMQP API validates SKU eligibility.
- Document the current AMQP storage-encryption SKU requirements.

### Behavior

- `encrypted_instance` and `kms_key_id` are `ForceNew`; changing either replaces the instance.
- `encrypted_instance = true` requires a non-empty `kms_key_id`, and setting `kms_key_id` requires `encrypted_instance = true`.
- The Provider passes SKU combinations through without local eligibility checks. Unsupported combinations are rejected by the AMQP API during creation.
- Storage encryption (`encrypted_instance`) is supported only for either of these configurations: Subscription `instance_type = "vip"`; or PayAsYouGo serverless with `serverless_charge_type = "provisioned"` and `edition = "dedicated"`.
- Update requests never send the encryption arguments.

### Acceptance coverage

- The encrypted-instance acceptance case creates an Alibaba Cloud KMS key first and then creates a PayAsYouGo serverless (provisioned, dedicated) AMQP instance with `encrypted_instance = true` and that key.
- The test precheck idempotently ensures the account-level AMQP encryption service-linked role exists without managing or deleting it as test state.
- Unit tests cover field dependency failures, omitted and disabled encryption, supported combinations, and pass-through behavior for combinations that the AMQP backend may reject.
- The encrypted case uses the supported PayAsYouGo serverless provisioned instance with `edition = "dedicated"`.

### Testing

- `go test ./alicloud -run "^TestUnitAliCloudAmqpInstanceEncryption$" -count=1`
- `go run scripts/testing/testing_coverage_rate_check.go -resource=alicloud_amqp_instance` (100% attribute and modified coverage)
- `TestAccAliCloudAmqpInstanceResource_encryptedServerlessDedicatedCreate` (PayAsYouGo serverless provisioned dedicated instance + `encrypted_instance` + `kms_key_id`)
- GitHub Actions checks (pass)
- `gofmt -d alicloud/resource_alicloud_amqp_instance.go alicloud/resource_alicloud_amqp_instance_test.go`
- `git diff --check`

=== RUN TestAccAliCloudAmqpInstanceResource_encryptedServerlessDedicatedCreate
--- PASS: TestAccAliCloudAmqpInstanceResource_encryptedServerlessDedicatedCreate (566.81s)
