### PR TITLE
resource/alicloud_alidns_cloud_gtm_monitor_template: drop 0 from failure_rate enum

### DIFF
--- a/alicloud/resource_alicloud_alidns_cloud_gtm_monitor_template.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_monitor_template.go
@@ -40,7 +40,7 @@ func resourceAliCloudAlidnsCloudGtmMonitorTemplate() *schema.Resource {
 			"failure_rate": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: IntInSlice([]int{0, 20, 50, 80, 100}),
+				ValidateFunc: IntInSlice([]int{20, 50, 80, 100}),
 			},
 			"interval": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_alidns_cloud_gtm_monitor_template_test.go
+++ b/alicloud/resource_alicloud_alidns_cloud_gtm_monitor_template_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -420,6 +421,87 @@ func TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12691(t *testing.T) {
 var AlicloudAlidnsCloudGtmMonitorTemplateMap12691 = map[string]string{}
 
 func AlicloudAlidnsCloudGtmMonitorTemplateBasicDependence12691(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// This case verifies the failure_rate ValidateFunc enum after removing 0:
+// 100 is accepted (it remains in the valid set), while 0 is rejected.
+func TestAccAliCloudAlidnsCloudGtmMonitorTemplate_failureRateEnum(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alidns_cloud_gtm_monitor_template.default"
+	ra := resourceAttrInit(resourceId, AlicloudAlidnsCloudGtmMonitorTemplateMapFailureRateEnum)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlidnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlidnsCloudGtmMonitorTemplate")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalidns%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlidnsCloudGtmMonitorTemplateBasicDependenceFailureRateEnum)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ip_version": "IPv4",
+					"timeout":    "2000",
+					"isp_city_nodes": []map[string]interface{}{
+						{
+							"city_code": "357",
+							"isp_code":  "465",
+						},
+						{
+							"city_code": "738",
+							"isp_code":  "465",
+						},
+					},
+					"evaluation_count": "2",
+					"protocol":         "http",
+					"extend_info":      "{\\\"code\\\":500,\\\"followRedirect\\\":true,\\\"path\\\":\\\"/\\\"}",
+					"failure_rate":     "100",
+					"name":             name,
+					"interval":         "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"failure_rate": "100",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"failure_rate": "0",
+				}),
+				ExpectError: regexp.MustCompile(`expected failure_rate to be one of`),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"failure_rate": "100",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"failure_rate": "100",
+					}),
+				),
+			},
+		},
+	})
+}
+
+var AlicloudAlidnsCloudGtmMonitorTemplateMapFailureRateEnum = map[string]string{}
+
+func AlicloudAlidnsCloudGtmMonitorTemplateBasicDependenceFailureRateEnum(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
     default = "%s"


### PR DESCRIPTION
### What does this PR do?

The `failure_rate` argument of the `alicloud_alidns_cloud_gtm_monitor_template` resource accepted `0` in its `ValidateFunc`, but the backing APIs (`CreateCloudGtmMonitorTemplate` / `UpdateCloudGtmMonitorTemplate`) only support `20 / 50 / 80 / 100`. This removes `0` from the valid set so that invalid configurations fail at plan time instead of being sent to the API and rejected there.

### Test results

All acceptance tests pass:

```
=== RUN TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12684
--- PASS: TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12684 (5.69s)

=== RUN TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12685
--- PASS: TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12685 (11.21s)

=== RUN TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12690
--- PASS: TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12690 (8.28s)

=== RUN TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12691
--- PASS: TestAccAliCloudAlidnsCloudGtmMonitorTemplate_basic12691 (5.78s)

=== RUN TestAccAliCloudAlidnsCloudGtmMonitorTemplate_failureRateEnum
--- PASS: TestAccAliCloudAlidnsCloudGtmMonitorTemplate_failureRateEnum (5.01s)
```

A new acceptance test `TestAccAliCloudAlidnsCloudGtmMonitorTemplate_failureRateEnum` is added to cover the enum change: `failure_rate=100` is accepted at create, while `failure_rate=0` is rejected by validation with `expected failure_rate to be one of [20 50 80 100]`.
