### PR TITLE
ci: expose heavy runner routing output

### DIFF
--- a/.github/actions/terraform-ci-select-policy/action.yml
+++ b/.github/actions/terraform-ci-select-policy/action.yml
@@ -11,6 +11,9 @@ outputs:
   runner:
     description: JSON string containing the selected runner label.
     value: ${{ steps.select.outputs.runner }}
+  heavy_runner:
+    description: JSON string containing the selected heavy runner label.
+    value: ${{ steps.select.outputs.heavy_runner }}
 
 runs:
   using: composite

--- a/.github/actions/terraform-ci-select-policy/route.js
+++ b/.github/actions/terraform-ci-select-policy/route.js
@@ -5,6 +5,7 @@ const POLICY_CHECK_NAME = "Basic Policy";
 const POLICY_TIMEOUT_MS = 90000;
 const POLICY_POLL_INTERVAL_MS = 3000;
 const TRUSTED_RUNNER = "terraform-ci-trusted";
+const TRUSTED_HEAVY_RUNNER = "terraform-ci-heavy";
 const EXTERNAL_RUNNER = "ubuntu-latest";
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const REPOSITORY_PATTERN =
@@ -195,12 +196,21 @@ function setOutputs(core, classification, relevant) {
   if (!core || typeof core.setOutput !== "function") {
     throw new Error("Actions output interface is invalid.");
   }
+  if (
+    !["trusted", "external"].includes(classification) ||
+    typeof relevant !== "boolean"
+  ) {
+    throw new Error("Actions routing output is invalid.");
+  }
   const runner =
     classification === "trusted" ? TRUSTED_RUNNER : EXTERNAL_RUNNER;
+  const heavyRunner =
+    classification === "trusted" ? TRUSTED_HEAVY_RUNNER : EXTERNAL_RUNNER;
   const outputs = {
     classification,
     relevant: String(relevant),
     runner: JSON.stringify(runner),
+    heavy_runner: JSON.stringify(heavyRunner),
   };
   for (const [name, value] of Object.entries(outputs)) {
     core.setOutput(name, value);

--- a/.github/actions/terraform-ci-select-policy/route.test.js
+++ b/.github/actions/terraform-ci-select-policy/route.test.js
@@ -152,6 +152,7 @@ test("pull_request selects the trusted runner from a valid binding", async () =>
     classification: "trusted",
     relevant: "true",
     runner: JSON.stringify("terraform-ci-trusted"),
+    heavy_runner: JSON.stringify("terraform-ci-heavy"),
   });
   assert.equal(result.calls.length, 1);
   assert.deepEqual(result.calls[0].args, {
@@ -174,6 +175,7 @@ test("pull_request selects the hosted runner for an external binding", async () 
     classification: "external",
     relevant: "false",
     runner: JSON.stringify("ubuntu-latest"),
+    heavy_runner: JSON.stringify("ubuntu-latest"),
   });
 });
 
@@ -232,6 +234,7 @@ test("push to the repository master branch is trusted and relevant", async () =>
     classification: "trusted",
     relevant: "true",
     runner: JSON.stringify("terraform-ci-trusted"),
+    heavy_runner: JSON.stringify("terraform-ci-heavy"),
   });
   assert.equal(result.calls.length, 0);
 });
@@ -336,6 +339,24 @@ for (const [name, externalId] of [
       ),
       /binding/i
     );
+  });
+}
+
+for (const classification of ["blocked", "invalid"]) {
+  test(`${classification} classification emits no executable routes`, async () => {
+    const candidate = checkRun({
+      external_id: JSON.stringify(binding({ c: classification })),
+    });
+    const result = harness([[candidate]]);
+
+    await assert.rejects(
+      selectPolicy({
+        context: pullRequestContext(),
+        ...result.options,
+      }),
+      /binding/i
+    );
+    assert.deepEqual(result.outputs, {});
   });
 }
 


### PR DESCRIPTION
### Summary

- expose a dedicated heavy runner route from the CI policy action
- keep external pull requests on GitHub-hosted runners
- fail closed before emitting routes for invalid classifications

### Tests

- `node --test .github/actions/terraform-ci-select-policy/route.test.js`
- `node --check .github/actions/terraform-ci-select-policy/route.js`
- `node --check .github/actions/terraform-ci-select-policy/route.test.js`
- `actionlint`