### PR TITLE
data-source/alicloud_vswitches: expose pagination parameters; data-source/alicloud_alikafka_consumer_groups: expose pagination parameters

### DIFF
--- a/alicloud/data_source_alicloud_alikafka_consumer_groups.go
+++ b/alicloud/data_source_alicloud_alikafka_consumer_groups.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/alikafka"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -33,6 +34,14 @@ func dataSourceAlicloudAlikafkaConsumerGroups() *schema.Resource {
 			},
 			"output_file": {
 				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"page_number": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"page_size": {
+				Type:     schema.TypeInt,
 				Optional: true,
 			},
 			// Computed values
@@ -67,7 +76,11 @@ func dataSourceAlicloudAlikafkaConsumerGroups() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"tags": tagsSchema(),
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 					},
 				},
 			},
@@ -93,40 +106,62 @@ func dataSourceAlicloudAlikafkaConsumerGroupsRead(d *schema.ResourceData, meta i
 		}
 	}
 
-	raw, err := alikafkaService.client.WithAlikafkaClient(func(alikafkaClient *alikafka.Client) (interface{}, error) {
-		return alikafkaClient.GetConsumerList(request)
-	})
-	if err != nil {
-		return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_alikafka_consumer_groups", request.GetActionName(), AlibabaCloudSdkGoERROR)
+	if v, ok := d.GetOk("page_number"); ok && v.(int) > 0 {
+		request.CurrentPage = requests.NewInteger(v.(int))
+	} else {
+		request.CurrentPage = requests.NewInteger(1)
 	}
-	addDebug(request.GetActionName(), raw, request.RpcRequest, request)
-	response, _ := raw.(*alikafka.GetConsumerListResponse)
+	pageSize := PageSizeLarge
+	if v, ok := d.GetOk("page_size"); ok && v.(int) > 0 {
+		pageSize = v.(int)
+	}
+	request.PageSize = requests.NewInteger(pageSize)
+
+	var r *regexp.Regexp
+	if v, ok := d.GetOk("consumer_id_regex"); ok && v.(string) != "" {
+		var compileErr error
+		r, compileErr = regexp.Compile(v.(string))
+		if compileErr != nil {
+			return WrapError(compileErr)
+		}
+	}
 
 	var filteredConsumerGroups []alikafka.ConsumerVO
-	nameRegex, ok := d.GetOk("consumer_id_regex")
-	for _, consumer := range response.ConsumerList.ConsumerVO {
-		var r *regexp.Regexp
-
-		if ok && nameRegex.(string) != "" {
-			if nameRegex != "" {
-				r, err = regexp.Compile(nameRegex.(string))
-				if err != nil {
-					return WrapError(err)
-				}
-			}
+	for {
+		raw, err := alikafkaService.client.WithAlikafkaClient(func(alikafkaClient *alikafka.Client) (interface{}, error) {
+			return alikafkaClient.GetConsumerList(request)
+		})
+		if err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_alikafka_consumer_groups", request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
+		addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+		response, _ := raw.(*alikafka.GetConsumerListResponse)
 
-		if r != nil && !r.MatchString(consumer.ConsumerId) {
-			continue
-		}
-
-		if len(idsMap) > 0 {
-			if _, ok := idsMap[fmt.Sprint(consumer.InstanceId, ":", consumer.ConsumerId)]; !ok {
+		for _, consumer := range response.ConsumerList.ConsumerVO {
+			if r != nil && !r.MatchString(consumer.ConsumerId) {
 				continue
 			}
+
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(consumer.InstanceId, ":", consumer.ConsumerId)]; !ok {
+					continue
+				}
+			}
+
+			filteredConsumerGroups = append(filteredConsumerGroups, consumer)
 		}
 
-		filteredConsumerGroups = append(filteredConsumerGroups, consumer)
+		if isPagingRequest(d) {
+			break
+		}
+		if len(response.ConsumerList.ConsumerVO) < pageSize {
+			break
+		}
+		page, err := getNextpageNumber(request.CurrentPage)
+		if err != nil {
+			return WrapError(err)
+		}
+		request.CurrentPage = page
 	}
 
 	return alikafkaConsumerGroupsDecriptionAttributes(d, filteredConsumerGroups, meta)

--- a/alicloud/data_source_alicloud_alikafka_consumer_groups_test.go
+++ b/alicloud/data_source_alicloud_alikafka_consumer_groups_test.go
@@ -14,6 +14,8 @@ func TestAccAAlikafkaConsumerGroupsDataSource(t *testing.T) {
 		existConfig: testAccCheckAAlikafkaConsumerGroupsDataSourceName(rand, map[string]string{
 			"instance_id": `"${alicloud_alikafka_instance.default.id}"`,
 			"ids":         `["${alicloud_alikafka_consumer_group.default.id}"]`,
+			"page_number": "1",
+			"page_size":   "10",
 		}),
 		fakeConfig: testAccCheckAAlikafkaConsumerGroupsDataSourceName(rand, map[string]string{
 			"instance_id": `"${alicloud_alikafka_instance.default.id}"`,

--- a/alicloud/data_source_alicloud_vswitches.go
+++ b/alicloud/data_source_alicloud_vswitches.go
@@ -76,6 +76,14 @@ func dataSourceAlicloudVswitches() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"page_number": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"page_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"vswitches": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -197,8 +205,19 @@ func dataSourceAlicloudVswitchesRead(d *schema.ResourceData, meta interface{}) e
 	if v, ok := d.GetOk("zone_id"); ok {
 		request["ZoneId"] = v
 	}
-	request["PageSize"] = PageSizeLarge
-	request["PageNumber"] = 1
+	pageSize := PageSizeLarge
+	if v, ok := d.GetOk("page_size"); ok && v.(int) > 0 {
+		pageSize = v.(int)
+	}
+	if pageSize > PageSizeLarge {
+		pageSize = PageSizeLarge
+	}
+	if v, ok := d.GetOk("page_number"); ok && v.(int) > 0 {
+		request["PageNumber"] = v.(int)
+	} else {
+		request["PageNumber"] = 1
+	}
+	request["PageSize"] = pageSize
 	var objects []map[string]interface{}
 	var vSwitchNameRegex *regexp.Regexp
 	if v, ok := d.GetOk("name_regex"); ok {
@@ -253,7 +272,10 @@ func dataSourceAlicloudVswitchesRead(d *schema.ResourceData, meta interface{}) e
 			}
 			objects = append(objects, item)
 		}
-		if len(result) < PageSizeLarge {
+		if isPagingRequest(d) {
+			break
+		}
+		if len(result) < pageSize {
 			break
 		}
 		request["PageNumber"] = request["PageNumber"].(int) + 1

--- a/alicloud/data_source_alicloud_vswitches_test.go
+++ b/alicloud/data_source_alicloud_vswitches_test.go
@@ -166,6 +166,8 @@ func TestAccAliCloudVPCVSwitchesDataSourceCoverage(t *testing.T) {
 					"vswitch_name":     "${alicloud_vswitch.default.vswitch_name}",
 					"vswitch_owner_id": 0,
 					"output_file":      "./test_output_file",
+					"page_number":      1,
+					"page_size":        10,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckExist(nil),
@@ -189,6 +191,8 @@ func TestAccAliCloudVPCVSwitchesDataSourceCoverage(t *testing.T) {
 					"vswitch_name":     "${alicloud_vswitch.default.vswitch_name}_fake",
 					"vswitch_owner_id": 1,
 					"output_file":      "./test_output_file_fake",
+					"page_number":      1,
+					"page_size":        10,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEmpty(nil),

--- a/website/docs/d/alikafka_consumer_groups.html.markdown
+++ b/website/docs/d/alikafka_consumer_groups.html.markdown
@@ -7,19 +7,19 @@ description: |-
     Provides a list of alikafka consumer groups available to the user.
 ---
 
-# alicloud\_alikakfa\_consumer\_groups
+# alicloud_alikafka_consumer_groups
 
 This data source provides a list of ALIKAFKA Consumer Groups in an Alibaba Cloud account according to the specified filters.
 
--> **NOTE:** Available in 1.56.0+
+-> **NOTE:** Available since v1.56.0+.
 
 ## Example Usage
 
-```
+```terraform
 data "alicloud_alikafka_consumer_groups" "consumer_groups_ds" {
-  instance_id = "xxx"
+  instance_id       = "xxx"
   consumer_id_regex = "CID-alikafkaGroupDatasourceName"
-  output_file = "consumerGroups.txt"
+  output_file       = "consumerGroups.txt"
 }
 
 output "first_group_name" {
@@ -35,15 +35,18 @@ The following arguments are supported:
 * `instance_id` - (Required) ID of the ALIKAFKA Instance that owns the consumer groups.
 * `consumer_id_regex` - (Optional) A regex string to filter results by the consumer group id. 
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `page_number` - (Optional) Current page number. The default value is `1`. When this argument is set, only the specified page of results is returned.
+* `page_size` - (Optional) Number of records per page. The default value is `50`.
 
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
 
 * `names` - A list of consumer group names.
+* `consumer_ids` - A list of consumer group IDs.
 * `groups` - A list of consumer group. Each element contains the following attributes:
-    * `id` - The ID of the consumer group, It is formatted to `<instance_id>:<consumer_id>`.
-    * `consumer_id` - The name of the consumer group.
-    * `remark` - The remark of the consumer group.
-    * `instance_id` - The instance_id of the instance.
-    * `tags` - A mapping of tags to assign to the consumer group.
+  * `id` - The ID of the consumer group, It is formatted to `<instance_id>:<consumer_id>`.
+  * `consumer_id` - The name of the consumer group.
+  * `remark` - The remark of the consumer group.
+  * `instance_id` - The instance_id of the instance.
+  * `tags` - A mapping of tags to assign to the consumer group.

--- a/website/docs/d/vswitches.html.markdown
+++ b/website/docs/d/vswitches.html.markdown
@@ -49,6 +49,8 @@ The following arguments are supported:
 * `vpc_id` - (Optional) ID of the VPC that owns the vSwitch.
 * `tags` - (Optional, Available in v1.55.3+) A mapping of tags to assign to the resource.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `page_number` - (Optional) Current page number. The default value is `1`. When this argument is set, only the specified page of results is returned.
+* `page_size` - (Optional) Number of records per page. The maximum value is `50`. The default value is `50`.
 * `ids` - (Optional, Available in 1.52.0+) A list of vSwitch IDs.
 * `resource_group_id` - (Optional, ForceNew, Available in 1.60.0+) The Id of resource group which VSWitch belongs.
 * `dry_run` - (Optional, ForceNew, Available in 1.119.0+) Specifies whether to precheck this request only. Valid values: `true` and `false`.


### PR DESCRIPTION
## What this PR does

Adds user-controllable pagination parameters to two data sources that previously paginated internally without exposing the page size to users.

### alicloud_vswitches
- Adds `page_number` (Optional) and `page_size` (Optional).
- When `page_number` is set, only the requested page is returned (single-page mode); otherwise all pages are fetched automatically as before.
- `page_size` is capped at the API maximum (50) for `DescribeVSwitches`.

### alicloud_alikafka_consumer_groups
- Adds `page_number` (Optional) and `page_size` (Optional), mapped to the `GetConsumerList` `CurrentPage`/`PageSize` parameters.
- Same single-page vs auto-paginate behavior as the other data sources.
- The data source previously issued a single list call; it now paginates through all pages by default and honors the user-supplied page when `page_number` is set.

## Notes
- Defaults preserve the previous behavior for existing configurations (no breaking change).
- Tests and documentation are updated accordingly.

## Test cases
=== RUN TestAccAliCloudVPCVSwitchesDataSourceBasic
=== RUN TestAccAliCloudVPCVSwitchesDataSourceCoverage
=== RUN TestAccAAlikafkaConsumerGroupsDataSource
