### PR TITLE
test(alicloud_kvstore_instance): ignore secondary_zone_id after PostPaid conversion in 7.0 acc test

### DIFF
--- a/alicloud/resource_alicloud_kvstore_instance_test.go
+++ b/alicloud/resource_alicloud_kvstore_instance_test.go
@@ -1100,6 +1100,7 @@ func TestAccAliCloudKVStoreRedisInstance_7_0(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"instance_charge_type": "PostPaid",
+						"secondary_zone_id":    REMOVEKEY,
 					}),
 				),
 			},


### PR DESCRIPTION
## Problem
`TestAccAliCloudKVStoreRedisInstance_7_0` fails at the PrePaid → PostPaid step:

```
Step 14 error: Check failed: ... Attribute 'secondary_zone_id' expected to be set
```

## Root cause
Follow-up to #9908 (resource/alicloud_kvstore_instance: support replica counts). After #9908, converting a dual-zone kvstore instance to PostPaid clears `secondary_zone_id` (the instance becomes single-zone). The 7.0 acc test creates the instance with `secondary_zone_id` set in step 1, and the shared check helper (`resourceAttrMapUpdateSet`) accumulates `secondary_zone_id: CHECKSET` across steps. By the PrePaid → PostPaid step the attribute is legitimately empty, but the accumulated `CHECKSET` still asserts it is set, so the check fails.

## Fix
Add `"secondary_zone_id": REMOVEKEY` to the PrePaid → PostPaid step's check map. This stops asserting the attribute from the step where #9908's behavior clears it, consistent with the REMOVEKEY pattern #9908 already uses for the subsequent big-update step (which removes `secondary_zone_id` from config and does not re-assert it). The effect carries forward through the accumulated check map.

## Verification
`TestAccAliCloudKVStoreRedisInstance_7_0`: `PASS=1 FAIL=0 SKIP=0`.

One-line diff.
