### PR TITLE
resource/alicloud_oos_secret_parameter: fix tags read returning tag bindings of other secret parameters

### DIFF
--- a/alicloud/resource_alicloud_oos_secret_parameter.go
+++ b/alicloud/resource_alicloud_oos_secret_parameter.go
@@ -193,7 +193,13 @@ func resourceAliCloudOosSecretParameterRead(d *schema.ResourceData, meta interfa
 	}
 
 	tagsMaps, _ := jsonpath.Get("$.TagResources.TagResource", objectRaw)
-	d.Set("tags", tagsToMap(tagsMaps))
+	tagResources := make([]interface{}, 0)
+	for _, tagResource := range convertToInterfaceArray(tagsMaps) {
+		if tagResourceMap, ok := tagResource.(map[string]interface{}); ok && fmt.Sprint(tagResourceMap["ResourceId"]) == d.Id() {
+			tagResources = append(tagResources, tagResource)
+		}
+	}
+	d.Set("tags", tagsToMap(tagResources))
 
 	d.Set("secret_parameter_name", d.Id())
 
@@ -254,6 +260,17 @@ func resourceAliCloudOosSecretParameterUpdate(d *schema.ResourceData, meta inter
 		addDebug(action, response, request)
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	if _, ok := request["Tags"]; ok {
+		oosServiceV2 := OosServiceV2{client}
+		expectedTags := make(map[string]interface{})
+		if v, ok := d.Get("tags").(map[string]interface{}); ok {
+			expectedTags = v
+		}
+		if err := oosServiceV2.WaitForOosSecretParameterTagsConverged(d.Id(), expectedTags, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return WrapError(err)
 		}
 	}
 

--- a/alicloud/resource_alicloud_oos_secret_parameter_test.go
+++ b/alicloud/resource_alicloud_oos_secret_parameter_test.go
@@ -273,6 +273,83 @@ func TestAccAliCloudOOSSecretParameter_basic1(t *testing.T) {
 	})
 }
 
+// TestAccAliCloudOOSSecretParameter_tagsIsolation verifies that each secret parameter
+// only reads back its own tags when multiple secret parameters exist in the same region.
+func TestAccAliCloudOOSSecretParameter_tagsIsolation(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_oos_secret_parameter.default"
+	checkoutSupportedRegions(t, true, connectivity.OOSSupportRegions)
+	ra := resourceAttrInit(resourceId, AlicloudOOSSecretParameterMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OosService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOosSecretParameter")
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%soossecretparameter%d", defaultRegionToTest, rand)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOosSecretParameterTagsIsolationConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("alicloud_oos_secret_parameter.default", "tags.%", "1"),
+					resource.TestCheckResourceAttr("alicloud_oos_secret_parameter.default", "tags.Created", "tfTestAcc"),
+					resource.TestCheckResourceAttr("alicloud_oos_secret_parameter.second", "tags.%", "1"),
+					resource.TestCheckResourceAttr("alicloud_oos_secret_parameter.second", "tags.For", "OosSecretParameterSecond"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOosSecretParameterTagsIsolationConfig(name string) string {
+	return fmt.Sprintf(`
+	variable "name" {
+		default = "%s"
+	}
+
+	data "alicloud_kms_keys" "default" {
+		status = "Enabled"
+	}
+
+	resource "alicloud_kms_key" "default" {
+		count = length(data.alicloud_kms_keys.default.ids) > 0 ? 0 : 1
+		description = var.name
+		status = "Enabled"
+		pending_window_in_days = 7
+	}
+
+	locals {
+		key_id = length(data.alicloud_kms_keys.default.ids) > 0 ? data.alicloud_kms_keys.default.ids.0 : concat(alicloud_kms_key.default.*.id, [""])[0]
+	}
+
+	resource "alicloud_oos_secret_parameter" "default" {
+		secret_parameter_name = var.name
+		value                 = "tf-testacc-oos_secret_parameter"
+		type                  = "Secret"
+		key_id                = local.key_id
+		tags = {
+			Created = "tfTestAcc"
+		}
+	}
+
+	resource "alicloud_oos_secret_parameter" "second" {
+		secret_parameter_name = "${var.name}_second"
+		value                 = "tf-testacc-oos_secret_parameter_second"
+		type                  = "Secret"
+		key_id                = local.key_id
+		tags = {
+			For = "OosSecretParameterSecond"
+		}
+	}
+	`, name)
+}
+
 var AlicloudOOSSecretParameterMap0 = map[string]string{
 	"secret_parameter_name": CHECKSET,
 }
@@ -346,6 +423,22 @@ func TestUnitAlicloudOOSSecretParameter(t *testing.T) {
 			},
 			"Type":            "type",
 			"ResourceGroupId": "resource_group_id",
+		},
+		"TagResources": map[string]interface{}{
+			"TagResource": []interface{}{
+				map[string]interface{}{
+					"TagKey":       "Created",
+					"TagValue":     "TF",
+					"ResourceId":   "MockName",
+					"ResourceType": "secretparameter",
+				},
+				map[string]interface{}{
+					"TagKey":       "For",
+					"TagValue":     "Test",
+					"ResourceId":   "MockName",
+					"ResourceType": "secretparameter",
+				},
+			},
 		},
 	}
 

--- a/alicloud/service_alicloud_oos_v2.go
+++ b/alicloud/service_alicloud_oos_v2.go
@@ -219,7 +219,7 @@ func (s *OosServiceV2) DescribeSecretParameterListTagResources(id string) (objec
 	action := "ListTagResources"
 	request = make(map[string]interface{})
 	query = make(map[string]interface{})
-	request["ResourceIds"] = expandSingletonToList(id)
+	request["ResourceIds"] = convertObjectToJsonString(expandSingletonToList(id))
 	request["RegionId"] = client.RegionId
 
 	request["ResourceType"] = "secretparameter"
@@ -245,6 +245,48 @@ func (s *OosServiceV2) DescribeSecretParameterListTagResources(id string) (objec
 	}
 
 	return response, nil
+}
+
+// WaitForOosSecretParameterTagsConverged polls ListTagResources until the tag bindings
+// read back for the specified secret parameter match the expected tags. Tag bindings
+// written through UpdateSecretParameter are propagated asynchronously to the tag
+// storage behind ListTagResources, so an immediate read may miss them.
+func (s *OosServiceV2) WaitForOosSecretParameterTagsConverged(id string, expectedTags map[string]interface{}, timeout time.Duration) error {
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err := resource.Retry(timeout, func() *resource.RetryError {
+		object, err := s.DescribeSecretParameterListTagResources(id)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+
+		tagsMaps, _ := jsonpath.Get("$.TagResources.TagResource", object)
+		tagResources := make([]interface{}, 0)
+		for _, tagResource := range convertToInterfaceArray(tagsMaps) {
+			if tagResourceMap, ok := tagResource.(map[string]interface{}); ok && fmt.Sprint(tagResourceMap["ResourceId"]) == id {
+				tagResources = append(tagResources, tagResource)
+			}
+		}
+		currentTags := tagsToMap(tagResources)
+		if len(currentTags) != len(expectedTags) {
+			wait()
+			return resource.RetryableError(Error("The tags of OOS secret parameter %s have not been propagated yet, current: %v, expected: %v.", id, currentTags, expectedTags))
+		}
+		for key, value := range expectedTags {
+			if fmt.Sprint(currentTags[key]) != fmt.Sprint(value) {
+				wait()
+				return resource.RetryableError(Error("The tags of OOS secret parameter %s have not been propagated yet, current: %v, expected: %v.", id, currentTags, expectedTags))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return WrapError(err)
+	}
+	return nil
 }
 
 func (s *OosServiceV2) OosSecretParameterStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
@@ -299,7 +341,7 @@ func (s *OosServiceV2) SetResourceTags(d *schema.ResourceData, resourceType stri
 			action = "UntagResources"
 			request = make(map[string]interface{})
 			query = make(map[string]interface{})
-			request["ResourceIds"] = expandSingletonToList(d.Id())
+			request["ResourceIds"] = convertObjectToJsonString(expandSingletonToList(d.Id()))
 			request["RegionId"] = client.RegionId
 			if v, ok := d.GetOk("tags"); ok {
 				tagsTagKeyJsonPath, err := jsonpath.Get("$.tag_key", v)
@@ -331,7 +373,7 @@ func (s *OosServiceV2) SetResourceTags(d *schema.ResourceData, resourceType stri
 			action = "TagResources"
 			request = make(map[string]interface{})
 			query = make(map[string]interface{})
-			request["ResourceIds"] = expandSingletonToList(d.Id())
+			request["ResourceIds"] = convertObjectToJsonString(expandSingletonToList(d.Id()))
 			request["RegionId"] = client.RegionId
 			tagsJsonPath, err := jsonpath.Get("$", d.Get("tags"))
 			if err == nil {


### PR DESCRIPTION
## Summary
- Fix the `ResourceIds` parameter sent to OOS `ListTagResources`, `TagResources` and `UntagResources` for `alicloud_oos_secret_parameter`. These APIs expect `ResourceIds` as a JSON array string (for example `["parameter-name"]`), but the provider sent it as a repeated parameter (`ResourceIds.1`), which the OOS gateway silently ignores. As a result, `ListTagResources` returned the tag bindings of **all** secret parameters in the region and the resource read merged them into the state of every secret parameter, so all secret parameters showed the same tags and `terraform plan` reported a persistent in-place update on `tags`.
- Serialize `ResourceIds` as a JSON array string in the three tag API calls and, as a defensive measure, filter the returned tag bindings by the resource's own ID before setting `tags` in state.
- Fix tag updates being lost from state: tag bindings written through `UpdateSecretParameter` are propagated asynchronously to the tag storage behind `ListTagResources`, so the immediate read after an update could observe no tag bindings and silently drop `tags` from the state. After updating tags the resource now waits until `ListTagResources` returns the expected tag bindings before refreshing state.

## Test plan
- [x] `gofmt` clean and `go vet ./alicloud` clean on the changed files.
- [x] Added regression test `TestAccAliCloudOOSSecretParameter_tagsIsolation`, which creates two secret parameters with distinct tags and asserts each one reads back only its own tags (with the previous behavior both resources read the merged tag bindings of the whole region).
- [ ] `TestAccAliCloudOOSSecretParameter_basic0` / `_basic1` / `_tagsIsolation` acceptance test results to be added after execution.
