### PR TITLE
New Data Source: alicloud_hbr_policy_bindings

### DIFF
--- a/alicloud/data_source_alicloud_hbr_policy_bindings.go
+++ b/alicloud/data_source_alicloud_hbr_policy_bindings.go
@@ -1,0 +1,339 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAlicloudHbrPolicyBindings() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudHbrPolicyBindingsRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"source_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"UDM_ECS", "NAS", "OSS", "File", "ECS_FILE", "OTS"}, false),
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsValidRegExp,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policy_bindings": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"data_source_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"disabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"exclude": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"include": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"speed_limit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_binding_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cross_account_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cross_account_role_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cross_account_user_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"advanced_options": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"oss_detail": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"ignore_archive_object": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"inventory_cleanup_policy": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"inventory_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"udm_detail": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"exclude_disk_id_list": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"destination_kms_key_id": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"disk_id_list": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudHbrPolicyBindingsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "DescribePolicyBindings"
+	request := make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("policy_id"); ok {
+		request["PolicyId"] = v
+	}
+	if v, ok := d.GetOk("source_type"); ok {
+		request["SourceType"] = v
+	}
+	request["MaxResults"] = PageSizeLarge
+
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var objects []map[string]interface{}
+	var response map[string]interface{}
+	var err error
+	for {
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPost("hbr", "2017-09-08", action, nil, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_hbr_policy_bindings", action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, err := jsonpath.Get("$.PolicyBindings[*]", response)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.PolicyBindings[*]", response)
+		}
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			policyId := fmt.Sprint(item["PolicyId"])
+			sourceType := fmt.Sprint(item["SourceType"])
+			dataSourceId := fmt.Sprint(item["DataSourceId"])
+			compositeId := fmt.Sprintf("%v:%v:%v", policyId, sourceType, dataSourceId)
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["PolicyBindingDescription"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[compositeId]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+		if nextToken, ok := response["NextToken"].(string); ok && nextToken != "" {
+			request["NextToken"] = nextToken
+		} else {
+			break
+		}
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, object := range objects {
+		policyId := fmt.Sprint(object["PolicyId"])
+		sourceType := fmt.Sprint(object["SourceType"])
+		dataSourceId := fmt.Sprint(object["DataSourceId"])
+		compositeId := fmt.Sprintf("%v:%v:%v", policyId, sourceType, dataSourceId)
+
+		advancedOptionsMaps := make([]map[string]interface{}, 0)
+		advancedOptionsRaw := make(map[string]interface{})
+		if object["AdvancedOptions"] != nil {
+			if raw, ok := object["AdvancedOptions"].(map[string]interface{}); ok {
+				advancedOptionsRaw = raw
+			}
+		}
+		if len(advancedOptionsRaw) > 0 {
+			advancedOptionsMap := make(map[string]interface{})
+
+			ossDetailMaps := make([]map[string]interface{}, 0)
+			ossDetailRaw := make(map[string]interface{})
+			if advancedOptionsRaw["OssDetail"] != nil {
+				if raw, ok := advancedOptionsRaw["OssDetail"].(map[string]interface{}); ok {
+					ossDetailRaw = raw
+				}
+			}
+			if len(ossDetailRaw) > 0 {
+				ossDetailMap := make(map[string]interface{})
+				ossDetailMap["ignore_archive_object"] = ossDetailRaw["IgnoreArchiveObject"]
+				ossDetailMap["inventory_cleanup_policy"] = ossDetailRaw["InventoryCleanupPolicy"]
+				ossDetailMap["inventory_id"] = ossDetailRaw["InventoryId"]
+				ossDetailMaps = append(ossDetailMaps, ossDetailMap)
+			}
+			advancedOptionsMap["oss_detail"] = ossDetailMaps
+
+			udmDetailMaps := make([]map[string]interface{}, 0)
+			udmDetailRaw := make(map[string]interface{})
+			if advancedOptionsRaw["UdmDetail"] != nil {
+				if raw, ok := advancedOptionsRaw["UdmDetail"].(map[string]interface{}); ok {
+					udmDetailRaw = raw
+				}
+			}
+			if len(udmDetailRaw) > 0 {
+				udmDetailMap := make(map[string]interface{})
+				udmDetailMap["destination_kms_key_id"] = udmDetailRaw["DestinationKmsKeyId"]
+
+				diskIdListRaw := make([]interface{}, 0)
+				if udmDetailRaw["DiskIdList"] != nil {
+					diskIdListRaw = convertToInterfaceArray(udmDetailRaw["DiskIdList"])
+				}
+				udmDetailMap["disk_id_list"] = diskIdListRaw
+
+				excludeDiskIdListRaw := make([]interface{}, 0)
+				if udmDetailRaw["ExcludeDiskIdList"] != nil {
+					excludeDiskIdListRaw = convertToInterfaceArray(udmDetailRaw["ExcludeDiskIdList"])
+				}
+				udmDetailMap["exclude_disk_id_list"] = excludeDiskIdListRaw
+				udmDetailMaps = append(udmDetailMaps, udmDetailMap)
+			}
+			advancedOptionsMap["udm_detail"] = udmDetailMaps
+
+			advancedOptionsMaps = append(advancedOptionsMaps, advancedOptionsMap)
+		}
+
+		mapping := map[string]interface{}{
+			"id":                         compositeId,
+			"policy_id":                  policyId,
+			"source_type":                sourceType,
+			"data_source_id":             dataSourceId,
+			"disabled":                   object["Disabled"],
+			"exclude":                    object["Exclude"],
+			"include":                    object["Include"],
+			"source":                     object["Source"],
+			"speed_limit":                object["SpeedLimit"],
+			"policy_binding_description": object["PolicyBindingDescription"],
+			"cross_account_type":         object["CrossAccountType"],
+			"cross_account_role_name":    object["CrossAccountRoleName"],
+			"cross_account_user_id":      object["CrossAccountUserId"],
+			"create_time":                fmt.Sprint(object["CreatedTime"]),
+			"advanced_options":           advancedOptionsMaps,
+		}
+		ids = append(ids, compositeId)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("policy_bindings", s); err != nil {
+		return WrapError(err)
+	}
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+
+	return nil
+}

--- a/alicloud/data_source_alicloud_hbr_policy_bindings_test.go
+++ b/alicloud/data_source_alicloud_hbr_policy_bindings_test.go
@@ -1,0 +1,142 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudHBRPolicyBindingsDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacchbrpb%d", rand)
+
+	bindingIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudHbrPolicyBindingsSourceConfig(name, rand, map[string]string{
+			"ids": `["${alicloud_hbr_policy_binding.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudHbrPolicyBindingsSourceConfig(name, rand, map[string]string{
+			"ids": `["${alicloud_hbr_policy_binding.default.id}_fake"]`,
+		}),
+	}
+
+	policyIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudHbrPolicyBindingsSourceConfig(name, rand, map[string]string{
+			"policy_id": `"${alicloud_hbr_policy_binding.default.policy_id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudHbrPolicyBindingsSourceConfig(name, rand, map[string]string{
+			"policy_id": `"${alicloud_hbr_policy_binding.default.policy_id}_fake"`,
+		}),
+	}
+
+	sourceTypeConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudHbrPolicyBindingsSourceConfig(name, rand, map[string]string{
+			"policy_id":   `"${alicloud_hbr_policy_binding.default.policy_id}"`,
+			"source_type": `"OSS"`,
+		}),
+		fakeConfig: testAccCheckAlicloudHbrPolicyBindingsSourceConfig(name, rand, map[string]string{
+			"policy_id":   `"${alicloud_hbr_policy_binding.default.policy_id}"`,
+			"source_type": `"NAS"`,
+		}),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudHbrPolicyBindingsSourceConfig(name, rand, map[string]string{
+			"policy_id":  `"${alicloud_hbr_policy_binding.default.policy_id}"`,
+			"name_regex": `"policy binding example"`,
+		}),
+		fakeConfig: testAccCheckAlicloudHbrPolicyBindingsSourceConfig(name, rand, map[string]string{
+			"policy_id":  `"${alicloud_hbr_policy_binding.default.policy_id}"`,
+			"name_regex": `"policy binding example_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudHbrPolicyBindingsSourceConfig(name, rand, map[string]string{
+			"ids":         `["${alicloud_hbr_policy_binding.default.id}"]`,
+			"policy_id":   `"${alicloud_hbr_policy_binding.default.policy_id}"`,
+			"source_type": `"OSS"`,
+			"name_regex":  `"policy binding example"`,
+		}),
+		fakeConfig: testAccCheckAlicloudHbrPolicyBindingsSourceConfig(name, rand, map[string]string{
+			"ids":         `["${alicloud_hbr_policy_binding.default.id}_fake"]`,
+			"policy_id":   `"${alicloud_hbr_policy_binding.default.policy_id}"`,
+			"source_type": `"OSS"`,
+			"name_regex":  `"policy binding example_fake"`,
+		}),
+	}
+
+	HbrPolicyBindingCheckInfo.dataSourceTestCheck(t, rand, bindingIdConf, policyIdConf, sourceTypeConf, nameRegexConf, allConf)
+}
+
+func testAccCheckAlicloudHbrPolicyBindingsSourceConfig(name string, rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+resource "alicloud_hbr_vault" "defaultyk84Hc" {
+  vault_type = "STANDARD"
+  vault_name = var.name
+}
+
+resource "alicloud_hbr_policy" "defaultoqWvHQ" {
+  policy_name = var.name
+  rules {
+    rule_type    = "BACKUP"
+    backup_type  = "COMPLETE"
+    schedule     = "I|0|P1D"
+    retention    = "7"
+    vault_id     = alicloud_hbr_vault.defaultyk84Hc.id
+    archive_days = "0"
+  }
+}
+
+resource "alicloud_oss_bucket" "defaultKtt2XY" {
+  storage_class = "Standard"
+}
+
+resource "alicloud_hbr_policy_binding" "default" {
+  source_type                = "OSS"
+  disabled                   = "false"
+  policy_id                  = alicloud_hbr_policy.defaultoqWvHQ.id
+  data_source_id             = alicloud_oss_bucket.defaultKtt2XY.id
+  policy_binding_description = "policy binding example"
+  source                     = "prefix-example-create/"
+}
+
+data "alicloud_hbr_policy_bindings" "default" {
+%s
+}
+`, name, strings.Join(pairs, "\n   "))
+	return config
+}
+
+var existHbrPolicyBindingMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"policy_bindings.#":                "1",
+		"policy_bindings.0.id":             CHECKSET,
+		"policy_bindings.0.policy_id":      CHECKSET,
+		"policy_bindings.0.source_type":    "OSS",
+		"policy_bindings.0.data_source_id": CHECKSET,
+		"policy_bindings.0.disabled":       "false",
+		"policy_bindings.0.create_time":    CHECKSET,
+	}
+}
+
+var fakeHbrPolicyBindingMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"policy_bindings.#": "0",
+	}
+}
+
+var HbrPolicyBindingCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_hbr_policy_bindings.default",
+	existMapFunc: existHbrPolicyBindingMapFunc,
+	fakeMapFunc:  fakeHbrPolicyBindingMapFunc,
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -571,6 +571,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cen_transit_router_peer_attachments":              dataSourceAlicloudCenTransitRouterPeerAttachments(),
 			"alicloud_amqp_instances":                                   dataSourceAliCloudAmqpInstances(),
 			"alicloud_hbr_vaults":                                       dataSourceAlicloudHbrVaults(),
+			"alicloud_hbr_policy_bindings":                              dataSourceAlicloudHbrPolicyBindings(),
 			"alicloud_ssl_certificates_service_certificates":            dataSourceAliCloudSslCertificatesServiceCertificates(),
 			"alicloud_arms_alert_contacts":                              dataSourceAlicloudArmsAlertContacts(),
 			"alicloud_arms_alert_robots":                                dataSourceAlicloudArmsAlertRobots(),

--- a/website/docs/d/hbr_policy_bindings.html.markdown
+++ b/website/docs/d/hbr_policy_bindings.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "Hybrid Backup Recovery (HBR)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_hbr_policy_bindings"
+sidebar_current: "docs-alicloud-datasource-hbr-policy-bindings"
+description: |-
+  Provides a list of Hybrid Backup Recovery (HBR) Policy Bindings to the user.
+---
+
+# alicloud_hbr_policy_bindings
+
+This data source provides the Hbr Policy Bindings of the current Alibaba Cloud user.
+
+-> **NOTE:** Available since v1.221.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+data "alicloud_hbr_policy_bindings" "ids" {
+  policy_id   = "example-policy-id"
+  source_type = "OSS"
+}
+
+output "hbr_policy_binding_id_1" {
+  value = data.alicloud_hbr_policy_bindings.ids.policy_bindings.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional, Computed) A list of Policy Binding IDs. The value is formulated as `<policy_id>:<source_type>:<data_source_id>`.
+* `policy_id` - (Optional) The ID of the backup policy. If specified, only the policy bindings under this policy are listed.
+* `source_type` - (Optional) The data source type of the policy binding. Valid values: `UDM_ECS`, `NAS`, `OSS`, `File`, `ECS_FILE`, `OTS`.
+  - `UDM_ECS` - indicates the ECS instance backup.
+  - `OSS` - indicates an OSS backup.
+  - `NAS` - indicates an Alibaba Cloud NAS Backup.
+  - `ECS_FILE` - indicates that the ECS file is backed up.
+  - `File` - indicates a local File backup.
+  - `OTS` - indicates the Tablestore backup.
+* `name_regex` - (Optional) A regex string to filter results by the policy binding description.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `ids` - A list of Policy Binding IDs.
+* `policy_bindings` - A list of Hbr Policy Bindings. Each element contains the following attributes:
+  * `id` - The ID of the Policy Binding. The value is formulated as `<policy_id>:<source_type>:<data_source_id>`.
+  * `policy_id` - The ID of the backup policy.
+  * `source_type` - The data source type of the policy binding.
+  * `data_source_id` - The ID of the data source bound to the policy.
+  * `disabled` - Whether the policy is effective for the data source. `true`: paused; `false`: not paused.
+  * `exclude` - The file type that does not need to be backed up. Valid only when `source_type` is `ECS_FILE` or `File`.
+  * `include` - The file types to be backed up. Valid only when `source_type` is `ECS_FILE` or `File`.
+  * `source` - The OSS prefix to be backed up. Valid only when `source_type` is `OSS`.
+  * `speed_limit` - The backup flow control. Valid only when `source_type` is `ECS_FILE` or `File`.
+  * `policy_binding_description` - The description of the policy binding.
+  * `cross_account_type` - The cross-account type. Valid values: `SELF_ACCOUNT`, `CROSS_ACCOUNT`.
+  * `cross_account_role_name` - The name of the cross-account authorization role. Valid only when `cross_account_type` is `CROSS_ACCOUNT`.
+  * `cross_account_user_id` - The ID of the actual account to which the data source belongs. Valid only when `cross_account_type` is `CROSS_ACCOUNT`.
+  * `create_time` - The creation time of the policy binding.
+  * `advanced_options` - The advanced backup options of the policy binding.
+    * `oss_detail` - The advanced options for OSS backup.
+      * `ignore_archive_object` - Whether archived objects are not prompted in task statistics and failed file lists.
+      * `inventory_cleanup_policy` - Whether to delete the inventory file after the backup.
+      * `inventory_id` - The name of the OSS inventory.
+    * `udm_detail` - The advanced options for ECS backup.
+      * `destination_kms_key_id` - The custom KMS key ID of encrypted copy.
+      * `disk_id_list` - The list of backup disks.
+      * `exclude_disk_id_list` - The list of cloud disk IDs that are not backed up.


### PR DESCRIPTION
This PR adds a new data source `alicloud_hbr_policy_bindings` to list Hybrid Backup Recovery (HBR) policy bindings.

## New Data Source

`alicloud_hbr_policy_bindings` - Provides a list of HBR Policy Bindings to the user. Supports filtering by `ids`, `policy_id`, `source_type`, and `name_regex`.

## Argument Reference

* `ids` - (Optional, Computed) A list of Policy Binding IDs. The value is formulated as `<policy_id>:<source_type>:<data_source_id>`.
* `policy_id` - (Optional) The ID of the backup policy. If specified, only the policy bindings under this policy are listed.
* `source_type` - (Optional) The data source type of the policy binding. Valid values: `UDM_ECS`, `NAS`, `OSS`, `File`, `ECS_FILE`, `OTS`.
* `name_regex` - (Optional) A regex string to filter results by the policy binding description.
* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).

## Attributes Reference

The following attributes are exported in addition to the arguments listed above:

* `ids` - A list of Policy Binding IDs.
* `policy_bindings` - A list of Hbr Policy Bindings. Each element contains the following attributes:
  * `id` - The ID of the Policy Binding. The value is formulated as `<policy_id>:<source_type>:<data_source_id>`.
  * `policy_id` - The ID of the backup policy.
  * `source_type` - The data source type of the policy binding.
  * `data_source_id` - The ID of the data source bound to the policy.
  * `disabled` - Whether the policy is effective for the data source.
  * `exclude` - The file type that does not need to be backed up.
  * `include` - The file types to be backed up.
  * `source` - The OSS prefix to be backed up.
  * `speed_limit` - The backup flow control.
  * `policy_binding_description` - The description of the policy binding.
  * `cross_account_type` - The cross-account type. Valid values: `SELF_ACCOUNT`, `CROSS_ACCOUNT`.
  * `cross_account_role_name` - The name of the cross-account authorization role.
  * `cross_account_user_id` - The ID of the actual account to which the data source belongs.
  * `create_time` - The creation time of the policy binding.
  * `advanced_options` - The advanced backup options of the policy binding.
    * `oss_detail` - The advanced options for OSS backup.
      * `ignore_archive_object` - Whether archived objects are not prompted in task statistics and failed file lists.
      * `inventory_cleanup_policy` - Whether to delete the inventory file after the backup.
      * `inventory_id` - The name of the OSS inventory.
    * `udm_detail` - The advanced options for ECS backup.
      * `destination_kms_key_id` - The custom KMS key ID of encrypted copy.
      * `disk_id_list` - The list of backup disks.
      * `exclude_disk_id_list` - The list of cloud disk IDs that are not backed up.

## Test Results

Remote acceptance tests passed:

```
=== RUN TestAccAlicloudHBRPolicyBindingsDataSource
--- PASS: TestAccAlicloudHBRPolicyBindingsDataSource (64.46s)

=== RUN TestAccAliCloudHbrPolicyBinding_basic6221
--- PASS: TestAccAliCloudHbrPolicyBinding_basic6221 (27.38s)
```
