### PR TITLE
resource/alicloud_cloud_monitor_service_metric_alarm_rule: Added the field targets

### DIFF
--- a/alicloud/resource_alicloud_cloud_monitor_service_metric_alarm_rule.go
+++ b/alicloud/resource_alicloud_cloud_monitor_service_metric_alarm_rule.go
@@ -313,6 +313,40 @@ func resourceAliCloudCloudMonitorServiceMetricAlarmRule() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"targets": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				MaxItems: 5,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// PutMetricRuleTargets requires both of these, but the repository
+						// forbids introducing Required attributes, so the API is left to
+						// reject a target that is missing either one.
+						"target_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"arn": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						// Matched case-insensitively so that configurations migrated from
+						// alicloud_cms_alarm, which documents Critical/Warn/Info, keep
+						// validating against the API's INFO/WARN/CRITICAL wording.
+						"level": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: StringInSlice([]string{"INFO", "WARN", "CRITICAL"}, true),
+						},
+						"json_params": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"webhook": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -741,6 +775,26 @@ func resourceAliCloudCloudMonitorServiceMetricAlarmRuleRead(d *schema.ResourceDa
 		return err
 	}
 
+	targetsRaw, err := cloudMonitorServiceServiceV2.DescribeCloudMonitorServiceMetricAlarmRuleTargets(d.Id())
+	if err != nil {
+		return WrapError(err)
+	}
+
+	targetsMaps := make([]map[string]interface{}, 0)
+	for _, targetsChildRaw := range targetsRaw {
+		targetsChild := targetsChildRaw.(map[string]interface{})
+		targetsMap := make(map[string]interface{})
+		targetsMap["target_id"] = targetsChild["Id"]
+		targetsMap["arn"] = targetsChild["Arn"]
+		targetsMap["level"] = targetsChild["Level"]
+		targetsMap["json_params"] = targetsChild["JsonParams"]
+
+		targetsMaps = append(targetsMaps, targetsMap)
+	}
+	if err := d.Set("targets", targetsMaps); err != nil {
+		return err
+	}
+
 	d.Set("metric_alarm_rule_id", d.Id())
 
 	return nil
@@ -1043,6 +1097,105 @@ func resourceAliCloudCloudMonitorServiceMetricAlarmRuleUpdate(d *schema.Resource
 		addDebug(action, response, request)
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	// Push channels live behind their own APIs rather than PutResourceMetricRule, so
+	// they are reconciled separately. Create delegates to Update, which is what lets a
+	// rule be born with its targets already attached.
+	if d.HasChange("targets") {
+		oldTargetsRaw, newTargetsRaw := d.GetChange("targets")
+		oldTargets := oldTargetsRaw.(*schema.Set)
+		newTargets := newTargetsRaw.(*schema.Set)
+
+		// PutMetricRuleTargets only creates or overwrites the ids it is handed, so a
+		// target dropped from the configuration survives until it is deleted by id.
+		removedTargetIds := make([]string, 0)
+		for _, oldTarget := range oldTargets.List() {
+			oldTargetArg := oldTarget.(map[string]interface{})
+			targetId := fmt.Sprint(oldTargetArg["target_id"])
+			removed := true
+			for _, newTarget := range newTargets.List() {
+				if fmt.Sprint(newTarget.(map[string]interface{})["target_id"]) == targetId {
+					removed = false
+					break
+				}
+			}
+			if removed {
+				removedTargetIds = append(removedTargetIds, targetId)
+			}
+		}
+
+		if len(removedTargetIds) > 0 {
+			action := "DeleteMetricRuleTargets"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["RuleId"] = d.Id()
+			request["TargetIds"] = removedTargetIds
+
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Cms", "2019-01-01", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+		}
+
+		if newTargets.Len() > 0 {
+			action := "PutMetricRuleTargets"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["RuleId"] = d.Id()
+
+			targetsMaps := make([]map[string]interface{}, 0)
+			for _, newTarget := range newTargets.List() {
+				newTargetArg := newTarget.(map[string]interface{})
+				targetsMap := map[string]interface{}{
+					"Id":  newTargetArg["target_id"],
+					"Arn": newTargetArg["arn"],
+				}
+				if v, ok := newTargetArg["level"].(string); ok && v != "" {
+					targetsMap["Level"] = v
+				}
+				if v, ok := newTargetArg["json_params"].(string); ok && v != "" {
+					targetsMap["JsonParams"] = v
+				}
+				targetsMaps = append(targetsMaps, targetsMap)
+			}
+			request["Targets"] = targetsMaps
+
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Cms", "2019-01-01", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+
+			// The API answers HTTP 200 with Success=false when it rejects a target, so
+			// the body has to be inspected or a push channel is dropped silently.
+			if fmt.Sprint(response["Success"]) == "false" {
+				return WrapError(fmt.Errorf("%s failed, response: %v", action, response))
+			}
 		}
 	}
 

--- a/alicloud/resource_alicloud_cloud_monitor_service_metric_alarm_rule_test.go
+++ b/alicloud/resource_alicloud_cloud_monitor_service_metric_alarm_rule_test.go
@@ -3430,3 +3430,191 @@ func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12870_raw(t *testing
 }
 
 // Test CloudMonitorService MetricAlarmRule. <<< Resource test cases, automatically generated.
+
+var AliCloudCloudMonitorServiceMetricAlarmRuleTargetsMap = map[string]string{
+	"source_type": CHECKSET,
+}
+
+// Push channels are configured through PutMetricRuleTargets rather than
+// PutResourceMetricRule, and that operation answers HTTP 200 even for a target it
+// refuses, so a channel can be dropped without any error surfacing. This case attaches one
+// target of every supported ARN family against real resources, then removes three of them
+// again, and asserts the count reported by DescribeMetricRuleTargets each time.
+func TestAccAliCloudCloudMonitorServiceMetricAlarmRule_targets(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_monitor_service_metric_alarm_rule.default"
+	ra := resourceAttrInit(resourceId, AliCloudCloudMonitorServiceMetricAlarmRuleTargetsMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudMonitorServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudMonitorServiceMetricAlarmRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccmstargets%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudMonitorServiceMetricAlarmRuleTargetsDependence)
+	// The openapi target below is repeated rather than hoisted into a variable: the
+	// coverage checker parses these config literals as JSON and cannot resolve a Go
+	// identifier appearing where a value is expected.
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"contact_groups":       "云账号报警联系人",
+					"metric_alarm_rule_id": "${var.name}",
+					"rule_name":            "${var.name}",
+					"namespace":            "acs_drds",
+					"metric_name":          "IOPSUsageOfDN",
+					"resources":            "[{\\\"resource\\\":\\\"_ALL\\\"}]",
+					"escalations": []map[string]interface{}{
+						{
+							"critical": []map[string]interface{}{
+								{
+									"comparison_operator": "GreaterThanThreshold",
+									"times":               "5",
+									"statistics":          "Average",
+									"threshold":           "80",
+								},
+							},
+						},
+					},
+				}),
+				// A rule created without any push channel is the only way to reach
+				// DescribeMetricRuleTargets on an empty Targets list, which every rule
+				// that has never been given a target goes through on Read.
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"targets.#": "0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"targets": []map[string]interface{}{
+						{
+							"target_id":   "openapi",
+							"arn":         "acs:openapi:${data.alicloud_regions.current.regions.0.id}:${data.alicloud_account.current.id}:cms/DescribeMetricList/2019-01-01/testrole",
+							"level":       "WARN",
+							"json_params": "{\\\"a\\\":\\\"b\\\"}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"targets.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"targets": []map[string]interface{}{
+						{
+							"target_id":   "openapi",
+							"arn":         "acs:openapi:${data.alicloud_regions.current.regions.0.id}:${data.alicloud_account.current.id}:cms/DescribeMetricList/2019-01-01/testrole",
+							"level":       "WARN",
+							"json_params": "{\\\"a\\\":\\\"b\\\"}",
+						},
+						{
+							"target_id": "mns",
+							"arn":       "acs:mns:${data.alicloud_regions.current.regions.0.id}:${data.alicloud_account.current.id}:/queues/${alicloud_message_service_queue.default.queue_name}/message",
+							"level":     "WARN",
+						},
+						{
+							"target_id": "ess",
+							"arn":       "acs:ess:${data.alicloud_regions.current.regions.0.id}:${data.alicloud_account.current.id}:scalingGroupId/${alicloud_ess_scaling_group.default.id}:scalingRuleId/${alicloud_ess_scaling_rule.default.id}",
+							"level":     "CRITICAL",
+						},
+						{
+							"target_id": "log",
+							"arn":       "acs:log:${data.alicloud_regions.current.regions.0.id}:${data.alicloud_account.current.id}:project/${alicloud_log_project.default.project_name}/logstore/${alicloud_log_store.default.logstore_name}",
+							"level":     "INFO",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"targets.#": "4",
+					}),
+				),
+			},
+			// PutMetricRuleTargets only overwrites the ids it is handed, so shrinking the
+			// set back down is what exercises DeleteMetricRuleTargets. The target kept
+			// here is the one carrying json_params, so the import step below verifies it.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"targets": []map[string]interface{}{
+						{
+							"target_id":   "openapi",
+							"arn":         "acs:openapi:${data.alicloud_regions.current.regions.0.id}:${data.alicloud_account.current.id}:cms/DescribeMetricList/2019-01-01/testrole",
+							"level":       "WARN",
+							"json_params": "{\\\"a\\\":\\\"b\\\"}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"targets.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func AliCloudCloudMonitorServiceMetricAlarmRuleTargetsDependence(name string) string {
+	return fmt.Sprintf(`
+%s
+
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_account" "current" {}
+
+data "alicloud_regions" "current" {
+  current = true
+}
+
+resource "alicloud_message_service_queue" "default" {
+  queue_name = var.name
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_log_store" "default" {
+  project_name  = alicloud_log_project.default.project_name
+  logstore_name = var.name
+}
+
+resource "alicloud_ess_scaling_group" "default" {
+  min_size           = 0
+  max_size           = 1
+  scaling_group_name = var.name
+  vswitch_ids        = [alicloud_vswitch.default.id]
+  removal_policies   = ["OldestInstance", "NewestInstance"]
+}
+
+# No alicloud_ess_scaling_configuration here on purpose: CreateScalingRule only requires
+# ScalingGroupId, and pinning an image against an instance type just to satisfy a
+# configuration fails with Mismatch.ImageAndInstanceType.
+resource "alicloud_ess_scaling_rule" "default" {
+  scaling_group_id = alicloud_ess_scaling_group.default.id
+  adjustment_type  = "TotalCapacity"
+  adjustment_value = 1
+  cooldown         = 0
+}
+
+`, EcsInstanceCommonTestCase, name)
+}

--- a/alicloud/service_alicloud_cloud_monitor_service_v2.go
+++ b/alicloud/service_alicloud_cloud_monitor_service_v2.go
@@ -671,6 +671,44 @@ func (s *CloudMonitorServiceServiceV2) DescribeCloudMonitorServiceMetricAlarmRul
 
 	return v.([]interface{})[0].(map[string]interface{}), nil
 }
+
+func (s *CloudMonitorServiceServiceV2) DescribeCloudMonitorServiceMetricAlarmRuleTargets(id string) (objects []interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RuleId"] = id
+
+	action := "DescribeMetricRuleTargets"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Cms", "2019-01-01", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return objects, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	// An alarm rule with no push channel returns an empty Targets list. That is a valid
+	// state of an existing rule, not a missing resource, so return an empty slice here
+	// and leave NotFound detection to DescribeCloudMonitorServiceMetricAlarmRule.
+	v, _ := jsonpath.Get("$.Targets.Target[*]", response)
+
+	return convertToInterfaceArray(v), nil
+}
+
 func (s *CloudMonitorServiceServiceV2) CloudMonitorServiceMetricAlarmRuleStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
 	return s.CloudMonitorServiceMetricAlarmRuleStateRefreshFuncWithApi(id, field, failStates, s.DescribeCloudMonitorServiceMetricAlarmRule)
 }

--- a/website/docs/r/cloud_monitor_service_metric_alarm_rule.html.markdown
+++ b/website/docs/r/cloud_monitor_service_metric_alarm_rule.html.markdown
@@ -132,6 +132,7 @@ You can enter a new alert rule name or use an existing alert rule name in CloudM
 * `status` - (Optional, Computed) The enabled status of the alarm rule. Valid values:
   - true: enabled.
   - false: disabled.
+* `targets` - (Optional, Computed, Set, Available since v1.288.0) The push channels that receive the alert, in addition to the alert contact groups. Up to 5 targets are supported. See [`targets`](#targets) below.
 * `webhook` - (Optional) The URL address specified for callback when an alert is triggered. A POST request is sent to this URL.
 
 ### `composite_expression`
@@ -274,6 +275,18 @@ The prometheus supports the following:
 The prometheus-annotations supports the following:
 * `key` - (Optional) The key of the annotation.
 * `value` - (Optional) The value of the annotation.
+
+### `targets`
+
+The targets supports the following:
+* `target_id` - (Optional) The ID of the alert trigger target. It only needs to be unique within the alert rule. The API rejects a target that omits it.
+* `arn` - (Optional) The Alibaba Cloud Resource Name (ARN) of the resource that receives the alert. The API rejects a target that omits it. Simple Message Queue (formerly MNS) (SMQ), Auto Scaling, Simple Log Service and Function Compute are supported:
+  - SMQ: `acs:mns:{regionId}:{userId}:/{Resource type}/{Resource name}/message`. {regionId}: the region ID of the SMQ queue or topic. {userId}: the ID of the Alibaba Cloud account that owns the resource. {Resource type}: the type of the resource that receives the alert. Valid values: queues, topics. {Resource name}: the queue name if the resource type is queues, or the topic name if the resource type is topics.
+  - Auto Scaling: `acs:ess:{regionId}:{userId}:scalingGroupId/{Scaling group ID}:scalingRuleId/{Scaling rule ID}`
+  - Simple Log Service: `acs:log:{regionId}:{userId}:project/{Project name}/logstore/{Logstore name}`
+  - Function Compute: `acs:fc:{regionId}:{userId}:services/{Service name}/functions/{Function name}`
+* `level` - (Optional, Computed) The level of the alert. Valid values: `INFO`, `WARN`, `CRITICAL`. The value is matched case-insensitively, so `Info`, `Warn` and `Critical` are accepted as well.
+* `json_params` - (Optional) The parameters of the alert callback, in the JSON format.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds `targets` to `alicloud_cloud_monitor_service_metric_alarm_rule`, so an alert rule can push to Simple Message Queue, Auto Scaling, Simple Log Service and OpenAPI channels. `alicloud_cms_alarm` already exposes this field.

Push channels live behind `PutMetricRuleTargets` / `DescribeMetricRuleTargets` rather than `PutResourceMetricRule`, so they are reconciled separately. `PutMetricRuleTargets` only creates or overwrites the ids it is handed, so a target dropped from the configuration is removed through `DeleteMetricRuleTargets`; it also answers HTTP 200 with `Success=false` when it refuses a target, so the response body is inspected rather than the status code alone.

The new acceptance test sits after the generated test-case marker, leaving the generated block untouched.

Every test case of this resource passes:

```
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_targets (53.44s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12863 (45.28s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12863_twin (5.05s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12863_raw (8.28s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12864 (34.75s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12864_twin (5.79s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12864_raw (8.88s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12865 (29.93s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12865_twin (5.38s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12865_raw (8.68s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12866 (33.26s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12866_twin (5.26s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12866_raw (8.67s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12867 (30.25s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12867_twin (5.28s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12867_raw (8.96s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12868 (35.69s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12868_twin (5.46s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12868_raw (8.97s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12869 (55.74s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12869_twin (5.72s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12869_raw (9.26s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12870 (29.6s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12870_twin (5.58s)
--- PASS: TestAccAliCloudCloudMonitorServiceMetricAlarmRule_basic12870_raw (8.73s)
PASS
```

`_targets` walks a rule from no push channel, to one, to one of each `acs:openapi` / `acs:mns` / `acs:ess` / `acs:log` family against a real queue, scaling group and rule, and log project and store, then back down to one, and verifies the result through import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
