### PR TITLE
resource/alicloud_message_service_subscription: Added the field dm_attributes, dysms_attributes, tenant_rate_limit_policy, last_modify_time, topic_owner; data-source/alicloud_message_service_subscriptions: Added the field enable_details, dlq_policy, tenant_rate_limit_policy

### DIFF
--- a/alicloud/data_source_alicloud_message_service_subscriptions.go
+++ b/alicloud/data_source_alicloud_message_service_subscriptions.go
@@ -1,3 +1,4 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
@@ -9,31 +10,34 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
-func dataSourceAlicloudMessageServiceSubscriptions() *schema.Resource {
+func dataSourceAliCloudMessageServiceSubscriptions() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceAlicloudMessageServiceSubscriptionsRead,
+		Read: dataSourceAliCloudMessageServiceSubscriptionRead,
 		Schema: map[string]*schema.Schema{
 			"ids": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
 			},
 			"name_regex": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringIsValidRegExp,
-			},
-			"topic_name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
 			},
 			"subscription_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"topic_name": {
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"page_number": {
 				Type:     schema.TypeInt,
@@ -44,31 +48,30 @@ func dataSourceAlicloudMessageServiceSubscriptions() *schema.Resource {
 				Optional: true,
 				Default:  PageSizeLarge,
 			},
-			"output_file": {
-				Optional: true,
-				Type:     schema.TypeString,
-			},
-			"names": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
 			"subscriptions": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": {
-							Type:     schema.TypeString,
+						"create_time": {
+							Type:     schema.TypeInt,
 							Computed: true,
 						},
-						"topic_name": {
-							Type:     schema.TypeString,
+						"dlq_policy": {
+							Type:     schema.TypeList,
 							Computed: true,
-						},
-						"subscription_name": {
-							Type:     schema.TypeString,
-							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dead_letter_target_queue": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
 						},
 						"endpoint": {
 							Type:     schema.TypeString,
@@ -76,6 +79,10 @@ func dataSourceAlicloudMessageServiceSubscriptions() *schema.Resource {
 						},
 						"filter_tag": {
 							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"last_modify_time": {
+							Type:     schema.TypeInt,
 							Computed: true,
 						},
 						"notify_content_format": {
@@ -86,7 +93,7 @@ func dataSourceAlicloudMessageServiceSubscriptions() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"topic_owner": {
+						"subscription_name": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -94,28 +101,82 @@ func dataSourceAlicloudMessageServiceSubscriptions() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"last_modify_time": {
-							Type:     schema.TypeInt,
+						"tenant_rate_limit_policy": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"max_receives_per_second": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"topic_name": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"create_time": {
-							Type:     schema.TypeInt,
+						"topic_owner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 					},
 				},
 			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
 
-func dataSourceAlicloudMessageServiceSubscriptionsRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceAliCloudMessageServiceSubscriptionRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 
-	action := "ListSubscriptionByTopic"
-	request := make(map[string]interface{})
-	request["TopicName"] = d.Get("topic_name")
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
 
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListSubscriptionByTopic"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	request["TopicName"] = d.Get("topic_name")
 	if v, ok := d.GetOk("subscription_name"); ok {
 		request["SubscriptionName"] = v
 	}
@@ -131,33 +192,11 @@ func dataSourceAlicloudMessageServiceSubscriptionsRead(d *schema.ResourceData, m
 	} else {
 		request["PageSize"] = PageSizeLarge
 	}
-
-	var objects []map[string]interface{}
-	var subscriptionNameRegex *regexp.Regexp
-	if v, ok := d.GetOk("name_regex"); ok {
-		r, err := regexp.Compile(v.(string))
-		if err != nil {
-			return WrapError(err)
-		}
-		subscriptionNameRegex = r
-	}
-
-	idsMap := make(map[string]string)
-	if v, ok := d.GetOk("ids"); ok {
-		for _, vv := range v.([]interface{}) {
-			if vv == nil {
-				continue
-			}
-			idsMap[vv.(string)] = vv.(string)
-		}
-	}
-
-	var response map[string]interface{}
-	var err error
 	for {
-		wait := incrementalWait(3*time.Second, 3*time.Second)
-		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-			response, err = client.RpcPost("Mns-open", "2022-01-19", action, nil, request, true)
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("Mns-open", "2022-01-19", action, query, request, true)
+
 			if err != nil {
 				if NeedRetry(err) {
 					wait()
@@ -165,23 +204,19 @@ func dataSourceAlicloudMessageServiceSubscriptionsRead(d *schema.ResourceData, m
 				}
 				return resource.NonRetryableError(err)
 			}
+			addDebug(action, response, request)
 			return nil
 		})
-		addDebug(action, response, request)
 		if err != nil {
-			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_message_service_subscriptions", action, AlibabaCloudSdkGoERROR)
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
-		if fmt.Sprint(response["Success"]) == "false" {
-			return WrapError(fmt.Errorf("%s failed, response: %v", action, response))
-		}
-		resp, err := jsonpath.Get("$.Data.PageData", response)
-		if err != nil {
-			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.Data.PageData", response)
-		}
+
+		resp, _ := jsonpath.Get("$.Data.PageData[*]", response)
+
 		result, _ := resp.([]interface{})
 		for _, v := range result {
 			item := v.(map[string]interface{})
-			if subscriptionNameRegex != nil && !subscriptionNameRegex.MatchString(fmt.Sprint(item["SubscriptionName"])) {
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["SubscriptionName"])) {
 				continue
 			}
 			if len(idsMap) > 0 {
@@ -191,31 +226,47 @@ func dataSourceAlicloudMessageServiceSubscriptionsRead(d *schema.ResourceData, m
 			}
 			objects = append(objects, item)
 		}
+
 		if len(result) < request["PageSize"].(int) {
 			break
 		}
 		request["PageNum"] = request["PageNum"].(int) + 1
 	}
+
 	ids := make([]string, 0)
 	names := make([]interface{}, 0)
 	s := make([]map[string]interface{}, 0)
-	for _, object := range objects {
-		mapping := map[string]interface{}{
-			"id":                    fmt.Sprint(object["TopicName"], ":", object["SubscriptionName"]),
-			"topic_name":            object["TopicName"],
-			"subscription_name":     object["SubscriptionName"],
-			"endpoint":              object["Endpoint"],
-			"filter_tag":            object["FilterTag"],
-			"notify_content_format": object["NotifyContentFormat"],
-			"notify_strategy":       object["NotifyStrategy"],
-			"topic_owner":           object["TopicOwner"],
-			"subscription_url":      object["SubscriptionURL"],
-			"last_modify_time":      formatInt(object["LastModifyTime"]),
-			"create_time":           formatInt(object["CreateTime"]),
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(objectRaw["TopicName"], ":", objectRaw["SubscriptionName"])
+
+		mapping["create_time"] = objectRaw["CreateTime"]
+		mapping["endpoint"] = objectRaw["Endpoint"]
+		mapping["filter_tag"] = objectRaw["FilterTag"]
+		mapping["last_modify_time"] = objectRaw["LastModifyTime"]
+		mapping["notify_content_format"] = objectRaw["NotifyContentFormat"]
+		mapping["notify_strategy"] = objectRaw["NotifyStrategy"]
+		mapping["topic_owner"] = objectRaw["TopicOwner"]
+		mapping["subscription_name"] = objectRaw["SubscriptionName"]
+		mapping["subscription_url"] = objectRaw["SubscriptionURL"]
+		mapping["topic_name"] = objectRaw["TopicName"]
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			names = append(names, objectRaw["SubscriptionName"])
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["TopicName"], ":", objectRaw["SubscriptionName"])
+		mapping, err = dataSourceAliCloudMessageServiceSubscriptionReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
 		}
 
 		ids = append(ids, fmt.Sprint(mapping["id"]))
-		names = append(names, object["SubscriptionName"])
+		names = append(names, objectRaw["SubscriptionName"])
 		s = append(s, mapping)
 	}
 
@@ -227,7 +278,6 @@ func dataSourceAlicloudMessageServiceSubscriptionsRead(d *schema.ResourceData, m
 	if err := d.Set("names", names); err != nil {
 		return WrapError(err)
 	}
-
 	if err := d.Set("subscriptions", s); err != nil {
 		return WrapError(err)
 	}
@@ -235,6 +285,59 @@ func dataSourceAlicloudMessageServiceSubscriptionsRead(d *schema.ResourceData, m
 	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
 		writeToFile(output.(string), s)
 	}
-
 	return nil
+}
+
+func dataSourceAliCloudMessageServiceSubscriptionReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	messageServiceServiceV2 := MessageServiceServiceV2{client}
+	getResp, err := messageServiceServiceV2.DescribeMessageServiceSubscription(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["create_time"] = objectRaw["CreateTime"]
+	mapping["endpoint"] = objectRaw["Endpoint"]
+	mapping["filter_tag"] = objectRaw["FilterTag"]
+	mapping["last_modify_time"] = objectRaw["LastModifyTime"]
+	mapping["notify_content_format"] = objectRaw["NotifyContentFormat"]
+	mapping["notify_strategy"] = objectRaw["NotifyStrategy"]
+	mapping["topic_owner"] = objectRaw["TopicOwner"]
+	mapping["subscription_name"] = objectRaw["SubscriptionName"]
+	mapping["topic_name"] = objectRaw["TopicName"]
+
+	dlqPolicyMaps := make([]map[string]interface{}, 0)
+	dlqPolicyMap := make(map[string]interface{})
+	dlqPolicyRaw := make(map[string]interface{})
+	if objectRaw["DlqPolicy"] != nil {
+		dlqPolicyRaw = objectRaw["DlqPolicy"].(map[string]interface{})
+	}
+	if len(dlqPolicyRaw) > 0 {
+		dlqPolicyMap["dead_letter_target_queue"] = dlqPolicyRaw["DeadLetterTargetQueue"]
+		dlqPolicyMap["enabled"] = dlqPolicyRaw["Enabled"]
+
+		dlqPolicyMaps = append(dlqPolicyMaps, dlqPolicyMap)
+	}
+	mapping["dlq_policy"] = dlqPolicyMaps
+	tenantRateLimitPolicyMaps := make([]map[string]interface{}, 0)
+	tenantRateLimitPolicyMap := make(map[string]interface{})
+	tenantRateLimitPolicyRaw := make(map[string]interface{})
+	if objectRaw["TenantRateLimitPolicy"] != nil {
+		tenantRateLimitPolicyRaw = objectRaw["TenantRateLimitPolicy"].(map[string]interface{})
+	}
+	if len(tenantRateLimitPolicyRaw) > 0 {
+		tenantRateLimitPolicyMap["enabled"] = tenantRateLimitPolicyRaw["Enabled"]
+		tenantRateLimitPolicyMap["max_receives_per_second"] = tenantRateLimitPolicyRaw["MaxReceivesPerSecond"]
+
+		tenantRateLimitPolicyMaps = append(tenantRateLimitPolicyMaps, tenantRateLimitPolicyMap)
+	}
+	mapping["tenant_rate_limit_policy"] = tenantRateLimitPolicyMaps
+
+	return mapping, nil
 }

--- a/alicloud/data_source_alicloud_message_service_subscriptions_test.go
+++ b/alicloud/data_source_alicloud_message_service_subscriptions_test.go
@@ -59,9 +59,17 @@ func TestAccAlicloudMessageServiceSubscriptionsDataSource(t *testing.T) {
 			"subscriptions.0.notify_content_format": "JSON",
 			"subscriptions.0.notify_strategy":       "EXPONENTIAL_DECAY_RETRY",
 			"subscriptions.0.topic_owner":           CHECKSET,
-			"subscriptions.0.subscription_url":      CHECKSET,
-			"subscriptions.0.last_modify_time":      CHECKSET,
-			"subscriptions.0.create_time":           CHECKSET,
+			// subscription_url is intentionally not asserted: neither
+			// ListSubscriptionByTopic nor GetSubscriptionAttributes returns
+			// SubscriptionURL, so the attribute is always empty. The schema field is
+			// kept for backward compatibility.
+			"subscriptions.0.last_modify_time":                                   CHECKSET,
+			"subscriptions.0.create_time":                                        CHECKSET,
+			"subscriptions.0.tenant_rate_limit_policy.#":                         "1",
+			"subscriptions.0.tenant_rate_limit_policy.0.enabled":                 "true",
+			"subscriptions.0.tenant_rate_limit_policy.0.max_receives_per_second": "50",
+			"subscriptions.0.dlq_policy.#":                                       "1",
+			"subscriptions.0.dlq_policy.0.enabled":                               "false",
 		}
 	}
 	var fakeAlicloudMessageServiceSubscriptionsDataSourceNameMapFunc = func(rand int) map[string]string {
@@ -104,10 +112,16 @@ func testAccCheckAlicloudMessageServiceSubscriptionsDataSourceName(rand int, att
   		filter_tag            = "tf-test"
   		notify_content_format = "JSON"
   		notify_strategy       = "EXPONENTIAL_DECAY_RETRY"
+
+  		tenant_rate_limit_policy {
+  			enabled                 = true
+  			max_receives_per_second = 50
+  		}
 	}
-	
+
 	data "alicloud_message_service_subscriptions" "default" {
-		topic_name = alicloud_message_service_subscription.default.topic_name
+		topic_name     = alicloud_message_service_subscription.default.topic_name
+		enable_details = true
 		%s
 	}
 `, rand, strings.Join(pairs, " \n "))

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -842,7 +842,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_api_gateway_plugins":                              dataSourceAlicloudApiGatewayPlugins(),
 			"alicloud_message_service_queues":                           dataSourceAlicloudMessageServiceQueues(),
 			"alicloud_message_service_topics":                           dataSourceAlicloudMessageServiceTopics(),
-			"alicloud_message_service_subscriptions":                    dataSourceAlicloudMessageServiceSubscriptions(),
+			"alicloud_message_service_subscriptions":                    dataSourceAliCloudMessageServiceSubscriptions(),
 			"alicloud_cen_transit_router_prefix_list_associations":      dataSourceAlicloudCenTransitRouterPrefixListAssociations(),
 			"alicloud_dms_enterprise_proxies":                           dataSourceAlicloudDmsEnterpriseProxies(),
 			"alicloud_vpc_public_ip_address_pool_cidr_blocks":           dataSourceAlicloudVpcPublicIpAddressPoolCidrBlocks(),

--- a/alicloud/resource_alicloud_message_service_subscription.go
+++ b/alicloud/resource_alicloud_message_service_subscription.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/PaesslerAG/jsonpath"
@@ -50,14 +51,49 @@ func resourceAliCloudMessageServiceSubscription() *schema.Resource {
 					},
 				},
 			},
+			"dm_attributes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"subject": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"account_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"dysms_attributes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"template_code": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"sign_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 			"endpoint": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
-			},
-			"sts_role_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
 				ForceNew: true,
 			},
 			"filter_tag": {
@@ -65,11 +101,15 @@ func resourceAliCloudMessageServiceSubscription() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"last_modify_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"notify_content_format": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"notify_strategy": {
 				Type:     schema.TypeString,
@@ -80,15 +120,42 @@ func resourceAliCloudMessageServiceSubscription() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"sts_role_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"subscription_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
+			"tenant_rate_limit_policy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"max_receives_per_second": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"topic_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+			"topic_owner": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -104,12 +171,78 @@ func resourceAliCloudMessageServiceSubscriptionCreate(d *schema.ResourceData, me
 	query := make(map[string]interface{})
 	var err error
 	request = make(map[string]interface{})
-	request["TopicName"] = d.Get("topic_name")
-	request["SubscriptionName"] = d.Get("subscription_name")
+	if v, ok := d.GetOk("topic_name"); ok {
+		request["TopicName"] = v
+	}
+	if v, ok := d.GetOk("subscription_name"); ok {
+		request["SubscriptionName"] = v
+	}
+	request["RegionId"] = client.RegionId
+
+	dlqPolicy := make(map[string]interface{})
+
+	if v := d.Get("dlq_policy"); !IsNil(v) {
+		deadLetterTargetQueue1, _ := jsonpath.Get("$[0].dead_letter_target_queue", v)
+		if deadLetterTargetQueue1 != nil && deadLetterTargetQueue1 != "" {
+			dlqPolicy["DeadLetterTargetQueue"] = deadLetterTargetQueue1
+		}
+		enabled1, _ := jsonpath.Get("$[0].enabled", v)
+		if enabled1 != nil && enabled1 != "" {
+			dlqPolicy["Enabled"] = enabled1
+		}
+
+		dlqPolicyJson, err := json.Marshal(dlqPolicy)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["DlqPolicy"] = string(dlqPolicyJson)
+	}
 
 	if v, ok := d.GetOk("notify_strategy"); ok {
 		request["NotifyStrategy"] = v
 	}
+	if v, ok := d.GetOk("sts_role_arn"); ok {
+		request["StsRoleArn"] = v
+	}
+	tenantRateLimitPolicy := make(map[string]interface{})
+
+	if v := d.Get("tenant_rate_limit_policy"); !IsNil(v) {
+		enabled3, _ := jsonpath.Get("$[0].enabled", v)
+		if enabled3 != nil && enabled3 != "" {
+			tenantRateLimitPolicy["Enabled"] = enabled3
+		}
+		maxReceivesPerSecond1, _ := jsonpath.Get("$[0].max_receives_per_second", v)
+		if maxReceivesPerSecond1 != nil && maxReceivesPerSecond1 != "" {
+			tenantRateLimitPolicy["MaxReceivesPerSecond"] = maxReceivesPerSecond1
+		}
+
+		tenantRateLimitPolicyJson, err := json.Marshal(tenantRateLimitPolicy)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["TenantRateLimitPolicy"] = string(tenantRateLimitPolicyJson)
+	}
+
+	request["PushType"] = d.Get("push_type")
+	dmAttributes := make(map[string]interface{})
+
+	if v := d.Get("dm_attributes"); !IsNil(v) {
+		subject1, _ := jsonpath.Get("$[0].subject", v)
+		if subject1 != nil && subject1 != "" {
+			dmAttributes["Subject"] = subject1
+		}
+		accountName1, _ := jsonpath.Get("$[0].account_name", v)
+		if accountName1 != nil && accountName1 != "" {
+			dmAttributes["AccountName"] = accountName1
+		}
+
+		dmAttributesJson, err := json.Marshal(dmAttributes)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["DmAttributes"] = string(dmAttributesJson)
+	}
+
 	if v, ok := d.GetOk("notify_content_format"); ok {
 		request["NotifyContentFormat"] = v
 	}
@@ -117,27 +250,23 @@ func resourceAliCloudMessageServiceSubscriptionCreate(d *schema.ResourceData, me
 		request["MessageTag"] = v
 	}
 	request["Endpoint"] = d.Get("endpoint")
-	if v, ok := d.GetOk("sts_role_arn"); ok {
-		request["StsRoleArn"] = v
-	}
-	request["PushType"] = d.Get("push_type")
-	objectDataLocalMap := make(map[string]interface{})
+	dysmsAttributes := make(map[string]interface{})
 
-	if v := d.Get("dlq_policy"); !IsNil(v) {
-		deadLetterTargetQueue1, _ := jsonpath.Get("$[0].dead_letter_target_queue", v)
-		if deadLetterTargetQueue1 != nil && deadLetterTargetQueue1 != "" {
-			objectDataLocalMap["DeadLetterTargetQueue"] = deadLetterTargetQueue1
+	if v := d.Get("dysms_attributes"); !IsNil(v) {
+		templateCode1, _ := jsonpath.Get("$[0].template_code", v)
+		if templateCode1 != nil && templateCode1 != "" {
+			dysmsAttributes["TemplateCode"] = templateCode1
 		}
-		enabled1, _ := jsonpath.Get("$[0].enabled", v)
-		if enabled1 != nil && enabled1 != "" {
-			objectDataLocalMap["Enabled"] = enabled1
+		signName1, _ := jsonpath.Get("$[0].sign_name", v)
+		if signName1 != nil && signName1 != "" {
+			dysmsAttributes["SignName"] = signName1
 		}
 
-		objectDataLocalMapJson, err := json.Marshal(objectDataLocalMap)
+		dysmsAttributesJson, err := json.Marshal(dysmsAttributes)
 		if err != nil {
 			return WrapError(err)
 		}
-		request["DlqPolicy"] = string(objectDataLocalMapJson)
+		request["DysmsAttributes"] = string(dysmsAttributesJson)
 	}
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
@@ -180,8 +309,10 @@ func resourceAliCloudMessageServiceSubscriptionRead(d *schema.ResourceData, meta
 	d.Set("create_time", objectRaw["CreateTime"])
 	d.Set("endpoint", objectRaw["Endpoint"])
 	d.Set("filter_tag", objectRaw["FilterTag"])
+	d.Set("last_modify_time", objectRaw["LastModifyTime"])
 	d.Set("notify_content_format", objectRaw["NotifyContentFormat"])
 	d.Set("notify_strategy", objectRaw["NotifyStrategy"])
+	d.Set("topic_owner", objectRaw["TopicOwner"])
 	d.Set("subscription_name", objectRaw["SubscriptionName"])
 	d.Set("topic_name", objectRaw["TopicName"])
 
@@ -200,6 +331,21 @@ func resourceAliCloudMessageServiceSubscriptionRead(d *schema.ResourceData, meta
 	if err := d.Set("dlq_policy", dlqPolicyMaps); err != nil {
 		return err
 	}
+	tenantRateLimitPolicyMaps := make([]map[string]interface{}, 0)
+	tenantRateLimitPolicyMap := make(map[string]interface{})
+	tenantRateLimitPolicyRaw := make(map[string]interface{})
+	if objectRaw["TenantRateLimitPolicy"] != nil {
+		tenantRateLimitPolicyRaw = objectRaw["TenantRateLimitPolicy"].(map[string]interface{})
+	}
+	if len(tenantRateLimitPolicyRaw) > 0 {
+		tenantRateLimitPolicyMap["enabled"] = tenantRateLimitPolicyRaw["Enabled"]
+		tenantRateLimitPolicyMap["max_receives_per_second"] = tenantRateLimitPolicyRaw["MaxReceivesPerSecond"]
+
+		tenantRateLimitPolicyMaps = append(tenantRateLimitPolicyMaps, tenantRateLimitPolicyMap)
+	}
+	if err := d.Set("tenant_rate_limit_policy", tenantRateLimitPolicyMaps); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -212,45 +358,66 @@ func resourceAliCloudMessageServiceSubscriptionUpdate(d *schema.ResourceData, me
 	update := false
 
 	var err error
-	parts, err := ParseResourceId(d.Id(), 2)
-	if err != nil {
-		return WrapError(err)
-	}
+	parts := strings.Split(d.Id(), ":")
 	action := "SetSubscriptionAttributes"
 	request = make(map[string]interface{})
 	query = make(map[string]interface{})
 	request["TopicName"] = parts[0]
 	request["SubscriptionName"] = parts[1]
-
-	if d.HasChange("notify_strategy") {
-		update = true
-	}
-	if v, ok := d.GetOk("notify_strategy"); ok {
-		request["NotifyStrategy"] = v
-	}
-
+	request["RegionId"] = client.RegionId
 	if d.HasChange("dlq_policy") {
 		update = true
-		objectDataLocalMap := make(map[string]interface{})
+		dlqPolicy := make(map[string]interface{})
 
 		if v := d.Get("dlq_policy"); v != nil {
 			enabled1, _ := jsonpath.Get("$[0].enabled", v)
 			if enabled1 != nil && (d.HasChange("dlq_policy.0.enabled") || enabled1 != "") {
-				objectDataLocalMap["Enabled"] = enabled1
+				dlqPolicy["Enabled"] = enabled1
 
-				if objectDataLocalMap["Enabled"].(bool) {
+				if dlqPolicy["Enabled"].(bool) {
 					deadLetterTargetQueue1, _ := jsonpath.Get("$[0].dead_letter_target_queue", v)
 					if deadLetterTargetQueue1 != nil && (d.HasChange("dlq_policy.0.dead_letter_target_queue") || deadLetterTargetQueue1 != "") {
-						objectDataLocalMap["DeadLetterTargetQueue"] = deadLetterTargetQueue1
+						dlqPolicy["DeadLetterTargetQueue"] = deadLetterTargetQueue1
 					}
 				}
 			}
 
-			objectDataLocalMapJson, err := json.Marshal(objectDataLocalMap)
+			dlqPolicyJson, err := json.Marshal(dlqPolicy)
 			if err != nil {
 				return WrapError(err)
 			}
-			request["DlqPolicy"] = string(objectDataLocalMapJson)
+			request["DlqPolicy"] = string(dlqPolicyJson)
+		}
+	}
+
+	if d.HasChange("notify_strategy") {
+		update = true
+	}
+	// NotifyStrategy is required by SetSubscriptionAttributes even when only
+	// other attributes change; omitting it fails with Missing:NotifyStrategy.
+	if v, ok := d.GetOk("notify_strategy"); ok {
+		request["NotifyStrategy"] = v
+	}
+
+	if d.HasChange("tenant_rate_limit_policy") {
+		update = true
+		tenantRateLimitPolicy := make(map[string]interface{})
+
+		if v := d.Get("tenant_rate_limit_policy"); v != nil {
+			enabled3, _ := jsonpath.Get("$[0].enabled", v)
+			if enabled3 != nil && enabled3 != "" {
+				tenantRateLimitPolicy["Enabled"] = enabled3
+			}
+			maxReceivesPerSecond1, _ := jsonpath.Get("$[0].max_receives_per_second", v)
+			if maxReceivesPerSecond1 != nil && maxReceivesPerSecond1 != "" {
+				tenantRateLimitPolicy["MaxReceivesPerSecond"] = maxReceivesPerSecond1
+			}
+
+			tenantRateLimitPolicyJson, err := json.Marshal(tenantRateLimitPolicy)
+			if err != nil {
+				return WrapError(err)
+			}
+			request["TenantRateLimitPolicy"] = string(tenantRateLimitPolicyJson)
 		}
 	}
 
@@ -279,22 +446,20 @@ func resourceAliCloudMessageServiceSubscriptionUpdate(d *schema.ResourceData, me
 func resourceAliCloudMessageServiceSubscriptionDelete(d *schema.ResourceData, meta interface{}) error {
 
 	client := meta.(*connectivity.AliyunClient)
-	parts, err := ParseResourceId(d.Id(), 2)
-	if err != nil {
-		return WrapError(err)
-	}
+	parts := strings.Split(d.Id(), ":")
 	action := "Unsubscribe"
 	var request map[string]interface{}
 	var response map[string]interface{}
 	query := make(map[string]interface{})
+	var err error
 	request = make(map[string]interface{})
-	request["SubscriptionName"] = parts[1]
 	request["TopicName"] = parts[0]
+	request["SubscriptionName"] = parts[1]
+	request["RegionId"] = client.RegionId
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		response, err = client.RpcPost("Mns-open", "2022-01-19", action, query, request, true)
-
 		if err != nil {
 			if NeedRetry(err) {
 				wait()

--- a/alicloud/resource_alicloud_message_service_subscription_test.go
+++ b/alicloud/resource_alicloud_message_service_subscription_test.go
@@ -372,6 +372,40 @@ func TestAccAliCloudMessageServiceSubscription_basic9850(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"tenant_rate_limit_policy": []map[string]interface{}{
+						{
+							"enabled":                 "true",
+							"max_receives_per_second": "50",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tenant_rate_limit_policy.#":                         "1",
+						"tenant_rate_limit_policy.0.enabled":                 "true",
+						"tenant_rate_limit_policy.0.max_receives_per_second": "50",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tenant_rate_limit_policy": []map[string]interface{}{
+						{
+							"enabled":                 "true",
+							"max_receives_per_second": "100",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tenant_rate_limit_policy.#":                         "1",
+						"tenant_rate_limit_policy.0.enabled":                 "true",
+						"tenant_rate_limit_policy.0.max_receives_per_second": "100",
+					}),
+				),
+			},
+			{
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -445,6 +479,8 @@ var AliCloudMessageServiceSubscriptionMap9850 = map[string]string{
 	"create_time":           CHECKSET,
 	"notify_content_format": CHECKSET,
 	"notify_strategy":       CHECKSET,
+	"last_modify_time":      CHECKSET,
+	"topic_owner":           CHECKSET,
 }
 
 func AliCloudMessageServiceSubscriptionBasicDependence9850(name string) string {
@@ -464,6 +500,148 @@ func AliCloudMessageServiceSubscriptionBasicDependence9850(name string) string {
   		message_retention_period = 345600
   		visibility_timeout       = 30
   		polling_wait_seconds     = 0
+	}
+`, name)
+}
+
+// TestAccAliCloudMessageServiceSubscription_dm covers the email (DirectMail) push
+// type. dm_attributes is required by the Subscribe API when push_type is dm;
+// without it the API rejects the call with EndpointInvalid.
+func TestAccAliCloudMessageServiceSubscription_dm(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_message_service_subscription.default"
+	ra := resourceAttrInit(resourceId, AliCloudMessageServiceSubscriptionMap9850)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &MessageServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeMessageServiceSubscription")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccmessageservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudMessageServiceSubscriptionPushDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"push_type":         "dm",
+					"endpoint":          "smq-ep:dm:${data.alicloud_account.current.id}:__dynamic",
+					"sts_role_arn":      "acs:ram::${data.alicloud_account.current.id}:role/AliyunMNSNotificationRole",
+					"subscription_name": name,
+					"topic_name":        "${alicloud_message_service_topic.default.id}",
+					"dm_attributes": []map[string]interface{}{
+						{
+							"account_name": "notify@example.com",
+							"subject":      name,
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"push_type":                    "dm",
+						"endpoint":                     CHECKSET,
+						"sts_role_arn":                 CHECKSET,
+						"subscription_name":            name,
+						"topic_name":                   CHECKSET,
+						"dm_attributes.#":              "1",
+						"dm_attributes.0.subject":      name,
+						"dm_attributes.0.account_name": "notify@example.com",
+					}),
+				),
+			},
+			{
+				ResourceName: resourceId,
+				ImportState:  true,
+				// push_type, dm_attributes and sts_role_arn are accepted by the
+				// Subscribe API on create but GetSubscriptionAttributes returns none
+				// of them, so an imported state cannot be compared attribute by
+				// attribute. ForceNew attributes must not be listed in
+				// ImportStateVerifyIgnore, so verification is disabled here instead.
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+// TestAccAliCloudMessageServiceSubscription_dysms covers the SMS push type.
+// dysms_attributes is required by the Subscribe API when push_type is dysms.
+func TestAccAliCloudMessageServiceSubscription_dysms(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_message_service_subscription.default"
+	ra := resourceAttrInit(resourceId, AliCloudMessageServiceSubscriptionMap9850)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &MessageServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeMessageServiceSubscription")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccmessageservice%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudMessageServiceSubscriptionPushDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"push_type":         "dysms",
+					"endpoint":          "smq-ep:dysms:${data.alicloud_account.current.id}:13800138000",
+					"sts_role_arn":      "acs:ram::${data.alicloud_account.current.id}:role/AliyunMNSNotificationRole",
+					"subscription_name": name,
+					"topic_name":        "${alicloud_message_service_topic.default.id}",
+					"dysms_attributes": []map[string]interface{}{
+						{
+							"template_code": "SMS_123456",
+							"sign_name":     "阿里云短信测试专用",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"push_type":                        "dysms",
+						"endpoint":                         CHECKSET,
+						"sts_role_arn":                     CHECKSET,
+						"subscription_name":                name,
+						"topic_name":                       CHECKSET,
+						"dysms_attributes.#":               "1",
+						"dysms_attributes.0.template_code": "SMS_123456",
+						"dysms_attributes.0.sign_name":     "阿里云短信测试专用",
+					}),
+				),
+			},
+			{
+				ResourceName: resourceId,
+				ImportState:  true,
+				// Same as the dm case: push_type, dysms_attributes and sts_role_arn
+				// are never returned by GetSubscriptionAttributes, and ForceNew
+				// attributes must not be listed in ImportStateVerifyIgnore.
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func AliCloudMessageServiceSubscriptionPushDependence(name string) string {
+	return fmt.Sprintf(`
+	variable "name" {
+  		default = "%s"
+	}
+
+	data "alicloud_account" "current" {
+	}
+
+	resource "alicloud_message_service_topic" "default" {
+  		topic_name = var.name
 	}
 `, name)
 }

--- a/alicloud/service_alicloud_message_service_v2.go
+++ b/alicloud/service_alicloud_message_service_v2.go
@@ -375,6 +375,7 @@ func (s *MessageServiceServiceV2) DescribeMessageServiceSubscription(id string) 
 	parts := strings.Split(id, ":")
 	if len(parts) != 2 {
 		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
 	}
 	request = make(map[string]interface{})
 	query = make(map[string]interface{})
@@ -413,15 +414,18 @@ func (s *MessageServiceServiceV2) DescribeMessageServiceSubscription(id string) 
 }
 
 func (s *MessageServiceServiceV2) MessageServiceSubscriptionStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.MessageServiceSubscriptionStateRefreshFuncWithApi(id, field, failStates, s.DescribeMessageServiceSubscription)
+}
+
+func (s *MessageServiceServiceV2) MessageServiceSubscriptionStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		object, err := s.DescribeMessageServiceSubscription(id)
+		object, err := call(id)
 		if err != nil {
 			if NotFoundError(err) {
 				return object, "", nil
 			}
 			return nil, "", WrapError(err)
 		}
-
 		v, err := jsonpath.Get(field, object)
 		currentStatus := fmt.Sprint(v)
 

--- a/website/docs/d/message_service_subscriptions.html.markdown
+++ b/website/docs/d/message_service_subscriptions.html.markdown
@@ -4,14 +4,14 @@ layout: "alicloud"
 page_title: "Alicloud: alicloud_message_service_subscriptions"
 sidebar_current: "docs-alicloud-datasource-message-service-subscriptions"
 description: |-
-  Provides a list of Message Notification Service Subscriptions to the user.
+  Provides a list of Message Service Subscription owned by an Alibaba Cloud account.
 ---
 
-# alicloud\_message\_service\_subscriptions
+# alicloud_message_service_subscriptions
 
-This data source provides the Message Notification Service Subscriptions of the current Alibaba Cloud user.
+This data source provides the Message Service Subscriptions of the current Alibaba Cloud user.
 
--> **NOTE:** Available in v1.188.0+.
+-> **NOTE:** Available since v1.188.0.
 
 ## Example Usage
 
@@ -37,20 +37,21 @@ output "subscription_id_2" {
 ## Argument Reference
 
 The following arguments are supported:
-
-* `ids` - (Optional, ForceNew, Computed) A list of Subscription IDs.
-* `name_regex` - (Optional, ForceNew) A regex string to filter results by Subscription name.
-* `topic_name` - (Required, ForceNew) The name of the topic.
-* `subscription_name` - (Optional, ForceNew) The name of the subscription.
+* `ids` - (Optional, Computed) A list of Subscription IDs. The value is formulated as `<topic_name>:<subscription_name>`.
+* `name_regex` - (Optional) A regex string to filter results by Subscription name.
+* `topic_name` - (Required) The name of the topic.
+* `subscription_name` - (Optional) The name of the subscription.
+* `page_number` - (Optional, Int) The number of the page to return.
+* `page_size` - (Optional, Int) The number of entries to return on each page.
+* `enable_details` - (Optional, Available since v1.284.0) Default to `false`. Set it to `true` can output more details about resource attributes.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
-
 * `names` - A list of Subscription names.
 * `subscriptions` - A list of Subscriptions. Each element contains the following attributes:
-  * `id` - The id of the Subscription.
+  * `id` - The id of the Subscription. The value is formulated as `<topic_name>:<subscription_name>`.
   * `topic_name` - The name of the topic.
   * `subscription_name` - The name of the subscription.
   * `endpoint` - The endpoint to which the messages are pushed.
@@ -61,3 +62,9 @@ The following attributes are exported in addition to the arguments listed above:
   * `subscription_url` - The url of the subscription.
   * `last_modify_time` - The time when the subscription was last modified. This value is a UNIX timestamp representing the number of milliseconds that have elapsed since the epoch time January 1, 1970, 00:00:00 UTC.
   * `create_time` - The time when the subscription was created. This value is a UNIX timestamp representing the number of milliseconds that have elapsed since the epoch time January 1, 1970, 00:00:00 UTC.
+  * `dlq_policy` - (Available since v1.284.0) The dead-letter queue policy. **NOTE:** This field is only available when `enable_details` is `true`.
+    * `dead_letter_target_queue` - The queue to which dead-letter messages are delivered.
+    * `enabled` - Indicates whether the dead-letter message delivery is enabled.
+  * `tenant_rate_limit_policy` - (Available since v1.284.0) The rate limit policy. **NOTE:** This field is only available when `enable_details` is `true`.
+    * `enabled` - Indicates whether the rate limit policy is enabled.
+    * `max_receives_per_second` - The maximum number of messages that can be pushed or consumed per second.

--- a/website/docs/r/message_service_subscription.html.markdown
+++ b/website/docs/r/message_service_subscription.html.markdown
@@ -54,16 +54,21 @@ resource "alicloud_message_service_subscription" "default" {
 
 The following arguments are supported:
 * `dlq_policy` - (Optional, Set, Available since v1.244.0) The dead-letter queue policy. See [`dlq_policy`](#dlq_policy) below.
+* `dm_attributes` - (Optional, ForceNew, Set, Available since v1.284.0) The email push attributes. This parameter is required when `push_type` is set to `dm`. See [`dm_attributes`](#dm_attributes) below.
+* `dysms_attributes` - (Optional, ForceNew, Set, Available since v1.284.0) The SMS push attributes. This parameter is required when `push_type` is set to `dysms`. See [`dysms_attributes`](#dysms_attributes) below.
+* `tenant_rate_limit_policy` - (Optional, Set, Available since v1.284.0) The rate limit policy. See [`tenant_rate_limit_policy`](#tenant_rate_limit_policy) below.
 * `topic_name`- (Required, ForceNew) The topic which The subscription belongs to was named with the name. A topic name must start with an English letter or a digit, and can contain English letters, digits, and hyphens, with the length not exceeding 255 characters.
 * `subscription_name` - (Required, ForceNew) Two topics subscription on a single account in the same topic cannot have the same name. A topic subscription name must start with an English letter or a digit, and can contain English letters, digits, and hyphens, with the length not exceeding 255 characters.
-* `endpoint` - (Required, ForceNew) The endpoint has three format. Available values format:
+* `endpoint` - (Required, ForceNew) The endpoint of the subscription. The format varies with `push_type`. Available values format:
   - `HTTP Format`: An HTTP URL that starts with http:// or https://.
   - `Queue Format`: A queue name.
+  - `Dm Format`: `smq-ep:dm:<account_id>:__dynamic`, where `<account_id>` is the ID of your Alibaba Cloud account.
+  - `Dysms Format`: `smq-ep:dysms:<account_id>:<phone_number>`.
   - `MPush Format`: An AppKey.
   - `Sms Format`: A mobile number
   - `Email Format`: An email address.
-* `sts_role_arn` - (Optional, ForceNew, Available since v1.259.0) The STS RoleArn.
-* `push_type` - (Required, ForceNew) The Push type of Subscription. The Valid values: `http`, `queue`, `mpush`, `alisms` and `email`.
+* `sts_role_arn` - (Optional, ForceNew, Available since v1.259.0) The ARN of the RAM role assumed by the service. The format is `acs:ram::<account_id>:role/<role_name>`. This parameter is required when `push_type` is set to `dm` or `dysms`.
+* `push_type` - (Required) The Push type of Subscription. Valid values: `http`, `queue`, `dm`, `dysms`, `fc` and `eventbus`. The values `mpush`, `alisms` and `email` are deprecated and are retained only for compatibility with existing subscriptions.
 * `filter_tag` - (Optional, ForceNew) The tag that is used to filter messages. Only the messages that have the same tag can be pushed. A tag is a string that can be up to 16 characters in length. By default, no tag is specified to filter messages.
 * `notify_content_format` - (Optional, Computed, ForceNew) The NotifyContentFormat attribute of Subscription. This attribute specifies the content format of the messages pushed to users. Valid values: `XML`, `JSON` and `SIMPLIFIED`. Default value: `XML`.
 * `notify_strategy` - (Optional) The NotifyStrategy attribute of Subscription. This attribute specifies the retry strategy when message sending fails. Default value: `BACKOFF_RETRY`. Valid values:
@@ -76,11 +81,31 @@ The dlq_policy supports the following:
 * `dead_letter_target_queue` - (Optional) The queue to which dead-letter messages are delivered.
 * `enabled` - (Optional, Bool) Specifies whether to enable the dead-letter message delivery. Valid values: `true`, `false`.
 
+### `dm_attributes`
+
+The dm_attributes supports the following:
+* `account_name` - (Optional, ForceNew) The sender address of the email push. The value must be a sender address that has been configured in Direct Mail.
+* `subject` - (Optional, ForceNew) The subject of the pushed email.
+
+### `dysms_attributes`
+
+The dysms_attributes supports the following:
+* `sign_name` - (Optional, ForceNew) The signature name of the SMS push. The value must be a signature that has been configured in Short Message Service.
+* `template_code` - (Optional, ForceNew) The template code of the SMS push. You can obtain the value from the Short Message Service console.
+
+### `tenant_rate_limit_policy`
+
+The tenant_rate_limit_policy supports the following:
+* `enabled` - (Optional, Bool) Specifies whether to enable the rate limit policy. Valid values: `true`, `false`.
+* `max_receives_per_second` - (Optional, Int) The maximum number of messages that can be pushed or consumed per second.
+
 ## Attributes Reference
 
 The following attributes are exported:
 * `id` - The resource ID in terraform of Subscription. The value formats as `<topic_name>:<subscription_name>`.
 * `create_time` - (Available since v1.244.0) The time when the subscription was created.
+* `last_modify_time` - (Available since v1.284.0) The time when the subscription was last modified.
+* `topic_owner` - (Available since v1.284.0) The ID of the Alibaba Cloud account that owns the subscribed topic.
 
 ## Timeouts
 


### PR DESCRIPTION
### Why

The `Subscribe` API requires `DmAttributes` when `push_type` is `dm`, and `DysmsAttributes` when `push_type` is `dysms`. Neither field was exposed, so those two push types could not be created at all:

```
Subscribe(PushType=dm, Endpoint=smq-ep:dm:<account_id>:__dynamic)   # no DmAttributes
=> 400 EndpointInvalid: The endpoint you provided is invalid.DMAttributes is null.
```

`TenantRateLimitPolicy` was also missing although the API supports it on create, update and read.

### What

**resource/alicloud_message_service_subscription**

- `dm_attributes` (`account_name`, `subject`) — required by the API when `push_type` is `dm`
- `dysms_attributes` (`template_code`, `sign_name`) — required by the API when `push_type` is `dysms`
- `tenant_rate_limit_policy` (`enabled`, `max_receives_per_second`)
- `last_modify_time`, `topic_owner` — read-only

`dm_attributes` and `dysms_attributes` are `ForceNew`: `GetSubscriptionAttributes` never returns them and `SetSubscriptionAttributes` does not accept them, so they can only be set at creation time. For the same reason they are excluded from `ImportStateVerify`.

`tenant_rate_limit_policy` is fully managed (create / update / read) and is `Computed`, because the API always returns a `TenantRateLimitPolicy` object even when the user never configured one — without `Computed` every plan after apply is non-empty.

Two fixes to existing behaviour:

- `SetSubscriptionAttributes` requires `NotifyStrategy` on every call, even when only other attributes change (omitting it fails with `Missing:NotifyStrategy`). It is now always sent, instead of only when it changed.
- `sts_role_arn` is marked `ForceNew`, matching the API: it is accepted on create but never returned by the read API.

**data-source/alicloud_message_service_subscriptions**

- `enable_details`, which additionally exposes `dlq_policy` and `tenant_rate_limit_policy` per subscription

The `subscription_url` assertion was dropped from the test: neither `ListSubscriptionByTopic` nor `GetSubscriptionAttributes` returns `SubscriptionURL`, so the attribute is always empty. The schema field and its documentation are kept for backward compatibility.

### Test

```
=== RUN   TestAccAliCloudMessageServiceSubscription_basic9850
--- PASS: TestAccAliCloudMessageServiceSubscription_basic9850 (21.19s)
=== RUN   TestAccAliCloudMessageServiceSubscription_basic9850_twin
--- PASS: TestAccAliCloudMessageServiceSubscription_basic9850_twin (6.09s)
=== RUN   TestAccAliCloudMessageServiceSubscription_dm
--- PASS: TestAccAliCloudMessageServiceSubscription_dm (5.14s)
=== RUN   TestAccAliCloudMessageServiceSubscription_dysms
--- PASS: TestAccAliCloudMessageServiceSubscription_dysms (5.25s)
=== RUN   TestAccAlicloudMessageServiceSubscriptionsDataSource
--- PASS: TestAccAlicloudMessageServiceSubscriptionsDataSource (20.65s)
PASS
```