### PR TITLE
test: validate irrelevant CI routing

### DIFF
--- a/testdata/ci-route-validation.md
+++ b/testdata/ci-route-validation.md
@@ -1,0 +1,5 @@
+# CI Route Validation
+
+This documentation-only marker verifies that unrelated repository changes do
+not schedule trusted execution jobs. It has no runtime or product behavior
+impact.


### PR DESCRIPTION
## Summary

- add a documentation-only CI routing marker
- verify that an unrelated change does not schedule trusted execution jobs

## Validation

- `markdownlint testdata/ci-route-validation.md`
- `./scripts/vetcheck.sh`
- `git diff --check`
