### PR TITLE
docs: clarify cross_account_type, disabled, source descriptions for alicloud_hbr_policy_binding

### DIFF
--- a/website/docs/r/hbr_policy_binding.html.markdown
+++ b/website/docs/r/hbr_policy_binding.html.markdown
@@ -81,17 +81,17 @@ resource "alicloud_hbr_policy_binding" "default" {
 The following arguments are supported:
 * `advanced_options` - (Optional, ForceNew, Computed, Set) Backup Advanced Options See [`advanced_options`](#advanced_options) below.
 * `cross_account_role_name` - (Optional, ForceNew, Available since v1.230.0) Valid only when CrossAccountType = CROSS_ACCOUNT, indicating the name of the cross-account authorization role of the data source, and the management account uses this role to access the data source.
-* `cross_account_type` - (Optional, ForceNew, Computed, Available since v1.230.0) Cross-account type, supported
+* `cross_account_type` - (Optional, ForceNew, Computed, Available since v1.230.0) Cross-account type of the data source. Valid values: `SELF_ACCOUNT` (the data source belongs to the current management account) and `CROSS_ACCOUNT` (the data source belongs to another account authorized through a cross-account role).
 * `cross_account_user_id` - (Optional, ForceNew, Int, Available since v1.230.0) Valid only when CrossAccountType = CROSS_ACCOUNT, indicating the ID of the actual account to which the data source belongs.
 * `data_source_id` - (Optional, ForceNew, Computed) The data source ID.
-* `disabled` - (Optional) Whether the policy is effective for the data source.
-  - true: Pause
-  - false: not paused
+* `disabled` - (Optional) Whether the policy is paused for the data source.
+  - `true`: pause backup for the data source.
+  - `false`: resume backup for the data source.
 * `exclude` - (Optional) This parameter is required only when the value of SourceType is ECS_FILE or File. Indicates a file type that does not need to be backed up. All files of this type are not backed up. A maximum of 255 characters is supported.
 * `include` - (Optional) This parameter is required only when the value of SourceType is ECS_FILE or File. Indicates the file types to be backed up, and all files of these types are backed up. A maximum of 255 characters is supported.
 * `policy_binding_description` - (Optional) Resource Description
 * `policy_id` - (Optional, ForceNew, Computed) The policy ID.
-* `source` - (Optional) When SourceType is OSS, a prefix is specified to be backed up. If it is not specified, the entire root directory of the Bucket is backed up.
+* `source` - (Optional) When SourceType is OSS, a prefix is specified to be backed up. The value is an object key prefix (not a full path); only objects whose keys start with the prefix are backed up. If it is not specified, the entire root directory of the Bucket is backed up.
 * `source_type` - (Optional, ForceNew, Computed, Available since v1.260.1) Data source type, value range:
   - `UDM_ECS`: indicates the ECS instance backup.
   - `OSS`: indicates an OSS backup.


### PR DESCRIPTION
## Summary

Clarify the argument descriptions for `alicloud_hbr_policy_binding` to improve accuracy and usability:

- `cross_account_type`: document the valid values (`SELF_ACCOUNT`, `CROSS_ACCOUNT`) and what each represents.
- `disabled`: clarify that `true` pauses backup for the data source and `false` resumes it.
- `source`: note that when `source_type` is `OSS`, the value is an object key prefix (not a full path); only objects whose keys start with the prefix are backed up.

## Motivation

The previous descriptions were imprecise:
- `cross_account_type` was described as "Cross-account type, supported" without listing the valid values.
- `disabled` used inconsistent formatting for the `true`/`false` semantics.
- `source` did not make clear that the OSS value is a key prefix rather than a full path.

## Testing

- Documentation-only change; no Go source or test files modified.
- `gofmt -l alicloud/` is clean for the HBR policy binding resource and test files.
- The existing `TestAccAliCloudHbrPolicyBinding_*` acceptance tests are unchanged and continue to exercise all schema attributes across the OSS, ECS_FILE, UDM_ECS, and cross-account scenarios.
