### PR TITLE
resource/alicloud_gpdb_instance: support upgrading the minor version of an instance

### DIFF
--- a/alicloud/resource_alicloud_gpdb_instance.go
+++ b/alicloud/resource_alicloud_gpdb_instance.go
@@ -56,6 +56,11 @@ func resourceAliCloudGpdbInstance() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"minor_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"vswitch_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -578,6 +583,9 @@ func resourceAliCloudGpdbDbInstanceRead(d *schema.ResourceData, meta interface{}
 
 	d.Set("engine", object["Engine"])
 	d.Set("engine_version", object["EngineVersion"])
+	if v, ok := object["MinorVersion"]; ok && fmt.Sprint(v) != "" {
+		d.Set("minor_version", v)
+	}
 	d.Set("vswitch_id", object["VSwitchId"])
 	d.Set("db_instance_mode", object["DBInstanceMode"])
 	d.Set("db_instance_category", object["DBInstanceCategory"])
@@ -831,6 +839,49 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
 		d.SetPartial("description")
+	}
+
+	update = false
+	request = map[string]interface{}{
+		"RegionId":     client.RegionId,
+		"DBInstanceId": d.Id(),
+	}
+	if !d.IsNewResource() && d.HasChange("minor_version") {
+		if v, ok := d.GetOk("minor_version"); ok && v.(string) != "" {
+			update = true
+			request["MinorVersion"] = v
+		}
+	}
+	if update {
+		action := "UpgradeDBVersion"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
+			response, err = client.RpcPost("gpdb", "2016-05-03", action, nil, request, true)
+			if err != nil {
+				if IsExpectedErrors(err, []string{"Throttling.User"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		// UpgradeDBVersion is asynchronous and returns a task id: the instance keeps
+		// reporting its previous status and minor version for a short window before the
+		// upgrade takes effect, so wait until the instance is back to a settled status
+		// (Running, or IDLE for serverless instances) and reports the target minor version.
+		minorVersionTarget := fmt.Sprint(request["MinorVersion"])
+		minorVersionStateConf := BuildStateConf([]string{}, []string{minorVersionTarget}, d.Timeout(schema.TimeoutUpdate), 30*time.Second, gpdbService.GpdbDbInstanceMinorVersionStateRefreshFunc(d.Id(), minorVersionTarget))
+		if _, err := minorVersionStateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+
+		d.SetPartial("minor_version")
 	}
 
 	update = false

--- a/alicloud/resource_alicloud_gpdb_instance_test.go
+++ b/alicloud/resource_alicloud_gpdb_instance_test.go
@@ -408,6 +408,99 @@ func TestAccAliCloudGPDBDBInstance_basic0(t *testing.T) {
 	})
 }
 
+// TestAccAliCloudGPDBDBInstance_minorVersion covers the minor_version attribute.
+// GPDB instances are always provisioned with the latest minor version and
+// UpgradeDBVersion cannot downgrade, so a real upgrade to a higher version cannot
+// be triggered deterministically on a freshly created instance (there is no higher
+// target available). This test instead verifies:
+//   - the current minor version is read back into state after creation;
+//   - minor_version is an in-place updatable attribute (a plan changing it must
+//     not force a replacement); this step is plan-only on purpose: UpgradeDBVersion
+//     accepts any version string and applies it asynchronously without synchronous
+//     validation, so pointing it at an unavailable version in an acceptance test
+//     would start a long-running asynchronous task on the instance instead of
+//     failing fast;
+//   - removing the attribute from the configuration keeps the value read back
+//     from the instance (no spurious diff, no upgrade triggered).
+//
+// The UpgradeDBVersion code path itself (request building, Throttling.User retry,
+// waiting for the instance to report the target version while settled) is covered
+// by TestUnitAliCloudGPDBDBInstance because it cannot be reached deterministically
+// in an acceptance environment.
+func TestAccAliCloudGPDBDBInstance_minorVersion(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_gpdb_instance.default"
+	ra := resourceAttrInit(resourceId, AliCloudGPDBDBInstanceMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GpdbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGpdbDbInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sgpdbdbinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudGPDBDBInstanceBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"db_instance_category":  "HighAvailability",
+					"db_instance_class":     "gpdb.group.segsdx1",
+					"db_instance_mode":      "StorageElastic",
+					"engine":                "gpdb",
+					"engine_version":        "6.0",
+					"zone_id":               "${data.alicloud_gpdb_zones.default.ids.0}",
+					"instance_network_type": "VPC",
+					"instance_spec":         "2C16G",
+					"instance_group_count":  "2",
+					"payment_type":          "PayAsYouGo",
+					"seg_storage_type":      "cloud_essd",
+					"seg_node_num":          "4",
+					"storage_size":          "50",
+					"vpc_id":                "${data.alicloud_vpcs.default.ids.0}",
+					"vswitch_id":            "${local.vswitch_id}",
+					"create_sample_data":    "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"minor_version": CHECKSET,
+					}),
+				),
+			},
+			{
+				// Plan-only: verify that changing minor_version is planned as an
+				// in-place update without applying it (see the function comment).
+				Config: testAccConfig(map[string]interface{}{
+					"minor_version": "6.3.11.2",
+				}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"minor_version": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"minor_version": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"period", "used_time", "db_instance_class", "security_ip_list", "instance_group_count", "create_sample_data", "parameters"},
+			},
+		},
+	})
+}
+
 func TestAccAliCloudGPDBDBInstancePrepaid(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_gpdb_instance.default"
@@ -1186,6 +1279,9 @@ func TestUnitAliCloudGPDBDBInstance(t *testing.T) {
 	ReadMockResponse := map[string]interface{}{
 		// DescribeDBInstanceAttribute
 		"Items": map[string]interface{}{
+			// DescribeDataShareInstances returns no data-share membership for
+			// the mocked instance; an empty list keeps the Read path error-free.
+			"DBInstance": []interface{}{},
 			"DBInstanceAttribute": []interface{}{
 				map[string]interface{}{
 					"DBInstanceId":          "CreateDBInstanceValue",
@@ -1195,14 +1291,17 @@ func TestUnitAliCloudGPDBDBInstance(t *testing.T) {
 					"Engine":                "CreateDBInstanceValue",
 					"EngineVersion":         "CreateDBInstanceValue",
 					"InstanceNetworkType":   "CreateDBInstanceValue",
+					"InstanceSpec":          "CreateDBInstanceValue",
 					"MaintainEndTime":       "CreateDBInstanceValue",
 					"MaintainStartTime":     "CreateDBInstanceValue",
 					"MasterNodeNum":         1,
+					"ResourceGroupId":       "CreateDBInstanceValue",
 					"SegmentCounts":         0,
 					"PayType":               "Postpaid",
 					"SegNodeNum":            4,
 					"DBInstanceStatus":      "Running",
 					"StorageSize":           50,
+					"StorageType":           "CreateDBInstanceValue",
 					"VSwitchId":             "CreateDBInstanceValue",
 					"VpcId":                 "CreateDBInstanceValue",
 					"ZoneId":                "CreateDBInstanceValue",
@@ -1253,7 +1352,10 @@ func TestUnitAliCloudGPDBDBInstance(t *testing.T) {
 	}
 
 	// Create
-	patches := gomonkey.ApplyMethod(reflect.TypeOf(&connectivity.AliyunClient{}), "NewGpdbClient", func(_ *connectivity.AliyunClient) (*client.Client, error) {
+	// The GPDB instance resource sends every request through AliyunClient.RpcPost,
+	// so the loadEndpoint failure branch is covered by patching that real method
+	// (there is no NewGpdbClient constructor on AliyunClient).
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(&connectivity.AliyunClient{}), "RpcPost", func(_ *connectivity.AliyunClient, _, _, _ string, _, _ map[string]interface{}, _ bool) (map[string]interface{}, error) {
 		return nil, &tea.SDKError{
 			Code:    String("loadEndpoint error"),
 			Data:    String("loadEndpoint error"),
@@ -1304,7 +1406,7 @@ func TestUnitAliCloudGPDBDBInstance(t *testing.T) {
 	}
 
 	// Update
-	patches = gomonkey.ApplyMethod(reflect.TypeOf(&connectivity.AliyunClient{}), "NewGpdbClient", func(_ *connectivity.AliyunClient) (*client.Client, error) {
+	patches = gomonkey.ApplyMethod(reflect.TypeOf(&connectivity.AliyunClient{}), "RpcPost", func(_ *connectivity.AliyunClient, _, _, _ string, _, _ map[string]interface{}, _ bool) (map[string]interface{}, error) {
 		return nil, &tea.SDKError{
 			Code:    String("loadEndpoint error"),
 			Data:    String("loadEndpoint error"),
@@ -1592,6 +1694,60 @@ func TestUnitAliCloudGPDBDBInstance(t *testing.T) {
 		}
 	}
 
+	// UpgradeDBVersion
+	attributesDiff = map[string]interface{}{
+		"minor_version": "6.6.2.21-202606241529",
+	}
+	diff, err = newInstanceDiff("alicloud_gpdb_instance", attributes, attributesDiff, dInit.State())
+	if err != nil {
+		t.Error(err)
+	}
+	dExisted, _ = schema.InternalMap(p["alicloud_gpdb_instance"].Schema).Data(dInit.State(), diff)
+	ReadMockResponseDiff = map[string]interface{}{
+		// DescribeDBInstanceAttribute Response
+		"Items": map[string]interface{}{
+			"DBInstanceAttribute": []interface{}{
+				map[string]interface{}{
+					"MinorVersion": "6.6.2.21-202606241529",
+				},
+			},
+		},
+	}
+	errorCodes = []string{"NonRetryableError", "Throttling.User", "nil"}
+	for index, errorCode := range errorCodes {
+		retryIndex := index - 1
+		gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, action *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			if *action == "UpgradeDBVersion" {
+				switch errorCode {
+				case "NonRetryableError":
+					return failedResponseMock(errorCode)
+				default:
+					retryIndex++
+					if retryIndex >= len(errorCodes)-1 {
+						return successResponseMock(ReadMockResponseDiff)
+					}
+					return failedResponseMock(errorCodes[retryIndex])
+				}
+			}
+			return ReadMockResponse, nil
+		})
+		err := resourceAliCloudGpdbDbInstanceUpdate(dExisted, rawClient)
+		switch errorCode {
+		case "NonRetryableError":
+			assert.NotNil(t, err)
+		default:
+			assert.Nil(t, err)
+			dCompare, _ := schema.InternalMap(p["alicloud_gpdb_instance"].Schema).Data(dExisted.State(), nil)
+			for key, value := range attributes {
+				_ = dCompare.Set(key, value)
+			}
+			assert.Equal(t, dCompare.State().Attributes, dExisted.State().Attributes)
+		}
+		if retryIndex >= len(errorCodes)-1 {
+			break
+		}
+	}
+
 	// Read
 	errorCodes = []string{"NonRetryableError", "Throttling", "nil", "{}"}
 	for index, errorCode := range errorCodes {
@@ -1623,7 +1779,7 @@ func TestUnitAliCloudGPDBDBInstance(t *testing.T) {
 	}
 
 	// Delete
-	patches = gomonkey.ApplyMethod(reflect.TypeOf(&connectivity.AliyunClient{}), "NewGpdbClient", func(_ *connectivity.AliyunClient) (*client.Client, error) {
+	patches = gomonkey.ApplyMethod(reflect.TypeOf(&connectivity.AliyunClient{}), "RpcPost", func(_ *connectivity.AliyunClient, _, _, _ string, _, _ map[string]interface{}, _ bool) (map[string]interface{}, error) {
 		return nil, &tea.SDKError{
 			Code:    String("loadEndpoint error"),
 			Data:    String("loadEndpoint error"),

--- a/alicloud/service_alicloud_gpdb.go
+++ b/alicloud/service_alicloud_gpdb.go
@@ -799,6 +799,32 @@ func (s *GpdbService) GpdbDbInstanceScaleStateRefreshFunc(id, field, target stri
 	}
 }
 
+// GpdbDbInstanceMinorVersionStateRefreshFunc waits until a minor version upgrade
+// triggered by UpgradeDBVersion has been applied. The upgrade is asynchronous: the
+// instance keeps reporting its previous status and MinorVersion for a short window
+// before the upgrade takes effect, so waiting only for a settled status can return
+// before the new version is applied and leave Read observing the stale value. The
+// upgrade is complete once the instance reports the target MinorVersion while its
+// status is back to Running, or IDLE for serverless instances.
+func (s *GpdbService) GpdbDbInstanceMinorVersionStateRefreshFunc(id, target string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := s.DescribeGpdbDbInstance(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return nil, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		status := fmt.Sprint(object["DBInstanceStatus"])
+		current := fmt.Sprint(object["MinorVersion"])
+		if (status == "Running" || status == "IDLE") && current == target {
+			return object, target, nil
+		}
+		// Not settled yet: report a non-target state so the waiter keeps polling.
+		return object, fmt.Sprintf("%s/%s", status, current), nil
+	}
+}
+
 func (s *GpdbService) DescribeGpdbDbInstancePlan(id string) (object map[string]interface{}, err error) {
 	var response map[string]interface{}
 	action := "DescribeDBInstancePlans"

--- a/website/docs/r/gpdb_instance.html.markdown
+++ b/website/docs/r/gpdb_instance.html.markdown
@@ -75,6 +75,10 @@ The following arguments are supported:
 
 * `engine` - (Required, ForceNew) The database engine used by the instance. Value options can refer to the latest docs [CreateDBInstance](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-createdbinstance) `EngineVersion`.
 * `engine_version` - (Required, ForceNew) The version of the database engine used by the instance.
+* `minor_version` - (Optional, Computed, Available since v1.287.0) The minor version of the instance. When this attribute is changed, the provider calls the [UpgradeDBVersion](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/api-gpdb-2016-05-03-upgradedbversion) operation to upgrade the minor version of the instance and waits until the upgrade is complete. The value must be a valid minor version of the instance's engine version.
+
+  -> **NOTE:** The instance is created with the latest minor version, so this attribute does not take effect at creation time; it only triggers a minor version upgrade when it is changed after the instance is created. The current minor version of the instance is read back into state.
+
 * `vswitch_id` - (Required, ForceNew) The vswitch id.
 * `db_instance_class` - (Optional, ForceNew) The db instance class. see [Instance specifications](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/instance-types).
 


### PR DESCRIPTION
## Summary
- Add a `minor_version` attribute to `alicloud_gpdb_instance`. Changing this attribute triggers the GPDB `UpgradeDBVersion` operation to upgrade the kernel minor version of the instance.
- `UpgradeDBVersion` is asynchronous and returns a task id. After the request succeeds, the provider waits until the instance is back to a settled status (`Running`, or `IDLE` for serverless instances) and `DescribeDBInstanceAttribute` reports the target minor version, so Read does not observe a stale version while the upgrade task is being processed.
- `Throttling.User` and other transient errors are retried with the provider's standard retry/backoff.
- The current minor version is read back into state (`minor_version` is `Optional` + `Computed`): instances are always created with the latest minor version, so the attribute does not take effect at creation time; it only triggers an upgrade when it is changed after the instance is created. Removing the attribute from the configuration keeps the value read back from the instance and does not trigger any upgrade.
- Docs updated for `minor_version`.

## Test plan
- [x] Added `TestAccAliCloudGPDBDBInstance_minorVersion`: create a StorageElastic instance, verify the minor version is read back into state, verify changing `minor_version` is planned as an in-place update (no replacement), verify removing the attribute causes no diff, then import.
- [x] Extended `TestUnitAliCloudGPDBDBInstance` to cover the `UpgradeDBVersion` update branch (request building, `Throttling.User` retry, waiting for the instance to report the target version).
- [x] `gofmt` clean on the changed files; `go vet ./alicloud` reports nothing beyond the pre-existing warnings already present on master.
- [ ] Remote acceptance run results will be posted once completed.
