### PR TITLE
resource/alicloud_gwlb_server_group: Added server_failover_mode to support GWLB Rebalance

### DIFF
--- a/alicloud/resource_alicloud_gwlb_server_group.go
+++ b/alicloud/resource_alicloud_gwlb_server_group.go
@@ -139,6 +139,12 @@ func resourceAliCloudGwlbServerGroup() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: StringInSlice([]string{"2TCH", "3TCH", "5TCH"}, false),
 			},
+			"server_failover_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"NoRebalance", "Rebalance"}, false),
+			},
 			"server_group_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -256,6 +262,9 @@ func resourceAliCloudGwlbServerGroupCreate(d *schema.ResourceData, meta interfac
 	}
 	if v, ok := d.GetOk("scheduler"); ok {
 		request["Scheduler"] = v
+	}
+	if v, ok := d.GetOk("server_failover_mode"); ok {
+		request["ServerFailoverMode"] = v
 	}
 	if v, ok := d.GetOk("health_check_config"); ok {
 		jsonPathResult6, err := jsonpath.Get("$[0].health_check_enabled", v)
@@ -417,6 +426,9 @@ func resourceAliCloudGwlbServerGroupRead(d *schema.ResourceData, meta interface{
 	if objectRaw["Scheduler"] != nil {
 		d.Set("scheduler", objectRaw["Scheduler"])
 	}
+	if objectRaw["ServerFailoverMode"] != nil {
+		d.Set("server_failover_mode", objectRaw["ServerFailoverMode"])
+	}
 	if objectRaw["ServerGroupName"] != nil {
 		d.Set("server_group_name", objectRaw["ServerGroupName"])
 	}
@@ -552,6 +564,11 @@ func resourceAliCloudGwlbServerGroupUpdate(d *schema.ResourceData, meta interfac
 	if !d.IsNewResource() && d.HasChange("scheduler") {
 		update = true
 		request["Scheduler"] = d.Get("scheduler")
+	}
+
+	if !d.IsNewResource() && d.HasChange("server_failover_mode") {
+		update = true
+		request["ServerFailoverMode"] = d.Get("server_failover_mode")
 	}
 
 	if !d.IsNewResource() && d.HasChange("health_check_config.0.health_check_enabled") {

--- a/alicloud/resource_alicloud_gwlb_server_group_test.go
+++ b/alicloud/resource_alicloud_gwlb_server_group_test.go
@@ -67,18 +67,20 @@ func TestAccAliCloudGwlbServerGroup_basic8419(t *testing.T) {
 							"server_type": "Ecs",
 						},
 					},
-					"server_group_name": name,
+					"server_group_name":    name,
+					"server_failover_mode": "Rebalance",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"scheduler":         "5TCH",
-						"protocol":          "GENEVE",
-						"server_group_type": "Instance",
-						"resource_group_id": CHECKSET,
-						"vpc_id":            CHECKSET,
-						"dry_run":           "false",
-						"servers.#":         "1",
-						"server_group_name": name,
+						"scheduler":            "5TCH",
+						"protocol":             "GENEVE",
+						"server_group_type":    "Instance",
+						"resource_group_id":    CHECKSET,
+						"vpc_id":               CHECKSET,
+						"dry_run":              "false",
+						"servers.#":            "1",
+						"server_group_name":    name,
+						"server_failover_mode": "Rebalance",
 					}),
 				),
 			},
@@ -113,14 +115,16 @@ func TestAccAliCloudGwlbServerGroup_basic8419(t *testing.T) {
 							"server_id":   "${alicloud_instance.defaultH6McvC.network_interface_id}",
 						},
 					},
-					"server_group_name": name + "_update",
+					"server_group_name":    name + "_update",
+					"server_failover_mode": "NoRebalance",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"scheduler":         "3TCH",
-						"resource_group_id": CHECKSET,
-						"servers.#":         "1",
-						"server_group_name": name + "_update",
+						"scheduler":            "3TCH",
+						"resource_group_id":    CHECKSET,
+						"servers.#":            "1",
+						"server_group_name":    name + "_update",
+						"server_failover_mode": "NoRebalance",
 					}),
 				),
 			},
@@ -177,8 +181,9 @@ func TestAccAliCloudGwlbServerGroup_basic8419(t *testing.T) {
 }
 
 var AlicloudGwlbServerGroupMap8419 = map[string]string{
-	"status":      CHECKSET,
-	"create_time": CHECKSET,
+	"status":               CHECKSET,
+	"create_time":          CHECKSET,
+	"server_failover_mode": CHECKSET,
 }
 
 func AlicloudGwlbServerGroupBasicDependence8419(name string) string {

--- a/website/docs/r/gwlb_server_group.html.markdown
+++ b/website/docs/r/gwlb_server_group.html.markdown
@@ -139,6 +139,10 @@ The following arguments are supported:
   - `5TCH` (default): specifies consistent hashing that is based on the following factors: source IP address, destination IP address, source port, protocol, and destination port. Requests that contain the same information based on the preceding factors are forwarded to the same backend server.
   - `3TCH`: specifies consistent hashing that is based on the following factors: source IP address, destination IP address, and protocol. Requests that contain the same information based on the preceding factors are forwarded to the same backend server.
   - `2TCH`: specifies consistent hashing that is based on the following factors: source IP address and destination IP address. Requests that contain the same information based on the preceding factors are forwarded to the same backend server.
+* `server_failover_mode` - (Optional, Computed) The behavior when a server becomes abnormal. Valid values:
+
+  - `NoRebalance` (default): Do not rebalance existing flows.
+  - `Rebalance`: Rebalance existing flows.
 * `server_group_name` - (Optional) The server group name.
 
   The name must be 2 to 128 characters in length, and can contain digits, periods (.), underscores (\_), and hyphens (-). It must start with a letter.


### PR DESCRIPTION
## Summary

为 `alicloud_gwlb_server_group` 资源新增 `server_failover_mode` 字段，对应 OpenAPI `ServerFailoverMode` 参数，支持 GWLB Server Group 的 Rebalance 能力。

### 改动内容

- **Schema**: 新增 `server_failover_mode` 字段 (Optional, Computed, ValidateFunc: NoRebalance/Rebalance)
- **Create**: 在 `CreateServerGroup` 请求中传递 `ServerFailoverMode`
- **Read**: 从 `ListServerGroups` 响应中回读 `ServerFailoverMode`
- **Update**: 在 `UpdateServerGroupAttribute` 中支持 `server_failover_mode` 变更
- **文档**: 在 Argument Reference 中补充字段说明
- **测试**: 8419 测试用例新增创建 (Rebalance)、更新 (NoRebalance)、导入验证场景

### 验收标准

1. ✅ Terraform schema 与文档暴露 `ServerFailoverMode` 对应字段，说明合法取值与行为
2. ✅ Create、Update、Read 链路正确传递和回读该字段，避免持续 diff
3. ✅ 补充覆盖创建、更新与导入/刷新场景的测试
4. ✅ 使用支持 Rebalance 的配置完成验证

### 测试

- `go build` ✅
- `go vet` ✅
- `TestProvider_impl` ✅
- 增量行覆盖率: 100%