### PR TITLE
resource/alicloud_ecs_disk: deprecate enable_auto_snapshot

### DIFF
--- a/alicloud/resource_alicloud_ecs_disk.go
+++ b/alicloud/resource_alicloud_ecs_disk.go
@@ -70,9 +70,10 @@ func resourceAliCloudEcsDisk() *schema.Resource {
 				Optional: true,
 			},
 			"enable_auto_snapshot": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "This field is deprecated. The automatic snapshot policy feature is enabled by default for a cloud disk after it is created. To use the automatic snapshot policy, apply one to the cloud disk.",
 			},
 			"encrypt_algorithm": {
 				Type:     schema.TypeString,

--- a/website/docs/r/ecs_disk.html.markdown
+++ b/website/docs/r/ecs_disk.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 * `dry_run` - (Optional, Bool) Specifies whether to check the validity of the request without actually making the request.request Default value: `false`. Valid values:
   - `true`: The validity of the request is checked, but the request is not made. Check items include the required parameters, request format, service limits, and available ECS resources. If the check fails, the corresponding error message is returned. If the check succeeds, the DryRunOperation error code is returned.
   - `false`: The validity of the request is checked. If the check succeeds, a 2xx HTTP status code is returned and the request is made.
-* `enable_auto_snapshot` - (Optional, Bool) Specifies whether to enable the automatic snapshot policy feature for the cloud disk. Valid values: `true`, `false`.
+* `enable_auto_snapshot` - (Deprecated, Optional, Bool) Specifies whether the automatic snapshot policy feature is enabled for the cloud disk. Valid values: `true` and `false`. The default value is empty, which indicates that the current value is not changed. **NOTE:** This parameter is deprecated. The automatic snapshot policy feature is enabled by default for a cloud disk after it is created. To use the automatic snapshot policy, apply one to the cloud disk.
 * `encrypted` - (Optional, ForceNew, Bool) Specifies whether to encrypt the disk. Default value: `false`. Valid values:
   - `true`: Enable.
   - `false`: Disable.


### PR DESCRIPTION
## Summary

- Deprecate `enable_auto_snapshot` in the ECS disk resource schema.
- Align the field description with the ECS API: an empty value leaves the current value unchanged, and cloud disks enable the automatic snapshot policy feature by default after creation.
- Document that applying an automatic snapshot policy to a cloud disk is all that is required to use the policy.

## Validation

- `go test ./alicloud -run '^$' -count=1`
- `go run scripts/testing/testing_coverage_rate_check.go -resource=alicloud_ecs_disk`
- `git diff --check`
