### PR TITLE
resource/alicloud_gwlb_listener: support tcp_idle_timeout

### DIFF
--- a/alicloud/resource_alicloud_gwlb_listener.go
+++ b/alicloud/resource_alicloud_gwlb_listener.go
@@ -47,6 +47,12 @@ func resourceAliCloudGwlbListener() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"tcp_idle_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: IntBetween(60, 6000),
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -82,6 +88,9 @@ func resourceAliCloudGwlbListenerCreate(d *schema.ResourceData, meta interface{}
 		request["ListenerDescription"] = v
 	}
 	request["ServerGroupId"] = d.Get("server_group_id")
+	if v, ok := d.GetOkExists("tcp_idle_timeout"); ok && v.(int) > 0 {
+		request["TcpIdleTimeout"] = v
+	}
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("Gwlb", "2024-04-15", action, query, request, true)
@@ -137,6 +146,9 @@ func resourceAliCloudGwlbListenerRead(d *schema.ResourceData, meta interface{}) 
 	if objectRaw["ServerGroupId"] != nil {
 		d.Set("server_group_id", objectRaw["ServerGroupId"])
 	}
+	if objectRaw["TcpIdleTimeout"] != nil {
+		d.Set("tcp_idle_timeout", objectRaw["TcpIdleTimeout"])
+	}
 	if objectRaw["ListenerStatus"] != nil {
 		d.Set("status", objectRaw["ListenerStatus"])
 	}
@@ -166,6 +178,10 @@ func resourceAliCloudGwlbListenerUpdate(d *schema.ResourceData, meta interface{}
 	if d.HasChange("listener_description") {
 		update = true
 		request["ListenerDescription"] = d.Get("listener_description")
+	}
+	if d.HasChange("tcp_idle_timeout") {
+		update = true
+		request["TcpIdleTimeout"] = d.Get("tcp_idle_timeout")
 	}
 
 	if d.HasChange("server_group_id") {

--- a/alicloud/resource_alicloud_gwlb_listener_test.go
+++ b/alicloud/resource_alicloud_gwlb_listener_test.go
@@ -190,11 +190,8 @@ resource "alicloud_gwlb_server_group" "defaultoAkLbr" {
     health_check_protocol        = "TCP"
     health_check_connect_port    = "80"
     health_check_connect_timeout = "5"
-    health_check_domain          = ""
     health_check_enabled         = true
-    health_check_http_code       = ["http_2xx", "http_4xx", "http_3xx"]
     health_check_interval        = "10"
-    health_check_path            = ""
     healthy_threshold            = "2"
     unhealthy_threshold          = "2"
   }
@@ -229,11 +226,8 @@ resource "alicloud_gwlb_server_group" "defaultN4DOzm" {
     health_check_protocol        = "TCP"
     health_check_connect_port    = "80"
     health_check_connect_timeout = "5"
-    health_check_domain          = ""
     health_check_enabled         = true
-    health_check_http_code       = ["http_2xx", "http_4xx", "http_3xx"]
     health_check_interval        = "10"
-    health_check_path            = ""
     healthy_threshold            = "2"
     unhealthy_threshold          = "2"
   }
@@ -267,3 +261,74 @@ resource "alicloud_gwlb_server_group" "defaultN4DOzm" {
 }
 
 // Test Gwlb Listener. <<< Resource test cases, automatically generated.
+
+// TestAccAliCloudGwlbListener_tcpIdleTimeout8508 covers the tcp_idle_timeout
+// attribute: server default on omit, custom value on create, and update.
+func TestAccAliCloudGwlbListener_tcpIdleTimeout8508(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_gwlb_listener.default"
+	ra := resourceAttrInit(resourceId, AlicloudGwlbListenerMap8508)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GwlbServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGwlbListener")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sgwlblistener%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudGwlbListenerBasicDependence8508)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-wulanchabu"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// omit tcp_idle_timeout → server default 350
+				Config: testAccConfig(map[string]interface{}{
+					"server_group_id":  "${alicloud_gwlb_server_group.defaultoAkLbr.id}",
+					"load_balancer_id": "${alicloud_gwlb_load_balancer.defaultQ5setL.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tcp_idle_timeout": "350",
+					}),
+				),
+			},
+			{
+				// set custom value 120
+				Config: testAccConfig(map[string]interface{}{
+					"server_group_id":  "${alicloud_gwlb_server_group.defaultoAkLbr.id}",
+					"load_balancer_id": "${alicloud_gwlb_load_balancer.defaultQ5setL.id}",
+					"tcp_idle_timeout": "120",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tcp_idle_timeout": "120",
+					}),
+				),
+			},
+			{
+				// update to 200
+				Config: testAccConfig(map[string]interface{}{
+					"server_group_id":  "${alicloud_gwlb_server_group.defaultoAkLbr.id}",
+					"load_balancer_id": "${alicloud_gwlb_load_balancer.defaultQ5setL.id}",
+					"tcp_idle_timeout": "200",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tcp_idle_timeout": "200",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"dry_run"},
+			},
+		},
+	})
+}

--- a/website/docs/r/gwlb_listener.html.markdown
+++ b/website/docs/r/gwlb_listener.html.markdown
@@ -133,6 +133,7 @@ The following arguments are supported:
 * `load_balancer_id` - (Required, ForceNew) The GWLB instance ID.
 * `server_group_id` - (Required) The server group ID.
 * `tags` - (Optional, Map) The tags. You can specify at most 20 tags in each call.
+* `tcp_idle_timeout` - (Optional, Computed, Int) The timeout period of an idle TCP connection. Unit: seconds. Valid values: `60` to `6000`. Default value: `350`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### What this PR does

Adds the `tcp_idle_timeout` attribute to the `alicloud_gwlb_listener` resource.

- Schema: optional integer, computed (server-side default of 350 seconds), valid range 60–6000.
- Create: sends `TcpIdleTimeout` (form parameter) on `CreateListener` when set.
- Read: populated from `GetListenerAttribute` (`$.TcpIdleTimeout`).
- Update: sends `TcpIdleTimeout` on `UpdateListenerAttribute` when the attribute changes.

Also drops the HTTP-only health check fields (`health_check_domain`, `health_check_http_code`, `health_check_path`) from the TCP server group fixture used by the listener acceptance tests. With a TCP health check the backend does not persist these fields, which previously produced a permanent non-empty plan on `health_check_config.0.health_check_http_code`.

### Test cases

Adds `TestAccAliCloudGwlbListener_tcpIdleTimeout8508` covering:
- server default when `tcp_idle_timeout` is omitted (350),
- a custom value on create (120),
- an update to another value (200),
- import verification.

### Test results

Remote acceptance test results will be appended once verification completes.
