### PR TITLE
docs: support setting skip_region_validation by the ALICLOUD_SKIP_REGION_VALIDATION environment variable

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -109,7 +109,7 @@ func Provider() terraform.ResourceProvider {
 			"skip_region_validation": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				DefaultFunc: schema.EnvDefaultFunc("ALICLOUD_SKIP_REGION_VALIDATION", false),
 				Description: descriptions["skip_region_validation"],
 			},
 			"configuration_source": {
@@ -2543,7 +2543,7 @@ func init() {
 
 		"assume_role_session_expiration": "The time after which the established session for assuming role expires. Valid value range: [900-3600] seconds. Default to 0 (in this case Alicloud use own default value).",
 
-		"skip_region_validation": "Skip static validation of region ID. Used by users of alternative AlibabaCloud-like APIs or users w/ access to regions that are not public (yet).",
+		"skip_region_validation": "Skip static validation of region ID. Used by users of alternative AlibabaCloud-like APIs or users w/ access to regions that are not public (yet). It can also be sourced from the `ALICLOUD_SKIP_REGION_VALIDATION` environment variable.",
 
 		"configuration_source": "Use this to mark a terraform configuration file source.",
 

--- a/alicloud/provider_test.go
+++ b/alicloud/provider_test.go
@@ -48,6 +48,34 @@ func TestProvider_impl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
 }
 
+func TestProviderSkipRegionValidation(t *testing.T) {
+	original := os.Getenv("ALICLOUD_SKIP_REGION_VALIDATION")
+	defer os.Setenv("ALICLOUD_SKIP_REGION_VALIDATION", original)
+
+	testCases := []struct {
+		name     string
+		env      string
+		raw      map[string]interface{}
+		expected bool
+	}{
+		{"unset env defaults to false", "", map[string]interface{}{}, false},
+		{"env true enables skip", "true", map[string]interface{}{}, true},
+		{"env false disables skip", "false", map[string]interface{}{}, false},
+		{"config overrides env", "true", map[string]interface{}{"skip_region_validation": false}, false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			os.Setenv("ALICLOUD_SKIP_REGION_VALIDATION", testCase.env)
+
+			d := schema.TestResourceDataRaw(t, Provider().(*schema.Provider).Schema, testCase.raw)
+			if got := d.Get("skip_region_validation").(bool); got != testCase.expected {
+				t.Fatalf("skip_region_validation: expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+}
+
 func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("ALICLOUD_ACCESS_KEY"); v == "" {
 		t.Fatal("ALICLOUD_ACCESS_KEY must be set for acceptance tests")

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -350,6 +350,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 * `sign_version` - (Optional, Available since v1.215.0) A [`sign_version`](#sign_version) block to specify the signature version used for the API requests of certain cloud products (currently `oss` and `sls`). Only one `sign_version` block may be in the configuration.
 
 * `skip_region_validation` - (Optional, Available since v1.52.0) Skip static validation of region ID. Used by users of alternative AlibabaCloud-like APIs or users w/ access to regions that are not public (yet).
+  Can also be set with the `ALICLOUD_SKIP_REGION_VALIDATION` environment variable since v1.287.0.
 
 * `configuration_source` - (Optional, Available since v1.56.0) Use a string to mark a configuration file source, like `terraform-alicloud-modules/terraform-alicloud-ecs-instance` or `terraform-provider-alicloud/examples/vpc`.
 The length should not more than 1024(Before 1.283.0, it should not more than 128. Before 1.207.2, it should not more than 64). Since the version 1.145.0, it supports to be set by environment variable `TF_APPEND_USER_AGENT`. See `Custom User-Agent Information`.


### PR DESCRIPTION
Supersedes #10026, addressing the review comments there:

- Only `ALICLOUD_SKIP_REGION_VALIDATION` is supported (no extra `ALIBABA_CLOUD_*` alias).
- No dedicated `DefaultFunc` helper and no hand-written boolean validation — the standard `schema.EnvDefaultFunc` is used, matching the other provider attributes. The SDK already coerces the env string to a bool and reports a non-parseable value as an error.

Behavior: an explicit value in the provider block wins; when the env var is unset the default stays `false`.

Docs for the provider argument and the schema description are updated accordingly.