### PR TITLE
resource/alicloud_gpdb_instance: support ServerlessPro instance mode

### DIFF
--- a/alicloud/resource_alicloud_gpdb_instance.go
+++ b/alicloud/resource_alicloud_gpdb_instance.go
@@ -54,10 +54,9 @@ func resourceAliCloudGpdbInstance() *schema.Resource {
 				ForceNew: true,
 			},
 			"db_instance_mode": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: StringInSlice([]string{"StorageElastic", "Serverless", "Classic"}, false),
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 			"db_instance_class": {
 				Type:     schema.TypeString,
@@ -71,9 +70,9 @@ func resourceAliCloudGpdbInstance() *schema.Resource {
 				ValidateFunc: StringInSlice([]string{"Basic", "HighAvailability"}, false),
 			},
 			"instance_spec": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: StringInSlice([]string{"2C16G", "4C32G", "16C128G", "2C8G", "4C16G", "8C32G", "8C64G", "16C64G", "32C256G", "64C512G", "96C768G", "128C1024G"}, false),
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"storage_size": {
 				Type:     schema.TypeInt,
@@ -195,6 +194,18 @@ func resourceAliCloudGpdbInstance() *schema.Resource {
 				ForceNew:     true,
 				Computed:     true,
 				ValidateFunc: StringInSlice([]string{"Manual", "Auto"}, false),
+			},
+			"serverless_resource": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"cache_storage_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
 			},
 			"prod_type": {
 				Type:     schema.TypeString,
@@ -461,6 +472,14 @@ func resourceAliCloudGpdbDbInstanceCreate(d *schema.ResourceData, meta interface
 		request["ServerlessMode"] = v
 	}
 
+	if v, ok := d.GetOk("serverless_resource"); ok {
+		request["ServerlessResource"] = v
+	}
+
+	if v, ok := d.GetOk("cache_storage_size"); ok {
+		request["CacheStorageSize"] = strconv.Itoa(v.(int))
+	}
+
 	if v, ok := d.GetOk("prod_type"); ok {
 		request["ProdType"] = v
 	}
@@ -555,6 +574,10 @@ func resourceAliCloudGpdbDbInstanceRead(d *schema.ResourceData, meta interface{}
 	d.Set("vswitch_id", object["VSwitchId"])
 	d.Set("db_instance_mode", object["DBInstanceMode"])
 	d.Set("db_instance_category", object["DBInstanceCategory"])
+	// instance_spec is Computed: for ServerlessPro the API returns a server-side
+	// placeholder (e.g. "1C8G") that is not user-configurable; sizing is driven
+	// by serverless_resource and cache_storage_size. Reading it back unconditionally
+	// keeps state in sync with the API without producing a spurious diff.
 	d.Set("instance_spec", object["InstanceSpec"])
 	d.Set("instance_network_type", object["InstanceNetworkType"])
 	d.Set("vpc_id", object["VpcId"])
@@ -573,6 +596,12 @@ func resourceAliCloudGpdbDbInstanceRead(d *schema.ResourceData, meta interface{}
 	d.Set("maintain_start_time", object["MaintainStartTime"])
 	d.Set("maintain_end_time", object["MaintainEndTime"])
 	d.Set("serverless_mode", object["ServerlessMode"])
+	if v, ok := object["ServerlessResource"]; ok && v != nil && fmt.Sprint(v) != "" && fmt.Sprint(v) != "0" {
+		d.Set("serverless_resource", formatInt(v))
+	}
+	if v, ok := object["CacheStorageSize"]; ok && v != nil && fmt.Sprint(v) != "" && fmt.Sprint(v) != "0" {
+		d.Set("cache_storage_size", formatInt(v))
+	}
 	d.Set("prod_type", object["ProdType"])
 	d.Set("description", object["DBInstanceDescription"])
 	d.Set("connection_string", object["ConnectionString"])

--- a/alicloud/resource_alicloud_gpdb_instance_test.go
+++ b/alicloud/resource_alicloud_gpdb_instance_test.go
@@ -510,7 +510,7 @@ func TestAccAliCloudGPDBDBInstancePrepaid(t *testing.T) {
 }
 
 // gpdbServerlessTestRegion returns the region for the GPDB serverless acceptance
-// tests. It defaults to cn-beijing, which has serverless inventory, and can be
+// tests. It defaults to cn-hangzhou, which has ServerlessPro inventory, and can be
 // overridden via the GPDB_SERVERLESS_REGION environment variable so the remote
 // ACC run can target another region if the default ever reports
 // OperationDenied.InsufficientResourceCapacity.
@@ -518,18 +518,18 @@ func gpdbServerlessTestRegion() string {
 	if v := os.Getenv("GPDB_SERVERLESS_REGION"); v != "" {
 		return v
 	}
-	return "cn-beijing"
+	return "cn-hangzhou"
 }
 
 // gpdbServerlessTestZone returns the zone for the GPDB serverless acceptance
-// tests, paired with gpdbServerlessTestRegion. Defaults to cn-beijing-h and can
+// tests, paired with gpdbServerlessTestRegion. Defaults to cn-hangzhou-j and can
 // be overridden via the GPDB_SERVERLESS_ZONE environment variable so the instance
 // and its vswitch stay in the same zone.
 func gpdbServerlessTestZone() string {
 	if v := os.Getenv("GPDB_SERVERLESS_ZONE"); v != "" {
 		return v
 	}
-	return "cn-beijing-h"
+	return "cn-hangzhou-j"
 }
 
 func TestAccAliCloudGPDBDBInstanceServerless(t *testing.T) {
@@ -631,6 +631,81 @@ func TestAccAliCloudGPDBDBInstanceServerless(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"data_share_status": "closed",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data", "parameters"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudGPDBDBInstanceServerlessPro(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_gpdb_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(gpdbServerlessTestRegion())})
+	ra := resourceAttrInit(resourceId, AliCloudGPDBDBInstanceMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GpdbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGpdbDbInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sgpdbdbinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudGPDBDBInstanceBasicDependence1)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"db_instance_mode":      "ServerlessPro",
+					"description":           name,
+					"engine":                "gpdb",
+					"engine_version":        "7.0",
+					"zone_id":               gpdbServerlessTestZone(),
+					"instance_network_type": "VPC",
+					"payment_type":          "PayAsYouGo",
+					"serverless_resource":   "16",
+					"cache_storage_size":    "800",
+					"vpc_id":                "${data.alicloud_vpcs.default.ids.0}",
+					"vswitch_id":            "${local.vswitch_id}",
+					"create_sample_data":    "false",
+					"ip_whitelist": []map[string]interface{}{
+						{
+							"security_ip_list": "127.0.0.1",
+						},
+					},
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "acceptance test",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"db_instance_mode":      "ServerlessPro",
+						"description":           name,
+						"engine":                "gpdb",
+						"engine_version":        "7.0",
+						"zone_id":               CHECKSET,
+						"instance_network_type": "VPC",
+						"payment_type":          "PayAsYouGo",
+						"serverless_resource":   "16",
+						"cache_storage_size":    "800",
+						"vpc_id":                CHECKSET,
+						"vswitch_id":            CHECKSET,
+						"ip_whitelist.#":        "1",
+						"tags.%":                "2",
+						"tags.Created":          "TF",
+						"tags.For":              "acceptance test",
 					}),
 				),
 			},

--- a/website/docs/r/gpdb_instance.html.markdown
+++ b/website/docs/r/gpdb_instance.html.markdown
@@ -10,7 +10,7 @@ description: |-
 # alicloud_gpdb_instance
 
 Provides a AnalyticDB for PostgreSQL instance resource supports replica set instances only. the AnalyticDB for PostgreSQL provides stable, reliable, and automatic scalable database services.
-You can see detail product introduction [here](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-createdbinstance)
+You can see the detail product introduction in the [CreateDBInstance](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-createdbinstance) API reference.
 
 -> **NOTE:** Available since v1.47.0.
 
@@ -84,13 +84,17 @@ The following arguments are supported:
 
   -> **NOTE:** This parameter must be passed in to create a storage reservation mode instance.
 
-* `db_instance_mode` - (Required, ForceNew) The db instance mode. Valid values: `StorageElastic`, `Serverless`, `Classic`.
-* `instance_spec` - (Optional) The specification of segment nodes. Valid values: `2C16G`, `4C32G`, `16C128G`, `2C8G`, `4C16G`, `8C32G`, `8C64G`, `16C64G`, `32C256G`, `64C512G`, `96C768G`, `128C1024G`.
+* `db_instance_mode` - (Required, ForceNew) The db instance mode. Valid values: `StorageElastic`, `Serverless`, `Classic`, `ServerlessPro`.
+
+  -> **NOTE:** `ServerlessPro` is a dedicated Serverless Pro instance form. When `db_instance_mode` is set to `ServerlessPro`, instance sizing is controlled via `serverless_resource` and `cache_storage_size` instead of `instance_spec`.
+
+* `instance_spec` - (Optional, Computed) The specification of segment nodes. Valid values: `2C16G`, `4C32G`, `16C128G`, `2C8G`, `4C16G`, `8C32G`, `8C64G`, `16C64G`, `32C256G`, `64C512G`, `96C768G`, `128C1024G`.
   - If `db_instance_category` is set to `HighAvailability`, and `db_instance_mode` is set to `StorageElastic`. Valid values: `2C16G`, `4C32G`, `16C128G`.
   - If `db_instance_category` is set to `Basic`, and `db_instance_mode` is set to `StorageElastic`. Valid values: `2C8G`, `4C16G`, `8C32G`, `16C64G`.
   - If `db_instance_mode` is set to `Serverless`. Valid values: `4C16G`, `8C32G`.
 
   -> **NOTE:** This parameter must be passed to create a storage elastic mode instance and a serverless version instance.
+  -> **NOTE:** For `ServerlessPro` instances, `instance_spec` is a server-side placeholder (e.g. `1C8G`) returned by the API and is not user-configurable; sizing is controlled via `serverless_resource` and `cache_storage_size`. The placeholder is read into state but should not be set in the configuration.
  
 * `storage_size` - (Optional, Int) The storage capacity. Unit: GB. Valid values: `50` to `4000`.
 
@@ -125,6 +129,8 @@ The following arguments are supported:
 * `maintain_end_time` - (Optional) The end time of the maintenance window for the instance. in the format of HH:mmZ (UTC time), for example 03:00Z. start time should be later than end time.
 * `resource_management_mode` - (Optional, Available since v1.225.0) Resource management mode. Valid values: `resourceGroup`, `resourceQueue`.
 * `serverless_mode` - (Optional, ForceNew, Available since v1.233.1) The mode of the Serverless instance. Valid values: `Manual`, `Auto`. **NOTE:** `serverless_mode` is valid only when `db_instance_mode` is set to `Serverless`.
+* `serverless_resource` - (Optional, ForceNew, Int, Available since v1.287.0) The computing resource threshold, in ACU. Valid values: `16` to `1024`. **NOTE:** `serverless_resource` is valid only when `db_instance_mode` is set to `ServerlessPro`.
+* `cache_storage_size` - (Optional, ForceNew, Int, Available since v1.287.0) The cache storage size, in GB. Valid values: `800` to `102400`. **NOTE:** `cache_storage_size` is valid only when `db_instance_mode` is set to `ServerlessPro`.
 * `prod_type` - (Optional, ForceNew, Available since v1.233.1) The type of the product. Default value: `standard`. Valid values: `standard`, `cost-effective`.
 * `data_share_status` - (Optional, Available since v1.233.1) Specifies whether to enable or disable data sharing. Default value: `closed`. Valid values:
   - `opened`: Enables data sharing.
@@ -146,7 +152,6 @@ The following arguments are supported:
 * `master_node_num` - (Optional, Int, Deprecated since v1.213.0) The number of Master nodes. **NOTE:** Field `master_node_num` has been deprecated from provider version 1.213.0.
 * `private_ip_address` - (Optional, Deprecated since v1.213.0) The private ip address. **NOTE:** Field `private_ip_address` has been deprecated from provider version 1.213.0.
 
-
 ### `ip_whitelist`
 
 The ip_whitelist supports the following:
@@ -162,6 +167,11 @@ The parameters supports the following:
 
 * `name` - (Required, Available since v1.231.0) The name of the parameter.
 * `value` - (Required, Available since v1.231.0) The value of the parameter.
+* `default_value` - (Available since v1.231.0) The default value of the parameter.
+* `is_changeable_config` - (Available since v1.231.0) Whether the parameter is changeable.
+* `force_restart_instance` - (Available since v1.231.0) Whether to force restart the instance to config the parameter.
+* `optional_range` - (Available since v1.231.0) The optional range of the parameter.
+* `parameter_description` - (Available since v1.231.0) The description of the parameter.
 
 ## Attributes Reference
 
@@ -171,12 +181,6 @@ The following attributes are exported:
 * `status` - The status of the instance.
 * `connection_string` - (Available since v1.196.0) The connection string of the instance.
 * `port` - (Available since v1.196.0) The connection port of the instance.
-* `parameters` - (Available since v1.231.0) A list of parameters. Each element contains the following attributes:
-  * `default_value` - (Available since v1.231.0) The default value of the parameter.
-  * `force_restart_instance` - (Available since v1.231.0) Whether to force restart the instance to config the parameter.
-  * `parameter_description` - (Available since v1.231.0) The description of the parameter.
-  * `optional_range` - (Available since v1.231.0) The optional range of the parameter.
-  * `is_changeable_config` - (Available since v1.231.0) Whether the parameter is changeable.
 
 ## Timeouts
 


### PR DESCRIPTION
## Summary
- Add `ServerlessPro` as a valid value for `db_instance_mode`.
- Add `serverless_resource` (Int, ForceNew, computing resource threshold in ACU, valid values `16` to `1024`) and pass it through to `CreateDBInstance` / read it back from `DescribeDBInstanceAttribute`.
- Add `cache_storage_size` (Int, ForceNew, cache storage size in GB, valid values `800` to `102400`) with the same create/read wiring.
- Update the resource documentation for the three attributes.

## Test plan
- [ ] `TestAccAliCloudGPDBDBInstanceServerlessPro`: create a `ServerlessPro` instance with `serverless_resource` and `cache_storage_size`, then import — remote acceptance run pending; results to be appended once complete.