### PR TITLE
ci: separate pull request policy from execution

### DIFF
--- a/.github/workflows/acctest-terraform-basic-policy.yml
+++ b/.github/workflows/acctest-terraform-basic-policy.yml
@@ -1,0 +1,208 @@
+name: Terraform Basic Policy
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - master
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  policy:
+    permissions:
+      checks: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Evaluate pull request policy
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const policyVersion = 1;
+            const supportedActions = new Set([
+              "opened",
+              "reopened",
+              "synchronize",
+              "ready_for_review",
+            ]);
+            const actionsApp = {
+              id: 15368,
+              slug: "github-actions",
+              owner: "github",
+            };
+            const pullRequest = context.payload.pull_request;
+            const author = pullRequest?.user?.login;
+            const headRepository = pullRequest?.head?.repo?.full_name;
+            const headSha = pullRequest?.head?.sha;
+            const baseRepository = pullRequest?.base?.repo?.full_name;
+            const baseRef = pullRequest?.base?.ref;
+            const pullNumber = pullRequest?.number;
+            const changedFileCount = pullRequest?.changed_files;
+            const expectedBaseRepository = `${context.repo.owner}/${context.repo.repo}`;
+            const repositoryPattern =
+              /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]{1,100}$/;
+
+            let classification = "invalid";
+            let relevant = false;
+            let failure = "";
+
+            try {
+              if (
+                context.eventName !== "pull_request_target" ||
+                !supportedActions.has(context.payload.action) ||
+                typeof author !== "string" ||
+                author.length === 0 ||
+                author.length > 100 ||
+                typeof headRepository !== "string" ||
+                !repositoryPattern.test(headRepository) ||
+                !/^[0-9a-f]{40}$/.test(headSha ?? "") ||
+                baseRepository !== expectedBaseRepository ||
+                baseRef !== "master" ||
+                !Number.isSafeInteger(pullNumber) ||
+                pullNumber <= 0 ||
+                !Number.isSafeInteger(changedFileCount) ||
+                changedFileCount < 0 ||
+                changedFileCount > 3000
+              ) {
+                throw new Error("invalid pull request metadata");
+              }
+
+              const changedFiles = [];
+              const pageCount = Math.ceil(changedFileCount / 100);
+              for (let page = 1; page <= pageCount; page += 1) {
+                const response = await github.rest.pulls.listFiles({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullNumber,
+                  per_page: 100,
+                  page,
+                });
+                if (!Array.isArray(response?.data)) {
+                  throw new Error("invalid changed-files response");
+                }
+                changedFiles.push(...response.data);
+              }
+
+              if (
+                changedFiles.length !== changedFileCount ||
+                changedFiles.some(
+                  (file) =>
+                    typeof file?.filename !== "string" ||
+                    file.filename.length === 0
+                )
+              ) {
+                throw new Error("incomplete changed-files response");
+              }
+
+              const protectedPathChanged = changedFiles.some(({ filename }) =>
+                filename.startsWith(".github/workflows/") ||
+                filename.startsWith(".github/actions/") ||
+                filename === ".github/CODEOWNERS" ||
+                filename === "action.yml" ||
+                filename === "action.yaml"
+              );
+              relevant =
+                protectedPathChanged ||
+                changedFiles.some(({ filename }) =>
+                  /^alicloud\/[^/]+\.go$/.test(filename)
+                );
+
+              const allowlistedAutomation =
+                author === "api-tool-agent" &&
+                headRepository === "api-tool-agent/terraform-provider-alicloud";
+
+              let trusted = allowlistedAutomation;
+              if (!trusted) {
+                try {
+                  const response =
+                    await github.rest.repos.getCollaboratorPermissionLevel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      username: author,
+                    });
+                  trusted = ["admin", "maintain", "write"].includes(
+                    response?.data?.permission
+                  );
+                } catch {
+                  core.warning(
+                    "Permission lookup failed; treating the author as external."
+                  );
+                }
+              }
+
+              classification = trusted ? "trusted" : "external";
+              if (!trusted && protectedPathChanged) {
+                classification = "blocked";
+                failure =
+                  "External pull request modifies protected CI control paths.";
+              }
+            } catch {
+              classification = "invalid";
+              relevant = false;
+              failure = "Pull request metadata or changed-files data is invalid.";
+            }
+
+            const binding = {
+              v: policyVersion,
+              p: Number.isSafeInteger(pullNumber) ? pullNumber : 0,
+              s: typeof headSha === "string" ? headSha : "",
+              r: typeof headRepository === "string" ? headRepository : "",
+              c: classification,
+              q: relevant,
+            };
+            const externalId = JSON.stringify(binding);
+            if (externalId.length > 255) {
+              failure = "Policy binding exceeds the Check Run size limit.";
+              binding.c = "invalid";
+              binding.q = false;
+            }
+
+            if (!/^[0-9a-f]{40}$/.test(binding.s)) {
+              throw new Error(
+                "Cannot publish Basic Policy without an exact pull request head SHA."
+              );
+            }
+
+            const detailsUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`;
+            const conclusion = failure ? "failure" : "success";
+            const summary = failure
+              ? failure
+              : `classification=${binding.c}; relevant=${binding.q}`;
+
+            const response = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "Basic Policy",
+              head_sha: binding.s,
+              status: "completed",
+              conclusion,
+              external_id: JSON.stringify(binding),
+              details_url: detailsUrl,
+              output: {
+                title: failure ? "Basic policy rejected" : "Basic policy passed",
+                summary,
+              },
+            });
+
+            if (
+              response?.data?.app?.id !== actionsApp.id ||
+              response?.data?.app?.slug !== actionsApp.slug ||
+              response?.data?.app?.owner?.login !== actionsApp.owner
+            ) {
+              throw new Error("Basic Policy Check Run source is invalid.");
+            }
+
+            if (failure) {
+              core.setFailed(failure);
+            }

--- a/.github/workflows/acctest-terraform-basic.yml
+++ b/.github/workflows/acctest-terraform-basic.yml
@@ -1,123 +1,212 @@
 name: Terrafrom Basic Checks
 on:
-  pull_request_target:
+  # Fork workflow changes require repository approval before this workflow can
+  # run. Never approve an external protected-path change when Basic Policy fails.
+  pull_request:
     types:
       - opened
       - reopened
       - synchronize
-    paths:
-      - .github/workflows/**
-      - .github/actions/**
-      - .github/CODEOWNERS
-      - action.yml
-      - action.yaml
-      - alicloud/*.go
+      - ready_for_review
     branches:
       - master
 
-permissions:
-  pull-requests: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   route:
+    permissions:
+      checks: read
+      pull-requests: read
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     outputs:
+      classification: ${{ steps.select.outputs.classification }}
+      relevant: ${{ steps.select.outputs.relevant }}
       runner: ${{ steps.select.outputs.runner }}
     steps:
-      - name: Select runner
+      - name: Wait for Basic Policy
         id: select
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const fallbackRunner = JSON.stringify("ubuntu-latest");
-            const trustedRunner = JSON.stringify("terraform-ci-trusted");
-            core.setOutput("runner", fallbackRunner);
-
+            const policyVersion = 1;
+            const supportedActions = new Set([
+              "opened",
+              "reopened",
+              "synchronize",
+              "ready_for_review",
+            ]);
+            const actionsApp = {
+              id: 15368,
+              slug: "github-actions",
+              owner: "github",
+            };
             const pullRequest = context.payload.pull_request;
-            const author = pullRequest?.user?.login;
             const headRepository = pullRequest?.head?.repo?.full_name;
             const headSha = pullRequest?.head?.sha;
+            const baseRepository = pullRequest?.base?.repo?.full_name;
+            const baseRef = pullRequest?.base?.ref;
             const pullNumber = pullRequest?.number;
-            const changedFileCount = pullRequest?.changed_files;
+            const expectedBaseRepository = `${context.repo.owner}/${context.repo.repo}`;
+            const expectedOrigin = new URL(context.serverUrl).origin;
+            const expectedDetailsPath = [
+              "",
+              context.repo.owner,
+              context.repo.repo,
+              "actions",
+              "runs",
+            ];
             const repositoryPattern =
               /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]{1,100}$/;
 
             if (
-              typeof author !== "string" ||
-              author.length === 0 ||
+              context.eventName !== "pull_request" ||
+              !supportedActions.has(context.payload.action) ||
               typeof headRepository !== "string" ||
               !repositoryPattern.test(headRepository) ||
               !/^[0-9a-f]{40}$/.test(headSha ?? "") ||
+              baseRepository !== expectedBaseRepository ||
+              baseRef !== "master" ||
               !Number.isSafeInteger(pullNumber) ||
-              pullNumber <= 0 ||
-              !Number.isSafeInteger(changedFileCount) ||
-              changedFileCount <= 0 ||
-              changedFileCount > 3000
+              pullNumber <= 0
             ) {
               throw new Error("Pull request metadata is invalid.");
             }
 
-            const changedFiles = [];
-            const pageCount = Math.ceil(changedFileCount / 100);
-            for (let page = 1; page <= pageCount; page += 1) {
-              const response = await github.rest.pulls.listFiles({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pullNumber,
-                per_page: 100,
-                page,
-              });
-              if (!Array.isArray(response?.data)) {
-                throw new Error("Changed-files API returned invalid data.");
+            const parseBinding = (externalId) => {
+              if (typeof externalId !== "string" || externalId.length > 255) {
+                throw new Error("Basic Policy binding is invalid.");
               }
-              changedFiles.push(...response.data);
-            }
+              let binding;
+              try {
+                binding = JSON.parse(externalId);
+              } catch {
+                throw new Error("Basic Policy binding is invalid.");
+              }
+              if (
+                binding === null ||
+                typeof binding !== "object" ||
+                Array.isArray(binding) ||
+                Object.keys(binding).sort().join(",") !== "c,p,q,r,s,v" ||
+                binding.v !== policyVersion ||
+                binding.p !== pullNumber ||
+                binding.s !== headSha ||
+                binding.r !== headRepository ||
+                !["trusted", "external", "blocked", "invalid"].includes(
+                  binding.c
+                ) ||
+                typeof binding.q !== "boolean"
+              ) {
+                throw new Error("Basic Policy binding is stale or invalid.");
+              }
+              return binding;
+            };
 
-            if (
-              changedFiles.length !== changedFileCount ||
-              changedFiles.some(
-                (file) => typeof file?.filename !== "string" || file.filename.length === 0
-              )
-            ) {
-              throw new Error("Changed-files API result is incomplete or invalid.");
-            }
+            const validateSource = (check) => {
+              let detailsUrl;
+              try {
+                detailsUrl = new URL(check?.details_url);
+              } catch {
+                throw new Error("Basic Policy Check Run source is invalid.");
+              }
+              const path = detailsUrl.pathname.split("/");
+              const runIdText = path[5];
+              const runId = Number(runIdText);
+              const canonicalDetailsUrl =
+                `${expectedOrigin}/${context.repo.owner}/${context.repo.repo}` +
+                `/actions/runs/${runIdText}`;
+              if (
+                check?.app?.id !== actionsApp.id ||
+                check?.app?.slug !== actionsApp.slug ||
+                check?.app?.owner?.login !== actionsApp.owner ||
+                detailsUrl.origin !== expectedOrigin ||
+                detailsUrl.username !== "" ||
+                detailsUrl.password !== "" ||
+                path.length !== 6 ||
+                !expectedDetailsPath.every(
+                  (segment, index) => path[index] === segment
+                ) ||
+                !/^[1-9][0-9]*$/.test(runIdText ?? "") ||
+                !Number.isSafeInteger(runId) ||
+                runId <= 0 ||
+                String(runId) !== runIdText ||
+                detailsUrl.search !== "" ||
+                detailsUrl.hash !== "" ||
+                check.details_url !== canonicalDetailsUrl
+              ) {
+                throw new Error("Basic Policy Check Run source is invalid.");
+              }
+            };
 
-            const protectedPathChanged = changedFiles.some(({ filename }) =>
-              filename.startsWith(".github/workflows/") ||
-              filename.startsWith(".github/actions/") ||
-              filename === ".github/CODEOWNERS" ||
-              filename === "action.yml" ||
-              filename === "action.yaml"
-            );
+            const delay = (milliseconds) =>
+              new Promise((resolve) => setTimeout(resolve, milliseconds));
+            const deadline = Date.now() + 90000;
 
-            const allowlistedAutomation =
-              author === "api-tool-agent" &&
-              headRepository === "api-tool-agent/terraform-provider-alicloud";
-
-            let trusted = allowlistedAutomation;
-            try {
-              if (!trusted) {
-                const response = await github.rest.repos.getCollaboratorPermissionLevel({
+            while (Date.now() < deadline) {
+              const checkRuns = await github.paginate(
+                github.rest.checks.listForRef,
+                {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  username: author,
-                });
-                trusted = response.data.permission === "admin" || response.data.permission === "write";
+                  ref: headSha,
+                  check_name: "Basic Policy",
+                  filter: "all",
+                  per_page: 100,
+                }
+              );
+              const candidates = checkRuns.filter(
+                (check) =>
+                  check?.name === "Basic Policy" && check?.head_sha === headSha
+              );
+
+              if (candidates.length === 0) {
+                await delay(3000);
+                continue;
               }
-            } catch {
-              core.warning("Permission lookup failed; using GitHub-hosted runner.");
+              if (candidates.length !== 1) {
+                throw new Error("Basic Policy Check Run is ambiguous.");
+              }
+
+              const check = candidates[0];
+              validateSource(check);
+              const binding = parseBinding(check.external_id);
+
+              if (check.status !== "completed") {
+                if (!["queued", "in_progress"].includes(check.status)) {
+                  throw new Error("Basic Policy Check Run status is invalid.");
+                }
+                await delay(3000);
+                continue;
+              }
+              if (check.conclusion !== "success") {
+                throw new Error("Basic Policy rejected this pull request.");
+              }
+              if (!["trusted", "external"].includes(binding.c)) {
+                throw new Error("Basic Policy classification is not executable.");
+              }
+
+              const runner =
+                binding.c === "trusted"
+                  ? JSON.stringify("terraform-ci-trusted")
+                  : JSON.stringify("ubuntu-latest");
+              core.setOutput("classification", binding.c);
+              core.setOutput("relevant", String(binding.q));
+              core.setOutput("runner", runner);
+              return;
             }
 
-            if (!trusted && protectedPathChanged) {
-              throw new Error("External pull request modifies protected CI control paths.");
-            }
-
-            if (trusted) {
-              core.setOutput("runner", trustedRunner);
-            }
+            throw new Error("Timed out waiting for a unique Basic Policy result.");
 
   BreakingChange:
     needs: route
+    if: ${{ needs.route.outputs.relevant == 'true' }}
+    permissions:
+      contents: read
     runs-on: ${{ fromJSON(needs.route.outputs.runner) }}
     steps:
       - name: Setup Go
@@ -139,6 +228,9 @@ jobs:
 
   Consistency:
     needs: route
+    if: ${{ needs.route.outputs.relevant == 'true' }}
+    permissions:
+      contents: read
     runs-on: ${{ fromJSON(needs.route.outputs.runner) }}
     steps:
       - name: Setup Go
@@ -160,6 +252,9 @@ jobs:
 
   Formatter:
     needs: route
+    if: ${{ needs.route.outputs.relevant == 'true' }}
+    permissions:
+      contents: read
     runs-on: ${{ fromJSON(needs.route.outputs.runner) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -213,6 +308,9 @@ jobs:
 
   Compile:
     needs: route
+    if: ${{ needs.route.outputs.relevant == 'true' }}
+    permissions:
+      contents: read
     runs-on: ${{ fromJSON(needs.route.outputs.runner) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Architecture

This change separates policy evaluation from pull request code execution.

- `Terraform Basic Policy` runs on `pull_request_target` from the base branch. Its only job stays on `ubuntu-latest`, has only `pull-requests: read` and `checks: write`, never checks out or executes pull request content, and publishes a completed custom `Basic Policy` Check Run on the exact head SHA.
- `Terrafrom Basic Checks` runs on `pull_request`. Its route job waits for exactly one successful `Basic Policy` result for the current head, then the existing BreakingChange, Consistency, Formatter, and Compile commands run against the exact pull request head.

The policy Check Run uses a compact `external_id` binding for the policy version, pull request number, head SHA, head repository, classification, and relevance flag. The execution route verifies that binding, the GitHub Actions App identity, completion, success, and uniqueness. It also parses `details_url` and requires the exact repository Actions URL with a positive safe-integer run ID and no credentials, extra path, query, or fragment. Missing, stale, ambiguous, rejected, or timed-out policy results fail closed.

## Threat boundary

- The policy workflow has no checkout, local actions, caches, artifacts, secrets, or pull request code execution.
- The execution workflow has an empty default permission set. Its route job has only `checks: read` and `pull-requests: read`; consumers have only `contents: read`.
- Trusted authors are the exact `api-tool-agent` fork or collaborators with write, maintain, or admin permission. They route to `terraform-ci-trusted`.
- Ordinary external pull requests route only to `ubuntu-latest`.
- External changes to workflows, local actions, CODEOWNERS, or root action metadata produce a failed `Basic Policy`.
- Checkout remains pinned to the exact head repository and SHA with credentials not persisted. Setup caches remain disabled, no secrets are referenced, and all Actions are pinned by commit SHA.

External fork workflow changes require repository approval before the `pull_request` workflow can execute. A failed `Basic Policy` for a protected-path change must never be approved. This operational approval gate is part of the security boundary; this change does not claim runner-group hard isolation.

This follows GitHub's guidance to keep privileged `pull_request_target` processing separate from workflows that execute pull request code: [Securely using pull_request_target](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target).

## Relevance

The policy workflow runs for every pull request. The four basic-check consumers run only when the change touches:

- `.github/workflows/**`
- `.github/actions/**`
- `.github/CODEOWNERS`
- root `action.yml` or `action.yaml`
- a direct `alicloud/*.go` file

Other pull requests receive a successful policy result with `relevant=false`, and the four consumers are explicitly skipped.

## Validation

- 13 policy mocks covering allowlisted automation, write/maintain/admin collaborators, ordinary external changes, irrelevant changes, protected-path rejection, permission lookup fallback, pagination, and invalid or incomplete metadata
- 36 execution mocks covering trusted and external routing, irrelevant skipping, delayed policy arrival, rejection, invalid App identity, stale binding, ambiguity, missing policy, invalid status and binding, timeout, valid numeric run URLs, and strict rejection of malformed or mismatched `details_url` values
- Static assertions for triggers, permissions, exact Check Run binding, strict source URL parsing, four consumer gates, exact checkout repository/SHA, disabled credentials and caches, pinned Actions, and prohibited inputs
- `actionlint` v1.7.7
- `git diff --check`
- Public-content sanitization and full diff review

## Bootstrap state

This pull request changes the event topology itself. Until this commit is on `master`, the new `pull_request_target` policy workflow cannot publish `Basic Policy` for the current head. The new `pull_request` route may therefore time out waiting for that check, while the old base-branch `pull_request_target` workflow may still fail at checkout v7. Those are expected one-time bootstrap failures, not validation of the post-merge topology.

## Administrator actions after merge

1. Add `Basic Policy` as a required status check for `master`.
2. Keep external fork workflow approval enabled.
3. Never approve an external protected-path workflow run when `Basic Policy` fails.
4. Validate fresh trusted, ordinary external, irrelevant, and external protected-path pull requests after merge.