### PR TITLE
resource/alicloud_pvtz_zone: support dns_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ENHANCEMENTS:
 
 - resource/alicloud_gpdb_instance: support backup_id. ([#9988](https://github.com/aliyun/terraform-provider-alicloud/issues/9988))
+- resource/alicloud_pvtz_zone: support dns_group (NORMAL_ZONE/FAST_ZONE). ([#10089](https://github.com/aliyun/terraform-provider-alicloud/issues/10089))
 
 ## 1.286.0 (July 24, 2026)
 

--- a/alicloud/resource_alicloud_pvtz_zone.go
+++ b/alicloud/resource_alicloud_pvtz_zone.go
@@ -42,6 +42,12 @@ func resourceAlicloudPvtzZone() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"RECORD", "ZONE"}, false),
 				Default:      "ZONE",
 			},
+			"dns_group": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"NORMAL_ZONE", "FAST_ZONE"}, false),
+			},
 			"record_count": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -141,6 +147,10 @@ func resourceAlicloudPvtzZoneCreate(d *schema.ResourceData, meta interface{}) er
 		request["ZoneName"] = v
 	}
 
+	if v, ok := d.GetOk("dns_group"); ok {
+		request["DnsGroup"] = v
+	}
+
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("pvtz", "2018-01-01", action, nil, request, false)
@@ -181,6 +191,7 @@ func resourceAlicloudPvtzZoneRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("zone_name", object["ZoneName"])
 	d.Set("name", object["ZoneName"])
 	d.Set("resource_group_id", object["ResourceGroupId"])
+	d.Set("dns_group", object["DnsGroup"])
 
 	if v, ok := object["SyncHostTask"]; ok && v != nil {
 		syncObject := v.(map[string]interface{})
@@ -284,6 +295,34 @@ func resourceAlicloudPvtzZoneUpdate(d *schema.ResourceData, meta interface{}) er
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
 		d.SetPartial("remark")
+	}
+
+	if !d.IsNewResource() && d.HasChange("dns_group") {
+		changeZoneDnsGroupReq := map[string]interface{}{
+			"ZoneId":   d.Id(),
+			"DnsGroup": d.Get("dns_group"),
+		}
+		if _, ok := d.GetOk("lang"); ok {
+			changeZoneDnsGroupReq["Lang"] = d.Get("lang")
+		}
+		action := "ChangeZoneDnsGroup"
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("pvtz", "2018-01-01", action, nil, changeZoneDnsGroupReq, false)
+			if err != nil {
+				if IsExpectedErrors(err, []string{"ServiceUnavailable", "System.Busy", "Throttling.User"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, changeZoneDnsGroupReq)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		d.SetPartial("dns_group")
 	}
 
 	update = false

--- a/alicloud/resource_alicloud_pvtz_zone_test.go
+++ b/alicloud/resource_alicloud_pvtz_zone_test.go
@@ -268,6 +268,66 @@ func TestAccAliCloudPvtzZone_basic(t *testing.T) {
 		},
 	})
 }
+func TestAccAliCloudPvtzZone_dnsGroup(t *testing.T) {
+	var v map[string]interface{}
+
+	resourceId := "alicloud_pvtz_zone.default"
+	ra := resourceAttrInit(resourceId, pvtzZoneBasicMap)
+
+	serviceFunc := func() interface{} {
+		return &PvtzService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+
+	rac := resourceAttrCheckInit(rc, ra)
+
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testacc%d.test.com", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourcePvtzZoneConfigDependence)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_name":         name,
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_name":         name,
+						"dns_group":         CHECKSET,
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"user_client_ip", "lang"},
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_name":         name,
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"dns_group":         "FAST_ZONE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"dns_group": "FAST_ZONE",
+					}),
+				),
+			},
+		},
+	})
+}
 func TestAccAliCloudPvtzZone_multi(t *testing.T) {
 	var v map[string]interface{}
 

--- a/website/docs/r/pvtz_zone.html.markdown
+++ b/website/docs/r/pvtz_zone.html.markdown
@@ -42,9 +42,10 @@ The following arguments are supported:
 * `zone_name` - (Optional, ForceNew) The zone_name of the Private Zone. The `zone_name` is required when the value of the `name`  is Empty.
 * `remark` - (Optional) The remark of the Private Zone.
 * `proxy_pattern` - (Optional, Available in 1.69.0+) The recursive DNS proxy. Valid values:
-    - ZONE: indicates that the recursive DNS proxy is disabled.
-    - RECORD: indicates that the recursive DNS proxy is enabled.
-    Default to "ZONE".
+  - ZONE: indicates that the recursive DNS proxy is disabled.
+  - RECORD: indicates that the recursive DNS proxy is enabled.
+  Default to "ZONE".
+* `dns_group` - (Optional) The built-in authoritative location zone of the Private Zone. Valid values: `NORMAL_ZONE` (normal zone) and `FAST_ZONE` (fast zone). If not specified, the system uses the account default (accounts opened after April 30, 2025 default to `FAST_ZONE`). Updating this field switches the zone from `NORMAL_ZONE` to `FAST_ZONE`; the reverse direction (`FAST_ZONE` -> `NORMAL_ZONE`) is not supported by the API.
 * `user_client_ip` - (Optional, Available in 1.69.0+) The IP address of the client.
 * `lang` - (Optional, Available in 1.69.0+) The language. Valid values: "zh", "en", "jp".
 * `resource_group_id` - (Optional, ForceNew, Available in v1.86.0+) The Id of resource group which the Private Zone belongs.
@@ -66,6 +67,7 @@ The following attributes are exported:
 * `id` - The ID of the Private Zone.
 * `record_count` - The count of the Private Zone Record.
 * `is_ptr` - Whether the Private Zone is ptr.
+* `dns_group` - The built-in authoritative location zone of the Private Zone.
 * `creation_time` - (Removed since v1.107.0+) The create time of the Private Zone.
 * `update_time` - (Removed since v1.107.0+) The update time of the Private Zone.
 


### PR DESCRIPTION
### Description

Add the `dns_group` field to the `alicloud_pvtz_zone` resource to support configuring the built-in authoritative location zone (`NORMAL_ZONE` / `FAST_ZONE`), keeping parity with the `AddZone` API and the console.

### Motivation

The `AddZone` API supports a `DnsGroup` parameter to choose between the normal zone (`NORMAL_ZONE`) and the fast zone (`FAST_ZONE`), but the Terraform resource did not expose it. Users could not configure the fast zone via Terraform.

### Changes

- **Schema**: add `dns_group` (`Optional + Computed`, `ValidateFunc` `StringInSlice(["NORMAL_ZONE", "FAST_ZONE"])`). When unset, the system uses the account default (accounts opened after 2025-04-30 default to `FAST_ZONE`).
- **Create**: send `DnsGroup` to `AddZone` when set.
- **Read**: populate `dns_group` from `DescribeZoneInfo` (`DnsGroup` field).
- **Update**: call `ChangeZoneDnsGroup` when `dns_group` changes — supports switching between normal/fast zone without recreation.
- **Docs**: document `dns_group` in argument reference and attributes reference.
- **Tests**: add `TestAccAliCloudPvtzZone_dnsGroup` covering create (default `dns_group`, i.e. unset), import, and an explicit `dns_group = "FAST_ZONE"` step. The `ChangeZoneDnsGroup` Update path is exercised on accounts whose default is `NORMAL_ZONE` (the step switches `NORMAL_ZONE` -> `FAST_ZONE`, the only direction the API allows); on post-2025-04-30 accounts that force `FAST_ZONE`, the explicit step is a no-op (state already `FAST_ZONE`). The reverse `FAST_ZONE` -> `NORMAL_ZONE` is not supported by the API (`Zone.DnsGroupChange.Forbidden4FastZone`).

### Verification

- `gofmt` + `go vet ./alicloud/` clean.
- Remote ACC: `TestAccAliCloudPvtzZone_dnsGroup` PASS.
