### PR TITLE
docs: resource/alicloud_db_backup_policy: skip backup_interval for unsupported MySQL instances

### DIFF
--- a/alicloud/resource_alicloud_db_backup_policy_test.go
+++ b/alicloud/resource_alicloud_db_backup_policy_test.go
@@ -172,6 +172,16 @@ func TestAccAliCloudRdsDBBackupPolicyMySql(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"backup_interval": "60",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"backup_interval": "60",
+					}),
+				),
+			},
 		},
 	})
 }

--- a/alicloud/service_alicloud_rds.go
+++ b/alicloud/service_alicloud_rds.go
@@ -970,7 +970,19 @@ func (s *RdsService) ModifyDBBackupPolicy(d *schema.ResourceData, updateForData,
 			request["ArchiveBackupKeepCount"] = archiveBackupKeepCount
 			request["ArchiveBackupKeepPolicy"] = archiveBackupKeepPolicy
 		}
-		if (instance["Engine"] == "MySQL" || instance["Engine"] == "PostgreSQL") && instance["DBInstanceStorageType"] != "local_ssd" {
+
+		// handle backup_interval
+		if instance["Engine"] == "MySQL" {
+			// Only MySQL 5.7 and 8.0 High-availability or Cluster Edition instances with cloud disk storage support setting the backup interval
+			engineVersion := fmt.Sprint(instance["EngineVersion"])
+			category := fmt.Sprint(instance["Category"])
+			if (engineVersion == "5.7" || engineVersion == "8.0") &&
+				(category == "HighAvailability" || category == "cluster") &&
+				instance["DBInstanceStorageType"] != "local_ssd" {
+				request["BackupInterval"] = backupInterval
+			}
+		}
+		if instance["Engine"] == "PostgreSQL" && instance["DBInstanceStorageType"] != "local_ssd" {
 			// Basic version cannot set backup interval
 			if v, ok := instance["Category"].(string); ok && v != "Basic" {
 				request["BackupInterval"] = backupInterval

--- a/website/docs/r/db_backup_policy.html.markdown
+++ b/website/docs/r/db_backup_policy.html.markdown
@@ -99,6 +99,9 @@ The following arguments are supported:
   - 360: A snapshot backup is performed once every 360 minutes.
   - 480: A snapshot backup is performed once every 480 minutes.
   - 720: A snapshot backup is performed once every 720 minutes.
+
+  -> **NOTE:** If the instance runs MySQL, `backup_interval` is supported only when the `engine_version` of the instance is `5.7` or `8.0`, the `category` of the instance is `HighAvailability` (High-availability Edition) or `cluster` (MySQL Cluster Edition), and the instance is not equipped with local disks (`db_instance_storage_type` is not `local_ssd`). This parameter is ignored for MySQL instances that do not meet all of these conditions.
+
 * `backup_priority` - (Optional, Int, Available since v1.229.1) Specifies whether the backup settings of a secondary instance are configured. Valid values:
   - 1: secondary instance preferred
   - 2: primary instance preferred


### PR DESCRIPTION
### Problem

The RDS `ModifyBackupPolicy` API accepts `BackupInterval` for MySQL only when the instance runs MySQL 5.7 or 8.0 on High-availability or Cluster Edition and is not equipped with local disks.

`alicloud_db_backup_policy` previously sent `BackupInterval` for every non-`local_ssd` MySQL instance whose `Category` was not `Basic`, so MySQL instances failing any of the remaining conditions (5.6, `serverless_*`, `Finance`) had the request rejected.

Because `backup_interval` defaults to `-1` when unset, the parameter was sent even for configurations that never reference the attribute.

### Change

- `RdsService.ModifyDBBackupPolicy`: for MySQL, gate `BackupInterval` on `EngineVersion` (`5.7`/`8.0`), `Category` (`HighAvailability`/`cluster`) and `DBInstanceStorageType != local_ssd`. PostgreSQL behaviour is unchanged.
- Add a `backup_interval` step to `TestAccAliCloudRdsDBBackupPolicyMySql`. The MySQL path had no coverage previously — the only `backup_interval` steps live in the PostgreSQL test.
- Document the MySQL constraint on `backup_interval`.

### Acceptance test

All five existing `alicloud_db_backup_policy` acceptance tests pass:

```
PASS: TestAccAliCloudRdsDBBackupPolicyMySql (1358.68s)
PASS: TestAccAliCloudRdsDBBackupPolicyMariaDB (2677.13s)
PASS: TestAccAliCloudRdsDBBackupPolicySQLServer (825.84s)
PASS: TestAccAliCloudRdsDBBackupPolicySQLServerAlwaysOn (1138.83s)
PASS: TestAccAliCloudRdsDBBackupPolicyPostgreSQL (1856.05s)
PASS=5 FAIL=0 SKIP=0
```

Checked against the generated request bodies, not the assertions alone:

- The MySQL fixture (8.0 / HighAvailability / cloud_essd) still sends `BackupInterval`, so the gate does not block eligible instances.
- The PostgreSQL fixture still sends `BackupInterval` on every `ModifyBackupPolicy` call, confirming the split of the previously shared `MySQL || PostgreSQL` condition preserved PostgreSQL behaviour.

Note on coverage: every fixture in the test file is an *eligible* instance, so no test exercises the new suppression branch itself. This run demonstrates no regression on the working path; it does not exercise the ineligible-MySQL path, which would need a 5.6 / `Finance` / `serverless_*` fixture.
