### PR TITLE
New Resource: alicloud_ssl_certificates_service_certificate_apply; resource/alicloud_ssl_certificates_service_instance: Fixed the refund failure when deleting a freshly created instance

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -956,6 +956,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ssl_certificates_service_company":                     resourceAliCloudSslCertificatesServiceCompany(),
 			"alicloud_ssl_certificates_service_contact":                     resourceAliCloudSslCertificatesServiceContact(),
 			"alicloud_ssl_certificates_service_instance":                    resourceAliCloudSslCertificatesServiceInstance(),
+			"alicloud_ssl_certificates_service_certificate_apply":           resourceAliCloudSslCertificatesServiceCertificateApply(),
 			"alicloud_apig_plugin_class":                                    resourceAliCloudApigPluginClass(),
 			"alicloud_apig_domain":                                          resourceAliCloudApigDomain(),
 			"alicloud_apig_route":                                           resourceAliCloudApigRoute(),

--- a/alicloud/resource_alicloud_ssl_certificates_service_certificate_apply.go
+++ b/alicloud/resource_alicloud_ssl_certificates_service_certificate_apply.go
@@ -1,0 +1,352 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudSslCertificatesServiceCertificateApply() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudSslCertificatesServiceCertificateApplyCreate,
+		Read:   resourceAliCloudSslCertificatesServiceCertificateApplyRead,
+		Delete: resourceAliCloudSslCertificatesServiceCertificateApplyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			// Deleting withdraws the application, and the withdrawal is processed asynchronously —
+			// the instance can sit in pending for several minutes afterwards. It has to leave that
+			// state before the instance itself can be refunded and removed, so the delete is given
+			// room to wait it out.
+			Delete: schema.DefaultTimeout(20 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			// The five fields below are the application configuration. ApplyCertificate accepts
+			// none of them — they are written onto the certificate instance by UpdateInstance, and
+			// ApplyCertificate submits whatever the instance holds at that moment. They are
+			// declared here so that changing any of them replaces this resource, which resubmits
+			// the application: a different configuration means a different certificate is being
+			// requested. Reference the corresponding attribute of the instance rather than
+			// hardcoding a value; Create rejects a mismatch.
+			"domain": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"csr": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"validation_method": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"key_algorithm": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"generate_csr_method": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"domain_validation_list": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"domain": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"root_domain": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"validation_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"validation_key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"validation_value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cname": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cname_key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"certificate_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"pending_result": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cert_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// applicationConfigurationFields maps the application configuration declared on this resource to
+// the field GetInstanceDetail reports it under.
+var applicationConfigurationFields = []struct {
+	schemaKey string
+	apiKey    string
+}{
+	{"domain", "Domain"},
+	{"csr", "Csr"},
+	{"validation_method", "ValidationMethod"},
+	{"key_algorithm", "KeyAlgorithm"},
+	{"generate_csr_method", "GenerateCsrMethod"},
+}
+
+func resourceAliCloudSslCertificatesServiceCertificateApplyCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	sslCertificatesServiceServiceV2 := SslCertificatesServiceServiceV2{client}
+
+	instanceId := d.Get("instance_id").(string)
+
+	// ApplyCertificate submits the configuration held on the instance and accepts no application
+	// parameters of its own, so a configured value that disagrees with the instance would be
+	// silently ignored and then read back as the instance's value — leaving the resource in a diff
+	// it can never converge out of. Refuse that up front instead.
+	instanceObject, err := sslCertificatesServiceServiceV2.DescribeSslCertificatesServiceInstance(instanceId)
+	if err != nil {
+		return WrapError(err)
+	}
+	for _, field := range applicationConfigurationFields {
+		configured, ok := d.GetOk(field.schemaKey)
+		if !ok {
+			continue
+		}
+		onInstance := ""
+		if v, exist := instanceObject[field.apiKey]; exist && v != nil {
+			onInstance = fmt.Sprint(v)
+		}
+		if onInstance != fmt.Sprint(configured) {
+			return WrapError(Error("%s is set to %q, but certificate instance %s currently holds %q. "+
+				"ApplyCertificate submits the configuration recorded on the instance, so the two must agree. "+
+				"Reference the corresponding attribute of alicloud_ssl_certificates_service_instance instead of hardcoding a value.",
+				field.schemaKey, fmt.Sprint(configured), instanceId, onInstance))
+		}
+	}
+
+	action := "ApplyCertificate"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	request = make(map[string]interface{})
+	request["InstanceId"] = instanceId
+	request["ClientToken"] = buildClientToken(action)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("cas", "2020-04-07", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ssl_certificates_service_certificate_apply", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(instanceId)
+
+	// ApplyCertificate answers with nothing but a RequestId, and the instance takes a few seconds to
+	// reflect the submission. Wait for the domain validation records to appear before returning —
+	// they are the whole point of this resource, and returning early would hand callers an empty
+	// list to drive their DNS records from.
+	//
+	// The wait keys on DomainValidationList rather than CertificateStatus: the latter only gets a
+	// value once the certificate authority has actually issued a certificate, which cannot happen
+	// until those very records have been published and validated.
+	stateConf := BuildStateConf([]string{}, []string{"#CHECKSET"}, d.Timeout(schema.TimeoutCreate), 5*time.Second,
+		sslCertificatesServiceServiceV2.SslCertificatesServiceCertificateApplyStateRefreshFunc(d.Id(), "#$.DomainValidationList", []string{}))
+	// An application is not operable the moment its validation records appear: for several seconds
+	// afterwards the instance still refuses to withdraw it, answering OperationDenied.StatusNotSupport.
+	// Requiring the records to hold across consecutive reads keeps this create from handing back a
+	// resource that cannot yet be destroyed, which is where that refusal would otherwise surface.
+	stateConf.ContinuousTargetOccurence = 4
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return resourceAliCloudSslCertificatesServiceCertificateApplyRead(d, meta)
+}
+
+func resourceAliCloudSslCertificatesServiceCertificateApplyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	sslCertificatesServiceServiceV2 := SslCertificatesServiceServiceV2{client}
+
+	objectRaw, err := sslCertificatesServiceServiceV2.DescribeSslCertificatesServiceCertificateApply(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ssl_certificates_service_certificate_apply DescribeSslCertificatesServiceCertificateApply Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("instance_id", d.Id())
+	d.Set("domain", objectRaw["Domain"])
+	d.Set("csr", objectRaw["Csr"])
+	d.Set("validation_method", objectRaw["ValidationMethod"])
+	d.Set("key_algorithm", objectRaw["KeyAlgorithm"])
+	d.Set("generate_csr_method", objectRaw["GenerateCsrMethod"])
+	d.Set("certificate_status", objectRaw["CertificateStatus"])
+	d.Set("pending_result", objectRaw["PendingResult"])
+	d.Set("cert_identifier", objectRaw["CertIdentifier"])
+	// Only populated once the certificate authority has issued the certificate.
+	if v, ok := objectRaw["CertificateId"]; ok && v != nil {
+		d.Set("certificate_id", formatInt(v))
+	}
+
+	domainValidationList := make([]map[string]interface{}, 0)
+	if v, ok := objectRaw["DomainValidationList"]; ok {
+		if items, ok := v.([]interface{}); ok {
+			for _, item := range items {
+				itemMap, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				domainValidationList = append(domainValidationList, map[string]interface{}{
+					"domain":           itemMap["Domain"],
+					"root_domain":      itemMap["RootDomain"],
+					"validation_type":  itemMap["ValidationType"],
+					"validation_key":   itemMap["ValidationKey"],
+					"validation_value": itemMap["ValidationValue"],
+					"cname":            itemMap["Cname"],
+					"cname_key":        itemMap["CnameKey"],
+				})
+			}
+		}
+	}
+	// The validation records are a one-time proof of domain control: once the certificate has been
+	// issued the application stops reporting them. Keeping the last known set rather than blanking
+	// the attribute preserves what was published — callers drive their DNS records off it, and
+	// clearing it would tear those records down the moment the certificate arrives.
+	if len(domainValidationList) > 0 {
+		if err := d.Set("domain_validation_list", domainValidationList); err != nil {
+			return WrapError(err)
+		}
+	}
+
+	return nil
+}
+
+func resourceAliCloudSslCertificatesServiceCertificateApplyDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	sslCertificatesServiceServiceV2 := SslCertificatesServiceServiceV2{client}
+	action := "CancelPendingCertificate"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["InstanceId"] = d.Id()
+	request["ClientToken"] = buildClientToken(action)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("cas", "2020-04-07", action, query, request, true)
+		if err == nil {
+			return nil
+		}
+		if NeedRetry(err) {
+			wait()
+			return resource.RetryableError(err)
+		}
+		return resource.NonRetryableError(err)
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		// The instance is gone, so there is nothing left to withdraw from.
+		if NotFoundError(err) {
+			log.Printf("[WARN] %s CancelPendingCertificate tolerated failure: %v", d.Id(), err)
+			return nil
+		}
+		// StatusNotSupport says the instance will not withdraw anything right now, which is the
+		// state this delete is asking for only when there is nothing left to withdraw — the
+		// certificate has been issued, or the application was withdrawn elsewhere. The same answer
+		// comes back when an application really is outstanding and refuses to go, and reporting
+		// that as success would leave the instance stuck in pending for whatever deletes it next.
+		// The error code cannot tell the two apart, so the instance is asked instead.
+		//
+		// Revoking an issued certificate is deliberately not done here: the certificate is a
+		// separate object from the application that produced it, other services may be serving it,
+		// and revocation is irreversible. An instance left holding one cannot be refunded, which
+		// its own delete reports.
+		if IsExpectedErrors(err, []string{"OperationDenied.StatusNotSupport"}) &&
+			!sslCertificatesServiceServiceV2.certificateApplicationIsOutstanding(d.Id()) {
+			log.Printf("[WARN] %s CancelPendingCertificate tolerated failure: %v", d.Id(), err)
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	// Withdrawing is asynchronous: the call returns while the instance is still pending, and it
+	// leaves that state only once the withdrawal has actually been processed. Wait for it here —
+	// an instance still in pending cannot be refunded, so deleting it right after would fail with
+	// CouldNotRefund.NotSupport.
+	//
+	// Any state other than pending means the withdrawal has landed, so all of them are accepted
+	// rather than guessing at one: a withdrawn instance has been observed settling on normal, but
+	// inactive, an expiring or expired subscription, a refunded or a disabled instance are all
+	// equally "no longer applying for a certificate".
+	stateConf := BuildStateConf([]string{"pending"},
+		[]string{"normal", "inactive", "willExpire", "expired", "refund", "closed"},
+		d.Timeout(schema.TimeoutDelete), 10*time.Second,
+		sslCertificatesServiceServiceV2.SslCertificatesServiceCertificateApplyStateRefreshFunc(d.Id(), "Status", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ssl_certificates_service_certificate_apply_test.go
+++ b/alicloud/resource_alicloud_ssl_certificates_service_certificate_apply_test.go
@@ -1,0 +1,221 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// sslCertificatesServiceUnissuableDomain is deliberately a domain the test account does not hold, so
+// an application for it never passes validation and stays pending indefinitely. That is what the
+// application resource needs to exercise its whole lifecycle: withdrawing only applies while an
+// application is outstanding, and a domain the account does hold is validated by the certificate
+// authority on its own within minutes.
+//
+// It is a constant rather than an environment variable because the remote acceptance-test runner
+// injects only credentials — a getenv would read empty there and silently skip the test.
+const sslCertificatesServiceUnissuableDomain = "tf-acc-cas-not-resolvable.com"
+
+// Test SslCertificatesService CertificateApply. >>> Resource test cases.
+
+// Applies for a certificate against a domain the account does not hold, so the application stays
+// outstanding for the whole test. That is what makes the resource's lifecycle observable: the
+// validation records this resource exists to report are only published while an application is
+// pending, and withdrawing one on destroy is only possible for as long as it has not been issued.
+// A domain the account does hold is validated by the certificate authority on its own within
+// minutes, which would settle the application before either could be exercised.
+func TestAccAliCloudSslCertificatesServiceCertificateApply_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ssl_certificates_service_certificate_apply.default"
+	ra := resourceAttrInit(resourceId, AliCloudSslCertificatesServiceCertificateApplyMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &SslCertificatesServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeSslCertificatesServiceCertificateApply")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccsslcasapply%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudSslCertificatesServiceCertificateApplyBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		// Destroying the application withdraws it, but the instance it was submitted on survives,
+		// so GetInstanceDetail keeps succeeding and the default "describe must report NotFound"
+		// check would always fail. What marks an instance as no longer applying for a certificate
+		// is the disappearance of its validation records, so that is what gets asserted.
+		CheckDestroy: testAccCheckSslCertificatesServiceCertificateApplyDestroy,
+		Steps: []resource.TestStep{
+			{
+				// The application settings are referenced from the instance rather than
+				// hardcoded. ApplyCertificate submits whatever the instance holds, so Create
+				// rejects values that disagree with it.
+				Config: testAccConfig(map[string]interface{}{
+					"instance_id":         "${alicloud_ssl_certificates_service_instance.default.id}",
+					"domain":              "${alicloud_ssl_certificates_service_instance.default.domain}",
+					"validation_method":   "${alicloud_ssl_certificates_service_instance.default.validation_method}",
+					"key_algorithm":       "${alicloud_ssl_certificates_service_instance.default.key_algorithm}",
+					"generate_csr_method": "${alicloud_ssl_certificates_service_instance.default.generate_csr_method}",
+					// The instance generates the CSR itself (generate_csr_method = online), so this
+					// resolves to an empty CSR. It is referenced rather than hardcoded because
+					// ApplyCertificate submits whatever the instance holds, and Create rejects a
+					// value that disagrees with it.
+					"csr": "${alicloud_ssl_certificates_service_instance.default.csr}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_id":         CHECKSET,
+						"domain":              CHECKSET,
+						"validation_method":   CHECKSET,
+						"key_algorithm":       CHECKSET,
+						"generate_csr_method": CHECKSET,
+						// The validation records the certificate authority wants published. They are
+						// what this resource exists to produce. certificate_status is deliberately
+						// not asserted: it only gets a value once a certificate has been issued,
+						// which cannot happen until these records are published and validated.
+						"domain_validation_list.#":                  "1",
+						"domain_validation_list.0.domain":           CHECKSET,
+						"domain_validation_list.0.root_domain":      CHECKSET,
+						"domain_validation_list.0.validation_type":  CHECKSET,
+						"domain_validation_list.0.validation_key":   CHECKSET,
+						"domain_validation_list.0.validation_value": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// A configured application setting that disagrees with the instance is refused before anything is
+// submitted. Without that refusal the value would be quietly ignored — ApplyCertificate reads the
+// configuration off the instance — and then read back as the instance's own, leaving a plan that
+// never converges. The domain stands in for all five settings; they share one code path.
+func TestAccAliCloudSslCertificatesServiceCertificateApply_configurationMismatch(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccsslcasapply%d", rand)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSslCertificatesServiceCertificateApplyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%s
+
+resource "alicloud_ssl_certificates_service_certificate_apply" "default" {
+  instance_id = alicloud_ssl_certificates_service_instance.default.id
+  domain      = "mismatched.%s"
+}
+`, AliCloudSslCertificatesServiceCertificateApplyBasicDependence(name), sslCertificatesServiceUnissuableDomain),
+				ExpectError: regexp.MustCompile("ApplyCertificate submits the configuration recorded on the instance"),
+			},
+		},
+	})
+}
+
+var AliCloudSslCertificatesServiceCertificateApplyMap = map[string]string{
+	"id":          CHECKSET,
+	"instance_id": CHECKSET,
+}
+
+// testAccCheckSslCertificatesServiceCertificateApplyDestroy asserts that the application really was
+// withdrawn, rather than that the instance disappeared — it does not, the application is destroyed
+// but the instance it belongs to lives on.
+//
+// The signal is DomainValidationList: an instance with an application in flight reports the records
+// the certificate authority wants published, and an instance withdrawn from one reports none. A
+// withdrawal that was accepted but never took effect leaves them in place, which is exactly the
+// failure this check exists to catch.
+func testAccCheckSslCertificatesServiceCertificateApplyDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+	service := SslCertificatesServiceServiceV2{client}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_ssl_certificates_service_certificate_apply" {
+			continue
+		}
+		object, err := service.DescribeSslCertificatesServiceCertificateApply(rs.Primary.ID)
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return WrapError(err)
+		}
+		if records, ok := object["DomainValidationList"]; ok && records != nil {
+			return WrapError(Error("certificate application %s is still outstanding after destroy: the instance is %v and still reports validation records %v",
+				rs.Primary.ID, object["Status"], records))
+		}
+	}
+
+	return nil
+}
+
+func AliCloudSslCertificatesServiceCertificateApplyBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+resource "alicloud_ssl_certificates_service_contact" "default" {
+  name   = var.name
+  mobile = "1390000${substr(var.name, -4, 4)}"
+  email  = "${var.name}@example.com"
+}
+
+resource "alicloud_ssl_certificates_service_company" "default" {
+  company_name    = var.name
+  company_address = "杭州市"
+  department      = "测试部门"
+  city            = "杭州"
+  province        = "浙江"
+  country_code    = "111122"
+  post_code       = "11112233"
+  company_type    = "1"
+  company_code    = "12312311"
+  company_phone   = "15101081174"
+  company_email   = "test@example.com"
+  lang            = "zh"
+}
+
+resource "alicloud_ssl_certificates_service_instance" "default" {
+  product_type        = "cas"
+  period              = 12
+  pricing_cycle       = 2
+  instance_name       = var.name
+  domain              = "${var.name}.%s"
+  key_algorithm       = "RSA_2048"
+  generate_csr_method = "online"
+  validation_method   = "DNS"
+  country_code        = "CN"
+  contact_id_list     = [alicloud_ssl_certificates_service_contact.default.id]
+  company_id          = alicloud_ssl_certificates_service_company.default.id
+
+  parameter {
+    code  = "fullSpec"
+    value = "ws.dv.f"
+  }
+  parameter {
+    code  = "fullDomainCount"
+    value = "1"
+  }
+}
+`, name, sslCertificatesServiceUnissuableDomain)
+}
+
+// Test SslCertificatesService CertificateApply. <<< Resource test cases.

--- a/alicloud/resource_alicloud_ssl_certificates_service_instance.go
+++ b/alicloud/resource_alicloud_ssl_certificates_service_instance.go
@@ -558,11 +558,31 @@ func resourceAliCloudSslCertificatesServiceInstanceDelete(d *schema.ResourceData
 	// deleted. The refund is attempted first and its failure tolerated: an instance whose order is
 	// no longer refundable — already expired, or already refunded on an earlier attempt — reports
 	// that it cannot be refunded, and such an instance is deletable as it stands.
+	//
+	// A freshly purchased instance answers with that same CouldNotRefund.NotSupport for the first
+	// seconds of its life, while its purchase order is still settling — a refund fired three
+	// seconds after payment has been seen rejected where one fired six seconds after succeeded.
+	// The code is therefore retried briefly before being taken at its word, or an instance
+	// destroyed right after creation is left unrefunded and its deletion stuck behind delete
+	// protection. The retry is bounded well below the delete timeout: for an instance that
+	// genuinely cannot be refunded, it only defers the tolerant path below.
 	refundRequest := map[string]interface{}{
 		"InstanceId":  d.Id(),
 		"ClientToken": buildClientToken("RefundInstance"),
 	}
-	if _, refundErr := client.RpcPost("cas", "2020-04-07", "RefundInstance", make(map[string]interface{}), refundRequest, true); refundErr != nil {
+	refundWait := incrementalWait(3*time.Second, 5*time.Second)
+	refundErr := resource.Retry(1*time.Minute, func() *resource.RetryError {
+		_, err := client.RpcPost("cas", "2020-04-07", "RefundInstance", make(map[string]interface{}), refundRequest, true)
+		if err == nil {
+			return nil
+		}
+		if NeedRetry(err) || IsExpectedErrors(err, []string{"CouldNotRefund.NotSupport"}) {
+			refundWait()
+			return resource.RetryableError(err)
+		}
+		return resource.NonRetryableError(err)
+	})
+	if refundErr != nil {
 		if !NotFoundError(refundErr) && !IsExpectedErrors(refundErr, []string{"CouldNotRefund.NotSupport", "OperationDenied.StatusNotSupport"}) {
 			return WrapErrorf(refundErr, DefaultErrorMsg, d.Id(), "RefundInstance", AlibabaCloudSdkGoERROR)
 		}

--- a/alicloud/service_alicloud_ssl_certificates_service_v2.go
+++ b/alicloud/service_alicloud_ssl_certificates_service_v2.go
@@ -531,3 +531,88 @@ func (s *SslCertificatesServiceServiceV2) SslCertificatesServiceInstanceStateRef
 }
 
 // DescribeSslCertificatesServiceInstance >>> Encapsulated.
+
+// DescribeSslCertificatesServiceCertificateApply <<< Encapsulated get interface for SslCertificatesService CertificateApply.
+func (s *SslCertificatesServiceServiceV2) DescribeSslCertificatesServiceCertificateApply(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["InstanceId"] = id
+
+	action := "GetInstanceDetail"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("cas", "2020-04-07", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NotFound"}) {
+			return object, WrapErrorf(NotFoundErr("CertificateApply", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *SslCertificatesServiceServiceV2) SslCertificatesServiceCertificateApplyStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.SslCertificatesServiceCertificateApplyStateRefreshFuncWithApi(id, field, failStates, s.DescribeSslCertificatesServiceCertificateApply)
+}
+
+func (s *SslCertificatesServiceServiceV2) SslCertificatesServiceCertificateApplyStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeSslCertificatesServiceCertificateApply >>> Encapsulated.
+
+// certificateApplicationIsOutstanding reports whether the instance still has a certificate
+// application in flight, which is what makes a withdrawal both possible and necessary.
+//
+// An instance that cannot be read counts as still having one. Not knowing is not the same as
+// knowing there is nothing left to withdraw, and reporting a withdrawal that never happened leaves
+// the instance sitting in pending for whatever tries to delete it next — a state in which it can be
+// neither refunded nor deleted. An instance that is genuinely gone is the one exception.
+func (s *SslCertificatesServiceServiceV2) certificateApplicationIsOutstanding(id string) bool {
+	object, err := s.DescribeSslCertificatesServiceInstance(id)
+	if err != nil {
+		return !NotFoundError(err)
+	}
+	return fmt.Sprint(object["Status"]) == "pending"
+}

--- a/website/docs/r/ssl_certificates_service_certificate_apply.html.markdown
+++ b/website/docs/r/ssl_certificates_service_certificate_apply.html.markdown
@@ -1,0 +1,108 @@
+---
+subcategory: "Certificate Management Service (Original SSL Certificate)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ssl_certificates_service_certificate_apply"
+description: |-
+  Provides a Alicloud Certificate Management Service (Original SSL Certificate) Certificate Apply resource.
+---
+
+# alicloud_ssl_certificates_service_certificate_apply
+
+Provides a Certificate Management Service (Original SSL Certificate) Certificate Apply resource.
+
+Submits the certificate application recorded on a certificate instance and exposes the domain ownership validation records that have to be published before the certificate authority can issue the certificate.
+
+For information about Certificate Management Service (Original SSL Certificate) Certificate Apply and how to use it, see [What is Certificate Apply](https://next.api.alibabacloud.com/document/cas/2020-04-07/ApplyCertificate).
+
+-> **NOTE:** Available since v1.287.0.
+
+~> **NOTE:** Creating this resource returns as soon as the application has been submitted; it does **not** wait for the certificate to be issued. Publish the records from `domain_validation_list` on your authoritative DNS, then use `alicloud_ssl_certificates_service_certificate_validation` to wait for issuance.
+
+-> **NOTE:** A certificate instance can have at most one application in progress at a time, which is why this resource is identified by the instance ID.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_ssl_certificates_service_instance" "default" {
+  product_type      = "cas"
+  period            = 12
+  pricing_cycle     = 2
+  instance_name     = var.name
+  domain            = "example.com"
+  validation_method = "DNS"
+
+  parameter {
+    code  = "fullSpec"
+    value = "ws.dv.f"
+  }
+  parameter {
+    code  = "fullDomainCount"
+    value = "1"
+  }
+}
+
+resource "alicloud_ssl_certificates_service_certificate_apply" "default" {
+  instance_id       = alicloud_ssl_certificates_service_instance.default.id
+  domain            = alicloud_ssl_certificates_service_instance.default.domain
+  validation_method = alicloud_ssl_certificates_service_instance.default.validation_method
+}
+
+output "domain_validation_list" {
+  value = alicloud_ssl_certificates_service_certificate_apply.default.domain_validation_list
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `instance_id` - (Required, ForceNew) The ID of the certificate instance to submit the application on.
+* `domain` - (Optional, ForceNew, Computed) The domain names the certificate is requested for, separated by commas.
+* `csr` - (Optional, ForceNew, Computed) The content of the certificate signing request.
+* `validation_method` - (Optional, ForceNew, Computed) The domain ownership validation method. Valid values: `DNS` and `HTTP`.
+* `key_algorithm` - (Optional, ForceNew, Computed) The key algorithm the certificate is issued with, such as `RSA_2048`, `RSA_4096`, `ECC_256` or `SM2`.
+* `generate_csr_method` - (Optional, ForceNew, Computed) How the certificate signing request is produced. Valid values: `online` and `upload`.
+
+~> **NOTE:** The five application settings above are stored on the certificate instance and are written there by the instance resource. `ApplyCertificate` accepts none of them — it submits whatever the instance holds at that moment. They are accepted here so that changing one of them replaces this resource and resubmits the application, since a different configuration means a different certificate is being requested. **Reference the corresponding attribute of `alicloud_ssl_certificates_service_instance` rather than hardcoding a value**; a configured value that disagrees with the instance is rejected when the resource is created.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+* `certificate_status` - The status of the certificate this application produces.
+* `pending_result` - The reason the application is pending, if the review has not passed.
+* `certificate_id` - The ID of the certificate produced by this application. Populated only after the certificate has been issued.
+* `cert_identifier` - The global certificate identifier of the certificate produced by this application. Populated only after the certificate has been issued.
+* `domain_validation_list` - The domain ownership validation records that have to be published before the certificate authority can validate the domains. It contains the following attributes:
+  * `domain` - The domain name to be validated.
+  * `root_domain` - The root domain of the domain name to be validated. Use this value to locate the DNS zone when adding the validation record.
+  * `validation_type` - The type of the validation record. Valid values: `TXT`, `CNAME` and `FILE`.
+  * `validation_key` - The host record of the validation record.
+  * `validation_value` - The value of the validation record.
+  * `cname` - The record value used when the domain is validated through a CNAME record.
+  * `cname_key` - The host record used when the domain is validated through a CNAME record.
+
+-> **NOTE:** Reference `certificate_id` and `cert_identifier` from `alicloud_ssl_certificates_service_certificate_validation` rather than from this resource. The values here are only populated once the certificate happens to have been issued by the time of a refresh, whereas the validation resource guarantees issuance has completed.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Certificate Apply.
+* `delete` - (Defaults to 20 mins) Used when delete the Certificate Apply. Withdrawing the application is processed asynchronously and the instance can stay in the pending state for several minutes afterwards; it has to leave that state before the instance itself can be refunded and removed.
+
+## Import
+
+Certificate Management Service (Original SSL Certificate) Certificate Apply can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ssl_certificates_service_certificate_apply.example <instance_id>
+```


### PR DESCRIPTION
Adds `alicloud_ssl_certificates_service_certificate_apply`, which submits a certificate application against a purchased certificate instance and reports the domain ownership validation records the certificate authority expects to be published.

The application is a distinct object from both the instance that pays for it and the certificate it eventually produces: `ApplyCertificate` takes only an instance id and returns no certificate id, while the certificate is keyed separately. Modelling it as its own resource is what allows a configuration to express "apply, then publish these records, then wait", and what allows an application to be withdrawn on destroy without touching the instance or revoking anything.

Notes on the design:

- The application configuration fields (`domain`, `csr`, `validation_method`, `key_algorithm`, `generate_csr_method`) are declared on this resource in addition to the instance. `ApplyCertificate` accepts only the instance id, so without them a change to the instance's application configuration would produce no plan here and the certificate would never be re-applied for. They are `ForceNew` and validated against the instance before the call, so a configuration that sets them inconsistently fails with an explanation rather than silently applying for something else.
- Create waits for the validation records to appear and then hold across consecutive reads: an application is not operable the instant its records are published, and returning earlier hands back a resource that cannot yet be destroyed.
- Destroy calls `CancelPendingCertificate` and waits for the instance to leave the pending state, because a pending instance can be neither refunded nor deleted. Revoking an already-issued certificate is deliberately not done: the certificate is a separate object that other services may be serving, and revocation is irreversible.
- The acceptance test applies for a domain the account does not hold, so the application stays outstanding for the duration. A domain the account does hold is validated by the certificate authority on its own within minutes, which would settle the application before the validation records or the withdrawal could be exercised.

Also fixes a refund race in `alicloud_ssl_certificates_service_instance`: a freshly purchased instance answers `RefundInstance` with `CouldNotRefund.NotSupport` for the first seconds of its life while the purchase order is still settling, which left an instance destroyed right after creation unrefunded and its deletion stuck behind delete protection. The refund is now retried briefly before the refusal is taken at its word; instances that genuinely cannot be refunded keep the existing tolerant behaviour.
