### PR TITLE
New Resource: alicloud_redis_global_security_ip_group, New Data Source: alicloud_redis_global_security_ip_groups

### DIFF
--- a/alicloud/data_source_alicloud_redis_global_security_ip_groups.go
+++ b/alicloud/data_source_alicloud_redis_global_security_ip_groups.go
@@ -1,0 +1,167 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudRedisGlobalSecurityIpGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudRedisGlobalSecurityIpGroupRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"global_security_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"global_ip_list": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"global_ig_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"global_security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudRedisGlobalSecurityIpGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeGlobalSecurityIPGroup"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("global_security_group_id"); ok {
+		request["GlobalSecurityGroupId"] = v
+	}
+	if v, ok := d.GetOk("engine"); ok {
+		request["Engine"] = v
+	}
+	if v, ok := d.GetOk("global_security_group_id"); ok {
+		request["GlobalSecurityGroupId"] = v
+	}
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+		response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	resp, _ := jsonpath.Get("$.GlobalSecurityIPGroup[*]", response)
+
+	result, _ := resp.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		if len(idsMap) > 0 {
+			if _, ok := idsMap[fmt.Sprint(item["GlobalSecurityGroupId"])]; !ok {
+				continue
+			}
+		}
+		objects = append(objects, item)
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["GlobalSecurityGroupId"]
+
+		mapping["global_ip_list"] = objectRaw["GIpList"]
+		mapping["global_ig_name"] = objectRaw["GlobalIgName"]
+		mapping["region_id"] = objectRaw["RegionId"]
+		mapping["global_security_group_id"] = objectRaw["GlobalSecurityGroupId"]
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("groups", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_redis_global_security_ip_groups.go
+++ b/alicloud/data_source_alicloud_redis_global_security_ip_groups.go
@@ -1,0 +1,160 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudRedisGlobalSecurityIpGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudRedisGlobalSecurityIpGroupRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"global_security_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"global_ip_list": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"global_ip_group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"global_security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudRedisGlobalSecurityIpGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeGlobalSecurityIPGroup"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("global_security_group_id"); ok {
+		request["GlobalSecurityGroupId"] = v
+	}
+	if v, ok := d.GetOk("engine"); ok {
+		request["Engine"] = v
+	}
+	if v, ok := d.GetOk("global_security_group_id"); ok {
+		request["GlobalSecurityGroupId"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+		response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	resp, _ := jsonpath.Get("$.GlobalSecurityIPGroup[*]", response)
+
+	result, _ := resp.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		if len(idsMap) > 0 {
+			if _, ok := idsMap[fmt.Sprint(item["GlobalSecurityGroupId"])]; !ok {
+				continue
+			}
+		}
+		objects = append(objects, item)
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["GlobalSecurityGroupId"]
+
+		mapping["global_ip_list"] = objectRaw["GIpList"]
+		mapping["global_ip_group_name"] = objectRaw["GlobalIgName"]
+		mapping["region_id"] = objectRaw["RegionId"]
+		mapping["global_security_group_id"] = objectRaw["GlobalSecurityGroupId"]
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("groups", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_redis_global_security_ip_groups_test.go
+++ b/alicloud/data_source_alicloud_redis_global_security_ip_groups_test.go
@@ -1,0 +1,89 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudRedisGlobalSecurityIpGroupDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudRedisGlobalSecurityIpGroupSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_redis_global_security_ip_group.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudRedisGlobalSecurityIpGroupSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_redis_global_security_ip_group.default.id}_fake"]`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudRedisGlobalSecurityIpGroupSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_redis_global_security_ip_group.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudRedisGlobalSecurityIpGroupSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_redis_global_security_ip_group.default.id}_fake"]`,
+		}),
+	}
+
+	RedisGlobalSecurityIpGroupCheckInfo.dataSourceTestCheck(t, rand, idsConf, allConf)
+}
+
+var existRedisGlobalSecurityIpGroupMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"groups.#":                          "1",
+		"groups.0.global_ip_group_name":     CHECKSET,
+		"groups.0.global_ip_list":           CHECKSET,
+		"groups.0.global_security_group_id": CHECKSET,
+		"groups.0.region_id":                CHECKSET,
+	}
+}
+
+var fakeRedisGlobalSecurityIpGroupMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"groups.#": "0",
+	}
+}
+
+var RedisGlobalSecurityIpGroupCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_redis_global_security_ip_groups.default",
+	existMapFunc: existRedisGlobalSecurityIpGroupMapFunc,
+	fakeMapFunc:  fakeRedisGlobalSecurityIpGroupMapFunc,
+}
+
+func testAccCheckAlicloudRedisGlobalSecurityIpGroupSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccRedisGlobalSecurityIpGroup%d"
+}
+variable "zone_id" {
+  default = "cn-beijing-h"
+}
+
+variable "region_id" {
+  default = "cn-beijing"
+}
+
+
+
+resource "alicloud_redis_global_security_ip_group" "default" {
+  global_ip_group_name = "ggn_test_create"
+  global_ip_list = "192.168.0.1,10.10.10.10,172.16.0.1"
+}
+
+data "alicloud_redis_global_security_ip_groups" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/data_source_alicloud_redis_global_security_ip_groups_test.go
+++ b/alicloud/data_source_alicloud_redis_global_security_ip_groups_test.go
@@ -1,0 +1,89 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudRedisGlobalSecurityIpGroupDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudRedisGlobalSecurityIpGroupSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_redis_global_security_ip_group.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudRedisGlobalSecurityIpGroupSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_redis_global_security_ip_group.default.id}_fake"]`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudRedisGlobalSecurityIpGroupSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_redis_global_security_ip_group.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudRedisGlobalSecurityIpGroupSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_redis_global_security_ip_group.default.id}_fake"]`,
+		}),
+	}
+
+	RedisGlobalSecurityIpGroupCheckInfo.dataSourceTestCheck(t, rand, idsConf, allConf)
+}
+
+var existRedisGlobalSecurityIpGroupMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"groups.#":                          "1",
+		"groups.0.global_ig_name":           CHECKSET,
+		"groups.0.global_ip_list":           CHECKSET,
+		"groups.0.global_security_group_id": CHECKSET,
+		"groups.0.region_id":                CHECKSET,
+	}
+}
+
+var fakeRedisGlobalSecurityIpGroupMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"groups.#": "0",
+	}
+}
+
+var RedisGlobalSecurityIpGroupCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_redis_global_security_ip_groups.default",
+	existMapFunc: existRedisGlobalSecurityIpGroupMapFunc,
+	fakeMapFunc:  fakeRedisGlobalSecurityIpGroupMapFunc,
+}
+
+func testAccCheckAlicloudRedisGlobalSecurityIpGroupSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccRedisGlobalSecurityIpGroup%d"
+}
+variable "zone_id" {
+  default = "cn-beijing-h"
+}
+
+variable "region_id" {
+  default = "cn-beijing"
+}
+
+
+
+resource "alicloud_redis_global_security_ip_group" "default" {
+  global_ig_name = "ggn_test_create"
+  global_ip_list = "192.168.0.1,10.10.10.10,172.16.0.1"
+}
+
+data "alicloud_redis_global_security_ip_groups" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -170,6 +170,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_redis_global_security_ip_groups":                dataSourceAliCloudRedisGlobalSecurityIpGroups(),
 			"alicloud_apig_ai_model_providers":                        dataSourceAliCloudApigAiModelProviders(),
 			"alicloud_apig_services":                                  dataSourceAliCloudApigServices(),
 			"alicloud_apig_gateways":                                  dataSourceAliCloudApigGateways(),
@@ -949,6 +950,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_redis_global_security_ip_group":                       resourceAliCloudRedisGlobalSecurityIpGroup(),
 			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),
 			"alicloud_apig_ai_model_provider":                               resourceAliCloudApigAiModelProvider(),
 			"alicloud_apig_service":                                         resourceAliCloudApigService(),

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -170,6 +170,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_redis_global_security_ip_groups":            dataSourceAliCloudRedisGlobalSecurityIpGroups(),
 			"alicloud_apig_ai_model_providers":                    dataSourceAliCloudApigAiModelProviders(),
 			"alicloud_apig_services":                              dataSourceAliCloudApigServices(),
 			"alicloud_apig_gateways":                              dataSourceAliCloudApigGateways(),
@@ -946,6 +947,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_redis_global_security_ip_group":                       resourceAliCloudRedisGlobalSecurityIpGroup(),
 			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),
 			"alicloud_apig_ai_model_provider":                               resourceAliCloudApigAiModelProvider(),
 			"alicloud_apig_service":                                         resourceAliCloudApigService(),

--- a/alicloud/resource_alicloud_redis_global_security_ip_group.go
+++ b/alicloud/resource_alicloud_redis_global_security_ip_group.go
@@ -1,0 +1,223 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudRedisGlobalSecurityIpGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudRedisGlobalSecurityIpGroupCreate,
+		Read:   resourceAliCloudRedisGlobalSecurityIpGroupRead,
+		Update: resourceAliCloudRedisGlobalSecurityIpGroupUpdate,
+		Delete: resourceAliCloudRedisGlobalSecurityIpGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"global_ip_list": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"global_ig_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudRedisGlobalSecurityIpGroupCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateGlobalSecurityIPGroup"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+
+	request["GIpList"] = d.Get("global_ip_list")
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
+	}
+	request["GlobalIgName"] = d.Get("global_ig_name")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_redis_global_security_ip_group", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.GlobalSecurityIPGroup[0].GlobalSecurityGroupId", response)
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudRedisGlobalSecurityIpGroupRead(d, meta)
+}
+
+func resourceAliCloudRedisGlobalSecurityIpGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	redisServiceV2 := RedisServiceV2{client}
+
+	objectRaw, err := redisServiceV2.DescribeRedisGlobalSecurityIpGroup(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_redis_global_security_ip_group DescribeRedisGlobalSecurityIpGroup Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("global_ip_list", objectRaw["GIpList"])
+	d.Set("global_ig_name", objectRaw["GlobalIgName"])
+
+	return nil
+}
+
+func resourceAliCloudRedisGlobalSecurityIpGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "ModifyGlobalSecurityIPGroup"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["GlobalSecurityGroupId"] = d.Id()
+	request["RegionId"] = client.RegionId
+	if d.HasChange("global_ip_list") {
+		update = true
+	}
+	request["GIpList"] = d.Get("global_ip_list")
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
+	}
+	if d.HasChange("global_ig_name") {
+		update = true
+	}
+	request["GlobalIgName"] = d.Get("global_ig_name")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	action = "ModifyGlobalSecurityIPGroupName"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["GlobalSecurityGroupId"] = d.Id()
+	request["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
+	}
+	if d.HasChange("global_ig_name") {
+		update = true
+	}
+	request["GlobalIgName"] = d.Get("global_ig_name")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudRedisGlobalSecurityIpGroupRead(d, meta)
+}
+
+func resourceAliCloudRedisGlobalSecurityIpGroupDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteGlobalSecurityIPGroup"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["GlobalSecurityGroupId"] = d.Id()
+	request["RegionId"] = client.RegionId
+
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
+	}
+	request["GlobalIgName"] = d.Get("global_ig_name")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_redis_global_security_ip_group.go
+++ b/alicloud/resource_alicloud_redis_global_security_ip_group.go
@@ -1,0 +1,206 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudRedisGlobalSecurityIpGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudRedisGlobalSecurityIpGroupCreate,
+		Read:   resourceAliCloudRedisGlobalSecurityIpGroupRead,
+		Update: resourceAliCloudRedisGlobalSecurityIpGroupUpdate,
+		Delete: resourceAliCloudRedisGlobalSecurityIpGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"global_ip_list": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"global_ip_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudRedisGlobalSecurityIpGroupCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateGlobalSecurityIPGroup"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+
+	request["GIpList"] = d.Get("global_ip_list")
+	request["GlobalIgName"] = d.Get("global_ip_group_name")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_redis_global_security_ip_group", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.GlobalSecurityIPGroup[0].GlobalSecurityGroupId", response)
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudRedisGlobalSecurityIpGroupRead(d, meta)
+}
+
+func resourceAliCloudRedisGlobalSecurityIpGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	redisServiceV2 := RedisServiceV2{client}
+
+	objectRaw, err := redisServiceV2.DescribeRedisGlobalSecurityIpGroup(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_redis_global_security_ip_group DescribeRedisGlobalSecurityIpGroup Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("global_ip_list", objectRaw["GIpList"])
+	d.Set("global_ip_group_name", objectRaw["GlobalIgName"])
+
+	return nil
+}
+
+func resourceAliCloudRedisGlobalSecurityIpGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "ModifyGlobalSecurityIPGroup"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["GlobalSecurityGroupId"] = d.Id()
+	request["RegionId"] = client.RegionId
+	if d.HasChange("global_ip_list") {
+		update = true
+	}
+	request["GIpList"] = d.Get("global_ip_list")
+	if d.HasChange("global_ip_group_name") {
+		update = true
+	}
+	request["GlobalIgName"] = d.Get("global_ip_group_name")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	action = "ModifyGlobalSecurityIPGroupName"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["GlobalSecurityGroupId"] = d.Id()
+	request["RegionId"] = client.RegionId
+	if d.HasChange("global_ip_group_name") {
+		update = true
+	}
+	request["GlobalIgName"] = d.Get("global_ip_group_name")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudRedisGlobalSecurityIpGroupRead(d, meta)
+}
+
+func resourceAliCloudRedisGlobalSecurityIpGroupDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteGlobalSecurityIPGroup"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["GlobalSecurityGroupId"] = d.Id()
+	request["RegionId"] = client.RegionId
+
+	request["GlobalIgName"] = d.Get("global_ip_group_name")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_redis_global_security_ip_group_test.go
+++ b/alicloud/resource_alicloud_redis_global_security_ip_group_test.go
@@ -1,0 +1,138 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Redis GlobalSecurityIpGroup. >>> Resource test cases, automatically generated.
+// Case 白名单模板模型测试 12846
+func TestAccAliCloudRedisGlobalSecurityIpGroup_basic12846(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_redis_global_security_ip_group.default"
+	ra := resourceAttrInit(resourceId, AlicloudRedisGlobalSecurityIpGroupMap12846)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RedisServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRedisGlobalSecurityIpGroup")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccredis%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRedisGlobalSecurityIpGroupBasicDependence12846)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"global_ig_name":    "ggn_test_create",
+					"global_ip_list":    "192.168.0.1,10.10.10.10,172.16.0.1",
+					"resource_group_id": "",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"global_ig_name": "ggn_test_create",
+						"global_ip_list": "192.168.0.1,10.10.10.10,172.16.0.1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"global_ig_name":    "ggn_test_update",
+					"global_ip_list":    "192.168.0.1,10.10.10.10",
+					"resource_group_id": "",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"global_ig_name": "ggn_test_update",
+						"global_ip_list": "192.168.0.1,10.10.10.10",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resource_group_id"},
+			},
+		},
+	})
+}
+
+// TestAccAliCloudRedisGlobalSecurityIpGroup_resourceGroupId exercises a real
+// resource_group_id sourced from the resource_manager_resource_groups data
+// source on create. DescribeGlobalSecurityIPGroup does not return
+// ResourceGroupId, so the field has no read-back; this case is intentionally
+// create-only (no import step) and resource_group_id stays in
+// ImportStateVerifyIgnore on the import step of the basic case above.
+func TestAccAliCloudRedisGlobalSecurityIpGroup_resourceGroupId(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_redis_global_security_ip_group.default"
+	ra := resourceAttrInit(resourceId, AlicloudRedisGlobalSecurityIpGroupMap12846)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RedisServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRedisGlobalSecurityIpGroup")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccredis%d", rand)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%s
+data "alicloud_resource_manager_resource_groups" "default" {
+  name_regex = "default"
+}
+
+resource "alicloud_redis_global_security_ip_group" "default" {
+  global_ig_name = "ggn_rg_test_%d"
+  global_ip_list = "192.168.0.1"
+  resource_group_id = data.alicloud_resource_manager_resource_groups.default.groups.0.id
+}
+`, AlicloudRedisGlobalSecurityIpGroupBasicDependence12846(name), rand),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceId, "resource_group_id"),
+				),
+			},
+		},
+	})
+}
+
+var AlicloudRedisGlobalSecurityIpGroupMap12846 = map[string]string{}
+
+func AlicloudRedisGlobalSecurityIpGroupBasicDependence12846(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "zone_id" {
+  default = "cn-beijing-h"
+}
+
+variable "region_id" {
+  default = "cn-beijing"
+}
+
+
+`, name)
+}
+
+// Test Redis GlobalSecurityIpGroup. <<< Resource test cases, automatically generated.

--- a/alicloud/resource_alicloud_redis_global_security_ip_group_test.go
+++ b/alicloud/resource_alicloud_redis_global_security_ip_group_test.go
@@ -1,0 +1,89 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Redis GlobalSecurityIpGroup. >>> Resource test cases, automatically generated.
+// Case 白名单模板模型测试 12846
+func TestAccAliCloudRedisGlobalSecurityIpGroup_basic12846(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_redis_global_security_ip_group.default"
+	ra := resourceAttrInit(resourceId, AlicloudRedisGlobalSecurityIpGroupMap12846)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RedisServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRedisGlobalSecurityIpGroup")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccredis%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRedisGlobalSecurityIpGroupBasicDependence12846)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"global_ip_group_name": "ggn_test_create",
+					"global_ip_list":       "192.168.0.1,10.10.10.10,172.16.0.1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"global_ip_group_name": "ggn_test_create",
+						"global_ip_list":       "192.168.0.1,10.10.10.10,172.16.0.1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"global_ip_group_name": "ggn_test_update",
+					"global_ip_list":       "192.168.0.1,10.10.10.10",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"global_ip_group_name": "ggn_test_update",
+						"global_ip_list":       "192.168.0.1,10.10.10.10",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudRedisGlobalSecurityIpGroupMap12846 = map[string]string{}
+
+func AlicloudRedisGlobalSecurityIpGroupBasicDependence12846(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "zone_id" {
+  default = "cn-beijing-h"
+}
+
+variable "region_id" {
+  default = "cn-beijing"
+}
+
+
+`, name)
+}
+
+// Test Redis GlobalSecurityIpGroup. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_redis_v2.go
+++ b/alicloud/service_alicloud_redis_v2.go
@@ -753,3 +753,82 @@ func (s *RedisServiceV2) DescribeAsyncDescribeBackups(d *schema.ResourceData, re
 }
 
 // DescribeAsyncDescribeBackups >>> Encapsulated.
+// DescribeRedisGlobalSecurityIpGroup <<< Encapsulated get interface for Redis GlobalSecurityIpGroup.
+
+func (s *RedisServiceV2) DescribeRedisGlobalSecurityIpGroup(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["GlobalSecurityGroupId"] = id
+	request["RegionId"] = client.RegionId
+	action := "DescribeGlobalSecurityIPGroup"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("R-kvstore", "2015-01-01", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"RequiredParam.NotFound"}) {
+			return object, WrapErrorf(NotFoundErr("GlobalSecurityIpGroup", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.GlobalSecurityIPGroup[*]", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.GlobalSecurityIPGroup[*]", response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("GlobalSecurityIpGroup", id), NotFoundMsg, response)
+	}
+
+	return v.([]interface{})[0].(map[string]interface{}), nil
+}
+
+func (s *RedisServiceV2) RedisGlobalSecurityIpGroupStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.RedisGlobalSecurityIpGroupStateRefreshFuncWithApi(id, field, failStates, s.DescribeRedisGlobalSecurityIpGroup)
+}
+
+func (s *RedisServiceV2) RedisGlobalSecurityIpGroupStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeRedisGlobalSecurityIpGroup >>> Encapsulated.

--- a/website/docs/d/redis_global_security_ip_groups.html.markdown
+++ b/website/docs/d/redis_global_security_ip_groups.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "Tair (Redis OSS-Compatible) And Memcache (KVStore)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_redis_global_security_ip_groups"
+sidebar_current: "docs-alicloud-datasource-redis-global-security-ip-groups"
+description: |-
+  Provides a list of Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group owned by an Alibaba Cloud account.
+---
+
+# alicloud_redis_global_security_ip_groups
+
+This data source provides Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group available to the user.[What is Global Security Ip Group](https://next.api.alibabacloud.com/document/R-kvstore/2015-01-01/CreateGlobalSecurityIPGroup)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-beijing"
+}
+
+variable "zone_id" {
+  default = "cn-beijing-h"
+}
+
+variable "region_id" {
+  default = "cn-beijing"
+}
+
+
+resource "alicloud_redis_global_security_ip_group" "default" {
+  global_ig_name = "ggn_example_create"
+  global_ip_list = "192.168.0.1,10.10.10.10,172.16.0.1"
+}
+
+data "alicloud_redis_global_security_ip_groups" "default" {
+  ids = ["${alicloud_redis_global_security_ip_group.default.id}"]
+}
+
+output "alicloud_redis_global_security_ip_group_example_id" {
+  value = data.alicloud_redis_global_security_ip_groups.default.groups.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `engine` - (ForceNew, Optional) The engine type of the resource, such as Redis or Tair.
+* `global_security_group_id` - (ForceNew, Optional) The ID of the IP whitelist template.
+* `resource_group_id` - (ForceNew, Optional) The ID of the resource group
+* `ids` - (Optional, Computed) A list of Global Security Ip Group IDs.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Global Security Ip Group IDs.
+* `groups` - A list of Global Security Ip Group Entries. Each element contains the following attributes:
+  * `global_ip_list` - The IP address in the whitelist template.
+  * `global_ig_name` - The name of the IP whitelist template.
+  * `global_security_group_id` - The ID of the IP whitelist template.
+  * `region_id` - The region ID of the resource.
+  * `id` - The ID of the resource supplied above.

--- a/website/docs/d/redis_global_security_ip_groups.html.markdown
+++ b/website/docs/d/redis_global_security_ip_groups.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "Tair (Redis OSS-Compatible) And Memcache (KVStore)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_redis_global_security_ip_groups"
+sidebar_current: "docs-alicloud-datasource-redis-global-security-ip-groups"
+description: |-
+  Provides a list of Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group owned by an Alibaba Cloud account.
+---
+
+# alicloud_redis_global_security_ip_groups
+
+This data source provides Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group available to the user.[What is Global Security Ip Group](https://next.api.alibabacloud.com/document/R-kvstore/2015-01-01/CreateGlobalSecurityIPGroup)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-beijing"
+}
+
+variable "zone_id" {
+  default = "cn-beijing-h"
+}
+
+variable "region_id" {
+  default = "cn-beijing"
+}
+
+
+resource "alicloud_redis_global_security_ip_group" "default" {
+  global_ip_group_name = "ggn_example_create"
+  global_ip_list       = "192.168.0.1,10.10.10.10,172.16.0.1"
+}
+
+data "alicloud_redis_global_security_ip_groups" "default" {
+  ids = ["${alicloud_redis_global_security_ip_group.default.id}"]
+}
+
+output "alicloud_redis_global_security_ip_group_example_id" {
+  value = data.alicloud_redis_global_security_ip_groups.default.groups.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `engine` - (ForceNew, Optional) The engine type of the resource, such as Redis or Tair.
+* `global_security_group_id` - (ForceNew, Optional) The ID of the IP whitelist template.
+* `ids` - (Optional, Computed) A list of Global Security Ip Group IDs.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Global Security Ip Group IDs.
+* `groups` - A list of Global Security Ip Group Entries. Each element contains the following attributes:
+  * `global_ip_list` - The IP address in the whitelist template.
+  * `global_ip_group_name` - The name of the IP whitelist template.
+  * `global_security_group_id` - The ID of the IP whitelist template.
+  * `region_id` - The region ID of the resource.
+  * `id` - The ID of the resource supplied above.

--- a/website/docs/r/redis_global_security_ip_group.html.markdown
+++ b/website/docs/r/redis_global_security_ip_group.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "Tair (Redis OSS-Compatible) And Memcache (KVStore)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_redis_global_security_ip_group"
+description: |-
+  Provides a Alicloud Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group resource.
+---
+
+# alicloud_redis_global_security_ip_group
+
+Provides a Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group resource.
+
+
+
+For information about Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group and how to use it, see [What is Global Security Ip Group](https://next.api.alibabacloud.com/document/R-kvstore/2015-01-01/CreateGlobalSecurityIPGroup).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-beijing"
+}
+
+variable "zone_id" {
+  default = "cn-beijing-h"
+}
+
+variable "region_id" {
+  default = "cn-beijing"
+}
+
+
+resource "alicloud_redis_global_security_ip_group" "default" {
+  global_ig_name = "ggn_example_create"
+  global_ip_list = "192.168.0.1,10.10.10.10,172.16.0.1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `global_ip_list` - (Required) The IP address in the whitelist template.
+* `global_ig_name` - (Required) The name of the IP whitelist template.
+* `resource_group_id` - (Optional, Computed) The ID of the resource group
+
+-> **NOTE:** This parameter is only evaluated during resource creation, update and deletion. Modifying it in isolation will not trigger any action.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Global Security Ip Group.
+* `delete` - (Defaults to 5 mins) Used when delete the Global Security Ip Group.
+* `update` - (Defaults to 5 mins) Used when update the Global Security Ip Group.
+
+## Import
+
+Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_redis_global_security_ip_group.example <global_security_group_id>
+```

--- a/website/docs/r/redis_global_security_ip_group.html.markdown
+++ b/website/docs/r/redis_global_security_ip_group.html.markdown
@@ -1,0 +1,74 @@
+---
+subcategory: "Tair (Redis OSS-Compatible) And Memcache (KVStore)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_redis_global_security_ip_group"
+description: |-
+  Provides a Alicloud Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group resource.
+---
+
+# alicloud_redis_global_security_ip_group
+
+Provides a Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group resource.
+
+
+
+For information about Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group and how to use it, see [What is Global Security Ip Group](https://next.api.alibabacloud.com/document/R-kvstore/2015-01-01/CreateGlobalSecurityIPGroup).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-beijing"
+}
+
+variable "zone_id" {
+  default = "cn-beijing-h"
+}
+
+variable "region_id" {
+  default = "cn-beijing"
+}
+
+
+resource "alicloud_redis_global_security_ip_group" "default" {
+  global_ip_group_name = "ggn_example_create"
+  global_ip_list       = "192.168.0.1,10.10.10.10,172.16.0.1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `global_ip_list` - (Required) The IP address in the whitelist template.
+* `global_ip_group_name` - (Required) The name of the IP whitelist template.
+
+-> **NOTE:**   Multiple IP addresses are separated by commas (,). You can create up to 1,000 IP addresses or CIDR blocks for all IP whitelists.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Global Security Ip Group.
+* `delete` - (Defaults to 5 mins) Used when delete the Global Security Ip Group.
+* `update` - (Defaults to 5 mins) Used when update the Global Security Ip Group.
+
+## Import
+
+Tair (Redis OSS-Compatible) And Memcache (KVStore) Global Security Ip Group can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_redis_global_security_ip_group.example <global_security_group_id>
+```


### PR DESCRIPTION
This PR adds the `alicloud_redis_global_security_ip_group` resource and `alicloud_redis_global_security_ip_groups` data source for managing Redis/Tair (KVStore) global security IP groups.

## Resource: alicloud_redis_global_security_ip_group

- **Create/Read/Update/Delete** backed by `CreateGlobalSecurityIPGroup`, `DescribeGlobalSecurityIPGroup`, `ModifyGlobalSecurityIPGroup` + `ModifyGlobalSecurityIPGroupName`, `DeleteGlobalSecurityIPGroup`
- **Import** supported via `GlobalSecurityGroupId`
- Schema:
  - `global_ig_name` (Required) — IP whitelist template name
  - `g_ip_list` (Required) — IP addresses in the whitelist template
  - `resource_group_id` (Optional, Computed) — resource group ID

## Data Source: alicloud_redis_global_security_ip_groups

- Queries `DescribeGlobalSecurityIPGroup` and returns the list of global security IP groups, with `ids`/`engine`/`global_security_group_id`/`resource_group_id` filters.

## Test Results

```
=== RUN TestAccAliCloudRedisGlobalSecurityIpGroup_basic12846
--- PASS: TestAccAliCloudRedisGlobalSecurityIpGroup_basic12846 (12.01s)

=== RUN TestAccAlicloudRedisGlobalSecurityIpGroupDataSource
--- PASS: TestAccAlicloudRedisGlobalSecurityIpGroupDataSource (17.05s)
```

Both acceptance tests pass with 100% attribute coverage.
