### PR TITLE
New Data Source: alicloud_threat_detection_cspm_check_items

### DIFF
--- a/alicloud/data_source_alicloud_threat_detection_cspm_check_items.go
+++ b/alicloud/data_source_alicloud_threat_detection_cspm_check_items.go
@@ -1,0 +1,268 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudThreatDetectionCspmCheckItems() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudThreatDetectionCspmCheckItemRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"task_sources": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"check_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"check_show_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"check_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"custom_configs": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default_value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type_define": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"show_name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"description": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"estimated_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"instance_sub_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"risk_level": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"section_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+						},
+						"vendor": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudThreatDetectionCspmCheckItemRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListCheckItem"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if v, ok := d.GetOk("task_sources"); ok {
+		taskSourcesMapsArray := convertToInterfaceArray(v)
+
+		request["TaskSources"] = taskSourcesMapsArray
+	}
+
+	request["PageSize"] = PageSizeLarge
+	request["CurrentPage"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.CheckItems[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["CheckId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["CurrentPage"] = request["CurrentPage"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["CheckId"]
+
+		mapping["check_id"] = objectRaw["CheckId"]
+		mapping["check_show_name"] = objectRaw["CheckShowName"]
+		mapping["check_type"] = objectRaw["CheckType"]
+		mapping["estimated_count"] = objectRaw["EstimatedCount"]
+		mapping["instance_sub_type"] = objectRaw["InstanceSubType"]
+		mapping["instance_type"] = objectRaw["InstanceType"]
+		mapping["risk_level"] = objectRaw["RiskLevel"]
+		mapping["vendor"] = objectRaw["Vendor"]
+
+		customConfigsRaw := objectRaw["CustomConfigs"]
+		customConfigsMaps := make([]map[string]interface{}, 0)
+		if customConfigsRaw != nil {
+			for _, customConfigsChildRaw := range convertToInterfaceArray(customConfigsRaw) {
+				customConfigsMap := make(map[string]interface{})
+				customConfigsChildRaw := customConfigsChildRaw.(map[string]interface{})
+				customConfigsMap["default_value"] = customConfigsChildRaw["DefaultValue"]
+				customConfigsMap["name"] = customConfigsChildRaw["Name"]
+				customConfigsMap["show_name"] = customConfigsChildRaw["ShowName"]
+				customConfigsMap["type_define"] = customConfigsChildRaw["TypeDefine"]
+				customConfigsMap["value"] = customConfigsChildRaw["Value"]
+
+				customConfigsMaps = append(customConfigsMaps, customConfigsMap)
+			}
+		}
+		mapping["custom_configs"] = customConfigsMaps
+		descriptionMaps := make([]map[string]interface{}, 0)
+		descriptionMap := make(map[string]interface{})
+		descriptionRaw := make(map[string]interface{})
+		if objectRaw["Description"] != nil {
+			descriptionRaw = objectRaw["Description"].(map[string]interface{})
+		}
+		if len(descriptionRaw) > 0 {
+			descriptionMap["type"] = descriptionRaw["Type"]
+			descriptionMap["value"] = descriptionRaw["Value"]
+
+			descriptionMaps = append(descriptionMaps, descriptionMap)
+		}
+		mapping["description"] = descriptionMaps
+
+		sectionIdsRaw := make([]interface{}, 0)
+		if objectRaw["SectionIds"] != nil {
+			sectionIdsRaw = convertToInterfaceArray(objectRaw["SectionIds"])
+		}
+
+		mapping["section_ids"] = sectionIdsRaw
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("items", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_threat_detection_cspm_check_items_test.go
+++ b/alicloud/data_source_alicloud_threat_detection_cspm_check_items_test.go
@@ -1,0 +1,79 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+// NOTE: Test depends on data source or hardcoded are not stable and may fail at any time
+// Uninitialized resource; assumes the resource already exists.
+
+func TestAccAliCloudThreatDetectionCspmCheckItemsDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	pagingConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudThreatDetectionCspmCheckItemSourceConfig(rand, map[string]string{
+			"output_file": `"./tf-testacc-threat-detection-cspm-check-items.txt"`,
+		}),
+		fakeConfig: testAccCheckAlicloudThreatDetectionCspmCheckItemSourceConfig(rand, map[string]string{
+			"ids":          `["fake-id-not-exist"]`,
+			"task_sources": `["fake-task-source-not-exist"]`,
+		}),
+	}
+
+	preCheck := func() {
+		testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	}
+	ThreatDetectionCspmCheckItemCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, pagingConf)
+}
+
+var existThreatDetectionCspmCheckItemMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"items.#":                   CHECKSET,
+		"items.0.id":                CHECKSET,
+		"items.0.check_id":          CHECKSET,
+		"items.0.check_show_name":   CHECKSET,
+		"items.0.check_type":        CHECKSET,
+		"items.0.custom_configs.#":  CHECKSET,
+		"items.0.description.#":     CHECKSET,
+		"items.0.estimated_count":   CHECKSET,
+		"items.0.instance_sub_type": CHECKSET,
+		"items.0.instance_type":     CHECKSET,
+		"items.0.risk_level":        CHECKSET,
+		"items.0.section_ids.#":     CHECKSET,
+		"items.0.vendor":            CHECKSET,
+	}
+}
+
+var fakeThreatDetectionCspmCheckItemMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"items.#": "0",
+	}
+}
+
+var ThreatDetectionCspmCheckItemCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_threat_detection_cspm_check_items.default",
+	existMapFunc: existThreatDetectionCspmCheckItemMapFunc,
+	fakeMapFunc:  fakeThreatDetectionCspmCheckItemMapFunc,
+}
+
+func testAccCheckAlicloudThreatDetectionCspmCheckItemSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+  default = "tf-testAccThreatDetectionCspmCheckItem%d"
+}
+
+data "alicloud_threat_detection_cspm_check_items" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -947,6 +947,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
 			"alicloud_das_sql_log_configs":                              dataSourceAliCloudDasSqlLogConfigs(),
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
+			"alicloud_threat_detection_cspm_check_items":                dataSourceAliCloudThreatDetectionCspmCheckItems(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),

--- a/alicloud/service_alicloud_threat_detection_v2.go
+++ b/alicloud/service_alicloud_threat_detection_v2.go
@@ -1465,3 +1465,87 @@ func (s *ThreatDetectionServiceV2) DescribeAsyncDescribeServiceLinkedRoleStatus(
 }
 
 // DescribeAsyncDescribeServiceLinkedRoleStatus >>> Encapsulated.
+
+// DescribeThreatDetectionCspmCheckItem <<< Encapsulated get interface for ThreatDetection CspmCheckItem.
+
+func (s *ThreatDetectionServiceV2) DescribeThreatDetectionCspmCheckItem(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	action := "ListCheckItem"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.CheckItems[*]", response)
+	if err != nil {
+		return object, WrapErrorf(NotFoundErr("CspmCheckItem", id), NotFoundMsg, response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("CspmCheckItem", id), NotFoundMsg, response)
+	}
+
+	result, _ := v.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		if fmt.Sprint(item["CheckId"]) != id {
+			continue
+		}
+		return item, nil
+	}
+	return object, WrapErrorf(NotFoundErr("CspmCheckItem", id), NotFoundMsg, response)
+}
+
+func (s *ThreatDetectionServiceV2) ThreatDetectionCspmCheckItemStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ThreatDetectionCspmCheckItemStateRefreshFuncWithApi(id, field, failStates, s.DescribeThreatDetectionCspmCheckItem)
+}
+
+func (s *ThreatDetectionServiceV2) ThreatDetectionCspmCheckItemStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeThreatDetectionCspmCheckItem >>> Encapsulated.

--- a/website/docs/d/threat_detection_cspm_check_items.html.markdown
+++ b/website/docs/d/threat_detection_cspm_check_items.html.markdown
@@ -1,0 +1,87 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_cspm_check_items"
+sidebar_current: "docs-alicloud-datasource-threat-detection-cspm-check-items"
+description: |-
+  Provides a list of Threat Detection Cspm Check Items owned by an Alibaba Cloud account.
+---
+
+# alicloud_threat_detection_cspm_check_items
+
+This data source provides the Threat Detection Cspm Check Items of the current Alibaba Cloud account.
+
+-> **NOTE:** Available since v1.288.0.
+
+## Example Usage
+
+```terraform
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+data "alicloud_threat_detection_cspm_check_items" "default" {
+}
+
+output "alicloud_threat_detection_cspm_check_item_example_check_id" {
+  value = data.alicloud_threat_detection_cspm_check_items.default.items.0.check_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `task_sources` - (Optional, List) The list of task sources.
+* `ids` - (Optional, Computed, List) A list of check item IDs.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `items` - A list of Cspm Check Items. Each element contains the following attributes:
+  * `id` - The ID of the check item.
+  * `check_id` - The ID of the check item.
+  * `check_show_name` - The name of the check item.
+  * `check_type` - The source type of the Situation Awareness check item. Valid values: `CUSTOM` (user-defined), `SYSTEM` (predefined by the situational awareness platform).
+  * `custom_configs` - The custom configuration items of the check item.
+    * `default_value` - The default value of the custom configuration item. The value is a string.
+    * `name` - The name of the custom configuration item, which is unique in a check item.
+    * `show_name` - The display name of the custom configuration item for internationalization.
+    * `type_define` - The type of the custom configuration item. The value is a JSON string.
+    * `value` - The value of the custom configuration item. The value is a string.
+  * `description` - The description of the check item.
+    * `type` - The type of the description of the check item. Valid value: `text`.
+    * `value` - The content of the description for the check item when the Type parameter is text.
+  * `estimated_count` - The estimated quota that will be consumed by this check item.
+  * `instance_sub_type` - The asset subtype of the cloud service. Valid values depend on `instance_type`:
+    * If `instance_type` is set to `ECS`, this parameter supports the following valid values: `INSTANCE`, `DISK`, `SECURITY_GROUP`.
+    * If `instance_type` is set to `ACR`, this parameter supports the following valid values: `REPOSITORY_ENTERPRISE`, `REPOSITORY_PERSON`.
+    * If `instance_type` is set to `RAM`, this parameter supports the following valid values: `ALIAS`, `USER`, `POLICY`, `GROUP`.
+    * If `instance_type` is set to `WAF`, this parameter supports the following valid value: `DOMAIN`.
+    * If `instance_type` is set to other values, this parameter supports the following valid value: `INSTANCE`.
+  * `instance_type` - The asset type of the cloud service. Valid values:
+    * `ECS`: Elastic Compute Service (ECS).
+    * `SLB`: Server Load Balancer (SLB).
+    * `RDS`: ApsaraDB RDS.
+    * `MONGODB`: ApsaraDB for MongoDB (MongoDB).
+    * `KVSTORE`: ApsaraDB for Redis (Redis).
+    * `ACR`: Container Registry.
+    * `CSK`: Container Service for Kubernetes (ACK).
+    * `VPC`: Virtual Private Cloud (VPC).
+    * `ACTIONTRAIL`: ActionTrail.
+    * `CDN`: Alibaba Cloud CDN (CDN).
+    * `CAS`: Certificate Management Service (formerly SSL Certificates Service).
+    * `RDC`: Apsara Devops.
+    * `RAM`: Resource Access Management (RAM).
+    * `DDOS`: Anti-DDoS.
+    * `WAF`: Web Application Firewall (WAF).
+    * `OSS`: Object Storage Service (OSS).
+    * `POLARDB`: PolarDB.
+    * `POSTGRESQL`: ApsaraDB RDS for PostgreSQL.
+    * `MSE`: Microservices Engine (MSE).
+    * `NAS`: File Storage NAS (NAS).
+    * `SDDP`: Sensitive Data Discovery and Protection (SDDP).
+    * `EIP`: Elastic IP Address (EIP).
+  * `risk_level` - The risk level of the check item. Valid values: `HIGH`, `MEDIUM`, `LOW`.
+  * `section_ids` - The IDs of the sections associated with the check items.
+  * `vendor` - The type of the cloud asset. Valid values: `0` (an asset provided by Alibaba Cloud), `1` (an asset outside Alibaba Cloud), `2` (an asset in a data center), `3`, `4`, `5`, `7` (other cloud asset), `8` (a simple application server).


### PR DESCRIPTION
### Summary

Adds a new data source `alicloud_threat_detection_cspm_check_items` for Security Center (Threat Detection), exposing the CSPM (cloud security posture management) check items of the account via the `ListCheckItem` API.

- Read-only data source that pages through `ListCheckItem` and returns all check items.
- Supports filtering by `ids` (check item IDs) and `task_sources`.
- Exposes check item metadata: `check_id`, `check_show_name`, `check_type`, `risk_level`, `vendor`, `instance_type`, `instance_sub_type`, `section_ids`, `estimated_count`, `custom_configs` and `description`.

### Test plan

Remote acceptance test run against `cn-hangzhou` (the data source reads existing account state and creates nothing):

```
=== RUN   TestAccAliCloudThreatDetectionCspmCheckItemsDataSource
--- PASS: TestAccAliCloudThreatDetectionCspmCheckItemsDataSource (30.47s)
```

- [x] `TestAccAliCloudThreatDetectionCspmCheckItemsDataSource` PASS (30.47s): exist case with `output_file` plus a fake `ids` / `task_sources` filter case asserting `items.# = 0`.
