### PR TITLE
resource/alicloud_polardb_cluster_endpoint: add SccMode support

### DIFF
--- a/.github/markdownlint/website-docs.json
+++ b/.github/markdownlint/website-docs.json
@@ -1,0 +1,11 @@
+{
+  "default": true,
+  "MD004": {
+    "style": "sublist"
+  },
+  "MD009": false,
+  "MD013": false,
+  "MD014": false,
+  "MD032": false,
+  "MD033": false
+}

--- a/alicloud/resource_alicloud_polardb_cluster_endpoint.go
+++ b/alicloud/resource_alicloud_polardb_cluster_endpoint.go
@@ -103,6 +103,23 @@ func resourceAlicloudPolarDBClusterEndpoint() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"scc_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"ON", "OFF"}, false),
+			},
+			"scc_wait_timeout": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"scc_timeout_action": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"0", "2"}, false),
+			},
 		},
 	}
 }
@@ -176,6 +193,9 @@ func resourceAlicloudPolarDBClusterEndpointRead(d *schema.ResourceData, meta int
 	}
 	d.Set("auto_add_new_nodes", autoAddNewNodes)
 	d.Set("read_write_mode", readWriteMode)
+	d.Set("scc_mode", object.SccMode)
+	d.Set("scc_wait_timeout", object.PolarSccWaitTimeout)
+	d.Set("scc_timeout_action", object.PolarSccTimeoutAction)
 
 	if err = polarDBService.RefreshEndpointConfig(d); err != nil {
 		return WrapError(err)
@@ -246,7 +266,7 @@ func resourceAlicloudPolarDBClusterEndpointUpdate(d *schema.ResourceData, meta i
 	}
 	dbClusterId := parts[0]
 	dbEndpointId := parts[1]
-	if d.HasChanges("nodes", "read_write_mode", "auto_add_new_nodes", "endpoint_config", "db_endpoint_description") {
+	if d.HasChanges("nodes", "read_write_mode", "auto_add_new_nodes", "endpoint_config", "db_endpoint_description", "scc_mode", "scc_wait_timeout", "scc_timeout_action") {
 		modifyEndpointRequest := polardb.CreateModifyDBClusterEndpointRequest()
 		modifyEndpointRequest.RegionId = client.RegionId
 		modifyEndpointRequest.DBClusterId = dbClusterId
@@ -278,6 +298,18 @@ func resourceAlicloudPolarDBClusterEndpointUpdate(d *schema.ResourceData, meta i
 		if d.HasChange("db_endpoint_description") {
 			modifyEndpointRequest.DBEndpointDescription = d.Get("db_endpoint_description").(string)
 			configItem["DBEndpointDescription"] = d.Get("db_endpoint_description").(string)
+		}
+		if d.HasChange("scc_mode") {
+			modifyEndpointRequest.SccMode = d.Get("scc_mode").(string)
+			configItem["SccMode"] = d.Get("scc_mode").(string)
+		}
+		if d.HasChange("scc_wait_timeout") {
+			modifyEndpointRequest.PolarSccWaitTimeout = d.Get("scc_wait_timeout").(string)
+			configItem["PolarSccWaitTimeout"] = d.Get("scc_wait_timeout").(string)
+		}
+		if d.HasChange("scc_timeout_action") {
+			modifyEndpointRequest.PolarSccTimeoutAction = d.Get("scc_timeout_action").(string)
+			configItem["PolarSccTimeoutAction"] = d.Get("scc_timeout_action").(string)
 		}
 		if err := resource.Retry(8*time.Minute, func() *resource.RetryError {
 			raw, err := client.WithPolarDBClient(func(polarDBClient *polardb.Client) (interface{}, error) {

--- a/alicloud/resource_alicloud_polardb_cluster_endpoint_test.go
+++ b/alicloud/resource_alicloud_polardb_cluster_endpoint_test.go
@@ -136,6 +136,40 @@ func TestAccAliCloudPolarDBClusterEndpointConfigUpdate(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"scc_mode": "ON",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"scc_mode": "ON",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"scc_mode":           "ON",
+					"scc_wait_timeout":   "500",
+					"scc_timeout_action": "2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"scc_mode":           "ON",
+						"scc_wait_timeout":   "500",
+						"scc_timeout_action": "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"scc_mode": "OFF",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"scc_mode": "OFF",
+					}),
+				),
+			},
+			{
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/website/docs/r/polardb_cluster_endpoint.html.markdown
+++ b/website/docs/r/polardb_cluster_endpoint.html.markdown
@@ -76,9 +76,13 @@ The following arguments are supported:
 * `db_endpoint_description` - (Optional) The name of the endpoint.
 * `connection_prefix` - (Optional) Prefix of the specified endpoint. The prefix must be 6 to 30 characters in length, and can contain lowercase letters, digits, and hyphens (-), must start with a letter and end with a digit or letter.
 * `port` - (Optional) Port of the specified endpoint. Valid values: 3000 to 5999.
-* `scc_mode` - (Optional) Specifies whether to enable the global consistency (high performance mode). Valid values: `ON`, `OFF`.
-* `scc_wait_timeout` - (Optional) The timeout period for global consistency. Unit: ms.
-* `scc_timeout_action` - (Optional) The degradation policy when global consistency times out. Valid values: `0` (send to the primary node), `2` (degrade to non-consistent read).
+* `scc_mode` - (Optional) Specifies whether to enable the global
+  consistency (high performance mode). Valid values: `ON`, `OFF`.
+* `scc_wait_timeout` - (Optional) The timeout period for global
+  consistency. Unit: ms.
+* `scc_timeout_action` - (Optional) The degradation policy when global
+  consistency times out. Valid values: `0` (send to the primary node),
+  `2` (degrade to non-consistent read).
 
 ## Attributes Reference
 

--- a/website/docs/r/polardb_cluster_endpoint.html.markdown
+++ b/website/docs/r/polardb_cluster_endpoint.html.markdown
@@ -76,6 +76,9 @@ The following arguments are supported:
 * `db_endpoint_description` - (Optional) The name of the endpoint.
 * `connection_prefix` - (Optional) Prefix of the specified endpoint. The prefix must be 6 to 30 characters in length, and can contain lowercase letters, digits, and hyphens (-), must start with a letter and end with a digit or letter.
 * `port` - (Optional) Port of the specified endpoint. Valid values: 3000 to 5999.
+* `scc_mode` - (Optional) Specifies whether to enable the global consistency (high performance mode). Valid values: `ON`, `OFF`.
+* `scc_wait_timeout` - (Optional) The timeout period for global consistency. Unit: ms.
+* `scc_timeout_action` - (Optional) The degradation policy when global consistency times out. Valid values: `0` (send to the primary node), `2` (degrade to non-consistent read).
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary

Adds `scc_mode`, `scc_wait_timeout`, and `scc_timeout_action` attributes to the `alicloud_polardb_cluster_endpoint` resource to support the global consistency (high performance mode) in PolarDB cluster endpoints via the `ModifyDBClusterEndpoint` API.

## Changes

- **Schema**: Added 3 new fields with validation (`scc_mode`: ON/OFF, `scc_timeout_action`: 0/2, `scc_wait_timeout`: free-form string)
- **Read**: Populates fields from `DBEndpoint` API response (`SccMode`, `PolarSccWaitTimeout`, `PolarSccTimeoutAction`)
- **Update**: Sends changes via `ModifyDBClusterEndpoint` API with retry and config effect waiting
- **Tests**: 3 new acceptance test steps covering ON, ON+timeout+action combo, and OFF transitions
- **Docs**: Updated argument reference in markdown documentation

## References

- [ModifyDBClusterEndpoint API](https://help.aliyun.com/zh/polardb/api-polardb-2017-08-01-modifydbclusterendpoint)
- [Terraform Resource Docs](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/polardb_cluster_endpoint)

Fixes: Aone #76182989