### PR TITLE
New Resource: alicloud_resource_manager_resource_group_settings

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1619,6 +1619,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cen_route_map":                                         resourceAlicloudCenRouteMap(),
 			"alicloud_resource_manager_role":                                 resourceAlicloudResourceManagerRole(),
 			"alicloud_resource_manager_resource_group":                       resourceAliCloudResourceManagerResourceGroup(),
+			"alicloud_resource_manager_resource_group_settings":              resourceAliCloudResourceManagerResourceGroupSettings(),
 			"alicloud_resource_manager_folder":                               resourceAliCloudResourceManagerFolder(),
 			"alicloud_resource_manager_handshake":                            resourceAliCloudResourceManagerHandshake(),
 			"alicloud_resource_manager_handshake_acceptance":                 resourceAliCloudResourceManagerHandshakeAcceptance(),

--- a/alicloud/resource_alicloud_resource_manager_resource_group_settings.go
+++ b/alicloud/resource_alicloud_resource_manager_resource_group_settings.go
@@ -1,0 +1,205 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudResourceManagerResourceGroupSettings() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudResourceManagerResourceGroupSettingsCreate,
+		Read:   resourceAliCloudResourceManagerResourceGroupSettingsRead,
+		Update: resourceAliCloudResourceManagerResourceGroupSettingsUpdate,
+		Delete: resourceAliCloudResourceManagerResourceGroupSettingsDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"resource_group_admin_setting_status": {
+				Type:     schema.TypeBool,
+				Required: true,
+			},
+			"resource_group_notification_setting_status": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudResourceManagerResourceGroupSettingsCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "UpdateResourceGroupAdminSetting"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["CreatorAsAdmin"] = d.Get("resource_group_admin_setting_status")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_resource_manager_resource_group_settings", action, AlibabaCloudSdkGoERROR)
+	}
+
+	accountId, err := client.AccountId()
+	d.SetId(accountId)
+
+	return resourceAliCloudResourceManagerResourceGroupSettingsUpdate(d, meta)
+}
+
+func resourceAliCloudResourceManagerResourceGroupSettingsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	resourceManagerServiceV2 := ResourceManagerServiceV2{client}
+
+	objectRaw, err := resourceManagerServiceV2.DescribeResourceManagerResourceGroupSettings(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_resource_manager_resource_group_settings DescribeResourceManagerResourceGroupSettings Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("resource_group_notification_setting_status", objectRaw["ResourceGroupNotificationEnableStatus"])
+
+	objectRaw, err = resourceManagerServiceV2.DescribeResourceGroupSettingsGetResourceGroupAdminSetting(d.Id())
+	if err != nil && !NotFoundError(err) {
+		return WrapError(err)
+	}
+
+	d.Set("resource_group_admin_setting_status", objectRaw["CreatorAsAdmin"])
+
+	return nil
+}
+
+func resourceAliCloudResourceManagerResourceGroupSettingsUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	resourceManagerServiceV2 := ResourceManagerServiceV2{client}
+	objectRaw, _ := resourceManagerServiceV2.DescribeResourceManagerResourceGroupSettings(d.Id())
+
+	initedResourceGroupNotificationSettingStatus := false
+	if _, ok := d.GetOkExists("resource_group_notification_setting_status"); ok && d.IsNewResource() {
+		initedResourceGroupNotificationSettingStatus = true
+	}
+	if initedResourceGroupNotificationSettingStatus || d.HasChange("resource_group_notification_setting_status") {
+		var err error
+		target := d.Get("resource_group_notification_setting_status").(bool)
+
+		currentStatus := objectRaw["ResourceGroupNotificationEnableStatus"]
+		if formatBool(currentStatus) != target {
+			if target == false {
+				action := "DisableResourceGroupNotification"
+				request = make(map[string]interface{})
+				query = make(map[string]interface{})
+
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+
+			}
+			if target == true {
+				action := "EnableResourceGroupNotification"
+				request = make(map[string]interface{})
+				query = make(map[string]interface{})
+
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+
+			}
+		}
+	}
+
+	var err error
+	action := "UpdateResourceGroupAdminSetting"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if !d.IsNewResource() && d.HasChange("resource_group_admin_setting_status") {
+		update = true
+	}
+	request["CreatorAsAdmin"] = d.Get("resource_group_admin_setting_status")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudResourceManagerResourceGroupSettingsRead(d, meta)
+}
+
+func resourceAliCloudResourceManagerResourceGroupSettingsDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource AliCloud Resource Resource Group Settings. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_resource_manager_resource_group_settings_test.go
+++ b/alicloud/resource_alicloud_resource_manager_resource_group_settings_test.go
@@ -1,0 +1,100 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// TestAccAliCloudResourceManagerResourceGroupSettings_basic0 covers the account-level
+// ResourceGroupSettings singleton. It exercises both attributes (admin setting +
+// notification setting) through create and every update branch (Enable/Disable
+// notification, UpdateResourceGroupAdminSetting), then re-imports the state.
+func TestAccAliCloudResourceManagerResourceGroupSettings_basic0(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_resource_manager_resource_group_settings.default"
+	ra := resourceAttrInit(resourceId, AlicloudResourceManagerResourceGroupSettingsMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ResourceManagerServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeResourceManagerResourceGroupSettings")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccresourcemanager%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudResourceManagerResourceGroupSettingsBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				// Create: both settings enabled. Covers the Required admin field and
+				// the Optional notification field (100% attribute coverage).
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_admin_setting_status":        true,
+					"resource_group_notification_setting_status": true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_admin_setting_status":        "true",
+						"resource_group_notification_setting_status": "true",
+					}),
+				),
+			},
+			{
+				// Update: disable notification while keeping admin enabled. Exercises
+				// the DisableResourceGroupNotification update branch.
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_notification_setting_status": false,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_admin_setting_status":        "true",
+						"resource_group_notification_setting_status": "false",
+					}),
+				),
+			},
+			{
+				// Update: switch admin to false and re-enable notification. Exercises
+				// the UpdateResourceGroupAdminSetting update branch and the
+				// EnableResourceGroupNotification update branch.
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_admin_setting_status":        false,
+					"resource_group_notification_setting_status": true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_admin_setting_status":        "false",
+						"resource_group_notification_setting_status": "true",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudResourceManagerResourceGroupSettingsMap0 = map[string]string{
+	"resource_group_admin_setting_status":        CHECKSET,
+	"resource_group_notification_setting_status": CHECKSET,
+}
+
+func AlicloudResourceManagerResourceGroupSettingsBasicDependence0(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+`, name)
+}

--- a/alicloud/service_alicloud_resource_manager_v2.go
+++ b/alicloud/service_alicloud_resource_manager_v2.go
@@ -1690,3 +1690,101 @@ func (s *ResourceManagerServiceV2) ResourceManagerResourceDirectorySharingStateR
 }
 
 // DescribeResourceManagerResourceDirectorySharing >>> Encapsulated.
+
+// DescribeResourceManagerResourceGroupSettings <<< Encapsulated get interface for ResourceManager ResourceGroupSettings.
+
+func (s *ResourceManagerServiceV2) DescribeResourceManagerResourceGroupSettings(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	action := "GetResourceGroupNotificationSetting"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *ResourceManagerServiceV2) DescribeResourceGroupSettingsGetResourceGroupAdminSetting(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	action := "GetResourceGroupAdminSetting"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("ResourceManager", "2020-03-31", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *ResourceManagerServiceV2) ResourceManagerResourceGroupSettingsStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ResourceManagerResourceGroupSettingsStateRefreshFuncWithApi(id, field, failStates, s.DescribeResourceManagerResourceGroupSettings)
+}
+
+func (s *ResourceManagerServiceV2) ResourceManagerResourceGroupSettingsStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeResourceManagerResourceGroupSettings >>> Encapsulated.

--- a/website/docs/r/resource_manager_resource_group_settings.html.markdown
+++ b/website/docs/r/resource_manager_resource_group_settings.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "Resource Manager"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_resource_manager_resource_group_settings"
+description: |-
+  Provides a Alicloud Resource Manager Resource Group Settings resource.
+---
+
+# alicloud_resource_manager_resource_group_settings
+
+Provides a Resource Manager Resource Group Settings resource.
+
+Resource group product feature settings, such as automatic group transfer, resource group administrator, and default resource group transfer notification.
+
+For information about Resource Manager Resource Group Settings and how to use it, see [What is Resource Group Settings](https://next.api.alibabacloud.com/document/ResourceManager/2020-03-31/UpdateResourceGroupAdminSetting).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_resource_manager_resource_group_settings" "default" {
+  resource_group_admin_setting_status        = true
+  resource_group_notification_setting_status = true
+}
+```
+
+### Deleting `alicloud_resource_manager_resource_group_settings` or removing it from your configuration
+
+Terraform cannot destroy resource `alicloud_resource_manager_resource_group_settings`. Terraform will remove this resource from the state file, however resources may remain.
+
+## Argument Reference
+
+The following arguments are supported:
+* `resource_group_admin_setting_status` - (Required) Specifies whether to designate the resource creator as the administrator of the resource group. When enabled, the user who creates a resource is automatically set as the administrator of the resource group that the resource belongs to. This maps to the `CreatorAsAdmin` parameter of the UpdateResourceGroupAdminSetting API.
+* `resource_group_notification_setting_status` - (Optional) Specifies whether to enable notifications when resources are automatically transferred to the default resource group. When enabled, a notification is sent upon automatic transfer of resources to the default resource group. This maps to the `ResourceGroupNotificationEnableStatus` field returned by GetResourceGroupNotificationSetting, and is toggled through the EnableResourceGroupNotification and DisableResourceGroupNotification APIs.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<Alibaba Cloud Account ID>`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Resource Group Settings.
+* `update` - (Defaults to 5 mins) Used when update the Resource Group Settings.
+
+## Import
+
+Resource Manager Resource Group Settings can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_resource_manager_resource_group_settings.example <Alibaba Cloud Account ID>
+```


### PR DESCRIPTION
### New Resource: alicloud_resource_manager_resource_group_settings

This PR adds a new resource `alicloud_resource_manager_resource_group_settings` for managing account-level Resource Manager feature settings.

#### Schema

- `resource_group_admin_setting_status` (Required, Bool) — designates the resource creator as the administrator of the resource group. Maps to the `CreatorAsAdmin` parameter of the `UpdateResourceGroupAdminSetting` API.
- `resource_group_notification_setting_status` (Optional, Bool) — toggles notifications for automatic resource transfers to the default resource group. Controlled through the `EnableResourceGroupNotification` and `DisableResourceGroupNotification` APIs.

#### Notes

The resource is an account-level singleton keyed by the Alibaba Cloud account ID. The `id` is set to the account ID and the resource supports `ImportStatePassthrough`. Terraform cannot destroy this resource; removing it from the configuration only removes it from state, leaving the cloud settings intact.

#### Test results

```
=== RUN TestAccAliCloudResourceManagerResourceGroupSettings_basic0
--- PASS: TestAccAliCloudResourceManagerResourceGroupSettings_basic0 (9.72s)
```

The acceptance test exercises create, both update branches (Enable/Disable notification, UpdateResourceGroupAdminSetting), and import.
