### PR TITLE
ci: route basic policy evaluation to isolated runners

### DIFF
--- a/.github/workflows/acctest-terraform-basic-policy.yml
+++ b/.github/workflows/acctest-terraform-basic-policy.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       checks: write
       pull-requests: read
-    runs-on: ubuntu-latest
+    runs-on: terraform-ci-policy
     timeout-minutes: 3
     steps:
       - name: Evaluate pull request policy

--- a/.github/workflows/acctest-terraform-basic.yml
+++ b/.github/workflows/acctest-terraform-basic.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       checks: read
       pull-requests: read
-    runs-on: ubuntu-latest
+    runs-on: terraform-ci-policy
     timeout-minutes: 3
     outputs:
       classification: ${{ steps.select.outputs.classification }}


### PR DESCRIPTION
## Summary

- route the pull request policy job to the dedicated policy runner scale set
- route the basic-check dispatcher to the same isolated scale set
- keep trusted and external consumer-job routing unchanged

## Validation

- workflow routing assertions
- policy behavior mocks
- actionlint
- repository changed-file vet check
- isolated runner admission, RBAC, and network-policy probes