### PR TITLE
New Resource: alicloud_ssl_certificates_service_certificate_validation

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -958,6 +958,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ssl_certificates_service_contact":                     resourceAliCloudSslCertificatesServiceContact(),
 			"alicloud_ssl_certificates_service_instance":                    resourceAliCloudSslCertificatesServiceInstance(),
 			"alicloud_ssl_certificates_service_certificate_apply":           resourceAliCloudSslCertificatesServiceCertificateApply(),
+			"alicloud_ssl_certificates_service_certificate_validation":      resourceAliCloudSslCertificatesServiceCertificateValidation(),
 			"alicloud_ssl_certificates_service_instance_certificate":        resourceAliCloudSslCertificatesServiceInstanceCertificate(),
 			"alicloud_apig_plugin_class":                                    resourceAliCloudApigPluginClass(),
 			"alicloud_apig_domain":                                          resourceAliCloudApigDomain(),

--- a/alicloud/resource_alicloud_ssl_certificates_service_certificate_validation.go
+++ b/alicloud/resource_alicloud_ssl_certificates_service_certificate_validation.go
@@ -1,0 +1,116 @@
+// This file is maintained by hand. The certificate validation resource is a wait with no backing
+// API of its own — something the generator cannot express — so unlike its sibling files it is not
+// regenerated from a specification.
+package alicloud
+
+import (
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudSslCertificatesServiceCertificateValidation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudSslCertificatesServiceCertificateValidationCreate,
+		Read:   resourceAliCloudSslCertificatesServiceCertificateValidationRead,
+		Delete: resourceAliCloudSslCertificatesServiceCertificateValidationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			// Domain validation and issuance are performed by the certificate authority. A DV
+			// certificate is usually issued within minutes of the validation records going live,
+			// while OV and EV certificates additionally go through a manual review that can take
+			// hours. Raise this timeout accordingly for those.
+			Create: schema.DefaultTimeout(75 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			// The IDs of whatever published the domain ownership validation records — typically
+			// alicloud_alidns_record resources created from the domain_validation_list reported by
+			// alicloud_ssl_certificates_service_certificate_apply. The values map to no API field
+			// and are never read; the attribute exists so that referencing the record IDs here
+			// makes Terraform publish the records before this wait starts, the same way an explicit
+			// depends_on would.
+			"validation_record_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"certificate_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"cert_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudSslCertificatesServiceCertificateValidationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	sslCertificatesServiceServiceV2 := SslCertificatesServiceServiceV2{client}
+
+	// This resource creates nothing. The application was already submitted by
+	// alicloud_ssl_certificates_service_certificate_apply, and the identity of the wait is the
+	// instance whose application is being waited on.
+	d.SetId(d.Get("instance_id").(string))
+
+	// Pending states are left empty on purpose: the intermediate states a certificate passes
+	// through while under review are not documented, and no API reports the progress of the manual
+	// review that OV and EV certificates go through. An empty pending list means "keep waiting
+	// unless the status is a target state or a failure state".
+	stateConf := BuildStateConf([]string{}, []string{"issued"}, d.Timeout(schema.TimeoutCreate), 30*time.Second,
+		sslCertificatesServiceServiceV2.SslCertificatesServiceCertificateValidationStateRefreshFunc(d.Id(), "CertificateStatus", []string{"revoked", "expired"}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return resourceAliCloudSslCertificatesServiceCertificateValidationRead(d, meta)
+}
+
+func resourceAliCloudSslCertificatesServiceCertificateValidationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	sslCertificatesServiceServiceV2 := SslCertificatesServiceServiceV2{client}
+
+	objectRaw, err := sslCertificatesServiceServiceV2.DescribeSslCertificatesServiceCertificateValidation(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ssl_certificates_service_certificate_validation DescribeSslCertificatesServiceCertificateValidation Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("instance_id", d.Id())
+	// CertificateId is typed inconsistently across this product: an integer here and on
+	// GetCertificateDetail, a string on ListCertificates. formatInt normalises whichever form
+	// comes back. It is only set once issuance has produced a certificate.
+	if v, ok := objectRaw["CertificateId"]; ok && v != nil {
+		d.Set("certificate_id", formatInt(v))
+	}
+	d.Set("cert_identifier", objectRaw["CertIdentifier"])
+	d.Set("certificate_status", objectRaw["CertificateStatus"])
+
+	return nil
+}
+
+func resourceAliCloudSslCertificatesServiceCertificateValidationDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource AliCloud Resource Certificate Validation. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_ssl_certificates_service_certificate_validation_test.go
+++ b/alicloud/resource_alicloud_ssl_certificates_service_certificate_validation_test.go
@@ -1,0 +1,140 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// Test SslCertificatesService CertificateValidation. >>> Resource test cases.
+
+// The wait is exercised against an instance whose certificate has already been issued, adopted
+// through the data source rather than issued here. Issuing a certificate inside the test would
+// mean buying an instance that can never be cleaned up afterwards — once a certificate has been
+// issued, the instance can be neither refunded nor deleted — so past issuance runs have left the
+// test account holding such instances permanently, and this test adopts one of those instead of
+// adding to them. Against an issued certificate the waiter returns on its first poll, which is
+// the wait's success path; the failure path is covered by the unissuable case below.
+func TestAccAliCloudSslCertificatesServiceCertificateValidation_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ssl_certificates_service_certificate_validation.default"
+	ra := resourceAttrInit(resourceId, AliCloudSslCertificatesServiceCertificateValidationMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &SslCertificatesServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeSslCertificatesServiceCertificateValidation")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccsslcasvalidation%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudSslCertificatesServiceCertificateValidationBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		// Destroying a wait calls no API, and the adopted instance belongs to the account, not to
+		// this test — there is nothing whose absence could be asserted.
+		CheckDestroy: func(s *terraform.State) error {
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_id": "${data.alicloud_ssl_certificates_service_instances.default.instances.0.instance_id}",
+					// The value is opaque to the resource — validation_record_ids maps to no API
+					// field and exists to order the wait after whatever publishes the validation
+					// records, so any string exercises exactly what the attribute does. The adopted
+					// certificate was validated before this test ran; nothing here published records.
+					"validation_record_ids": []string{"${data.alicloud_ssl_certificates_service_instances.default.instances.0.instance_id}"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_id":        CHECKSET,
+						"certificate_id":     CHECKSET,
+						"cert_identifier":    CHECKSET,
+						"certificate_status": "issued",
+					}),
+				),
+			},
+			{
+				ResourceName: resourceId,
+				ImportState:  true,
+				// Per-attribute verification is off because validation_record_ids exists only to
+				// order the graph — it maps to no API field and is never read back, so an imported
+				// wait cannot recover it.
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+var AliCloudSslCertificatesServiceCertificateValidationMap = map[string]string{
+	"id":          CHECKSET,
+	"instance_id": CHECKSET,
+}
+
+func AliCloudSslCertificatesServiceCertificateValidationBasicDependence(name string) string {
+	return `
+data "alicloud_ssl_certificates_service_instances" "default" {
+  certificate_status = "issued"
+}
+`
+}
+
+// The failure path: an application for a domain the account does not hold never validates, so the
+// certificate is never issued and the wait must surface that rather than report success. A short
+// create timeout keeps the case fast — the assertion is that the waiter gives up loudly, and on
+// what error.
+//
+// The unissuable domain is also what makes this case self-cleaning, unlike the issued case above:
+// a certificate that was never issued leaves the application withdrawable and the instance
+// refundable, so the destroy step tears the whole chain down and asserts that in passing.
+func TestAccAliCloudSslCertificatesServiceCertificateValidation_unissuable(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccsslcasvalidation%d", rand)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		// The destroy step itself is the cleanup assertion: it fails the test if the application
+		// cannot be withdrawn or the instance cannot be refunded and deleted.
+		CheckDestroy: func(s *terraform.State) error {
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+%s
+
+resource "alicloud_ssl_certificates_service_certificate_apply" "default" {
+  instance_id         = alicloud_ssl_certificates_service_instance.default.id
+  domain              = alicloud_ssl_certificates_service_instance.default.domain
+  validation_method   = alicloud_ssl_certificates_service_instance.default.validation_method
+  key_algorithm       = alicloud_ssl_certificates_service_instance.default.key_algorithm
+  generate_csr_method = alicloud_ssl_certificates_service_instance.default.generate_csr_method
+}
+
+resource "alicloud_ssl_certificates_service_certificate_validation" "default" {
+  instance_id = alicloud_ssl_certificates_service_certificate_apply.default.instance_id
+
+  timeouts {
+    create = "3m"
+  }
+}
+`, AliCloudSslCertificatesServiceCertificateApplyBasicDependence(name)),
+				ExpectError: regexp.MustCompile("timeout while waiting for state to become 'issued'"),
+			},
+		},
+	})
+}
+
+// Test SslCertificatesService CertificateValidation. <<< Resource test cases.

--- a/alicloud/service_alicloud_ssl_certificates_service_v2.go
+++ b/alicloud/service_alicloud_ssl_certificates_service_v2.go
@@ -686,3 +686,73 @@ func (s *SslCertificatesServiceServiceV2) SslCertificatesServiceInstanceCertific
 }
 
 // DescribeSslCertificatesServiceInstanceCertificate >>> Encapsulated.
+
+// DescribeSslCertificatesServiceCertificateValidation <<< Encapsulated get interface for SslCertificatesService CertificateValidation.
+func (s *SslCertificatesServiceServiceV2) DescribeSslCertificatesServiceCertificateValidation(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["InstanceId"] = id
+
+	action := "GetInstanceDetail"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("cas", "2020-04-07", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NotFound"}) {
+			return object, WrapErrorf(NotFoundErr("CertificateValidation", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *SslCertificatesServiceServiceV2) SslCertificatesServiceCertificateValidationStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.SslCertificatesServiceCertificateValidationStateRefreshFuncWithApi(id, field, failStates, s.DescribeSslCertificatesServiceCertificateValidation)
+}
+
+func (s *SslCertificatesServiceServiceV2) SslCertificatesServiceCertificateValidationStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeSslCertificatesServiceCertificateValidation >>> Encapsulated.

--- a/website/docs/r/ssl_certificates_service_certificate_validation.html.markdown
+++ b/website/docs/r/ssl_certificates_service_certificate_validation.html.markdown
@@ -1,0 +1,124 @@
+---
+subcategory: "Certificate Management Service (Original SSL Certificate)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ssl_certificates_service_certificate_validation"
+description: |-
+  Provides a Alicloud Certificate Management Service (Original SSL Certificate) Certificate Validation resource.
+---
+
+# alicloud_ssl_certificates_service_certificate_validation
+
+Provides a Certificate Management Service (Original SSL Certificate) Certificate Validation resource.
+
+Waits until the certificate application submitted on a certificate instance has been issued, and exposes the resulting certificate for downstream services to reference.
+
+Certificate validation is the step between applying and issuance: the certificate authority verifies that the applicant controls the domain — for a DV certificate typically by checking a DNS record published under it, carrying the values that `alicloud_ssl_certificates_service_certificate_apply` reports in `domain_validation_list`. Once that verification passes, the authority issues the certificate a few minutes later. This resource represents the wait for that outcome.
+
+For information about Certificate Management Service (Original SSL Certificate) and domain validation, see [SSL Certificates Service](https://www.alibabacloud.com/help/product/28533.html).
+
+-> **NOTE:** Available since v1.287.0.
+
+~> **NOTE:** This resource creates nothing in the cloud. It only waits: after the application has been submitted and the domain validation records have been published, it polls the instance until the certificate is issued. Destroying it calls no API and leaves the certificate untouched. It exists so that downstream resources can depend on a certificate that has actually been issued, rather than on one that has merely been requested.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_ssl_certificates_service_instance" "default" {
+  product_type      = "cas"
+  period            = 12
+  pricing_cycle     = 2
+  instance_name     = var.name
+  domain            = "example.com"
+  validation_method = "DNS"
+
+  parameter {
+    code  = "fullSpec"
+    value = "ws.dv.f"
+  }
+  parameter {
+    code  = "fullDomainCount"
+    value = "1"
+  }
+}
+
+resource "alicloud_ssl_certificates_service_certificate_apply" "default" {
+  instance_id       = alicloud_ssl_certificates_service_instance.default.id
+  domain            = alicloud_ssl_certificates_service_instance.default.domain
+  validation_method = alicloud_ssl_certificates_service_instance.default.validation_method
+}
+
+resource "alicloud_alidns_record" "default" {
+  for_each = {
+    for v in alicloud_ssl_certificates_service_certificate_apply.default.domain_validation_list :
+    v.domain => v
+  }
+  domain_name = each.value.root_domain
+  rr          = each.value.validation_key
+  type        = each.value.validation_type
+  value       = each.value.validation_value
+  ttl         = 600
+}
+
+resource "alicloud_ssl_certificates_service_certificate_validation" "default" {
+  instance_id           = alicloud_ssl_certificates_service_instance.default.id
+  validation_record_ids = [for r in alicloud_alidns_record.default : r.id]
+
+  timeouts {
+    create = "120m"
+  }
+}
+```
+
+Downstream services should reference the certificate exposed by this resource, so that the reference is only resolved once the certificate actually exists:
+
+```terraform
+resource "alicloud_alb_listener" "default" {
+  certificates {
+    certificate_id = alicloud_ssl_certificates_service_certificate_validation.default.cert_identifier
+  }
+}
+```
+
+### Deleting `alicloud_ssl_certificates_service_certificate_validation` or removing it from your configuration
+
+Terraform cannot destroy resource `alicloud_ssl_certificates_service_certificate_validation`. Terraform will remove this resource from the state file, however resources may remain.
+
+## Argument Reference
+
+The following arguments are supported:
+* `instance_id` - (Required, ForceNew) The ID of the certificate instance whose application is being waited on.
+* `validation_record_ids` - (Optional, ForceNew, List) The IDs of the DNS records carrying the domain ownership validation information. The values themselves are never read; they exist so that Terraform creates the validation records before it starts waiting for issuance.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+* `certificate_id` - The ID of the issued certificate.
+* `cert_identifier` - The global certificate identifier, formatted as the certificate ID plus `-` plus the site region ID. Alibaba Cloud services such as ALB, CDN and WAF reference a certificate by this value.
+* `certificate_status` - The status of the issued certificate.
+
+-> **NOTE:** Enabling managed renewal on the certificate instance causes a **new certificate** to be issued when the certificate is renewed, which changes `certificate_id` and `cert_identifier`. Resources referencing these attributes pick up the new certificate on the next apply.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 75 mins) Used when waiting for the certificate to be issued. A DV certificate is usually issued within minutes of the validation records going live. OV and EV certificates additionally go through a manual review that can take hours and exposes no progress API, so raise this timeout for them.
+* `delete` - (Defaults to 5 mins) Used when delete the Certificate Validation.
+
+## Import
+
+Certificate Management Service (Original SSL Certificate) Certificate Validation can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ssl_certificates_service_certificate_validation.example <instance_id>
+```


### PR DESCRIPTION
### Summary

Adds `alicloud_ssl_certificates_service_certificate_validation` for Certificate Management Service
(Original SSL Certificate).

`alicloud_ssl_certificates_service_certificate_apply` submits an application and reports the domain
validation records the certificate authority wants published, but issuance happens on the authority's
side and takes minutes. This resource is the wait in between: it blocks until the certificate reaches
`issued`, so anything that consumes the certificate can depend on it.

### Notes

- **It calls no API of its own.** Create polls `GetInstanceDetail` until `CertificateStatus` becomes
  `issued`; `revoked` and `expired` are treated as failure states. Destroying it does nothing — the
  certificate it waited for goes on existing, so the resource is simply dropped from state.

- **`validation_record_ids` maps to no API field.** It exists so a configuration can order the wait
  after whatever publishes the domain validation records, in the same way `depends_on` would. It is
  never read back, which is why import verification is off for this resource.

- **Create is given a 75-minute timeout.** Issuance time is set by the certificate authority, not by
  the API, and DV issuance has been observed taking upwards of ten minutes.

### Acceptance tests

Two cases in `cn-hangzhou`, one per outcome of a wait:

- `_basic` — the success path. It adopts an instance whose certificate has already been issued,
  found through the `alicloud_ssl_certificates_service_instances` data source, and asserts the wait
  completes and reports the certificate. Adopting rather than issuing is deliberate: an instance
  whose certificate has been issued can be neither refunded nor deleted, so a test that issued its
  own certificate would permanently leave a paid instance behind on every run.

- `_unissuable` — the failure path. It applies for a certificate on a domain the account does not
  hold, so validation never succeeds, and asserts the wait times out loudly rather than reporting
  success. Because nothing is ever issued, the application can be withdrawn and the instance
  refunded — the destroy step tears the whole chain down and doubles as the cleanup assertion.
