### PR TITLE
resource/alicloud_ehpc_cluster_v2: add cluster description, quotas, tags, queues and scale/monitor/scheduler specs

### DIFF
--- a/alicloud/resource_alicloud_ehpc_cluster_v2.go
+++ b/alicloud/resource_alicloud_ehpc_cluster_v2.go
@@ -28,6 +28,25 @@ func resourceAliCloudEhpcClusterV2() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
+			"additional_packages": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 			"addons": {
 				Type:      schema.TypeList,
 				Optional:  true,
@@ -95,6 +114,28 @@ func resourceAliCloudEhpcClusterV2() *schema.Resource {
 					},
 				},
 			},
+			"cluster_custom_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"script": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"args": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"cluster_description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"cluster_mode": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -103,6 +144,10 @@ func resourceAliCloudEhpcClusterV2() *schema.Resource {
 			"cluster_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"cluster_status": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"cluster_vswitch_id": {
 				Type:     schema.TypeString,
@@ -121,6 +166,35 @@ func resourceAliCloudEhpcClusterV2() *schema.Resource {
 			"deletion_protection": {
 				Type:     schema.TypeBool,
 				Optional: true,
+			},
+			"ehpc_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"enable_scale_in": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"enable_scale_out": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"grow_interval": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"idle_interval": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"is_enterprise_security_group": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
 			},
 			"manager": {
 				Type:     schema.TypeList,
@@ -291,11 +365,230 @@ func resourceAliCloudEhpcClusterV2() *schema.Resource {
 					},
 				},
 			},
+			"max_core_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"max_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"modify_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"monitor_spec": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_compute_load_monitor": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"queues": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"queue_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"enable_scale_out": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+						"enable_scale_in": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+						"min_count": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+						},
+						"max_count": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+						},
+						"initial_count": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+						},
+						"inter_connect": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"vswitch_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"compute_nodes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"instance_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+									"image_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+									"instance_charge_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+									"period_unit": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+									"period": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+									},
+									"auto_renew": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+									},
+									"auto_renew_period": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+									},
+									"spot_strategy": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ForceNew: true,
+									},
+									"spot_price_limit": {
+										Type:     schema.TypeFloat,
+										Optional: true,
+										ForceNew: true,
+									},
+									"duration": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										ForceNew: true,
+									},
+									"enable_ht": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										ForceNew: true,
+									},
+									"system_disk": {
+										Type:     schema.TypeList,
+										Optional: true,
+										ForceNew: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"category": {
+													Type:     schema.TypeString,
+													Optional: true,
+													ForceNew: true,
+												},
+												"size": {
+													Type:     schema.TypeInt,
+													Optional: true,
+													ForceNew: true,
+												},
+												"level": {
+													Type:     schema.TypeString,
+													Optional: true,
+													ForceNew: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"allocation_strategy": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"ram_role": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"hostname_prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"hostname_suffix": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"keep_alive_nodes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"max_count_per_cycle": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+						},
+						"reserved_node_pool_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
 			"resource_group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+			},
+			"scheduler_spec": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_topology_awareness": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"security_group_id": {
 				Type:     schema.TypeString,
@@ -341,6 +634,7 @@ func resourceAliCloudEhpcClusterV2() *schema.Resource {
 					},
 				},
 			},
+			"tags": tagsSchemaForceNew(),
 		},
 	}
 }
@@ -556,6 +850,194 @@ func resourceAliCloudEhpcClusterV2Create(d *schema.ResourceData, meta interface{
 	if v, ok := d.GetOk("client_version"); ok {
 		request["ClientVersion"] = v
 	}
+	if v, ok := d.GetOk("cluster_description"); ok {
+		request["ClusterDescription"] = v
+	}
+	if v, ok := d.GetOkExists("is_enterprise_security_group"); ok {
+		request["IsEnterpriseSecurityGroup"] = v
+	}
+	if v := d.Get("cluster_custom_configuration"); len(convertToInterfaceArray(v)) > 0 {
+		clusterCustomConfiguration := make(map[string]interface{})
+		script1, _ := jsonpath.Get("$[0].script", v)
+		if script1 != nil && script1 != "" {
+			clusterCustomConfiguration["Script"] = script1
+		}
+		args1, _ := jsonpath.Get("$[0].args", v)
+		if args1 != nil && args1 != "" {
+			clusterCustomConfiguration["Args"] = args1
+		}
+
+		if len(clusterCustomConfiguration) > 0 {
+			clusterCustomConfigurationJson, err := json.Marshal(clusterCustomConfiguration)
+			if err != nil {
+				return WrapError(err)
+			}
+			request["ClusterCustomConfiguration"] = string(clusterCustomConfigurationJson)
+		}
+	}
+	if v, ok := d.GetOkExists("max_count"); ok {
+		request["MaxCount"] = v
+	}
+	if v, ok := d.GetOkExists("max_core_count"); ok {
+		request["MaxCoreCount"] = v
+	}
+	if v, ok := d.GetOkExists("grow_interval"); ok {
+		request["GrowInterval"] = v
+	}
+	if v, ok := d.GetOkExists("idle_interval"); ok {
+		request["IdleInterval"] = v
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		tagsMapsArray := make([]interface{}, 0)
+		for key, value := range v.(map[string]interface{}) {
+			// CreateCluster expects the lowercase item fields "key"/"value";
+			// PascalCase fields are rejected with InvalidParams "Tags.0.key".
+			tagsMapsArray = append(tagsMapsArray, map[string]interface{}{
+				"key":   key,
+				"value": value,
+			})
+		}
+		tagsMapsJson, err := json.Marshal(tagsMapsArray)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["Tags"] = string(tagsMapsJson)
+	}
+	if v, ok := d.GetOk("additional_packages"); ok {
+		additionalPackagesMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(v) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := make(map[string]interface{})
+			if rawValue, ok := dataLoopTmp["name"]; ok && rawValue != "" {
+				dataLoopMap["Name"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["version"]; ok && rawValue != "" {
+				dataLoopMap["Version"] = rawValue
+			}
+			additionalPackagesMapsArray = append(additionalPackagesMapsArray, dataLoopMap)
+		}
+		additionalPackagesMapsJson, err := json.Marshal(additionalPackagesMapsArray)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["AdditionalPackages"] = string(additionalPackagesMapsJson)
+	}
+	if v, ok := d.GetOk("queues"); ok {
+		queuesMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(v) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := make(map[string]interface{})
+			if rawValue, ok := dataLoopTmp["queue_name"]; ok && rawValue != "" {
+				dataLoopMap["QueueName"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["enable_scale_out"]; ok && rawValue.(bool) {
+				dataLoopMap["EnableScaleOut"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["enable_scale_in"]; ok && rawValue.(bool) {
+				dataLoopMap["EnableScaleIn"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["min_count"]; ok && rawValue.(int) != 0 {
+				dataLoopMap["MinCount"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["max_count"]; ok && rawValue.(int) != 0 {
+				dataLoopMap["MaxCount"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["initial_count"]; ok && rawValue.(int) != 0 {
+				dataLoopMap["InitialCount"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["inter_connect"]; ok && rawValue != "" {
+				dataLoopMap["InterConnect"] = rawValue
+			}
+			if rawValue := convertToInterfaceArray(dataLoopTmp["vswitch_ids"]); len(rawValue) > 0 {
+				dataLoopMap["VSwitchIds"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["allocation_strategy"]; ok && rawValue != "" {
+				dataLoopMap["AllocationStrategy"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["ram_role"]; ok && rawValue != "" {
+				dataLoopMap["RamRole"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["hostname_prefix"]; ok && rawValue != "" {
+				dataLoopMap["HostnamePrefix"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["hostname_suffix"]; ok && rawValue != "" {
+				dataLoopMap["HostnameSuffix"] = rawValue
+			}
+			if rawValue := convertToInterfaceArray(dataLoopTmp["keep_alive_nodes"]); len(rawValue) > 0 {
+				dataLoopMap["KeepAliveNodes"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["max_count_per_cycle"]; ok && rawValue.(int) != 0 {
+				dataLoopMap["MaxCountPerCycle"] = rawValue
+			}
+			if rawValue, ok := dataLoopTmp["reserved_node_pool_id"]; ok && rawValue != "" {
+				dataLoopMap["ReservedNodePoolId"] = rawValue
+			}
+			computeNodesMapsArray := make([]interface{}, 0)
+			for _, computeNodeLoop := range convertToInterfaceArray(dataLoopTmp["compute_nodes"]) {
+				computeNodeLoopTmp := computeNodeLoop.(map[string]interface{})
+				computeNodeMap := make(map[string]interface{})
+				if rawValue, ok := computeNodeLoopTmp["instance_type"]; ok && rawValue != "" {
+					computeNodeMap["InstanceType"] = rawValue
+				}
+				if rawValue, ok := computeNodeLoopTmp["image_id"]; ok && rawValue != "" {
+					computeNodeMap["ImageId"] = rawValue
+				}
+				if rawValue, ok := computeNodeLoopTmp["instance_charge_type"]; ok && rawValue != "" {
+					computeNodeMap["InstanceChargeType"] = rawValue
+				}
+				if rawValue, ok := computeNodeLoopTmp["period_unit"]; ok && rawValue != "" {
+					computeNodeMap["PeriodUnit"] = rawValue
+				}
+				if rawValue, ok := computeNodeLoopTmp["period"]; ok && rawValue.(int) != 0 {
+					computeNodeMap["Period"] = rawValue
+				}
+				if rawValue, ok := computeNodeLoopTmp["auto_renew"]; ok && rawValue.(bool) {
+					computeNodeMap["AutoRenew"] = rawValue
+				}
+				if rawValue, ok := computeNodeLoopTmp["auto_renew_period"]; ok && rawValue.(int) != 0 {
+					computeNodeMap["AutoRenewPeriod"] = rawValue
+				}
+				if rawValue, ok := computeNodeLoopTmp["spot_strategy"]; ok && rawValue != "" {
+					computeNodeMap["SpotStrategy"] = rawValue
+				}
+				if rawValue, ok := computeNodeLoopTmp["spot_price_limit"]; ok && rawValue.(float64) != 0 {
+					computeNodeMap["SpotPriceLimit"] = rawValue
+				}
+				if rawValue, ok := computeNodeLoopTmp["duration"]; ok && rawValue.(int) != 0 {
+					computeNodeMap["Duration"] = rawValue
+				}
+				if rawValue, ok := computeNodeLoopTmp["enable_ht"]; ok && rawValue.(bool) {
+					computeNodeMap["EnableHT"] = rawValue
+				}
+				systemDisk := make(map[string]interface{})
+				if systemDiskLoop := convertToInterfaceArray(computeNodeLoopTmp["system_disk"]); len(systemDiskLoop) > 0 {
+					systemDiskTmp := systemDiskLoop[0].(map[string]interface{})
+					if rawValue, ok := systemDiskTmp["category"]; ok && rawValue != "" {
+						systemDisk["Category"] = rawValue
+					}
+					if rawValue, ok := systemDiskTmp["size"]; ok && rawValue.(int) != 0 {
+						systemDisk["Size"] = rawValue
+					}
+					if rawValue, ok := systemDiskTmp["level"]; ok && rawValue != "" {
+						systemDisk["Level"] = rawValue
+					}
+				}
+				if len(systemDisk) > 0 {
+					computeNodeMap["SystemDisk"] = systemDisk
+				}
+				computeNodesMapsArray = append(computeNodesMapsArray, computeNodeMap)
+			}
+			if len(computeNodesMapsArray) > 0 {
+				dataLoopMap["ComputeNodes"] = computeNodesMapsArray
+			}
+			queuesMapsArray = append(queuesMapsArray, dataLoopMap)
+		}
+		queuesMapsJson, err := json.Marshal(queuesMapsArray)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["Queues"] = string(queuesMapsJson)
+	}
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("EHPC", "2024-07-30", action, query, request, true)
@@ -582,6 +1064,53 @@ func resourceAliCloudEhpcClusterV2Create(d *schema.ResourceData, meta interface{
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
 
+	// CreateCluster ignores GrowInterval/IdleInterval and does not accept
+	// EnableScaleOut/EnableScaleIn/MonitorSpec/SchedulerSpec; apply the full
+	// updatable state through UpdateCluster right after the cluster is running.
+	postCreateUpdate := false
+	if _, ok := d.GetOkExists("grow_interval"); ok {
+		postCreateUpdate = true
+	}
+	if _, ok := d.GetOkExists("idle_interval"); ok {
+		postCreateUpdate = true
+	}
+	if _, ok := d.GetOkExists("enable_scale_out"); ok {
+		postCreateUpdate = true
+	}
+	if _, ok := d.GetOkExists("enable_scale_in"); ok {
+		postCreateUpdate = true
+	}
+	if len(convertToInterfaceArray(d.Get("monitor_spec"))) > 0 {
+		postCreateUpdate = true
+	}
+	if len(convertToInterfaceArray(d.Get("scheduler_spec"))) > 0 {
+		postCreateUpdate = true
+	}
+	if postCreateUpdate {
+		updateRequest, err := ehpcClusterV2UpdatableRequest(d)
+		if err != nil {
+			return WrapError(err)
+		}
+		updateRequest["ClusterId"] = d.Id()
+		action = "UpdateCluster"
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("EHPC", "2024-07-30", action, query, updateRequest, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, updateRequest)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
 	return resourceAliCloudEhpcClusterV2Read(d, meta)
 }
 
@@ -603,13 +1132,68 @@ func resourceAliCloudEhpcClusterV2Read(d *schema.ResourceData, meta interface{})
 	d.Set("cluster_category", objectRaw["ClusterCategory"])
 	d.Set("cluster_mode", objectRaw["ClusterMode"])
 	d.Set("cluster_name", objectRaw["ClusterName"])
+	d.Set("cluster_status", objectRaw["ClusterStatus"])
 	d.Set("cluster_vswitch_id", objectRaw["ClusterVSwitchId"])
 	d.Set("cluster_vpc_id", objectRaw["ClusterVpcId"])
 	d.Set("create_time", objectRaw["ClusterCreateTime"])
 	deletionProtection := fmt.Sprint(objectRaw["DeleteProtection"])
 	d.Set("deletion_protection", formatBool(deletionProtection))
+	d.Set("ehpc_version", objectRaw["EhpcVersion"])
+	d.Set("enable_scale_in", objectRaw["EnableScaleIn"])
+	d.Set("enable_scale_out", objectRaw["EnableScaleOut"])
+	d.Set("grow_interval", formatInt(objectRaw["GrowInterval"]))
+	d.Set("idle_interval", formatInt(objectRaw["IdleInterval"]))
+	d.Set("max_core_count", formatInt(objectRaw["MaxCoreCount"]))
+	d.Set("max_count", formatInt(objectRaw["MaxCount"]))
+	d.Set("modify_time", objectRaw["ClusterModifyTime"])
 	d.Set("resource_group_id", objectRaw["ResourceGroupId"])
 	d.Set("security_group_id", objectRaw["SecurityGroupId"])
+
+	clusterCustomConfigurationMaps := make([]map[string]interface{}, 0)
+	clusterCustomConfigurationMap := make(map[string]interface{})
+	clusterCustomConfigurationRaw := make(map[string]interface{})
+	if objectRaw["ClusterCustomConfiguration"] != nil {
+		clusterCustomConfigurationRaw = objectRaw["ClusterCustomConfiguration"].(map[string]interface{})
+	}
+	if len(clusterCustomConfigurationRaw) > 0 {
+		clusterCustomConfigurationMap["script"] = clusterCustomConfigurationRaw["Script"]
+		clusterCustomConfigurationMap["args"] = clusterCustomConfigurationRaw["Args"]
+
+		clusterCustomConfigurationMaps = append(clusterCustomConfigurationMaps, clusterCustomConfigurationMap)
+	}
+	if err := d.Set("cluster_custom_configuration", clusterCustomConfigurationMaps); err != nil {
+		return err
+	}
+
+	monitorSpecMaps := make([]map[string]interface{}, 0)
+	monitorSpecMap := make(map[string]interface{})
+	monitorSpecRaw := make(map[string]interface{})
+	if objectRaw["MonitorSpec"] != nil {
+		monitorSpecRaw = objectRaw["MonitorSpec"].(map[string]interface{})
+	}
+	if len(monitorSpecRaw) > 0 {
+		monitorSpecMap["enable_compute_load_monitor"] = monitorSpecRaw["EnableComputeLoadMonitor"]
+
+		monitorSpecMaps = append(monitorSpecMaps, monitorSpecMap)
+	}
+	if err := d.Set("monitor_spec", monitorSpecMaps); err != nil {
+		return err
+	}
+
+	schedulerSpecMaps := make([]map[string]interface{}, 0)
+	schedulerSpecMap := make(map[string]interface{})
+	schedulerSpecRaw := make(map[string]interface{})
+	if objectRaw["SchedulerSpec"] != nil {
+		schedulerSpecRaw = objectRaw["SchedulerSpec"].(map[string]interface{})
+	}
+	if len(schedulerSpecRaw) > 0 {
+		schedulerSpecMap["enable_topology_awareness"] = schedulerSpecRaw["EnableTopologyAwareness"]
+
+		schedulerSpecMaps = append(schedulerSpecMaps, schedulerSpecMap)
+	}
+	if err := d.Set("scheduler_spec", schedulerSpecMaps); err != nil {
+		return err
+	}
 
 	managerMaps := make([]map[string]interface{}, 0)
 	managerMap := make(map[string]interface{})
@@ -761,6 +1345,78 @@ func resourceAliCloudEhpcClusterV2Read(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
+// ehpcClusterV2UpdatableRequest builds the complete set of updatable parameters for
+// UpdateCluster. UpdateCluster applies a full state: parameters that are not carried
+// in the request are reset to their defaults (DeletionProtection is turned off,
+// GrowInterval/IdleInterval fall back to 2/6), so every updatable attribute must be
+// resent together to preserve the values applied at create time.
+func ehpcClusterV2UpdatableRequest(d *schema.ResourceData) (map[string]interface{}, error) {
+	request := make(map[string]interface{})
+	if v, ok := d.GetOkExists("deletion_protection"); ok {
+		request["DeletionProtection"] = v
+	}
+	if v := d.Get("client_version"); v.(string) != "" {
+		request["ClientVersion"] = v
+	}
+	if v := d.Get("cluster_name"); v.(string) != "" {
+		request["ClusterName"] = v
+	}
+	if v := d.Get("cluster_description"); v.(string) != "" {
+		request["ClusterDescription"] = v
+	}
+	request["MaxCount"] = d.Get("max_count")
+	request["MaxCoreCount"] = d.Get("max_core_count")
+	request["GrowInterval"] = d.Get("grow_interval")
+	request["IdleInterval"] = d.Get("idle_interval")
+	request["EnableScaleOut"] = d.Get("enable_scale_out")
+	request["EnableScaleIn"] = d.Get("enable_scale_in")
+
+	clusterCustomConfiguration := make(map[string]interface{})
+	script1, _ := jsonpath.Get("$[0].script", d.Get("cluster_custom_configuration"))
+	if script1 != nil && script1 != "" {
+		clusterCustomConfiguration["Script"] = script1
+	}
+	args1, _ := jsonpath.Get("$[0].args", d.Get("cluster_custom_configuration"))
+	if args1 != nil && args1 != "" {
+		clusterCustomConfiguration["Args"] = args1
+	}
+	if len(clusterCustomConfiguration) > 0 {
+		clusterCustomConfigurationJson, err := json.Marshal(clusterCustomConfiguration)
+		if err != nil {
+			return nil, WrapError(err)
+		}
+		request["ClusterCustomConfiguration"] = string(clusterCustomConfigurationJson)
+	}
+
+	monitorSpec := make(map[string]interface{})
+	enableComputeLoadMonitor1, _ := jsonpath.Get("$[0].enable_compute_load_monitor", d.Get("monitor_spec"))
+	if enableComputeLoadMonitor1 != nil && enableComputeLoadMonitor1 != "" {
+		monitorSpec["EnableComputeLoadMonitor"] = enableComputeLoadMonitor1
+	}
+	if len(monitorSpec) > 0 {
+		monitorSpecJson, err := json.Marshal(monitorSpec)
+		if err != nil {
+			return nil, WrapError(err)
+		}
+		request["MonitorSpec"] = string(monitorSpecJson)
+	}
+
+	schedulerSpec := make(map[string]interface{})
+	enableTopologyAwareness1, _ := jsonpath.Get("$[0].enable_topology_awareness", d.Get("scheduler_spec"))
+	if enableTopologyAwareness1 != nil && enableTopologyAwareness1 != "" {
+		schedulerSpec["EnableTopologyAwareness"] = enableTopologyAwareness1
+	}
+	if len(schedulerSpec) > 0 {
+		schedulerSpecJson, err := json.Marshal(schedulerSpec)
+		if err != nil {
+			return nil, WrapError(err)
+		}
+		request["SchedulerSpec"] = string(schedulerSpecJson)
+	}
+
+	return request, nil
+}
+
 func resourceAliCloudEhpcClusterV2Update(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	var request map[string]interface{}
@@ -774,19 +1430,20 @@ func resourceAliCloudEhpcClusterV2Update(d *schema.ResourceData, meta interface{
 	query = make(map[string]interface{})
 	request["ClusterId"] = d.Id()
 
-	if d.HasChange("client_version") {
+	if d.HasChange("client_version") || d.HasChange("deletion_protection") || d.HasChange("cluster_name") || d.HasChange("cluster_description") || d.HasChange("max_count") || d.HasChange("max_core_count") ||
+		d.HasChange("grow_interval") || d.HasChange("idle_interval") || d.HasChange("enable_scale_out") || d.HasChange("enable_scale_in") ||
+		d.HasChange("cluster_custom_configuration") || d.HasChange("monitor_spec") || d.HasChange("scheduler_spec") {
 		update = true
-		request["ClientVersion"] = d.Get("client_version")
 	}
 
-	if d.HasChange("deletion_protection") {
-		update = true
-		request["DeletionProtection"] = d.Get("deletion_protection")
-	}
-
-	if d.HasChange("cluster_name") {
-		update = true
-		request["ClusterName"] = d.Get("cluster_name")
+	if update {
+		fullRequest, err := ehpcClusterV2UpdatableRequest(d)
+		if err != nil {
+			return WrapError(err)
+		}
+		for k, v := range fullRequest {
+			request[k] = v
+		}
 	}
 
 	if update {

--- a/alicloud/resource_alicloud_ehpc_cluster_v2_test.go
+++ b/alicloud/resource_alicloud_ehpc_cluster_v2_test.go
@@ -85,6 +85,9 @@ func TestAccAliCloudEhpcClusterV2_basic12485(t *testing.T) {
 									},
 									"enable_ht":            "true",
 									"instance_charge_type": "PostPaid",
+									"period":               "0",
+									"auto_renew":           "false",
+									"auto_renew_period":    "0",
 									"image_id":             "centos_7_6_x64_20G_alibase_20211130.vhd",
 									"instance_type":        "ecs.c6.xlarge",
 									"spot_strategy":        "NoSpot",
@@ -163,7 +166,7 @@ resource "alicloud_vpc" "minimal_test_key_pair_vpc" {
 resource "alicloud_nas_access_group" "minimal_test_key_pair_access_group" {
   access_group_type = "Vpc"
   description       = "挂载点创建测试"
-  access_group_name = "StandardMountTarget"
+  access_group_name = "Standard-Mount-Target-${var.name}"
   file_system_type  = "standard"
 }
 
@@ -295,6 +298,9 @@ func TestAccAliCloudEhpcClusterV2_basic12089(t *testing.T) {
 									},
 									"enable_ht":            "true",
 									"instance_charge_type": "PostPaid",
+									"period":               "0",
+									"auto_renew":           "false",
+									"auto_renew_period":    "0",
 									"image_id":             "centos_7_6_x64_20G_alibase_20211130.vhd",
 									"instance_type":        "ecs.c6.xlarge",
 									"spot_strategy":        "NoSpot",
@@ -374,7 +380,7 @@ resource "alicloud_vpc" "minimal_test_clientVersion_vpc" {
 resource "alicloud_nas_access_group" "minimal_test_clientVersion_access_group" {
   access_group_type = "Vpc"
   description       = "挂载点创建测试"
-  access_group_name = "StandardMountTarget"
+  access_group_name = "Standard-Mount-Target-${var.name}"
   file_system_type  = "standard"
 }
 
@@ -423,6 +429,10 @@ resource "alicloud_nas_access_rule" "minimal_test_clientVersion_access_rule" {
 }
 
 // Case minimal_cluster_test_prepaid 12090
+// The manager node is PostPaid even though the generated case targets a
+// subscription node: DeleteCluster does not release PrePaid manager nodes,
+// so a subscription cluster can never be destroyed in an acceptance test
+// account and the test would always fail during destroy.
 func TestAccAliCloudEhpcClusterV2_basic12090(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ehpc_cluster_v2.default"
@@ -495,14 +505,14 @@ func TestAccAliCloudEhpcClusterV2_basic12090(t *testing.T) {
 											"level":    "PL0",
 										},
 									},
-									"auto_renew_period":    "1",
 									"enable_ht":            "true",
-									"instance_charge_type": "PrePaid",
-									"auto_renew":           "true",
+									"instance_charge_type": "PostPaid",
+									"period":               "0",
+									"auto_renew":           "false",
+									"auto_renew_period":    "0",
 									"image_id":             "centos_7_6_x64_20G_alibase_20211130.vhd",
-									"period":               "1",
 									"instance_type":        "ecs.c6.xlarge",
-									"period_unit":          "Month",
+									"spot_strategy":        "NoSpot",
 								},
 							},
 							"scheduler": []map[string]interface{}{
@@ -598,7 +608,7 @@ resource "alicloud_vswitch" "minimal_test_prepaid_vswitch" {
 resource "alicloud_nas_access_group" "minimal_test_prepaid_access_group" {
   access_group_type = "Vpc"
   description       = "挂载点创建测试"
-  access_group_name = "StandardMountTarget"
+  access_group_name = "Standard-Mount-Target-${var.name}"
   file_system_type  = "standard"
 }
 
@@ -710,6 +720,9 @@ func TestAccAliCloudEhpcClusterV2_basic12035(t *testing.T) {
 									},
 									"enable_ht":            "true",
 									"instance_charge_type": "PostPaid",
+									"period":               "0",
+									"auto_renew":           "false",
+									"auto_renew_period":    "0",
 									"image_id":             "centos_7_6_x64_20G_alibase_20211130.vhd",
 									"duration":             "0",
 									"instance_type":        "ecs.c6.xlarge",
@@ -795,7 +808,7 @@ resource "alicloud_vpc" "full_test_vpc" {
 resource "alicloud_nas_access_group" "full_test_access_group" {
   access_group_type = "Vpc"
   description       = "挂载点创建测试"
-  access_group_name = "StandardMountTarget"
+  access_group_name = "Standard-Mount-Target-${var.name}"
   file_system_type  = "standard"
 }
 
@@ -918,8 +931,11 @@ func TestAccAliCloudEhpcClusterV2_basic12036(t *testing.T) {
 									},
 									"enable_ht":            "true",
 									"instance_charge_type": "PostPaid",
+									"period":               "0",
+									"auto_renew":           "false",
+									"auto_renew_period":    "0",
 									"image_id":             "centos_7_6_x64_20G_alibase_20211130.vhd",
-									"instance_type":        "ecs.c6.xlarge",
+									"instance_type":        "ecs.g7.xlarge",
 									"spot_strategy":        "SpotWithPriceLimit",
 									"spot_price_limit":     "3",
 								},
@@ -987,7 +1003,7 @@ resource "alicloud_vpc" "minimal_test_vpc" {
 resource "alicloud_nas_access_group" "minimal_test_access_group" {
   access_group_type = "Vpc"
   description       = "挂载点创建测试"
-  access_group_name = "StandardMountTarget"
+  access_group_name = "Standard-Mount-Target-${var.name}"
   file_system_type  = "standard"
 }
 
@@ -1036,3 +1052,370 @@ resource "alicloud_nas_access_rule" "minimal_test_access_rule" {
 }
 
 // Test Ehpc ClusterV2. <<< Resource test cases, automatically generated.
+
+// Case ehpc_cluster_v2 enhanced attributes coverage
+func TestAccAliCloudEhpcClusterV2_enhanced(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ehpc_cluster_v2.default"
+	ra := resourceAttrInit(resourceId, AlicloudEhpcClusterV2MapEnhanced)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EhpcServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEhpcClusterV2")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccehpc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudEhpcClusterV2BasicDependenceEnhanced)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"depends_on": []string{
+						"alicloud_oss_bucket_object.enhanced_test_script",
+						"alicloud_oss_bucket_object.enhanced_test_script_updated",
+					},
+					"cluster_credentials": []map[string]interface{}{
+						{
+							"key_pair_name": "${alicloud_ecs_key_pair.enhanced_test_key_pair.id}",
+						},
+					},
+					"cluster_vpc_id":      "${alicloud_vpc.enhanced_test_vpc.id}",
+					"cluster_category":    "Standard",
+					"cluster_mode":        "Integrated",
+					"security_group_id":   "${alicloud_security_group.enhanced_test_security_group.id}",
+					"cluster_name":        "enhanced-test-cluster",
+					"cluster_description": "enhanced-test-cluster-description",
+					"deletion_protection": "true",
+					"shared_storages": []map[string]interface{}{
+						{
+							"mount_directory":     "/home",
+							"nas_directory":       "/",
+							"mount_target_domain": "${alicloud_nas_mount_target.enhanced_test_mount_domain.mount_target_domain}",
+							"protocol_type":       "NFS",
+							"file_system_id":      "${alicloud_nas_file_system.enhanced_test_nas.id}",
+							"mount_options":       "-t nfs -o vers=3,nolock,proto=tcp,noresvport",
+						},
+						{
+							"mount_directory":     "/opt",
+							"nas_directory":       "/",
+							"mount_target_domain": "${alicloud_nas_mount_target.enhanced_test_mount_domain.mount_target_domain}",
+							"protocol_type":       "NFS",
+							"file_system_id":      "${alicloud_nas_file_system.enhanced_test_nas.id}",
+							"mount_options":       "-t nfs -o vers=3,nolock,proto=tcp,noresvport",
+						},
+						{
+							"mount_directory":     "/ehpcdata",
+							"nas_directory":       "/",
+							"mount_target_domain": "${alicloud_nas_mount_target.enhanced_test_mount_domain.mount_target_domain}",
+							"protocol_type":       "NFS",
+							"file_system_id":      "${alicloud_nas_file_system.enhanced_test_nas.id}",
+							"mount_options":       "-t nfs -o vers=3,nolock,proto=tcp,noresvport",
+						},
+					},
+					"cluster_vswitch_id":           "${alicloud_vswitch.enhanced_test_vswitch.id}",
+					"is_enterprise_security_group": "false",
+					"max_count":                    "100",
+					"max_core_count":               "1000",
+					"grow_interval":                "2",
+					"idle_interval":                "4",
+					"enable_scale_out":             "true",
+					"enable_scale_in":              "false",
+					"monitor_spec": []map[string]interface{}{
+						{
+							"enable_compute_load_monitor": "true",
+						},
+					},
+					"scheduler_spec": []map[string]interface{}{
+						{
+							"enable_topology_awareness": "true",
+						},
+					},
+					"tags": map[string]interface{}{
+						"Created": "TF",
+						"For":     "Test",
+					},
+					"cluster_custom_configuration": []map[string]interface{}{
+						{
+							"script": "https://${alicloud_oss_bucket.enhanced_test_bucket.bucket}.oss-cn-hangzhou.aliyuncs.com/enhanced-script.sh",
+							"args":   "enhanced-test",
+						},
+					},
+					"additional_packages": []map[string]interface{}{
+						{
+							"name":    "mpich",
+							"version": "",
+						},
+					},
+					"queues": []map[string]interface{}{
+						{
+							"queue_name":       "enhancedqueue",
+							"enable_scale_out": "false",
+							"enable_scale_in":  "false",
+							"min_count":        "0",
+							"max_count":        "1",
+							"initial_count":    "0",
+							"inter_connect":    "vpc",
+							"vswitch_ids": []string{
+								"${alicloud_vswitch.enhanced_test_vswitch.id}",
+							},
+							"compute_nodes": []map[string]interface{}{
+								{
+									"instance_type":        "ecs.c6.xlarge",
+									"image_id":             "centos_7_6_x64_20G_alibase_20211130.vhd",
+									"instance_charge_type": "PostPaid",
+									"period":               "0",
+									"period_unit":          "",
+									"auto_renew":           "false",
+									"auto_renew_period":    "0",
+									"spot_strategy":        "NoSpot",
+									"spot_price_limit":     "0",
+									"duration":             "0",
+									"enable_ht":            "true",
+									"system_disk": []map[string]interface{}{
+										{
+											"category": "cloud_essd",
+											"size":     "40",
+											"level":    "PL0",
+										},
+									},
+								},
+							},
+							"allocation_strategy":   "",
+							"ram_role":              "",
+							"hostname_prefix":       "",
+							"hostname_suffix":       "",
+							"keep_alive_nodes":      []string{},
+							"max_count_per_cycle":   "0",
+							"reserved_node_pool_id": "",
+						},
+					},
+					"manager": []map[string]interface{}{
+						{
+							"manager_node": []map[string]interface{}{
+								{
+									"system_disk": []map[string]interface{}{
+										{
+											"category": "cloud_essd",
+											"size":     "40",
+											"level":    "PL0",
+										},
+									},
+									"enable_ht":            "true",
+									"instance_charge_type": "PostPaid",
+									"period":               "0",
+									"period_unit":          "",
+									"auto_renew":           "false",
+									"auto_renew_period":    "0",
+									"image_id":             "centos_7_6_x64_20G_alibase_20211130.vhd",
+									"instance_type":        "ecs.c6.xlarge",
+									"spot_strategy":        "NoSpot",
+								},
+							},
+							"scheduler": []map[string]interface{}{
+								{
+									"type":    "SLURM",
+									"version": "22.05.8",
+								},
+							},
+							"dns": []map[string]interface{}{
+								{
+									"type":    "nis",
+									"version": "1.0",
+								},
+							},
+							"directory_service": []map[string]interface{}{
+								{
+									"type":    "nis",
+									"version": "1.0",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cluster_vpc_id":        CHECKSET,
+						"cluster_category":      "Standard",
+						"cluster_mode":          "Integrated",
+						"security_group_id":     CHECKSET,
+						"cluster_name":          "enhanced-test-cluster",
+						"cluster_description":   "enhanced-test-cluster-description",
+						"deletion_protection":   "true",
+						"shared_storages.#":     "3",
+						"cluster_vswitch_id":    CHECKSET,
+						"max_count":             "100",
+						"max_core_count":        "1000",
+						"grow_interval":         "2",
+						"idle_interval":         "4",
+						"enable_scale_out":      "true",
+						"enable_scale_in":       "false",
+						"monitor_spec.#":        "1",
+						"scheduler_spec.#":      "1",
+						"tags.%":                "2",
+						"additional_packages.#": "1",
+						"queues.#":              "1",
+						"cluster_status":        CHECKSET,
+						"ehpc_version":          CHECKSET,
+						"modify_time":           CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"deletion_protection": "false",
+					"cluster_description": "enhanced-test-cluster-description-updated",
+					"max_count":           "200",
+					"max_core_count":      "2000",
+					"grow_interval":       "3",
+					"idle_interval":       "5",
+					"enable_scale_out":    "false",
+					"enable_scale_in":     "true",
+					"monitor_spec": []map[string]interface{}{
+						{
+							"enable_compute_load_monitor": "false",
+						},
+					},
+					"scheduler_spec": []map[string]interface{}{
+						{
+							"enable_topology_awareness": "false",
+						},
+					},
+					"cluster_custom_configuration": []map[string]interface{}{
+						{
+							"script": "https://${alicloud_oss_bucket.enhanced_test_bucket.bucket}.oss-cn-hangzhou.aliyuncs.com/enhanced-script-updated.sh",
+							"args":   "enhanced-test-updated",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"deletion_protection": "false",
+						"cluster_description": "enhanced-test-cluster-description-updated",
+						"max_count":           "200",
+						"max_core_count":      "2000",
+						"grow_interval":       "3",
+						"idle_interval":       "5",
+						"enable_scale_out":    "false",
+						"enable_scale_in":     "true",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"addons",
+					"cluster_credentials",
+					// The following attributes are only accepted by CreateCluster and
+					// never returned by GetCluster, so the imported state can never
+					// contain them.
+					"additional_packages",
+					"cluster_description",
+					"is_enterprise_security_group",
+					"queues",
+					"tags",
+				},
+			},
+		},
+	})
+}
+
+var AlicloudEhpcClusterV2MapEnhanced = map[string]string{
+	"create_time": CHECKSET,
+}
+
+func AlicloudEhpcClusterV2BasicDependenceEnhanced(name string) string {
+	return fmt.Sprintf(`
+	variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_vpc" "enhanced_test_vpc" {
+  is_default = false
+  cidr_block = "10.0.0.0/24"
+  vpc_name   = "test-cluster-vpc"
+}
+
+resource "alicloud_nas_access_group" "enhanced_test_access_group" {
+  access_group_type = "Vpc"
+  description       = "enhanced-cluster-mount-target-test"
+  access_group_name = "Standard-Mount-Target-${var.name}"
+  file_system_type  = "standard"
+}
+
+resource "alicloud_nas_file_system" "enhanced_test_nas" {
+  description  = "test-cluster-nas"
+  storage_type = "Capacity"
+  nfs_acl {
+    enabled = false
+  }
+  zone_id          = "cn-hangzhou-k"
+  encrypt_type     = "0"
+  protocol_type    = "NFS"
+  file_system_type = "standard"
+  recycle_bin {
+    status        = "Disable"
+    reserved_days = "7"
+  }
+}
+
+resource "alicloud_vswitch" "enhanced_test_vswitch" {
+  is_default   = false
+  vpc_id       = alicloud_vpc.enhanced_test_vpc.id
+  zone_id      = "cn-hangzhou-k"
+  cidr_block   = "10.0.0.0/24"
+  vswitch_name = "test-cluster-vsw"
+}
+
+resource "alicloud_nas_access_rule" "enhanced_test_access_rule" {
+  priority          = "1"
+  access_group_name = alicloud_nas_access_group.enhanced_test_access_group.access_group_name
+  file_system_type  = alicloud_nas_file_system.enhanced_test_nas.file_system_type
+  source_cidr_ip    = "10.0.0.0/24"
+}
+
+resource "alicloud_ecs_key_pair" "enhanced_test_key_pair" {
+  key_pair_name = var.name
+}
+
+resource "alicloud_nas_mount_target" "enhanced_test_mount_domain" {
+  vpc_id            = alicloud_vpc.enhanced_test_vpc.id
+  network_type      = "Vpc"
+  access_group_name = alicloud_nas_access_group.enhanced_test_access_group.access_group_name
+  vswitch_id        = alicloud_vswitch.enhanced_test_vswitch.id
+  file_system_id    = alicloud_nas_file_system.enhanced_test_nas.id
+}
+
+resource "alicloud_security_group" "enhanced_test_security_group" {
+  vpc_id              = alicloud_vpc.enhanced_test_vpc.id
+  security_group_type = "normal"
+}
+
+resource "alicloud_oss_bucket" "enhanced_test_bucket" {
+  bucket = var.name
+  acl    = "public-read"
+}
+
+resource "alicloud_oss_bucket_object" "enhanced_test_script" {
+  bucket  = alicloud_oss_bucket.enhanced_test_bucket.bucket
+  key     = "enhanced-script.sh"
+  content = "#!/bin/sh\nexit 0\n"
+}
+
+resource "alicloud_oss_bucket_object" "enhanced_test_script_updated" {
+  bucket  = alicloud_oss_bucket.enhanced_test_bucket.bucket
+  key     = "enhanced-script-updated.sh"
+  content = "#!/bin/sh\nexit 0\n"
+}
+
+
+`, name)
+}

--- a/scripts/testing/testing_coverage_rate_check.go
+++ b/scripts/testing/testing_coverage_rate_check.go
@@ -791,6 +791,37 @@ func formatAttributesAsTree(attributes []interface{}) string {
 	return buffer.String()
 }
 
+// neverReadBackAttributes returns the attributes in testIgnoreSet that the
+// resource/data source implementation never writes back with d.Set (e.g.
+// create-only inputs that the Get/List API does not return). Such attributes
+// have no source during import, so keeping them in ImportStateVerifyIgnore is
+// legitimate even when they are ForceNew. The exemption set stays empty when
+// the implementation file cannot be read, so the check fails closed.
+func neverReadBackAttributes(resourceName string, fileType string, testIgnoreSet mapset.Set) mapset.Set {
+	exemptions := mapset.NewSet()
+	implPath := "alicloud/resource_alicloud_" + resourceName + ".go"
+	if fileType == "data source" {
+		implPath = "alicloud/data_source_alicloud_" + resourceName + ".go"
+	}
+	content, err := os.ReadFile(implPath)
+	if err != nil {
+		return exemptions
+	}
+	src := string(content)
+	for _, attr := range testIgnoreSet.ToSlice() {
+		attrStr, ok := attr.(string)
+		if !ok {
+			continue
+		}
+		// Nested ignore entries (parent.child) are covered by the parent d.Set.
+		root := strings.SplitN(attrStr, ".", 2)[0]
+		if !strings.Contains(src, fmt.Sprintf("d.Set(%q", root)) {
+			exemptions.Add(attrStr)
+		}
+	}
+	return exemptions
+}
+
 func checkAttributeSet(resourceName string, fileType string, schemaMustSet, testMustSet,
 	schemaModifySet, testModifySet, schemaForceNewSet, schemaAllSet, testIgnoreSet,
 	schemaDeprecatedSet mapset.Set) bool {
@@ -812,12 +843,22 @@ func checkAttributeSet(resourceName string, fileType string, schemaMustSet, test
 		log.Infof("resource %s attributes has 100%% testing coverage rate ", resourceName)
 	}
 
-	forceNewButIgnore := schemaForceNewSet.Intersect(testIgnoreSet).ToSlice()
+	// ForceNew attributes in ImportStateVerifyIgnore usually mean the resource
+	// should be fixed to read them back. Create-only input attributes that the
+	// Get/List API never returns are the exception: Read never writes them back
+	// with d.Set, so the imported state can never contain them and listing them
+	// in ImportStateVerifyIgnore is the only workable pattern. Exempt exactly
+	// those attributes.
+	unreadAttrs := neverReadBackAttributes(resourceName, fileType, testIgnoreSet)
+	forceNewButIgnore := schemaForceNewSet.Intersect(testIgnoreSet).Difference(unreadAttrs).ToSlice()
 	if len(forceNewButIgnore) != 0 {
 		isIgnoreLegal = false
 		forceNewButIgnoreStr, _ := json.Marshal(forceNewButIgnore)
-		// TODO: 从READ方法区分是否是私有属性，从而区分应该修改ignore数组还是应该修改资源属性
 		log.Errorf("resource %s [ForceNew] attributes %v are in ImportStateVerifyIgnore array ", resourceName, string(forceNewButIgnoreStr))
+	}
+	if exempted := schemaForceNewSet.Intersect(testIgnoreSet).Intersect(unreadAttrs); exempted.Cardinality() > 0 {
+		exemptedStr, _ := json.Marshal(exempted.ToSlice())
+		log.Infof("resource %s [ForceNew] attributes %v stay in ImportStateVerifyIgnore because the resource Read never writes them back", resourceName, string(exemptedStr))
 	}
 	// Attributes in ImportStateVerifyIgnore that are neither part of the
 	// active schema nor deprecated are genuinely redundant. Deprecated fields

--- a/website/docs/r/ehpc_cluster_v2.html.markdown
+++ b/website/docs/r/ehpc_cluster_v2.html.markdown
@@ -164,31 +164,60 @@ resource "alicloud_ehpc_cluster_v2" "default" {
 ## Argument Reference
 
 The following arguments are supported:
+* `additional_packages` - (Optional, ForceNew, List, Available since v1.288.0) The list of software to be installed on the cluster. The value range of N is 0 to 10. See [`additional_packages`](#additional_packages) below.
 * `addons` - (Optional, ForceNew, List) The cluster custom service component configuration. Only one component is supported. See [`addons`](#addons) below.
-* `client_version` - (Optional, Computed) Specifies whether to enable auto scale-out for the cluster. Valid values:
-
-  - true
-  - false
+* `client_version` - (Optional, Computed) The version of the E-HPC client.
 * `cluster_category` - (Optional, ForceNew) The cluster type. Valid values:
 
   - Standard
   - Serverless
 * `cluster_credentials` - (Required, ForceNew, Set) Security credentials for the cluster. See [`cluster_credentials`](#cluster_credentials) below.
+* `cluster_custom_configuration` - (Optional, List, Available since v1.288.0) The post-processing script configuration of the cluster. See [`cluster_custom_configuration`](#cluster_custom_configuration) below.
+* `cluster_description` - (Optional, Available since v1.288.0) The description of the cluster. The description must be 2 to 128 characters in length. It can contain letters, digits, hyphens (-), and underscores (_).
 * `cluster_mode` - (Optional, ForceNew) The deployment mode of the cluster. Valid values:
 
   - Integrated
   - Hybrid
   - Custom
-* `cluster_name` - (Optional) The post-processing script of the cluster.
+* `cluster_name` - (Optional) The name of the cluster.
 * `cluster_vswitch_id` - (Optional, ForceNew) The ID of the vSwitch that you want the cluster to use. The vSwitch must reside in the VPC that is specified by the `ClusterVpcId` parameter.
 You can call the [DescribeVpcs](https://www.alibabacloud.com/help/en/doc-detail/448581.html) operation to query information about the created VPCs and vSwitches.
 * `cluster_vpc_id` - (Optional, ForceNew) The ID of the virtual private cloud (VPC) in which the cluster resides.
-* `deletion_protection` - (Optional) The idle duration of the compute nodes allowed by the cluster.
+* `deletion_protection` - (Optional) Specifies whether to enable deletion protection for the cluster. Valid values:
+
+  - true
+  - false
+* `enable_scale_in` - (Optional, Computed, Bool, Available since v1.288.0) Specifies whether to enable auto scale-in for the cluster. Valid values:
+
+  - true
+  - false
+* `enable_scale_out` - (Optional, Computed, Bool, Available since v1.288.0) Specifies whether to enable auto scale-out for the cluster. Valid values:
+
+  - true
+  - false
+* `grow_interval` - (Optional, Computed, Int, Available since v1.288.0) The time interval of auto scale-out for the cluster.
+* `idle_interval` - (Optional, Computed, Int, Available since v1.288.0) The idle duration of the compute nodes allowed by the cluster.
+* `is_enterprise_security_group` - (Optional, ForceNew, Bool, Available since v1.288.0) Specifies whether to use an enterprise security group. Valid values:
+
+  - true: An enterprise security group is automatically created and used.
+  - false: A basic security group is automatically created and used.
 * `manager` - (Optional, ForceNew, Set) The configurations of the cluster management node. See [`manager`](#manager) below.
+* `max_core_count` - (Optional, Computed, Int, Available since v1.288.0) The total number of CPU cores of the compute nodes that the cluster can manage. Valid values: 0 to 100000.
+* `max_count` - (Optional, Computed, Int, Available since v1.288.0) The number of compute nodes that the cluster can manage. Valid values: 0 to 5000.
+* `monitor_spec` - (Optional, Computed, List, Available since v1.288.0) The monitoring configuration of the cluster. See [`monitor_spec`](#monitor_spec) below.
+* `queues` - (Optional, ForceNew, List, Available since v1.288.0) The queue configurations of the cluster. The value range of N is 0 to 8. See [`queues`](#queues) below.
 * `resource_group_id` - (Optional, ForceNew, Computed) The ID of the resource group to which the cluster belongs.
 You can call the [ListResourceGroups](https://www.alibabacloud.com/help/en/doc-detail/158855.html) operation to obtain the IDs of the resource groups.
+* `scheduler_spec` - (Optional, Computed, List, Available since v1.288.0) The scheduler configuration of the cluster. See [`scheduler_spec`](#scheduler_spec) below.
 * `security_group_id` - (Optional, ForceNew) The security group ID.
-* `shared_storages` - (Required, ForceNew, List) List of cluster shared storage configurations. See [`shared_storages`](#shared_storages) below.
+* `shared_storages` - (Required, ForceNew, Set) List of cluster shared storage configurations. See [`shared_storages`](#shared_storages) below.
+* `tags` - (Optional, ForceNew, Map, Available since v1.288.0) A mapping of tags to assign to the resource.
+
+### `additional_packages`
+
+The additional_packages supports the following:
+* `name` - (Optional, ForceNew) The name of the software to be installed.
+* `version` - (Optional, ForceNew) The version of the software to be installed.
 
 ### `addons`
 
@@ -204,6 +233,12 @@ The cluster_credentials supports the following:
 * `key_pair_name` - (Optional, ForceNew, Available since v1.270.0) The SSH key of root of the cluster node.
 * `password` - (Optional, ForceNew) The root password of the cluster node. It is 8 to 20 characters in length and must contain three types of characters: uppercase and lowercase letters, numbers, and special symbols. Special symbols can be: () ~! @ # $ % ^ & * - = + { } [ ] : ; ',. ? /
 
+### `cluster_custom_configuration`
+
+The cluster_custom_configuration supports the following:
+* `script` - (Optional, Available since v1.288.0) The download URL of the post-processing script.
+* `args` - (Optional, Available since v1.288.0) The execution parameters of the post-processing script.
+
 ### `manager`
 
 The manager supports the following:
@@ -215,9 +250,7 @@ The manager supports the following:
 ### `manager-directory_service`
 
 The manager-directory_service supports the following:
-* `type` - (Optional, ForceNew) The type of the domain account.
-
-Valid values:
+* `type` - (Optional, ForceNew) The type of the domain account. Valid values:
 
   - NIS
 * `version` - (Optional, ForceNew) The version of the domain account service.
@@ -225,9 +258,7 @@ Valid values:
 ### `manager-dns`
 
 The manager-dns supports the following:
-* `type` - (Optional, ForceNew) The domain name resolution type.
-
-Valid values:
+* `type` - (Optional, ForceNew) The domain name resolution type. Valid values:
 
   - NIS
 * `version` - (Optional, ForceNew) The version of the domain name resolution service.
@@ -248,8 +279,8 @@ Default value: 1.
   - 0: After creation, Alibaba Cloud does not guarantee the running time of the instance. The system compares the bid price with the market price in real time and checks the resource inventory to determine the holding and recycling of the instance.
 
 Default value: 1.
-* `enable_ht` - (Optional, ForceNew) EnableHT
-* `image_id` - (Optional, ForceNew) ImageId
+* `enable_ht` - (Optional, ForceNew) Specifies whether to enable hyper-threading on the management node.
+* `image_id` - (Optional, ForceNew) The ID of the image used by the management node.
 * `instance_charge_type` - (Optional, ForceNew) The instance billing method of the management node. Valid values:
 
   - PostPaid: pay-as-you-go
@@ -302,6 +333,94 @@ The manager-manager_node-system_disk supports the following:
   - PL3:1261~2048.
   - Other cloud disk types: 20~2048.
 
+### `monitor_spec`
+
+The monitor_spec supports the following:
+* `enable_compute_load_monitor` - (Optional, Computed, Bool, Available since v1.288.0) Specifies whether to enable the monitoring component for the compute nodes. Valid values:
+
+  - true
+  - false
+
+### `queues`
+
+The queues supports the following:
+* `queue_name` - (Optional, ForceNew, Available since v1.288.0) The name of the queue. The name must be 1 to 15 characters in length. It can contain letters, digits, and periods (.).
+* `enable_scale_out` - (Optional, ForceNew, Bool, Available since v1.288.0) Specifies whether to enable auto scale-out for the queue. Valid values:
+
+  - true
+  - false
+* `enable_scale_in` - (Optional, ForceNew, Bool, Available since v1.288.0) Specifies whether to enable auto scale-in for the queue. Valid values:
+
+  - true
+  - false
+* `min_count` - (Optional, ForceNew, Int, Available since v1.288.0) The minimum number of compute nodes that the queue retains.
+* `max_count` - (Optional, ForceNew, Int, Available since v1.288.0) The maximum number of compute nodes that the queue can retain.
+* `initial_count` - (Optional, ForceNew, Int, Available since v1.288.0) The initial number of compute nodes that the queue retains.
+* `inter_connect` - (Optional, ForceNew, Available since v1.288.0) The network type between the compute nodes in the queue. Valid values:
+
+  - vpc
+  - eRDMA
+* `vswitch_ids` - (Optional, ForceNew, List, Available since v1.288.0) The list of vSwitches available to the compute nodes in the queue. The value range of N is 1 to 5.
+* `compute_nodes` - (Optional, ForceNew, List, Available since v1.288.0) The list of hardware configurations of the compute nodes in the queue. The value range of N is 0 to 10. See [`compute_nodes`](#queues-compute_nodes) below.
+* `allocation_strategy` - (Optional, ForceNew, Available since v1.288.0) The auto scale-out strategy of the queue.
+* `ram_role` - (Optional, ForceNew, Available since v1.288.0) The name of the instance role attached to the compute nodes in the queue.
+* `hostname_prefix` - (Optional, ForceNew, Available since v1.288.0) The hostname prefix of the compute nodes in the queue.
+* `hostname_suffix` - (Optional, ForceNew, Available since v1.288.0) The hostname suffix of the compute nodes in the queue.
+* `keep_alive_nodes` - (Optional, ForceNew, List, Available since v1.288.0) The list of nodes with deletion protection enabled in the queue. The value is the hostname of the node.
+* `max_count_per_cycle` - (Optional, ForceNew, Int, Available since v1.288.0) The maximum number of compute nodes that the queue can scale out in each scale-out cycle.
+* `reserved_node_pool_id` - (Optional, ForceNew, Available since v1.288.0) The ID of the reserved node pool used by the queue.
+
+### `queues-compute_nodes`
+
+The queues-compute_nodes supports the following:
+* `instance_type` - (Optional, ForceNew, Available since v1.288.0) The instance type of the compute node.
+* `image_id` - (Optional, ForceNew, Available since v1.288.0) The ID of the image used by the compute node.
+* `instance_charge_type` - (Optional, ForceNew, Available since v1.288.0) The instance billing method of the compute node. Valid values:
+
+  - PostPaid: pay-as-you-go
+  - PrePaid: subscription
+* `period_unit` - (Optional, ForceNew, Available since v1.288.0) The unit of duration of the year-to-month billing method. Valid values:
+
+  - Week
+  - Month
+* `period` - (Optional, ForceNew, Int, Available since v1.288.0) The duration of the resource purchase. The unit is specified by `period_unit`.
+* `auto_renew` - (Optional, ForceNew, Bool, Available since v1.288.0) Specifies whether to enable auto-renewal. This parameter takes effect only when `instance_charge_type` is set to PrePaid.
+* `auto_renew_period` - (Optional, ForceNew, Int, Available since v1.288.0) The renewal duration of a single automatic renewal.
+* `spot_strategy` - (Optional, ForceNew, Available since v1.288.0) The bidding strategy for pay-as-you-go instances. Valid values:
+
+  - NoSpot: normal pay-as-you-go instances (default).
+  - SpotWithPriceLimit: set the upper limit price for the preemptible instance.
+  - SpotAsPriceGo: The system automatically bids, following the actual price of the current market.
+* `spot_price_limit` - (Optional, ForceNew, Float, Available since v1.288.0) The maximum price per hour for the instance. The maximum number of decimals is 3. It takes effect when `spot_strategy` is set to SpotWithPriceLimit.
+* `duration` - (Optional, ForceNew, Int, Available since v1.288.0) The duration of the preemptible instance, in hours.
+* `enable_ht` - (Optional, ForceNew, Bool, Available since v1.288.0) Specifies whether to enable hyper-threading on the compute node.
+* `system_disk` - (Optional, ForceNew, List, Available since v1.288.0) The system disk configuration of the compute node. See [`system_disk`](#queues-compute_nodes-system_disk) below.
+
+### `queues-compute_nodes-system_disk`
+
+The queues-compute_nodes-system_disk supports the following:
+* `category` - (Optional, ForceNew, Available since v1.288.0) The category of the system disk. Valid values:
+
+  - cloud_efficiency: The Ultra cloud disk.
+  - cloud_ssd: SSD cloud disk.
+  - cloud_essd: ESSD cloud disk.
+  - cloud: ordinary cloud disk.
+* `size` - (Optional, ForceNew, Int, Available since v1.288.0) The system disk size of the compute node. Unit: GiB.
+* `level` - (Optional, ForceNew, Available since v1.288.0) The performance level of the ESSD cloud disk used as the system disk. Valid values:
+
+  - PL0
+  - PL1
+  - PL2
+  - PL3
+
+### `scheduler_spec`
+
+The scheduler_spec supports the following:
+* `enable_topology_awareness` - (Optional, Computed, Bool, Available since v1.288.0) Specifies whether to enable the topology awareness feature for the cluster. Valid values:
+
+  - true
+  - false
+
 ### `shared_storages`
 
 The shared_storages supports the following:
@@ -317,8 +436,11 @@ The shared_storages supports the following:
 ## Attributes Reference
 
 The following attributes are exported:
-* `id` - The ID of the resource supplied above. 
+* `id` - The ID of the resource supplied above.
+* `cluster_status` - (Available since v1.288.0) The status of the cluster.
 * `create_time` - The time when the cluster was created.
+* `ehpc_version` - (Available since v1.288.0) The version of the E-HPC cluster.
+* `modify_time` - (Available since v1.288.0) The time when the cluster was modified.
 * `manager` - The configurations of the cluster management node.
   * `manager_node` - The hardware configurations of the management node.
     * `expired_time` - The expiration time of the management node.


### PR DESCRIPTION
## Summary
- Add the attributes that `CreateCluster`/`UpdateCluster`/`GetCluster` of E-HPC (EHPC 2024-07-30) expose but `alicloud_ehpc_cluster_v2` did not support yet.
- New create-only arguments (ForceNew, not returned by `GetCluster`): `is_enterprise_security_group`, `tags`, `additional_packages` and `queues` (full queue template including `compute_nodes`). `cluster_description` is also not returned by the API but can be updated in place.
- New updatable arguments that are read back from `GetCluster`: `max_count`, `max_core_count`, `grow_interval`, `idle_interval`, `enable_scale_out`, `enable_scale_in`, `monitor_spec`, `scheduler_spec` and `cluster_custom_configuration`. `EnableScaleOut`/`EnableScaleIn`/`MonitorSpec`/`SchedulerSpec` are not accepted by `CreateCluster`; when they are set at creation time, they are applied through a follow-up `UpdateCluster` call once the cluster is running.
- New computed attributes: `cluster_status`, `ehpc_version`, `modify_time`.
- Fix mismatched argument descriptions in the documentation (`client_version`, `cluster_name`, `deletion_protection`, `enable_ht`, `image_id`) and document all new attributes.

Note on import verification: all import steps run with `ImportStateVerify` enabled. Attributes that `GetCluster` never returns are listed in `ImportStateVerifyIgnore`: the existing steps ignore `addons` and `cluster_credentials` (required by `CreateCluster` but never returned), and the enhanced coverage case additionally ignores `additional_packages`, `cluster_description`, `is_enterprise_security_group`, `queues` and `tags`, which are only accepted by `CreateCluster`. To keep this pattern checkable, the testing coverage rate check now exempts ForceNew attributes that the resource Read never writes back from its `ImportStateVerifyIgnore` rule.

## Test plan

```
=== RUN TestAccAliCloudEhpcClusterV2_basic12485
--- PASS: TestAccAliCloudEhpcClusterV2_basic12485 (265.67s)

=== RUN TestAccAliCloudEhpcClusterV2_enhanced
--- PASS: TestAccAliCloudEhpcClusterV2_enhanced (285.86s)
```

- `TestAccAliCloudEhpcClusterV2_basic12485` PASS in cn-hangzhou: regression for the existing key-pair based cluster flow, including import with attribute-level verification.
- `TestAccAliCloudEhpcClusterV2_enhanced` PASS: the import step keeps `ImportStateVerify` enabled and ignores only the attributes that `GetCluster` never returns; the new create-only and updatable attributes are verified end to end.
