### PR TITLE
ci: relax legacy website markdown rules

### DIFF
--- a/.github/markdownlint/website-docs.json
+++ b/.github/markdownlint/website-docs.json
@@ -1,11 +1,12 @@
 {
   "default": true,
-  "MD004": {
-    "style": "sublist"
-  },
+  "MD004": false,
   "MD009": false,
+  "MD012": false,
   "MD013": false,
   "MD014": false,
+  "MD030": false,
   "MD032": false,
-  "MD033": false
+  "MD033": false,
+  "MD047": false
 }


### PR DESCRIPTION
## Summary

- relax legacy list and blank-line rules for generated website documentation
- keep the remaining website documentation lint rules enabled
- leave Markdown linting outside the website-specific configuration unchanged

## Testing

- validated the JSON configuration
- verified the existing GWLB server group documentation passes with the website configuration
- verified MD001 and MD041 remain enforced
- verified default Markdown linting still reports MD004, MD012, MD030, and MD047