### PR TITLE
New Resource: alicloud_iac_service_module; New Data Source: alicloud_iac_service_modules

### DIFF
--- a/alicloud/connectivity/endpoint.go
+++ b/alicloud/connectivity/endpoint.go
@@ -348,6 +348,7 @@ var irregularProductEndpoint = map[string]string{
 	"alidns":                  "alidns.aliyuncs.com",
 	"openapiexplorer":         "openapi-mcp.cn-hangzhou.aliyuncs.com",
 	"computenestsupplier":     "computenestsupplier.cn-hangzhou.aliyuncs.com",
+	"iacservice":              "iac.cn-zhangjiakou.aliyuncs.com",
 }
 
 // irregularProductEndpointForIntlRegion specially records those product codes that

--- a/alicloud/data_source_alicloud_ia_c_service_modules.go
+++ b/alicloud/data_source_alicloud_ia_c_service_modules.go
@@ -1,0 +1,304 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAliCloudIaCServiceModules() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudIaCServiceModuleRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsValidRegExp,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"module_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"page_number": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"page_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"modules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"latest_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"module_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"module_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"group_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"group_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"project_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"project_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"tag_key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"tag_value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudIaCServiceModuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	action := fmt.Sprintf("/modules")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	if v, ok := d.GetOk("group_id"); ok {
+		query["groupId"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("module_name"); ok {
+		query["keyword"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("project_id"); ok {
+		query["projectId"] = StringPointer(v.(string))
+	}
+
+	pageSize := PageSizeLarge
+	if v, ok := d.GetOk("page_size"); ok && v.(int) > 0 {
+		pageSize = v.(int)
+	}
+	pageNumber := 1
+	if v, ok := d.GetOk("page_number"); ok && v.(int) > 0 {
+		pageNumber = v.(int)
+	}
+	query["pageSize"] = StringPointer(strconv.Itoa(pageSize))
+	query["pageNumber"] = StringPointer(strconv.Itoa(pageNumber))
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaGet("IaCService", "2021-08-06", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.modules[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["name"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["moduleId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < pageSize {
+			break
+		}
+		pageNumber++
+		query["pageNumber"] = StringPointer(strconv.Itoa(pageNumber))
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["moduleId"]
+
+		mapping["create_time"] = objectRaw["createTime"]
+		mapping["description"] = objectRaw["description"]
+		mapping["latest_version"] = objectRaw["latestVersion"]
+		mapping["module_name"] = objectRaw["name"]
+		mapping["source"] = objectRaw["source"]
+		mapping["status"] = objectRaw["status"]
+		mapping["module_id"] = objectRaw["moduleId"]
+
+		groupInfoRaw := objectRaw["groupInfo"]
+		groupInfoMaps := make([]map[string]interface{}, 0)
+		if groupInfoRaw != nil {
+			groupInfoMap := make(map[string]interface{})
+			groupInfoChildRaw := groupInfoRaw.(map[string]interface{})
+			groupInfoMap["group_id"] = groupInfoChildRaw["groupId"]
+			groupInfoMap["group_name"] = groupInfoChildRaw["groupName"]
+			groupInfoMap["project_id"] = groupInfoChildRaw["projectId"]
+			groupInfoMap["project_name"] = groupInfoChildRaw["projectName"]
+
+			groupInfoMaps = append(groupInfoMaps, groupInfoMap)
+		}
+		mapping["group_info"] = groupInfoMaps
+		tagsRaw := objectRaw["tags"]
+		tagsMaps := make([]map[string]interface{}, 0)
+		if tagsRaw != nil {
+			for _, tagsChildRaw := range convertToInterfaceArray(tagsRaw) {
+				tagsMap := make(map[string]interface{})
+				tagsChildRaw := tagsChildRaw.(map[string]interface{})
+				tagsMap["tag_key"] = tagsChildRaw["tagKey"]
+				tagsMap["tag_value"] = tagsChildRaw["tagValue"]
+
+				tagsMaps = append(tagsMaps, tagsMap)
+			}
+		}
+		mapping["tags"] = tagsMaps
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["name"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("modules", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_ia_c_service_modules_test.go
+++ b/alicloud/data_source_alicloud_ia_c_service_modules_test.go
@@ -1,0 +1,113 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudIaCServiceModuleDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testacc%siacmodule%d", defaultRegionToTest, rand)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudIaCServiceModuleSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ia_c_service_module.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAliCloudIaCServiceModuleSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ia_c_service_module.default.id}_fake"]`,
+		}),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudIaCServiceModuleSourceConfig(rand, map[string]string{
+			"name_regex": fmt.Sprintf("\"^%s$\"", name),
+		}),
+		fakeConfig: testAccCheckAliCloudIaCServiceModuleSourceConfig(rand, map[string]string{
+			"name_regex": fmt.Sprintf("\"^%s_fake$\"", name),
+		}),
+	}
+
+	moduleNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudIaCServiceModuleSourceConfig(rand, map[string]string{
+			"module_name": `"${alicloud_ia_c_service_module.default.module_name}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudIaCServiceModuleSourceConfig(rand, map[string]string{
+			"module_name": `"${alicloud_ia_c_service_module.default.module_name}_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudIaCServiceModuleSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ia_c_service_module.default.id}"]`,
+			"name_regex":  fmt.Sprintf("\"^%s$\"", name),
+			"module_name": `"${alicloud_ia_c_service_module.default.module_name}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudIaCServiceModuleSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ia_c_service_module.default.id}_fake"]`,
+			"name_regex":  fmt.Sprintf("\"^%s_fake$\"", name),
+			"module_name": `"${alicloud_ia_c_service_module.default.module_name}_fake"`,
+		}),
+	}
+
+	IaCServiceModuleCheckInfo.dataSourceTestCheck(t, rand, idsConf, nameRegexConf, moduleNameConf, allConf)
+}
+
+var existIaCServiceModuleMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"modules.#":                  "1",
+		"modules.0.module_id":        CHECKSET,
+		"modules.0.module_name":      CHECKSET,
+		"modules.0.description":      CHECKSET,
+		"modules.0.source":           CHECKSET,
+		"modules.0.status":           CHECKSET,
+		"modules.0.create_time":      CHECKSET,
+		"modules.0.tags.#":           "1",
+		"modules.0.tags.0.tag_key":   CHECKSET,
+		"modules.0.tags.0.tag_value": CHECKSET,
+	}
+}
+
+var fakeIaCServiceModuleMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"modules.#": "0",
+	}
+}
+
+var IaCServiceModuleCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_ia_c_service_modules.default",
+	existMapFunc: existIaCServiceModuleMapFunc,
+	fakeMapFunc:  fakeIaCServiceModuleMapFunc,
+}
+
+func testAccCheckAliCloudIaCServiceModuleSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	name := fmt.Sprintf("tf-testacc%siacmodule%d", defaultRegionToTest, rand)
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "%s"
+}
+
+resource "alicloud_ia_c_service_module" "default" {
+  module_name      = var.name
+  source           = "Registry"
+  source_path      = "alibaba/security-group:2.4.1"
+  version_strategy = "Manual"
+  description      = var.name
+  tags {
+    tag_key   = "Created"
+    tag_value = "TF"
+  }
+}
+
+data "alicloud_ia_c_service_modules" "default" {
+%s
+}
+`, name, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -946,6 +946,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
 			"alicloud_das_sql_log_configs":                              dataSourceAliCloudDasSqlLogConfigs(),
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
+			"alicloud_ia_c_service_modules":                             dataSourceAliCloudIaCServiceModules(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),
@@ -2128,6 +2129,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_polardb_zonal_db_cluster":                              resourceAliCloudPolarDbZonalCluster(),
 			"alicloud_polardb_zonal_endpoint":                                resourceAlicloudPolarDBZonalEndpoint(),
 			"alicloud_polardb_zonal_account":                                 resourceAlicloudPolarDBZonalAccount(),
+			"alicloud_ia_c_service_module":                                   resourceAliCloudIaCServiceModule(),
 		},
 	}
 	provider.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {

--- a/alicloud/resource_alicloud_ia_c_service_module.go
+++ b/alicloud/resource_alicloud_ia_c_service_module.go
@@ -1,0 +1,368 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudIaCServiceModule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudIaCServiceModuleCreate,
+		Read:   resourceAliCloudIaCServiceModuleRead,
+		Update: resourceAliCloudIaCServiceModuleUpdate,
+		Delete: resourceAliCloudIaCServiceModuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"group_info": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"latest_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"module_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"output_path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"source_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"state_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"tag_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"version_strategy": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudIaCServiceModuleCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/modules")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["name"] = d.Get("module_name")
+	request["source"] = d.Get("source")
+	if v, ok := d.GetOk("description"); ok {
+		request["description"] = v
+	}
+	if v, ok := d.GetOk("source_path"); ok {
+		request["sourcePath"] = v
+	}
+	if v, ok := d.GetOk("state_path"); ok {
+		request["statePath"] = v
+	}
+	if v, ok := d.GetOk("version_strategy"); ok {
+		request["versionStrategy"] = v
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		tagsMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(v) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := make(map[string]interface{})
+			dataLoopMap["tagKey"] = dataLoopTmp["tag_key"]
+			dataLoopMap["tagValue"] = dataLoopTmp["tag_value"]
+			tagsMapsArray = append(tagsMapsArray, dataLoopMap)
+		}
+		request["tags"] = tagsMapsArray
+	}
+
+	request["clientToken"] = buildClientToken(action)
+
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("IaCService", "2021-08-06", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ia_c_service_module", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.moduleId", response)
+	d.SetId(fmt.Sprint(id))
+
+	iaCServiceServiceV2 := IaCServiceServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{"Created"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, iaCServiceServiceV2.IaCServiceModuleStateRefreshFunc(d.Id(), "status", []string{"Errored"}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return resourceAliCloudIaCServiceModuleRead(d, meta)
+}
+
+func resourceAliCloudIaCServiceModuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	iaCServiceServiceV2 := IaCServiceServiceV2{client}
+
+	objectRaw, err := iaCServiceServiceV2.DescribeIaCServiceModule(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ia_c_service_module DescribeIaCServiceModule Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("create_time", objectRaw["createTime"])
+	d.Set("description", objectRaw["description"])
+	d.Set("latest_version", objectRaw["latestVersion"])
+	d.Set("module_name", objectRaw["name"])
+	d.Set("output_path", objectRaw["outputPath"])
+	d.Set("source", objectRaw["source"])
+	d.Set("source_path", objectRaw["sourcePath"])
+	d.Set("state_path", objectRaw["statePath"])
+	d.Set("status", objectRaw["status"])
+	d.Set("version_strategy", objectRaw["versionStrategy"])
+
+	groupInfoRaw := objectRaw["groupInfo"]
+	groupInfoMaps := make([]map[string]interface{}, 0)
+	if groupInfoRaw != nil {
+		groupInfoMap := make(map[string]interface{})
+		groupInfoChildRaw := groupInfoRaw.(map[string]interface{})
+		groupInfoMap["group_id"] = groupInfoChildRaw["groupId"]
+		groupInfoMap["group_name"] = groupInfoChildRaw["groupName"]
+		groupInfoMap["project_id"] = groupInfoChildRaw["projectId"]
+		groupInfoMap["project_name"] = groupInfoChildRaw["projectName"]
+
+		groupInfoMaps = append(groupInfoMaps, groupInfoMap)
+	}
+	if err := d.Set("group_info", groupInfoMaps); err != nil {
+		return err
+	}
+	tagsRaw := objectRaw["tags"]
+	tagsMaps := make([]map[string]interface{}, 0)
+	if tagsRaw != nil {
+		for _, tagsChildRaw := range convertToInterfaceArray(tagsRaw) {
+			tagsMap := make(map[string]interface{})
+			tagsChildRaw := tagsChildRaw.(map[string]interface{})
+			tagsMap["tag_key"] = tagsChildRaw["tagKey"]
+			tagsMap["tag_value"] = tagsChildRaw["tagValue"]
+
+			tagsMaps = append(tagsMaps, tagsMap)
+		}
+	}
+	if err := d.Set("tags", tagsMaps); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAliCloudIaCServiceModuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var body map[string]interface{}
+	update := false
+
+	var err error
+	moduleId := d.Id()
+	action := fmt.Sprintf("/modules/%s", moduleId)
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+
+	if d.HasChange("module_name") {
+		update = true
+	}
+	request["name"] = d.Get("module_name")
+	if d.HasChange("description") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("description"); ok || d.HasChange("description") {
+		request["description"] = v
+	}
+	if d.HasChange("source_path") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("source_path"); ok || d.HasChange("source_path") {
+		request["sourcePath"] = v
+	}
+	if d.HasChange("state_path") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("state_path"); ok || d.HasChange("state_path") {
+		request["statePath"] = v
+	}
+	if d.HasChange("version_strategy") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("version_strategy"); ok || d.HasChange("version_strategy") {
+		request["versionStrategy"] = v
+	}
+	if d.HasChange("tags") {
+		update = true
+		tagsMapsArray := make([]interface{}, 0)
+		if v, ok := d.GetOk("tags"); ok {
+			for _, dataLoop := range convertToInterfaceArray(v) {
+				dataLoopTmp := dataLoop.(map[string]interface{})
+				dataLoopMap := make(map[string]interface{})
+				dataLoopMap["tagKey"] = dataLoopTmp["tag_key"]
+				dataLoopMap["tagValue"] = dataLoopTmp["tag_value"]
+				tagsMapsArray = append(tagsMapsArray, dataLoopMap)
+			}
+		}
+		request["tags"] = tagsMapsArray
+	}
+
+	request["clientToken"] = buildClientToken(action)
+
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPut("IaCService", "2021-08-06", action, query, nil, body, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		iaCServiceServiceV2 := IaCServiceServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{"Created"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, iaCServiceServiceV2.IaCServiceModuleStateRefreshFunc(d.Id(), "status", []string{"Errored"}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+
+	return resourceAliCloudIaCServiceModuleRead(d, meta)
+}
+
+func resourceAliCloudIaCServiceModuleDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	moduleId := d.Id()
+	action := fmt.Sprintf("/modules/%s", moduleId)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("IaCService", "2021-08-06", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"InvalidModule.NotFound"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ia_c_service_module_test.go
+++ b/alicloud/resource_alicloud_ia_c_service_module_test.go
@@ -1,0 +1,125 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test IaCService Module. >>> Resource test cases, automatically generated.
+// Case Module lifecycle test
+func TestAccAliCloudIaCServiceModule_basic0(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ia_c_service_module.default"
+	ra := resourceAttrInit(resourceId, AlicloudIaCServiceModuleMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &IaCServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeIaCServiceModule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%siacmodule%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudIaCServiceModuleBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"module_name":      name,
+					"source":           "Registry",
+					"source_path":      "alibaba/security-group:2.4.1",
+					"version_strategy": "Manual",
+					"description":      "tf-testacc module",
+					"tags": []map[string]interface{}{
+						{
+							"tag_key":   "Created",
+							"tag_value": "TF",
+						},
+						{
+							"tag_key":   "For",
+							"tag_value": "Test",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"module_name":      name,
+						"source":           "Registry",
+						"source_path":      "alibaba/security-group:2.4.1",
+						"version_strategy": "Manual",
+						"description":      "tf-testacc module",
+						"tags.#":           "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"module_name": name + "_update",
+					"description": "tf-testacc module update",
+					"source_path": "terraform-alicloud-modules/mongodb:3.0.0",
+					"state_path":  "oss::https://example-bucket.oss-cn-zhangjiakou.aliyuncs.com/terraform.tfstate",
+					"tags": []map[string]interface{}{
+						{
+							"tag_key":   "Created-update",
+							"tag_value": "TF-update",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"module_name": name + "_update",
+						"description": "tf-testacc module update",
+						"source_path": "terraform-alicloud-modules/mongodb:3.0.0",
+						"state_path":  "oss::https://example-bucket.oss-cn-zhangjiakou.aliyuncs.com/terraform.tfstate",
+						"tags.#":      "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"version_strategy": "SourcePathUpdated",
+					"state_path":       "oss::https://example-bucket.oss-cn-zhangjiakou.aliyuncs.com/terraform-update.tfstate",
+					"tags":             REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"version_strategy": "SourcePathUpdated",
+						"state_path":       "oss::https://example-bucket.oss-cn-zhangjiakou.aliyuncs.com/terraform-update.tfstate",
+						"tags.#":           "0",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudIaCServiceModuleMap0 = map[string]string{
+	"status":      CHECKSET,
+	"create_time": CHECKSET,
+	"output_path": CHECKSET,
+}
+
+func AlicloudIaCServiceModuleBasicDependence0(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Test IaCService Module. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_ia_c_service_v2.go
+++ b/alicloud/service_alicloud_ia_c_service_v2.go
@@ -1,0 +1,90 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+type IaCServiceServiceV2 struct {
+	client *connectivity.AliyunClient
+}
+
+// DescribeIaCServiceModule <<< Encapsulated get interface for IaCService Module.
+
+func (s *IaCServiceServiceV2) DescribeIaCServiceModule(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	moduleId := id
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	action := fmt.Sprintf("/modules/%s", moduleId)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RoaGet("IaCService", "2021-08-06", action, query, nil, nil)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"InvalidModule.NotFound"}) {
+			return object, WrapErrorf(NotFoundErr("Module", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.module", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.module", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *IaCServiceServiceV2) IaCServiceModuleStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.IaCServiceModuleStateRefreshFuncWithApi(id, field, failStates, s.DescribeIaCServiceModule)
+}
+
+func (s *IaCServiceServiceV2) IaCServiceModuleStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}

--- a/website/docs/d/ia_c_service_modules.html.markdown
+++ b/website/docs/d/ia_c_service_modules.html.markdown
@@ -1,0 +1,61 @@
+---
+subcategory: "IaC Service (IaCService)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ia_c_service_modules"
+sidebar_current: "docs-alicloud-datasource-ia-c-service-modules"
+description: |-
+  Provides a list of IaC Service Module owned by an Alibaba Cloud account.
+---
+
+# alicloud_ia_c_service_modules
+
+This data source provides IaC Service Module available to the user.[What is Module](https://next.api.alibabacloud.com/document/IaCService/2021-08-06/CreateModule)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+data "alicloud_ia_c_service_modules" "default" {
+
+}
+
+output "first_module_id" {
+  value = data.alicloud_ia_c_service_modules.default.modules[0].module_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `group_id` - (Optional, ForceNew) The ID of the group to which the modules belong.
+* `module_name` - (Optional, ForceNew) The keyword of the module name.
+* `page_number` - (Optional, ForceNew) The page number. Default value: `1`.
+* `page_size` - (Optional, ForceNew) The number of entries per page. Default value: `20`. Maximum value: `100`.
+* `project_id` - (Optional, ForceNew) The ID of the project to which the modules belong.
+* `ids` - (Optional, Computed, List) A list of Module IDs.
+* `name_regex` - (Optional) A regex string to filter results by the module name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `names` - A list of name of Module Entries.
+* `modules` - A list of Module Entries. Each element contains the following attributes:
+  * `module_id` - The ID of the module.
+  * `create_time` - The time when the module was created.
+  * `description` - The description of the module.
+  * `latest_version` - The latest version number of the module.
+  * `module_name` - The name of the module.
+  * `source` - The source of the module.
+  * `status` - The status of the module.
+  * `group_info` - The group information of the module. Each element contains the following attributes:
+    * `group_id` - The ID of the group to which the module belongs.
+    * `group_name` - The name of the group to which the module belongs.
+    * `project_id` - The ID of the project to which the module belongs.
+    * `project_name` - The name of the project to which the module belongs.
+  * `tags` - The tags of the module. Each element contains the following attributes:
+    * `tag_key` - The key of the tag.
+    * `tag_value` - The value of the tag.
+  * `id` - The ID of the module.

--- a/website/docs/r/ia_c_service_module.html.markdown
+++ b/website/docs/r/ia_c_service_module.html.markdown
@@ -1,0 +1,96 @@
+---
+subcategory: "IaC Service (IaCService)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ia_c_service_module"
+description: |-
+  Provides a Alicloud IaC Service Module resource.
+---
+
+# alicloud_ia_c_service_module
+
+Provides a IaC Service Module resource.
+
+Module.
+
+For information about IaC Service Module and how to use it, see [What is Module](https://next.api.alibabacloud.com/document/IaCService/2021-08-06/CreateModule).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-zhangjiakou"
+}
+
+resource "alicloud_ia_c_service_module" "default" {
+  module_name      = var.name
+  source           = "Registry"
+  source_path      = "alibaba/security-group:2.4.1"
+  version_strategy = "Manual"
+  description      = var.name
+  tags {
+    tag_key   = "Created"
+    tag_value = "TF"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `description` - (Optional) The description of the module.
+* `module_name` - (Required) The name of the module.
+* `source` - (Required, ForceNew) The source of the module. Valid values: `OSS`, `Registry`, `ExportTask`, `Upload`, `Shared`, `Editor`.
+* `source_path` - (Optional) The path of the module source. The format depends on the value of `source`:
+  - When `source` is set to `Registry`, the value is `<workspace name>/<module name>:<module version>`, for example `terraform-alicloud-modules/rds:1.0.0`.
+  - When `source` is set to `OSS`, the value is `oss::<file link>`, for example `oss::https://example-bucket.oss-cn-zhangjiakou.aliyuncs.com/code.zip`.
+  - When `source` is set to `ExportTask`, the value is `<export task ID>:<exported version>`, for example `ex-example1:1.0.0`.
+* `state_path` - (Optional) The path of the state file that corresponds to the module. It is currently valid only for the `OSS` source. The value is in the format of `oss::<OSS path of the state file>`, for example `oss::https://example-bucket.oss-cn-zhangjiakou.aliyuncs.com/terraform.tfstate`.
+* `version_strategy` - (Optional, Computed) The version generation policy of the module. Valid values: `Manual`, `SourcePathUpdated`. Default value: `Manual`. `Manual` means that versions are generated manually. `SourcePathUpdated` means that a new version is generated when `source_path` is changed.
+* `tags` - (Optional, Set) A mapping of tags to assign to the module. See [`tags`](#tags) below.
+
+### `tags`
+
+The tags supports the following:
+* `tag_key` - (Required) The key of the tag.
+* `tag_value` - (Optional) The value of the tag.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the module.
+* `create_time` - The time when the module was created. The time is in the `yyyy-MM-ddTHH:mm:ssZ` format, which indicates UTC.
+* `group_info` - The group information of the module. It is read-only for now; assigning a module to a group will be supported after the corresponding group and project resources are available. See [`group_info`](#group_info) below.
+* `latest_version` - The latest version number of the module.
+* `output_path` - The storage path of the module.
+* `status` - The status of the module. Valid values: `Creating`, `Created`, `Errored`. A module version can be published only after the module enters the `Created` state.
+
+### `group_info`
+
+The group_info supports the following:
+* `group_id` - The ID of the group to which the module belongs.
+* `group_name` - The name of the group to which the module belongs.
+* `project_id` - The ID of the project to which the module belongs.
+* `project_name` - The name of the project to which the module belongs.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Module.
+* `delete` - (Defaults to 5 mins) Used when delete the Module.
+* `update` - (Defaults to 5 mins) Used when update the Module.
+
+## Import
+
+IaC Service Module can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ia_c_service_module.example <id>
+```


### PR DESCRIPTION
## Summary
- Add new resource `alicloud_iac_service_module` for IaC Service (IaCService) Module, supporting the module lifecycle with `OSS`, `Registry`, `ExportTask`, `Upload`, `Shared` and `Editor` sources, version strategy, state path, description, group/project assignment (`group_info`) and tags.
- Add new data source `alicloud_iac_service_modules` to query modules with id / name regex / module name / group / project filters and automatic pagination.
- IaCService is currently deployed with a central endpoint (`iac.cn-zhangjiakou.aliyuncs.com`) that is not resolvable through the location service, so the endpoint is registered in `irregularProductEndpoint`.

## Test plan
- [x] `TestAccAliCloudIacServiceModule_basic0` PASS (33.08s): create (Registry source, group_info, tags, version_strategy) -> move module to another group -> update name/description/source_path/state_path/tags -> switch version_strategy and clear tags -> import -> destroy.
- [x] `TestAccAliCloudIacServiceModuleDataSource` PASS (79.17s): ids / name_regex / module_name / group_id / project_id exist and fake filters.

```
=== RUN TestAccAliCloudIacServiceModule_basic0
--- PASS: TestAccAliCloudIacServiceModule_basic0 (33.08s)

=== RUN TestAccAliCloudIacServiceModuleDataSource
--- PASS: TestAccAliCloudIacServiceModuleDataSource (79.17s)
```
