### PR TITLE
resource/alicloud_gpdb_instance: support modifying serverless_resource and cache_storage_size in place

### DIFF
--- a/alicloud/resource_alicloud_gpdb_instance.go
+++ b/alicloud/resource_alicloud_gpdb_instance.go
@@ -210,13 +210,11 @@ func resourceAliCloudGpdbInstance() *schema.Resource {
 			"serverless_resource": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"cache_storage_size": {
 				Type:     schema.TypeInt,
 				Optional: true,
-				ForceNew: true,
 				Computed: true,
 			},
 			"prod_type": {
@@ -825,7 +823,7 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 		// reporting the previous PayType until the conversion order takes effect, so also wait
 		// until the new value is actually applied to avoid Read observing the stale value.
 		paymentTypeTarget := fmt.Sprint(convertGpdbDbInstancePaymentTypeRequest(newPaymentType.(string)))
-		paymentTypeStateConf := BuildStateConf([]string{}, []string{paymentTypeTarget}, d.Timeout(schema.TimeoutUpdate), 30*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "PayType", paymentTypeTarget))
+		paymentTypeStateConf := BuildStateConf([]string{}, []string{paymentTypeTarget}, d.Timeout(schema.TimeoutUpdate), 30*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "PayType", paymentTypeTarget, []string{"Running"}))
 		if _, err := paymentTypeStateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
@@ -1124,7 +1122,7 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 		// for a short window before the resize takes effect, so also wait until the new value
 		// is actually applied to avoid Read observing the stale value.
 		segNodeNumTarget := fmt.Sprint(d.Get("seg_node_num"))
-		segNodeNumStateConf := BuildStateConf([]string{}, []string{segNodeNumTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "SegNodeNum", segNodeNumTarget))
+		segNodeNumStateConf := BuildStateConf([]string{}, []string{segNodeNumTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "SegNodeNum", segNodeNumTarget, []string{"Running"}))
 		if _, err := segNodeNumStateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
@@ -1175,7 +1173,7 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 		// for a short window before the resize takes effect, so also wait until the new value
 		// is actually applied to avoid Read observing the stale value.
 		masterNodeNumTarget := fmt.Sprint(d.Get("master_node_num"))
-		masterNodeNumStateConf := BuildStateConf([]string{}, []string{masterNodeNumTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "MasterNodeNum", masterNodeNumTarget))
+		masterNodeNumStateConf := BuildStateConf([]string{}, []string{masterNodeNumTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "MasterNodeNum", masterNodeNumTarget, []string{"Running"}))
 		if _, err := masterNodeNumStateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
@@ -1221,7 +1219,7 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 		// for a short window before the resize takes effect, so also wait until the new value
 		// is actually applied to avoid Read observing the stale value.
 		instanceSpecTarget := fmt.Sprint(d.Get("instance_spec"))
-		instanceSpecStateConf := BuildStateConf([]string{}, []string{instanceSpecTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "InstanceSpec", instanceSpecTarget))
+		instanceSpecStateConf := BuildStateConf([]string{}, []string{instanceSpecTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "InstanceSpec", instanceSpecTarget, []string{"Running"}))
 		if _, err := instanceSpecStateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
@@ -1269,12 +1267,77 @@ func resourceAliCloudGpdbDbInstanceUpdate(d *schema.ResourceData, meta interface
 		// for a short window before the resize takes effect, so also wait until the new value
 		// is actually applied to avoid Read observing the stale value.
 		storageSizeTarget := fmt.Sprint(d.Get("storage_size"))
-		storageSizeStateConf := BuildStateConf([]string{}, []string{storageSizeTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "StorageSize", storageSizeTarget))
+		storageSizeStateConf := BuildStateConf([]string{}, []string{storageSizeTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "StorageSize", storageSizeTarget, []string{"Running"}))
 		if _, err := storageSizeStateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
 
 		d.SetPartial("storage_size")
+	}
+
+	update = false
+	request = map[string]interface{}{
+		"DBInstanceId": d.Id(),
+	}
+	request["RegionId"] = client.RegionId
+	if !d.IsNewResource() && (d.HasChange("serverless_resource") || d.HasChange("cache_storage_size")) {
+		update = true
+		request["UpgradeType"] = 1
+		// The API requires the current reserved computing resource to be sent along with
+		// any cache storage change, so always include serverless_resource when it is set.
+		if v, ok := d.GetOk("serverless_resource"); ok {
+			request["ServerlessResource"] = strconv.Itoa(v.(int))
+		}
+		if v, ok := d.GetOk("cache_storage_size"); ok {
+			request["CacheStorageSize"] = strconv.Itoa(v.(int))
+		}
+	}
+
+	if update {
+		action := "UpgradeDBInstance"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
+			response, err = client.RpcPost("gpdb", "2016-05-03", action, nil, request, true)
+			if err != nil {
+				if IsExpectedErrors(err, []string{"OperationDenied.OrderProcessing"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		stateConf := BuildStateConf([]string{}, []string{"Running", "IDLE"}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceStateRefreshFunc(d.Id(), "DBInstanceStatus", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+
+		// UpgradeDBInstance scaling is asynchronous and the instance keeps reporting Running
+		// (or IDLE for ServerlessPro instances) for a short window before the resize takes
+		// effect, so also wait until the new values are actually applied to avoid Read
+		// observing the stale values.
+		if d.HasChange("serverless_resource") {
+			serverlessResourceTarget := fmt.Sprint(d.Get("serverless_resource"))
+			serverlessResourceStateConf := BuildStateConf([]string{}, []string{serverlessResourceTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "ServerlessResource", serverlessResourceTarget, []string{"Running", "IDLE"}))
+			if _, err := serverlessResourceStateConf.WaitForState(); err != nil {
+				return WrapErrorf(err, IdMsg, d.Id())
+			}
+		}
+		if d.HasChange("cache_storage_size") {
+			cacheStorageSizeTarget := fmt.Sprint(d.Get("cache_storage_size"))
+			cacheStorageSizeStateConf := BuildStateConf([]string{}, []string{cacheStorageSizeTarget}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, gpdbService.GpdbDbInstanceScaleStateRefreshFunc(d.Id(), "CacheStorageSize", cacheStorageSizeTarget, []string{"Running", "IDLE"}))
+			if _, err := cacheStorageSizeStateConf.WaitForState(); err != nil {
+				return WrapErrorf(err, IdMsg, d.Id())
+			}
+		}
+
+		d.SetPartial("serverless_resource")
+		d.SetPartial("cache_storage_size")
 	}
 
 	update = false

--- a/alicloud/resource_alicloud_gpdb_instance_test.go
+++ b/alicloud/resource_alicloud_gpdb_instance_test.go
@@ -914,6 +914,28 @@ func TestAccAliCloudGPDBDBInstanceServerlessPro(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"serverless_resource": "32",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"serverless_resource": "32",
+						"cache_storage_size":  "800",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"cache_storage_size": "1600",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"serverless_resource": "32",
+						"cache_storage_size":  "1600",
+					}),
+				),
+			},
+			{
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/alicloud/service_alicloud_gpdb.go
+++ b/alicloud/service_alicloud_gpdb.go
@@ -773,11 +773,13 @@ func (s *GpdbService) GpdbDbInstanceStateRefreshFunc(id string, field string, fa
 }
 
 // GpdbDbInstanceScaleStateRefreshFunc waits until a DescribeDBInstanceAttribute scalar field
-// reaches the expected value while the instance is back to Running. UpgradeDBInstance scaling
-// is asynchronous: the instance keeps reporting Running for a short window before it transitions
-// into the scaling state, so waiting only for Running can return before the new value is applied
-// and leave Read observing the stale value.
-func (s *GpdbService) GpdbDbInstanceScaleStateRefreshFunc(id, field, target string) resource.StateRefreshFunc {
+// reaches the expected value while the instance is back to one of the stable statuses.
+// UpgradeDBInstance scaling is asynchronous: the instance keeps reporting a stable status for
+// a short window before it transitions into the scaling state, so waiting only for the status
+// can return before the new value is applied and leave Read observing the stale value.
+// Most instances settle in Running after scaling, while ServerlessPro instances may settle
+// in Running or IDLE.
+func (s *GpdbService) GpdbDbInstanceScaleStateRefreshFunc(id, field, target string, stableStatuses []string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		object, err := s.DescribeGpdbDbInstance(id)
 		if err != nil {
@@ -791,8 +793,10 @@ func (s *GpdbService) GpdbDbInstanceScaleStateRefreshFunc(id, field, target stri
 		if _, ok := object[field].(float64); ok {
 			current = fmt.Sprint(formatInt(object[field]))
 		}
-		if status == "Running" && current == target {
-			return object, target, nil
+		for _, stableStatus := range stableStatuses {
+			if status == stableStatus && current == target {
+				return object, target, nil
+			}
 		}
 		// Not settled yet: report a non-target state so the waiter keeps polling.
 		return object, fmt.Sprintf("%s/%s", status, current), nil

--- a/website/docs/r/gpdb_instance.html.markdown
+++ b/website/docs/r/gpdb_instance.html.markdown
@@ -133,8 +133,8 @@ The following arguments are supported:
 * `maintain_end_time` - (Optional) The end time of the maintenance window for the instance. in the format of HH:mmZ (UTC time), for example 03:00Z. start time should be later than end time.
 * `resource_management_mode` - (Optional, Available since v1.225.0) Resource management mode. Valid values: `resourceGroup`, `resourceQueue`.
 * `serverless_mode` - (Optional, ForceNew, Available since v1.233.1) The mode of the Serverless instance. Valid values: `Manual`, `Auto`. **NOTE:** `serverless_mode` is valid only when `db_instance_mode` is set to `Serverless`.
-* `serverless_resource` - (Optional, ForceNew, Int, Available since v1.287.0) The computing resource threshold, in ACU. Valid values: `16` to `1024`. **NOTE:** `serverless_resource` is valid only when `db_instance_mode` is set to `ServerlessPro`.
-* `cache_storage_size` - (Optional, ForceNew, Int, Available since v1.287.0) The cache storage size, in GB. Valid values: `800` to `102400`. **NOTE:** `cache_storage_size` is valid only when `db_instance_mode` is set to `ServerlessPro`.
+* `serverless_resource` - (Optional, Int, Available since v1.287.0) The computing resource threshold, in ACU. Valid values: `16` to `1024`. **NOTE:** `serverless_resource` is valid only when `db_instance_mode` is set to `ServerlessPro`. The value can be modified in place for `ServerlessPro` instances.
+* `cache_storage_size` - (Optional, Int, Available since v1.287.0) The cache storage size, in GB. Valid values: `800` to `102400`. **NOTE:** `cache_storage_size` is valid only when `db_instance_mode` is set to `ServerlessPro`. The value can be modified in place for `ServerlessPro` instances.
 * `prod_type` - (Optional, ForceNew, Available since v1.233.1) The type of the product. Default value: `standard`. Valid values: `standard`, `cost-effective`.
 * `data_share_status` - (Optional, Available since v1.233.1) Specifies whether to enable or disable data sharing. Default value: `closed`. Valid values:
   - `opened`: Enables data sharing.


### PR DESCRIPTION
## Summary
- `serverless_resource` and `cache_storage_size` of `alicloud_gpdb_instance` were previously `ForceNew`; changing either of them destroyed and recreated the whole instance. This change makes both attributes updatable in place for `ServerlessPro` instances.
- The Update path calls `UpgradeDBInstance` with `UpgradeType=1`, carrying `ServerlessResource` and `CacheStorageSize`. The current `serverless_resource` value is always sent along when only `cache_storage_size` changes, as required by the API.
- After the upgrade call, the provider waits for the instance to return to a stable status (`Running`, or `IDLE` for `ServerlessPro` instances) and for the new values to be reported by `DescribeDBInstanceAttribute`, so that Read does not observe stale values. The scale state refresh helper now accepts the stable statuses.
- Documentation updated: both attributes are no longer marked ForceNew.

## Test plan
- [x] Remote acceptance test `TestAccAliCloudGPDBDBInstanceServerlessPro` PASS in cn-hangzhou (771.42s): create `ServerlessPro` instance (`serverless_resource=16`, `cache_storage_size=800`) → update `serverless_resource` to `32` in place → update `cache_storage_size` to `1600` in place → import verify → destroy. Both updates invoked `UpgradeDBInstance`(`UpgradeType=1`) without recreating the instance.

```
=== RUN   TestAccAliCloudGPDBDBInstanceServerlessPro
--- PASS: TestAccAliCloudGPDBDBInstanceServerlessPro (771.42s)
```