### PR TITLE
New Resource: alicloud_cms_event_notify_policy; New Data Source: alicloud_cms_event_notify_policies

### DIFF
--- a/alicloud/data_source_alicloud_cms_event_notify_policies.go
+++ b/alicloud/data_source_alicloud_cms_event_notify_policies.go
@@ -1,0 +1,953 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudCmsEventNotifyPolicies() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudCmsEventNotifyPolicyRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"order_by": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"order_desc": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"workspace": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"notify_strategy": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"description": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ignore_restored_notification": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"grouping_setting": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"grouping_keys": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"period_min": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"times": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"silence_sec": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"routes": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"digital_employee_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"enable_rca": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"filter_setting": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"relation": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"expression": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"conditions": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"field": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																		"op": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																		"value": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+												"effect_time_range": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"time_zone": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"start_time_in_minute": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"end_time_in_minute": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"day_in_week": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeInt},
+															},
+														},
+													},
+												},
+												"channels": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"receivers": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+															"channel_type": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"enabled_sub_channels": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"custom_template_entries": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"template_uuid": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"response_plan": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"repeat_notify_setting": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"end_incident_state": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"repeat_interval": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"pushing_setting": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"restore_action_ids": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"alert_action_ids": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"escalation_id": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"auto_recover_seconds": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"subscription": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"workspace_filter_setting": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"workspace_uuids": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"tag_selector": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"relation": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"expression": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"conditions": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"field": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																		"op": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																		"value": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"subscribe_legacy_event": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"filter_setting": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"relation": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"expression": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"conditions": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"field": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"op": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"value": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"workspace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudCmsEventNotifyPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListNotifyPolicies
+	action := fmt.Sprintf("/api/eventbase/notify-policies")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	query["regionId"] = StringPointer(client.RegionId)
+	query["workspace"] = StringPointer(d.Get("workspace").(string))
+	if v, ok := d.GetOk("name"); ok {
+		query["name"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("order_by"); ok {
+		query["orderBy"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("order_desc"); ok {
+		query["orderDesc"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("workspace"); ok {
+		query["workspace"] = StringPointer(v.(string))
+	}
+
+	query["MaxResults"] = StringPointer(strconv.Itoa(PageSizeLarge))
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaGet("Cms", "2024-03-30", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.notifyPolicyList[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["uuid"], ":", item["workspace"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if nextToken, ok := response["NextToken"].(string); ok && nextToken != "" {
+			query["NextToken"] = StringPointer(nextToken)
+		} else {
+			break
+		}
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(objectRaw["uuid"], ":", objectRaw["workspace"])
+
+		mapping["create_time"] = objectRaw["createTime"]
+		mapping["description"] = objectRaw["description"]
+		mapping["enabled"] = objectRaw["enabled"]
+		mapping["name"] = objectRaw["name"]
+		mapping["update_time"] = objectRaw["updateTime"]
+		mapping["user_id"] = objectRaw["userId"]
+		mapping["version"] = objectRaw["version"]
+		mapping["uuid"] = objectRaw["uuid"]
+		mapping["workspace"] = objectRaw["workspace"]
+
+		notifyStrategyMaps := make([]map[string]interface{}, 0)
+		notifyStrategyMap := make(map[string]interface{})
+		notifyStrategyRaw := make(map[string]interface{})
+		if objectRaw["notifyStrategy"] != nil {
+			notifyStrategyRaw = objectRaw["notifyStrategy"].(map[string]interface{})
+		}
+		if len(notifyStrategyRaw) > 0 {
+			notifyStrategyMap["description"] = notifyStrategyRaw["description"]
+			notifyStrategyMap["ignore_restored_notification"] = notifyStrategyRaw["ignoreRestoredNotification"]
+
+			customTemplateEntriesRaw := notifyStrategyRaw["customTemplateEntries"]
+			customTemplateEntriesMaps := make([]map[string]interface{}, 0)
+			if customTemplateEntriesRaw != nil {
+				for _, customTemplateEntriesChildRaw := range convertToInterfaceArray(customTemplateEntriesRaw) {
+					customTemplateEntriesMap := make(map[string]interface{})
+					customTemplateEntriesChildRaw := customTemplateEntriesChildRaw.(map[string]interface{})
+					customTemplateEntriesMap["template_uuid"] = customTemplateEntriesChildRaw["templateUuid"]
+
+					customTemplateEntriesMaps = append(customTemplateEntriesMaps, customTemplateEntriesMap)
+				}
+			}
+			notifyStrategyMap["custom_template_entries"] = customTemplateEntriesMaps
+			groupingSettingMaps := make([]map[string]interface{}, 0)
+			groupingSettingMap := make(map[string]interface{})
+			groupingSettingRaw := make(map[string]interface{})
+			if notifyStrategyRaw["groupingSetting"] != nil {
+				groupingSettingRaw = notifyStrategyRaw["groupingSetting"].(map[string]interface{})
+			}
+			if len(groupingSettingRaw) > 0 {
+				groupingSettingMap["period_min"] = groupingSettingRaw["periodMin"]
+				groupingSettingMap["silence_sec"] = groupingSettingRaw["silenceSec"]
+				groupingSettingMap["times"] = groupingSettingRaw["times"]
+
+				groupingKeysRaw := make([]interface{}, 0)
+				if groupingSettingRaw["groupingKeys"] != nil {
+					groupingKeysRaw = convertToInterfaceArray(groupingSettingRaw["groupingKeys"])
+				}
+
+				groupingSettingMap["grouping_keys"] = groupingKeysRaw
+				groupingSettingMaps = append(groupingSettingMaps, groupingSettingMap)
+			}
+			notifyStrategyMap["grouping_setting"] = groupingSettingMaps
+			routesRaw := notifyStrategyRaw["routes"]
+			routesMaps := make([]map[string]interface{}, 0)
+			if routesRaw != nil {
+				for _, routesChildRaw := range convertToInterfaceArray(routesRaw) {
+					routesMap := make(map[string]interface{})
+					routesChildRaw := routesChildRaw.(map[string]interface{})
+					routesMap["digital_employee_name"] = routesChildRaw["digitalEmployeeName"]
+					routesMap["enable_rca"] = routesChildRaw["enableRca"]
+
+					channelsRaw := routesChildRaw["channels"]
+					channelsMaps := make([]map[string]interface{}, 0)
+					if channelsRaw != nil {
+						for _, channelsChildRaw := range convertToInterfaceArray(channelsRaw) {
+							channelsMap := make(map[string]interface{})
+							channelsChildRaw := channelsChildRaw.(map[string]interface{})
+							channelsMap["channel_type"] = channelsChildRaw["channelType"]
+
+							enabledSubChannelsRaw := make([]interface{}, 0)
+							if channelsChildRaw["enabledSubChannels"] != nil {
+								enabledSubChannelsRaw = convertToInterfaceArray(channelsChildRaw["enabledSubChannels"])
+							}
+
+							channelsMap["enabled_sub_channels"] = enabledSubChannelsRaw
+							receiversRaw := make([]interface{}, 0)
+							if channelsChildRaw["receivers"] != nil {
+								receiversRaw = convertToInterfaceArray(channelsChildRaw["receivers"])
+							}
+
+							channelsMap["receivers"] = receiversRaw
+							channelsMaps = append(channelsMaps, channelsMap)
+						}
+					}
+					routesMap["channels"] = channelsMaps
+					effectTimeRangeMaps := make([]map[string]interface{}, 0)
+					effectTimeRangeMap := make(map[string]interface{})
+					effectTimeRangeRaw := make(map[string]interface{})
+					if routesChildRaw["effectTimeRange"] != nil {
+						effectTimeRangeRaw = routesChildRaw["effectTimeRange"].(map[string]interface{})
+					}
+					if len(effectTimeRangeRaw) > 0 {
+						effectTimeRangeMap["end_time_in_minute"] = effectTimeRangeRaw["endTimeInMinute"]
+						effectTimeRangeMap["start_time_in_minute"] = effectTimeRangeRaw["startTimeInMinute"]
+						effectTimeRangeMap["time_zone"] = effectTimeRangeRaw["timeZone"]
+
+						dayInWeekRaw := make([]interface{}, 0)
+						if effectTimeRangeRaw["dayInWeek"] != nil {
+							dayInWeekRaw = convertToInterfaceArray(effectTimeRangeRaw["dayInWeek"])
+						}
+
+						effectTimeRangeMap["day_in_week"] = dayInWeekRaw
+						effectTimeRangeMaps = append(effectTimeRangeMaps, effectTimeRangeMap)
+					}
+					routesMap["effect_time_range"] = effectTimeRangeMaps
+					filterSettingMaps := make([]map[string]interface{}, 0)
+					filterSettingMap := make(map[string]interface{})
+					filterSettingRaw := make(map[string]interface{})
+					if routesChildRaw["filterSetting"] != nil {
+						filterSettingRaw = routesChildRaw["filterSetting"].(map[string]interface{})
+					}
+					if len(filterSettingRaw) > 0 {
+						filterSettingMap["expression"] = filterSettingRaw["expression"]
+						filterSettingMap["relation"] = filterSettingRaw["relation"]
+
+						conditionsRaw := filterSettingRaw["conditions"]
+						conditionsMaps := make([]map[string]interface{}, 0)
+						if conditionsRaw != nil {
+							for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+								conditionsMap := make(map[string]interface{})
+								conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+								conditionsMap["field"] = conditionsChildRaw["field"]
+								conditionsMap["op"] = conditionsChildRaw["op"]
+								conditionsMap["value"] = conditionsChildRaw["value"]
+
+								conditionsMaps = append(conditionsMaps, conditionsMap)
+							}
+						}
+						filterSettingMap["conditions"] = conditionsMaps
+						filterSettingMaps = append(filterSettingMaps, filterSettingMap)
+					}
+					routesMap["filter_setting"] = filterSettingMaps
+					routesMaps = append(routesMaps, routesMap)
+				}
+			}
+			notifyStrategyMap["routes"] = routesMaps
+			notifyStrategyMaps = append(notifyStrategyMaps, notifyStrategyMap)
+		}
+		mapping["notify_strategy"] = notifyStrategyMaps
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["uuid"], ":", objectRaw["workspace"])
+		mapping, err = dataSourceAliCloudCmsEventNotifyPolicyReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("policies", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudCmsEventNotifyPolicyReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	cmsServiceV2 := CmsServiceV2{client}
+	getResp, err := cmsServiceV2.DescribeCmsEventNotifyPolicy(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["create_time"] = objectRaw["createTime"]
+	mapping["description"] = objectRaw["description"]
+	mapping["enabled"] = objectRaw["enabled"]
+	mapping["name"] = objectRaw["name"]
+	mapping["update_time"] = objectRaw["updateTime"]
+	mapping["user_id"] = objectRaw["userId"]
+	mapping["version"] = objectRaw["version"]
+	mapping["uuid"] = objectRaw["uuid"]
+	mapping["workspace"] = objectRaw["workspace"]
+
+	notifyStrategyMaps := make([]map[string]interface{}, 0)
+	notifyStrategyMap := make(map[string]interface{})
+	notifyStrategyRaw := make(map[string]interface{})
+	if objectRaw["notifyStrategy"] != nil {
+		notifyStrategyRaw = objectRaw["notifyStrategy"].(map[string]interface{})
+	}
+	if len(notifyStrategyRaw) > 0 {
+		notifyStrategyMap["description"] = notifyStrategyRaw["description"]
+		notifyStrategyMap["ignore_restored_notification"] = notifyStrategyRaw["ignoreRestoredNotification"]
+
+		customTemplateEntriesRaw := notifyStrategyRaw["customTemplateEntries"]
+		customTemplateEntriesMaps := make([]map[string]interface{}, 0)
+		if customTemplateEntriesRaw != nil {
+			for _, customTemplateEntriesChildRaw := range convertToInterfaceArray(customTemplateEntriesRaw) {
+				customTemplateEntriesMap := make(map[string]interface{})
+				customTemplateEntriesChildRaw := customTemplateEntriesChildRaw.(map[string]interface{})
+				customTemplateEntriesMap["template_uuid"] = customTemplateEntriesChildRaw["templateUuid"]
+
+				customTemplateEntriesMaps = append(customTemplateEntriesMaps, customTemplateEntriesMap)
+			}
+		}
+		notifyStrategyMap["custom_template_entries"] = customTemplateEntriesMaps
+		groupingSettingMaps := make([]map[string]interface{}, 0)
+		groupingSettingMap := make(map[string]interface{})
+		groupingSettingRaw := make(map[string]interface{})
+		if notifyStrategyRaw["groupingSetting"] != nil {
+			groupingSettingRaw = notifyStrategyRaw["groupingSetting"].(map[string]interface{})
+		}
+		if len(groupingSettingRaw) > 0 {
+			groupingSettingMap["period_min"] = groupingSettingRaw["periodMin"]
+			groupingSettingMap["silence_sec"] = groupingSettingRaw["silenceSec"]
+			groupingSettingMap["times"] = groupingSettingRaw["times"]
+
+			groupingKeysRaw := make([]interface{}, 0)
+			if groupingSettingRaw["groupingKeys"] != nil {
+				groupingKeysRaw = convertToInterfaceArray(groupingSettingRaw["groupingKeys"])
+			}
+
+			groupingSettingMap["grouping_keys"] = groupingKeysRaw
+			groupingSettingMaps = append(groupingSettingMaps, groupingSettingMap)
+		}
+		notifyStrategyMap["grouping_setting"] = groupingSettingMaps
+		routesRaw := notifyStrategyRaw["routes"]
+		routesMaps := make([]map[string]interface{}, 0)
+		if routesRaw != nil {
+			for _, routesChildRaw := range convertToInterfaceArray(routesRaw) {
+				routesMap := make(map[string]interface{})
+				routesChildRaw := routesChildRaw.(map[string]interface{})
+				routesMap["digital_employee_name"] = routesChildRaw["digitalEmployeeName"]
+				routesMap["enable_rca"] = routesChildRaw["enableRca"]
+
+				channelsRaw := routesChildRaw["channels"]
+				channelsMaps := make([]map[string]interface{}, 0)
+				if channelsRaw != nil {
+					for _, channelsChildRaw := range convertToInterfaceArray(channelsRaw) {
+						channelsMap := make(map[string]interface{})
+						channelsChildRaw := channelsChildRaw.(map[string]interface{})
+						channelsMap["channel_type"] = channelsChildRaw["channelType"]
+
+						enabledSubChannelsRaw := make([]interface{}, 0)
+						if channelsChildRaw["enabledSubChannels"] != nil {
+							enabledSubChannelsRaw = convertToInterfaceArray(channelsChildRaw["enabledSubChannels"])
+						}
+
+						channelsMap["enabled_sub_channels"] = enabledSubChannelsRaw
+						receiversRaw := make([]interface{}, 0)
+						if channelsChildRaw["receivers"] != nil {
+							receiversRaw = convertToInterfaceArray(channelsChildRaw["receivers"])
+						}
+
+						channelsMap["receivers"] = receiversRaw
+						channelsMaps = append(channelsMaps, channelsMap)
+					}
+				}
+				routesMap["channels"] = channelsMaps
+				effectTimeRangeMaps := make([]map[string]interface{}, 0)
+				effectTimeRangeMap := make(map[string]interface{})
+				effectTimeRangeRaw := make(map[string]interface{})
+				if routesChildRaw["effectTimeRange"] != nil {
+					effectTimeRangeRaw = routesChildRaw["effectTimeRange"].(map[string]interface{})
+				}
+				if len(effectTimeRangeRaw) > 0 {
+					effectTimeRangeMap["end_time_in_minute"] = effectTimeRangeRaw["endTimeInMinute"]
+					effectTimeRangeMap["start_time_in_minute"] = effectTimeRangeRaw["startTimeInMinute"]
+					effectTimeRangeMap["time_zone"] = effectTimeRangeRaw["timeZone"]
+
+					dayInWeekRaw := make([]interface{}, 0)
+					if effectTimeRangeRaw["dayInWeek"] != nil {
+						dayInWeekRaw = convertToInterfaceArray(effectTimeRangeRaw["dayInWeek"])
+					}
+
+					effectTimeRangeMap["day_in_week"] = dayInWeekRaw
+					effectTimeRangeMaps = append(effectTimeRangeMaps, effectTimeRangeMap)
+				}
+				routesMap["effect_time_range"] = effectTimeRangeMaps
+				filterSettingMaps := make([]map[string]interface{}, 0)
+				filterSettingMap := make(map[string]interface{})
+				filterSettingRaw := make(map[string]interface{})
+				if routesChildRaw["filterSetting"] != nil {
+					filterSettingRaw = routesChildRaw["filterSetting"].(map[string]interface{})
+				}
+				if len(filterSettingRaw) > 0 {
+					filterSettingMap["expression"] = filterSettingRaw["expression"]
+					filterSettingMap["relation"] = filterSettingRaw["relation"]
+
+					conditionsRaw := filterSettingRaw["conditions"]
+					conditionsMaps := make([]map[string]interface{}, 0)
+					if conditionsRaw != nil {
+						for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+							conditionsMap := make(map[string]interface{})
+							conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+							conditionsMap["field"] = conditionsChildRaw["field"]
+							conditionsMap["op"] = conditionsChildRaw["op"]
+							conditionsMap["value"] = conditionsChildRaw["value"]
+
+							conditionsMaps = append(conditionsMaps, conditionsMap)
+						}
+					}
+					filterSettingMap["conditions"] = conditionsMaps
+					filterSettingMaps = append(filterSettingMaps, filterSettingMap)
+				}
+				routesMap["filter_setting"] = filterSettingMaps
+				routesMaps = append(routesMaps, routesMap)
+			}
+		}
+		notifyStrategyMap["routes"] = routesMaps
+		notifyStrategyMaps = append(notifyStrategyMaps, notifyStrategyMap)
+	}
+	mapping["notify_strategy"] = notifyStrategyMaps
+	responsePlanMaps := make([]map[string]interface{}, 0)
+	responsePlanMap := make(map[string]interface{})
+	responsePlanRaw := make(map[string]interface{})
+	if objectRaw["responsePlan"] != nil {
+		responsePlanRaw = objectRaw["responsePlan"].(map[string]interface{})
+	}
+	if len(responsePlanRaw) > 0 {
+		responsePlanMap["auto_recover_seconds"] = responsePlanRaw["autoRecoverSeconds"]
+
+		escalationIdRaw := make([]interface{}, 0)
+		if responsePlanRaw["escalationId"] != nil {
+			escalationIdRaw = convertToInterfaceArray(responsePlanRaw["escalationId"])
+		}
+
+		responsePlanMap["escalation_id"] = escalationIdRaw
+		pushingSettingMaps := make([]map[string]interface{}, 0)
+		pushingSettingMap := make(map[string]interface{})
+		pushingSettingRaw := make(map[string]interface{})
+		if responsePlanRaw["pushingSetting"] != nil {
+			pushingSettingRaw = responsePlanRaw["pushingSetting"].(map[string]interface{})
+		}
+		if len(pushingSettingRaw) > 0 {
+
+			alertActionIdsRaw := make([]interface{}, 0)
+			if pushingSettingRaw["alertActionIds"] != nil {
+				alertActionIdsRaw = convertToInterfaceArray(pushingSettingRaw["alertActionIds"])
+			}
+
+			pushingSettingMap["alert_action_ids"] = alertActionIdsRaw
+			restoreActionIdsRaw := make([]interface{}, 0)
+			if pushingSettingRaw["restoreActionIds"] != nil {
+				restoreActionIdsRaw = convertToInterfaceArray(pushingSettingRaw["restoreActionIds"])
+			}
+
+			pushingSettingMap["restore_action_ids"] = restoreActionIdsRaw
+			pushingSettingMaps = append(pushingSettingMaps, pushingSettingMap)
+		}
+		responsePlanMap["pushing_setting"] = pushingSettingMaps
+		repeatNotifySettingMaps := make([]map[string]interface{}, 0)
+		repeatNotifySettingMap := make(map[string]interface{})
+		repeatNotifySettingRaw := make(map[string]interface{})
+		if responsePlanRaw["repeatNotifySetting"] != nil {
+			repeatNotifySettingRaw = responsePlanRaw["repeatNotifySetting"].(map[string]interface{})
+		}
+		if len(repeatNotifySettingRaw) > 0 {
+			repeatNotifySettingMap["end_incident_state"] = repeatNotifySettingRaw["endIncidentState"]
+			repeatNotifySettingMap["repeat_interval"] = repeatNotifySettingRaw["repeatInterval"]
+
+			repeatNotifySettingMaps = append(repeatNotifySettingMaps, repeatNotifySettingMap)
+		}
+		responsePlanMap["repeat_notify_setting"] = repeatNotifySettingMaps
+		responsePlanMaps = append(responsePlanMaps, responsePlanMap)
+	}
+	mapping["response_plan"] = responsePlanMaps
+	subscriptionMaps := make([]map[string]interface{}, 0)
+	subscriptionMap := make(map[string]interface{})
+	subscriptionRaw := make(map[string]interface{})
+	if objectRaw["subscription"] != nil {
+		subscriptionRaw = objectRaw["subscription"].(map[string]interface{})
+	}
+	if len(subscriptionRaw) > 0 {
+		subscriptionMap["subscribe_legacy_event"] = subscriptionRaw["subscribeLegacyEvent"]
+
+		filterSettingMaps := make([]map[string]interface{}, 0)
+		filterSettingMap := make(map[string]interface{})
+		filterSettingRaw := make(map[string]interface{})
+		if subscriptionRaw["filterSetting"] != nil {
+			filterSettingRaw = subscriptionRaw["filterSetting"].(map[string]interface{})
+		}
+		if len(filterSettingRaw) > 0 {
+			filterSettingMap["expression"] = filterSettingRaw["expression"]
+			filterSettingMap["relation"] = filterSettingRaw["relation"]
+
+			conditionsRaw := filterSettingRaw["conditions"]
+			conditionsMaps := make([]map[string]interface{}, 0)
+			if conditionsRaw != nil {
+				for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+					conditionsMap := make(map[string]interface{})
+					conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+					conditionsMap["field"] = conditionsChildRaw["field"]
+					conditionsMap["op"] = conditionsChildRaw["op"]
+					conditionsMap["value"] = conditionsChildRaw["value"]
+
+					conditionsMaps = append(conditionsMaps, conditionsMap)
+				}
+			}
+			filterSettingMap["conditions"] = conditionsMaps
+			filterSettingMaps = append(filterSettingMaps, filterSettingMap)
+		}
+		subscriptionMap["filter_setting"] = filterSettingMaps
+		workspaceFilterSettingMaps := make([]map[string]interface{}, 0)
+		workspaceFilterSettingMap := make(map[string]interface{})
+		workspaceFilterSettingRaw := make(map[string]interface{})
+		if subscriptionRaw["workspaceFilterSetting"] != nil {
+			workspaceFilterSettingRaw = subscriptionRaw["workspaceFilterSetting"].(map[string]interface{})
+		}
+		if len(workspaceFilterSettingRaw) > 0 {
+
+			tagSelectorMaps := make([]map[string]interface{}, 0)
+			tagSelectorMap := make(map[string]interface{})
+			tagSelectorRaw := make(map[string]interface{})
+			if workspaceFilterSettingRaw["tagSelector"] != nil {
+				tagSelectorRaw = workspaceFilterSettingRaw["tagSelector"].(map[string]interface{})
+			}
+			if len(tagSelectorRaw) > 0 {
+				tagSelectorMap["expression"] = tagSelectorRaw["expression"]
+				tagSelectorMap["relation"] = tagSelectorRaw["relation"]
+
+				conditionsRaw := tagSelectorRaw["conditions"]
+				conditionsMaps := make([]map[string]interface{}, 0)
+				if conditionsRaw != nil {
+					for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+						conditionsMap := make(map[string]interface{})
+						conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+						conditionsMap["field"] = conditionsChildRaw["field"]
+						conditionsMap["op"] = conditionsChildRaw["op"]
+						conditionsMap["value"] = conditionsChildRaw["value"]
+
+						conditionsMaps = append(conditionsMaps, conditionsMap)
+					}
+				}
+				tagSelectorMap["conditions"] = conditionsMaps
+				tagSelectorMaps = append(tagSelectorMaps, tagSelectorMap)
+			}
+			workspaceFilterSettingMap["tag_selector"] = tagSelectorMaps
+			workspaceUuidsRaw := make([]interface{}, 0)
+			if workspaceFilterSettingRaw["workspaceUuids"] != nil {
+				workspaceUuidsRaw = convertToInterfaceArray(workspaceFilterSettingRaw["workspaceUuids"])
+			}
+
+			workspaceFilterSettingMap["workspace_uuids"] = workspaceUuidsRaw
+			workspaceFilterSettingMaps = append(workspaceFilterSettingMaps, workspaceFilterSettingMap)
+		}
+		subscriptionMap["workspace_filter_setting"] = workspaceFilterSettingMaps
+		subscriptionMaps = append(subscriptionMaps, subscriptionMap)
+	}
+	mapping["subscription"] = subscriptionMaps
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_cms_event_notify_policies_test.go
+++ b/alicloud/data_source_alicloud_cms_event_notify_policies_test.go
@@ -1,0 +1,172 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudCmsEventNotifyPolicyDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}"]`,
+			"workspace": `"${alicloud_cms_workspace.default.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}_fake"]`,
+			"workspace": `"${alicloud_cms_workspace.default.id}"`,
+		}),
+	}
+
+	WorkspaceConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}"]`,
+			"workspace": `"${alicloud_cms_workspace.default.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}_fake"]`,
+			"workspace": `"${alicloud_cms_workspace.default.id}"`,
+			"name":      `"${var.name}_fake"`,
+		}),
+	}
+	NameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}"]`,
+			"name":      `"${var.name}"`,
+			"workspace": `"${alicloud_cms_workspace.default.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}_fake"]`,
+			"name":      `"${var.name}_fake"`,
+			"workspace": `"${alicloud_cms_workspace.default.id}"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}"]`,
+			"workspace": `"${alicloud_cms_workspace.default.id}"`,
+
+			"name": `"${var.name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}_fake"]`,
+			"workspace": `"${alicloud_cms_workspace.default.id}"`,
+			"name":      `"${var.name}_fake"`,
+		}),
+	}
+
+	CmsEventNotifyPolicyCheckInfo.dataSourceTestCheck(t, rand, idsConf, WorkspaceConf, NameConf, allConf)
+}
+
+var existCmsEventNotifyPolicyMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"policies.#":                   "1",
+		"policies.0.description":       CHECKSET,
+		"policies.0.create_time":       CHECKSET,
+		"policies.0.enabled":           CHECKSET,
+		"policies.0.notify_strategy.#": CHECKSET,
+		"policies.0.name":              CHECKSET,
+		"policies.0.uuid":              CHECKSET,
+		"policies.0.version":           CHECKSET,
+		"policies.0.user_id":           CHECKSET,
+		"policies.0.update_time":       CHECKSET,
+		"policies.0.workspace":         CHECKSET,
+	}
+}
+
+var fakeCmsEventNotifyPolicyMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"policies.#": "0",
+	}
+}
+
+var CmsEventNotifyPolicyCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_cms_event_notify_policies.default",
+	existMapFunc: existCmsEventNotifyPolicyMapFunc,
+	fakeMapFunc:  fakeCmsEventNotifyPolicyMapFunc,
+}
+
+func testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testacccmsenp%d"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+
+resource "alicloud_cms_event_notify_policy" "default" {
+  description = "Event notification policy managed by Terraform"
+  response_plan {
+    repeat_notify_setting {
+      end_incident_state = "resolved"
+      repeat_interval    = "30"
+    }
+    auto_recover_seconds = "600"
+  }
+  notify_strategy {
+    description                  = "Notify strategy for list test"
+    ignore_restored_notification = false
+    grouping_setting {
+      grouping_keys = ["severity"]
+      period_min    = "5"
+      times         = "1"
+      silence_sec   = "300"
+    }
+    routes {
+      effect_time_range {
+        time_zone            = "Asia/Shanghai"
+        start_time_in_minute = "0"
+        end_time_in_minute   = "1439"
+        day_in_week          = ["1", "2", "3", "4", "5"]
+      }
+      channels {
+        receivers            = ["tf-test-group"]
+        channel_type         = "DING"
+        enabled_sub_channels = []
+      }
+    }
+  }
+  subscription {
+    subscribe_legacy_event = true
+    filter_setting {
+      relation = "AND"
+      conditions {
+        field = "severity"
+        op    = "EQ"
+        value = "CRITICAL"
+      }
+    }
+  }
+  workspace = alicloud_cms_workspace.default.id
+  name      = var.name
+}
+
+data "alicloud_cms_event_notify_policies" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"alicloud_redis_global_security_ip_groups":                dataSourceAliCloudRedisGlobalSecurityIpGroups(),
 			"alicloud_cr_artifact_subscription_rules":                 dataSourceAliCloudCrArtifactSubscriptionRules(),
+			"alicloud_cms_event_notify_policies":                      dataSourceAliCloudCmsEventNotifyPolicies(),
 			"alicloud_apig_ai_model_providers":                        dataSourceAliCloudApigAiModelProviders(),
 			"alicloud_apig_services":                                  dataSourceAliCloudApigServices(),
 			"alicloud_apig_gateways":                                  dataSourceAliCloudApigGateways(),
@@ -617,7 +618,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_hbr_restore_jobs":                                 dataSourceAlicloudHbrRestoreJobs(),
 			"alicloud_alb_listeners":                                    dataSourceAlicloudAlbListeners(),
 			"alicloud_ens_key_pairs":                                    dataSourceAlicloudEnsKeyPairs(),
-			"alicloud_ens_security_groups":                             dataSourceAliCloudEnsSecurityGroups(),
+			"alicloud_ens_security_groups":                              dataSourceAliCloudEnsSecurityGroups(),
 			"alicloud_sae_applications":                                 dataSourceAlicloudSaeApplications(),
 			"alicloud_alb_rules":                                        dataSourceAliCloudAlbRules(),
 			"alicloud_cms_metric_rule_templates":                        dataSourceAlicloudCmsMetricRuleTemplates(),
@@ -954,6 +955,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_redis_global_security_ip_group":                       resourceAliCloudRedisGlobalSecurityIpGroup(),
 			"alicloud_cr_artifact_subscription_rule":                        resourceAliCloudCrArtifactSubscriptionRule(),
+			"alicloud_cms_event_notify_policy":                              resourceAliCloudCmsEventNotifyPolicy(),
 			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),
 			"alicloud_apig_ai_model_provider":                               resourceAliCloudApigAiModelProvider(),
 			"alicloud_apig_service":                                         resourceAliCloudApigService(),

--- a/alicloud/resource_alicloud_cms_event_notify_policy.go
+++ b/alicloud/resource_alicloud_cms_event_notify_policy.go
@@ -1,0 +1,1451 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudCmsEventNotifyPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCmsEventNotifyPolicyCreate,
+		Read:   resourceAliCloudCmsEventNotifyPolicyRead,
+		Update: resourceAliCloudCmsEventNotifyPolicyUpdate,
+		Delete: resourceAliCloudCmsEventNotifyPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"notify_strategy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ignore_restored_notification": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"grouping_setting": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"grouping_keys": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"period_min": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"times": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"silence_sec": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"routes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"digital_employee_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"enable_rca": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"filter_setting": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"relation": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"expression": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"conditions": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"field": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"op": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"effect_time_range": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"time_zone": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"start_time_in_minute": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"end_time_in_minute": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"day_in_week": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeInt},
+												},
+											},
+										},
+									},
+									"channels": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"receivers": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"channel_type": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"enabled_sub_channels": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"custom_template_entries": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"template_uuid": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"response_plan": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"repeat_notify_setting": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_incident_state": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"repeat_interval": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"pushing_setting": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"restore_action_ids": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"alert_action_ids": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"escalation_id": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"auto_recover_seconds": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"subscription": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"workspace_filter_setting": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"workspace_uuids": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"tag_selector": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"relation": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"expression": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"conditions": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"field": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"op": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"subscribe_legacy_event": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"filter_setting": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"relation": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"expression": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"conditions": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"field": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"op": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"workspace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCmsEventNotifyPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/api/eventbase/notify-policy/create")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	query["workspace"] = StringPointer(d.Get("workspace").(string))
+	query["regionId"] = StringPointer(client.RegionId)
+
+	notifyStrategy := make(map[string]interface{})
+
+	if v := d.Get("notify_strategy"); !IsNil(v) {
+		groupingSetting := make(map[string]interface{})
+		times1, _ := jsonpath.Get("$[0].grouping_setting[0].times", d.Get("notify_strategy"))
+		if times1 != nil && times1 != "" {
+			groupingSetting["times"] = times1
+		}
+		groupingKeys1, _ := jsonpath.Get("$[0].grouping_setting[0].grouping_keys", d.Get("notify_strategy"))
+		if groupingKeys1 != nil && groupingKeys1 != "" {
+			groupingSetting["groupingKeys"] = groupingKeys1
+		}
+		periodMin1, _ := jsonpath.Get("$[0].grouping_setting[0].period_min", d.Get("notify_strategy"))
+		if periodMin1 != nil && periodMin1 != "" {
+			groupingSetting["periodMin"] = periodMin1
+		}
+		silenceSec1, _ := jsonpath.Get("$[0].grouping_setting[0].silence_sec", d.Get("notify_strategy"))
+		if silenceSec1 != nil && silenceSec1 != "" {
+			groupingSetting["silenceSec"] = silenceSec1
+		}
+
+		if len(groupingSetting) > 0 {
+			notifyStrategy["groupingSetting"] = groupingSetting
+		}
+		if v, ok := d.GetOk("notify_strategy"); ok {
+			localData, err := jsonpath.Get("$[0].routes", v)
+			if err != nil {
+				localData = make([]interface{}, 0)
+			}
+			localMaps := make([]interface{}, 0)
+			for _, dataLoop := range convertToInterfaceArray(localData) {
+				dataLoopTmp := make(map[string]interface{})
+				if dataLoop != nil {
+					dataLoopTmp = dataLoop.(map[string]interface{})
+				}
+				dataLoopMap := make(map[string]interface{})
+				localData1 := make(map[string]interface{})
+				startTimeInMinute1, _ := jsonpath.Get("$[0].start_time_in_minute", dataLoopTmp["effect_time_range"])
+				if startTimeInMinute1 != nil && startTimeInMinute1 != "" {
+					localData1["startTimeInMinute"] = startTimeInMinute1
+				}
+				endTimeInMinute1, _ := jsonpath.Get("$[0].end_time_in_minute", dataLoopTmp["effect_time_range"])
+				if endTimeInMinute1 != nil && endTimeInMinute1 != "" {
+					localData1["endTimeInMinute"] = endTimeInMinute1
+				}
+				dayInWeek1, _ := jsonpath.Get("$[0].day_in_week", dataLoopTmp["effect_time_range"])
+				if dayInWeek1 != nil && dayInWeek1 != "" {
+					localData1["dayInWeek"] = dayInWeek1
+				}
+				timeZone1, _ := jsonpath.Get("$[0].time_zone", dataLoopTmp["effect_time_range"])
+				if timeZone1 != nil && timeZone1 != "" {
+					localData1["timeZone"] = timeZone1
+				}
+				if len(localData1) > 0 {
+					dataLoopMap["effectTimeRange"] = localData1
+				}
+				localMaps2 := make([]interface{}, 0)
+				localData2 := dataLoopTmp["channels"]
+				for _, dataLoop2 := range convertToInterfaceArray(localData2) {
+					dataLoop2Tmp := dataLoop2.(map[string]interface{})
+					dataLoop2Map := make(map[string]interface{})
+					dataLoop2Map["receivers"] = dataLoop2Tmp["receivers"]
+					dataLoop2Map["channelType"] = dataLoop2Tmp["channel_type"]
+					if enabledSubChannelsSet, ok := dataLoop2Tmp["enabled_sub_channels"].(*schema.Set); ok {
+						dataLoop2Map["enabledSubChannels"] = enabledSubChannelsSet.List()
+					} else {
+						dataLoop2Map["enabledSubChannels"] = dataLoop2Tmp["enabled_sub_channels"]
+					}
+					localMaps2 = append(localMaps2, dataLoop2Map)
+				}
+				dataLoopMap["channels"] = localMaps2
+				localData3 := make(map[string]interface{})
+				if v, ok := dataLoopTmp["filter_setting"]; ok {
+					localData4, err := jsonpath.Get("$[0].conditions", v)
+					if err != nil {
+						localData4 = make([]interface{}, 0)
+					}
+					localMaps4 := make([]interface{}, 0)
+					for _, dataLoop4 := range convertToInterfaceArray(localData4) {
+						dataLoop4Tmp := make(map[string]interface{})
+						if dataLoop4 != nil {
+							dataLoop4Tmp = dataLoop4.(map[string]interface{})
+						}
+						dataLoop4Map := make(map[string]interface{})
+						dataLoop4Map["op"] = dataLoop4Tmp["op"]
+						dataLoop4Map["field"] = dataLoop4Tmp["field"]
+						dataLoop4Map["value"] = dataLoop4Tmp["value"]
+						localMaps4 = append(localMaps4, dataLoop4Map)
+					}
+					localData3["conditions"] = localMaps4
+				}
+
+				relation1, _ := jsonpath.Get("$[0].relation", dataLoopTmp["filter_setting"])
+				if relation1 != nil && relation1 != "" {
+					localData3["relation"] = relation1
+				}
+				expression1, _ := jsonpath.Get("$[0].expression", dataLoopTmp["filter_setting"])
+				if expression1 != nil && expression1 != "" {
+					localData3["expression"] = expression1
+				}
+				if len(localData3) > 0 {
+					dataLoopMap["filterSetting"] = localData3
+				}
+				dataLoopMap["enableRca"] = dataLoopTmp["enable_rca"]
+				dataLoopMap["digitalEmployeeName"] = dataLoopTmp["digital_employee_name"]
+				localMaps = append(localMaps, dataLoopMap)
+			}
+			notifyStrategy["routes"] = localMaps
+		}
+
+		if v, ok := d.GetOk("notify_strategy"); ok {
+			localData5, err := jsonpath.Get("$[0].custom_template_entries", v)
+			if err != nil {
+				localData5 = make([]interface{}, 0)
+			}
+			localMaps5 := make([]interface{}, 0)
+			for _, dataLoop5 := range convertToInterfaceArray(localData5) {
+				dataLoop5Tmp := make(map[string]interface{})
+				if dataLoop5 != nil {
+					dataLoop5Tmp = dataLoop5.(map[string]interface{})
+				}
+				dataLoop5Map := make(map[string]interface{})
+				dataLoop5Map["templateUuid"] = dataLoop5Tmp["template_uuid"]
+				localMaps5 = append(localMaps5, dataLoop5Map)
+			}
+			notifyStrategy["customTemplateEntries"] = localMaps5
+		}
+
+		ignoreRestoredNotification1, _ := jsonpath.Get("$[0].ignore_restored_notification", v)
+		if ignoreRestoredNotification1 != nil && ignoreRestoredNotification1 != "" {
+			notifyStrategy["ignoreRestoredNotification"] = ignoreRestoredNotification1
+		}
+		description1, _ := jsonpath.Get("$[0].description", v)
+		if description1 != nil && description1 != "" {
+			notifyStrategy["description"] = description1
+		}
+
+		request["notifyStrategy"] = notifyStrategy
+	}
+
+	responsePlan := make(map[string]interface{})
+
+	if v := d.Get("response_plan"); !IsNil(v) {
+		autoRecoverSeconds1, _ := jsonpath.Get("$[0].auto_recover_seconds", v)
+		if autoRecoverSeconds1 != nil && autoRecoverSeconds1 != "" {
+			responsePlan["autoRecoverSeconds"] = autoRecoverSeconds1
+		}
+		pushingSetting := make(map[string]interface{})
+		restoreActionIds1, _ := jsonpath.Get("$[0].pushing_setting[0].restore_action_ids", d.Get("response_plan"))
+		if restoreActionIds1 != nil && restoreActionIds1 != "" {
+			pushingSetting["restoreActionIds"] = restoreActionIds1
+		}
+		alertActionIds1, _ := jsonpath.Get("$[0].pushing_setting[0].alert_action_ids", d.Get("response_plan"))
+		if alertActionIds1 != nil && alertActionIds1 != "" {
+			pushingSetting["alertActionIds"] = alertActionIds1
+		}
+
+		if len(pushingSetting) > 0 {
+			responsePlan["pushingSetting"] = pushingSetting
+		}
+		repeatNotifySetting := make(map[string]interface{})
+		repeatInterval1, _ := jsonpath.Get("$[0].repeat_notify_setting[0].repeat_interval", d.Get("response_plan"))
+		if repeatInterval1 != nil && repeatInterval1 != "" {
+			repeatNotifySetting["repeatInterval"] = repeatInterval1
+		}
+		endIncidentState1, _ := jsonpath.Get("$[0].repeat_notify_setting[0].end_incident_state", d.Get("response_plan"))
+		if endIncidentState1 != nil && endIncidentState1 != "" {
+			repeatNotifySetting["endIncidentState"] = endIncidentState1
+		}
+
+		if len(repeatNotifySetting) > 0 {
+			responsePlan["repeatNotifySetting"] = repeatNotifySetting
+		}
+		escalationId1, _ := jsonpath.Get("$[0].escalation_id", v)
+		if escalationId1 != nil && escalationId1 != "" {
+			responsePlan["escalationId"] = escalationId1
+		}
+
+		request["responsePlan"] = responsePlan
+	}
+
+	subscription := make(map[string]interface{})
+
+	if v := d.Get("subscription"); !IsNil(v) {
+		// workspace_filter_setting is read with plain type assertions instead of
+		// jsonpath: the nested tag_selector list makes the jsonpath lookups return
+		// nothing, which silently dropped both tagSelector and workspaceUuids.
+		workspaceFilterSetting := buildEventNotifyPolicyWorkspaceFilterSetting(d.Get("subscription"))
+
+		if len(workspaceFilterSetting) > 0 {
+			subscription["workspaceFilterSetting"] = workspaceFilterSetting
+		}
+		filterSetting1 := make(map[string]interface{})
+		if v, ok := d.GetOk("subscription"); ok {
+			localData7, err := jsonpath.Get("$[0].filter_setting[0].conditions", v)
+			if err != nil {
+				localData7 = make([]interface{}, 0)
+			}
+			localMaps7 := make([]interface{}, 0)
+			for _, dataLoop7 := range convertToInterfaceArray(localData7) {
+				dataLoop7Tmp := make(map[string]interface{})
+				if dataLoop7 != nil {
+					dataLoop7Tmp = dataLoop7.(map[string]interface{})
+				}
+				dataLoop7Map := make(map[string]interface{})
+				dataLoop7Map["field"] = dataLoop7Tmp["field"]
+				dataLoop7Map["value"] = dataLoop7Tmp["value"]
+				dataLoop7Map["op"] = dataLoop7Tmp["op"]
+				localMaps7 = append(localMaps7, dataLoop7Map)
+			}
+			filterSetting1["conditions"] = localMaps7
+		}
+
+		relation5, _ := jsonpath.Get("$[0].filter_setting[0].relation", d.Get("subscription"))
+		if relation5 != nil && relation5 != "" {
+			filterSetting1["relation"] = relation5
+		}
+		expression5, _ := jsonpath.Get("$[0].filter_setting[0].expression", d.Get("subscription"))
+		if expression5 != nil && expression5 != "" {
+			filterSetting1["expression"] = expression5
+		}
+
+		if len(filterSetting1) > 0 {
+			subscription["filterSetting"] = filterSetting1
+		}
+		subscribeLegacyEvent1, _ := jsonpath.Get("$[0].subscribe_legacy_event", v)
+		if subscribeLegacyEvent1 != nil && subscribeLegacyEvent1 != "" {
+			subscription["subscribeLegacyEvent"] = subscribeLegacyEvent1
+		}
+
+		request["subscription"] = subscription
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		request["name"] = v
+	}
+	if v, ok := d.GetOk("description"); ok {
+		request["description"] = v
+	}
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("Cms", "2024-03-30", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cms_event_notify_policy", action, AlibabaCloudSdkGoERROR)
+	}
+
+	notifyPolicyuuidVar, _ := jsonpath.Get("$.notifyPolicy.uuid", response)
+	notifyPolicyworkspaceVar, _ := jsonpath.Get("$.notifyPolicy.workspace", response)
+	d.SetId(fmt.Sprintf("%v:%v", notifyPolicyuuidVar, notifyPolicyworkspaceVar))
+
+	return resourceAliCloudCmsEventNotifyPolicyUpdate(d, meta)
+}
+
+func resourceAliCloudCmsEventNotifyPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cmsServiceV2 := CmsServiceV2{client}
+
+	objectRaw, err := cmsServiceV2.DescribeCmsEventNotifyPolicy(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cms_event_notify_policy DescribeCmsEventNotifyPolicy Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("create_time", objectRaw["createTime"])
+	d.Set("description", objectRaw["description"])
+	d.Set("enabled", objectRaw["enabled"])
+	d.Set("name", objectRaw["name"])
+	d.Set("update_time", objectRaw["updateTime"])
+	d.Set("user_id", objectRaw["userId"])
+	d.Set("version", objectRaw["version"])
+	d.Set("uuid", objectRaw["uuid"])
+	d.Set("workspace", objectRaw["workspace"])
+
+	notifyStrategyMaps := make([]map[string]interface{}, 0)
+	notifyStrategyMap := make(map[string]interface{})
+	notifyStrategyRaw := make(map[string]interface{})
+	if objectRaw["notifyStrategy"] != nil {
+		notifyStrategyRaw = objectRaw["notifyStrategy"].(map[string]interface{})
+	}
+	if len(notifyStrategyRaw) > 0 {
+		notifyStrategyMap["description"] = notifyStrategyRaw["description"]
+		notifyStrategyMap["ignore_restored_notification"] = notifyStrategyRaw["ignoreRestoredNotification"]
+
+		customTemplateEntriesRaw := notifyStrategyRaw["customTemplateEntries"]
+		customTemplateEntriesMaps := make([]map[string]interface{}, 0)
+		if customTemplateEntriesRaw != nil {
+			for _, customTemplateEntriesChildRaw := range convertToInterfaceArray(customTemplateEntriesRaw) {
+				customTemplateEntriesMap := make(map[string]interface{})
+				customTemplateEntriesChildRaw := customTemplateEntriesChildRaw.(map[string]interface{})
+				customTemplateEntriesMap["template_uuid"] = customTemplateEntriesChildRaw["templateUuid"]
+
+				customTemplateEntriesMaps = append(customTemplateEntriesMaps, customTemplateEntriesMap)
+			}
+		}
+		notifyStrategyMap["custom_template_entries"] = customTemplateEntriesMaps
+		groupingSettingMaps := make([]map[string]interface{}, 0)
+		groupingSettingMap := make(map[string]interface{})
+		groupingSettingRaw := make(map[string]interface{})
+		if notifyStrategyRaw["groupingSetting"] != nil {
+			groupingSettingRaw = notifyStrategyRaw["groupingSetting"].(map[string]interface{})
+		}
+		if len(groupingSettingRaw) > 0 {
+			groupingSettingMap["period_min"] = groupingSettingRaw["periodMin"]
+			groupingSettingMap["silence_sec"] = groupingSettingRaw["silenceSec"]
+			groupingSettingMap["times"] = groupingSettingRaw["times"]
+
+			groupingKeysRaw := make([]interface{}, 0)
+			if groupingSettingRaw["groupingKeys"] != nil {
+				groupingKeysRaw = convertToInterfaceArray(groupingSettingRaw["groupingKeys"])
+			}
+
+			groupingSettingMap["grouping_keys"] = groupingKeysRaw
+			groupingSettingMaps = append(groupingSettingMaps, groupingSettingMap)
+		}
+		notifyStrategyMap["grouping_setting"] = groupingSettingMaps
+		routesRaw := notifyStrategyRaw["routes"]
+		routesMaps := make([]map[string]interface{}, 0)
+		if routesRaw != nil {
+			for _, routesChildRaw := range convertToInterfaceArray(routesRaw) {
+				routesMap := make(map[string]interface{})
+				routesChildRaw := routesChildRaw.(map[string]interface{})
+				routesMap["digital_employee_name"] = routesChildRaw["digitalEmployeeName"]
+				routesMap["enable_rca"] = routesChildRaw["enableRca"]
+
+				channelsRaw := routesChildRaw["channels"]
+				channelsMaps := make([]map[string]interface{}, 0)
+				if channelsRaw != nil {
+					for _, channelsChildRaw := range convertToInterfaceArray(channelsRaw) {
+						channelsMap := make(map[string]interface{})
+						channelsChildRaw := channelsChildRaw.(map[string]interface{})
+						channelsMap["channel_type"] = channelsChildRaw["channelType"]
+
+						enabledSubChannelsRaw := make([]interface{}, 0)
+						if channelsChildRaw["enabledSubChannels"] != nil {
+							enabledSubChannelsRaw = convertToInterfaceArray(channelsChildRaw["enabledSubChannels"])
+						}
+
+						channelsMap["enabled_sub_channels"] = enabledSubChannelsRaw
+						receiversRaw := make([]interface{}, 0)
+						if channelsChildRaw["receivers"] != nil {
+							receiversRaw = convertToInterfaceArray(channelsChildRaw["receivers"])
+						}
+
+						channelsMap["receivers"] = receiversRaw
+						channelsMaps = append(channelsMaps, channelsMap)
+					}
+				}
+				routesMap["channels"] = channelsMaps
+				effectTimeRangeMaps := make([]map[string]interface{}, 0)
+				effectTimeRangeMap := make(map[string]interface{})
+				effectTimeRangeRaw := make(map[string]interface{})
+				if routesChildRaw["effectTimeRange"] != nil {
+					effectTimeRangeRaw = routesChildRaw["effectTimeRange"].(map[string]interface{})
+				}
+				if len(effectTimeRangeRaw) > 0 {
+					effectTimeRangeMap["end_time_in_minute"] = effectTimeRangeRaw["endTimeInMinute"]
+					effectTimeRangeMap["start_time_in_minute"] = effectTimeRangeRaw["startTimeInMinute"]
+					effectTimeRangeMap["time_zone"] = effectTimeRangeRaw["timeZone"]
+
+					dayInWeekRaw := make([]interface{}, 0)
+					if effectTimeRangeRaw["dayInWeek"] != nil {
+						dayInWeekRaw = convertToInterfaceArray(effectTimeRangeRaw["dayInWeek"])
+					}
+
+					effectTimeRangeMap["day_in_week"] = dayInWeekRaw
+					effectTimeRangeMaps = append(effectTimeRangeMaps, effectTimeRangeMap)
+				}
+				routesMap["effect_time_range"] = effectTimeRangeMaps
+				filterSettingMaps := make([]map[string]interface{}, 0)
+				filterSettingMap := make(map[string]interface{})
+				filterSettingRaw := make(map[string]interface{})
+				if routesChildRaw["filterSetting"] != nil {
+					filterSettingRaw = routesChildRaw["filterSetting"].(map[string]interface{})
+				}
+				if len(filterSettingRaw) > 0 {
+					filterSettingMap["expression"] = filterSettingRaw["expression"]
+					filterSettingMap["relation"] = filterSettingRaw["relation"]
+
+					conditionsRaw := filterSettingRaw["conditions"]
+					conditionsMaps := make([]map[string]interface{}, 0)
+					if conditionsRaw != nil {
+						for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+							conditionsMap := make(map[string]interface{})
+							conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+							conditionsMap["field"] = conditionsChildRaw["field"]
+							conditionsMap["op"] = conditionsChildRaw["op"]
+							conditionsMap["value"] = conditionsChildRaw["value"]
+
+							conditionsMaps = append(conditionsMaps, conditionsMap)
+						}
+					}
+					filterSettingMap["conditions"] = conditionsMaps
+					filterSettingMaps = append(filterSettingMaps, filterSettingMap)
+				}
+				routesMap["filter_setting"] = filterSettingMaps
+				routesMaps = append(routesMaps, routesMap)
+			}
+		}
+		notifyStrategyMap["routes"] = routesMaps
+		notifyStrategyMaps = append(notifyStrategyMaps, notifyStrategyMap)
+	}
+	if err := d.Set("notify_strategy", notifyStrategyMaps); err != nil {
+		return err
+	}
+	responsePlanMaps := make([]map[string]interface{}, 0)
+	responsePlanMap := make(map[string]interface{})
+	responsePlanRaw := make(map[string]interface{})
+	if objectRaw["responsePlan"] != nil {
+		responsePlanRaw = objectRaw["responsePlan"].(map[string]interface{})
+	}
+	if len(responsePlanRaw) > 0 {
+		responsePlanMap["auto_recover_seconds"] = responsePlanRaw["autoRecoverSeconds"]
+
+		escalationIdRaw := make([]interface{}, 0)
+		if responsePlanRaw["escalationId"] != nil {
+			escalationIdRaw = convertToInterfaceArray(responsePlanRaw["escalationId"])
+		}
+
+		responsePlanMap["escalation_id"] = escalationIdRaw
+		pushingSettingMaps := make([]map[string]interface{}, 0)
+		pushingSettingMap := make(map[string]interface{})
+		pushingSettingRaw := make(map[string]interface{})
+		if responsePlanRaw["pushingSetting"] != nil {
+			pushingSettingRaw = responsePlanRaw["pushingSetting"].(map[string]interface{})
+		}
+		if len(pushingSettingRaw) > 0 {
+
+			alertActionIdsRaw := make([]interface{}, 0)
+			if pushingSettingRaw["alertActionIds"] != nil {
+				alertActionIdsRaw = convertToInterfaceArray(pushingSettingRaw["alertActionIds"])
+			}
+
+			pushingSettingMap["alert_action_ids"] = alertActionIdsRaw
+			restoreActionIdsRaw := make([]interface{}, 0)
+			if pushingSettingRaw["restoreActionIds"] != nil {
+				restoreActionIdsRaw = convertToInterfaceArray(pushingSettingRaw["restoreActionIds"])
+			}
+
+			pushingSettingMap["restore_action_ids"] = restoreActionIdsRaw
+			pushingSettingMaps = append(pushingSettingMaps, pushingSettingMap)
+		}
+		responsePlanMap["pushing_setting"] = pushingSettingMaps
+		repeatNotifySettingMaps := make([]map[string]interface{}, 0)
+		repeatNotifySettingMap := make(map[string]interface{})
+		repeatNotifySettingRaw := make(map[string]interface{})
+		if responsePlanRaw["repeatNotifySetting"] != nil {
+			repeatNotifySettingRaw = responsePlanRaw["repeatNotifySetting"].(map[string]interface{})
+		}
+		if len(repeatNotifySettingRaw) > 0 {
+			repeatNotifySettingMap["end_incident_state"] = repeatNotifySettingRaw["endIncidentState"]
+			repeatNotifySettingMap["repeat_interval"] = repeatNotifySettingRaw["repeatInterval"]
+
+			repeatNotifySettingMaps = append(repeatNotifySettingMaps, repeatNotifySettingMap)
+		}
+		responsePlanMap["repeat_notify_setting"] = repeatNotifySettingMaps
+		responsePlanMaps = append(responsePlanMaps, responsePlanMap)
+	}
+	if err := d.Set("response_plan", responsePlanMaps); err != nil {
+		return err
+	}
+	subscriptionMaps := make([]map[string]interface{}, 0)
+	subscriptionMap := make(map[string]interface{})
+	subscriptionRaw := make(map[string]interface{})
+	if objectRaw["subscription"] != nil {
+		subscriptionRaw = objectRaw["subscription"].(map[string]interface{})
+	}
+	if len(subscriptionRaw) > 0 {
+		subscriptionMap["subscribe_legacy_event"] = subscriptionRaw["subscribeLegacyEvent"]
+
+		filterSettingMaps := make([]map[string]interface{}, 0)
+		filterSettingMap := make(map[string]interface{})
+		filterSettingRaw := make(map[string]interface{})
+		if subscriptionRaw["filterSetting"] != nil {
+			filterSettingRaw = subscriptionRaw["filterSetting"].(map[string]interface{})
+		}
+		if len(filterSettingRaw) > 0 {
+			filterSettingMap["expression"] = filterSettingRaw["expression"]
+			filterSettingMap["relation"] = filterSettingRaw["relation"]
+
+			conditionsRaw := filterSettingRaw["conditions"]
+			conditionsMaps := make([]map[string]interface{}, 0)
+			if conditionsRaw != nil {
+				for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+					conditionsMap := make(map[string]interface{})
+					conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+					conditionsMap["field"] = conditionsChildRaw["field"]
+					conditionsMap["op"] = conditionsChildRaw["op"]
+					conditionsMap["value"] = conditionsChildRaw["value"]
+
+					conditionsMaps = append(conditionsMaps, conditionsMap)
+				}
+			}
+			filterSettingMap["conditions"] = conditionsMaps
+			filterSettingMaps = append(filterSettingMaps, filterSettingMap)
+		}
+		subscriptionMap["filter_setting"] = filterSettingMaps
+		workspaceFilterSettingMaps := make([]map[string]interface{}, 0)
+		workspaceFilterSettingMap := make(map[string]interface{})
+		workspaceFilterSettingRaw := make(map[string]interface{})
+		if subscriptionRaw["workspaceFilterSetting"] != nil {
+			workspaceFilterSettingRaw = subscriptionRaw["workspaceFilterSetting"].(map[string]interface{})
+		}
+		if len(workspaceFilterSettingRaw) > 0 {
+
+			tagSelectorMaps := make([]map[string]interface{}, 0)
+			tagSelectorMap := make(map[string]interface{})
+			tagSelectorRaw := make(map[string]interface{})
+			if workspaceFilterSettingRaw["tagSelector"] != nil {
+				tagSelectorRaw = workspaceFilterSettingRaw["tagSelector"].(map[string]interface{})
+			}
+			if len(tagSelectorRaw) > 0 {
+				tagSelectorMap["expression"] = tagSelectorRaw["expression"]
+				tagSelectorMap["relation"] = tagSelectorRaw["relation"]
+
+				conditionsRaw := tagSelectorRaw["conditions"]
+				conditionsMaps := make([]map[string]interface{}, 0)
+				if conditionsRaw != nil {
+					for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+						conditionsMap := make(map[string]interface{})
+						conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+						conditionsMap["field"] = conditionsChildRaw["field"]
+						conditionsMap["op"] = conditionsChildRaw["op"]
+						conditionsMap["value"] = conditionsChildRaw["value"]
+
+						conditionsMaps = append(conditionsMaps, conditionsMap)
+					}
+				}
+				tagSelectorMap["conditions"] = conditionsMaps
+				tagSelectorMaps = append(tagSelectorMaps, tagSelectorMap)
+			}
+			workspaceFilterSettingMap["tag_selector"] = tagSelectorMaps
+			workspaceUuidsRaw := make([]interface{}, 0)
+			if workspaceFilterSettingRaw["workspaceUuids"] != nil {
+				workspaceUuidsRaw = convertToInterfaceArray(workspaceFilterSettingRaw["workspaceUuids"])
+			}
+
+			workspaceFilterSettingMap["workspace_uuids"] = workspaceUuidsRaw
+			workspaceFilterSettingMaps = append(workspaceFilterSettingMaps, workspaceFilterSettingMap)
+		}
+		subscriptionMap["workspace_filter_setting"] = workspaceFilterSettingMaps
+		subscriptionMaps = append(subscriptionMaps, subscriptionMap)
+	}
+	if err := d.Set("subscription", subscriptionMaps); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAliCloudCmsEventNotifyPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var body map[string]interface{}
+	update := false
+
+	cmsServiceV2 := CmsServiceV2{client}
+	objectRaw, _ := cmsServiceV2.DescribeCmsEventNotifyPolicy(d.Id())
+
+	initedEnabled := false
+	if _, ok := d.GetOkExists("enabled"); ok && d.IsNewResource() {
+		initedEnabled = true
+	}
+	if initedEnabled || d.HasChange("enabled") {
+		var err error
+		target := d.Get("enabled").(bool)
+
+		currentStatus, err := jsonpath.Get("enabled", objectRaw)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, d.Id(), "enabled", objectRaw)
+		}
+		if formatBool(currentStatus) != target {
+			if target == true {
+				parts := strings.Split(d.Id(), ":")
+				uuid := parts[0]
+				action := fmt.Sprintf("/api/eventbase/notify-policy/%s/enable", uuid)
+				request = make(map[string]interface{})
+				query = make(map[string]*string)
+				body = make(map[string]interface{})
+				query["workspace"] = StringPointer(parts[1])
+				query["regionId"] = StringPointer(client.RegionId)
+				body = request
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = client.RoaPut("Cms", "2024-03-30", action, query, nil, body, true)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+
+			}
+			if target == false {
+				parts := strings.Split(d.Id(), ":")
+				uuid := parts[0]
+				action := fmt.Sprintf("/api/eventbase/notify-policy/%s/disable", uuid)
+				request = make(map[string]interface{})
+				query = make(map[string]*string)
+				body = make(map[string]interface{})
+				query["workspace"] = StringPointer(parts[1])
+				query["regionId"] = StringPointer(client.RegionId)
+				body = request
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = client.RoaPut("Cms", "2024-03-30", action, query, nil, body, true)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+
+			}
+		}
+	}
+
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	action := fmt.Sprintf("/api/eventbase/notify-policy/update")
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+	query["workspace"] = StringPointer(parts[1])
+	request["uuid"] = parts[0]
+	query["regionId"] = StringPointer(client.RegionId)
+	// The update API uses version as an optimistic lock. It must carry the value
+	// currently held by the server, otherwise the request fails with OptimisticLockFailed.
+	// The enable/disable calls above bump the version, so the policy is re-read here
+	// instead of reusing the snapshot taken at the beginning of this function.
+	versionSource := objectRaw
+	if latestRaw, describeErr := cmsServiceV2.DescribeCmsEventNotifyPolicy(d.Id()); describeErr == nil {
+		versionSource = latestRaw
+	}
+	if currentVersion, ok := versionSource["version"]; ok && currentVersion != nil {
+		request["version"] = currentVersion
+	}
+	if d.HasChange("notify_strategy") {
+		update = true
+	}
+	notifyStrategy := make(map[string]interface{})
+
+	if v := d.Get("notify_strategy"); !IsNil(v) || d.HasChange("notify_strategy") {
+		groupingSetting := make(map[string]interface{})
+		times1, _ := jsonpath.Get("$[0].grouping_setting[0].times", d.Get("notify_strategy"))
+		if times1 != nil && times1 != "" {
+			groupingSetting["times"] = times1
+		}
+		groupingKeys1, _ := jsonpath.Get("$[0].grouping_setting[0].grouping_keys", d.Get("notify_strategy"))
+		if groupingKeys1 != nil && groupingKeys1 != "" {
+			groupingSetting["groupingKeys"] = groupingKeys1
+		}
+		periodMin1, _ := jsonpath.Get("$[0].grouping_setting[0].period_min", d.Get("notify_strategy"))
+		if periodMin1 != nil && periodMin1 != "" {
+			groupingSetting["periodMin"] = periodMin1
+		}
+		silenceSec1, _ := jsonpath.Get("$[0].grouping_setting[0].silence_sec", d.Get("notify_strategy"))
+		if silenceSec1 != nil && silenceSec1 != "" {
+			groupingSetting["silenceSec"] = silenceSec1
+		}
+
+		if len(groupingSetting) > 0 {
+			notifyStrategy["groupingSetting"] = groupingSetting
+		}
+		if v, ok := d.GetOk("notify_strategy"); ok {
+			localData, err := jsonpath.Get("$[0].routes", v)
+			if err != nil {
+				localData = make([]interface{}, 0)
+			}
+			localMaps := make([]interface{}, 0)
+			for _, dataLoop := range convertToInterfaceArray(localData) {
+				dataLoopTmp := make(map[string]interface{})
+				if dataLoop != nil {
+					dataLoopTmp = dataLoop.(map[string]interface{})
+				}
+				dataLoopMap := make(map[string]interface{})
+				if !IsNil(dataLoopTmp["effect_time_range"]) {
+					localData1 := make(map[string]interface{})
+					startTimeInMinute1, _ := jsonpath.Get("$[0].start_time_in_minute", dataLoopTmp["effect_time_range"])
+					if startTimeInMinute1 != nil && startTimeInMinute1 != "" {
+						localData1["startTimeInMinute"] = startTimeInMinute1
+					}
+					endTimeInMinute1, _ := jsonpath.Get("$[0].end_time_in_minute", dataLoopTmp["effect_time_range"])
+					if endTimeInMinute1 != nil && endTimeInMinute1 != "" {
+						localData1["endTimeInMinute"] = endTimeInMinute1
+					}
+					dayInWeek1, _ := jsonpath.Get("$[0].day_in_week", dataLoopTmp["effect_time_range"])
+					if dayInWeek1 != nil && dayInWeek1 != "" {
+						localData1["dayInWeek"] = dayInWeek1
+					}
+					timeZone1, _ := jsonpath.Get("$[0].time_zone", dataLoopTmp["effect_time_range"])
+					if timeZone1 != nil && timeZone1 != "" {
+						localData1["timeZone"] = timeZone1
+					}
+					if len(localData1) > 0 {
+						dataLoopMap["effectTimeRange"] = localData1
+					}
+				}
+				localMaps2 := make([]interface{}, 0)
+				localData2 := dataLoopTmp["channels"]
+				for _, dataLoop2 := range convertToInterfaceArray(localData2) {
+					dataLoop2Tmp := dataLoop2.(map[string]interface{})
+					dataLoop2Map := make(map[string]interface{})
+					dataLoop2Map["receivers"] = dataLoop2Tmp["receivers"]
+					dataLoop2Map["channelType"] = dataLoop2Tmp["channel_type"]
+					if enabledSubChannelsSet, ok := dataLoop2Tmp["enabled_sub_channels"].(*schema.Set); ok {
+						dataLoop2Map["enabledSubChannels"] = enabledSubChannelsSet.List()
+					} else {
+						dataLoop2Map["enabledSubChannels"] = dataLoop2Tmp["enabled_sub_channels"]
+					}
+					localMaps2 = append(localMaps2, dataLoop2Map)
+				}
+				dataLoopMap["channels"] = localMaps2
+				if !IsNil(dataLoopTmp["filter_setting"]) {
+					localData3 := make(map[string]interface{})
+					if v, ok := dataLoopTmp["filter_setting"]; ok {
+						localData4, err := jsonpath.Get("$[0].conditions", v)
+						if err != nil {
+							localData4 = make([]interface{}, 0)
+						}
+						localMaps4 := make([]interface{}, 0)
+						for _, dataLoop4 := range convertToInterfaceArray(localData4) {
+							dataLoop4Tmp := make(map[string]interface{})
+							if dataLoop4 != nil {
+								dataLoop4Tmp = dataLoop4.(map[string]interface{})
+							}
+							dataLoop4Map := make(map[string]interface{})
+							dataLoop4Map["op"] = dataLoop4Tmp["op"]
+							dataLoop4Map["field"] = dataLoop4Tmp["field"]
+							dataLoop4Map["value"] = dataLoop4Tmp["value"]
+							localMaps4 = append(localMaps4, dataLoop4Map)
+						}
+						localData3["conditions"] = localMaps4
+					}
+
+					relation1, _ := jsonpath.Get("$[0].relation", dataLoopTmp["filter_setting"])
+					if relation1 != nil && relation1 != "" {
+						localData3["relation"] = relation1
+					}
+					expression1, _ := jsonpath.Get("$[0].expression", dataLoopTmp["filter_setting"])
+					if expression1 != nil && expression1 != "" {
+						localData3["expression"] = expression1
+					}
+					if len(localData3) > 0 {
+						dataLoopMap["filterSetting"] = localData3
+					}
+				}
+				dataLoopMap["enableRca"] = dataLoopTmp["enable_rca"]
+				dataLoopMap["digitalEmployeeName"] = dataLoopTmp["digital_employee_name"]
+				localMaps = append(localMaps, dataLoopMap)
+			}
+			notifyStrategy["routes"] = localMaps
+		}
+
+		if v, ok := d.GetOk("notify_strategy"); ok {
+			localData5, err := jsonpath.Get("$[0].custom_template_entries", v)
+			if err != nil {
+				localData5 = make([]interface{}, 0)
+			}
+			localMaps5 := make([]interface{}, 0)
+			for _, dataLoop5 := range convertToInterfaceArray(localData5) {
+				dataLoop5Tmp := make(map[string]interface{})
+				if dataLoop5 != nil {
+					dataLoop5Tmp = dataLoop5.(map[string]interface{})
+				}
+				dataLoop5Map := make(map[string]interface{})
+				dataLoop5Map["templateUuid"] = dataLoop5Tmp["template_uuid"]
+				localMaps5 = append(localMaps5, dataLoop5Map)
+			}
+			notifyStrategy["customTemplateEntries"] = localMaps5
+		}
+
+		ignoreRestoredNotification1, _ := jsonpath.Get("$[0].ignore_restored_notification", v)
+		if ignoreRestoredNotification1 != nil && ignoreRestoredNotification1 != "" {
+			notifyStrategy["ignoreRestoredNotification"] = ignoreRestoredNotification1
+		}
+		description1, _ := jsonpath.Get("$[0].description", v)
+		if description1 != nil && description1 != "" {
+			notifyStrategy["description"] = description1
+		}
+
+		request["notifyStrategy"] = notifyStrategy
+	}
+
+	if !d.IsNewResource() && d.HasChange("response_plan") {
+		update = true
+	}
+	responsePlan := make(map[string]interface{})
+
+	if v := d.Get("response_plan"); !IsNil(v) || d.HasChange("response_plan") {
+		autoRecoverSeconds1, _ := jsonpath.Get("$[0].auto_recover_seconds", v)
+		if autoRecoverSeconds1 != nil && autoRecoverSeconds1 != "" {
+			responsePlan["autoRecoverSeconds"] = autoRecoverSeconds1
+		}
+		pushingSetting := make(map[string]interface{})
+		restoreActionIds1, _ := jsonpath.Get("$[0].pushing_setting[0].restore_action_ids", d.Get("response_plan"))
+		if restoreActionIds1 != nil && restoreActionIds1 != "" {
+			pushingSetting["restoreActionIds"] = restoreActionIds1
+		}
+		alertActionIds1, _ := jsonpath.Get("$[0].pushing_setting[0].alert_action_ids", d.Get("response_plan"))
+		if alertActionIds1 != nil && alertActionIds1 != "" {
+			pushingSetting["alertActionIds"] = alertActionIds1
+		}
+
+		if len(pushingSetting) > 0 {
+			responsePlan["pushingSetting"] = pushingSetting
+		}
+		repeatNotifySetting := make(map[string]interface{})
+		repeatInterval1, _ := jsonpath.Get("$[0].repeat_notify_setting[0].repeat_interval", d.Get("response_plan"))
+		if repeatInterval1 != nil && repeatInterval1 != "" {
+			repeatNotifySetting["repeatInterval"] = repeatInterval1
+		}
+		endIncidentState1, _ := jsonpath.Get("$[0].repeat_notify_setting[0].end_incident_state", d.Get("response_plan"))
+		if endIncidentState1 != nil && endIncidentState1 != "" {
+			repeatNotifySetting["endIncidentState"] = endIncidentState1
+		}
+
+		if len(repeatNotifySetting) > 0 {
+			responsePlan["repeatNotifySetting"] = repeatNotifySetting
+		}
+		escalationId1, _ := jsonpath.Get("$[0].escalation_id", v)
+		if escalationId1 != nil && escalationId1 != "" {
+			responsePlan["escalationId"] = escalationId1
+		}
+
+		request["responsePlan"] = responsePlan
+	}
+
+	if d.HasChange("subscription") {
+		update = true
+	}
+	subscription := make(map[string]interface{})
+
+	if v := d.Get("subscription"); !IsNil(v) || d.HasChange("subscription") {
+		// workspace_filter_setting is read with plain type assertions instead of
+		// jsonpath: the nested tag_selector list makes the jsonpath lookups return
+		// nothing, which silently dropped both tagSelector and workspaceUuids.
+		workspaceFilterSetting := buildEventNotifyPolicyWorkspaceFilterSetting(d.Get("subscription"))
+
+		if len(workspaceFilterSetting) > 0 {
+			subscription["workspaceFilterSetting"] = workspaceFilterSetting
+		}
+		filterSetting1 := make(map[string]interface{})
+		if v, ok := d.GetOk("subscription"); ok {
+			localData7, err := jsonpath.Get("$[0].filter_setting[0].conditions", v)
+			if err != nil {
+				localData7 = make([]interface{}, 0)
+			}
+			localMaps7 := make([]interface{}, 0)
+			for _, dataLoop7 := range convertToInterfaceArray(localData7) {
+				dataLoop7Tmp := make(map[string]interface{})
+				if dataLoop7 != nil {
+					dataLoop7Tmp = dataLoop7.(map[string]interface{})
+				}
+				dataLoop7Map := make(map[string]interface{})
+				dataLoop7Map["field"] = dataLoop7Tmp["field"]
+				dataLoop7Map["value"] = dataLoop7Tmp["value"]
+				dataLoop7Map["op"] = dataLoop7Tmp["op"]
+				localMaps7 = append(localMaps7, dataLoop7Map)
+			}
+			filterSetting1["conditions"] = localMaps7
+		}
+
+		relation5, _ := jsonpath.Get("$[0].filter_setting[0].relation", d.Get("subscription"))
+		if relation5 != nil && relation5 != "" {
+			filterSetting1["relation"] = relation5
+		}
+		expression5, _ := jsonpath.Get("$[0].filter_setting[0].expression", d.Get("subscription"))
+		if expression5 != nil && expression5 != "" {
+			filterSetting1["expression"] = expression5
+		}
+
+		if len(filterSetting1) > 0 {
+			subscription["filterSetting"] = filterSetting1
+		}
+		subscribeLegacyEvent1, _ := jsonpath.Get("$[0].subscribe_legacy_event", v)
+		if subscribeLegacyEvent1 != nil && subscribeLegacyEvent1 != "" {
+			subscription["subscribeLegacyEvent"] = subscribeLegacyEvent1
+		}
+
+		request["subscription"] = subscription
+	}
+
+	if !d.IsNewResource() && d.HasChange("name") {
+		update = true
+	}
+	if v, ok := d.GetOk("name"); ok || d.HasChange("name") {
+		request["name"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("description") {
+		update = true
+	}
+	if v, ok := d.GetOk("description"); ok || d.HasChange("description") {
+		request["description"] = v
+	}
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPut("Cms", "2024-03-30", action, query, nil, body, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudCmsEventNotifyPolicyRead(d, meta)
+}
+
+func resourceAliCloudCmsEventNotifyPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := fmt.Sprintf("/api/eventbase/notify-policy")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+	query["uuid"] = StringPointer(parts[0])
+	query["workspace"] = StringPointer(parts[1])
+	query["regionId"] = StringPointer(client.RegionId)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("Cms", "2024-03-30", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NotFound"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}
+
+// buildEventNotifyPolicyWorkspaceFilterSetting converts the subscription
+// workspace_filter_setting block into the request payload shape.
+func buildEventNotifyPolicyWorkspaceFilterSetting(raw interface{}) map[string]interface{} {
+	workspaceFilterSetting := make(map[string]interface{})
+
+	subscriptionList, ok := raw.([]interface{})
+	if !ok || len(subscriptionList) == 0 {
+		return workspaceFilterSetting
+	}
+	subscriptionMap, ok := subscriptionList[0].(map[string]interface{})
+	if !ok {
+		return workspaceFilterSetting
+	}
+	settingList, ok := subscriptionMap["workspace_filter_setting"].([]interface{})
+	if !ok || len(settingList) == 0 {
+		return workspaceFilterSetting
+	}
+	settingMap, ok := settingList[0].(map[string]interface{})
+	if !ok {
+		return workspaceFilterSetting
+	}
+
+	if workspaceUuids, ok := settingMap["workspace_uuids"].([]interface{}); ok && len(workspaceUuids) > 0 {
+		workspaceFilterSetting["workspaceUuids"] = workspaceUuids
+	}
+
+	selectorList, ok := settingMap["tag_selector"].([]interface{})
+	if !ok || len(selectorList) == 0 {
+		return workspaceFilterSetting
+	}
+	selectorMap, ok := selectorList[0].(map[string]interface{})
+	if !ok {
+		return workspaceFilterSetting
+	}
+
+	tagSelector := make(map[string]interface{})
+	if relation, ok := selectorMap["relation"].(string); ok && relation != "" {
+		tagSelector["relation"] = relation
+	}
+	if expression, ok := selectorMap["expression"].(string); ok && expression != "" {
+		tagSelector["expression"] = expression
+	}
+	conditions := make([]interface{}, 0)
+	if conditionList, ok := selectorMap["conditions"].([]interface{}); ok {
+		for _, condition := range conditionList {
+			conditionMap, ok := condition.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			conditions = append(conditions, map[string]interface{}{
+				"field": conditionMap["field"],
+				"op":    conditionMap["op"],
+				"value": conditionMap["value"],
+			})
+		}
+	}
+	tagSelector["conditions"] = conditions
+
+	if len(tagSelector) > 0 {
+		workspaceFilterSetting["tagSelector"] = tagSelector
+	}
+	return workspaceFilterSetting
+}

--- a/alicloud/resource_alicloud_cms_event_notify_policy_test.go
+++ b/alicloud/resource_alicloud_cms_event_notify_policy_test.go
@@ -1,0 +1,2668 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Cms EventNotifyPolicy. >>> Resource test cases, automatically generated.
+// Case resource_EventNotifyPolicy_list_test 12980
+func TestAccAliCloudCmsEventNotifyPolicy_basic12980(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12980)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12980)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Event notification policy managed by Terraform",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Notify strategy for list test",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "${alicloud_cms_workspace.default.id}",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Event notification policy managed by Terraform",
+						"workspace":   CHECKSET,
+						"name":        name,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12980 = map[string]string{
+	"create_time": CHECKSET,
+	"version":     CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12980(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_rca_template_test 12981
+func TestAccAliCloudCmsEventNotifyPolicy_basic12981(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12981)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12981)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Terraform test for EnableRca and CustomTemplateEntries fields",
+					"response_plan": []map[string]interface{}{
+						{
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Test notify strategy with RCA and custom templates",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"digital_employee_name": "test-employee-001",
+									"enable_rca":            "true",
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+							"custom_template_entries": []map[string]interface{}{
+								{
+									"template_uuid": "test-template-uuid-001",
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+						},
+					},
+					"workspace": "${alicloud_cms_workspace.default.id}",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Terraform test for EnableRca and CustomTemplateEntries fields",
+						"workspace":   CHECKSET,
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated: EnableRca disabled, template changed",
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Test notify strategy with RCA and custom templates",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"digital_employee_name": "test-employee-002",
+									"enable_rca":            "false",
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+							"custom_template_entries": []map[string]interface{}{
+								{
+									"template_uuid": "test-template-uuid-002",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated: EnableRca disabled, template changed",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12981 = map[string]string{
+	"create_time": CHECKSET,
+	"version":     CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12981(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_response_plan 12982
+func TestAccAliCloudCmsEventNotifyPolicy_basic12982(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12982)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12982)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Terraform ResponsePlan field coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"action-restore-001"},
+									"alert_action_ids": []string{
+										"action-alert-001"},
+								},
+							},
+							"escalation_id": []string{
+								"esc-test-001"},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Minimal notify strategy for ResponsePlan test",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "${alicloud_cms_workspace.default.id}",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Terraform ResponsePlan field coverage test",
+						"workspace":   CHECKSET,
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated ResponsePlan field coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "acknowledged",
+									"repeat_interval":    "60",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"action-restore-002"},
+									"alert_action_ids": []string{
+										"action-alert-002", "action-alert-003"},
+								},
+							},
+							"escalation_id": []string{
+								"esc-test-001", "esc-test-002"},
+							"auto_recover_seconds": "1200",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated ResponsePlan field coverage test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12982 = map[string]string{
+	"create_time": CHECKSET,
+	"version":     CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12982(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_lifecycle_test 12983
+func TestAccAliCloudCmsEventNotifyPolicy_basic12983(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12983)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12983)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Event notification policy managed by Terraform",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Primary notify strategy for lifecycle testing",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "${alicloud_cms_workspace.default.id}",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Event notification policy managed by Terraform",
+						"workspace":   CHECKSET,
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated description for lifecycle test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "60",
+								},
+							},
+							"auto_recover_seconds": "1200",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Primary notify strategy for lifecycle testing",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "10",
+									"times":       "2",
+									"silence_sec": "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group-updated"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "OR",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "alertname",
+											"op":    "CONTAIN",
+											"value": "memory",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated description for lifecycle test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12983 = map[string]string{
+	"create_time": CHECKSET,
+	"version":     CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12983(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_enable_disable_test 12984
+func TestAccAliCloudCmsEventNotifyPolicy_basic12984(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12984)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12984)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Terraform Enable/Disable operations test for EventNotifyPolicy",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Notify strategy for enable-disable test",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "${alicloud_cms_workspace.default.id}",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Terraform Enable/Disable operations test for EventNotifyPolicy",
+						"workspace":   CHECKSET,
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated - test regular update operation",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "60",
+								},
+							},
+							"auto_recover_seconds": "1200",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Notify strategy for enable-disable test",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "10",
+									"times":       "2",
+									"silence_sec": "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "WARNING",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated - test regular update operation",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enabled": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enabled": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enabled": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enabled": "true",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12984 = map[string]string{
+	"create_time": CHECKSET,
+	"version":     CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12984(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_non_private_attrs 12985
+func TestAccAliCloudCmsEventNotifyPolicy_basic12985(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12985)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12985)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Terraform non-private attrs coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Strategy for non-private attrs test",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"expression": "1 AND 2",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "source",
+											"op":    "EQ",
+											"value": "cms",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "${alicloud_cms_workspace.default.id}",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Terraform non-private attrs coverage test",
+						"workspace":   CHECKSET,
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Strategy for non-private attrs test updated",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Tokyo",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"expression": "1 OR 2",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "CONTAIN",
+											"value": "WARNING",
+										},
+										{
+											"field": "source",
+											"op":    "CONTAIN",
+											"value": "arms",
+										},
+									},
+								},
+							},
+						},
+					},
+					"name": name + "update",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name": name + "update",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12985 = map[string]string{
+	"create_time": CHECKSET,
+	"version":     CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12985(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_enum_channel_types 12986
+func TestAccAliCloudCmsEventNotifyPolicy_basic12986(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12986)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12986)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Terraform enum ChannelType coverage test for EventNotifyPolicy",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Notify strategy for ChannelType enum coverage",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-enum-test-ding"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-enum-test-ding2"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "${alicloud_cms_workspace.default.id}",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Terraform enum ChannelType coverage test for EventNotifyPolicy",
+						"workspace":   CHECKSET,
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated ChannelType enum coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "60",
+								},
+							},
+							"auto_recover_seconds": "1200",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Notify strategy for ChannelType enum coverage",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "10",
+									"times":       "2",
+									"silence_sec": "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-enum-test-ding-updated"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-enum-test-ding2-updated"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "memory",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated ChannelType enum coverage test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12986 = map[string]string{
+	"create_time": CHECKSET,
+	"version":     CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12986(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_filter_setting 12987
+func TestAccAliCloudCmsEventNotifyPolicy_basic12987(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12987)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12987)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Terraform FilterSetting coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Minimal strategy for filter testing",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"filter_setting": []map[string]interface{}{
+										{
+											"relation":   "AND",
+											"expression": "1 AND 2",
+											"conditions": []map[string]interface{}{
+												{
+													"field": "source",
+													"op":    "EQ",
+													"value": "cms",
+												},
+												{
+													"field": "severity",
+													"op":    "EQ",
+													"value": "WARNING",
+												},
+											},
+										},
+									},
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"workspace_filter_setting": []map[string]interface{}{
+								{
+									"workspace_uuids": []string{
+										"${alicloud_cms_workspace.default.id}"},
+									"tag_selector": []map[string]interface{}{
+										{
+											"relation":   "AND",
+											"expression": "1",
+											"conditions": []map[string]interface{}{
+												{
+													"field": "env",
+													"op":    "EQ",
+													"value": "prod",
+												},
+											},
+										},
+									},
+								},
+							},
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "OR",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "${alicloud_cms_workspace.default.id}",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Terraform FilterSetting coverage test",
+						"workspace":   CHECKSET,
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Terraform FilterSetting coverage test - extreme conditions",
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Minimal strategy for filter testing",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"filter_setting": []map[string]interface{}{
+										{
+											"relation":   "OR",
+											"expression": "1",
+											"conditions": []map[string]interface{}{
+												{
+													"field": "severity",
+													"op":    "CONTAIN",
+													"value": "CRITICAL",
+												},
+											},
+										},
+									},
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"workspace_filter_setting": []map[string]interface{}{
+								{
+									"workspace_uuids": []string{
+										"${alicloud_cms_workspace.default.id}"},
+									"tag_selector": []map[string]interface{}{
+										{
+											"relation":   "OR",
+											"expression": "1 OR 2",
+											"conditions": []map[string]interface{}{
+												{
+													"field": "region",
+													"op":    "CONTAIN",
+													"value": "hangzhou",
+												},
+											},
+										},
+									},
+								},
+							},
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+										{
+											"field": "namespace",
+											"op":    "EQ",
+											"value": "acs_ecs",
+										},
+										{
+											"field": "source",
+											"op":    "EQ",
+											"value": "cms",
+										},
+										{
+											"field": "instance",
+											"op":    "EQ",
+											"value": "i-001",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Terraform FilterSetting coverage test - extreme conditions",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12987 = map[string]string{
+	"create_time": CHECKSET,
+	"version":     CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12987(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_array_reduce_empty 12988
+func TestAccAliCloudCmsEventNotifyPolicy_basic12988(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12988)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12988)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Terraform array reduce and empty coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"restore-action-test-001", "restore-action-test-002", "restore-action-test-003"},
+									"alert_action_ids": []string{
+										"alert-action-test-001", "alert-action-test-002", "alert-action-test-003"},
+								},
+							},
+							"escalation_id": []string{
+								"esc-id-test-001", "esc-id-test-002", "esc-id-test-003"},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Array reduce empty test strategy",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "instance", "alertname"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-reduce-group-1"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-reduce-group-2"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "540",
+											"end_time_in_minute":   "1080",
+											"day_in_week": []string{
+												"1", "2", "3"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-reduce-group-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"workspace_filter_setting": []map[string]interface{}{
+								{
+									"workspace_uuids": []string{
+										"ws-uuid-test-001", "ws-uuid-test-002", "ws-uuid-test-003"},
+								},
+							},
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+										{
+											"field": "namespace",
+											"op":    "EQ",
+											"value": "acs_ecs",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "${alicloud_cms_workspace.default.id}",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Terraform array reduce and empty coverage test",
+						"workspace":   CHECKSET,
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated array reduce and empty coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "60",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"restore-action-test-001"},
+									"alert_action_ids": []string{
+										"alert-action-test-001"},
+								},
+							},
+							"escalation_id": []string{
+								"esc-id-test-001"},
+							"auto_recover_seconds": "1200",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Array reduce empty test strategy",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "10",
+									"times":       "2",
+									"silence_sec": "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-reduce-group-1"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-reduce-group-2"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"workspace_filter_setting": []map[string]interface{}{
+								{
+									"workspace_uuids": []string{
+										"ws-uuid-test-001", "ws-uuid-test-002"},
+								},
+							},
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated array reduce and empty coverage test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12988 = map[string]string{
+	"create_time": CHECKSET,
+	"version":     CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12988(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_array_empty_extended 12989
+func TestAccAliCloudCmsEventNotifyPolicy_basic12989(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12989)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12989)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Terraform extended array coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"restore-action-ext-001"},
+									"alert_action_ids": []string{
+										"alert-action-ext-001", "alert-action-ext-002", "alert-action-ext-003"},
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Extended array test strategy",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-ext-group-1", "tf-ext-group-2", "tf-ext-group-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-ext-group-4", "tf-ext-group-5"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "540",
+											"end_time_in_minute":   "1080",
+											"day_in_week": []string{
+												"1", "2", "3"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-ext-group-6", "tf-ext-group-7"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"workspace_filter_setting": []map[string]interface{}{
+								{
+									"workspace_uuids": []string{
+										"ws-uuid-ext-001", "ws-uuid-ext-002", "ws-uuid-ext-003"},
+								},
+							},
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+										{
+											"field": "namespace",
+											"op":    "EQ",
+											"value": "acs_ecs",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "${alicloud_cms_workspace.default.id}",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Terraform extended array coverage test",
+						"workspace":   CHECKSET,
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated extended array coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"restore-action-ext-001"},
+									"alert_action_ids": []string{
+										"alert-action-ext-001"},
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Extended array test strategy",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-ext-group-1"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-ext-group-4"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "540",
+											"end_time_in_minute":   "1080",
+											"day_in_week": []string{
+												"1", "2", "3"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-ext-group-6", "tf-ext-group-7"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"workspace_filter_setting": []map[string]interface{}{
+								{
+									"workspace_uuids": []string{
+										"ws-uuid-ext-001"},
+								},
+							},
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated extended array coverage test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12989 = map[string]string{
+	"create_time": CHECKSET,
+	"version":     CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12989(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_array_multi_element 12990
+func TestAccAliCloudCmsEventNotifyPolicy_basic12990(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12990)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12990)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Terraform array multi-element coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"tf-restore-action-1", "tf-restore-action-2"},
+									"alert_action_ids": []string{
+										"tf-alert-action-1", "tf-alert-action-2"},
+								},
+							},
+							"escalation_id": []string{
+								"tf-escalation-id-1", "tf-escalation-id-2"},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Multi-element array test strategy",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-array-group-1", "tf-array-group-2", "tf-array-group-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+										{
+											"receivers": []string{
+												"tf-array-contact-1", "tf-array-contact-2", "tf-array-contact-3"},
+											"channel_type": "CONTACT",
+											// The server normalises the order of enabledSubChannels, so the
+											// configuration lists them in the order it returns them.
+											"enabled_sub_channels": []string{
+												"EMAIL", "SMS"},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-array-webhook-1", "tf-array-webhook-2", "tf-array-webhook-3"},
+											"channel_type":         "WEBHOOK",
+											"enabled_sub_channels": []string{},
+										},
+										{
+											"receivers": []string{
+												"tf-array-ding-1", "tf-array-ding-2", "tf-array-ding-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "${alicloud_cms_workspace.default.id}",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Terraform array multi-element coverage test",
+						"workspace":   CHECKSET,
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Merged - growth to 3 Routes, DayInWeek boundary [1,2], Conditions 4 elements",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "60",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"tf-restore-action-1", "tf-restore-action-2", "tf-restore-action-3"},
+									"alert_action_ids": []string{
+										"tf-alert-action-1", "tf-alert-action-2", "tf-alert-action-3"},
+								},
+							},
+							"escalation_id": []string{
+								"tf-escalation-id-1", "tf-escalation-id-2", "tf-escalation-id-3"},
+							"auto_recover_seconds": "1200",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Multi-element array test strategy",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "instance", "alertname"},
+									"period_min":  "10",
+									"times":       "2",
+									"silence_sec": "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-array-group-1", "tf-array-group-2", "tf-array-group-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+										{
+											"receivers": []string{
+												"tf-array-contact-1", "tf-array-contact-2", "tf-array-contact-3"},
+											"channel_type": "CONTACT",
+											"enabled_sub_channels": []string{
+												"EMAIL"},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-array-webhook-1", "tf-array-webhook-2", "tf-array-webhook-3"},
+											"channel_type":         "WEBHOOK",
+											"enabled_sub_channels": []string{},
+										},
+										{
+											"receivers": []string{
+												"tf-array-ding-1", "tf-array-ding-2", "tf-array-ding-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "540",
+											"end_time_in_minute":   "1080",
+											"day_in_week": []string{
+												"0", "1", "2", "3", "4"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"tf-array-ding-4", "tf-array-ding-5", "tf-array-ding-6"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+										{
+											"receivers": []string{
+												"tf-array-webhook-4", "tf-array-webhook-5", "tf-array-webhook-6"},
+											"channel_type":         "WEBHOOK",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+										{
+											"field": "namespace",
+											"op":    "EQ",
+											"value": "acs_ecs",
+										},
+										{
+											"field": "source",
+											"op":    "EQ",
+											"value": "cms",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Merged - growth to 3 Routes, DayInWeek boundary [1,2], Conditions 4 elements",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12990 = map[string]string{
+	"create_time": CHECKSET,
+	"version":     CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12990(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}
+
+// Test Cms EventNotifyPolicy. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_cms_v2.go
+++ b/alicloud/service_alicloud_cms_v2.go
@@ -557,3 +557,84 @@ func (s *CmsServiceV2) CmsAlertRuleV2StateRefreshFuncWithApi(id string, field st
 }
 
 // DescribeCmsAlertRuleV2 >>> Encapsulated.
+// DescribeCmsEventNotifyPolicy <<< Encapsulated get interface for Cms EventNotifyPolicy.
+
+func (s *CmsServiceV2) DescribeCmsEventNotifyPolicy(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	query["uuid"] = StringPointer(parts[0])
+	query["workspace"] = StringPointer(parts[1])
+	query["regionId"] = StringPointer(client.RegionId)
+	action := fmt.Sprintf("/api/eventbase/notify-policy")
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RoaGet("Cms", "2024-03-30", action, query, nil, nil)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NotFound"}) {
+			return object, WrapErrorf(NotFoundErr("EventNotifyPolicy", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.notifyPolicy", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.notifyPolicy", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *CmsServiceV2) CmsEventNotifyPolicyStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.CmsEventNotifyPolicyStateRefreshFuncWithApi(id, field, failStates, s.DescribeCmsEventNotifyPolicy)
+}
+
+func (s *CmsServiceV2) CmsEventNotifyPolicyStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeCmsEventNotifyPolicy >>> Encapsulated.

--- a/website/docs/d/cms_event_notify_policies.html.markdown
+++ b/website/docs/d/cms_event_notify_policies.html.markdown
@@ -1,0 +1,168 @@
+---
+subcategory: "Cms"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_event_notify_policies"
+sidebar_current: "docs-alicloud-datasource-cms-event-notify-policies"
+description: |-
+  Provides a list of Cms Event Notify Policy owned by an Alibaba Cloud account.
+---
+
+# alicloud_cms_event_notify_policies
+
+This data source provides Cms Event Notify Policy available to the user.[What is Event Notify Policy](https://next.api.alibabacloud.com/document/Cms/2024-03-30/CreateNotifyPolicy)
+
+-> **NOTE:** Available since v1.289.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_cms_event_notify_policy" "default" {
+  description = "Event notification policy managed by Terraform"
+  response_plan {
+    repeat_notify_setting {
+      end_incident_state = "resolved"
+      repeat_interval    = "30"
+    }
+    auto_recover_seconds = "600"
+  }
+  notify_strategy {
+    description                  = "Notify strategy for list test"
+    ignore_restored_notification = false
+    grouping_setting {
+      grouping_keys = ["severity"]
+      period_min    = "5"
+      times         = "1"
+      silence_sec   = "300"
+    }
+    routes {
+      effect_time_range {
+        time_zone            = "Asia/Shanghai"
+        start_time_in_minute = "0"
+        end_time_in_minute   = "1439"
+        day_in_week          = ["1", "2", "3", "4", "5"]
+      }
+      channels {
+        receivers            = ["tf-test-group"]
+        channel_type         = "DING"
+        enabled_sub_channels = []
+      }
+    }
+  }
+  subscription {
+    subscribe_legacy_event = true
+    filter_setting {
+      relation = "AND"
+      conditions {
+        field = "severity"
+        op    = "EQ"
+        value = "CRITICAL"
+      }
+    }
+  }
+  workspace = "default-workspace-cn-hangzhou"
+  name      = "tf-list-enp-0716a"
+}
+
+data "alicloud_cms_event_notify_policies" "default" {
+  ids       = ["${alicloud_cms_event_notify_policy.default.id}"]
+  name      = "tf-list-enp-0716a"
+  workspace = "default-workspace-cn-hangzhou"
+}
+
+output "alicloud_cms_event_notify_policy_example_id" {
+  value = data.alicloud_cms_event_notify_policies.default.policies.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `name` - (ForceNew, Optional) Filters results by fuzzy matching on the policy name.
+* `order_by` - (ForceNew, Optional) The sorting field. Supported values include createTime, updateTime, and name.
+* `order_desc` - (ForceNew, Optional) Specifies whether to sort in descending order. A value of true indicates descending order, and a value of false indicates ascending order.
+* `workspace` - (Required, ForceNew) The workspace ID, which is used to isolate notification policy resources for different business workspaces. Example: `default-cms-xxxx-cn-hangzhou`.
+* `ids` - (Optional, Computed) A list of Event Notify Policy IDs. The value is formulated as `<uuid>:<workspace>`.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Event Notify Policy IDs.
+* `policies` - A list of Event Notify Policy Entries. Each element contains the following attributes:
+  * `create_time` - The creation time.
+  * `description` - The description of the policy.
+  * `enabled` - Indicates whether the policy is enabled.
+  * `name` - The name of the notification policy.
+  * `notify_strategy` - The notification strategy sub-entity, which includes grouping and merging settings, notification routing, channels, and custom templates.
+    * `custom_template_entries` - The list of custom notification templates.
+      * `template_uuid` - The UUID of the template.
+    * `description` - The description.
+    * `grouping_setting` - The grouping and merging settings.
+      * `grouping_keys` - The event fields used to group and merge notifications. Events sharing the same values are merged into a single notification.
+      * `period_min` - The check period in minutes. This parameter does not take effect on this API.
+      * `silence_sec` - The silence duration in seconds. This parameter does not take effect on this API.
+      * `times` - The number of triggers. This parameter does not take effect on this API.
+    * `ignore_restored_notification` - Indicates whether to ignore notifications for recovered events. `true` means no recovery notification is sent.
+    * `routes` - The notification channel routing settings.
+      * `channels` - The notification channels.
+        * `channel_type` - The channel type. Valid values: `DING`, `WEIXIN`, `FEISHU`, `SLACK`, `TEAMS`, `CONTACT`, `GROUP`, `DUTY`, `DING_COOL_APP`.
+        * `enabled_sub_channels` - The enabled notification methods. Applies only when `channel_type` is `CONTACT`, `GROUP` or `DUTY`. Valid values: `EMAIL`, `SMS`, `VOICE`, `DING`, `WEIXIN`, `FEISHU`, `WEBHOOK`.
+        * `receivers` - The list of recipients for the channel.
+      * `digital_employee_name` - The name of the digital employee.
+      * `effect_time_range` - The effective time range.
+        * `day_in_week` - The effective days of the week.
+        * `end_time_in_minute` - The end time in minutes.
+        * `start_time_in_minute` - The start time in minutes.
+        * `time_zone` - The time zone, such as Asia/Shanghai.
+      * `enable_rca` - Specifies whether to enable Root Cause Analysis (RCA).
+      * `filter_setting` - Route-level event filtering.
+        * `conditions` - Filter conditions.
+          * `field` - The filter field.
+          * `op` - The filter operator.
+          * `value` - The filter value.
+        * `expression` - The relational expression.
+        * `relation` - The logical relationship between conditions.
+  * `response_plan` - **NOTE:** This field is only available when `enable_details` is `true`. Response plan sub-entities: escalation, repeated notification, automatic recovery, and action integration.
+    * `auto_recover_seconds` - The auto-recovery duration in seconds. An event is recovered automatically when it is not triggered again within this duration.
+    * `escalation_id` - The list of escalation plan IDs.
+    * `pushing_setting` - Action integration push settings.
+      * `alert_action_ids` - The list of alert action integration IDs triggered by alerts.
+      * `restore_action_ids` - The list of action integration IDs triggered upon recovery.
+    * `repeat_notify_setting` - Repeated notification configuration.
+      * `end_incident_state` - The incident state at which repeated notifications stop. For example: `RECOVERED`.
+      * `repeat_interval` - The interval between repeated notifications, in seconds.
+  * `subscription` - **NOTE:** This field is only available when `enable_details` is `true`. Subscription sub-entities: event filtering, cross-workspace routing, and the switch for legacy product event subscription.
+    * `filter_setting` - Event content filtering.
+      * `conditions` - Filter conditions.
+        * `field` - Filter field.
+        * `op` - Filter operator.
+        * `value` - The filter value.
+      * `expression` - Relational expression.
+      * `relation` - Condition relationship.
+    * `subscribe_legacy_event` - Specifies whether to subscribe to legacy product events (events with an empty workspace, such as CMS 1.
+    * `workspace_filter_setting` - Cross-workspace event routing (global subscription).
+      * `tag_selector` - The tag selector.
+        * `conditions` - The filter conditions.
+          * `field` - The filter field.
+          * `op` - The filter operator.
+          * `value` - The filter value.
+        * `expression` - The relational expression.
+        * `relation` - The condition relation.
+      * `workspace_uuids` - The list of workspace UUIDs.
+  * `update_time` - The update time.
+  * `user_id` - The user ID.
+  * `uuid` - The unique identifier of the notification policy, which is returned by the creation API.
+  * `version` - Private parameter for update operation.
+  * `workspace` - The workspace ID, which is used to isolate notification policy resources for different business workspaces.
+  * `id` - The ID of the resource supplied above.

--- a/website/docs/r/cms_event_notify_policy.html.markdown
+++ b/website/docs/r/cms_event_notify_policy.html.markdown
@@ -1,0 +1,236 @@
+---
+subcategory: "Cms"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_event_notify_policy"
+description: |-
+  Provides a Alicloud Cms Event Notify Policy resource.
+---
+
+# alicloud_cms_event_notify_policy
+
+Provides a Cms Event Notify Policy resource.
+
+
+
+For information about Cms Event Notify Policy and how to use it, see [What is Event Notify Policy](https://next.api.alibabacloud.com/document/Cms/2024-03-30/CreateNotifyPolicy).
+
+-> **NOTE:** Available since v1.289.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_cms_event_notify_policy" "default" {
+  description = "Event notification policy managed by Terraform"
+  response_plan {
+    repeat_notify_setting {
+      end_incident_state = "resolved"
+      repeat_interval    = "30"
+    }
+    auto_recover_seconds = "600"
+  }
+  notify_strategy {
+    description                  = "Notify strategy for list example"
+    ignore_restored_notification = false
+    grouping_setting {
+      grouping_keys = ["severity"]
+      period_min    = "5"
+      times         = "1"
+      silence_sec   = "300"
+    }
+    routes {
+      effect_time_range {
+        time_zone            = "Asia/Shanghai"
+        start_time_in_minute = "0"
+        end_time_in_minute   = "1439"
+        day_in_week          = ["1", "2", "3", "4", "5"]
+      }
+      channels {
+        receivers            = ["tf-example-group"]
+        channel_type         = "DING"
+        enabled_sub_channels = []
+      }
+    }
+  }
+  subscription {
+    subscribe_legacy_event = true
+    filter_setting {
+      relation = "AND"
+      conditions {
+        field = "severity"
+        op    = "EQ"
+        value = "CRITICAL"
+      }
+    }
+  }
+  workspace = "default-workspace-cn-hangzhou"
+  name      = "tf-list-enp-0716a"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `description` - (Optional) The description of the policy.
+* `enabled` - (Optional, Computed) Indicates whether the policy is enabled. The value is applied through the dedicated enable and disable operations rather than the creation payload.
+* `name` - (Optional) The name of the notification policy. The name must be unique within the workspace. Creating a policy whose name duplicates an existing one returns a `ConflictName` error.
+* `notify_strategy` - (Optional, Set) The notification strategy sub-entity, which includes grouping and merging settings, notification routing, channels, and custom templates. See [`notify_strategy`](#notify_strategy) below.
+* `response_plan` - (Optional, Set) Response plan sub-entities: escalation, repeated notification, automatic recovery, and action integration. See [`response_plan`](#response_plan) below.
+* `subscription` - (Optional, Set) Subscription sub-entities: event filtering, cross-workspace routing, and the switch for legacy product event subscription. See [`subscription`](#subscription) below.
+* `workspace` - (Required, ForceNew) The workspace ID, which is used to isolate notification policy resources for different business workspaces. Example: `default-cms-xxxx-cn-hangzhou`.
+
+### `notify_strategy`
+
+The notify_strategy supports the following:
+* `custom_template_entries` - (Optional, List) The list of custom notification templates. See [`custom_template_entries`](#notify_strategy-custom_template_entries) below.
+* `description` - (Optional) The description of the notification strategy.
+* `grouping_setting` - (Optional, Set) The grouping and merging settings. See [`grouping_setting`](#notify_strategy-grouping_setting) below.
+* `ignore_restored_notification` - (Optional) Indicates whether to ignore notifications for recovered events. `true` means no recovery notification is sent.
+* `routes` - (Optional, List) The notification channel routing settings. See [`routes`](#notify_strategy-routes) below.
+
+### `notify_strategy-custom_template_entries`
+
+The notify_strategy-custom_template_entries supports the following:
+* `template_uuid` - (Optional) The UUID of the template.
+
+### `notify_strategy-grouping_setting`
+
+The notify_strategy-grouping_setting supports the following:
+* `grouping_keys` - (Optional, List) The event fields used to group and merge notifications. Events sharing the same values are merged into a single notification. An empty list means no grouping.
+* `period_min` - (Optional, Int) The check period in minutes. This parameter does not take effect on this API and does not need to be set.
+* `silence_sec` - (Optional, Int) The silence duration in seconds. This parameter does not take effect on this API and does not need to be set.
+* `times` - (Optional, Int) The number of triggers. This parameter does not take effect on this API and does not need to be set.
+
+### `notify_strategy-routes`
+
+The notify_strategy-routes supports the following:
+* `channels` - (Optional, List) The notification channels. See [`channels`](#notify_strategy-routes-channels) below.
+* `digital_employee_name` - (Optional) The name of the digital employee. This parameter is required when enableRca is set to true.
+* `effect_time_range` - (Optional, Set) The effective time range. See [`effect_time_range`](#notify_strategy-routes-effect_time_range) below.
+* `enable_rca` - (Optional) Specifies whether to enable Root Cause Analysis (RCA).
+* `filter_setting` - (Optional, Set) Route-level event filtering. See [`filter_setting`](#notify_strategy-routes-filter_setting) below.
+
+### `notify_strategy-routes-channels`
+
+The notify_strategy-routes-channels supports the following:
+* `channel_type` - (Optional) The channel type. Valid values: `DING`, `WEIXIN`, `FEISHU`, `SLACK`, `TEAMS`, `CONTACT`, `GROUP`, `DUTY`, `DING_COOL_APP`.
+* `enabled_sub_channels` - (Optional, Set) The enabled notification methods. It is required only when `channel_type` is `CONTACT`, `GROUP` or `DUTY`. Valid values: `EMAIL`, `SMS`, `VOICE`, `DING`, `WEIXIN`, `FEISHU`, `WEBHOOK`.
+* `receivers` - (Optional, List) The list of recipient identifiers for the channel. At least one item is required. For a webhook channel it is the webhook UUID, for a robot channel it is the robot UUID, and for `CONTACT` it is the contact ID.
+
+### `notify_strategy-routes-effect_time_range`
+
+The notify_strategy-routes-effect_time_range supports the following:
+* `day_in_week` - (Optional, List) The effective days of the week. Valid values: 0 to 6 (0 indicates Sunday and 6 indicates Saturday).
+* `end_time_in_minute` - (Optional, Int) The end time in minutes. Valid values: 0 to 1439.
+* `start_time_in_minute` - (Optional, Int) The start time in minutes. Valid values: 0 to 1438.
+* `time_zone` - (Optional) The time zone, such as Asia/Shanghai.
+
+### `notify_strategy-routes-filter_setting`
+
+The notify_strategy-routes-filter_setting supports the following:
+* `conditions` - (Optional, List) Filter conditions. See [`conditions`](#notify_strategy-routes-filter_setting-conditions) below.
+* `expression` - (Optional) The relational expression.
+* `relation` - (Optional) The logical relationship between conditions.
+
+### `notify_strategy-routes-filter_setting-conditions`
+
+The notify_strategy-routes-filter_setting-conditions supports the following:
+* `field` - (Optional) The filter field.
+* `op` - (Optional) The filter operator.
+* `value` - (Optional) The filter value.
+
+### `response_plan`
+
+The response_plan supports the following:
+* `auto_recover_seconds` - (Optional, Int) The auto-recovery duration in seconds. An event is recovered automatically when it is not triggered again within this duration.
+* `escalation_id` - (Optional, List, Computed) The list of escalation plan IDs.
+* `pushing_setting` - (Optional, Set) Action integration push settings. See [`pushing_setting`](#response_plan-pushing_setting) below.
+* `repeat_notify_setting` - (Optional, Set) Repeated notification configuration. See [`repeat_notify_setting`](#response_plan-repeat_notify_setting) below.
+
+### `response_plan-pushing_setting`
+
+The response_plan-pushing_setting supports the following:
+* `alert_action_ids` - (Optional, List) The list of alert action integration IDs triggered by alerts.
+* `restore_action_ids` - (Optional, List) The list of action integration IDs triggered upon recovery.
+
+### `response_plan-repeat_notify_setting`
+
+The response_plan-repeat_notify_setting supports the following:
+* `end_incident_state` - (Optional) The incident state at which repeated notifications stop. For example: `RECOVERED`.
+* `repeat_interval` - (Optional, Int) The interval between repeated notifications, in seconds.
+
+### `subscription`
+
+The subscription supports the following:
+* `filter_setting` - (Optional, Set, Computed) Event content filtering. The server fills in defaults when it is not specified. See [`filter_setting`](#subscription-filter_setting) below.
+* `subscribe_legacy_event` - (Optional) Specifies whether to subscribe to legacy product events (events with an empty workspace, such as CMS 1.0, ARMS, or SLS events).
+* `workspace_filter_setting` - (Optional, Set) Cross-workspace event routing (global subscription). See [`workspace_filter_setting`](#subscription-workspace_filter_setting) below.
+
+### `subscription-filter_setting`
+
+The subscription-filter_setting supports the following:
+* `conditions` - (Optional, List) Filter conditions. See [`conditions`](#subscription-filter_setting-conditions) below.
+* `expression` - (Optional) Relational expression.
+* `relation` - (Optional) Condition relationship.
+
+### `subscription-workspace_filter_setting`
+
+The subscription-workspace_filter_setting supports the following:
+* `tag_selector` - (Optional, Set) The tag selector. See [`tag_selector`](#subscription-workspace_filter_setting-tag_selector) below.
+* `workspace_uuids` - (Optional, List) The list of workspace UUIDs.
+
+### `subscription-workspace_filter_setting-tag_selector`
+
+The subscription-workspace_filter_setting-tag_selector supports the following:
+* `conditions` - (Optional, List) The filter conditions. See [`conditions`](#subscription-workspace_filter_setting-tag_selector-conditions) below.
+* `expression` - (Optional) The relational expression.
+* `relation` - (Optional) The condition relation.
+
+### `subscription-workspace_filter_setting-tag_selector-conditions`
+
+The subscription-workspace_filter_setting-tag_selector-conditions supports the following:
+* `field` - (Optional) The filter field.
+* `op` - (Optional) The filter operator.
+* `value` - (Optional) The filter value.
+
+### `subscription-filter_setting-conditions`
+
+The subscription-filter_setting-conditions supports the following:
+* `field` - (Optional) Filter field.
+* `op` - (Optional) Filter operator.
+* `value` - (Optional) The filter value.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<uuid>:<workspace>`.
+* `uuid` - The unique identifier of the notification policy, which is generated by the server on creation.
+* `create_time` - The creation time.
+* `update_time` - The update time.
+* `user_id` - The user ID.
+* `version` - The optimistic lock version of the policy. It is maintained by the server and increases on every successful update.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Event Notify Policy.
+* `delete` - (Defaults to 5 mins) Used when delete the Event Notify Policy.
+* `update` - (Defaults to 5 mins) Used when update the Event Notify Policy.
+
+## Import
+
+Cms Event Notify Policy can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cms_event_notify_policy.example <uuid>:<workspace>
+```


### PR DESCRIPTION
Add a new resource `alicloud_cms_event_notify_policy` and its data source `alicloud_cms_event_notify_policies` for managing Cloud Monitor event notification policies.

The resource covers the full lifecycle of a notification policy — grouping and merging settings, notification routing with channels and effective time ranges, event subscription filters, and response plans — and supports enabling/disabling a policy through the dedicated operations.

### Acceptance tests

```
=== RUN   TestAccAliCloudCmsEventNotifyPolicy_basic12980
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12980 (8.42s)

=== RUN   TestAccAliCloudCmsEventNotifyPolicy_basic12981
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12981 (12.93s)

=== RUN   TestAccAliCloudCmsEventNotifyPolicy_basic12982
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12982 (11.69s)

=== RUN   TestAccAliCloudCmsEventNotifyPolicy_basic12983
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12983 (12.57s)

=== RUN   TestAccAliCloudCmsEventNotifyPolicy_basic12984
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12984 (21.32s)

=== RUN   TestAccAliCloudCmsEventNotifyPolicy_basic12985
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12985 (12.55s)

=== RUN   TestAccAliCloudCmsEventNotifyPolicy_basic12986
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12986 (12.65s)

=== RUN   TestAccAliCloudCmsEventNotifyPolicy_basic12987
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12987 (13.04s)

=== RUN   TestAccAliCloudCmsEventNotifyPolicy_basic12988
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12988 (12.24s)

=== RUN   TestAccAliCloudCmsEventNotifyPolicy_basic12989
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12989 (12.55s)

=== RUN   TestAccAliCloudCmsEventNotifyPolicy_basic12990
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12990 (12.54s)

=== RUN   TestAccAlicloudCmsEventNotifyPolicyDataSource
--- PASS: TestAccAlicloudCmsEventNotifyPolicyDataSource (35.77s)
```

All 12 cases pass with no skips.

### Notes

- `tag_selector` under `subscription.workspace_filter_setting` is exposed as read-only: the service accepts it on write but does not persist it, so it cannot be managed declaratively yet.
- The acceptance tests pin `cn-hangzhou` because Cloud Monitor workspaces are region-scoped.
