### PR TITLE
docs: correct router_id description and fix list indentation in vpc resource

### DIFF
--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -120,12 +120,12 @@ The following attributes are exported:
 * `id` - The ID of the resource supplied above.
 * `create_time` - The creation time of the VPC.
 * `ipv6_cidr_blocks` - The IPv6 CIDR block information of the VPC.
-    * `ipv6_cidr_block` - The IPv6 CIDR block of the VPC.
-    * `ipv6_isp` - Valid values: **BGP** (default): Alibaba Cloud BGP IPv6.
+  * `ipv6_cidr_block` - The IPv6 CIDR block of the VPC.
+  * `ipv6_isp` - Valid values: **BGP** (default): Alibaba Cloud BGP IPv6.
 * `is_default` - Specifies whether to create the default VPC in the specified region.
 * `region_id` - The ID of the region where the VPC is located.
 * `route_table_id` - The ID of the system route table.
-* `router_id` - The region ID of the VPC to which the route table belongs.
+* `router_id` - The router ID of the VPC.
 * `status` - The status of the VPC.   `Pending`: The VPC is being configured. `Available`: The VPC is available.
 
 ## Timeouts


### PR DESCRIPTION
## Description

The `router_id` attribute description in the `alicloud_vpc` resource documentation incorrectly stated it was "The region ID of the VPC to which the route table belongs."

The `router_id` attribute is populated from the `VRouterId` field returned by the VPC DescribeVpcs API, which represents the router ID of the VPC (e.g. `vrt-xxx`). This PR corrects the description to accurately reflect the attribute's meaning.

## Changes

- `website/docs/r/vpc.html.markdown`:
  - corrected the `router_id` attribute description from "The region ID of the VPC to which the route table belongs." to "The router ID of the VPC."
  - fixed the nested list indentation for `ipv6_cidr_block` and `ipv6_isp` from 4 spaces to 2 spaces to satisfy the markdown-lint MD007 rule

## Test

Docs-only change, no code or test changes required.
