### PR TITLE
ci: align generated docs lint with whitespace checks

### DIFF
--- a/.github/markdownlint/website-docs.json
+++ b/.github/markdownlint/website-docs.json
@@ -3,7 +3,9 @@
   "MD004": {
     "style": "sublist"
   },
+  "MD009": false,
   "MD013": false,
   "MD014": false,
+  "MD032": false,
   "MD033": false
 }

--- a/.github/workflows/document-check.yml
+++ b/.github/workflows/document-check.yml
@@ -88,6 +88,7 @@ jobs:
             fi
             base_sha="$PR_BASE_SHA"
           fi
+          git diff --check "$base_sha" HEAD -- website/docs
           markdown_files=()
           while IFS= read -r -d '' changed_file; do
             if [[ -f "$changed_file" ]] &&


### PR DESCRIPTION
### What this PR does

- disables MD009 and MD032 for generated website docs whose established format conflicts with those rules
- keeps full-file markdownlint checks for all other enabled rules
- adds `git diff --check` for `website/docs` so newly introduced whitespace errors still fail CI

### Testing

- verified the generated document changed by PR #10042 passes markdownlint-cli 0.47.0 with the updated config
- verified a synthetic trailing-space diff is rejected by `git diff --check`
- ran actionlint 1.7.7, ignoring only the repository's existing custom runner-label diagnostic
