### PR TITLE
New Resource: alicloud_message_service_account_logging

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -945,6 +945,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),
 			"alicloud_apig_ai_model_provider":                               resourceAliCloudApigAiModelProvider(),
 			"alicloud_apig_service":                                         resourceAliCloudApigService(),
 			"alicloud_gpdb_api_key":                                         resourceAliCloudGpdbApiKey(),

--- a/alicloud/resource_alicloud_message_service_account_logging.go
+++ b/alicloud/resource_alicloud_message_service_account_logging.go
@@ -1,0 +1,191 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudMessageServiceAccountLogging() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudMessageServiceAccountLoggingCreate,
+		Read:   resourceAliCloudMessageServiceAccountLoggingRead,
+		Update: resourceAliCloudMessageServiceAccountLoggingUpdate,
+		Delete: resourceAliCloudMessageServiceAccountLoggingDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"log_enabled": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"log_store_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"message_trace_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"project_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudMessageServiceAccountLoggingCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "SetAccountAttributes"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	request["ClientToken"] = buildClientToken(action)
+
+	if v, ok := d.GetOkExists("log_enabled"); ok {
+		request["LogEnabled"] = v
+	}
+	if v, ok := d.GetOk("project_name"); ok {
+		request["ProjectName"] = v
+	}
+	if v, ok := d.GetOk("log_store_name"); ok {
+		request["LogStoreName"] = v
+	}
+	if v, ok := d.GetOkExists("message_trace_enabled"); ok {
+		request["MessageTraceEnabled"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Mns-open", "2022-01-19", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_message_service_account_logging", action, AlibabaCloudSdkGoERROR)
+	}
+
+	accountId, err := client.AccountId()
+	if err != nil {
+		return WrapError(err)
+	}
+	d.SetId(accountId)
+
+	return resourceAliCloudMessageServiceAccountLoggingRead(d, meta)
+}
+
+func resourceAliCloudMessageServiceAccountLoggingRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	messageServiceServiceV2 := MessageServiceServiceV2{client}
+
+	objectRaw, err := messageServiceServiceV2.DescribeMessageServiceAccountLogging(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_message_service_account_logging DescribeMessageServiceAccountLogging Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("log_enabled", objectRaw["LogEnabled"])
+	d.Set("log_store_name", objectRaw["LogStoreName"])
+	d.Set("message_trace_enabled", objectRaw["MessageTraceEnabled"])
+	d.Set("project_name", objectRaw["ProjectName"])
+
+	return nil
+}
+
+func resourceAliCloudMessageServiceAccountLoggingUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	update := false
+
+	var err error
+	action := "SetAccountAttributes"
+	request = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	request["ClientToken"] = buildClientToken(action)
+
+	if d.HasChange("log_enabled") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("log_enabled"); ok {
+		request["LogEnabled"] = v
+	}
+
+	if d.HasChange("project_name") {
+		update = true
+	}
+	if v, ok := d.GetOk("project_name"); ok {
+		request["ProjectName"] = v
+	}
+
+	if d.HasChange("log_store_name") {
+		update = true
+	}
+	if v, ok := d.GetOk("log_store_name"); ok {
+		request["LogStoreName"] = v
+	}
+
+	if d.HasChange("message_trace_enabled") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("message_trace_enabled"); ok {
+		request["MessageTraceEnabled"] = v
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Mns-open", "2022-01-19", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudMessageServiceAccountLoggingRead(d, meta)
+}
+
+func resourceAliCloudMessageServiceAccountLoggingDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource AliCloud Resource Account Logging. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_message_service_account_logging_test.go
+++ b/alicloud/resource_alicloud_message_service_account_logging_test.go
@@ -1,0 +1,121 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// MessageService AccountLogging is an account-level singleton (SetAccountAttributes / GetAccountAttributes);
+// destroy is a no-op, so CheckDestroy cannot be asserted. When log_enabled is false the API returns no
+// project_name / log_store_name, so those are cleared together with disabling logging.
+// lintignore: AT001
+func TestAccAliCloudMessageServiceAccountLogging_basic0(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_message_service_account_logging.default"
+	ra := resourceAttrInit(resourceId, AlicloudMessageServiceAccountLoggingMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &MessageServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeMessageServiceAccountLogging")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-example-mns-log-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudMessageServiceAccountLoggingBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"log_enabled":           "true",
+					"message_trace_enabled": "false",
+					"project_name":          "${alicloud_log_project.default.project_name}",
+					"log_store_name":        "${alicloud_log_store.default.logstore_name}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"log_enabled":           "true",
+						"message_trace_enabled": "false",
+						"project_name":          CHECKSET,
+						"log_store_name":        CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"message_trace_enabled": "true",
+					"project_name":          "${alicloud_log_project.update.project_name}",
+					"log_store_name":        "${alicloud_log_store.update.logstore_name}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"message_trace_enabled": "true",
+						"project_name":          CHECKSET,
+						"log_store_name":        CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"log_enabled":    "false",
+					"project_name":   "",
+					"log_store_name": "",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"log_enabled":    "false",
+						"project_name":   "",
+						"log_store_name": "",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudMessageServiceAccountLoggingMap0 = map[string]string{}
+
+func AlicloudMessageServiceAccountLoggingBasicDependence0(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+  description  = "tf-testacc message service account logging"
+}
+
+resource "alicloud_log_store" "default" {
+  project_name     = alicloud_log_project.default.project_name
+  logstore_name    = var.name
+  retention_period = 30
+  shard_count      = 2
+}
+
+resource "alicloud_log_project" "update" {
+  project_name = "${var.name}-update"
+  description  = "tf-testacc message service account logging update"
+}
+
+resource "alicloud_log_store" "update" {
+  project_name     = alicloud_log_project.update.project_name
+  logstore_name    = "${var.name}-update"
+  retention_period = 30
+  shard_count      = 2
+}
+`, name)
+}

--- a/alicloud/service_alicloud_message_service_v2.go
+++ b/alicloud/service_alicloud_message_service_v2.go
@@ -601,3 +601,43 @@ func (s *MessageServiceServiceV2) MessageServiceEventRuleStateRefreshFunc(id str
 }
 
 // DescribeMessageServiceEventRule >>> Encapsulated.
+
+// DescribeMessageServiceAccountLogging <<< Encapsulated get interface for MessageService AccountLogging.
+
+func (s *MessageServiceServiceV2) DescribeMessageServiceAccountLogging(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	action := "GetAccountAttributes"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Mns-open", "2022-01-19", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Data", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Data", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+// DescribeMessageServiceAccountLogging >>> Encapsulated.

--- a/website/docs/r/message_service_account_logging.html.markdown
+++ b/website/docs/r/message_service_account_logging.html.markdown
@@ -1,0 +1,77 @@
+---
+subcategory: "Message Service"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_message_service_account_logging"
+description: |-
+  Provides a Alicloud Message Service Account Logging resource.
+---
+
+# alicloud_message_service_account_logging
+
+Provides a Message Service Account Logging resource.
+
+Account Logging Configuration.
+
+For information about Message Service Account Logging and how to use it, see [What is Account Logging](https://next.api.alibabacloud.com/document/Mns-open/2022-01-19/SetAccountAttributes).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+  description  = "example project for account logging"
+}
+
+resource "alicloud_log_store" "default" {
+  project_name     = alicloud_log_project.default.project_name
+  logstore_name    = var.name
+  retention_period = 30
+  shard_count      = 2
+}
+
+resource "alicloud_message_service_account_logging" "default" {
+  log_enabled           = true
+  message_trace_enabled = false
+  project_name          = alicloud_log_project.default.project_name
+  log_store_name        = alicloud_log_store.default.logstore_name
+}
+```
+
+### Deleting `alicloud_message_service_account_logging` or removing it from your configuration
+
+Terraform cannot destroy resource `alicloud_message_service_account_logging`. Terraform will remove this resource from the state file, however resources may remain.
+
+## Argument Reference
+
+The following arguments are supported:
+* `log_enabled` - (Required) Whether to enable delivering the account operation logs to Simple Log Service (SLS).
+* `log_store_name` - (Optional) The name of the SLS Logstore that receives the logs. Required when `log_enabled` is `true`.
+* `project_name` - (Optional) The name of the SLS Project that the Logstore belongs to. Required when `log_enabled` is `true`.
+* `message_trace_enabled` - (Optional) Whether to enable the message trace feature.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<Alibaba Cloud Account ID>`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Account Logging.
+* `update` - (Defaults to 5 mins) Used when update the Account Logging.
+
+## Import
+
+Message Service Account Logging can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_message_service_account_logging.example <Alibaba Cloud Account ID>
+```


### PR DESCRIPTION
## Summary
- Add new resource `alicloud_message_service_account_logging` to manage the account-level Message Service (MNS) logging configuration: toggle delivery of account operation logs to Simple Log Service (SLS), set the destination SLS project and logstore, and toggle the message trace feature.
- Backed by `SetAccountAttributes` (create/update) and `GetAccountAttributes` (read). The resource is an account-level singleton whose `id` is the Alibaba Cloud account ID. There is no data source because the API exposes no list interface for this account-level configuration.

## Test plan
- [x] `TestAccAliCloudMessageServiceAccountLogging_basic0` PASS: create (`log_enabled` / `message_trace_enabled` / `project_name` / `log_store_name`) → update `message_trace_enabled` → import → destroy.

```
=== RUN   TestAccAliCloudMessageServiceAccountLogging_basic0
--- PASS: TestAccAliCloudMessageServiceAccountLogging_basic0 (14.79s)
PASS
```
