### PR TITLE
resource/alicloud_ram_policy: fix force delete leaving orphaned policies; resource/alicloud_ram_role: fix force delete leaving orphaned roles

### DIFF
--- a/alicloud/resource_alicloud_ram_policy.go
+++ b/alicloud/resource_alicloud_ram_policy.go
@@ -395,12 +395,16 @@ func resourceAliCloudRamPolicyDelete(d *schema.ResourceData, meta interface{}) e
 		addDebug(listAction, response, listRequest)
 
 		if err != nil {
-			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			if IsExpectedErrors(err, []string{"EntityNotExist.Policy"}) || NotFoundError(err) {
+				return nil
+			}
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), listAction, AlibabaCloudSdkGoERROR)
 		}
 
-		userResp, err := jsonpath.Get("$.Users.User", response)
+		listResponse := response
+		userResp, err := jsonpath.Get("$.Users.User", listResponse)
 		if err != nil {
-			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.Users.User", response)
+			return WrapErrorf(err, FailedGetAttributeMsg, listAction, "$.Users.User", listResponse)
 		}
 		if userResp != nil && len(userResp.([]interface{})) > 0 {
 			for _, v := range userResp.([]interface{}) {
@@ -422,20 +426,20 @@ func resourceAliCloudRamPolicyDelete(d *schema.ResourceData, meta interface{}) e
 					}
 					return nil
 				})
-				addDebug(action, response, userRequest)
+				addDebug(userAction, response, userRequest)
 
 				if err != nil {
-					if IsExpectedErrors(err, []string{"EntityNotExist"}) || NotFoundError(err) {
-						return nil
+					if IsExpectedErrors(err, []string{"EntityNotExist", "EntityNotExist.User", "EntityNotExist.User.Policy", "EntityNotExist.Policy"}) || NotFoundError(err) {
+						continue
 					}
-					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), userAction, AlibabaCloudSdkGoERROR)
 				}
 			}
 		}
 
-		groupResp, err := jsonpath.Get("$.Groups.Group", response)
+		groupResp, err := jsonpath.Get("$.Groups.Group", listResponse)
 		if err != nil {
-			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.Groups.Group", response)
+			return WrapErrorf(err, FailedGetAttributeMsg, listAction, "$.Groups.Group", listResponse)
 		}
 		if groupResp != nil && len(groupResp.([]interface{})) > 0 {
 			for _, v := range groupResp.([]interface{}) {
@@ -457,20 +461,20 @@ func resourceAliCloudRamPolicyDelete(d *schema.ResourceData, meta interface{}) e
 					}
 					return nil
 				})
-				addDebug(action, response, groupRequest)
+				addDebug(groupAction, response, groupRequest)
 
 				if err != nil {
-					if IsExpectedErrors(err, []string{"EntityNotExist"}) || NotFoundError(err) {
-						return nil
+					if IsExpectedErrors(err, []string{"EntityNotExist", "EntityNotExist.Group", "EntityNotExist.Group.Policy", "EntityNotExist.Policy"}) || NotFoundError(err) {
+						continue
 					}
-					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), groupAction, AlibabaCloudSdkGoERROR)
 				}
 			}
 		}
 
-		roleResp, err := jsonpath.Get("$.Roles.Role", response)
+		roleResp, err := jsonpath.Get("$.Roles.Role", listResponse)
 		if err != nil {
-			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.Roles.Role", response)
+			return WrapErrorf(err, FailedGetAttributeMsg, listAction, "$.Roles.Role", listResponse)
 		}
 		if roleResp != nil && len(roleResp.([]interface{})) > 0 {
 			for _, v := range roleResp.([]interface{}) {
@@ -492,13 +496,13 @@ func resourceAliCloudRamPolicyDelete(d *schema.ResourceData, meta interface{}) e
 					}
 					return nil
 				})
-				addDebug(action, response, roleRequest)
+				addDebug(roleAction, response, roleRequest)
 
 				if err != nil {
-					if IsExpectedErrors(err, []string{"EntityNotExist"}) || NotFoundError(err) {
-						return nil
+					if IsExpectedErrors(err, []string{"EntityNotExist", "EntityNotExist.Role", "EntityNotExist.Role.Policy", "EntityNotExist.Policy"}) || NotFoundError(err) {
+						continue
 					}
-					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), roleAction, AlibabaCloudSdkGoERROR)
 				}
 			}
 		}
@@ -520,23 +524,24 @@ func resourceAliCloudRamPolicyDelete(d *schema.ResourceData, meta interface{}) e
 			}
 			return nil
 		})
-		addDebug(action, response, listVersionsRequest)
+		addDebug(listVersionsAction, response, listVersionsRequest)
 
 		if err != nil {
 			if IsExpectedErrors(err, []string{"EntityNotExist.Policy"}) || NotFoundError(err) {
 				return nil
 			}
-			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), listVersionsAction, AlibabaCloudSdkGoERROR)
 		}
 
 		versionsResp, er := jsonpath.Get("$.PolicyVersions.PolicyVersion", response)
 		if er != nil {
-			return WrapErrorf(er, FailedGetAttributeMsg, action, "$.PolicyVersions.PolicyVersion", response)
+			return WrapErrorf(er, FailedGetAttributeMsg, listVersionsAction, "$.PolicyVersions.PolicyVersion", response)
 		}
 		// More than one means there are other versions besides the default version
 		if versionsResp != nil && len(versionsResp.([]interface{})) > 1 {
 			for _, v := range versionsResp.([]interface{}) {
-				if !v.(map[string]interface{})["IsDefaultVersion"].(bool) {
+				isDefaultVersion, _ := v.(map[string]interface{})["IsDefaultVersion"].(bool)
+				if !isDefaultVersion {
 					versionAction := "DeletePolicyVersion"
 					versionRequest := map[string]interface{}{
 						"PolicyName": d.Id(),
@@ -556,6 +561,13 @@ func resourceAliCloudRamPolicyDelete(d *schema.ResourceData, meta interface{}) e
 						return nil
 					})
 					addDebug(versionAction, response, versionRequest)
+
+					if err != nil {
+						if IsExpectedErrors(err, []string{"EntityNotExist.Policy", "EntityNotExist.Policy.Version"}) || NotFoundError(err) {
+							continue
+						}
+						return WrapErrorf(err, DefaultErrorMsg, d.Id(), versionAction, AlibabaCloudSdkGoERROR)
+					}
 				}
 			}
 		}

--- a/alicloud/resource_alicloud_ram_role.go
+++ b/alicloud/resource_alicloud_ram_role.go
@@ -371,12 +371,12 @@ func resourceAliCloudRamRoleDelete(d *schema.ResourceData, meta interface{}) err
 			if IsExpectedErrors(err, []string{"EntityNotExist.Role"}) || NotFoundError(err) {
 				return nil
 			}
-			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), listAction, AlibabaCloudSdkGoERROR)
 		}
 
 		policyResp, err := jsonpath.Get("$.Policies.Policy", response)
 		if err != nil {
-			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.Policies.Policy", response)
+			return WrapErrorf(err, FailedGetAttributeMsg, listAction, "$.Policies.Policy", response)
 		}
 
 		// Loop and remove the Policies from the Role
@@ -389,6 +389,7 @@ func resourceAliCloudRamRoleDelete(d *schema.ResourceData, meta interface{}) err
 					"PolicyType": v.(map[string]interface{})["PolicyType"],
 				}
 
+				wait := incrementalWait(3*time.Second, 3*time.Second)
 				err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 					response, err = client.RpcPost("Ram", "2015-05-01", policyAction, nil, policyRequest, true)
 					if err != nil {
@@ -400,13 +401,13 @@ func resourceAliCloudRamRoleDelete(d *schema.ResourceData, meta interface{}) err
 					}
 					return nil
 				})
-				addDebug(action, response, policyRequest)
+				addDebug(policyAction, response, policyRequest)
 
 				if err != nil {
-					if IsExpectedErrors(err, []string{"EntityNotExist"}) || NotFoundError(err) {
-						return nil
+					if IsExpectedErrors(err, []string{"EntityNotExist", "EntityNotExist.Role", "EntityNotExist.Role.Policy", "EntityNotExist.Policy"}) || NotFoundError(err) {
+						continue
 					}
-					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), policyAction, AlibabaCloudSdkGoERROR)
 				}
 			}
 


### PR DESCRIPTION
Fixes #10093

## Problem

With `force = true`, the delete path treated "entity already detached" as "delete finished". `DetachPolicyFromUser/Group/Role` returning `EntityNotExist.*` hit a `return nil` that exited the whole Delete function, so `ListPolicyVersions` and `DeletePolicy` never ran. Terraform reported `Destruction complete` and cleaned state while the policy remained in the account with `attachment_count = 0`.

This triggers when an `alicloud_ram_role_policy_attachment` for the same (policy, role) pair is destroyed in the same run: the attachment detaches first, `ListEntitiesForPolicy` still returns the stale role, and the provider's own detach then reports `EntityNotExist.Role.Policy`.

`alicloud_ram_role` had the identical defect in its own force-delete path and orphaned the **role** the same way, so it is fixed here too.

The intended meaning of that branch is "nothing left to detach here, carry on", so it is now `continue`. `alicloud_ram_group` and `alicloud_ram_user` already implement this step correctly (`if err != nil && !IsExpectedErrors(...)`), so this brings the two outliers in line with the existing convention.

## Also fixed in the same delete paths

- **`ListEntitiesForPolicy`'s response was overwritten by the detach calls.** `response` is one function-scoped variable reused by every `RpcPost`, so after the user loop ran, `jsonpath.Get("$.Groups.Group", response)` read a `DetachPolicyFromUser` response, which has no `Groups`/`Roles` keys. Group and role entities were silently never detached and `DeletePolicy` then retried `DeleteConflict.*` to timeout. Snapshotted as `listResponse`. This one is deterministic whenever a policy is attached to a user *and* a group/role.
- **Explicit not-found codes.** The detach sites now match `EntityNotExist.<entity>[.Policy]` — the same codes the `ram_*_policy_attachment` resources already use — instead of the bare `EntityNotExist`, which only matched by substring against the error payload rather than the error code.
- **`DeletePolicyVersion`'s error was assigned and never checked.** A failure there is now reported instead of surfacing later as an unexplained `DeleteConflict.Policy.Version` retried to the delete timeout.
- **`ListEntitiesForPolicy` now tolerates a missing policy**, matching the equivalent call in `alicloud_ram_role`, so a policy deleted out of band no longer fails destroy.
- **Guarded the `IsDefaultVersion` type assertion.**
- **Errors and debug output now name the API that actually failed** instead of labelling every failure `DeletePolicy` / `DeleteRole`.
- **`alicloud_ram_role`'s detach loop builds a fresh `incrementalWait` per iteration**, so backoff no longer accumulates from the preceding list call.

## Acceptance tests

```
$ make testacc TEST=./alicloud TESTARGS='-run=TestAccAliCloudRamPolicy'

PASS: TestAccAliCloudRamPolicy_multi (4.56s)
PASS: TestAccAliCloudRamPolicy_basic10003 (14.16s)
PASS: TestAccAliCloudRamPolicy_basic10003_twin (3.65s)
PASS: TestAccAliCloudRamPolicy_basic10005 (14.64s)
PASS: TestAccAliCloudRamPolicy_basic10005_twin (3.74s)
PASS: TestAccAliCloudRamPolicy_basic10006 (14.86s)
PASS: TestAccAliCloudRamPolicy_basic10006_twin (3.82s)
PASS: TestAccAliCloudRamPolicyDocumentDataSource0 (4.13s)
PASS: TestAccAliCloudRamPolicyDocumentDataSource1 (3.68s)
PASS: TestAccAliCloudRamPolicyDocumentDataSource2 (3.81s)
PASS: TestAccAliCloudRamPolicyDocumentDataSource3 (3.72s)
PASS: TestAccAliCloudRamPolicyDocumentDataSource4 (3.74s)

PASS=12 FAIL=0 SKIP=0
```

```
$ make testacc TEST=./alicloud TESTARGS='-run=TestAccAliCloudRamRole'

PASS: TestAccAliCloudRamRole_multi (4.15s)
PASS: TestAccAliCloudRamRole_basic5886 (18.46s)
PASS: TestAccAliCloudRamRole_basic5886_twin (3.90s)
PASS: TestAccAliCloudRamRole_basic5888 (17.45s)
PASS: TestAccAliCloudRamRole_basic5888_twin (3.67s)
PASS: TestAccAliCloudRamRole_basic5890 (18.67s)
PASS: TestAccAliCloudRamRole_basic5890_twin (3.89s)
PASS: TestAccAliCloudRamRolesDataSource_basic0 (51.65s)
PASS: TestAccAliCloudRamRolesDataSource_basic1 (45.01s)
PASS: TestAccAliCloudRamRolePolicyAttachment_basic9050 (4.28s)
PASS: TestAccAliCloudRamRolePolicyAttachment_basic9051 (4.48s)
FAIL: TestAccAliCloudRamRoleAttachment_basic0 (4.85s)
FAIL: TestAccAliCloudRamRoleAttachment_basic0_twin (3.84s)

PASS=11 FAIL=2 SKIP=0
```

All 23 cases covering the two changed resources pass.

The 2 failures are unrelated to this change and were confirmed pre-existing by running the same suite against an unmodified `master` checkout, where they fail identically:

- they fail during `plan`, because `data.alicloud_instance_types.default.instance_types` comes back as an empty list in the test region and `instance_types[0]` cannot be indexed — no RAM API call is reached;
- `alicloud_ram_role_attachment` is a different resource, in a file this PR does not touch, and has been deprecated since v1.250.0 in favour of `alicloud_ecs_ram_role_attachment`;
- they were only selected because the run pattern `TestAccAliCloudRamRole*` also prefix-matches `TestAccAliCloudRamRoleAttachment*`.

## Note on coverage

No existing test places a policy and an attachment resource in the same configuration, so the changed detach loops are not executed by the suites above — they demonstrate no regression rather than proving the fix. A regression case (policy attached to a user and a role, `force = true`, then destroy) would cover the deterministic response-overwrite half of this and can be added if preferred.
