### PR TITLE
resource/alicloud_rocketmq_instance: tolerate BSS renewal query failure in Read

### DIFF
--- a/alicloud/resource_alicloud_rocketmq_instance.go
+++ b/alicloud/resource_alicloud_rocketmq_instance.go
@@ -652,13 +652,20 @@ func resourceAliCloudRocketmqInstanceRead(d *schema.ResourceData, meta interface
 	bssOpenApiService := BssOpenApiService{client}
 	queryAvailableInstancesObject, err := bssOpenApiService.QueryAvailableInstancesWithoutProductType(d.Id(), client.RegionId, "ons", "ons")
 	if err != nil {
-		return WrapError(err)
+		// The renewal info from the BSS billing API only feeds three non-critical
+		// attributes (auto_renew/auto_renew_period/auto_renew_period_unit). For some
+		// account and region combinations the billing endpoint is not applicable and
+		// returns an error even though the instance itself is healthy, which must not
+		// abort the whole read. Treat the query as best-effort: log and skip these
+		// attributes instead of returning a fatal error.
+		log.Printf("[WARN] querying renewal info for RocketMQ instance %s failed, skip setting auto_renew attributes: %v", d.Id(), err)
+	} else {
+		d.Set("auto_renew", queryAvailableInstancesObject["RenewStatus"] == "AutoRenewal")
+		if v, ok := queryAvailableInstancesObject["RenewalDuration"]; ok && fmt.Sprint(v) != "0" {
+			d.Set("auto_renew_period", formatInt(v))
+		}
+		d.Set("auto_renew_period_unit", convertAmqpInstanceRenewalDurationUnitResponse(queryAvailableInstancesObject["RenewalDurationUnit"]))
 	}
-	d.Set("auto_renew", queryAvailableInstancesObject["RenewStatus"] == "AutoRenewal")
-	if v, ok := queryAvailableInstancesObject["RenewalDuration"]; ok && fmt.Sprint(v) != "0" {
-		d.Set("auto_renew_period", formatInt(v))
-	}
-	d.Set("auto_renew_period_unit", convertAmqpInstanceRenewalDurationUnitResponse(queryAvailableInstancesObject["RenewalDurationUnit"]))
 
 	objectRaw, err = rocketmqServiceV2.DescribeInstanceGetInstanceIpWhitelist(d.Id())
 	if err != nil && !NotFoundError(err) {

--- a/alicloud/resource_alicloud_rocketmq_instance_test.go
+++ b/alicloud/resource_alicloud_rocketmq_instance_test.go
@@ -43,8 +43,9 @@ func TestAccAliCloudRocketmqInstance_SendReceiveRatioValidation(t *testing.T) {
 					"instance_name": name,
 					"product_info": []map[string]interface{}{
 						{
-							"msg_process_spec":       "rmq.p2.4xlarge",
-							"send_receive_ratio":     "0.03", // This should be out of range [0.05, 0.5] to test validation
+							"msg_process_spec": "rmq.p2.4xlarge",
+							// send_receive_ratio 0.03 is intentionally out of range [0.05, 0.5] to trigger the expected validation error
+							"send_receive_ratio":     "0.03",
 							"message_retention_time": "70",
 						},
 					},
@@ -1170,6 +1171,11 @@ func TestAccAliCloudRocketmqInstance_basic4101(t *testing.T) {
 							},
 						},
 					},
+					"software": []map[string]interface{}{
+						{
+							"maintain_time": "02:00-06:00",
+						},
+					},
 					"payment_type":    "PayAsYouGo",
 					"sub_series_code": "cluster_ha",
 					"instance_name":   name,
@@ -1191,6 +1197,11 @@ func TestAccAliCloudRocketmqInstance_basic4101(t *testing.T) {
 							"acl_types": []string{
 								"default", "apache_acl", "aliyun_ram"},
 							"default_vpc_auth_free": "false",
+						},
+					},
+					"software": []map[string]interface{}{
+						{
+							"maintain_time": "03:00-07:00",
 						},
 					},
 				}),


### PR DESCRIPTION
### Summary

`resourceAliCloudRocketmqInstanceRead` queries renewal information from the BSS billing API (`QueryAvailableInstances`) to populate three non-critical attributes: `auto_renew`, `auto_renew_period` and `auto_renew_period_unit`.

Previously any error from that billing query was returned as a fatal error, which aborted the whole Read. An instance that was created successfully and is `RUNNING` could still fail `terraform apply` during the refresh/read step whenever the billing endpoint is not applicable for a given account-and-region combination (for example a domestic-station account operating in an international region, where the international billing system has no record of the account and returns an error).

### Fix

Degrade the renewal query to best-effort: on failure, log a warning and skip setting the three `auto_renew*` attributes instead of failing Read. This matches the tolerant handling already used by `alicloud_amqp_instance`, whose Read guards its equivalent billing query rather than treating it as fatal. Instance provisioning and all primary attributes are unaffected.

### Relationship to the prior region-lookup fix

A prior fix (commit 7b7f95b6) improved the BSS helper's region lookup and added an international-endpoint fallback, which resolved the common case. However a fatal path remains at the call site: when the billing endpoint still cannot resolve the instance for a given account-and-region combination, the error propagates as `return WrapError(err)` and aborts the whole Read. This change complements the helper-side fix by closing that residual gap at the call site, so a billing query failure can never take down an otherwise-healthy instance refresh.

### Test changes

Two minimal, related test-file adjustments were needed for the resource coverage gate to run cleanly on this resource:

- `TestAccAliCloudRocketmqInstance_SendReceiveRatioValidation`: move the inline `//` comment that explained the intentional out-of-range `send_receive_ratio` value onto its own line. The coverage checker strips whitespace before extracting each step's config, and an inline comment glued the next key onto the comment text and produced invalid JSON (`invalid character '/'`), so the checker could not even parse the config. The comment text and intent are preserved.
- `TestAccAliCloudRocketmqInstance_basic4101`: restore minimal `software { maintain_time = "02:00-06:00" }` coverage in the create step, and add a second step that sets `maintain_time = "03:00-07:00"`. The same prior stabilization commit removed the `software`/`maintain_time` coverage from the basic cases, which left these two attributes uncovered and failed both the must-set and modified coverage gates. The values are the same time-window format previously used by the basic cases; the second step exercises the maintainTime update path with a changed value.

### Test / verification

This failure only manifests with a specific account-type by region combination against the live BSS billing endpoint, so it cannot be reproduced in a standalone unit test without mocking the BSS RPC layer (the resource has no such test seam). The change is otherwise a no-op for the common case, where the billing query succeeds and the attributes are set exactly as before.

Remote acceptance test cases scoped for verification:

- TestAccAliCloudRocketmqInstance_basic4101
- TestAccAliCloudRocketmqInstance_basic4128
- TestAccAliCloudRocketmqInstance_basic4665
- TestAccAliCloudRocketmqInstance_basic4101_twin
- TestAccAliCloudRocketmqInstance_basic4128_twin
- TestAccAliCloudRocketmqInstance_basic4665_twin
- TestAccAliCloudRocketmqInstance_basic6747
- TestAccAliCloudRocketmqInstance_bugfix
- TestAccAliCloudRocketmqInstance_SendReceiveRatioValidation

The pre-patch Read fails for the affected account/region combination; the post-patch Read completes and skips the `auto_renew*` attributes. The `basic4101` case additionally exercises the restored `software`/`maintain_time` update path; if the maintainTime update proves unstable against the live API, that coverage should be re-evaluated rather than weakening the assertion.
