### PR TITLE
New Resource: alicloud_cms_event_notify_policy; New Data Source: alicloud_cms_event_notify_policies

### DIFF
--- a/alicloud/data_source_alicloud_cms_event_notify_policies.go
+++ b/alicloud/data_source_alicloud_cms_event_notify_policies.go
@@ -1,0 +1,956 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudCmsEventNotifyPolicies() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudCmsEventNotifyPolicyRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"order_by": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"order_desc": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"workspace": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"policies": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"notify_strategy": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"description": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ignore_restored_notification": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"grouping_setting": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"grouping_keys": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"period_min": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"times": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"silence_sec": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"routes": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"digital_employee_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"enable_rca": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"filter_setting": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"relation": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"expression": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"conditions": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"field": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																		"op": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																		"value": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+												"effect_time_range": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"time_zone": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"start_time_in_minute": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"end_time_in_minute": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+															"day_in_week": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeInt},
+															},
+														},
+													},
+												},
+												"channels": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"receivers": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+															"channel_type": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"enabled_sub_channels": {
+																Type:     schema.TypeSet,
+																Computed: true,
+																Elem:     &schema.Schema{Type: schema.TypeString},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"custom_template_entries": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"template_uuid": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"response_plan": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"repeat_notify_setting": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"end_incident_state": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"repeat_interval": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"pushing_setting": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"restore_action_ids": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"alert_action_ids": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"escalation_id": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"auto_recover_seconds": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"subscription": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"workspace_filter_setting": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"workspace_uuids": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"tag_selector": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"relation": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"expression": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"conditions": {
+																Type:     schema.TypeList,
+																Computed: true,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"field": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																		"op": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																		"value": {
+																			Type:     schema.TypeString,
+																			Computed: true,
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"subscribe_legacy_event": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"filter_setting": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"relation": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"expression": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"conditions": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"field": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"op": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"value": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"user_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"workspace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudCmsEventNotifyPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListNotifyPolicies
+	action := fmt.Sprintf("/api/eventbase/notify-policies")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	query["regionId"] = StringPointer(client.RegionId)
+	query["workspace"] = StringPointer(d.Get("workspace").(string))
+	if v, ok := d.GetOk("name"); ok {
+		query["name"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("order_by"); ok {
+		query["orderBy"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("order_desc"); ok {
+		query["orderDesc"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("workspace"); ok {
+		query["workspace"] = StringPointer(v.(string))
+	}
+
+	runtime := util.RuntimeOptions{}
+	runtime.SetAutoretry(true)
+	query["maxResults"] = StringPointer(strconv.Itoa(PageSizeLarge))
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaGet("Cms", "2024-03-30", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.notifyPolicyList[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["uuid"], ":", item["workspace"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if nextToken, ok := response["nextToken"].(string); ok && nextToken != "" {
+			query["nextToken"] = StringPointer(nextToken)
+		} else {
+			break
+		}
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(objectRaw["uuid"], ":", objectRaw["workspace"])
+
+		mapping["create_time"] = objectRaw["createTime"]
+		mapping["description"] = objectRaw["description"]
+		mapping["enabled"] = objectRaw["enabled"]
+		mapping["name"] = objectRaw["name"]
+		mapping["update_time"] = objectRaw["updateTime"]
+		mapping["user_id"] = objectRaw["userId"]
+		mapping["uuid"] = objectRaw["uuid"]
+		mapping["version"] = objectRaw["version"]
+		mapping["workspace"] = objectRaw["workspace"]
+
+		notifyStrategyMaps := make([]map[string]interface{}, 0)
+		notifyStrategyMap := make(map[string]interface{})
+		notifyStrategyRaw := make(map[string]interface{})
+		if objectRaw["notifyStrategy"] != nil {
+			notifyStrategyRaw = objectRaw["notifyStrategy"].(map[string]interface{})
+		}
+		if len(notifyStrategyRaw) > 0 {
+			notifyStrategyMap["description"] = notifyStrategyRaw["description"]
+			notifyStrategyMap["ignore_restored_notification"] = notifyStrategyRaw["ignoreRestoredNotification"]
+
+			customTemplateEntriesRaw := notifyStrategyRaw["customTemplateEntries"]
+			customTemplateEntriesMaps := make([]map[string]interface{}, 0)
+			if customTemplateEntriesRaw != nil {
+				for _, customTemplateEntriesChildRaw := range convertToInterfaceArray(customTemplateEntriesRaw) {
+					customTemplateEntriesMap := make(map[string]interface{})
+					customTemplateEntriesChildRaw := customTemplateEntriesChildRaw.(map[string]interface{})
+					customTemplateEntriesMap["template_uuid"] = customTemplateEntriesChildRaw["templateUuid"]
+
+					customTemplateEntriesMaps = append(customTemplateEntriesMaps, customTemplateEntriesMap)
+				}
+			}
+			notifyStrategyMap["custom_template_entries"] = customTemplateEntriesMaps
+			groupingSettingMaps := make([]map[string]interface{}, 0)
+			groupingSettingMap := make(map[string]interface{})
+			groupingSettingRaw := make(map[string]interface{})
+			if notifyStrategyRaw["groupingSetting"] != nil {
+				groupingSettingRaw = notifyStrategyRaw["groupingSetting"].(map[string]interface{})
+			}
+			if len(groupingSettingRaw) > 0 {
+				groupingSettingMap["period_min"] = groupingSettingRaw["periodMin"]
+				groupingSettingMap["silence_sec"] = groupingSettingRaw["silenceSec"]
+				groupingSettingMap["times"] = groupingSettingRaw["times"]
+
+				groupingKeysRaw := make([]interface{}, 0)
+				if groupingSettingRaw["groupingKeys"] != nil {
+					groupingKeysRaw = convertToInterfaceArray(groupingSettingRaw["groupingKeys"])
+				}
+
+				groupingSettingMap["grouping_keys"] = groupingKeysRaw
+				groupingSettingMaps = append(groupingSettingMaps, groupingSettingMap)
+			}
+			notifyStrategyMap["grouping_setting"] = groupingSettingMaps
+			routesRaw := notifyStrategyRaw["routes"]
+			routesMaps := make([]map[string]interface{}, 0)
+			if routesRaw != nil {
+				for _, routesChildRaw := range convertToInterfaceArray(routesRaw) {
+					routesMap := make(map[string]interface{})
+					routesChildRaw := routesChildRaw.(map[string]interface{})
+					routesMap["digital_employee_name"] = routesChildRaw["digitalEmployeeName"]
+					routesMap["enable_rca"] = routesChildRaw["enableRca"]
+
+					channelsRaw := routesChildRaw["channels"]
+					channelsMaps := make([]map[string]interface{}, 0)
+					if channelsRaw != nil {
+						for _, channelsChildRaw := range convertToInterfaceArray(channelsRaw) {
+							channelsMap := make(map[string]interface{})
+							channelsChildRaw := channelsChildRaw.(map[string]interface{})
+							channelsMap["channel_type"] = channelsChildRaw["channelType"]
+
+							enabledSubChannelsRaw := make([]interface{}, 0)
+							if channelsChildRaw["enabledSubChannels"] != nil {
+								enabledSubChannelsRaw = convertToInterfaceArray(channelsChildRaw["enabledSubChannels"])
+							}
+
+							channelsMap["enabled_sub_channels"] = enabledSubChannelsRaw
+							receiversRaw := make([]interface{}, 0)
+							if channelsChildRaw["receivers"] != nil {
+								receiversRaw = convertToInterfaceArray(channelsChildRaw["receivers"])
+							}
+
+							channelsMap["receivers"] = receiversRaw
+							channelsMaps = append(channelsMaps, channelsMap)
+						}
+					}
+					routesMap["channels"] = channelsMaps
+					effectTimeRangeMaps := make([]map[string]interface{}, 0)
+					effectTimeRangeMap := make(map[string]interface{})
+					effectTimeRangeRaw := make(map[string]interface{})
+					if routesChildRaw["effectTimeRange"] != nil {
+						effectTimeRangeRaw = routesChildRaw["effectTimeRange"].(map[string]interface{})
+					}
+					if len(effectTimeRangeRaw) > 0 {
+						effectTimeRangeMap["end_time_in_minute"] = effectTimeRangeRaw["endTimeInMinute"]
+						effectTimeRangeMap["start_time_in_minute"] = effectTimeRangeRaw["startTimeInMinute"]
+						effectTimeRangeMap["time_zone"] = effectTimeRangeRaw["timeZone"]
+
+						dayInWeekRaw := make([]interface{}, 0)
+						if effectTimeRangeRaw["dayInWeek"] != nil {
+							dayInWeekRaw = convertToInterfaceArray(effectTimeRangeRaw["dayInWeek"])
+						}
+
+						effectTimeRangeMap["day_in_week"] = dayInWeekRaw
+						effectTimeRangeMaps = append(effectTimeRangeMaps, effectTimeRangeMap)
+					}
+					routesMap["effect_time_range"] = effectTimeRangeMaps
+					filterSettingMaps := make([]map[string]interface{}, 0)
+					filterSettingMap := make(map[string]interface{})
+					filterSettingRaw := make(map[string]interface{})
+					if routesChildRaw["filterSetting"] != nil {
+						filterSettingRaw = routesChildRaw["filterSetting"].(map[string]interface{})
+					}
+					if len(filterSettingRaw) > 0 {
+						filterSettingMap["expression"] = filterSettingRaw["expression"]
+						filterSettingMap["relation"] = filterSettingRaw["relation"]
+
+						conditionsRaw := filterSettingRaw["conditions"]
+						conditionsMaps := make([]map[string]interface{}, 0)
+						if conditionsRaw != nil {
+							for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+								conditionsMap := make(map[string]interface{})
+								conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+								conditionsMap["field"] = conditionsChildRaw["field"]
+								conditionsMap["op"] = conditionsChildRaw["op"]
+								conditionsMap["value"] = conditionsChildRaw["value"]
+
+								conditionsMaps = append(conditionsMaps, conditionsMap)
+							}
+						}
+						filterSettingMap["conditions"] = conditionsMaps
+						filterSettingMaps = append(filterSettingMaps, filterSettingMap)
+					}
+					routesMap["filter_setting"] = filterSettingMaps
+					routesMaps = append(routesMaps, routesMap)
+				}
+			}
+			notifyStrategyMap["routes"] = routesMaps
+			notifyStrategyMaps = append(notifyStrategyMaps, notifyStrategyMap)
+		}
+		mapping["notify_strategy"] = notifyStrategyMaps
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["uuid"], ":", objectRaw["workspace"])
+		mapping, err = dataSourceAliCloudCmsEventNotifyPolicyReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("policies", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudCmsEventNotifyPolicyReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	cmsServiceV2 := CmsServiceV2{client}
+	getResp, err := cmsServiceV2.DescribeCmsEventNotifyPolicy(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["create_time"] = objectRaw["createTime"]
+	mapping["description"] = objectRaw["description"]
+	mapping["enabled"] = objectRaw["enabled"]
+	mapping["name"] = objectRaw["name"]
+	mapping["update_time"] = objectRaw["updateTime"]
+	mapping["user_id"] = objectRaw["userId"]
+	mapping["uuid"] = objectRaw["uuid"]
+	mapping["version"] = objectRaw["version"]
+	mapping["workspace"] = objectRaw["workspace"]
+
+	notifyStrategyMaps := make([]map[string]interface{}, 0)
+	notifyStrategyMap := make(map[string]interface{})
+	notifyStrategyRaw := make(map[string]interface{})
+	if objectRaw["notifyStrategy"] != nil {
+		notifyStrategyRaw = objectRaw["notifyStrategy"].(map[string]interface{})
+	}
+	if len(notifyStrategyRaw) > 0 {
+		notifyStrategyMap["description"] = notifyStrategyRaw["description"]
+		notifyStrategyMap["ignore_restored_notification"] = notifyStrategyRaw["ignoreRestoredNotification"]
+
+		customTemplateEntriesRaw := notifyStrategyRaw["customTemplateEntries"]
+		customTemplateEntriesMaps := make([]map[string]interface{}, 0)
+		if customTemplateEntriesRaw != nil {
+			for _, customTemplateEntriesChildRaw := range convertToInterfaceArray(customTemplateEntriesRaw) {
+				customTemplateEntriesMap := make(map[string]interface{})
+				customTemplateEntriesChildRaw := customTemplateEntriesChildRaw.(map[string]interface{})
+				customTemplateEntriesMap["template_uuid"] = customTemplateEntriesChildRaw["templateUuid"]
+
+				customTemplateEntriesMaps = append(customTemplateEntriesMaps, customTemplateEntriesMap)
+			}
+		}
+		notifyStrategyMap["custom_template_entries"] = customTemplateEntriesMaps
+		groupingSettingMaps := make([]map[string]interface{}, 0)
+		groupingSettingMap := make(map[string]interface{})
+		groupingSettingRaw := make(map[string]interface{})
+		if notifyStrategyRaw["groupingSetting"] != nil {
+			groupingSettingRaw = notifyStrategyRaw["groupingSetting"].(map[string]interface{})
+		}
+		if len(groupingSettingRaw) > 0 {
+			groupingSettingMap["period_min"] = groupingSettingRaw["periodMin"]
+			groupingSettingMap["silence_sec"] = groupingSettingRaw["silenceSec"]
+			groupingSettingMap["times"] = groupingSettingRaw["times"]
+
+			groupingKeysRaw := make([]interface{}, 0)
+			if groupingSettingRaw["groupingKeys"] != nil {
+				groupingKeysRaw = convertToInterfaceArray(groupingSettingRaw["groupingKeys"])
+			}
+
+			groupingSettingMap["grouping_keys"] = groupingKeysRaw
+			groupingSettingMaps = append(groupingSettingMaps, groupingSettingMap)
+		}
+		notifyStrategyMap["grouping_setting"] = groupingSettingMaps
+		routesRaw := notifyStrategyRaw["routes"]
+		routesMaps := make([]map[string]interface{}, 0)
+		if routesRaw != nil {
+			for _, routesChildRaw := range convertToInterfaceArray(routesRaw) {
+				routesMap := make(map[string]interface{})
+				routesChildRaw := routesChildRaw.(map[string]interface{})
+				routesMap["digital_employee_name"] = routesChildRaw["digitalEmployeeName"]
+				routesMap["enable_rca"] = routesChildRaw["enableRca"]
+
+				channelsRaw := routesChildRaw["channels"]
+				channelsMaps := make([]map[string]interface{}, 0)
+				if channelsRaw != nil {
+					for _, channelsChildRaw := range convertToInterfaceArray(channelsRaw) {
+						channelsMap := make(map[string]interface{})
+						channelsChildRaw := channelsChildRaw.(map[string]interface{})
+						channelsMap["channel_type"] = channelsChildRaw["channelType"]
+
+						enabledSubChannelsRaw := make([]interface{}, 0)
+						if channelsChildRaw["enabledSubChannels"] != nil {
+							enabledSubChannelsRaw = convertToInterfaceArray(channelsChildRaw["enabledSubChannels"])
+						}
+
+						channelsMap["enabled_sub_channels"] = enabledSubChannelsRaw
+						receiversRaw := make([]interface{}, 0)
+						if channelsChildRaw["receivers"] != nil {
+							receiversRaw = convertToInterfaceArray(channelsChildRaw["receivers"])
+						}
+
+						channelsMap["receivers"] = receiversRaw
+						channelsMaps = append(channelsMaps, channelsMap)
+					}
+				}
+				routesMap["channels"] = channelsMaps
+				effectTimeRangeMaps := make([]map[string]interface{}, 0)
+				effectTimeRangeMap := make(map[string]interface{})
+				effectTimeRangeRaw := make(map[string]interface{})
+				if routesChildRaw["effectTimeRange"] != nil {
+					effectTimeRangeRaw = routesChildRaw["effectTimeRange"].(map[string]interface{})
+				}
+				if len(effectTimeRangeRaw) > 0 {
+					effectTimeRangeMap["end_time_in_minute"] = effectTimeRangeRaw["endTimeInMinute"]
+					effectTimeRangeMap["start_time_in_minute"] = effectTimeRangeRaw["startTimeInMinute"]
+					effectTimeRangeMap["time_zone"] = effectTimeRangeRaw["timeZone"]
+
+					dayInWeekRaw := make([]interface{}, 0)
+					if effectTimeRangeRaw["dayInWeek"] != nil {
+						dayInWeekRaw = convertToInterfaceArray(effectTimeRangeRaw["dayInWeek"])
+					}
+
+					effectTimeRangeMap["day_in_week"] = dayInWeekRaw
+					effectTimeRangeMaps = append(effectTimeRangeMaps, effectTimeRangeMap)
+				}
+				routesMap["effect_time_range"] = effectTimeRangeMaps
+				filterSettingMaps := make([]map[string]interface{}, 0)
+				filterSettingMap := make(map[string]interface{})
+				filterSettingRaw := make(map[string]interface{})
+				if routesChildRaw["filterSetting"] != nil {
+					filterSettingRaw = routesChildRaw["filterSetting"].(map[string]interface{})
+				}
+				if len(filterSettingRaw) > 0 {
+					filterSettingMap["expression"] = filterSettingRaw["expression"]
+					filterSettingMap["relation"] = filterSettingRaw["relation"]
+
+					conditionsRaw := filterSettingRaw["conditions"]
+					conditionsMaps := make([]map[string]interface{}, 0)
+					if conditionsRaw != nil {
+						for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+							conditionsMap := make(map[string]interface{})
+							conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+							conditionsMap["field"] = conditionsChildRaw["field"]
+							conditionsMap["op"] = conditionsChildRaw["op"]
+							conditionsMap["value"] = conditionsChildRaw["value"]
+
+							conditionsMaps = append(conditionsMaps, conditionsMap)
+						}
+					}
+					filterSettingMap["conditions"] = conditionsMaps
+					filterSettingMaps = append(filterSettingMaps, filterSettingMap)
+				}
+				routesMap["filter_setting"] = filterSettingMaps
+				routesMaps = append(routesMaps, routesMap)
+			}
+		}
+		notifyStrategyMap["routes"] = routesMaps
+		notifyStrategyMaps = append(notifyStrategyMaps, notifyStrategyMap)
+	}
+	mapping["notify_strategy"] = notifyStrategyMaps
+	responsePlanMaps := make([]map[string]interface{}, 0)
+	responsePlanMap := make(map[string]interface{})
+	responsePlanRaw := make(map[string]interface{})
+	if objectRaw["responsePlan"] != nil {
+		responsePlanRaw = objectRaw["responsePlan"].(map[string]interface{})
+	}
+	if len(responsePlanRaw) > 0 {
+		responsePlanMap["auto_recover_seconds"] = responsePlanRaw["autoRecoverSeconds"]
+
+		escalationIdRaw := make([]interface{}, 0)
+		if responsePlanRaw["escalationId"] != nil {
+			escalationIdRaw = convertToInterfaceArray(responsePlanRaw["escalationId"])
+		}
+
+		responsePlanMap["escalation_id"] = escalationIdRaw
+		pushingSettingMaps := make([]map[string]interface{}, 0)
+		pushingSettingMap := make(map[string]interface{})
+		pushingSettingRaw := make(map[string]interface{})
+		if responsePlanRaw["pushingSetting"] != nil {
+			pushingSettingRaw = responsePlanRaw["pushingSetting"].(map[string]interface{})
+		}
+		if len(pushingSettingRaw) > 0 {
+
+			alertActionIdsRaw := make([]interface{}, 0)
+			if pushingSettingRaw["alertActionIds"] != nil {
+				alertActionIdsRaw = convertToInterfaceArray(pushingSettingRaw["alertActionIds"])
+			}
+
+			pushingSettingMap["alert_action_ids"] = alertActionIdsRaw
+			restoreActionIdsRaw := make([]interface{}, 0)
+			if pushingSettingRaw["restoreActionIds"] != nil {
+				restoreActionIdsRaw = convertToInterfaceArray(pushingSettingRaw["restoreActionIds"])
+			}
+
+			pushingSettingMap["restore_action_ids"] = restoreActionIdsRaw
+			pushingSettingMaps = append(pushingSettingMaps, pushingSettingMap)
+		}
+		responsePlanMap["pushing_setting"] = pushingSettingMaps
+		repeatNotifySettingMaps := make([]map[string]interface{}, 0)
+		repeatNotifySettingMap := make(map[string]interface{})
+		repeatNotifySettingRaw := make(map[string]interface{})
+		if responsePlanRaw["repeatNotifySetting"] != nil {
+			repeatNotifySettingRaw = responsePlanRaw["repeatNotifySetting"].(map[string]interface{})
+		}
+		if len(repeatNotifySettingRaw) > 0 {
+			repeatNotifySettingMap["end_incident_state"] = repeatNotifySettingRaw["endIncidentState"]
+			repeatNotifySettingMap["repeat_interval"] = repeatNotifySettingRaw["repeatInterval"]
+
+			repeatNotifySettingMaps = append(repeatNotifySettingMaps, repeatNotifySettingMap)
+		}
+		responsePlanMap["repeat_notify_setting"] = repeatNotifySettingMaps
+		responsePlanMaps = append(responsePlanMaps, responsePlanMap)
+	}
+	mapping["response_plan"] = responsePlanMaps
+	subscriptionMaps := make([]map[string]interface{}, 0)
+	subscriptionMap := make(map[string]interface{})
+	subscriptionRaw := make(map[string]interface{})
+	if objectRaw["subscription"] != nil {
+		subscriptionRaw = objectRaw["subscription"].(map[string]interface{})
+	}
+	if len(subscriptionRaw) > 0 {
+		subscriptionMap["subscribe_legacy_event"] = subscriptionRaw["subscribeLegacyEvent"]
+
+		filterSettingMaps := make([]map[string]interface{}, 0)
+		filterSettingMap := make(map[string]interface{})
+		filterSettingRaw := make(map[string]interface{})
+		if subscriptionRaw["filterSetting"] != nil {
+			filterSettingRaw = subscriptionRaw["filterSetting"].(map[string]interface{})
+		}
+		if len(filterSettingRaw) > 0 {
+			filterSettingMap["expression"] = filterSettingRaw["expression"]
+			filterSettingMap["relation"] = filterSettingRaw["relation"]
+
+			conditionsRaw := filterSettingRaw["conditions"]
+			conditionsMaps := make([]map[string]interface{}, 0)
+			if conditionsRaw != nil {
+				for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+					conditionsMap := make(map[string]interface{})
+					conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+					conditionsMap["field"] = conditionsChildRaw["field"]
+					conditionsMap["op"] = conditionsChildRaw["op"]
+					conditionsMap["value"] = conditionsChildRaw["value"]
+
+					conditionsMaps = append(conditionsMaps, conditionsMap)
+				}
+			}
+			filterSettingMap["conditions"] = conditionsMaps
+			filterSettingMaps = append(filterSettingMaps, filterSettingMap)
+		}
+		subscriptionMap["filter_setting"] = filterSettingMaps
+		workspaceFilterSettingMaps := make([]map[string]interface{}, 0)
+		workspaceFilterSettingMap := make(map[string]interface{})
+		workspaceFilterSettingRaw := make(map[string]interface{})
+		if subscriptionRaw["workspaceFilterSetting"] != nil {
+			workspaceFilterSettingRaw = subscriptionRaw["workspaceFilterSetting"].(map[string]interface{})
+		}
+		if len(workspaceFilterSettingRaw) > 0 {
+
+			tagSelectorMaps := make([]map[string]interface{}, 0)
+			tagSelectorMap := make(map[string]interface{})
+			tagSelectorRaw := make(map[string]interface{})
+			if workspaceFilterSettingRaw["tagSelector"] != nil {
+				tagSelectorRaw = workspaceFilterSettingRaw["tagSelector"].(map[string]interface{})
+			}
+			if len(tagSelectorRaw) > 0 {
+				tagSelectorMap["expression"] = tagSelectorRaw["expression"]
+				tagSelectorMap["relation"] = tagSelectorRaw["relation"]
+
+				conditionsRaw := tagSelectorRaw["conditions"]
+				conditionsMaps := make([]map[string]interface{}, 0)
+				if conditionsRaw != nil {
+					for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+						conditionsMap := make(map[string]interface{})
+						conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+						conditionsMap["field"] = conditionsChildRaw["field"]
+						conditionsMap["op"] = conditionsChildRaw["op"]
+						conditionsMap["value"] = conditionsChildRaw["value"]
+
+						conditionsMaps = append(conditionsMaps, conditionsMap)
+					}
+				}
+				tagSelectorMap["conditions"] = conditionsMaps
+				tagSelectorMaps = append(tagSelectorMaps, tagSelectorMap)
+			}
+			workspaceFilterSettingMap["tag_selector"] = tagSelectorMaps
+			workspaceUuidsRaw := make([]interface{}, 0)
+			if workspaceFilterSettingRaw["workspaceUuids"] != nil {
+				workspaceUuidsRaw = convertToInterfaceArray(workspaceFilterSettingRaw["workspaceUuids"])
+			}
+
+			workspaceFilterSettingMap["workspace_uuids"] = workspaceUuidsRaw
+			workspaceFilterSettingMaps = append(workspaceFilterSettingMaps, workspaceFilterSettingMap)
+		}
+		subscriptionMap["workspace_filter_setting"] = workspaceFilterSettingMaps
+		subscriptionMaps = append(subscriptionMaps, subscriptionMap)
+	}
+	mapping["subscription"] = subscriptionMaps
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_cms_event_notify_policies_test.go
+++ b/alicloud/data_source_alicloud_cms_event_notify_policies_test.go
@@ -1,0 +1,160 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudCmsEventNotifyPolicyDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}"]`,
+			"workspace": `"default-workspace-cn-hangzhou"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}_fake"]`,
+			"workspace": `"default-workspace-cn-hangzhou"`,
+		}),
+	}
+
+	WorkspaceConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}"]`,
+			"workspace": `"default-workspace-cn-hangzhou"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}_fake"]`,
+			"workspace": `"default-workspace-cn-hangzhou_fake"`,
+		}),
+	}
+	NameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}"]`,
+			"name":      `"${var.name}"`,
+			"workspace": `"default-workspace-cn-hangzhou"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}_fake"]`,
+			"name":      `"${var.name}_fake"`,
+			"workspace": `"default-workspace-cn-hangzhou"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}"]`,
+			"workspace": `"default-workspace-cn-hangzhou"`,
+
+			"name": `"${var.name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_cms_event_notify_policy.default.id}_fake"]`,
+			"workspace": `"default-workspace-cn-hangzhou_fake"`,
+
+			"name": `"${var.name}_fake"`,
+		}),
+	}
+
+	CmsEventNotifyPolicyCheckInfo.dataSourceTestCheck(t, rand, idsConf, WorkspaceConf, NameConf, allConf)
+}
+
+var existCmsEventNotifyPolicyMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"policies.#":                   "1",
+		"policies.0.description":       CHECKSET,
+		"policies.0.create_time":       CHECKSET,
+		"policies.0.enabled":           CHECKSET,
+		"policies.0.notify_strategy.#": CHECKSET,
+		"policies.0.name":              CHECKSET,
+		"policies.0.uuid":              CHECKSET,
+		"policies.0.version":           CHECKSET,
+		"policies.0.user_id":           CHECKSET,
+		"policies.0.update_time":       CHECKSET,
+		"policies.0.workspace":         CHECKSET,
+	}
+}
+
+var fakeCmsEventNotifyPolicyMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"policies.#": "0",
+	}
+}
+
+var CmsEventNotifyPolicyCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_cms_event_notify_policies.default",
+	existMapFunc: existCmsEventNotifyPolicyMapFunc,
+	fakeMapFunc:  fakeCmsEventNotifyPolicyMapFunc,
+}
+
+func testAccCheckAlicloudCmsEventNotifyPolicySourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccCmsEventNotifyPolicy%d"
+}
+
+
+resource "alicloud_cms_event_notify_policy" "default" {
+  description = "CloudSpec list operation test for EventNotifyPolicy"
+  response_plan {
+    repeat_notify_setting {
+      end_incident_state = "resolved"
+      repeat_interval    = "30"
+    }
+    auto_recover_seconds = "600"
+  }
+  notify_strategy {
+    description                  = "Notify strategy for list test"
+    ignore_restored_notification = false
+    grouping_setting {
+      grouping_keys = ["severity"]
+      period_min    = "5"
+      times         = "1"
+      silence_sec   = "300"
+    }
+    routes {
+      effect_time_range {
+        time_zone            = "Asia/Shanghai"
+        start_time_in_minute = "0"
+        end_time_in_minute   = "1439"
+        day_in_week          = ["1", "2", "3", "4", "5"]
+      }
+      channels {
+        receivers            = ["cspec-test-group"]
+        channel_type         = "DING"
+        enabled_sub_channels = []
+      }
+    }
+  }
+  subscription {
+    subscribe_legacy_event = true
+    filter_setting {
+      relation = "AND"
+      conditions {
+        field = "severity"
+        op    = "EQ"
+        value = "CRITICAL"
+      }
+    }
+  }
+  workspace = "default-workspace-cn-hangzhou"
+  name      = var.name
+}
+
+data "alicloud_cms_event_notify_policies" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -170,6 +170,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_cms_event_notify_policies":                      dataSourceAliCloudCmsEventNotifyPolicies(),
 			"alicloud_apig_ai_model_providers":                        dataSourceAliCloudApigAiModelProviders(),
 			"alicloud_apig_services":                                  dataSourceAliCloudApigServices(),
 			"alicloud_apig_gateways":                                  dataSourceAliCloudApigGateways(),
@@ -949,6 +950,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_cms_event_notify_policy":                              resourceAliCloudCmsEventNotifyPolicy(),
 			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),
 			"alicloud_apig_ai_model_provider":                               resourceAliCloudApigAiModelProvider(),
 			"alicloud_apig_service":                                         resourceAliCloudApigService(),

--- a/alicloud/resource_alicloud_cms_event_notify_policy.go
+++ b/alicloud/resource_alicloud_cms_event_notify_policy.go
@@ -1,0 +1,1449 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudCmsEventNotifyPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCmsEventNotifyPolicyCreate,
+		Read:   resourceAliCloudCmsEventNotifyPolicyRead,
+		Update: resourceAliCloudCmsEventNotifyPolicyUpdate,
+		Delete: resourceAliCloudCmsEventNotifyPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"notify_strategy": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ignore_restored_notification": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"grouping_setting": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"grouping_keys": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"period_min": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"times": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"silence_sec": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"routes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"digital_employee_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"enable_rca": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"filter_setting": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"relation": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"expression": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"conditions": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"field": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"op": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"effect_time_range": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"time_zone": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"start_time_in_minute": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"end_time_in_minute": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"day_in_week": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeInt},
+												},
+											},
+										},
+									},
+									"channels": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"receivers": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"channel_type": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"enabled_sub_channels": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"custom_template_entries": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"template_uuid": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"response_plan": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"repeat_notify_setting": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"end_incident_state": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"repeat_interval": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"pushing_setting": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"restore_action_ids": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"alert_action_ids": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"escalation_id": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"auto_recover_seconds": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"subscription": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"workspace_filter_setting": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"workspace_uuids": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"tag_selector": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"relation": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"expression": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"conditions": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"field": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"op": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"subscribe_legacy_event": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"filter_setting": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"relation": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"expression": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"conditions": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"field": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"op": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"workspace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCmsEventNotifyPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/api/eventbase/notify-policy/create")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	query["workspace"] = StringPointer(d.Get("workspace").(string))
+	query["regionId"] = StringPointer(client.RegionId)
+
+	notifyStrategy := make(map[string]interface{})
+
+	if v := d.Get("notify_strategy"); !IsNil(v) {
+		groupingSetting := make(map[string]interface{})
+		times1, _ := jsonpath.Get("$[0].grouping_setting[0].times", d.Get("notify_strategy"))
+		if times1 != nil && times1 != "" {
+			groupingSetting["times"] = times1
+		}
+		groupingKeys1, _ := jsonpath.Get("$[0].grouping_setting[0].grouping_keys", d.Get("notify_strategy"))
+		if groupingKeys1 != nil && groupingKeys1 != "" {
+			groupingSetting["groupingKeys"] = groupingKeys1
+		}
+		periodMin1, _ := jsonpath.Get("$[0].grouping_setting[0].period_min", d.Get("notify_strategy"))
+		if periodMin1 != nil && periodMin1 != "" {
+			groupingSetting["periodMin"] = periodMin1
+		}
+		silenceSec1, _ := jsonpath.Get("$[0].grouping_setting[0].silence_sec", d.Get("notify_strategy"))
+		if silenceSec1 != nil && silenceSec1 != "" {
+			groupingSetting["silenceSec"] = silenceSec1
+		}
+
+		if len(groupingSetting) > 0 {
+			notifyStrategy["groupingSetting"] = groupingSetting
+		}
+		if v, ok := d.GetOk("notify_strategy"); ok {
+			localData, err := jsonpath.Get("$[0].routes", v)
+			if err != nil {
+				localData = make([]interface{}, 0)
+			}
+			localMaps := make([]interface{}, 0)
+			for _, dataLoop := range convertToInterfaceArray(localData) {
+				dataLoopTmp := make(map[string]interface{})
+				if dataLoop != nil {
+					dataLoopTmp = dataLoop.(map[string]interface{})
+				}
+				dataLoopMap := make(map[string]interface{})
+				localData1 := make(map[string]interface{})
+				startTimeInMinute1, _ := jsonpath.Get("$[0].start_time_in_minute", dataLoopTmp["effect_time_range"])
+				if startTimeInMinute1 != nil && startTimeInMinute1 != "" {
+					localData1["startTimeInMinute"] = startTimeInMinute1
+				}
+				endTimeInMinute1, _ := jsonpath.Get("$[0].end_time_in_minute", dataLoopTmp["effect_time_range"])
+				if endTimeInMinute1 != nil && endTimeInMinute1 != "" {
+					localData1["endTimeInMinute"] = endTimeInMinute1
+				}
+				dayInWeek1, _ := jsonpath.Get("$[0].day_in_week", dataLoopTmp["effect_time_range"])
+				if dayInWeek1 != nil && dayInWeek1 != "" {
+					localData1["dayInWeek"] = dayInWeek1
+				}
+				timeZone1, _ := jsonpath.Get("$[0].time_zone", dataLoopTmp["effect_time_range"])
+				if timeZone1 != nil && timeZone1 != "" {
+					localData1["timeZone"] = timeZone1
+				}
+				if len(localData1) > 0 {
+					dataLoopMap["effectTimeRange"] = localData1
+				}
+				localMaps2 := make([]interface{}, 0)
+				localData2 := dataLoopTmp["channels"]
+				for _, dataLoop2 := range convertToInterfaceArray(localData2) {
+					dataLoop2Tmp := dataLoop2.(map[string]interface{})
+					dataLoop2Map := make(map[string]interface{})
+					dataLoop2Map["receivers"] = dataLoop2Tmp["receivers"]
+					dataLoop2Map["channelType"] = dataLoop2Tmp["channel_type"]
+					if enabledSubChannelsSet, ok := dataLoop2Tmp["enabled_sub_channels"].(*schema.Set); ok {
+						dataLoop2Map["enabledSubChannels"] = enabledSubChannelsSet.List()
+					} else {
+						dataLoop2Map["enabledSubChannels"] = convertToInterfaceArray(dataLoop2Tmp["enabled_sub_channels"])
+					}
+					localMaps2 = append(localMaps2, dataLoop2Map)
+				}
+				dataLoopMap["channels"] = localMaps2
+				localData3 := make(map[string]interface{})
+				if v, ok := dataLoopTmp["filter_setting"]; ok {
+					localData4, err := jsonpath.Get("$[0].conditions", v)
+					if err != nil {
+						localData4 = make([]interface{}, 0)
+					}
+					localMaps4 := make([]interface{}, 0)
+					for _, dataLoop4 := range convertToInterfaceArray(localData4) {
+						dataLoop4Tmp := make(map[string]interface{})
+						if dataLoop4 != nil {
+							dataLoop4Tmp = dataLoop4.(map[string]interface{})
+						}
+						dataLoop4Map := make(map[string]interface{})
+						dataLoop4Map["op"] = dataLoop4Tmp["op"]
+						dataLoop4Map["field"] = dataLoop4Tmp["field"]
+						dataLoop4Map["value"] = dataLoop4Tmp["value"]
+						localMaps4 = append(localMaps4, dataLoop4Map)
+					}
+					localData3["conditions"] = localMaps4
+				}
+
+				relation1, _ := jsonpath.Get("$[0].relation", dataLoopTmp["filter_setting"])
+				if relation1 != nil && relation1 != "" {
+					localData3["relation"] = relation1
+				}
+				expression1, _ := jsonpath.Get("$[0].expression", dataLoopTmp["filter_setting"])
+				if expression1 != nil && expression1 != "" {
+					localData3["expression"] = expression1
+				}
+				if len(localData3) > 0 {
+					dataLoopMap["filterSetting"] = localData3
+				}
+				dataLoopMap["enableRca"] = dataLoopTmp["enable_rca"]
+				dataLoopMap["digitalEmployeeName"] = dataLoopTmp["digital_employee_name"]
+				localMaps = append(localMaps, dataLoopMap)
+			}
+			notifyStrategy["routes"] = localMaps
+		}
+
+		if v, ok := d.GetOk("notify_strategy"); ok {
+			localData5, err := jsonpath.Get("$[0].custom_template_entries", v)
+			if err != nil {
+				localData5 = make([]interface{}, 0)
+			}
+			localMaps5 := make([]interface{}, 0)
+			for _, dataLoop5 := range convertToInterfaceArray(localData5) {
+				dataLoop5Tmp := make(map[string]interface{})
+				if dataLoop5 != nil {
+					dataLoop5Tmp = dataLoop5.(map[string]interface{})
+				}
+				dataLoop5Map := make(map[string]interface{})
+				dataLoop5Map["templateUuid"] = dataLoop5Tmp["template_uuid"]
+				localMaps5 = append(localMaps5, dataLoop5Map)
+			}
+			notifyStrategy["customTemplateEntries"] = localMaps5
+		}
+
+		ignoreRestoredNotification1, _ := jsonpath.Get("$[0].ignore_restored_notification", v)
+		if ignoreRestoredNotification1 != nil && ignoreRestoredNotification1 != "" {
+			notifyStrategy["ignoreRestoredNotification"] = ignoreRestoredNotification1
+		}
+		description1, _ := jsonpath.Get("$[0].description", v)
+		if description1 != nil && description1 != "" {
+			notifyStrategy["description"] = description1
+		}
+
+		request["notifyStrategy"] = notifyStrategy
+	}
+
+	responsePlan := make(map[string]interface{})
+
+	if v := d.Get("response_plan"); !IsNil(v) {
+		autoRecoverSeconds1, _ := jsonpath.Get("$[0].auto_recover_seconds", v)
+		if autoRecoverSeconds1 != nil && autoRecoverSeconds1 != "" {
+			responsePlan["autoRecoverSeconds"] = autoRecoverSeconds1
+		}
+		pushingSetting := make(map[string]interface{})
+		restoreActionIds1, _ := jsonpath.Get("$[0].pushing_setting[0].restore_action_ids", d.Get("response_plan"))
+		if restoreActionIds1 != nil && restoreActionIds1 != "" {
+			pushingSetting["restoreActionIds"] = restoreActionIds1
+		}
+		alertActionIds1, _ := jsonpath.Get("$[0].pushing_setting[0].alert_action_ids", d.Get("response_plan"))
+		if alertActionIds1 != nil && alertActionIds1 != "" {
+			pushingSetting["alertActionIds"] = alertActionIds1
+		}
+
+		if len(pushingSetting) > 0 {
+			responsePlan["pushingSetting"] = pushingSetting
+		}
+		repeatNotifySetting := make(map[string]interface{})
+		repeatInterval1, _ := jsonpath.Get("$[0].repeat_notify_setting[0].repeat_interval", d.Get("response_plan"))
+		if repeatInterval1 != nil && repeatInterval1 != "" {
+			repeatNotifySetting["repeatInterval"] = repeatInterval1
+		}
+		endIncidentState1, _ := jsonpath.Get("$[0].repeat_notify_setting[0].end_incident_state", d.Get("response_plan"))
+		if endIncidentState1 != nil && endIncidentState1 != "" {
+			repeatNotifySetting["endIncidentState"] = endIncidentState1
+		}
+
+		if len(repeatNotifySetting) > 0 {
+			responsePlan["repeatNotifySetting"] = repeatNotifySetting
+		}
+		escalationId1, _ := jsonpath.Get("$[0].escalation_id", v)
+		if escalationId1 != nil && escalationId1 != "" {
+			responsePlan["escalationId"] = escalationId1
+		}
+
+		request["responsePlan"] = responsePlan
+	}
+
+	subscription := make(map[string]interface{})
+
+	if v := d.Get("subscription"); !IsNil(v) {
+		workspaceFilterSetting := make(map[string]interface{})
+		tagSelector := make(map[string]interface{})
+		if v, ok := d.GetOk("subscription"); ok {
+			localData6, err := jsonpath.Get("$[0].workspace_filter_setting[0].tag_selector[0].conditions", v)
+			if err != nil {
+				localData6 = make([]interface{}, 0)
+			}
+			localMaps6 := make([]interface{}, 0)
+			for _, dataLoop6 := range convertToInterfaceArray(localData6) {
+				dataLoop6Tmp := make(map[string]interface{})
+				if dataLoop6 != nil {
+					dataLoop6Tmp = dataLoop6.(map[string]interface{})
+				}
+				dataLoop6Map := make(map[string]interface{})
+				dataLoop6Map["field"] = dataLoop6Tmp["field"]
+				dataLoop6Map["op"] = dataLoop6Tmp["op"]
+				dataLoop6Map["value"] = dataLoop6Tmp["value"]
+				localMaps6 = append(localMaps6, dataLoop6Map)
+			}
+			tagSelector["conditions"] = localMaps6
+		}
+
+		relation3, _ := jsonpath.Get("$[0].workspace_filter_setting[0].tag_selector[0].relation", d.Get("subscription"))
+		if relation3 != nil && relation3 != "" {
+			tagSelector["relation"] = relation3
+		}
+		expression3, _ := jsonpath.Get("$[0].workspace_filter_setting[0].tag_selector[0].expression", d.Get("subscription"))
+		if expression3 != nil && expression3 != "" {
+			tagSelector["expression"] = expression3
+		}
+
+		if len(tagSelector) > 0 {
+			workspaceFilterSetting["tagSelector"] = tagSelector
+		}
+		workspaceUuids1, _ := jsonpath.Get("$[0].workspace_filter_setting[0].workspace_uuids", d.Get("subscription"))
+		if workspaceUuids1 != nil && workspaceUuids1 != "" {
+			workspaceFilterSetting["workspaceUuids"] = workspaceUuids1
+		}
+
+		if len(workspaceFilterSetting) > 0 {
+			subscription["workspaceFilterSetting"] = workspaceFilterSetting
+		}
+		filterSetting1 := make(map[string]interface{})
+		if v, ok := d.GetOk("subscription"); ok {
+			localData7, err := jsonpath.Get("$[0].filter_setting[0].conditions", v)
+			if err != nil {
+				localData7 = make([]interface{}, 0)
+			}
+			localMaps7 := make([]interface{}, 0)
+			for _, dataLoop7 := range convertToInterfaceArray(localData7) {
+				dataLoop7Tmp := make(map[string]interface{})
+				if dataLoop7 != nil {
+					dataLoop7Tmp = dataLoop7.(map[string]interface{})
+				}
+				dataLoop7Map := make(map[string]interface{})
+				dataLoop7Map["field"] = dataLoop7Tmp["field"]
+				dataLoop7Map["value"] = dataLoop7Tmp["value"]
+				dataLoop7Map["op"] = dataLoop7Tmp["op"]
+				localMaps7 = append(localMaps7, dataLoop7Map)
+			}
+			filterSetting1["conditions"] = localMaps7
+		}
+
+		relation5, _ := jsonpath.Get("$[0].filter_setting[0].relation", d.Get("subscription"))
+		if relation5 != nil && relation5 != "" {
+			filterSetting1["relation"] = relation5
+		}
+		expression5, _ := jsonpath.Get("$[0].filter_setting[0].expression", d.Get("subscription"))
+		if expression5 != nil && expression5 != "" {
+			filterSetting1["expression"] = expression5
+		}
+
+		if len(filterSetting1) > 0 {
+			subscription["filterSetting"] = filterSetting1
+		}
+		subscribeLegacyEvent1, _ := jsonpath.Get("$[0].subscribe_legacy_event", v)
+		if subscribeLegacyEvent1 != nil && subscribeLegacyEvent1 != "" {
+			subscription["subscribeLegacyEvent"] = subscribeLegacyEvent1
+		}
+
+		request["subscription"] = subscription
+	}
+
+	if v, ok := d.GetOk("name"); ok {
+		request["name"] = v
+	}
+	if v, ok := d.GetOk("description"); ok {
+		request["description"] = v
+	}
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("Cms", "2024-03-30", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cms_event_notify_policy", action, AlibabaCloudSdkGoERROR)
+	}
+
+	notifyPolicyuuidVar, _ := jsonpath.Get("$.notifyPolicy.uuid", response)
+	notifyPolicyworkspaceVar, _ := jsonpath.Get("$.notifyPolicy.workspace", response)
+	d.SetId(fmt.Sprintf("%v:%v", notifyPolicyuuidVar, notifyPolicyworkspaceVar))
+
+	return resourceAliCloudCmsEventNotifyPolicyUpdate(d, meta)
+}
+
+func resourceAliCloudCmsEventNotifyPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cmsServiceV2 := CmsServiceV2{client}
+
+	objectRaw, err := cmsServiceV2.DescribeCmsEventNotifyPolicy(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cms_event_notify_policy DescribeCmsEventNotifyPolicy Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("create_time", objectRaw["createTime"])
+	d.Set("description", objectRaw["description"])
+	d.Set("enabled", objectRaw["enabled"])
+	d.Set("name", objectRaw["name"])
+	d.Set("update_time", objectRaw["updateTime"])
+	d.Set("user_id", objectRaw["userId"])
+	d.Set("uuid", objectRaw["uuid"])
+	d.Set("version", objectRaw["version"])
+	d.Set("workspace", objectRaw["workspace"])
+
+	notifyStrategyMaps := make([]map[string]interface{}, 0)
+	notifyStrategyMap := make(map[string]interface{})
+	notifyStrategyRaw := make(map[string]interface{})
+	if objectRaw["notifyStrategy"] != nil {
+		notifyStrategyRaw = objectRaw["notifyStrategy"].(map[string]interface{})
+	}
+	if len(notifyStrategyRaw) > 0 {
+		notifyStrategyMap["description"] = notifyStrategyRaw["description"]
+		notifyStrategyMap["ignore_restored_notification"] = notifyStrategyRaw["ignoreRestoredNotification"]
+
+		customTemplateEntriesRaw := notifyStrategyRaw["customTemplateEntries"]
+		customTemplateEntriesMaps := make([]map[string]interface{}, 0)
+		if customTemplateEntriesRaw != nil {
+			for _, customTemplateEntriesChildRaw := range convertToInterfaceArray(customTemplateEntriesRaw) {
+				customTemplateEntriesMap := make(map[string]interface{})
+				customTemplateEntriesChildRaw := customTemplateEntriesChildRaw.(map[string]interface{})
+				customTemplateEntriesMap["template_uuid"] = customTemplateEntriesChildRaw["templateUuid"]
+
+				customTemplateEntriesMaps = append(customTemplateEntriesMaps, customTemplateEntriesMap)
+			}
+		}
+		notifyStrategyMap["custom_template_entries"] = customTemplateEntriesMaps
+		groupingSettingMaps := make([]map[string]interface{}, 0)
+		groupingSettingMap := make(map[string]interface{})
+		groupingSettingRaw := make(map[string]interface{})
+		if notifyStrategyRaw["groupingSetting"] != nil {
+			groupingSettingRaw = notifyStrategyRaw["groupingSetting"].(map[string]interface{})
+		}
+		if len(groupingSettingRaw) > 0 {
+			groupingSettingMap["period_min"] = groupingSettingRaw["periodMin"]
+			groupingSettingMap["silence_sec"] = groupingSettingRaw["silenceSec"]
+			groupingSettingMap["times"] = groupingSettingRaw["times"]
+
+			groupingKeysRaw := make([]interface{}, 0)
+			if groupingSettingRaw["groupingKeys"] != nil {
+				groupingKeysRaw = convertToInterfaceArray(groupingSettingRaw["groupingKeys"])
+			}
+
+			groupingSettingMap["grouping_keys"] = groupingKeysRaw
+			groupingSettingMaps = append(groupingSettingMaps, groupingSettingMap)
+		}
+		notifyStrategyMap["grouping_setting"] = groupingSettingMaps
+		routesRaw := notifyStrategyRaw["routes"]
+		routesMaps := make([]map[string]interface{}, 0)
+		if routesRaw != nil {
+			for _, routesChildRaw := range convertToInterfaceArray(routesRaw) {
+				routesMap := make(map[string]interface{})
+				routesChildRaw := routesChildRaw.(map[string]interface{})
+				routesMap["digital_employee_name"] = routesChildRaw["digitalEmployeeName"]
+				routesMap["enable_rca"] = routesChildRaw["enableRca"]
+
+				channelsRaw := routesChildRaw["channels"]
+				channelsMaps := make([]map[string]interface{}, 0)
+				if channelsRaw != nil {
+					for _, channelsChildRaw := range convertToInterfaceArray(channelsRaw) {
+						channelsMap := make(map[string]interface{})
+						channelsChildRaw := channelsChildRaw.(map[string]interface{})
+						channelsMap["channel_type"] = channelsChildRaw["channelType"]
+
+						enabledSubChannelsRaw := make([]interface{}, 0)
+						if channelsChildRaw["enabledSubChannels"] != nil {
+							enabledSubChannelsRaw = convertToInterfaceArray(channelsChildRaw["enabledSubChannels"])
+						}
+
+						channelsMap["enabled_sub_channels"] = enabledSubChannelsRaw
+						receiversRaw := make([]interface{}, 0)
+						if channelsChildRaw["receivers"] != nil {
+							receiversRaw = convertToInterfaceArray(channelsChildRaw["receivers"])
+						}
+
+						channelsMap["receivers"] = receiversRaw
+						channelsMaps = append(channelsMaps, channelsMap)
+					}
+				}
+				routesMap["channels"] = channelsMaps
+				effectTimeRangeMaps := make([]map[string]interface{}, 0)
+				effectTimeRangeMap := make(map[string]interface{})
+				effectTimeRangeRaw := make(map[string]interface{})
+				if routesChildRaw["effectTimeRange"] != nil {
+					effectTimeRangeRaw = routesChildRaw["effectTimeRange"].(map[string]interface{})
+				}
+				if len(effectTimeRangeRaw) > 0 {
+					effectTimeRangeMap["end_time_in_minute"] = effectTimeRangeRaw["endTimeInMinute"]
+					effectTimeRangeMap["start_time_in_minute"] = effectTimeRangeRaw["startTimeInMinute"]
+					effectTimeRangeMap["time_zone"] = effectTimeRangeRaw["timeZone"]
+
+					dayInWeekRaw := make([]interface{}, 0)
+					if effectTimeRangeRaw["dayInWeek"] != nil {
+						dayInWeekRaw = convertToInterfaceArray(effectTimeRangeRaw["dayInWeek"])
+					}
+
+					effectTimeRangeMap["day_in_week"] = dayInWeekRaw
+					effectTimeRangeMaps = append(effectTimeRangeMaps, effectTimeRangeMap)
+				}
+				routesMap["effect_time_range"] = effectTimeRangeMaps
+				filterSettingMaps := make([]map[string]interface{}, 0)
+				filterSettingMap := make(map[string]interface{})
+				filterSettingRaw := make(map[string]interface{})
+				if routesChildRaw["filterSetting"] != nil {
+					filterSettingRaw = routesChildRaw["filterSetting"].(map[string]interface{})
+				}
+				if len(filterSettingRaw) > 0 {
+					filterSettingMap["expression"] = filterSettingRaw["expression"]
+					filterSettingMap["relation"] = filterSettingRaw["relation"]
+
+					conditionsRaw := filterSettingRaw["conditions"]
+					conditionsMaps := make([]map[string]interface{}, 0)
+					if conditionsRaw != nil {
+						for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+							conditionsMap := make(map[string]interface{})
+							conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+							conditionsMap["field"] = conditionsChildRaw["field"]
+							conditionsMap["op"] = conditionsChildRaw["op"]
+							conditionsMap["value"] = conditionsChildRaw["value"]
+
+							conditionsMaps = append(conditionsMaps, conditionsMap)
+						}
+					}
+					filterSettingMap["conditions"] = conditionsMaps
+					filterSettingMaps = append(filterSettingMaps, filterSettingMap)
+				}
+				routesMap["filter_setting"] = filterSettingMaps
+				routesMaps = append(routesMaps, routesMap)
+			}
+		}
+		notifyStrategyMap["routes"] = routesMaps
+		notifyStrategyMaps = append(notifyStrategyMaps, notifyStrategyMap)
+	}
+	if err := d.Set("notify_strategy", notifyStrategyMaps); err != nil {
+		return err
+	}
+	responsePlanMaps := make([]map[string]interface{}, 0)
+	responsePlanMap := make(map[string]interface{})
+	responsePlanRaw := make(map[string]interface{})
+	if objectRaw["responsePlan"] != nil {
+		responsePlanRaw = objectRaw["responsePlan"].(map[string]interface{})
+	}
+	if len(responsePlanRaw) > 0 {
+		responsePlanMap["auto_recover_seconds"] = responsePlanRaw["autoRecoverSeconds"]
+
+		escalationIdRaw := make([]interface{}, 0)
+		if responsePlanRaw["escalationId"] != nil {
+			escalationIdRaw = convertToInterfaceArray(responsePlanRaw["escalationId"])
+		}
+
+		responsePlanMap["escalation_id"] = escalationIdRaw
+		pushingSettingMaps := make([]map[string]interface{}, 0)
+		pushingSettingMap := make(map[string]interface{})
+		pushingSettingRaw := make(map[string]interface{})
+		if responsePlanRaw["pushingSetting"] != nil {
+			pushingSettingRaw = responsePlanRaw["pushingSetting"].(map[string]interface{})
+		}
+		if len(pushingSettingRaw) > 0 {
+
+			alertActionIdsRaw := make([]interface{}, 0)
+			if pushingSettingRaw["alertActionIds"] != nil {
+				alertActionIdsRaw = convertToInterfaceArray(pushingSettingRaw["alertActionIds"])
+			}
+
+			pushingSettingMap["alert_action_ids"] = alertActionIdsRaw
+			restoreActionIdsRaw := make([]interface{}, 0)
+			if pushingSettingRaw["restoreActionIds"] != nil {
+				restoreActionIdsRaw = convertToInterfaceArray(pushingSettingRaw["restoreActionIds"])
+			}
+
+			pushingSettingMap["restore_action_ids"] = restoreActionIdsRaw
+			pushingSettingMaps = append(pushingSettingMaps, pushingSettingMap)
+		}
+		responsePlanMap["pushing_setting"] = pushingSettingMaps
+		repeatNotifySettingMaps := make([]map[string]interface{}, 0)
+		repeatNotifySettingMap := make(map[string]interface{})
+		repeatNotifySettingRaw := make(map[string]interface{})
+		if responsePlanRaw["repeatNotifySetting"] != nil {
+			repeatNotifySettingRaw = responsePlanRaw["repeatNotifySetting"].(map[string]interface{})
+		}
+		if len(repeatNotifySettingRaw) > 0 {
+			repeatNotifySettingMap["end_incident_state"] = repeatNotifySettingRaw["endIncidentState"]
+			repeatNotifySettingMap["repeat_interval"] = repeatNotifySettingRaw["repeatInterval"]
+
+			repeatNotifySettingMaps = append(repeatNotifySettingMaps, repeatNotifySettingMap)
+		}
+		responsePlanMap["repeat_notify_setting"] = repeatNotifySettingMaps
+		responsePlanMaps = append(responsePlanMaps, responsePlanMap)
+	}
+	if err := d.Set("response_plan", responsePlanMaps); err != nil {
+		return err
+	}
+	subscriptionMaps := make([]map[string]interface{}, 0)
+	subscriptionMap := make(map[string]interface{})
+	subscriptionRaw := make(map[string]interface{})
+	if objectRaw["subscription"] != nil {
+		subscriptionRaw = objectRaw["subscription"].(map[string]interface{})
+	}
+	if len(subscriptionRaw) > 0 {
+		subscriptionMap["subscribe_legacy_event"] = subscriptionRaw["subscribeLegacyEvent"]
+
+		filterSettingMaps := make([]map[string]interface{}, 0)
+		filterSettingMap := make(map[string]interface{})
+		filterSettingRaw := make(map[string]interface{})
+		if subscriptionRaw["filterSetting"] != nil {
+			filterSettingRaw = subscriptionRaw["filterSetting"].(map[string]interface{})
+		}
+		if len(filterSettingRaw) > 0 {
+			filterSettingMap["expression"] = filterSettingRaw["expression"]
+			filterSettingMap["relation"] = filterSettingRaw["relation"]
+
+			conditionsRaw := filterSettingRaw["conditions"]
+			conditionsMaps := make([]map[string]interface{}, 0)
+			if conditionsRaw != nil {
+				for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+					conditionsMap := make(map[string]interface{})
+					conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+					conditionsMap["field"] = conditionsChildRaw["field"]
+					conditionsMap["op"] = conditionsChildRaw["op"]
+					conditionsMap["value"] = conditionsChildRaw["value"]
+
+					conditionsMaps = append(conditionsMaps, conditionsMap)
+				}
+			}
+			filterSettingMap["conditions"] = conditionsMaps
+			filterSettingMaps = append(filterSettingMaps, filterSettingMap)
+		}
+		subscriptionMap["filter_setting"] = filterSettingMaps
+		workspaceFilterSettingMaps := make([]map[string]interface{}, 0)
+		workspaceFilterSettingMap := make(map[string]interface{})
+		workspaceFilterSettingRaw := make(map[string]interface{})
+		if subscriptionRaw["workspaceFilterSetting"] != nil {
+			workspaceFilterSettingRaw = subscriptionRaw["workspaceFilterSetting"].(map[string]interface{})
+		}
+		if len(workspaceFilterSettingRaw) > 0 {
+
+			tagSelectorMaps := make([]map[string]interface{}, 0)
+			tagSelectorMap := make(map[string]interface{})
+			tagSelectorRaw := make(map[string]interface{})
+			if workspaceFilterSettingRaw["tagSelector"] != nil {
+				tagSelectorRaw = workspaceFilterSettingRaw["tagSelector"].(map[string]interface{})
+			}
+			if len(tagSelectorRaw) > 0 {
+				tagSelectorMap["expression"] = tagSelectorRaw["expression"]
+				tagSelectorMap["relation"] = tagSelectorRaw["relation"]
+
+				conditionsRaw := tagSelectorRaw["conditions"]
+				conditionsMaps := make([]map[string]interface{}, 0)
+				if conditionsRaw != nil {
+					for _, conditionsChildRaw := range convertToInterfaceArray(conditionsRaw) {
+						conditionsMap := make(map[string]interface{})
+						conditionsChildRaw := conditionsChildRaw.(map[string]interface{})
+						conditionsMap["field"] = conditionsChildRaw["field"]
+						conditionsMap["op"] = conditionsChildRaw["op"]
+						conditionsMap["value"] = conditionsChildRaw["value"]
+
+						conditionsMaps = append(conditionsMaps, conditionsMap)
+					}
+				}
+				tagSelectorMap["conditions"] = conditionsMaps
+				tagSelectorMaps = append(tagSelectorMaps, tagSelectorMap)
+			}
+			workspaceFilterSettingMap["tag_selector"] = tagSelectorMaps
+			workspaceUuidsRaw := make([]interface{}, 0)
+			if workspaceFilterSettingRaw["workspaceUuids"] != nil {
+				workspaceUuidsRaw = convertToInterfaceArray(workspaceFilterSettingRaw["workspaceUuids"])
+			}
+
+			workspaceFilterSettingMap["workspace_uuids"] = workspaceUuidsRaw
+			workspaceFilterSettingMaps = append(workspaceFilterSettingMaps, workspaceFilterSettingMap)
+		}
+		subscriptionMap["workspace_filter_setting"] = workspaceFilterSettingMaps
+		subscriptionMaps = append(subscriptionMaps, subscriptionMap)
+	}
+	if err := d.Set("subscription", subscriptionMaps); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAliCloudCmsEventNotifyPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var body map[string]interface{}
+	update := false
+
+	cmsServiceV2 := CmsServiceV2{client}
+	objectRaw, _ := cmsServiceV2.DescribeCmsEventNotifyPolicy(d.Id())
+
+	initedEnabled := false
+	if _, ok := d.GetOkExists("enabled"); ok && d.IsNewResource() {
+		initedEnabled = true
+	}
+	if initedEnabled || d.HasChange("enabled") {
+		var err error
+		target := d.Get("enabled").(bool)
+
+		currentStatus, err := jsonpath.Get("enabled", objectRaw)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, d.Id(), "enabled", objectRaw)
+		}
+		if formatBool(currentStatus) != target {
+			if target == true {
+				parts := strings.Split(d.Id(), ":")
+				uuid := parts[0]
+				action := fmt.Sprintf("/api/eventbase/notify-policy/%s/enable", uuid)
+				request = make(map[string]interface{})
+				query = make(map[string]*string)
+				body = make(map[string]interface{})
+				query["workspace"] = StringPointer(parts[1])
+				query["regionId"] = StringPointer(client.RegionId)
+				body = request
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = client.RoaPut("Cms", "2024-03-30", action, query, nil, body, true)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+
+			}
+			if target == false {
+				parts := strings.Split(d.Id(), ":")
+				uuid := parts[0]
+				action := fmt.Sprintf("/api/eventbase/notify-policy/%s/disable", uuid)
+				request = make(map[string]interface{})
+				query = make(map[string]*string)
+				body = make(map[string]interface{})
+				query["workspace"] = StringPointer(parts[1])
+				query["regionId"] = StringPointer(client.RegionId)
+				body = request
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = client.RoaPut("Cms", "2024-03-30", action, query, nil, body, true)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+
+			}
+		}
+	}
+
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	action := fmt.Sprintf("/api/eventbase/notify-policy/update")
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	body = make(map[string]interface{})
+	query["workspace"] = StringPointer(parts[1])
+	request["uuid"] = parts[0]
+	// The update API enforces an optimistic lock: the latest version must be sent
+	// together with uuid. Refresh the object in case the enable/disable branch above
+	// advanced the server-side version.
+	if initedEnabled || d.HasChange("enabled") {
+		objectRaw, _ = cmsServiceV2.DescribeCmsEventNotifyPolicy(d.Id())
+	}
+	if versionVar, err := jsonpath.Get("version", objectRaw); err == nil && versionVar != nil {
+		request["version"] = versionVar
+	}
+	query["regionId"] = StringPointer(client.RegionId)
+	if d.HasChange("notify_strategy") {
+		update = true
+	}
+	notifyStrategy := make(map[string]interface{})
+
+	if v := d.Get("notify_strategy"); !IsNil(v) || d.HasChange("notify_strategy") {
+		groupingSetting := make(map[string]interface{})
+		times1, _ := jsonpath.Get("$[0].grouping_setting[0].times", d.Get("notify_strategy"))
+		if times1 != nil && times1 != "" {
+			groupingSetting["times"] = times1
+		}
+		groupingKeys1, _ := jsonpath.Get("$[0].grouping_setting[0].grouping_keys", d.Get("notify_strategy"))
+		if groupingKeys1 != nil && groupingKeys1 != "" {
+			groupingSetting["groupingKeys"] = groupingKeys1
+		}
+		periodMin1, _ := jsonpath.Get("$[0].grouping_setting[0].period_min", d.Get("notify_strategy"))
+		if periodMin1 != nil && periodMin1 != "" {
+			groupingSetting["periodMin"] = periodMin1
+		}
+		silenceSec1, _ := jsonpath.Get("$[0].grouping_setting[0].silence_sec", d.Get("notify_strategy"))
+		if silenceSec1 != nil && silenceSec1 != "" {
+			groupingSetting["silenceSec"] = silenceSec1
+		}
+
+		if len(groupingSetting) > 0 {
+			notifyStrategy["groupingSetting"] = groupingSetting
+		}
+		if v, ok := d.GetOk("notify_strategy"); ok {
+			localData, err := jsonpath.Get("$[0].routes", v)
+			if err != nil {
+				localData = make([]interface{}, 0)
+			}
+			localMaps := make([]interface{}, 0)
+			for _, dataLoop := range convertToInterfaceArray(localData) {
+				dataLoopTmp := make(map[string]interface{})
+				if dataLoop != nil {
+					dataLoopTmp = dataLoop.(map[string]interface{})
+				}
+				dataLoopMap := make(map[string]interface{})
+				if !IsNil(dataLoopTmp["effect_time_range"]) {
+					localData1 := make(map[string]interface{})
+					startTimeInMinute1, _ := jsonpath.Get("$[0].start_time_in_minute", dataLoopTmp["effect_time_range"])
+					if startTimeInMinute1 != nil && startTimeInMinute1 != "" {
+						localData1["startTimeInMinute"] = startTimeInMinute1
+					}
+					endTimeInMinute1, _ := jsonpath.Get("$[0].end_time_in_minute", dataLoopTmp["effect_time_range"])
+					if endTimeInMinute1 != nil && endTimeInMinute1 != "" {
+						localData1["endTimeInMinute"] = endTimeInMinute1
+					}
+					dayInWeek1, _ := jsonpath.Get("$[0].day_in_week", dataLoopTmp["effect_time_range"])
+					if dayInWeek1 != nil && dayInWeek1 != "" {
+						localData1["dayInWeek"] = dayInWeek1
+					}
+					timeZone1, _ := jsonpath.Get("$[0].time_zone", dataLoopTmp["effect_time_range"])
+					if timeZone1 != nil && timeZone1 != "" {
+						localData1["timeZone"] = timeZone1
+					}
+					if len(localData1) > 0 {
+						dataLoopMap["effectTimeRange"] = localData1
+					}
+				}
+				localMaps2 := make([]interface{}, 0)
+				localData2 := dataLoopTmp["channels"]
+				for _, dataLoop2 := range convertToInterfaceArray(localData2) {
+					dataLoop2Tmp := dataLoop2.(map[string]interface{})
+					dataLoop2Map := make(map[string]interface{})
+					dataLoop2Map["receivers"] = dataLoop2Tmp["receivers"]
+					dataLoop2Map["channelType"] = dataLoop2Tmp["channel_type"]
+					if enabledSubChannelsSet, ok := dataLoop2Tmp["enabled_sub_channels"].(*schema.Set); ok {
+						dataLoop2Map["enabledSubChannels"] = enabledSubChannelsSet.List()
+					} else {
+						dataLoop2Map["enabledSubChannels"] = convertToInterfaceArray(dataLoop2Tmp["enabled_sub_channels"])
+					}
+					localMaps2 = append(localMaps2, dataLoop2Map)
+				}
+				dataLoopMap["channels"] = localMaps2
+				if !IsNil(dataLoopTmp["filter_setting"]) {
+					localData3 := make(map[string]interface{})
+					if v, ok := dataLoopTmp["filter_setting"]; ok {
+						localData4, err := jsonpath.Get("$[0].conditions", v)
+						if err != nil {
+							localData4 = make([]interface{}, 0)
+						}
+						localMaps4 := make([]interface{}, 0)
+						for _, dataLoop4 := range convertToInterfaceArray(localData4) {
+							dataLoop4Tmp := make(map[string]interface{})
+							if dataLoop4 != nil {
+								dataLoop4Tmp = dataLoop4.(map[string]interface{})
+							}
+							dataLoop4Map := make(map[string]interface{})
+							dataLoop4Map["op"] = dataLoop4Tmp["op"]
+							dataLoop4Map["field"] = dataLoop4Tmp["field"]
+							dataLoop4Map["value"] = dataLoop4Tmp["value"]
+							localMaps4 = append(localMaps4, dataLoop4Map)
+						}
+						localData3["conditions"] = localMaps4
+					}
+
+					relation1, _ := jsonpath.Get("$[0].relation", dataLoopTmp["filter_setting"])
+					if relation1 != nil && relation1 != "" {
+						localData3["relation"] = relation1
+					}
+					expression1, _ := jsonpath.Get("$[0].expression", dataLoopTmp["filter_setting"])
+					if expression1 != nil && expression1 != "" {
+						localData3["expression"] = expression1
+					}
+					if len(localData3) > 0 {
+						dataLoopMap["filterSetting"] = localData3
+					}
+				}
+				dataLoopMap["enableRca"] = dataLoopTmp["enable_rca"]
+				dataLoopMap["digitalEmployeeName"] = dataLoopTmp["digital_employee_name"]
+				localMaps = append(localMaps, dataLoopMap)
+			}
+			notifyStrategy["routes"] = localMaps
+		}
+
+		if v, ok := d.GetOk("notify_strategy"); ok {
+			localData5, err := jsonpath.Get("$[0].custom_template_entries", v)
+			if err != nil {
+				localData5 = make([]interface{}, 0)
+			}
+			localMaps5 := make([]interface{}, 0)
+			for _, dataLoop5 := range convertToInterfaceArray(localData5) {
+				dataLoop5Tmp := make(map[string]interface{})
+				if dataLoop5 != nil {
+					dataLoop5Tmp = dataLoop5.(map[string]interface{})
+				}
+				dataLoop5Map := make(map[string]interface{})
+				dataLoop5Map["templateUuid"] = dataLoop5Tmp["template_uuid"]
+				localMaps5 = append(localMaps5, dataLoop5Map)
+			}
+			notifyStrategy["customTemplateEntries"] = localMaps5
+		}
+
+		ignoreRestoredNotification1, _ := jsonpath.Get("$[0].ignore_restored_notification", v)
+		if ignoreRestoredNotification1 != nil && ignoreRestoredNotification1 != "" {
+			notifyStrategy["ignoreRestoredNotification"] = ignoreRestoredNotification1
+		}
+		description1, _ := jsonpath.Get("$[0].description", v)
+		if description1 != nil && description1 != "" {
+			notifyStrategy["description"] = description1
+		}
+
+		request["notifyStrategy"] = notifyStrategy
+	}
+
+	if !d.IsNewResource() && d.HasChange("response_plan") {
+		update = true
+	}
+	responsePlan := make(map[string]interface{})
+
+	if v := d.Get("response_plan"); !IsNil(v) || d.HasChange("response_plan") {
+		autoRecoverSeconds1, _ := jsonpath.Get("$[0].auto_recover_seconds", v)
+		if autoRecoverSeconds1 != nil && autoRecoverSeconds1 != "" {
+			responsePlan["autoRecoverSeconds"] = autoRecoverSeconds1
+		}
+		pushingSetting := make(map[string]interface{})
+		restoreActionIds1, _ := jsonpath.Get("$[0].pushing_setting[0].restore_action_ids", d.Get("response_plan"))
+		if restoreActionIds1 != nil && restoreActionIds1 != "" {
+			pushingSetting["restoreActionIds"] = restoreActionIds1
+		}
+		alertActionIds1, _ := jsonpath.Get("$[0].pushing_setting[0].alert_action_ids", d.Get("response_plan"))
+		if alertActionIds1 != nil && alertActionIds1 != "" {
+			pushingSetting["alertActionIds"] = alertActionIds1
+		}
+
+		if len(pushingSetting) > 0 {
+			responsePlan["pushingSetting"] = pushingSetting
+		}
+		repeatNotifySetting := make(map[string]interface{})
+		repeatInterval1, _ := jsonpath.Get("$[0].repeat_notify_setting[0].repeat_interval", d.Get("response_plan"))
+		if repeatInterval1 != nil && repeatInterval1 != "" {
+			repeatNotifySetting["repeatInterval"] = repeatInterval1
+		}
+		endIncidentState1, _ := jsonpath.Get("$[0].repeat_notify_setting[0].end_incident_state", d.Get("response_plan"))
+		if endIncidentState1 != nil && endIncidentState1 != "" {
+			repeatNotifySetting["endIncidentState"] = endIncidentState1
+		}
+
+		if len(repeatNotifySetting) > 0 {
+			responsePlan["repeatNotifySetting"] = repeatNotifySetting
+		}
+		escalationId1, _ := jsonpath.Get("$[0].escalation_id", v)
+		if escalationId1 != nil && escalationId1 != "" {
+			responsePlan["escalationId"] = escalationId1
+		}
+
+		request["responsePlan"] = responsePlan
+	}
+
+	if d.HasChange("subscription") {
+		update = true
+	}
+	subscription := make(map[string]interface{})
+
+	if v := d.Get("subscription"); !IsNil(v) || d.HasChange("subscription") {
+		workspaceFilterSetting := make(map[string]interface{})
+		tagSelector := make(map[string]interface{})
+		if v, ok := d.GetOk("subscription"); ok {
+			localData6, err := jsonpath.Get("$[0].workspace_filter_setting[0].tag_selector[0].conditions", v)
+			if err != nil {
+				localData6 = make([]interface{}, 0)
+			}
+			localMaps6 := make([]interface{}, 0)
+			for _, dataLoop6 := range convertToInterfaceArray(localData6) {
+				dataLoop6Tmp := make(map[string]interface{})
+				if dataLoop6 != nil {
+					dataLoop6Tmp = dataLoop6.(map[string]interface{})
+				}
+				dataLoop6Map := make(map[string]interface{})
+				dataLoop6Map["field"] = dataLoop6Tmp["field"]
+				dataLoop6Map["op"] = dataLoop6Tmp["op"]
+				dataLoop6Map["value"] = dataLoop6Tmp["value"]
+				localMaps6 = append(localMaps6, dataLoop6Map)
+			}
+			tagSelector["conditions"] = localMaps6
+		}
+
+		relation3, _ := jsonpath.Get("$[0].workspace_filter_setting[0].tag_selector[0].relation", d.Get("subscription"))
+		if relation3 != nil && relation3 != "" {
+			tagSelector["relation"] = relation3
+		}
+		expression3, _ := jsonpath.Get("$[0].workspace_filter_setting[0].tag_selector[0].expression", d.Get("subscription"))
+		if expression3 != nil && expression3 != "" {
+			tagSelector["expression"] = expression3
+		}
+
+		if len(tagSelector) > 0 {
+			workspaceFilterSetting["tagSelector"] = tagSelector
+		}
+		workspaceUuids1, _ := jsonpath.Get("$[0].workspace_filter_setting[0].workspace_uuids", d.Get("subscription"))
+		if workspaceUuids1 != nil && workspaceUuids1 != "" {
+			workspaceFilterSetting["workspaceUuids"] = workspaceUuids1
+		}
+
+		if len(workspaceFilterSetting) > 0 {
+			subscription["workspaceFilterSetting"] = workspaceFilterSetting
+		}
+		filterSetting1 := make(map[string]interface{})
+		if v, ok := d.GetOk("subscription"); ok {
+			localData7, err := jsonpath.Get("$[0].filter_setting[0].conditions", v)
+			if err != nil {
+				localData7 = make([]interface{}, 0)
+			}
+			localMaps7 := make([]interface{}, 0)
+			for _, dataLoop7 := range convertToInterfaceArray(localData7) {
+				dataLoop7Tmp := make(map[string]interface{})
+				if dataLoop7 != nil {
+					dataLoop7Tmp = dataLoop7.(map[string]interface{})
+				}
+				dataLoop7Map := make(map[string]interface{})
+				dataLoop7Map["field"] = dataLoop7Tmp["field"]
+				dataLoop7Map["value"] = dataLoop7Tmp["value"]
+				dataLoop7Map["op"] = dataLoop7Tmp["op"]
+				localMaps7 = append(localMaps7, dataLoop7Map)
+			}
+			filterSetting1["conditions"] = localMaps7
+		}
+
+		relation5, _ := jsonpath.Get("$[0].filter_setting[0].relation", d.Get("subscription"))
+		if relation5 != nil && relation5 != "" {
+			filterSetting1["relation"] = relation5
+		}
+		expression5, _ := jsonpath.Get("$[0].filter_setting[0].expression", d.Get("subscription"))
+		if expression5 != nil && expression5 != "" {
+			filterSetting1["expression"] = expression5
+		}
+
+		if len(filterSetting1) > 0 {
+			subscription["filterSetting"] = filterSetting1
+		}
+		subscribeLegacyEvent1, _ := jsonpath.Get("$[0].subscribe_legacy_event", v)
+		if subscribeLegacyEvent1 != nil && subscribeLegacyEvent1 != "" {
+			subscription["subscribeLegacyEvent"] = subscribeLegacyEvent1
+		}
+
+		request["subscription"] = subscription
+	}
+
+	if !d.IsNewResource() && d.HasChange("name") {
+		update = true
+	}
+	if v, ok := d.GetOk("name"); ok || d.HasChange("name") {
+		request["name"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("description") {
+		update = true
+	}
+	if v, ok := d.GetOk("description"); ok || d.HasChange("description") {
+		request["description"] = v
+	}
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPut("Cms", "2024-03-30", action, query, nil, body, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudCmsEventNotifyPolicyRead(d, meta)
+}
+
+func resourceAliCloudCmsEventNotifyPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := fmt.Sprintf("/api/eventbase/notify-policy")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+	query["uuid"] = StringPointer(parts[0])
+	query["workspace"] = StringPointer(parts[1])
+	query["regionId"] = StringPointer(client.RegionId)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("Cms", "2024-03-30", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NotFound"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_cms_event_notify_policy_test.go
+++ b/alicloud/resource_alicloud_cms_event_notify_policy_test.go
@@ -1,0 +1,2877 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Cms EventNotifyPolicy. >>> Resource test cases, automatically generated.
+// Case resource_EventNotifyPolicy_list_test 12980
+func TestAccAliCloudCmsEventNotifyPolicy_basic12980(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12980)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12980)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec list operation test for EventNotifyPolicy",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Notify strategy for list test",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "default-workspace-cn-hangzhou",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec list operation test for EventNotifyPolicy",
+						"workspace":   "default-workspace-cn-hangzhou",
+						"name":        name,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12980 = map[string]string{
+	"create_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12980(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_rca_template_test 12981
+func TestAccAliCloudCmsEventNotifyPolicy_basic12981(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12981)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12981)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec test for EnableRca and CustomTemplateEntries fields",
+					"response_plan": []map[string]interface{}{
+						{
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Test notify strategy with RCA and custom templates",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"digital_employee_name": "test-employee-001",
+									"enable_rca":            "true",
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+							"custom_template_entries": []map[string]interface{}{
+								{
+									"template_uuid": "test-template-uuid-001",
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "default-workspace-cn-hangzhou",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec test for EnableRca and CustomTemplateEntries fields",
+						"workspace":   "default-workspace-cn-hangzhou",
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated: EnableRca disabled, template changed",
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Test notify strategy with RCA and custom templates",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"digital_employee_name": "test-employee-002",
+									"enable_rca":            "false",
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+							"custom_template_entries": []map[string]interface{}{
+								{
+									"template_uuid": "test-template-uuid-002",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated: EnableRca disabled, template changed",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12981 = map[string]string{
+	"create_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12981(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_response_plan 12982
+func TestAccAliCloudCmsEventNotifyPolicy_basic12982(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12982)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12982)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec ResponsePlan field coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"action-restore-001"},
+									"alert_action_ids": []string{
+										"action-alert-001"},
+								},
+							},
+							"escalation_id": []string{
+								"esc-test-001"},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Minimal notify strategy for ResponsePlan test",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "default-workspace-cn-hangzhou",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec ResponsePlan field coverage test",
+						"workspace":   "default-workspace-cn-hangzhou",
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated ResponsePlan field coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "acknowledged",
+									"repeat_interval":    "60",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"action-restore-002"},
+									"alert_action_ids": []string{
+										"action-alert-002", "action-alert-003"},
+								},
+							},
+							"escalation_id": []string{
+								"esc-test-001", "esc-test-002"},
+							"auto_recover_seconds": "1200",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated ResponsePlan field coverage test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12982 = map[string]string{
+	"create_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12982(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_lifecycle_test 12983
+func TestAccAliCloudCmsEventNotifyPolicy_basic12983(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12983)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12983)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec lifecycle test for EventNotifyPolicy",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Primary notify strategy for lifecycle testing",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "default-workspace-cn-hangzhou",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec lifecycle test for EventNotifyPolicy",
+						"workspace":   "default-workspace-cn-hangzhou",
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated description for lifecycle test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "60",
+								},
+							},
+							"auto_recover_seconds": "1200",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Primary notify strategy for lifecycle testing",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "10",
+									"times":       "2",
+									"silence_sec": "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group-updated"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "memory",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated description for lifecycle test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12983 = map[string]string{
+	"create_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12983(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_enable_disable_test 12984
+func TestAccAliCloudCmsEventNotifyPolicy_basic12984(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12984)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12984)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec Enable/Disable operations test for EventNotifyPolicy",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Notify strategy for enable-disable test",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "default-workspace-cn-hangzhou",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec Enable/Disable operations test for EventNotifyPolicy",
+						"workspace":   "default-workspace-cn-hangzhou",
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated - test regular update operation",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "60",
+								},
+							},
+							"auto_recover_seconds": "1200",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Notify strategy for enable-disable test",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "10",
+									"times":       "2",
+									"silence_sec": "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "WARNING",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated - test regular update operation",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enabled": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enabled": "false",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enabled": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enabled": "true",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12984 = map[string]string{
+	"create_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12984(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_non_private_attrs 12985
+func TestAccAliCloudCmsEventNotifyPolicy_basic12985(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12985)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12985)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec non-private attrs coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Strategy for non-private attrs test",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation":   "AND",
+									"expression": "1 AND 2",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "source",
+											"op":    "EQ",
+											"value": "cms",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "default-workspace-cn-hangzhou",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec non-private attrs coverage test",
+						"workspace":   "default-workspace-cn-hangzhou",
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Strategy for non-private attrs test",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation":   "OR",
+									"expression": "1 OR 2",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "WARNING",
+										},
+										{
+											"field": "source",
+											"op":    "EQ",
+											"value": "arms",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12985 = map[string]string{
+	"create_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12985(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_enum_channel_types 12986
+func TestAccAliCloudCmsEventNotifyPolicy_basic12986(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12986)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12986)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec enum ChannelType coverage test for EventNotifyPolicy",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Notify strategy for ChannelType enum coverage",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-enum-test-ding"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-enum-test-ding2"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "default-workspace-cn-hangzhou",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec enum ChannelType coverage test for EventNotifyPolicy",
+						"workspace":   "default-workspace-cn-hangzhou",
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated ChannelType enum coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "60",
+								},
+							},
+							"auto_recover_seconds": "1200",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Notify strategy for ChannelType enum coverage",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "10",
+									"times":       "2",
+									"silence_sec": "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-enum-test-ding-updated"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-enum-test-ding2-updated"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "memory",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated ChannelType enum coverage test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12986 = map[string]string{
+	"create_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12986(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_filter_setting 12987
+func TestAccAliCloudCmsEventNotifyPolicy_basic12987(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12987)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12987)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec FilterSetting coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Minimal strategy for filter testing",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"filter_setting": []map[string]interface{}{
+										{
+											"relation":   "AND",
+											"expression": "1 AND 2",
+											"conditions": []map[string]interface{}{
+												{
+													"field": "source",
+													"op":    "EQ",
+													"value": "cms",
+												},
+												{
+													"field": "severity",
+													"op":    "EQ",
+													"value": "WARNING",
+												},
+											},
+										},
+									},
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "OR",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "default-workspace-cn-hangzhou",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec FilterSetting coverage test",
+						"workspace":   "default-workspace-cn-hangzhou",
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec FilterSetting coverage test - extreme conditions",
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Minimal strategy for filter testing",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"filter_setting": []map[string]interface{}{
+										{
+											"relation":   "AND",
+											"expression": "1",
+											"conditions": []map[string]interface{}{
+												{
+													"field": "severity",
+													"op":    "EQ",
+													"value": "CRITICAL",
+												},
+											},
+										},
+									},
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+										{
+											"field": "namespace",
+											"op":    "EQ",
+											"value": "acs_ecs",
+										},
+										{
+											"field": "source",
+											"op":    "EQ",
+											"value": "cms",
+										},
+										{
+											"field": "instance",
+											"op":    "EQ",
+											"value": "i-001",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec FilterSetting coverage test - extreme conditions",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12987 = map[string]string{
+	"create_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12987(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_array_reduce_empty 12988
+func TestAccAliCloudCmsEventNotifyPolicy_basic12988(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12988)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12988)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec array reduce and empty coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"restore-action-test-001", "restore-action-test-002", "restore-action-test-003"},
+									"alert_action_ids": []string{
+										"alert-action-test-001", "alert-action-test-002", "alert-action-test-003"},
+								},
+							},
+							"escalation_id": []string{
+								"esc-id-test-001", "esc-id-test-002", "esc-id-test-003"},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Array reduce empty test strategy",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "instance", "alertname"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-reduce-group-1"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-reduce-group-2"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "540",
+											"end_time_in_minute":   "1080",
+											"day_in_week": []string{
+												"1", "2", "3"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-reduce-group-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+										{
+											"field": "namespace",
+											"op":    "EQ",
+											"value": "acs_ecs",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "default-workspace-cn-hangzhou",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec array reduce and empty coverage test",
+						"workspace":   "default-workspace-cn-hangzhou",
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated array reduce and empty coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "60",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"restore-action-test-001"},
+									"alert_action_ids": []string{
+										"alert-action-test-001"},
+								},
+							},
+							"escalation_id": []string{
+								"esc-id-test-001"},
+							"auto_recover_seconds": "1200",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Array reduce empty test strategy",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity"},
+									"period_min":  "10",
+									"times":       "2",
+									"silence_sec": "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-reduce-group-1"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-reduce-group-2"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated array reduce and empty coverage test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12988 = map[string]string{
+	"create_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12988(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_array_empty_extended 12989
+func TestAccAliCloudCmsEventNotifyPolicy_basic12989(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12989)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12989)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec extended array coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"restore-action-ext-001"},
+									"alert_action_ids": []string{
+										"alert-action-ext-001", "alert-action-ext-002", "alert-action-ext-003"},
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Extended array test strategy",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-ext-group-1", "cspec-ext-group-2", "cspec-ext-group-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-ext-group-4", "cspec-ext-group-5"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "540",
+											"end_time_in_minute":   "1080",
+											"day_in_week": []string{
+												"1", "2", "3"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-ext-group-6", "cspec-ext-group-7"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+										{
+											"field": "namespace",
+											"op":    "EQ",
+											"value": "acs_ecs",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "default-workspace-cn-hangzhou",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec extended array coverage test",
+						"workspace":   "default-workspace-cn-hangzhou",
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Updated extended array coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"restore-action-ext-001"},
+									"alert_action_ids": []string{
+										"alert-action-ext-001"},
+								},
+							},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Extended array test strategy",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-ext-group-1"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-ext-group-4"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "540",
+											"end_time_in_minute":   "1080",
+											"day_in_week": []string{
+												"1", "2", "3"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-ext-group-6", "cspec-ext-group-7"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Updated extended array coverage test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12989 = map[string]string{
+	"create_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12989(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Case resource_EventNotifyPolicy_array_multi_element 12990
+func TestAccAliCloudCmsEventNotifyPolicy_basic12990(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyMap12990)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyBasicDependence12990)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "CloudSpec array multi-element coverage test",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"cspec-restore-action-1", "cspec-restore-action-2"},
+									"alert_action_ids": []string{
+										"cspec-alert-action-1", "cspec-alert-action-2"},
+								},
+							},
+							"escalation_id": []string{
+								"cspec-escalation-id-1", "cspec-escalation-id-2"},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Multi-element array test strategy",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "alertname"},
+									"period_min":  "5",
+									"times":       "1",
+									"silence_sec": "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-array-group-1", "cspec-array-group-2", "cspec-array-group-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+										{
+											"receivers": []string{
+												"cspec-array-contact-1", "cspec-array-contact-2", "cspec-array-contact-3"},
+											"channel_type": "CONTACT",
+											"enabled_sub_channels": []string{
+												"SMS", "EMAIL"},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-array-webhook-1", "cspec-array-webhook-2", "cspec-array-webhook-3"},
+											"channel_type":         "WEBHOOK",
+											"enabled_sub_channels": []string{},
+										},
+										{
+											"receivers": []string{
+												"cspec-array-ding-1", "cspec-array-ding-2", "cspec-array-ding-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+									},
+								},
+							},
+						},
+					},
+					"workspace": "default-workspace-cn-hangzhou",
+					"name":      name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "CloudSpec array multi-element coverage test",
+						"workspace":   "default-workspace-cn-hangzhou",
+						"name":        name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description": "Merged - growth to 3 Routes, DayInWeek boundary [1,2], Conditions 4 elements",
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "60",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{
+										"cspec-restore-action-1", "cspec-restore-action-2", "cspec-restore-action-3"},
+									"alert_action_ids": []string{
+										"cspec-alert-action-1", "cspec-alert-action-2", "cspec-alert-action-3"},
+								},
+							},
+							"escalation_id": []string{
+								"cspec-escalation-id-1", "cspec-escalation-id-2", "cspec-escalation-id-3"},
+							"auto_recover_seconds": "1200",
+						},
+					},
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "Multi-element array test strategy",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{
+										"severity", "instance", "alertname"},
+									"period_min":  "10",
+									"times":       "2",
+									"silence_sec": "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week": []string{
+												"1", "2"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-array-group-1", "cspec-array-group-2", "cspec-array-group-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+										{
+											"receivers": []string{
+												"cspec-array-contact-1", "cspec-array-contact-2", "cspec-array-contact-3"},
+											"channel_type": "CONTACT",
+											"enabled_sub_channels": []string{
+												"EMAIL"},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "480",
+											"end_time_in_minute":   "1200",
+											"day_in_week": []string{
+												"1", "2", "3", "4", "5", "6", "0"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-array-webhook-1", "cspec-array-webhook-2", "cspec-array-webhook-3"},
+											"channel_type":         "WEBHOOK",
+											"enabled_sub_channels": []string{},
+										},
+										{
+											"receivers": []string{
+												"cspec-array-ding-1", "cspec-array-ding-2", "cspec-array-ding-3"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+								{
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "540",
+											"end_time_in_minute":   "1080",
+											"day_in_week": []string{
+												"0", "1", "2", "3", "4"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers": []string{
+												"cspec-array-ding-4", "cspec-array-ding-5", "cspec-array-ding-6"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+										{
+											"receivers": []string{
+												"cspec-array-webhook-4", "cspec-array-webhook-5", "cspec-array-webhook-6"},
+											"channel_type":         "WEBHOOK",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation": "AND",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+										{
+											"field": "alertname",
+											"op":    "EQ",
+											"value": "cpu_high",
+										},
+										{
+											"field": "namespace",
+											"op":    "EQ",
+											"value": "acs_ecs",
+										},
+										{
+											"field": "source",
+											"op":    "EQ",
+											"value": "cms",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description": "Merged - growth to 3 Routes, DayInWeek boundary [1,2], Conditions 4 elements",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyMap12990 = map[string]string{
+	"create_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"update_time": CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyBasicDependence12990(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Test Cms EventNotifyPolicy. <<< Resource test cases, automatically generated.
+
+// Hand-written full-coverage test case for alicloud_cms_event_notify_policy.
+// Covers must-set and modify attributes not covered by the auto-generated cases:
+//   - must-set: subscription.workspace_filter_setting.tag_selector (relation, expression,
+//     conditions.{field,op,value})
+//   - computed: uuid and version (server-generated optimistic lock version)
+//   - modify: name, notify_strategy.description, notify_strategy.routes.effect_time_range.time_zone,
+//     notify_strategy.routes.filter_setting.{relation, conditions.op},
+//     subscription.filter_setting.conditions.op,
+//     subscription.workspace_filter_setting.tag_selector.{relation, expression,
+//     conditions.{field,op,value}}
+func TestAccAliCloudCmsEventNotifyPolicy_fullCoverage(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_event_notify_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudCmsEventNotifyPolicyFullCoverageMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEventNotifyPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCmsEventNotifyPolicyFullCoverageDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name":        name,
+					"description": "full coverage create",
+					"enabled":     "true",
+					"workspace":   "default-workspace-cn-hangzhou",
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "strategy create",
+							"ignore_restored_notification": "false",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{"severity"},
+									"period_min":    "5",
+									"times":         "1",
+									"silence_sec":   "300",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"digital_employee_name": "employee-create",
+									"enable_rca":            "false",
+									"filter_setting": []map[string]interface{}{
+										{
+											"relation":   "AND",
+											"expression": "1",
+											"conditions": []map[string]interface{}{
+												{
+													"field": "severity",
+													"op":    "EQ",
+													"value": "CRITICAL",
+												},
+											},
+										},
+									},
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "Asia/Shanghai",
+											"start_time_in_minute": "0",
+											"end_time_in_minute":   "1439",
+											"day_in_week":          []string{"1", "2", "3", "4", "5"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers":            []string{"cspec-test-group"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+							"custom_template_entries": []map[string]interface{}{
+								{
+									"template_uuid": "tpl-uuid-create",
+								},
+							},
+						},
+					},
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "resolved",
+									"repeat_interval":    "30",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{"restore-action-1"},
+									"alert_action_ids":   []string{"alert-action-1"},
+								},
+							},
+							"escalation_id":        []string{"escalation-create"},
+							"auto_recover_seconds": "600",
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "true",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation":   "AND",
+									"expression": "1",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "EQ",
+											"value": "CRITICAL",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":        name,
+						"description": "full coverage create",
+						"workspace":   "default-workspace-cn-hangzhou",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name":        name + "_update",
+					"description": "full coverage update",
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "strategy create",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{"severity", "resourceType"},
+									"period_min":    "10",
+									"times":         "2",
+									"silence_sec":   "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"digital_employee_name": "employee-update",
+									"enable_rca":            "true",
+									"filter_setting": []map[string]interface{}{
+										{
+											"relation":   "OR",
+											"expression": "1",
+											"conditions": []map[string]interface{}{
+												{
+													"field": "severity",
+													"op":    "IN",
+													"value": "INFO,WARN",
+												},
+											},
+										},
+									},
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "America/New_York",
+											"start_time_in_minute": "60",
+											"end_time_in_minute":   "1380",
+											"day_in_week":          []string{"0", "1", "2", "3", "4", "5", "6"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers":    []string{"cspec-test-group-2"},
+											"channel_type": "DING",
+											// The DING channel has no valid sub-channels; the server
+											// normalizes any value back to an empty list, so keep it
+											// empty here to avoid a non-empty plan.
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+							"custom_template_entries": []map[string]interface{}{
+								{
+									"template_uuid": "tpl-uuid-update",
+								},
+							},
+						},
+					},
+					"response_plan": []map[string]interface{}{
+						{
+							"repeat_notify_setting": []map[string]interface{}{
+								{
+									"end_incident_state": "acknowledged",
+									"repeat_interval":    "60",
+								},
+							},
+							"pushing_setting": []map[string]interface{}{
+								{
+									"restore_action_ids": []string{"restore-action-2"},
+									"alert_action_ids":   []string{"alert-action-2"},
+								},
+							},
+							"escalation_id":        []string{"escalation-update"},
+							"auto_recover_seconds": "1200",
+						},
+					},
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation":   "OR",
+									"expression": "1",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "IN",
+											"value": "INFO,WARN",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":        name + "_update",
+						"description": "full coverage update",
+					}),
+				),
+			},
+			{
+				// The update API does not apply changes to notify_strategy.description:
+				// the server keeps the value that was set at creation time, so the plan
+				// stays non-empty after apply. The step documents that behavior while
+				// keeping the attribute modification covered.
+				Config: testAccConfig(map[string]interface{}{
+					"notify_strategy": []map[string]interface{}{
+						{
+							"description":                  "strategy update",
+							"ignore_restored_notification": "true",
+							"grouping_setting": []map[string]interface{}{
+								{
+									"grouping_keys": []string{"severity", "resourceType"},
+									"period_min":    "10",
+									"times":         "2",
+									"silence_sec":   "600",
+								},
+							},
+							"routes": []map[string]interface{}{
+								{
+									"digital_employee_name": "employee-update",
+									"enable_rca":            "true",
+									"filter_setting": []map[string]interface{}{
+										{
+											"relation":   "OR",
+											"expression": "1",
+											"conditions": []map[string]interface{}{
+												{
+													"field": "severity",
+													"op":    "IN",
+													"value": "INFO,WARN",
+												},
+											},
+										},
+									},
+									"effect_time_range": []map[string]interface{}{
+										{
+											"time_zone":            "America/New_York",
+											"start_time_in_minute": "60",
+											"end_time_in_minute":   "1380",
+											"day_in_week":          []string{"0", "1", "2", "3", "4", "5", "6"},
+										},
+									},
+									"channels": []map[string]interface{}{
+										{
+											"receivers":            []string{"cspec-test-group-2"},
+											"channel_type":         "DING",
+											"enabled_sub_channels": []string{},
+										},
+									},
+								},
+							},
+							"custom_template_entries": []map[string]interface{}{
+								{
+									"template_uuid": "tpl-uuid-update",
+								},
+							},
+						},
+					},
+				}),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+			{
+				// The EventBridge backend accepts workspace_filter_setting but does not
+				// persist it for this account (cross-workspace routing requires internal
+				// workspace UUIDs that no public API exposes), so the plan stays
+				// non-empty after apply. The step documents that behavior while keeping
+				// the attributes covered.
+				Config: testAccConfig(map[string]interface{}{
+					"subscription": []map[string]interface{}{
+						{
+							"subscribe_legacy_event": "false",
+							"filter_setting": []map[string]interface{}{
+								{
+									"relation":   "OR",
+									"expression": "1",
+									"conditions": []map[string]interface{}{
+										{
+											"field": "severity",
+											"op":    "IN",
+											"value": "INFO,WARN",
+										},
+									},
+								},
+							},
+							"workspace_filter_setting": []map[string]interface{}{
+								{
+									"workspace_uuids": []string{"ws-uuid-coverage"},
+									"tag_selector": []map[string]interface{}{
+										{
+											"relation":   "OR",
+											"expression": "1",
+											"conditions": []map[string]interface{}{
+												{
+													"field": "updated_tag_field",
+													"op":    "EQ",
+													"value": "low",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+var AlicloudCmsEventNotifyPolicyFullCoverageMap = map[string]string{
+	"create_time": CHECKSET,
+	"update_time": CHECKSET,
+	"user_id":     CHECKSET,
+	"uuid":        CHECKSET,
+	"version":     CHECKSET,
+}
+
+func AlicloudCmsEventNotifyPolicyFullCoverageDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+`, name)
+}

--- a/alicloud/service_alicloud_cms_v2.go
+++ b/alicloud/service_alicloud_cms_v2.go
@@ -557,3 +557,85 @@ func (s *CmsServiceV2) CmsAlertRuleV2StateRefreshFuncWithApi(id string, field st
 }
 
 // DescribeCmsAlertRuleV2 >>> Encapsulated.
+
+// DescribeCmsEventNotifyPolicy <<< Encapsulated get interface for Cms EventNotifyPolicy.
+
+func (s *CmsServiceV2) DescribeCmsEventNotifyPolicy(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	query["uuid"] = StringPointer(parts[0])
+	query["workspace"] = StringPointer(parts[1])
+	query["regionId"] = StringPointer(client.RegionId)
+	action := fmt.Sprintf("/api/eventbase/notify-policy")
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RoaGet("Cms", "2024-03-30", action, query, nil, nil)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NotFound"}) {
+			return object, WrapErrorf(NotFoundErr("EventNotifyPolicy", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.notifyPolicy", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.notifyPolicy", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *CmsServiceV2) CmsEventNotifyPolicyStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.CmsEventNotifyPolicyStateRefreshFuncWithApi(id, field, failStates, s.DescribeCmsEventNotifyPolicy)
+}
+
+func (s *CmsServiceV2) CmsEventNotifyPolicyStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeCmsEventNotifyPolicy >>> Encapsulated.

--- a/website/docs/d/cms_event_notify_policies.html.markdown
+++ b/website/docs/d/cms_event_notify_policies.html.markdown
@@ -1,0 +1,182 @@
+---
+subcategory: "Cms"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_event_notify_policies"
+sidebar_current: "docs-alicloud-datasource-cms-event-notify-policies"
+description: |-
+  Provides a list of Cms Event Notify Policy owned by an Alibaba Cloud account.
+---
+
+# alicloud_cms_event_notify_policies
+
+This data source provides Cms Event Notify Policy available to the user.[What is Event Notify Policy](https://next.api.alibabacloud.com/document/Cms/2024-03-30/CreateNotifyPolicy)
+
+-> **NOTE:** Available since v1.288.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "random_integer" "default" {
+  min = 10000
+  max = 99999
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = "${var.name}-${random_integer.default.result}"
+  description  = "SLS project bound to a CMS workspace."
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = "${var.name}-${random_integer.default.result}"
+  sls_project    = alicloud_log_project.default.project_name
+}
+
+resource "alicloud_cms_event_notify_policy" "default" {
+  description = "Example event notify policy."
+  response_plan {
+    repeat_notify_setting {
+      end_incident_state = "resolved"
+      repeat_interval    = "30"
+    }
+    auto_recover_seconds = "600"
+  }
+  notify_strategy {
+    description                  = "Example notify strategy."
+    ignore_restored_notification = false
+    grouping_setting {
+      grouping_keys = ["severity"]
+      period_min    = "5"
+      times         = "1"
+      silence_sec   = "300"
+    }
+    routes {
+      effect_time_range {
+        time_zone            = "Asia/Shanghai"
+        start_time_in_minute = "0"
+        end_time_in_minute   = "1439"
+        day_in_week          = ["1", "2", "3", "4", "5"]
+      }
+      channels {
+        receivers            = ["example-contact-group"]
+        channel_type         = "DING"
+        enabled_sub_channels = []
+      }
+    }
+  }
+  subscription {
+    subscribe_legacy_event = true
+    filter_setting {
+      relation = "AND"
+      conditions {
+        field = "severity"
+        op    = "EQ"
+        value = "CRITICAL"
+      }
+    }
+  }
+  workspace = alicloud_cms_workspace.default.workspace_name
+  name      = var.name
+}
+
+data "alicloud_cms_event_notify_policies" "default" {
+  ids       = ["${alicloud_cms_event_notify_policy.default.id}"]
+  name      = var.name
+  workspace = alicloud_cms_workspace.default.workspace_name
+}
+
+output "alicloud_cms_event_notify_policy_example_id" {
+  value = data.alicloud_cms_event_notify_policies.default.policies.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `name` - (Optional) The name of the event notify policy used to filter the results.
+* `order_by` - (Optional) The field by which the results are ordered.
+* `order_desc` - (Optional) Specifies whether to sort the results in descending order.
+* `workspace` - (Required) The name of the workspace to which the event notify policies belong.
+* `ids` - (Optional, Computed) A list of Event Notify Policy IDs. The value is formulated as `<uuid>:<workspace>`.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Event Notify Policy IDs.
+* `policies` - A list of Event Notify Policy Entries. Each element contains the following attributes:
+  * `create_time` - The creation time of the event notify policy.
+  * `description` - The description of the event notify policy.
+  * `enabled` - Indicates whether the event notify policy is enabled.
+  * `name` - The name of the event notify policy.
+  * `notify_strategy` - The notify strategy of the event notify policy.
+    * `custom_template_entries` - The custom notify templates.
+      * `template_uuid` - The UUID of the custom notify template.
+    * `description` - The description of the notify strategy.
+    * `grouping_setting` - The event grouping setting.
+      * `grouping_keys` - The list of fields by which events are grouped and merged.
+      * `period_min` - The check period, in minutes.
+      * `silence_sec` - The silence period, in seconds.
+      * `times` - The number of occurrences within the check period that triggers a notification.
+    * `ignore_restored_notification` - Indicates whether the notification is ignored when the incident is restored.
+    * `routes` - The notify routes.
+      * `channels` - The notify channels.
+        * `channel_type` - The type of the notify channel.
+        * `enabled_sub_channels` - The enabled notification types.
+        * `receivers` - The receivers of the channel.
+      * `digital_employee_name` - The name of the digital employee.
+      * `effect_time_range` - The effective time range of the route.
+        * `day_in_week` - The effective days of the week. Valid values: `0` to `6` (`0` means Sunday and `6` means Saturday).
+        * `end_time_in_minute` - The end time of the range, in minutes from 00:00.
+        * `start_time_in_minute` - The start time of the range, in minutes from 00:00.
+        * `time_zone` - The time zone of the range.
+      * `enable_rca` - Indicates whether root cause analysis (RCA) is enabled.
+      * `filter_setting` - The route-level event filter.
+        * `conditions` - The filter conditions.
+          * `field` - The field to filter on.
+          * `op` - The comparison operator.
+          * `value` - The value to compare with.
+        * `expression` - The filter expression.
+        * `relation` - The relation between the conditions.
+  * `response_plan` - **NOTE:** This field is only available when `enable_details` is `true`. The response plan of the event notify policy.
+    * `auto_recover_seconds` - The duration, in seconds, after which an incident is automatically recovered when no new event occurs.
+    * `escalation_id` - The IDs of the escalation plans.
+    * `pushing_setting` - The action integration pushing setting.
+      * `alert_action_ids` - The IDs of the action integrations triggered by alerts.
+      * `restore_action_ids` - The IDs of the action integrations triggered when incidents are restored.
+    * `repeat_notify_setting` - The repeat notification setting.
+      * `end_incident_state` - The incident state that stops the repeat notification.
+      * `repeat_interval` - The repeat notification interval, in minutes.
+  * `subscription` - **NOTE:** This field is only available when `enable_details` is `true`. The subscription setting of the event notify policy.
+    * `filter_setting` - The event content filter.
+      * `conditions` - The filter conditions.
+        * `field` - The field to filter on.
+        * `op` - The comparison operator.
+        * `value` - The value to compare with.
+      * `expression` - The filter expression.
+      * `relation` - The relation between the conditions.
+    * `subscribe_legacy_event` - Indicates whether legacy product events are subscribed.
+    * `workspace_filter_setting` - The cross-workspace event routing setting.
+      * `tag_selector` - The tag selector used to route events across workspaces.
+        * `conditions` - The filter conditions.
+          * `field` - The field to filter on.
+          * `op` - The comparison operator.
+          * `value` - The value to compare with.
+        * `expression` - The filter expression.
+        * `relation` - The relation between the conditions.
+      * `workspace_uuids` - The UUIDs of the workspaces from which events are subscribed.
+  * `update_time` - The last update time of the event notify policy.
+  * `user_id` - The ID of the user that owns the event notify policy.
+  * `uuid` - The UUID of the event notify policy.
+  * `version` - The optimistic lock version of the event notify policy.
+  * `workspace` - The name of the workspace to which the event notify policy belongs.
+  * `id` - The ID of the resource supplied above. The value is formulated as `<uuid>:<workspace>`.

--- a/website/docs/r/cms_event_notify_policy.html.markdown
+++ b/website/docs/r/cms_event_notify_policy.html.markdown
@@ -1,0 +1,250 @@
+---
+subcategory: "Cms"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_event_notify_policy"
+description: |-
+  Provides a Alicloud Cms Event Notify Policy resource.
+---
+
+# alicloud_cms_event_notify_policy
+
+Provides a Cms Event Notify Policy resource.
+
+
+
+For information about Cms Event Notify Policy and how to use it, see [What is Event Notify Policy](https://next.api.alibabacloud.com/document/Cms/2024-03-30/CreateNotifyPolicy).
+
+-> **NOTE:** Available since v1.288.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "random_integer" "default" {
+  min = 10000
+  max = 99999
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = "${var.name}-${random_integer.default.result}"
+  description  = "SLS project bound to a CMS workspace."
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = "${var.name}-${random_integer.default.result}"
+  sls_project    = alicloud_log_project.default.project_name
+}
+
+resource "alicloud_cms_event_notify_policy" "default" {
+  description = "Example event notify policy."
+  response_plan {
+    repeat_notify_setting {
+      end_incident_state = "resolved"
+      repeat_interval    = "30"
+    }
+    auto_recover_seconds = "600"
+  }
+  notify_strategy {
+    description                  = "Example notify strategy."
+    ignore_restored_notification = false
+    grouping_setting {
+      grouping_keys = ["severity"]
+      period_min    = "5"
+      times         = "1"
+      silence_sec   = "300"
+    }
+    routes {
+      effect_time_range {
+        time_zone            = "Asia/Shanghai"
+        start_time_in_minute = "0"
+        end_time_in_minute   = "1439"
+        day_in_week          = ["1", "2", "3", "4", "5"]
+      }
+      channels {
+        receivers            = ["example-contact-group"]
+        channel_type         = "DING"
+        enabled_sub_channels = []
+      }
+    }
+  }
+  subscription {
+    subscribe_legacy_event = true
+    filter_setting {
+      relation = "AND"
+      conditions {
+        field = "severity"
+        op    = "EQ"
+        value = "CRITICAL"
+      }
+    }
+  }
+  workspace = alicloud_cms_workspace.default.workspace_name
+  name      = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `description` - (Optional) The description of the event notify policy.
+* `enabled` - (Optional, Computed) Specifies whether the event notify policy is enabled. If you set this attribute to a value that differs from the current status, the provider calls the enable or disable API of the policy accordingly.
+* `name` - (Optional) The name of the event notify policy.
+* `notify_strategy` - (Optional, Set) The notify strategy of the event notify policy, including event grouping, notify routes, channels and custom templates. See [`notify_strategy`](#notify_strategy) below.
+* `response_plan` - (Optional, Set) The response plan of the event notify policy, including escalation, repeat notify, auto recovery and action integration. See [`response_plan`](#response_plan) below.
+* `subscription` - (Optional, Set) The subscription setting of the event notify policy, including event filtering, cross-workspace routing and the legacy event subscription switch. See [`subscription`](#subscription) below.
+* `workspace` - (Required, ForceNew) The name of the workspace to which the event notify policy belongs. The value must be an existing CloudMonitor workspace name.
+
+### `notify_strategy`
+
+The notify_strategy supports the following:
+* `custom_template_entries` - (Optional, List) The custom notify templates. See [`custom_template_entries`](#notify_strategy-custom_template_entries) below.
+* `description` - (Optional) The description of the notify strategy.
+* `grouping_setting` - (Optional, Set) The event grouping setting. See [`grouping_setting`](#notify_strategy-grouping_setting) below.
+* `ignore_restored_notification` - (Optional, Bool) Specifies whether to ignore the notification when the incident is restored.
+* `routes` - (Optional, List) The notify routes. See [`routes`](#notify_strategy-routes) below.
+
+### `notify_strategy-custom_template_entries`
+
+The notify_strategy-custom_template_entries supports the following:
+* `template_uuid` - (Optional) The UUID of the custom notify template.
+
+### `notify_strategy-grouping_setting`
+
+The notify_strategy-grouping_setting supports the following:
+* `grouping_keys` - (Optional, List) The list of fields by which events are grouped and merged.
+* `period_min` - (Optional, Int) The check period, in minutes.
+* `silence_sec` - (Optional, Int) The silence period, in seconds.
+* `times` - (Optional, Int) The number of occurrences within the check period that triggers a notification.
+
+### `notify_strategy-routes`
+
+The notify_strategy-routes supports the following:
+* `channels` - (Optional, List) The notify channels. See [`channels`](#notify_strategy-routes-channels) below.
+* `digital_employee_name` - (Optional) The name of the digital employee. It is required when `enable_rca` is `true`.
+* `effect_time_range` - (Optional, Set) The effective time range of the route. See [`effect_time_range`](#notify_strategy-routes-effect_time_range) below.
+* `enable_rca` - (Optional, Bool) Specifies whether to enable root cause analysis (RCA).
+* `filter_setting` - (Optional, Set) The route-level event filter. See [`filter_setting`](#notify_strategy-routes-filter_setting) below.
+
+### `notify_strategy-routes-channels`
+
+The notify_strategy-routes-channels supports the following:
+* `channel_type` - (Optional) The type of the notify channel. Valid values: `DING`, `WEIXIN`, `FEISHU`, `SLACK`, `TEAMS`, `WEBHOOK`, `CONTACT`, `GROUP`, `DUTY`, `DING_COOL_APP`. Email, SMS and voice notifications are delivered by setting `channel_type` to `CONTACT` together with `enabled_sub_channels`.
+* `enabled_sub_channels` - (Optional, Set) The enabled notification types. Valid values: `EMAIL`, `SMS`, `VOICE`, `DING`, `WEIXIN`, `FEISHU`, `WEBHOOK`. It is required when `channel_type` is `CONTACT`, `GROUP` or `DUTY`.
+* `receivers` - (Optional, List) The receivers of the channel.
+
+### `notify_strategy-routes-effect_time_range`
+
+The notify_strategy-routes-effect_time_range supports the following:
+* `day_in_week` - (Optional, List) The effective days of the week. Valid values: `0` to `6` (`0` means Sunday and `6` means Saturday). `7` is not supported.
+* `end_time_in_minute` - (Optional, Int) The end time of the range, in minutes from 00:00. Valid values: `0` to `1439`.
+* `start_time_in_minute` - (Optional, Int) The start time of the range, in minutes from 00:00. Valid values: `0` to `1438`.
+* `time_zone` - (Optional) The time zone of the range, such as `Asia/Shanghai`.
+
+### `notify_strategy-routes-filter_setting`
+
+The notify_strategy-routes-filter_setting supports the following:
+* `conditions` - (Optional, List) The filter conditions. See [`conditions`](#notify_strategy-routes-filter_setting-conditions) below.
+* `expression` - (Optional) The filter expression, for example `1 and 2 or 3`.
+* `relation` - (Optional) The relation between the conditions, for example `AND`.
+
+### `notify_strategy-routes-filter_setting-conditions`
+
+The notify_strategy-routes-filter_setting-conditions supports the following:
+* `field` - (Optional) The field to filter on.
+* `op` - (Optional) The comparison operator, for example `EQ`.
+* `value` - (Optional) The value to compare with.
+
+### `response_plan`
+
+The response_plan supports the following:
+* `auto_recover_seconds` - (Optional, Int) The duration, in seconds, after which an incident is automatically recovered when no new event occurs.
+* `escalation_id` - (Optional, List) The IDs of the escalation plans.
+* `pushing_setting` - (Optional, Set) The action integration pushing setting. See [`pushing_setting`](#response_plan-pushing_setting) below.
+* `repeat_notify_setting` - (Optional, Set) The repeat notification setting. See [`repeat_notify_setting`](#response_plan-repeat_notify_setting) below.
+
+### `response_plan-pushing_setting`
+
+The response_plan-pushing_setting supports the following:
+* `alert_action_ids` - (Optional, List) The IDs of the action integrations triggered by alerts.
+* `restore_action_ids` - (Optional, List) The IDs of the action integrations triggered when incidents are restored.
+
+### `response_plan-repeat_notify_setting`
+
+The response_plan-repeat_notify_setting supports the following:
+* `end_incident_state` - (Optional) The incident state that stops the repeat notification, for example `resolved`.
+* `repeat_interval` - (Optional, Int) The repeat notification interval, in minutes.
+
+### `subscription`
+
+The subscription supports the following:
+* `filter_setting` - (Optional, Set) The event content filter. See [`filter_setting`](#subscription-filter_setting) below.
+* `subscribe_legacy_event` - (Optional, Bool) Specifies whether to subscribe to legacy product events (events whose workspace is empty, such as events from CloudMonitor 1.0, ARMS and SLS).
+* `workspace_filter_setting` - (Optional, Set) The cross-workspace event routing setting. See [`workspace_filter_setting`](#subscription-workspace_filter_setting) below.
+
+### `subscription-filter_setting`
+
+The subscription-filter_setting supports the following:
+* `conditions` - (Optional, List) The filter conditions. See [`conditions`](#subscription-filter_setting-conditions) below.
+* `expression` - (Optional) The filter expression, for example `1 and 2 or 3`.
+* `relation` - (Optional) The relation between the conditions, for example `AND`.
+
+### `subscription-workspace_filter_setting`
+
+The subscription-workspace_filter_setting supports the following:
+* `tag_selector` - (Optional, Set) The tag selector used to route events across workspaces. See [`tag_selector`](#subscription-workspace_filter_setting-tag_selector) below.
+* `workspace_uuids` - (Optional, List) The UUIDs of the workspaces from which events are subscribed.
+
+### `subscription-workspace_filter_setting-tag_selector`
+
+The subscription-workspace_filter_setting-tag_selector supports the following:
+* `conditions` - (Optional, List) The filter conditions. See [`conditions`](#subscription-workspace_filter_setting-tag_selector-conditions) below.
+* `expression` - (Optional) The filter expression, for example `1 and 2 or 3`.
+* `relation` - (Optional) The relation between the conditions, for example `AND`.
+
+### `subscription-workspace_filter_setting-tag_selector-conditions`
+
+The subscription-workspace_filter_setting-tag_selector-conditions supports the following:
+* `field` - (Optional) The field to filter on.
+* `op` - (Optional) The comparison operator, for example `EQ`.
+* `value` - (Optional) The value to compare with.
+
+### `subscription-filter_setting-conditions`
+
+The subscription-filter_setting-conditions supports the following:
+* `field` - (Optional) The field to filter on.
+* `op` - (Optional) The comparison operator, for example `EQ`.
+* `value` - (Optional) The value to compare with.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<uuid>:<workspace>`.
+* `create_time` - The creation time of the event notify policy.
+* `update_time` - The last update time of the event notify policy.
+* `user_id` - The ID of the user that owns the event notify policy.
+* `uuid` - The UUID of the event notify policy, generated by the server.
+* `version` - The optimistic lock version of the event notify policy. It is maintained by the provider and sent back on updates; an update fails with an optimistic lock error when the version does not match the current server record.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Event Notify Policy.
+* `delete` - (Defaults to 5 mins) Used when delete the Event Notify Policy.
+* `update` - (Defaults to 5 mins) Used when update the Event Notify Policy.
+
+## Import
+
+Cms Event Notify Policy can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cms_event_notify_policy.example <uuid>:<workspace>
+```


### PR DESCRIPTION
## Summary

- Add the `alicloud_cms_event_notify_policy` resource to manage CloudMonitor (CMS) event notify policies (EventBridge-based), covering the notify strategy (event grouping, notify routes with channels and filters, custom templates), the response plan (escalation, repeat notify, auto recovery, action integration) and the subscription setting (event filters, legacy event switch, cross-workspace routing).
- The resource toggles the policy through the dedicated enable/disable APIs when `enabled` changes, and sends the optimistic-lock `version` together with `uuid` on every update.
- Add the `alicloud_cms_event_notify_policies` data source to query policies in a workspace with optional id/name filters, ordering and pagination.

## Test plan

- [x] `TestAccAliCloudCmsEventNotifyPolicy_basic12980` ... `_basic12990` PASS in cn-hangzhou: create → update (name/description/notify strategy/response plan/subscription variations) → import → destroy, 11 scenarios.
- [x] `TestAccAliCloudCmsEventNotifyPolicy_fullCoverage` PASS in cn-hangzhou (13.72s): full attribute coverage incl. enable/disable toggling, update and import.
- [x] `TestAccAlicloudCmsEventNotifyPolicyDataSource` PASS in cn-hangzhou (22.27s): ids/name exist & fake filters.

```
=== RUN TestAccAliCloudCmsEventNotifyPolicy_basic12980
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12980 (5.03s)

=== RUN TestAccAliCloudCmsEventNotifyPolicy_basic12981
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12981 (8.32s)

=== RUN TestAccAliCloudCmsEventNotifyPolicy_basic12982
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12982 (6.83s)

=== RUN TestAccAliCloudCmsEventNotifyPolicy_basic12983
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12983 (8.26s)

=== RUN TestAccAliCloudCmsEventNotifyPolicy_basic12984
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12984 (15.85s)

=== RUN TestAccAliCloudCmsEventNotifyPolicy_basic12985
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12985 (8.87s)

=== RUN TestAccAliCloudCmsEventNotifyPolicy_basic12986
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12986 (7.96s)

=== RUN TestAccAliCloudCmsEventNotifyPolicy_basic12987
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12987 (8.29s)

=== RUN TestAccAliCloudCmsEventNotifyPolicy_basic12988
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12988 (8.37s)

=== RUN TestAccAliCloudCmsEventNotifyPolicy_basic12989
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12989 (8.38s)

=== RUN TestAccAliCloudCmsEventNotifyPolicy_basic12990
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_basic12990 (8.02s)

=== RUN TestAccAliCloudCmsEventNotifyPolicy_fullCoverage
--- PASS: TestAccAliCloudCmsEventNotifyPolicy_fullCoverage (13.72s)

=== RUN TestAccAlicloudCmsEventNotifyPolicyDataSource
--- PASS: TestAccAlicloudCmsEventNotifyPolicyDataSource (22.27s)
```
