### PR TITLE
resource/alicloud_kvstore_instance: reclaim instance id on lost create response

### DIFF
--- a/alicloud/resource_alicloud_kvstore_instance.go
+++ b/alicloud/resource_alicloud_kvstore_instance.go
@@ -599,7 +599,34 @@ func resourceAliCloudKvstoreInstanceCreate(d *schema.ResourceData, meta interfac
 	addDebug(action, response, request)
 
 	if err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, "alicloud_kvstore_instance", action, AlibabaCloudSdkGoERROR)
+		// A lost-response / timeout error (Post "https://..." or Client.Timeout) means the
+		// request very likely reached the backend, which may already have accepted the
+		// instance creation even though the InstanceId never made it back to the client.
+		// The request carries a stable idempotency Token set once above, so replaying
+		// CreateInstance returns the already-accepted instance instead of provisioning a
+		// new one. Best-effort reclaim its InstanceId here so the instance is tracked in
+		// state and stays destroyable rather than leaking.
+		if NoCodeRegexRetry(err) && (response == nil || response["InstanceId"] == nil) {
+			reclaimWait := incrementalWait(3*time.Second, 3*time.Second)
+			_ = resource.Retry(1*time.Minute, func() *resource.RetryError {
+				reclaimResp, reclaimErr := client.RpcPost("R-kvstore", "2015-01-01", action, nil, request, true)
+				if reclaimErr != nil {
+					if NoCodeRegexRetry(reclaimErr) {
+						reclaimWait()
+						return resource.RetryableError(reclaimErr)
+					}
+					return resource.NonRetryableError(reclaimErr)
+				}
+				response = reclaimResp
+				return nil
+			})
+			addDebug(action+"_Reclaim", response, request)
+		}
+		if response == nil || response["InstanceId"] == nil {
+			return WrapErrorf(err, DefaultErrorMsg, "alicloud_kvstore_instance", action, AlibabaCloudSdkGoERROR)
+		}
+		// InstanceId reclaimed from the idempotent replay; fall through to persist it in
+		// state and wait for the instance to reach Normal.
 	}
 
 	d.SetId(fmt.Sprint(response["InstanceId"]))


### PR DESCRIPTION
### Problem

`resource_alicloud_kvstore_instance` returned early on a lost-response / timeout error from `CreateInstance` (e.g. `Post "https://..."` or `Client.Timeout`) **before** `d.SetId`. In that window the backend may have already accepted the instance creation while the `InstanceId` never made it back to the client, so the instance was never written to state — leaving an untracked, leaked instance that a later apply would try to re-create and that `destroy` cannot clean up.

### Fix

When `CreateInstance` fails with a retryable lost-response / timeout error and no `InstanceId` was returned, perform a bounded (1 minute) best-effort idempotent replay of `CreateInstance`. The create request carries a stable idempotency `Token` set once at the start of the create call, so the replay returns the already-accepted instance instead of provisioning a new one. On a successful reclaim the `InstanceId` is persisted via `d.SetId` and the resource waits for `Normal`.

- Non-retryable errors keep the original behavior (return the original error).
- The normal, successful create path is byte-for-byte unchanged.

### Test

```
TestAccAliCloudKVStoreInstance
```
Remote acceptance tests to be attached.