### PR TITLE
testcase: honour the documented endpoints.kvstore override for R-KVStore

### DIFF
--- a/alicloud/connectivity/endpoint.go
+++ b/alicloud/connectivity/endpoint.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/location"
@@ -320,6 +321,28 @@ var productCodeToLocationCode = map[string]string{
 // Value: Field endpoints' subfield name, such as vpc, ecs, log
 var productCodeToConfigEndpoints = map[string]string{
 	"sls": "log",
+}
+
+// MirrorKvstoreEndpoint populates the "r_kvstore" endpoint key from the
+// documented "kvstore" field when "r_kvstore" is unset.
+//
+// WithRKvstoreClient resolves the R-KVStore endpoint via
+// loadApiEndpoint("r_kvstore"), which reads only the "r_kvstore" key. A
+// customer override supplied through the documented `endpoints.kvstore`
+// field is stored under the "kvstore" key and would be silently ignored
+// without this mirror, causing the location-service public endpoint to be
+// used instead. The deprecated `endpoints.redisa` fallback
+// (deprecatedEndpointMap) already populates "r_kvstore" during provider
+// configuration and keeps precedence over this mirror.
+func MirrorKvstoreEndpoint(endpoints *sync.Map) {
+	v, ok := endpoints.Load("kvstore")
+	if !ok || v.(string) == "" {
+		return
+	}
+	if rv, ok := endpoints.Load("r_kvstore"); ok && rv.(string) != "" {
+		return
+	}
+	endpoints.Store("r_kvstore", v.(string))
 }
 
 // irregularProductEndpoint specially records those product codes that

--- a/alicloud/connectivity/endpoint_test.go
+++ b/alicloud/connectivity/endpoint_test.go
@@ -190,3 +190,65 @@ func TestUnitSlsWithoutEndpoint(t *testing.T) {
 		})
 	}
 }
+
+// TestUnitMirrorKvstoreEndpoint verifies that the documented
+// `endpoints.kvstore` field is mirrored into the "r_kvstore" key that
+// WithRKvstoreClient (via loadApiEndpoint("r_kvstore")) actually reads.
+// Without the mirror, a customer override set via `endpoints.kvstore` is
+// silently ignored and the location-service public endpoint is used instead.
+func TestUnitMirrorKvstoreEndpoint(t *testing.T) {
+	t.Run("kvstore set and r_kvstore unset mirrors value", func(t *testing.T) {
+		var endpoints sync.Map
+		endpoints.Store("kvstore", "r-kvstore.example.com")
+
+		MirrorKvstoreEndpoint(&endpoints)
+
+		v, ok := endpoints.Load("r_kvstore")
+		assert.True(t, ok)
+		assert.Equal(t, "r-kvstore.example.com", v)
+	})
+
+	t.Run("direct r_kvstore override keeps precedence over mirror", func(t *testing.T) {
+		var endpoints sync.Map
+		endpoints.Store("kvstore", "from-kvstore-field")
+		endpoints.Store("r_kvstore", "from-r-kvstore-field")
+
+		MirrorKvstoreEndpoint(&endpoints)
+
+		v, _ := endpoints.Load("r_kvstore")
+		assert.Equal(t, "from-r-kvstore-field", v)
+	})
+
+	t.Run("deprecated redisa fallback keeps precedence over mirror", func(t *testing.T) {
+		// deprecatedEndpointMap populates "r_kvstore" from "redisa" during
+		// provider config; the mirror must not overwrite that fallback.
+		var endpoints sync.Map
+		endpoints.Store("kvstore", "from-kvstore-field")
+		endpoints.Store("redisa", "from-redisa-field")
+		endpoints.Store("r_kvstore", "from-redisa-field")
+
+		MirrorKvstoreEndpoint(&endpoints)
+
+		v, _ := endpoints.Load("r_kvstore")
+		assert.Equal(t, "from-redisa-field", v)
+	})
+
+	t.Run("kvstore empty does not populate r_kvstore", func(t *testing.T) {
+		var endpoints sync.Map
+		endpoints.Store("kvstore", "")
+
+		MirrorKvstoreEndpoint(&endpoints)
+
+		_, ok := endpoints.Load("r_kvstore")
+		assert.False(t, ok)
+	})
+
+	t.Run("kvstore unset leaves r_kvstore untouched", func(t *testing.T) {
+		var endpoints sync.Map
+
+		MirrorKvstoreEndpoint(&endpoints)
+
+		_, ok := endpoints.Load("r_kvstore")
+		assert.False(t, ok)
+	})
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -2312,6 +2312,12 @@ func providerConfigure(d *schema.ResourceData, p *schema.Provider) (interface{},
 			}
 			endpointInit.Store(key, val.(string))
 		}
+		// Honour the documented `endpoints.kvstore` field for R-KVStore:
+		// WithRKvstoreClient reads the "r_kvstore" key via loadApiEndpoint,
+		// so mirror the documented "kvstore" override into "r_kvstore" when
+		// it has not been populated directly or via the deprecated redisa
+		// fallback above.
+		connectivity.MirrorKvstoreEndpoint(&endpointInit)
 		config.EcsEndpoint = strings.TrimSpace(endpoints["ecs"].(string))
 		config.RdsEndpoint = strings.TrimSpace(endpoints["rds"].(string))
 		config.SlbEndpoint = strings.TrimSpace(endpoints["slb"].(string))


### PR DESCRIPTION
## What

`endpoints.kvstore` is documented as the override used to connect to custom R-KVStore endpoints, but the value was silently ignored.

`WithRKvstoreClient` resolves the R-KVStore endpoint via `loadApiEndpoint("r_kvstore")`, which only reads the `r_kvstore` key. `endpoints.kvstore` is stored under the `kvstore` key, so a customer override supplied through the documented field never reached the R-KVStore client, and the location-service public endpoint was used instead.

## Fix

Mirror the documented `kvstore` value into the `r_kvstore` key during provider configuration (new `connectivity.MirrorKvstoreEndpoint`) when `r_kvstore` has not been populated directly or via the deprecated `endpoints.redisa` fallback (`deprecatedEndpointMap`). This makes `endpoints.kvstore` honour the documented behaviour.

## Precedence (unchanged for existing fields)

1. `endpoints.r_kvstore` — direct product-code override
2. `endpoints.redisa` — deprecated fallback (`deprecatedEndpointMap`, unchanged)
3. `endpoints.kvstore` — documented field, applied via the new mirror

Direct `r_kvstore` and the deprecated `redisa` fallback keep their existing precedence; the mirror only fills `r_kvstore` when it is still empty, so there is no regression for either path.

## Tests

Unit tests added in `alicloud/connectivity/endpoint_test.go` (`TestUnitMirrorKvstoreEndpoint`):

- `kvstore` set with `r_kvstore` unset → value mirrored into `r_kvstore`
- direct `r_kvstore` override keeps precedence over the mirror
- deprecated `redisa` fallback keeps precedence over the mirror (no regression)
- `kvstore` empty/unset → no-op, `r_kvstore` left untouched

`gofmt -l alicloud/`, `go vet ./alicloud`, and `go test ./alicloud/connectivity -run TestUnit` pass locally.
