### PR TITLE
ci: add reusable Terraform policy selector

### DIFF
--- a/.github/actions/terraform-ci-select-policy/action.yml
+++ b/.github/actions/terraform-ci-select-policy/action.yml
@@ -1,0 +1,28 @@
+name: Select Terraform CI policy
+description: Validate Basic Policy and select the runner for a supported event.
+
+outputs:
+  classification:
+    description: Validated trusted or external event classification.
+    value: ${{ steps.select.outputs.classification }}
+  relevant:
+    description: Whether provider CI consumer jobs should run.
+    value: ${{ steps.select.outputs.relevant }}
+  runner:
+    description: JSON string containing the selected runner label.
+    value: ${{ steps.select.outputs.runner }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate Basic Policy and select runner
+      id: select
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        TERRAFORM_CI_ROUTE_MODULE: ${{ github.action_path }}/route.js
+      with:
+        script: |
+          const { selectPolicy } = require(
+            process.env.TERRAFORM_CI_ROUTE_MODULE
+          );
+          await selectPolicy({ github, context, core });

--- a/.github/actions/terraform-ci-select-policy/route.js
+++ b/.github/actions/terraform-ci-select-policy/route.js
@@ -1,0 +1,298 @@
+"use strict";
+
+const POLICY_VERSION = 1;
+const POLICY_CHECK_NAME = "Basic Policy";
+const POLICY_TIMEOUT_MS = 90000;
+const POLICY_POLL_INTERVAL_MS = 3000;
+const TRUSTED_RUNNER = "terraform-ci-trusted";
+const EXTERNAL_RUNNER = "ubuntu-latest";
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const REPOSITORY_PATTERN =
+  /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]{1,100}$/;
+const PULL_REQUEST_ACTIONS = new Set([
+  "opened",
+  "reopened",
+  "synchronize",
+  "ready_for_review",
+]);
+const ACTIONS_APP = Object.freeze({
+  id: 15368,
+  slug: "github-actions",
+  name: "GitHub Actions",
+  owner: "github",
+});
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isCommitSha(value) {
+  return (
+    typeof value === "string" &&
+    SHA_PATTERN.test(value) &&
+    value !== "0".repeat(40)
+  );
+}
+
+function expectedRepository(context) {
+  const owner = context?.repo?.owner;
+  const repo = context?.repo?.repo;
+  const fullName = `${owner}/${repo}`;
+  if (
+    typeof owner !== "string" ||
+    typeof repo !== "string" ||
+    !REPOSITORY_PATTERN.test(fullName)
+  ) {
+    throw new Error("Repository metadata is invalid.");
+  }
+  return { fullName, owner, repo };
+}
+
+function expectedServerOrigin(context) {
+  if (typeof context?.serverUrl !== "string") {
+    throw new Error("Server metadata is invalid.");
+  }
+  let server;
+  try {
+    server = new URL(context.serverUrl);
+  } catch {
+    throw new Error("Server metadata is invalid.");
+  }
+  if (
+    server.protocol !== "https:" ||
+    server.username !== "" ||
+    server.password !== "" ||
+    (server.pathname !== "" && server.pathname !== "/") ||
+    server.search !== "" ||
+    server.hash !== ""
+  ) {
+    throw new Error("Server metadata is invalid.");
+  }
+  return server.origin;
+}
+
+function pullRequestMetadata(context, repository) {
+  const payload = context?.payload;
+  const pullRequest = payload?.pull_request;
+  if (!isRecord(payload) || !isRecord(pullRequest)) {
+    throw new Error("Pull request metadata is invalid.");
+  }
+
+  const pullNumber = pullRequest.number;
+  const headRepository = pullRequest.head?.repo?.full_name;
+  const headSha = pullRequest.head?.sha;
+  const baseRepository = pullRequest.base?.repo?.full_name;
+  const baseRef = pullRequest.base?.ref;
+  if (
+    !Number.isSafeInteger(pullNumber) ||
+    pullNumber <= 0 ||
+    typeof headRepository !== "string" ||
+    !REPOSITORY_PATTERN.test(headRepository) ||
+    !isCommitSha(headSha) ||
+    baseRepository !== repository.fullName ||
+    baseRef !== "master"
+  ) {
+    throw new Error("Pull request metadata is invalid.");
+  }
+
+  return { headRepository, headSha, pullNumber };
+}
+
+function eventMetadata(context, repository) {
+  if (context?.eventName === "push") {
+    const payload = context.payload;
+    const ref = "refs/heads/master";
+    if (
+      !isRecord(payload) ||
+      payload.action !== undefined ||
+      payload.repository?.full_name !== repository.fullName ||
+      payload.ref !== ref ||
+      context.ref !== ref ||
+      payload.deleted !== false ||
+      !isCommitSha(context.sha) ||
+      payload.after !== context.sha
+    ) {
+      throw new Error("Push metadata is invalid.");
+    }
+    return { kind: "push" };
+  }
+
+  const pullRequest = pullRequestMetadata(context, repository);
+  if (context?.eventName === "pull_request") {
+    if (!PULL_REQUEST_ACTIONS.has(context.payload.action)) {
+      throw new Error("Pull request metadata is invalid.");
+    }
+    return { kind: "pull_request", ...pullRequest };
+  }
+
+  if (context?.eventName === "pull_request_review") {
+    const review = context.payload.review;
+    if (
+      context.payload.action !== "submitted" ||
+      !isRecord(review) ||
+      review.state !== "approved" ||
+      review.commit_id !== pullRequest.headSha
+    ) {
+      throw new Error("Pull request review metadata is invalid.");
+    }
+    return { kind: "pull_request_review", ...pullRequest };
+  }
+
+  throw new Error("Unsupported event.");
+}
+
+function parseBinding(externalId, pullRequest) {
+  if (
+    typeof externalId !== "string" ||
+    externalId.length === 0 ||
+    externalId.length > 255
+  ) {
+    throw new Error("Basic Policy binding is invalid.");
+  }
+
+  let binding;
+  try {
+    binding = JSON.parse(externalId);
+  } catch {
+    throw new Error("Basic Policy binding is invalid.");
+  }
+  if (
+    !isRecord(binding) ||
+    Object.keys(binding).sort().join(",") !== "c,p,q,r,s,v" ||
+    binding.v !== POLICY_VERSION ||
+    binding.p !== pullRequest.pullNumber ||
+    binding.s !== pullRequest.headSha ||
+    binding.r !== pullRequest.headRepository ||
+    !["trusted", "external"].includes(binding.c) ||
+    typeof binding.q !== "boolean"
+  ) {
+    throw new Error("Basic Policy binding is stale or invalid.");
+  }
+  return binding;
+}
+
+function validateSource(check, repository, pullRequest, origin) {
+  const checkId = check?.id;
+  const canonicalUrl =
+    `${origin}/${repository.owner}/${repository.repo}/runs/${checkId}`;
+  if (
+    !Number.isSafeInteger(checkId) ||
+    checkId <= 0 ||
+    check?.name !== POLICY_CHECK_NAME ||
+    check?.head_sha !== pullRequest.headSha ||
+    check?.app?.id !== ACTIONS_APP.id ||
+    check?.app?.slug !== ACTIONS_APP.slug ||
+    check?.app?.name !== ACTIONS_APP.name ||
+    check?.app?.owner?.login !== ACTIONS_APP.owner ||
+    check?.details_url !== canonicalUrl ||
+    check?.html_url !== canonicalUrl
+  ) {
+    throw new Error("Basic Policy Check Run source is invalid.");
+  }
+}
+
+function setOutputs(core, classification, relevant) {
+  if (!core || typeof core.setOutput !== "function") {
+    throw new Error("Actions output interface is invalid.");
+  }
+  const runner =
+    classification === "trusted" ? TRUSTED_RUNNER : EXTERNAL_RUNNER;
+  const outputs = {
+    classification,
+    relevant: String(relevant),
+    runner: JSON.stringify(runner),
+  };
+  for (const [name, value] of Object.entries(outputs)) {
+    core.setOutput(name, value);
+  }
+  return outputs;
+}
+
+async function selectPolicy({
+  github,
+  context,
+  core,
+  now = Date.now,
+  sleep = (milliseconds) =>
+    new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  timeoutMs = POLICY_TIMEOUT_MS,
+  pollIntervalMs = POLICY_POLL_INTERVAL_MS,
+}) {
+  const repository = expectedRepository(context);
+  const origin = expectedServerOrigin(context);
+  const event = eventMetadata(context, repository);
+
+  if (event.kind === "push") {
+    return setOutputs(core, "trusted", true);
+  }
+
+  if (
+    !github ||
+    typeof github.paginate !== "function" ||
+    typeof github.rest?.checks?.listForRef !== "function"
+  ) {
+    throw new Error("GitHub Checks interface is invalid.");
+  }
+  if (
+    typeof now !== "function" ||
+    typeof sleep !== "function" ||
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs <= 0 ||
+    timeoutMs > POLICY_TIMEOUT_MS ||
+    !Number.isSafeInteger(pollIntervalMs) ||
+    pollIntervalMs <= 0 ||
+    pollIntervalMs > timeoutMs
+  ) {
+    throw new Error("Polling configuration is invalid.");
+  }
+
+  const deadline = now() + timeoutMs;
+  while (now() < deadline) {
+    const checkRuns = await github.paginate(
+      github.rest.checks.listForRef,
+      {
+        owner: repository.owner,
+        repo: repository.repo,
+        ref: event.headSha,
+        check_name: POLICY_CHECK_NAME,
+        filter: "all",
+        per_page: 100,
+      }
+    );
+    if (!Array.isArray(checkRuns)) {
+      throw new Error("Basic Policy Check Run lookup is invalid.");
+    }
+
+    const candidates = checkRuns.filter(
+      (check) => check?.name === POLICY_CHECK_NAME
+    );
+    if (candidates.length === 0) {
+      await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - now())));
+      continue;
+    }
+    if (candidates.length !== 1) {
+      throw new Error("Basic Policy Check Run is ambiguous.");
+    }
+
+    const check = candidates[0];
+    validateSource(check, repository, event, origin);
+    const binding = parseBinding(check.external_id, event);
+    if (check.status !== "completed") {
+      if (!["queued", "in_progress"].includes(check.status)) {
+        throw new Error("Basic Policy Check Run status is invalid.");
+      }
+      await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - now())));
+      continue;
+    }
+    if (check.conclusion !== "success") {
+      throw new Error("Basic Policy rejected this event.");
+    }
+    return setOutputs(core, binding.c, binding.q);
+  }
+
+  throw new Error("Timed out waiting for a unique Basic Policy result.");
+}
+
+module.exports = {
+  selectPolicy,
+};

--- a/.github/actions/terraform-ci-select-policy/route.test.js
+++ b/.github/actions/terraform-ci-select-policy/route.test.js
@@ -1,0 +1,401 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { selectPolicy } = require("./route.js");
+
+const OWNER = "aliyun";
+const REPO = "terraform-provider-alicloud";
+const HEAD_REPOSITORY = "api-tool-agent/terraform-provider-alicloud";
+const HEAD_SHA = "1234567890abcdef1234567890abcdef12345678";
+const OTHER_SHA = "abcdef1234567890abcdef1234567890abcdef12";
+const CHECK_ID = 123456789;
+const CHECK_URL =
+  `https://github.com/${OWNER}/${REPO}/runs/${CHECK_ID}`;
+
+function pullRequest() {
+  return {
+    number: 100,
+    head: {
+      repo: { full_name: HEAD_REPOSITORY },
+      sha: HEAD_SHA,
+    },
+    base: {
+      repo: { full_name: `${OWNER}/${REPO}` },
+      ref: "master",
+    },
+  };
+}
+
+function pullRequestContext(overrides = {}) {
+  const eventName = overrides.eventName ?? "pull_request";
+  const payload = {
+    action: overrides.action ?? "synchronize",
+    pull_request: pullRequest(),
+  };
+  if (eventName === "pull_request_review") {
+    payload.action = overrides.action ?? "submitted";
+    payload.review = {
+      state: overrides.reviewState ?? "approved",
+      commit_id: overrides.reviewCommitId ?? HEAD_SHA,
+      body: overrides.reviewBody ?? "",
+    };
+  }
+  return {
+    eventName,
+    payload,
+    repo: { owner: OWNER, repo: REPO },
+    serverUrl: "https://github.com",
+    sha: HEAD_SHA,
+    ref: `refs/pull/${payload.pull_request.number}/merge`,
+  };
+}
+
+function pushContext(overrides = {}) {
+  const sha = overrides.sha ?? HEAD_SHA;
+  const ref = overrides.ref ?? "refs/heads/master";
+  const repository =
+    overrides.repository ?? `${OWNER}/${REPO}`;
+  return {
+    eventName: "push",
+    payload: {
+      after: overrides.after ?? sha,
+      deleted: overrides.deleted ?? false,
+      ref,
+      repository: { full_name: repository },
+    },
+    repo: { owner: OWNER, repo: REPO },
+    serverUrl: "https://github.com",
+    sha,
+    ref,
+  };
+}
+
+function binding(overrides = {}) {
+  return {
+    v: 1,
+    p: 100,
+    s: HEAD_SHA,
+    r: HEAD_REPOSITORY,
+    c: "trusted",
+    q: true,
+    ...overrides,
+  };
+}
+
+function checkRun(overrides = {}) {
+  const value = {
+    id: CHECK_ID,
+    name: "Basic Policy",
+    head_sha: HEAD_SHA,
+    external_id: JSON.stringify(binding()),
+    status: "completed",
+    conclusion: "success",
+    details_url: CHECK_URL,
+    html_url: CHECK_URL,
+    app: {
+      id: 15368,
+      slug: "github-actions",
+      name: "GitHub Actions",
+      owner: { login: "github" },
+    },
+  };
+  return Object.assign(value, overrides);
+}
+
+function harness(responses = [[]]) {
+  let clock = 0;
+  let index = 0;
+  const calls = [];
+  const outputs = {};
+  const listForRef = async () => {
+    throw new Error("paginate must own the request");
+  };
+  const github = {
+    rest: { checks: { listForRef } },
+    paginate: async (method, args) => {
+      calls.push({ method, args });
+      const response = responses[Math.min(index, responses.length - 1)];
+      index += 1;
+      return response;
+    },
+  };
+  const core = {
+    setOutput(name, value) {
+      outputs[name] = value;
+    },
+  };
+  const options = {
+    github,
+    core,
+    now: () => clock,
+    sleep: async (milliseconds) => {
+      clock += milliseconds;
+    },
+    timeoutMs: 2,
+    pollIntervalMs: 1,
+  };
+  return { calls, github, core, options, outputs };
+}
+
+async function execute(context, responses) {
+  const testHarness = harness(responses);
+  await selectPolicy({ context, ...testHarness.options });
+  return testHarness;
+}
+
+test("pull_request selects the trusted runner from a valid binding", async () => {
+  const result = await execute(pullRequestContext(), [[checkRun()]]);
+
+  assert.deepEqual(result.outputs, {
+    classification: "trusted",
+    relevant: "true",
+    runner: JSON.stringify("terraform-ci-trusted"),
+  });
+  assert.equal(result.calls.length, 1);
+  assert.deepEqual(result.calls[0].args, {
+    owner: OWNER,
+    repo: REPO,
+    ref: HEAD_SHA,
+    check_name: "Basic Policy",
+    filter: "all",
+    per_page: 100,
+  });
+});
+
+test("pull_request selects the hosted runner for an external binding", async () => {
+  const external = checkRun({
+    external_id: JSON.stringify(binding({ c: "external", q: false })),
+  });
+  const result = await execute(pullRequestContext(), [[external]]);
+
+  assert.deepEqual(result.outputs, {
+    classification: "external",
+    relevant: "false",
+    runner: JSON.stringify("ubuntu-latest"),
+  });
+});
+
+test("pull_request_review accepts only an exact approved review", async () => {
+  const result = await execute(
+    pullRequestContext({ eventName: "pull_request_review" }),
+    [[checkRun()]]
+  );
+  assert.equal(result.outputs.classification, "trusted");
+  assert.equal(result.outputs.relevant, "true");
+});
+
+test("pull_request_review rejects edited reviews", async () => {
+  await assert.rejects(
+    execute(
+      pullRequestContext({
+        eventName: "pull_request_review",
+        action: "edited",
+      }),
+      [[checkRun()]]
+    ),
+    /review metadata/i
+  );
+});
+
+test("pull_request_review ignores approval text in the body", async () => {
+  await assert.rejects(
+    execute(
+      pullRequestContext({
+        eventName: "pull_request_review",
+        reviewState: "commented",
+        reviewBody: "approved",
+      }),
+      [[checkRun()]]
+    ),
+    /review metadata/i
+  );
+});
+
+test("pull_request_review rejects approval for a stale head", async () => {
+  await assert.rejects(
+    execute(
+      pullRequestContext({
+        eventName: "pull_request_review",
+        reviewCommitId: OTHER_SHA,
+      }),
+      [[checkRun()]]
+    ),
+    /review metadata/i
+  );
+});
+
+test("push to the repository master branch is trusted and relevant", async () => {
+  const result = await execute(pushContext(), []);
+  assert.deepEqual(result.outputs, {
+    classification: "trusted",
+    relevant: "true",
+    runner: JSON.stringify("terraform-ci-trusted"),
+  });
+  assert.equal(result.calls.length, 0);
+});
+
+test("push rejects another repository", async () => {
+  await assert.rejects(
+    execute(pushContext({ repository: "someone/else" }), []),
+    /push metadata/i
+  );
+});
+
+test("push rejects another ref", async () => {
+  await assert.rejects(
+    execute(pushContext({ ref: "refs/heads/feature" }), []),
+    /push metadata/i
+  );
+});
+
+test("push rejects a stale or deleted commit", async () => {
+  await assert.rejects(
+    execute(pushContext({ after: OTHER_SHA }), []),
+    /push metadata/i
+  );
+  await assert.rejects(
+    execute(pushContext({ deleted: true }), []),
+    /push metadata/i
+  );
+  await assert.rejects(
+    execute(pushContext({ sha: "0".repeat(40) }), []),
+    /push metadata/i
+  );
+});
+
+test("zero Basic Policy checks times out closed", async () => {
+  await assert.rejects(
+    execute(pullRequestContext(), [[]]),
+    /timed out/i
+  );
+});
+
+test("duplicate Basic Policy checks fail closed", async () => {
+  await assert.rejects(
+    execute(pullRequestContext(), [[checkRun(), checkRun({ id: 2 })]]),
+    /ambiguous/i
+  );
+});
+
+for (const [name, mutate] of [
+  ["id", (check) => { check.app.id = 1; }],
+  ["slug", (check) => { check.app.slug = "other"; }],
+  ["name", (check) => { check.app.name = "Other"; }],
+  ["owner", (check) => { check.app.owner.login = "other"; }],
+]) {
+  test(`wrong GitHub Actions app ${name} fails closed`, async () => {
+    const candidate = checkRun();
+    mutate(candidate);
+    await assert.rejects(
+      execute(pullRequestContext(), [[candidate]]),
+      /source/i
+    );
+  });
+}
+
+for (const [name, mutate] of [
+  ["details URL", (check) => { check.details_url += "?spoofed=1"; }],
+  ["HTML URL", (check) => { check.html_url += "?spoofed=1"; }],
+]) {
+  test(`wrong canonical ${name} fails closed`, async () => {
+    const candidate = checkRun();
+    mutate(candidate);
+    await assert.rejects(
+      execute(pullRequestContext(), [[candidate]]),
+      /source/i
+    );
+  });
+}
+
+test("wrong Check Run head SHA fails closed", async () => {
+  await assert.rejects(
+    execute(
+      pullRequestContext(),
+      [[checkRun({ head_sha: OTHER_SHA })]]
+    ),
+    /source/i
+  );
+});
+
+for (const [name, externalId] of [
+  ["invalid JSON", "not-json"],
+  ["extra key", JSON.stringify({ ...binding(), extra: true })],
+  ["stale SHA", JSON.stringify(binding({ s: OTHER_SHA }))],
+  ["wrong pull request", JSON.stringify(binding({ p: 101 }))],
+  ["wrong repository", JSON.stringify(binding({ r: "someone/else" }))],
+  ["blocked classification", JSON.stringify(binding({ c: "blocked" }))],
+  ["non-boolean relevance", JSON.stringify(binding({ q: "true" }))],
+]) {
+  test(`external_id ${name} fails closed`, async () => {
+    await assert.rejects(
+      execute(
+        pullRequestContext(),
+        [[checkRun({ external_id: externalId })]]
+      ),
+      /binding/i
+    );
+  });
+}
+
+test("an overlong external_id fails closed", async () => {
+  await assert.rejects(
+    execute(
+      pullRequestContext(),
+      [[checkRun({ external_id: "x".repeat(256) })]]
+    ),
+    /binding/i
+  );
+});
+
+test("queued and in-progress checks are polled before success", async () => {
+  const queued = checkRun({ status: "queued", conclusion: null });
+  const inProgress = checkRun({ status: "in_progress", conclusion: null });
+  const result = harness([[queued], [inProgress], [checkRun()]]);
+  result.options.timeoutMs = 4;
+  await selectPolicy({
+    context: pullRequestContext(),
+    ...result.options,
+  });
+  assert.equal(result.calls.length, 3);
+  assert.equal(result.outputs.classification, "trusted");
+});
+
+test("an unknown Check Run status fails closed", async () => {
+  await assert.rejects(
+    execute(
+      pullRequestContext(),
+      [[checkRun({ status: "waiting", conclusion: null })]]
+    ),
+    /status/i
+  );
+});
+
+test("a completed non-success Check Run fails closed", async () => {
+  await assert.rejects(
+    execute(
+      pullRequestContext(),
+      [[checkRun({ conclusion: "failure" })]]
+    ),
+    /rejected/i
+  );
+});
+
+test("malformed pull request metadata fails closed", async () => {
+  const context = pullRequestContext();
+  context.payload.pull_request.number = "100";
+  await assert.rejects(
+    execute(context, [[checkRun()]]),
+    /pull request metadata/i
+  );
+});
+
+test("unsupported events fail closed", async () => {
+  const context = pullRequestContext();
+  context.eventName = "workflow_dispatch";
+  await assert.rejects(
+    execute(context, [[checkRun()]]),
+    /unsupported event/i
+  );
+});


### PR DESCRIPTION
## Summary

- add a reusable composite action that validates the Basic Policy result before selecting a runner
- support pull request, approved review, and repository master push events with fail-closed metadata validation
- add unit coverage for trusted and external routing, review binding, source validation, polling, and rejection paths

## Scope

This pull request adds the selector foundation only. It does not migrate existing jobs. Follow-up workflow changes should reference the immutable merge commit from this pull request.

## Validation

- node --test .github/actions/terraform-ci-select-policy/route.test.js
- action-validator .github/actions/terraform-ci-select-policy/action.yml
- actionlint synthetic workflow using the local composite action
- git diff --check