### PR TITLE
fix: report the released v2 version in the API User-Agent

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+      - '-s -w -X github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity.providerVersion={{.Version}}'
     goos:
       - freebsd
       - windows

--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -189,7 +189,7 @@ var loadSdkfromRemoteMutex = sync.Mutex{}
 var loadSdkEndpointMutex = sync.Mutex{}
 
 // The main version number that is being run at the moment.
-var providerVersion = "1.287.0"
+var providerVersion = "2.0.0-beta2"
 
 // Temporarily maintain map for old ecs client methods and store special endpoint information
 var EndpointMap = map[string]string{


### PR DESCRIPTION
Set the baked constant to `2.0.0-beta2` so unstamped local builds stop claiming v1.