### PR TITLE
resource/alicloud_oss_bucket_acl: handle pointer ACL responses; testcase: cover SPI parsing

### DIFF
--- a/alicloud/resource_alicloud_oss_bucket_acl_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_acl_test.go
@@ -4,10 +4,71 @@ import (
 	"fmt"
 	"testing"
 
+	ossclient "github.com/alibabacloud-go/alibabacloud-gateway-oss-util/client"
+	"github.com/alibabacloud-go/tea/tea"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
+
+func TestAccAliCloudOssBucketAcl_pointerResponseUnit(t *testing.T) {
+	apiName := "GetBucketAcl"
+	responseXML := "<AccessControlPolicy><AccessControlList><Grant>private</Grant></AccessControlList></AccessControlPolicy>"
+	parsed, err := ossclient.ParseXml(&responseXML, &apiName)
+	if err != nil {
+		t.Fatalf("parse OSS ACL response: %s", err)
+	}
+
+	acl, err := parseOssBucketAclResponse(tea.ToMap(parsed))
+	if err != nil {
+		t.Fatalf("parse pointer-backed OSS ACL response: %s", err)
+	}
+	if got := acl["Grant"]; got != "private" {
+		t.Fatalf("Grant = %#v, want private", got)
+	}
+}
+
+func TestAccAliCloudOssBucketAcl_pointerResponse(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_oss_bucket_acl.default"
+	ra := resourceAttrInit(resourceId, AlicloudOssBucketAclMap6192)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OssServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOssBucketAcl")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sossbucketacl%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudOssBucketAclBasicDependence6192)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		CheckDestroy:  rac.checkResourceDestroy(),
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"bucket": "${alicloud_oss_bucket.CreateBucket.bucket}",
+					"acl":    "private",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"bucket": CHECKSET,
+						"acl":    "private",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
 
 // Test Oss BucketAcl. >>> Resource test cases, automatically generated.
 // Case 测试BucketAcl 6192

--- a/alicloud/service_alicloud_oss_v2.go
+++ b/alicloud/service_alicloud_oss_v2.go
@@ -16,6 +16,28 @@ type OssServiceV2 struct {
 	client *connectivity.AliyunClient
 }
 
+func parseOssBucketAclResponse(response map[string]interface{}) (map[string]interface{}, error) {
+	responseJSON, err := json.Marshal(response)
+	if err != nil {
+		return nil, err
+	}
+
+	var normalizedResponse map[string]interface{}
+	if err := json.Unmarshal(responseJSON, &normalizedResponse); err != nil {
+		return nil, err
+	}
+
+	v, err := jsonpath.Get("$.AccessControlPolicy.AccessControlList", normalizedResponse)
+	if err != nil {
+		return nil, err
+	}
+	acl, ok := v.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected AccessControlList type %T", v)
+	}
+	return acl, nil
+}
+
 // DescribeOssBucketAcl <<< Encapsulated get interface for Oss BucketAcl.
 
 func (s *OssServiceV2) DescribeOssBucketAcl(id string) (object map[string]interface{}, err error) {
@@ -54,12 +76,12 @@ func (s *OssServiceV2) DescribeOssBucketAcl(id string) (object map[string]interf
 		return object, WrapErrorf(NotFoundErr("BucketAcl", id), NotFoundMsg, response)
 	}
 
-	v, err := jsonpath.Get("$.AccessControlPolicy.AccessControlList", response)
+	v, err := parseOssBucketAclResponse(response)
 	if err != nil {
 		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.AccessControlPolicy.AccessControlList", response)
 	}
 
-	return v.(map[string]interface{}), nil
+	return v, nil
 }
 
 func (s *OssServiceV2) OssBucketAclStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {


### PR DESCRIPTION
## Summary
- Normalize the pointer-backed GetBucketAcl response before reading the access control list.
- Add a regression test for the OSS XML SPI response shape.

## Testing
- go test ./alicloud -run "^TestParseOssBucketAclResponse$" -count=1
- go test ./alicloud -run "^$" -count=1