### PR TITLE
docs: fix router_id description incorrectly stating region ID

### DIFF
--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -120,12 +120,12 @@ The following attributes are exported:
 * `id` - The ID of the resource supplied above.
 * `create_time` - The creation time of the VPC.
 * `ipv6_cidr_blocks` - The IPv6 CIDR block information of the VPC.
-    * `ipv6_cidr_block` - The IPv6 CIDR block of the VPC.
-    * `ipv6_isp` - Valid values: **BGP** (default): Alibaba Cloud BGP IPv6.
+  * `ipv6_cidr_block` - The IPv6 CIDR block of the VPC.
+  * `ipv6_isp` - Valid values: **BGP** (default): Alibaba Cloud BGP IPv6.
 * `is_default` - Specifies whether to create the default VPC in the specified region.
 * `region_id` - The ID of the region where the VPC is located.
 * `route_table_id` - The ID of the system route table.
-* `router_id` - The region ID of the VPC to which the route table belongs.
+* `router_id` - The ID of the VRouter.
 * `status` - The status of the VPC.   `Pending`: The VPC is being configured. `Available`: The VPC is available.
 
 ## Timeouts


### PR DESCRIPTION
## What

The `router_id` attribute description in the `alicloud_vpc` resource documentation incorrectly states it is "the region ID of the VPC to which the route table belongs."

## Why it is wrong

`router_id` is the ID of the VPC router (VRouter), returned by the VPC API (`DescribeVpcAttribute`) as `VRouterId` (e.g. `vrt-xxx`). It is not a region ID. The description appears to have been confused with the adjacent `region_id` attribute, which *is* the region ID.

## Fix

Correct the description to `The ID of the VRouter.` to align with the OpenAPI definition and the provider source behavior.

This is a documentation-only change — it does not affect the field set, type, constraints, or CRUD behavior.
