### PR TITLE
testcase: fix account identifier format in alicloud_max_compute_role_user_attachment tests

### DIFF
--- a/alicloud/resource_alicloud_max_compute_role_user_attachment_test.go
+++ b/alicloud/resource_alicloud_max_compute_role_user_attachment_test.go
@@ -65,15 +65,15 @@ variable "name" {
 }
 
 variable "aliyun_user" {
-  default = "ALIYUN$openapiautomation@test.aliyunid.com"
+  default = "ALIYUN$openapiautomation_testcloud_com"
 }
 
 variable "ram_user" {
-  default = "RAM$openapiautomation@test.aliyunid.com:tf-example"
+  default = "RAM$openapiautomation_testcloud_com:tf-example"
 }
 
 variable "ram_role" {
-  default = "RAM$openapiautomation@test.aliyunid.com:role/terraform-no-ak-assumerole-no-deleting"
+  default = "RAM$openapiautomation_testcloud_com:role/terraform-no-ak-assumerole-no-deleting"
 }
 
 variable "role_name" {
@@ -143,15 +143,15 @@ variable "name" {
 }
 
 variable "aliyun_user" {
-  default = "ALIYUN$openapiautomation@test.aliyunid.com"
+  default = "ALIYUN$openapiautomation_testcloud_com"
 }
 
 variable "ram_user" {
-  default = "RAM$openapiautomation@test.aliyunid.com:tf-example"
+  default = "RAM$openapiautomation_testcloud_com:tf-example"
 }
 
 variable "ram_role" {
-  default = "RAM$openapiautomation@test.aliyunid.com:role/terraform-no-ak-assumerole-no-deleting"
+  default = "RAM$openapiautomation_testcloud_com:role/terraform-no-ak-assumerole-no-deleting"
 }
 
 variable "role_name" {
@@ -221,15 +221,15 @@ variable "name" {
 }
 
 variable "aliyun_user" {
-  default = "ALIYUN$openapiautomation@test.aliyunid.com"
+  default = "ALIYUN$openapiautomation_testcloud_com"
 }
 
 variable "ram_user" {
-  default = "RAM$openapiautomation@test.aliyunid.com:tf-example"
+  default = "RAM$openapiautomation_testcloud_com:tf-example"
 }
 
 variable "ram_role" {
-  default = "RAM$openapiautomation@test.aliyunid.com:role/terraform-no-ak-assumerole-no-deleting"
+  default = "RAM$openapiautomation_testcloud_com:role/terraform-no-ak-assumerole-no-deleting"
 }
 
 variable "role_name" {
@@ -299,15 +299,15 @@ variable "name" {
 }
 
 variable "aliyun_user" {
-  default = "ALIYUN$openapiautomation@test.aliyunid.com"
+  default = "ALIYUN$openapiautomation_testcloud_com"
 }
 
 variable "ram_user" {
-  default = "RAM$openapiautomation@test.aliyunid.com:tf-example"
+  default = "RAM$openapiautomation_testcloud_com:tf-example"
 }
 
 variable "ram_role" {
-  default = "RAM$openapiautomation@test.aliyunid.com:role/terraform-no-ak-assumerole-no-deleting"
+  default = "RAM$openapiautomation_testcloud_com:role/terraform-no-ak-assumerole-no-deleting"
 }
 
 variable "role_name" {
@@ -377,15 +377,15 @@ variable "name" {
 }
 
 variable "aliyun_user" {
-  default = "ALIYUN$openapiautomation@test.aliyunid.com"
+  default = "ALIYUN$openapiautomation_testcloud_com"
 }
 
 variable "ram_user" {
-  default = "RAM$openapiautomation@test.aliyunid.com:tf-example"
+  default = "RAM$openapiautomation_testcloud_com:tf-example"
 }
 
 variable "ram_role" {
-  default = "RAM$openapiautomation@test.aliyunid.com:role/terraform-no-ak-assumerole-no-deleting"
+  default = "RAM$openapiautomation_testcloud_com:role/terraform-no-ak-assumerole-no-deleting"
 }
 
 variable "role_name" {


### PR DESCRIPTION
## Summary
- Fix the hardcoded account identifiers in the `alicloud_max_compute_role_user_attachment` acceptance tests. MaxCompute identifies accounts by a canonical name in which `@` and `.` are replaced with `_`; the tests used email-style identifiers, so the role-user API rejected every create with `ILLEGAL_ARGUMENT ... is not a valid account`.
- Updated the `aliyun_user`, `ram_user` and `ram_role` variables in all five dependence blocks. The resource `Read` compares the stored user string against the value returned by the role-user list API with plain string equality, so the configured value has to match the canonical form exactly — a tolerant create alone would not be enough.
- Test-only change; no resource or service code is modified.

## Test plan
```
=== RUN   TestAccAliCloudMaxComputeRoleUserAttachment_basic9962
--- PASS: TestAccAliCloudMaxComputeRoleUserAttachment_basic9962 (7.06s)

=== RUN   TestAccAliCloudMaxComputeRoleUserAttachment_basic9961
--- PASS: TestAccAliCloudMaxComputeRoleUserAttachment_basic9961 (6.39s)

=== RUN   TestAccAliCloudMaxComputeRoleUserAttachment_basic9966
--- PASS: TestAccAliCloudMaxComputeRoleUserAttachment_basic9966 (6.42s)

=== RUN   TestAccAliCloudMaxComputeRoleUserAttachment_basic9967
--- PASS: TestAccAliCloudMaxComputeRoleUserAttachment_basic9967 (6.27s)

=== RUN   TestAccAliCloudMaxComputeRoleUserAttachment_basic9960
--- PASS: TestAccAliCloudMaxComputeRoleUserAttachment_basic9960 (5.83s)
```
All five cases PASS in `cn-hangzhou` (create → read → import → destroy). `gofmt -l` clean, `go vet ./alicloud/` clean for the changed file.
