### PR TITLE
ci: align markdownlint with generated website docs

### DIFF
--- a/.github/markdownlint/website-docs.json
+++ b/.github/markdownlint/website-docs.json
@@ -1,0 +1,9 @@
+{
+  "default": true,
+  "MD004": {
+    "style": "sublist"
+  },
+  "MD013": false,
+  "MD014": false,
+  "MD033": false
+}

--- a/.github/workflows/document-check.yml
+++ b/.github/workflows/document-check.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - master
     paths:
+      - .github/markdownlint/website-docs.json
       - .github/workflows/document-check.yml
       - .go-version
       - website/docs/**
@@ -101,7 +102,9 @@ jobs:
             echo "No Markdown files changed."
             exit 0
           fi
-          npx --yes markdownlint-cli@0.47.0 -- "${markdown_files[@]}"
+          npx --yes markdownlint-cli@0.47.0 \
+            --config .github/markdownlint/website-docs.json \
+            -- "${markdown_files[@]}"
 
   misspell:
     needs: route


### PR DESCRIPTION
## Summary

- add a markdownlint configuration scoped to generated website documentation
- keep full-file linting for changed documentation files
- preserve the default rule set while aligning list style, line length, command prompt, and inline HTML rules with the existing docs format

## Validation

- verified a representative generated resource document passes
- verified trailing whitespace and missing list spacing still fail with MD009 and MD032
- verified the workflow skips cleanly when no Markdown documents are changed