### PR TITLE
ci: make basic policy checks reusable

### DIFF
--- a/.github/workflows/acctest-terraform-basic-policy.yml
+++ b/.github/workflows/acctest-terraform-basic-policy.yml
@@ -37,6 +37,7 @@ jobs:
             const actionsApp = {
               id: 15368,
               slug: "github-actions",
+              name: "GitHub Actions",
               owner: "github",
             };
             const pullRequest = context.payload.pull_request;
@@ -172,36 +173,90 @@ jobs:
               );
             }
 
-            const detailsUrl =
-              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
-              `/actions/runs/${context.runId}`;
             const conclusion = failure ? "failure" : "success";
             const summary = failure
               ? failure
               : `classification=${binding.c}; relevant=${binding.q}`;
+            const checkOutput = {
+              title: failure ? "Basic policy rejected" : "Basic policy passed",
+              summary,
+            };
+            const expectedOrigin = new URL(context.serverUrl).origin;
+            const validateCheck = (check) => {
+              const checkId = check?.id;
+              const canonicalCheckUrl =
+                `${expectedOrigin}/${context.repo.owner}/${context.repo.repo}` +
+                `/runs/${checkId}`;
+              if (
+                !Number.isSafeInteger(checkId) ||
+                checkId <= 0 ||
+                check?.name !== "Basic Policy" ||
+                check?.head_sha !== binding.s ||
+                check?.external_id !== externalId ||
+                check?.status !== "completed" ||
+                check?.conclusion !== conclusion ||
+                check?.app?.id !== actionsApp.id ||
+                check?.app?.slug !== actionsApp.slug ||
+                check?.app?.name !== actionsApp.name ||
+                check?.app?.owner?.login !== actionsApp.owner ||
+                check?.details_url !== canonicalCheckUrl ||
+                check?.html_url !== canonicalCheckUrl
+              ) {
+                throw new Error("Basic Policy Check Run source is invalid.");
+              }
+            };
 
-            const response = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: "Basic Policy",
-              head_sha: binding.s,
-              status: "completed",
-              conclusion,
-              external_id: JSON.stringify(binding),
-              details_url: detailsUrl,
-              output: {
-                title: failure ? "Basic policy rejected" : "Basic policy passed",
-                summary,
-              },
-            });
-
-            if (
-              response?.data?.app?.id !== actionsApp.id ||
-              response?.data?.app?.slug !== actionsApp.slug ||
-              response?.data?.app?.owner?.login !== actionsApp.owner
-            ) {
-              throw new Error("Basic Policy Check Run source is invalid.");
+            const checkRuns = await github.paginate(
+              github.rest.checks.listForRef,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: binding.s,
+                check_name: "Basic Policy",
+                filter: "all",
+                per_page: 100,
+              }
+            );
+            if (!Array.isArray(checkRuns)) {
+              throw new Error("Basic Policy Check Run lookup is invalid.");
             }
+            const reusableChecks = checkRuns.filter(
+              (check) =>
+                check?.name === "Basic Policy" &&
+                check?.head_sha === binding.s &&
+                check?.external_id === externalId
+            );
+            if (reusableChecks.length > 1) {
+              throw new Error("Basic Policy Check Run is ambiguous.");
+            }
+
+            let response;
+            if (reusableChecks.length === 0) {
+              response = await github.rest.checks.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: "Basic Policy",
+                head_sha: binding.s,
+                status: "completed",
+                conclusion,
+                external_id: externalId,
+                output: checkOutput,
+              });
+            } else {
+              const reusableCheck = reusableChecks[0];
+              validateCheck(reusableCheck);
+              response = await github.rest.checks.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                check_run_id: reusableCheck.id,
+                status: "completed",
+                conclusion,
+                external_id: externalId,
+                details_url: reusableCheck.details_url,
+                output: checkOutput,
+              });
+            }
+            validateCheck(response?.data);
 
             if (failure) {
               core.setFailed(failure);

--- a/.github/workflows/acctest-terraform-basic.yml
+++ b/.github/workflows/acctest-terraform-basic.yml
@@ -44,6 +44,7 @@ jobs:
             const actionsApp = {
               id: 15368,
               slug: "github-actions",
+              name: "GitHub Actions",
               owner: "github",
             };
             const pullRequest = context.payload.pull_request;
@@ -54,13 +55,6 @@ jobs:
             const pullNumber = pullRequest?.number;
             const expectedBaseRepository = `${context.repo.owner}/${context.repo.repo}`;
             const expectedOrigin = new URL(context.serverUrl).origin;
-            const expectedDetailsPath = [
-              "",
-              context.repo.owner,
-              context.repo.repo,
-              "actions",
-              "runs",
-            ];
             const repositoryPattern =
               /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]{1,100}$/;
 
@@ -108,36 +102,19 @@ jobs:
             };
 
             const validateSource = (check) => {
-              let detailsUrl;
-              try {
-                detailsUrl = new URL(check?.details_url);
-              } catch {
-                throw new Error("Basic Policy Check Run source is invalid.");
-              }
-              const path = detailsUrl.pathname.split("/");
-              const runIdText = path[5];
-              const runId = Number(runIdText);
-              const canonicalDetailsUrl =
+              const checkId = check?.id;
+              const canonicalCheckUrl =
                 `${expectedOrigin}/${context.repo.owner}/${context.repo.repo}` +
-                `/actions/runs/${runIdText}`;
+                `/runs/${checkId}`;
               if (
+                !Number.isSafeInteger(checkId) ||
+                checkId <= 0 ||
                 check?.app?.id !== actionsApp.id ||
                 check?.app?.slug !== actionsApp.slug ||
+                check?.app?.name !== actionsApp.name ||
                 check?.app?.owner?.login !== actionsApp.owner ||
-                detailsUrl.origin !== expectedOrigin ||
-                detailsUrl.username !== "" ||
-                detailsUrl.password !== "" ||
-                path.length !== 6 ||
-                !expectedDetailsPath.every(
-                  (segment, index) => path[index] === segment
-                ) ||
-                !/^[1-9][0-9]*$/.test(runIdText ?? "") ||
-                !Number.isSafeInteger(runId) ||
-                runId <= 0 ||
-                String(runId) !== runIdText ||
-                detailsUrl.search !== "" ||
-                detailsUrl.hash !== "" ||
-                check.details_url !== canonicalDetailsUrl
+                check?.details_url !== canonicalCheckUrl ||
+                check?.html_url !== canonicalCheckUrl
               ) {
                 throw new Error("Basic Policy Check Run source is invalid.");
               }
@@ -327,4 +304,4 @@ jobs:
           cache: false
       - name: vet
         run: |
-          make vet
+          ./scripts/vetcheck.sh


### PR DESCRIPTION
## Summary

- Accept the canonical GitHub-normalized Check Run URL derived from the exact Check Run ID.
- Reuse an existing Basic Policy Check Run for the same head and binding.
- Fail closed when matching policy checks are ambiguous or have an invalid source.

## Security

The execution workflow continues to require the exact repository, pull request, head SHA, policy binding, GitHub Actions app identity, completed status, successful conclusion, and canonical Check Run URLs. Noncanonical URLs, mismatched IDs, query strings, fragments, encoded paths, and duplicate checks are rejected.

## Validation

- Canonical and adversarial Check Run mocks
- Create, update, and duplicate rerun mocks
- actionlint
- Pre-push sanitization