### PR TITLE
provider: add support for na-south-1 region validation

### DIFF
--- a/alicloud/connectivity/regions.go
+++ b/alicloud/connectivity/regions.go
@@ -37,6 +37,8 @@ const (
 	USEast1      = Region("us-east-1")
 	USSouthEast1 = Region("us-southeast-1")
 
+	NASouth1 = Region("na-south-1")
+
 	MEEast1    = Region("me-east-1")
 	MECentral1 = Region("me-central-1")
 
@@ -64,6 +66,7 @@ const (
 var ValidRegions = []Region{
 	Hangzhou, Qingdao, Beijing, Shenzhen, Hongkong, Shanghai, Zhangjiakou, Huhehaote, ChengDu, HeYuan, WuLanChaBu, GuangZhou, NanJing, FuZhou, ZhongWei,
 	USWest1, USEast1, USSouthEast1,
+	NASouth1,
 	APNorthEast1, APNorthEast2, APSouthEast1, APSouthEast2, APSouthEast3, APSouthEast5, APSouthEast6, APSouthEast7, APSouthEast8,
 	APSouth1,
 	MEEast1, MECentral1,

--- a/alicloud/connectivity/regions_test.go
+++ b/alicloud/connectivity/regions_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestUnitCommonRegionDefinitions(t *testing.T) {
 	t.Run("AllExportedRegionsInValidRegions", func(t *testing.T) {
 		definedRegions := []Region{
-			Hangzhou, Qingdao, Beijing, ZhongWei, APSouthEast8,
+			Hangzhou, Qingdao, Beijing, ZhongWei, APSouthEast8, NASouth1,
 		}
 
 		validMap := make(map[Region]bool)


### PR DESCRIPTION
Add `na-south-1` to the `ValidRegions` list so users targeting this region no longer hit:

```
Error: Invalid Alibaba Cloud region: na-south-1. You can skip checking this region by setting provider parameter 'skip_region_validation'.
```

and no longer need to set `skip_region_validation = true`.

The region is live — its service endpoints resolve (`ecs.na-south-1.aliyuncs.com`, `vpc.na-south-1.aliyuncs.com`, `oss-na-south-1.aliyuncs.com`).

The region definitions unit test is updated to assert the new constant is present in `ValidRegions`.

Fixes #10100