### PR TITLE
resource/alicloud_ram_security_preference: fix login_network_masks and login_session_duration being cleared by updating the other attributes

### DIFF
--- a/alicloud/resource_alicloud_ram_security_preference.go
+++ b/alicloud/resource_alicloud_ram_security_preference.go
@@ -263,8 +263,8 @@ func resourceAliCloudRamSecurityPreferenceUpdate(d *schema.ResourceData, meta in
 
 	if d.HasChange("login_session_duration") {
 		update = true
-		request["LoginSessionDuration"] = d.Get("login_session_duration")
 	}
+	request["LoginSessionDuration"] = d.Get("login_session_duration")
 
 	if d.HasChange("max_idle_days_for_access_keys") {
 		update = true
@@ -306,8 +306,8 @@ func resourceAliCloudRamSecurityPreferenceUpdate(d *schema.ResourceData, meta in
 
 	if d.HasChange("login_network_masks") {
 		update = true
-		request["LoginNetworkMasks"] = d.Get("login_network_masks")
 	}
+	request["LoginNetworkMasks"] = d.Get("login_network_masks")
 
 	if d.HasChange("allow_user_to_login_with_passkey") {
 		update = true

--- a/alicloud/resource_alicloud_ram_security_preference_test.go
+++ b/alicloud/resource_alicloud_ram_security_preference_test.go
@@ -879,10 +879,7 @@ func AlicloudRamSecurityPreferenceBasicDependence10751(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
     default = "%s"
-}
-
-
-`, name)
+}`, name)
 }
 
 // Test Ram SecurityPreference. <<< Resource test cases, automatically generated.


### PR DESCRIPTION
### Problem

`SetSecurityPreference` resets every parameter which is not passed in: `LoginNetworkMasks` falls back to allowing the entire network and `LoginSessionDuration` falls back to its default value `6`.

The update built the request only from the changed attributes, so two consecutive applies of the same configuration kept flipping:

| Apply | Detected change | Sent | Result |
|---|---|---|---|
| 1st | `login_network_masks` | `LoginNetworkMasks` | `LoginSessionDuration` reset to `6` |
| 2nd | `login_session_duration` | `LoginSessionDuration` | `LoginNetworkMasks` cleared |

The configuration never converged, and the login mask was silently lost on the cloud side.

### Fix

`LoginNetworkMasks` and `LoginSessionDuration` are always passed in when updating, so changing one of them no longer clears the other. `d.HasChange` still decides whether the update is needed.