### PR TITLE
resource/alicloud_gpdb_instance: support modifying payment_type between PayAsYouGo and Subscription

### DIFF
--- a/alicloud/resource_alicloud_gpdb_instance.go
+++ b/alicloud/resource_alicloud_gpdb_instance.go
@@ -35,6 +35,14 @@ func resourceAliCloudGpdbInstance() *schema.Resource {
 			if (backupId == "") != (srcDbInstanceName == "") {
 				return fmt.Errorf("`backup_id` and `src_db_instance_name` must be set together (both set or both empty); the GPDB CreateDBInstance API requires BackupId and SrcDbInstanceName to be null or not null at the same time")
 			}
+			if diff.Id() != "" && diff.HasChange("payment_type") {
+				_, newPaymentType := diff.GetChange("payment_type")
+				if fmt.Sprint(newPaymentType) == "Subscription" {
+					if diff.Get("period").(string) == "" || diff.Get("used_time").(string) == "" {
+						return fmt.Errorf("`period` and `used_time` must be set when `payment_type` is modified to `Subscription`; the GPDB ModifyDBInstancePayType API requires Period and UsedTime for converting an instance to the prepaid billing method")
+					}
+				}
+			}
 			return nil
 		},
 		Schema: map[string]*schema.Schema{
@@ -112,7 +120,6 @@ func resourceAliCloudGpdbInstance() *schema.Resource {
 			"payment_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ForceNew:     true,
 				Computed:     true,
 				ValidateFunc: StringInSlice([]string{"PayAsYouGo", "Subscription"}, false),
 			},
@@ -723,6 +730,76 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 			return WrapError(err)
 		}
 		d.SetPartial("tags")
+	}
+
+	if !d.IsNewResource() && d.HasChange("payment_type") {
+		_, newPaymentType := d.GetChange("payment_type")
+		request = map[string]interface{}{
+			"RegionId":     client.RegionId,
+			"DBInstanceId": d.Id(),
+			"PayType":      convertGpdbDbInstancePaymentTypeRequest(newPaymentType.(string)),
+		}
+		if newPaymentType.(string) == "Subscription" {
+			period := ""
+			if v, ok := d.GetOk("period"); ok {
+				period = v.(string)
+			}
+			usedTime := ""
+			if v, ok := d.GetOk("used_time"); ok {
+				usedTime = v.(string)
+			}
+			if period == "" {
+				return fmt.Errorf("`period` must be set when `payment_type` is modified to `Subscription`; the GPDB ModifyDBInstancePayType API requires Period (valid values: `Month`, `Year`) for converting an instance to the prepaid billing method")
+			}
+			if usedTime == "" {
+				return fmt.Errorf("`used_time` must be set when `payment_type` is modified to `Subscription`; the GPDB ModifyDBInstancePayType API requires UsedTime (1 to 9 when `period` is `Month`, 1 to 3 when `period` is `Year`) for converting an instance to the prepaid billing method")
+			}
+			usedTimeInt, err := strconv.Atoi(usedTime)
+			if err != nil {
+				return fmt.Errorf("`used_time` must be an integer string when `payment_type` is modified to `Subscription`, got %q", usedTime)
+			}
+			if (period == "Month" && (usedTimeInt < 1 || usedTimeInt > 9)) || (period == "Year" && (usedTimeInt < 1 || usedTimeInt > 3)) {
+				return fmt.Errorf("`used_time` %q is invalid: when `period` is `Month`, `used_time` must be between 1 and 9, and when `period` is `Year`, `used_time` must be between 1 and 3", usedTime)
+			}
+			// The ModifyDBInstancePayType API only requires Period and UsedTime when
+			// converting an instance to the prepaid billing method; they must not be
+			// sent when converting back to PayAsYouGo.
+			request["Period"] = period
+			request["UsedTime"] = usedTime
+		}
+		action := "ModifyDBInstancePayType"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
+			response, err = client.RpcPost("gpdb", "2016-05-03", action, nil, request, true)
+			if err != nil {
+				if IsExpectedErrors(err, []string{"OperationDenied.OrderProcessing"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		stateConf := BuildStateConf([]string{}, []string{"Running"}, d.Timeout(schema.TimeoutUpdate), 30*time.Second, gpdbService.GpdbDbInstanceStateRefreshFunc(d.Id(), "DBInstanceStatus", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+
+		// The billing method conversion is order-driven: DescribeDBInstanceAttribute may keep
+		// reporting the previous PayType until the conversion order takes effect, so also wait
+		// until the new value is actually applied to avoid Read observing the stale value.
+		paymentTypeTarget := fmt.Sprint(convertGpdbDbInstancePaymentTypeRequest(newPaymentType.(string)))
+		paymentTypeStateConf := BuildStateConf([]string{}, []string{paymentTypeTarget}, d.Timeout(schema.TimeoutUpdate), 30*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "PayType", paymentTypeTarget))
+		if _, err := paymentTypeStateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+
+		d.SetPartial("payment_type")
 	}
 
 	update := false

--- a/alicloud/resource_alicloud_gpdb_instance_test.go
+++ b/alicloud/resource_alicloud_gpdb_instance_test.go
@@ -505,6 +505,117 @@ func TestAccAliCloudGPDBDBInstancePrepaid(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data", "parameters"},
 			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type": "PayAsYouGo",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"payment_type": "PayAsYouGo",
+					}),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAliCloudGPDBDBInstanceModifyPaymentType verifies modifying the billing
+// method of an existing instance in both directions (PayAsYouGo -> Subscription
+// and Subscription -> PayAsYouGo) via the GPDB ModifyDBInstancePayType API. The
+// instance is pinned to cn-beijing and uses the cheapest Basic StorageElastic
+// form (2C8G, 2 segment nodes, 50GB storage), because the conversion to
+// Subscription produces a real one-month prepaid order that cannot be refunded.
+// The final update returns the instance to PayAsYouGo so Delete can release the
+// real instance and the destroy check can verify cleanup.
+func TestAccAliCloudGPDBDBInstanceModifyPaymentType(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_gpdb_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region("cn-beijing")})
+	ra := resourceAttrInit(resourceId, AliCloudGPDBDBInstanceMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GpdbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGpdbDbInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sgpdbdbinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudGPDBDBInstanceBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"db_instance_category":  "Basic",
+					"db_instance_mode":      "StorageElastic",
+					"description":           name,
+					"engine":                "gpdb",
+					"engine_version":        "6.0",
+					"zone_id":               "${data.alicloud_gpdb_zones.default.ids.0}",
+					"instance_network_type": "VPC",
+					"instance_spec":         "2C8G",
+					"payment_type":          "PayAsYouGo",
+					"seg_storage_type":      "cloud_essd",
+					"seg_node_num":          "2",
+					"storage_size":          "50",
+					"vpc_id":                "${data.alicloud_vpcs.default.ids.0}",
+					"vswitch_id":            "${local.vswitch_id}",
+					"create_sample_data":    "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"db_instance_category":  "Basic",
+						"db_instance_mode":      "StorageElastic",
+						"description":           name,
+						"engine":                "gpdb",
+						"engine_version":        "6.0",
+						"zone_id":               CHECKSET,
+						"instance_network_type": "VPC",
+						"instance_spec":         "2C8G",
+						"payment_type":          "PayAsYouGo",
+						"seg_storage_type":      "cloud_essd",
+						"seg_node_num":          "2",
+						"storage_size":          "50",
+						"vpc_id":                CHECKSET,
+						"vswitch_id":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type": "Subscription",
+					"period":       "Month",
+					"used_time":    "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"payment_type": "Subscription",
+					}),
+				),
+			},
+			{
+				// Convert the Subscription instance back to PayAsYouGo. Period and
+				// UsedTime are only required when converting to Subscription, so the
+				// values that remain in the configuration are not sent in this step.
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type": "PayAsYouGo",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"payment_type": "PayAsYouGo",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data", "parameters"},
+			},
 		},
 	})
 }

--- a/website/docs/r/gpdb_instance.html.markdown
+++ b/website/docs/r/gpdb_instance.html.markdown
@@ -104,8 +104,8 @@ The following arguments are supported:
 * `vpc_id` - (Optional, ForceNew) The vpc ID of the resource.
 * `zone_id` - (Optional, ForceNew) The zone ID of the instance.
 * `instance_group_count` - (Optional, ForceNew, Int) The number of nodes. Valid values: `2`, `4`, `8`, `12`, `16`, `24`, `32`, `64`, `96`, `128`.
-* `payment_type` - (Optional, ForceNew) The billing method of the instance. Valid values: `Subscription`, `PayAsYouGo`.
-* `period` - (Optional) The duration that you will buy the resource, in month. required when `payment_type` is `Subscription`. Valid values: `Year`, `Month`.
+* `payment_type` - (Optional) The billing method of the instance. Valid values: `Subscription`, `PayAsYouGo`. **NOTE:** From provider version 1.287.0, `payment_type` can be modified in both directions between `Subscription` and `PayAsYouGo`. When modifying the billing method of an instance to `Subscription`, `period` and `used_time` are required; when modifying the billing method of an instance to `PayAsYouGo`, `period` and `used_time` are not required. See [ModifyDBInstancePayType](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-modifydbinstancepaytype).
+* `period` - (Optional) The duration that you will buy the resource, in month. required when `payment_type` is `Subscription`, including when `payment_type` is modified to `Subscription`. Valid values: `Year`, `Month`.
 * `resource_group_id` - (Optional) The ID of the enterprise resource group to which the instance belongs.
 * `master_cu` - (Optional, Int, Available since v1.213.0) The amount of coordinator node resources. Valid values: `2`, `4`, `8`, `16`, `32`.
 * `seg_node_num` - (Optional, Int) Calculate the number of nodes. Valid values: `2` to `512`. The value range of the high-availability version of the storage elastic mode is `4` to `512`, and the value must be a multiple of `4`. The value range of the basic version of the storage elastic mode is `2` to `512`, and the value must be a multiple of `2`. The-Serverless version has a value range of `2` to `512`. The value must be a multiple of `2`.
@@ -138,7 +138,7 @@ The following arguments are supported:
 
   -> **NOTE:** `data_share_status` is valid only when `db_instance_mode` is set to `Serverless`.
 
-* `used_time` - (Optional) The used time. When the parameter `period` is `Year`, the `used_time` value is `1` to `3`. When the parameter `period` is `Month`, the `used_time` value is `1` to `9`.
+* `used_time` - (Optional) The used time. When the parameter `period` is `Year`, the `used_time` value is `1` to `3`. When the parameter `period` is `Month`, the `used_time` value is `1` to `9`. **NOTE:** From provider version 1.287.0, `used_time` is required (together with `period`) when `payment_type` is modified to `Subscription`.
 * `description` - (Optional) The description of the instance.
 * `backup_id` - (Optional, ForceNew, Available since v1.287.0) The ID of the backup set. If specified, the instance is created from the existing backup set. See [CreateDBInstance](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-createdbinstance).
 * `src_db_instance_name` - (Optional, ForceNew, Available since v1.287.0) The source instance ID for creating an instance from a backup set. Must be set together with `backup_id`; the GPDB CreateDBInstance API requires `SrcDbInstanceName` and `BackupId` to be null or not null at the same time. See [CreateDBInstance](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-createdbinstance).


### PR DESCRIPTION
## Summary
- Support modifying the billing method of an existing `alicloud_gpdb_instance` in both directions between `PayAsYouGo` and `Subscription` via the GPDB `ModifyDBInstancePayType` API: remove `ForceNew` from `payment_type` and add the corresponding update branch.
- `period` and `used_time` are required when modifying `payment_type` to `Subscription` (`period`: `Month`/`Year`; `used_time`: 1-9 when `period` is `Month`, 1-3 when `period` is `Year`); both are validated before the API call. They are not sent when modifying `payment_type` to `PayAsYouGo`.
- After the conversion request succeeds, the provider waits until the instance is `Running` and `DescribeDBInstanceAttribute` reports the new `PayType`, so Read does not observe a stale billing method while the conversion order is being processed.
- Docs updated for `payment_type`, `period` and `used_time`.

## Test plan
- [x] Added `TestAccAliCloudGPDBDBInstanceModifyPaymentType`: create a pay-as-you-go StorageElastic instance (cn-beijing), modify `payment_type` to `Subscription` with `period = Month` and `used_time = 1`, modify it back to `PayAsYouGo`, then verify and import.
- [x] `gofmt` and `go vet ./alicloud` pass.
- [ ] Remote acceptance run of `TestAccAliCloudGPDBDBInstanceModifyPaymentType` will be posted once completed.
