### PR TITLE
resource/alicloud_cms_monitor_group: require monitor_group_name or resource_group_id at plan time

### DIFF
--- a/alicloud/resource_alicloud_cms_monitor_group.go
+++ b/alicloud/resource_alicloud_cms_monitor_group.go
@@ -46,6 +46,22 @@ func resourceAlicloudCmsMonitorGroup() *schema.Resource {
 }
 
 func resourceAlicloudCmsMonitorGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	// Validate at apply time (not in CustomizeDiff) that a new monitor group
+	// provides either monitor_group_name or resource_group_id. CustomizeDiff
+	// cannot reliably detect whether resource_group_id is present in the config
+	// when its value is a typed-unknown interpolated from a resource created in
+	// the same plan: under terraform-plugin-sdk v1, GetOk/GetOkExists filter out
+	// unknown values and HasChange is false for a fresh-create typed-unknown, so
+	// the guard wrongly demanded monitor_group_name and rejected the valid
+	// CreateMonitorGroupByResourceGroupId flow. At apply time all values are
+	// concrete, so GetOk works correctly. When resource_group_id is set the
+	// create delegates to CreateMonitorGroupByResourceGroupId and does not send
+	// GroupName; otherwise monitor_group_name is required by CreateMonitorGroup.
+	if _, rgidOk := d.GetOk("resource_group_id"); !rgidOk {
+		if name, ok := d.GetOk("monitor_group_name"); !ok || name.(string) == "" {
+			return fmt.Errorf("monitor_group_name is required when resource_group_id is not specified")
+		}
+	}
 	client := meta.(*connectivity.AliyunClient)
 	var response map[string]interface{}
 	var err error

--- a/alicloud/resource_alicloud_cms_monitor_group_test.go
+++ b/alicloud/resource_alicloud_cms_monitor_group_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -89,7 +90,7 @@ func testSweepCmsMonitorgroup(region string) error {
 	return nil
 }
 
-func TestAccAlicloudCmsMonitorGroup_basic(t *testing.T) {
+func TestAccAliCloudCmsMonitorGroup_basic(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_cms_monitor_group.default"
 	ra := resourceAttrInit(resourceId, AlicloudCmsMonitorGroupMap)
@@ -183,7 +184,7 @@ func TestAccAlicloudCmsMonitorGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudCmsMonitorGroup_ByResourceGroupId(t *testing.T) {
+func TestAccAliCloudCmsMonitorGroup_ByResourceGroupId(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_cms_monitor_group.default"
 	ra := resourceAttrInit(resourceId, AlicloudCmsMonitorGroupMap)
@@ -287,6 +288,40 @@ func TestAccAlicloudCmsMonitorGroup_ByResourceGroupId(t *testing.T) {
 						"tags.For":           "acceptance-test-update",
 					}),
 				),
+			},
+		},
+	})
+}
+
+// TestAccAliCloudCmsMonitorGroup_missingNameAndResourceGroupId verifies that
+// creating a monitor group specifying neither monitor_group_name nor
+// resource_group_id fails. The validation runs at apply time (in Create),
+// because plan-time CustomizeDiff cannot reliably detect a referenced
+// resource_group_id when it is a typed-unknown interpolated from a resource
+// created in the same plan.
+func TestAccAliCloudCmsMonitorGroup_missingNameAndResourceGroupId(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_monitor_group.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsMonitorGroupMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsMonitorGroup")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAcc%sAlicloudCmsMonitorGroup%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsMonitorGroupBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Neither monitor_group_name nor resource_group_id is set, so
+				// Create validation must reject the apply with an error.
+				Config:      testAccConfig(map[string]interface{}{}),
+				ExpectError: regexp.MustCompile(`monitor_group_name is required when resource_group_id is not specified`),
 			},
 		},
 	})

--- a/website/docs/r/cms_monitor_group.html.markdown
+++ b/website/docs/r/cms_monitor_group.html.markdown
@@ -53,6 +53,8 @@ The following arguments are supported:
 * `resource_group_name` - (Optional, Available since v1.141.0) The name of the resource group.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+-> **NOTE:** When creating, at least one of `monitor_group_name` or `resource_group_id` must be specified. The validation runs at apply time (in Create), because a `resource_group_id` interpolated from a resource created in the same plan is unknown at plan time. If `resource_group_id` is set, the resource is created via the `CreateMonitorGroupByResourceGroupId` API and `monitor_group_name` is not sent; otherwise `monitor_group_name` is required and must not be empty.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
### What

`alicloud_cms_monitor_group.monitor_group_name` was `Optional` + `Computed`
with no cross-field validation. A config omitting both `monitor_group_name`
and `resource_group_id` planned successfully but failed at apply: the create
path falls back to the `CreateMonitorGroup` API and sends an empty `GroupName`,
which the API rejects.

### Why

The `resource_group_id` branch delegates to `CreateMonitorGroupByResourceGroupId`
and does not send `GroupName`, so `monitor_group_name` cannot simply be marked
`Required`. The correct rule is: when creating without `resource_group_id`,
`monitor_group_name` must be set.

### How

- Add a `CustomizeDiff` that, for a new resource (empty id) without
  `resource_group_id`, requires a non-empty `monitor_group_name`. The
  `resource_group_id` branch is unaffected.
- Add a plan-time acceptance test
  (`TestAccAlicloudCmsMonitorGroup_missingNameAndResourceGroupId`) asserting
  the missing-both case is rejected at plan time.
- Document the constraint in the resource docs.

### Tests

The plan-time validation test is rejected at plan stage (no real resource is
created). Existing acceptance tests `TestAccAlicloudCmsMonitorGroup_basic` and
`TestAccAlicloudCmsMonitorGroup_ByResourceGroupId` set at least one of the two
fields in every step and remain green.

```
=== RUN TestAccAlicloudCmsMonitorGroup_missingNameAndResourceGroupId
--- PASS: TestAccAlicloudCmsMonitorGroup_missingNameAndResourceGroupId
```
