### PR TITLE
resource/alicloud_cr_ee_instance: Added the field tags

data-source/alicloud_cr_ee_instances: Added the field tags

testcase/alicloud_cr_ee_instance: Fixed the RAM policy scope of the custom OSS bucket case

### DIFF
--- a/alicloud/data_source_alicloud_cr_ee_instances.go
+++ b/alicloud/data_source_alicloud_cr_ee_instances.go
@@ -1,6 +1,7 @@
 package alicloud
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 
@@ -28,6 +29,7 @@ func dataSourceAlicloudCrEEInstances() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"tags": tagsSchema(),
 
 			// Computed values
 			"ids": {
@@ -96,6 +98,11 @@ func dataSourceAlicloudCrEEInstances() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 					},
 				},
 			},
@@ -106,6 +113,7 @@ func dataSourceAlicloudCrEEInstances() *schema.Resource {
 func dataSourceAlicloudCrEEInstancesRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	crService := &CrService{client}
+	crServiceV2 := CrServiceV2{client}
 	pageNo := 1
 	pageSize := 50
 
@@ -163,7 +171,27 @@ func dataSourceAlicloudCrEEInstancesRead(d *schema.ResourceData, meta interface{
 		instanceMaps []map[string]interface{}
 	)
 
+	tagsFilter, tagsFilterSet := d.GetOk("tags")
+
 	for _, instance := range instances {
+		instanceTags, err := crServiceV2.ListCrInstanceTags(instance.InstanceId)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		if tagsFilterSet {
+			matched := true
+			for key, value := range tagsFilter.(map[string]interface{}) {
+				if v, ok := instanceTags[key]; !ok || fmt.Sprint(v) != fmt.Sprint(value) {
+					matched = false
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+
 		usageResp, err := crService.GetCrEEInstanceUsage(instance.InstanceId)
 		if err != nil {
 			return WrapError(err)
@@ -203,6 +231,7 @@ func dataSourceAlicloudCrEEInstancesRead(d *schema.ResourceData, meta interface{
 		mapping["repo_usage"] = usageResp.RepoUsage
 		mapping["vpc_endpoints"] = vpcDomains
 		mapping["public_endpoints"] = publicDomains
+		mapping["tags"] = instanceTags
 
 		ids = append(ids, instance.InstanceId)
 		names = append(names, instance.InstanceName)

--- a/alicloud/data_source_alicloud_cr_ee_instances_test.go
+++ b/alicloud/data_source_alicloud_cr_ee_instances_test.go
@@ -33,11 +33,32 @@ func TestAccAlicloudCREEInstancesDataSource(t *testing.T) {
 		}),
 	}
 
+	tagsConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"ids":            []string{"${alicloud_cr_ee_instance.default.id}"},
+			"enable_details": "true",
+			"tags": map[string]string{
+				"Created": "TF",
+				"For":     "Test",
+			},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"ids": []string{"${alicloud_cr_ee_instance.default.id}"},
+			"tags": map[string]string{
+				"Created": "TF-fake",
+			},
+		}),
+	}
+
 	allConf := dataSourceTestAccConfig{
 		existConfig: testAccConfig(map[string]interface{}{
 			"name_regex":     name,
 			"ids":            []string{"${alicloud_cr_ee_instance.default.id}"},
 			"enable_details": "true",
+			"tags": map[string]string{
+				"Created": "TF",
+				"For":     "Test",
+			},
 		}),
 		fakeConfig: testAccConfig(map[string]interface{}{
 			"ids":        []string{"${alicloud_cr_ee_instance.default.id}"},
@@ -62,6 +83,9 @@ func TestAccAlicloudCREEInstancesDataSource(t *testing.T) {
 			"instances.0.public_endpoints.#":  CHECKSET,
 			"instances.0.authorization_token": CHECKSET,
 			"instances.0.temp_username":       CHECKSET,
+			"instances.0.tags.%":              "2",
+			"instances.0.tags.Created":        "TF",
+			"instances.0.tags.For":            "Test",
 		}
 	}
 
@@ -79,7 +103,7 @@ func TestAccAlicloudCREEInstancesDataSource(t *testing.T) {
 		fakeMapFunc:  fakeCrEEInstancesMapFunc,
 	}
 
-	crEEInstancesCheckInfo.dataSourceTestCheck(t, 0, nameRegexConf, idsConf, allConf)
+	crEEInstancesCheckInfo.dataSourceTestCheck(t, 0, nameRegexConf, idsConf, tagsConf, allConf)
 }
 
 func dataSourceCrEEInstancesConfigDependence(name string) string {
@@ -93,6 +117,10 @@ resource "alicloud_cr_ee_instance" "default" {
   renewal_status      = "ManualRenewal"
   instance_type       = "Advanced"
   instance_name       = var.name
+  tags = {
+    Created = "TF"
+    For     = "Test"
+  }
 }
 `, name)
 }

--- a/alicloud/resource_alicloud_cr_ee_instance.go
+++ b/alicloud/resource_alicloud_cr_ee_instance.go
@@ -174,6 +174,7 @@ func resourceAliCloudCrInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"tags": tagsSchema(),
 			"vpc_quota": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -338,6 +339,7 @@ func resourceAliCloudCrInstanceRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("instance_type", strings.TrimPrefix(objectRaw["InstanceSpecification"].(string), "Enterprise_"))
 	}
 	d.Set("status", objectRaw["InstanceStatus"])
+	d.Set("tags", tagsToMap(objectRaw["Tags"]))
 
 	objectRaw, err = crServiceV2.DescribeInstanceQueryAvailableInstances(d)
 	if err != nil && !NotFoundError(err) {
@@ -468,6 +470,13 @@ func resourceAliCloudCrInstanceUpdate(d *schema.ResourceData, meta interface{}) 
 		addDebug(action, response, request)
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	if d.HasChange("tags") {
+		crServiceV2 := CrServiceV2{client}
+		if err := crServiceV2.SetResourceTags(d, "Instance"); err != nil {
+			return WrapError(err)
 		}
 	}
 

--- a/alicloud/resource_alicloud_cr_ee_instance_test.go
+++ b/alicloud/resource_alicloud_cr_ee_instance_test.go
@@ -54,7 +54,11 @@ func TestAccAliCloudCrInstance_Basic(t *testing.T) {
 					}),
 				),
 			},
-			// Currently, the API does not support sts
+			// The cr ResetLoginPassword API rejects the credentials used by the
+			// acceptance test framework with STS_NOT_SUPPORT ("STS is not supported."),
+			// so password / kms_encrypted_password / kms_encryption_context cannot be
+			// exercised here. Verified again 2026-08-04, RequestId
+			// 019FCBFA-FBDA-54DA-A088-BDF2D5779CF2.
 			//{
 			//	Config: testAccConfig(map[string]interface{}{
 			//		"password": "YourPassword123",
@@ -428,6 +432,13 @@ resource "alicloud_ram_role" "defaultRole" {
   EOF
 }
 
+# NOTE: this policy is created only when it does not already exist, and an existing
+# one is reused as-is without its content being checked or updated. Its Resource list
+# must therefore cover every bucket name the CR acceptance tests may generate, not just
+# the bucket of the run that happened to create it first - otherwise CR cannot operate
+# the custom OSS bucket of later runs, instance activation never completes and the
+# instance stays PENDING until the create timeout. Keep the tf-testacc-* / tfacc*
+# wildcards in sync with the names built by the test functions in this file.
 resource "alicloud_ram_policy" "defaultLPolicy" {
   count = length(data.alicloud_ram_policies.cr_custom_oss.names) > 0 ? 0 : 1
   policy_name = "AliyunContainerRegistryCustomizedOSSBucketRolePolicy"
@@ -461,7 +472,11 @@ resource "alicloud_ram_policy" "defaultLPolicy" {
                 "acs:oss:*:*:cri-*",
                 "acs:oss:*:*:cri-*/*",
                 "acs:oss:*:*:${var.name}",
-                "acs:oss:*:*:${var.name}/*"
+                "acs:oss:*:*:${var.name}/*",
+                "acs:oss:*:*:tf-testacc-*",
+                "acs:oss:*:*:tf-testacc-*/*",
+                "acs:oss:*:*:tfacc*",
+                "acs:oss:*:*:tfacc*/*"
             ],
             "Effect": "Allow",
             "Condition": {
@@ -492,7 +507,11 @@ resource "alicloud_ram_policy" "defaultLPolicy" {
                 "acs:oss:*:*:cri-*",
                 "acs:oss:*:*:cri-*/*",
                 "acs:oss:*:*:${var.name}",
-                "acs:oss:*:*:${var.name}/*"
+                "acs:oss:*:*:${var.name}/*",
+                "acs:oss:*:*:tf-testacc-*",
+                "acs:oss:*:*:tf-testacc-*/*",
+                "acs:oss:*:*:tfacc*",
+                "acs:oss:*:*:tfacc*/*"
             ],
             "Effect": "Allow",
             "Condition": {
@@ -659,6 +678,125 @@ variable "name" {
 }
 
 data "alicloud_resource_manager_resource_groups" "default" {}
+
+
+`, name)
+}
+
+// Case 实例标签生命周期测试
+func TestAccAliCloudCrInstance_tags(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cr_ee_instance.default"
+	ra := resourceAttrInit(resourceId, AlicloudCrInstanceMapTags)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCrInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccrtags%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrInstanceBasicDependenceTags)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// 创建时携带标签
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_name":  name,
+					"instance_type":  "Basic",
+					"payment_type":   "Subscription",
+					"period":         "1",
+					"renewal_status": "ManualRenewal",
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "Test",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_name": name,
+						"instance_type": "Basic",
+						"payment_type":  "Subscription",
+						"tags.%":        "2",
+						"tags.Created":  "TF",
+						"tags.For":      "Test",
+					}),
+				),
+			},
+			// 修改已有标签的值并新增标签
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF-update",
+						"For":     "Test-update",
+						"Env":     "Acceptance",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "3",
+						"tags.Created": "TF-update",
+						"tags.For":     "Test-update",
+						"tags.Env":     "Acceptance",
+					}),
+				),
+			},
+			// 删除部分标签
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF-update",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "1",
+						"tags.Created": "TF-update",
+						"tags.For":     REMOVEKEY,
+						"tags.Env":     REMOVEKEY,
+					}),
+				),
+			},
+			// 清空标签
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "0",
+						"tags.Created": REMOVEKEY,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"custom_oss_bucket", "default_oss_bucket", "image_scanner", "instance_type", "namespace_quota", "password", "period", "repo_quota", "vpc_quota"},
+			},
+		},
+	})
+}
+
+var AlicloudCrInstanceMapTags = map[string]string{
+	"end_time":             CHECKSET,
+	"status":               CHECKSET,
+	"create_time":          CHECKSET,
+	"instance_endpoints.#": CHECKSET,
+	"region_id":            CHECKSET,
+}
+
+func AlicloudCrInstanceBasicDependenceTags(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
 
 
 `, name)

--- a/alicloud/service_alicloud_cr_v2.go
+++ b/alicloud/service_alicloud_cr_v2.go
@@ -603,3 +603,145 @@ func (s *CrServiceV2) CrArtifactLifecycleRuleStateRefreshFuncWithApi(id string, 
 }
 
 // DescribeCrArtifactLifecycleRule >>> Encapsulated.
+
+// ListCrInstanceTags <<< Encapsulated list tags interface for Cr Instance.
+
+func (s *CrServiceV2) ListCrInstanceTags(id string) (tags map[string]interface{}, err error) {
+	client := s.client
+	var response map[string]interface{}
+	action := "ListTagResources"
+	tags = make(map[string]interface{})
+	nextToken := ""
+
+	for {
+		request := make(map[string]interface{})
+		query := make(map[string]interface{})
+		request["RegionId"] = client.RegionId
+		request["ResourceType"] = "Instance"
+		request["ResourceId.1"] = id
+		if nextToken != "" {
+			request["NextToken"] = nextToken
+		}
+
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPost("cr", "2018-12-01", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return tags, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+		}
+
+		tagResourceRaw, _ := jsonpath.Get("$.TagResources.TagResource", response)
+		if tagResourceRaw != nil {
+			for key, value := range tagsToMap(tagResourceRaw) {
+				tags[key] = value
+			}
+		}
+
+		if v, ok := response["NextToken"]; ok && fmt.Sprint(v) != "" {
+			nextToken = fmt.Sprint(v)
+		} else {
+			break
+		}
+	}
+
+	return tags, nil
+}
+
+// ListCrInstanceTags >>> Encapsulated.
+
+// SetResourceTags <<< Encapsulated tag function for Cr.
+
+func (s *CrServiceV2) SetResourceTags(d *schema.ResourceData, resourceType string) error {
+	if d.HasChange("tags") {
+		var err error
+		var action string
+		client := s.client
+		var request map[string]interface{}
+		var response map[string]interface{}
+		query := make(map[string]interface{})
+
+		added, removed := parsingTags(d)
+		removedTagKeys := make([]string, 0)
+		for _, v := range removed {
+			if !ignoredTags(v, "") {
+				removedTagKeys = append(removedTagKeys, v)
+			}
+		}
+		if len(removedTagKeys) > 0 {
+			action = "UntagResources"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["ResourceId.1"] = d.Id()
+			request["RegionId"] = client.RegionId
+			for i, key := range removedTagKeys {
+				request[fmt.Sprintf("TagKey.%d", i+1)] = key
+			}
+
+			request["ResourceType"] = resourceType
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("cr", "2018-12-01", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+
+		}
+
+		if len(added) > 0 {
+			action = "TagResources"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["ResourceId.1"] = d.Id()
+			request["RegionId"] = client.RegionId
+			count := 1
+			for key, value := range added {
+				request[fmt.Sprintf("Tag.%d.Key", count)] = key
+				request[fmt.Sprintf("Tag.%d.Value", count)] = value
+				count++
+			}
+
+			request["ResourceType"] = resourceType
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("cr", "2018-12-01", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+
+		}
+	}
+
+	return nil
+}
+
+// SetResourceTags >>> tag function encapsulated.

--- a/website/docs/d/cr_ee_instances.html.markdown
+++ b/website/docs/d/cr_ee_instances.html.markdown
@@ -11,11 +11,11 @@ description: |-
 
 This data source provides a list Container Registry Enterprise Edition instances on Alibaba Cloud.
 
--> **NOTE:** Available in v1.86.0+
+-> **NOTE:** Available since v1.86.0
 
 ## Example Usage
 
-```
+```terraform
 # Declare the data source
 data "alicloud_cr_ee_instances" "my_instances" {
   name_regex  = "my-instances"
@@ -35,6 +35,7 @@ The following arguments are supported:
 * `name_regex` - (Optional) A regex string to filter results by instance name.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 * `enable_details` - (Optional, Available in 1.132.0+) Default to `true`. Set it to true can output instance authorization token.
+* `tags` - (Optional, Available since v1.288.0) A mapping of tags to filter results by. An instance is returned only when it carries every tag listed here with the same value.
 
 ## Attributes Reference
 
@@ -55,4 +56,5 @@ The following attributes are exported in addition to the arguments listed above:
   * `public_endpoints` - A list of domains for access on internet network.
   * `authorization_token` - The password that was used to log on to the registry.
   * `temp_username` - The username that was used to log on to the registry.
+  * `tags` - (Available since v1.288.0) A mapping of tags assigned to the instance.
   

--- a/website/docs/r/cr_ee_instance.html.markdown
+++ b/website/docs/r/cr_ee_instance.html.markdown
@@ -46,6 +46,10 @@ resource "alicloud_cr_ee_instance" "default" {
   renewal_status = "AutoRenewal"
   instance_type  = "Advanced"
   instance_name  = "${var.name}-${random_integer.default.result}"
+  tags = {
+    Created = "TF"
+    For     = "Test"
+  }
 }
 ```
 
@@ -108,6 +112,7 @@ The following arguments are supported:
 -> **NOTE:** The parameter is immutable after resource creation. It only applies during resource creation and has no effect when modified post-creation.
 
 * `resource_group_id` - (Optional, Computed, Available since v1.235.0) The ID of the resource group
+* `tags` - (Optional, Map, Available since v1.288.0) A mapping of tags to assign to the resource.
 * `vpc_quota` - (Optional, Int, Available since v1.268.0) The number of VPC access controls.
 
 -> **NOTE:** The parameter is immutable after resource creation. It only applies during resource creation and has no effect when modified post-creation.


### PR DESCRIPTION
Add tag support to the CR Enterprise Edition instance resource and data source, backed by the cr `TagResources` / `UntagResources` / `ListTagResources` APIs.

### resource/alicloud_cr_ee_instance

- New `tags` argument.
- Read picks tags up from the existing `GetInstance` response, which already returns `Tags`, so no extra API call is added to the read path.
- Update applies the diff through `CrServiceV2.SetResourceTags` (`TagResources` / `UntagResources`, `ResourceType` `Instance`). Create reaches tags through the existing Create -> Update chain.
- The `acs:` system tags CR attaches on its own (such as `acs:rm:rgId`) are filtered by the existing `tagsToMap` / `ignoredTags` helpers, so they do not produce a perpetual diff.

### datasource/alicloud_cr_ee_instances

- New `tags` filter: an instance is returned only when it carries every requested tag with the same value.
- New per-instance `tags` attribute, read through `CrServiceV2.ListCrInstanceTags` with `NextToken` pagination.

### testcase/alicloud_cr_ee_instance

`TestAccAliCloudCrInstance_basic7970_modified` has been failing on a 6m create timeout. The cause is in the test itself: it creates the RAM policy behind `AliyunContainerRegistryCustomizedOSSBucketRole` only when no policy of that name exists, and reuses an existing one without checking or updating its content, while the policy document scoped the OSS permissions to `${var.name}` — the bucket of whichever run created it first. Since every run generates a new randomised bucket name, from the second run onwards CR held only `ListBuckets` on the bucket passed as `custom_oss_bucket`, instance activation never completed and the order was never committed.

`tf-testacc-*` and `tfacc*` wildcards are added alongside the existing entries so a freshly created policy covers every bucket name the CR test functions in this file can generate, with a comment recording the constraint.

### Acceptance tests

All eight cases pass, including the previously failing one:

```
TestAccAliCloudCrInstance_tags                    PASS  185.49s   (new)
TestAccAlicloudCREEInstancesDataSource            PASS  186.80s
TestAccAliCloudCrInstance_Basic                   PASS  134.14s
TestAccAliCloudCrInstance_Standard                PASS  192.07s
TestAccAliCloudCrInstance_Advanced                PASS  169.69s
TestAccAliCloudCrInstance_EconomyDisableScanner   PASS  168.25s
TestAccAliCloudCrInstance_basic8613               PASS  261.95s
TestAccAliCloudCrInstance_basic7970_modified      PASS  226.84s   (was a 372s timeout failure)
```

`TestAccAliCloudCrInstance_tags` covers the full tag lifecycle: create with tags, change values and add one, remove a subset, clear all, then import.

The existing cases were re-run to check for regressions. Their debug logs contain no `TagResources` / `UntagResources` / `ListTagResources` calls at all, confirming the new branch stays inert when `tags` is not configured.