### PR TITLE
resource/alicloud_gpdb_instance: support status to pause or resume a Serverless instance

### DIFF
--- a/alicloud/resource_alicloud_gpdb_instance.go
+++ b/alicloud/resource_alicloud_gpdb_instance.go
@@ -369,8 +369,23 @@ func resourceAliCloudGpdbInstance() *schema.Resource {
 				ForceNew: true,
 			},
 			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"Running", "Stopped"}, false),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// The status returned by the API uses a different vocabulary than
+					// the configurable status: a paused instance is exposed as STOPPED
+					// (or STOPPING while being paused) and a running instance is
+					// exposed as Running (or STARTING while being resumed).
+					if new == "Stopped" && (old == "STOPPED" || old == "STOPPING") {
+						return true
+					}
+					if new == "Running" && (old == "Running" || old == "STARTING") {
+						return true
+					}
+					return false
+				},
 			},
 		},
 	}
@@ -562,6 +577,14 @@ func resourceAliCloudGpdbDbInstanceCreate(d *schema.ResourceData, meta interface
 		sslEnabledStateConf := BuildStateConf([]string{}, []string{fmt.Sprint(v)}, d.Timeout(schema.TimeoutCreate), 5*time.Second, gpdbService.DBInstanceSSLStateRefreshFunc(d, []string{}))
 		if _, err := sslEnabledStateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+
+	// A new instance is always created in the running state, so pause it
+	// afterwards when status is set to Stopped.
+	if v, ok := d.GetOk("status"); ok && fmt.Sprint(v) == "Stopped" {
+		if err := gpdbDbInstancePauseOrResume(client, &gpdbService, d.Id(), "Stopped", d.Timeout(schema.TimeoutCreate)); err != nil {
+			return err
 		}
 	}
 
@@ -1544,9 +1567,80 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 		d.SetPartial("data_share_status")
 	}
 
+	if !d.IsNewResource() && d.HasChange("status") {
+		_, desiredStatusRaw := d.GetChange("status")
+		desiredStatus := desiredStatusRaw.(string)
+		if desiredStatus != "" {
+			if err := gpdbDbInstancePauseOrResume(client, &gpdbService, d.Id(), desiredStatus, d.Timeout(schema.TimeoutUpdate)); err != nil {
+				return err
+			}
+		}
+		d.SetPartial("status")
+	}
+
 	d.Partial(false)
 
 	return resourceAliCloudGpdbDbInstanceRead(d, meta)
+}
+
+// gpdbDbInstancePauseOrResume pauses or resumes an instance according to the
+// desired status ("Stopped" or "Running") and waits until the instance status
+// converges. The API call is skipped when the instance is already in the
+// desired state or is transitioning to it, so the operation is idempotent.
+func gpdbDbInstancePauseOrResume(client *connectivity.AliyunClient, gpdbService *GpdbService, id, desiredStatus string, timeout time.Duration) error {
+	object, err := gpdbService.DescribeGpdbDbInstance(id)
+	if err != nil {
+		return WrapError(err)
+	}
+	currentStatus := fmt.Sprint(object["DBInstanceStatus"])
+	action := ""
+	targetStatus := ""
+	if desiredStatus == "Stopped" {
+		// PauseInstance only takes effect on a running instance, so skip the
+		// call when the instance is already paused or being paused.
+		if currentStatus != "STOPPED" && currentStatus != "STOPPING" {
+			action = "PauseInstance"
+		}
+		targetStatus = "STOPPED"
+	} else if desiredStatus == "Running" {
+		// ResumeInstance only takes effect on a paused instance, so skip the
+		// call when the instance is already running or being resumed.
+		if currentStatus != "Running" && currentStatus != "STARTING" {
+			action = "ResumeInstance"
+		}
+		targetStatus = "Running"
+	} else {
+		return nil
+	}
+	if action != "" {
+		request := map[string]interface{}{
+			"DBInstanceId": id,
+		}
+		var response map[string]interface{}
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(client.GetRetryTimeout(timeout), func() *resource.RetryError {
+			response, err = client.RpcPost("gpdb", "2016-05-03", action, nil, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	// Pausing or resuming an instance is asynchronous, so wait until the
+	// instance status converges to the target one.
+	stateConf := BuildStateConf([]string{}, []string{targetStatus}, timeout, 30*time.Second, gpdbService.GpdbDbInstanceStateRefreshFunc(id, "DBInstanceStatus", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, id)
+	}
+	return nil
 }
 
 func resourceAliCloudGpdbDbInstanceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_gpdb_instance_test.go
+++ b/alicloud/resource_alicloud_gpdb_instance_test.go
@@ -923,6 +923,122 @@ func TestAccAliCloudGPDBDBInstanceServerlessPro(t *testing.T) {
 	})
 }
 
+// Pausing or resuming an instance is only supported for Serverless instances
+// with kernel version V1.0.2.1 or later, so this case runs against a Serverless
+// instance and drives the whole pause -> resume cycle through status.
+func TestAccAliCloudGPDBDBInstanceServerless_status(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_gpdb_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(gpdbServerlessTestRegion())})
+	ra := resourceAttrInit(resourceId, AliCloudGPDBDBInstanceMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GpdbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGpdbDbInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sgpdbdbinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudGPDBDBInstanceBasicDependence1)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"db_instance_mode":      "Serverless",
+					"description":           name,
+					"engine":                "gpdb",
+					"engine_version":        "6.0",
+					"zone_id":               gpdbServerlessTestZone(),
+					"instance_network_type": "VPC",
+					"instance_spec":         "4C16G",
+					"payment_type":          "PayAsYouGo",
+					"seg_node_num":          "2",
+					"vpc_id":                "${data.alicloud_vpcs.default.ids.0}",
+					"vswitch_id":            "${local.vswitch_id}",
+					"serverless_mode":       "Manual",
+					"status":                "Running",
+					"create_sample_data":    "false",
+					"ip_whitelist": []map[string]interface{}{
+						{
+							"security_ip_list": "127.0.0.1",
+						},
+					},
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "acceptance test",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"db_instance_mode": "Serverless",
+						"description":      name,
+						"engine":           "gpdb",
+						"engine_version":   "6.0",
+						"zone_id":          CHECKSET,
+						"status":           "Running",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "Stopped",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "STOPPED",
+					}),
+				),
+			},
+			{
+				// Re-apply the same configuration to make sure a paused instance
+				// does not produce a permanent diff and no extra API call is made.
+				Config: testAccConfig(map[string]interface{}{
+					"status": "Stopped",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "STOPPED",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "Running",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "Running",
+					}),
+				),
+			},
+			{
+				// Removing status from the configuration leaves the instance
+				// unmanaged: no diff is produced and the instance keeps its
+				// current state.
+				Config: testAccConfig(map[string]interface{}{
+					"status": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "Running",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data", "parameters"},
+			},
+		},
+	})
+}
+
 func TestAccAliCloudGPDBDBInstanceServerless_twin(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_gpdb_instance.default"

--- a/website/docs/r/gpdb_instance.html.markdown
+++ b/website/docs/r/gpdb_instance.html.markdown
@@ -142,6 +142,18 @@ The following arguments are supported:
 
   -> **NOTE:** `data_share_status` is valid only when `db_instance_mode` is set to `Serverless`.
 
+* `status` - (Optional, Available since v1.288.0) The expected status of the instance. Valid values:
+  - `Running`: The instance is expected to be running. If the instance is paused, the provider resumes it.
+  - `Stopped`: The instance is expected to be stopped. If the instance is running, the provider pauses it.
+
+  When `status` is not set, it keeps the read-only behavior and the provider does not manage the instance status.
+
+  -> **NOTE:** Setting `status` actually pauses or resumes the instance. Pausing or resuming an instance is supported only for Serverless instances with kernel version V1.0.2.1 or later, the instance must be charged with the PayAsYouGo billing method, and pausing takes effect only when the instance is in the running state. See [PauseInstance](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-pauseinstance) and [ResumeInstance](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-resumeinstance).
+
+  -> **NOTE:** Pausing or resuming an instance is asynchronous. While a pause or resume request is in progress, the status of the instance transitions through `STOPPING` or `STARTING` and then converges to `STOPPED` (paused) or `Running` (resumed).
+
+  -> **NOTE:** `status` does not take part in the instance creation. A new instance is always created in the running state and is paused afterwards when `status` is set to `Stopped`.
+
 * `used_time` - (Optional) The used time. When the parameter `period` is `Year`, the `used_time` value is `1` to `3`. When the parameter `period` is `Month`, the `used_time` value is `1` to `9`. **NOTE:** From provider version 1.287.0, `used_time` is required (together with `period`) when `payment_type` is modified to `Subscription`.
 * `description` - (Optional) The description of the instance.
 * `backup_id` - (Optional, ForceNew, Available since v1.287.0) The ID of the backup set. If specified, the instance is created from the existing backup set. See [CreateDBInstance](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-createdbinstance).
@@ -182,7 +194,7 @@ The parameters supports the following:
 The following attributes are exported:
 
 * `id` - The resource ID in terraform of AnalyticDB for PostgreSQL.
-* `status` - The status of the instance.
+* `status` - The status of the instance. When the instance is paused, the value is `STOPPED`.
 * `connection_string` - (Available since v1.196.0) The connection string of the instance.
 * `port` - (Available since v1.196.0) The connection port of the instance.
 


### PR DESCRIPTION
## Summary
- Make the existing `status` attribute of `alicloud_gpdb_instance` configurable (`Optional` + `Computed`) so that a Serverless instance can be paused and resumed through Terraform. Valid values: `Running` and `Paused`.
- When `status` is not configured, the attribute keeps its previous read-only behavior, so existing configurations are not affected.

## How it works
- On update, when `status` changes the provider calls `PauseInstance` / `ResumeInstance` and waits until the instance status converges (`STOPPED` for paused, `Running` for resumed). The API call is skipped when the instance is already in (or already transitioning to) the target state, so the operation is idempotent.
- The status reported by the API (`Running` / `STARTING` / `STOPPING` / `STOPPED`) uses a different vocabulary than the configurable one (`Running` / `Paused`). A diff suppress function maps between them so that no permanent diff is produced after apply.
- Creating an instance with `status = "Paused"` first creates the instance (a new instance always starts running) and then pauses it.
- Pausing or resuming is only supported for Serverless instances with kernel version V1.0.2.1 or later, and pausing takes effect only on a running PayAsYouGo instance.

## Test plan
- New acceptance case `TestAccAliCloudGPDBDBInstanceServerless_status` drives the full cycle on a Serverless instance: create with `status = "Running"` -> switch to `Paused` (status converges to `STOPPED`) -> re-apply the same configuration (no spurious diff, no extra API call) -> switch back to `Running` -> remove `status` from the configuration (unmanaged, no diff) -> import verify -> destroy.
- `gofmt` clean; `go vet ./alicloud` reports no new warnings.
