### PR TITLE
resource/alicloud_kms_value_added_service: fix recreating on every plan

### DIFF
--- a/alicloud/resource_alicloud_kms_value_added_service.go
+++ b/alicloud/resource_alicloud_kms_value_added_service.go
@@ -1,15 +1,33 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/PaesslerAG/jsonpath"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// kmsValueAddedServiceAlreadyHeldMsg explains an order that is accepted but never becomes an
+// effective instance because the account already holds the service.
+const kmsValueAddedServiceAlreadyHeldMsg = "This account may already hold this value added service - " +
+	"it can be purchased only once while it is in effect, and a duplicate order is refunded immediately. " +
+	"Check the KMS console and, if the service is already in effect, import it with " +
+	"'terraform import alicloud_kms_value_added_service.<name> <instance_id>' instead of creating it."
+
+// Default key rotation is the one value added service this resource supports, and it mints instance
+// ids under a prefix of its own, so an existing instance of it can be recognised before ordering a
+// duplicate that would only be refunded. The prefix is checked only for this service: the expert
+// service shares the 'kst-' prefix with alicloud_kms_instance, so a prefix match there would refuse a
+// create over an unrelated KMS instance, and a wrong refusal leaves the user no way forward.
+const (
+	// The status an instance reaches once the service is actually in effect. Shared by the create wait and
+	// the already-held pre-flight so the two cannot disagree about what "held" means.
+	kmsValueAddedServiceEffectiveStatus = "Normal"
 )
 
 func resourceAliCloudKmsValueAddedService() *schema.Resource {
@@ -22,9 +40,9 @@ func resourceAliCloudKmsValueAddedService() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"create_time": {
@@ -70,7 +88,6 @@ func resourceAliCloudKmsValueAddedService() *schema.Resource {
 func resourceAliCloudKmsValueAddedServiceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	client := meta.(*connectivity.AliyunClient)
-
 	action := "CreateInstance"
 	var request map[string]interface{}
 	var response map[string]interface{}
@@ -81,6 +98,9 @@ func resourceAliCloudKmsValueAddedServiceCreate(d *schema.ResourceData, meta int
 	request["ClientToken"] = buildClientToken(action)
 
 	request["SubscriptionType"] = "Subscription"
+	if v, ok := d.GetOk("payment_type"); ok {
+		request["SubscriptionType"] = v.(string)
+	}
 	if v, ok := d.GetOk("renew_status"); ok {
 		request["RenewalStatus"] = v
 	}
@@ -119,6 +139,36 @@ func resourceAliCloudKmsValueAddedServiceCreate(d *schema.ResourceData, meta int
 			request["ProductType"] = "kms_ppi_public_intl"
 		}
 	}
+	kmsServiceV2 := KmsServiceV2{client}
+
+	// Ordering a value added service the account already holds is accepted and then refunded rather than
+	// rejected, so nothing about the order itself reveals the duplicate. Recognising the existing instance
+	// by its id prefix turns that into an immediate, actionable failure instead of a refunded order and a
+	// wait that can only end in the same message.
+	//
+	// Only an instance that is actually in effect counts. The prefix matches every instance the service
+	// ever minted, including ones that hold nothing: a refunded order from an earlier apply lingers in
+	// Creating for minutes, and an expired one stays listed. Refusing on those would block a create that
+	// the account is entitled to make, and a wrong refusal leaves the user no way forward - which is worse
+	// than the refunded order this check exists to avoid, because the wait below still catches that.
+	if d.Get("value_added_service").(string) == "2" {
+		instances, err := kmsServiceV2.ListKmsValueAddedServiceInstancesByPrefix("dkr-")
+		if err != nil {
+			return WrapError(err)
+		}
+		now := time.Now()
+		heldIds := make([]string, 0)
+		for _, instance := range instances {
+			if kmsValueAddedServiceInEffect(instance, now) {
+				heldIds = append(heldIds, fmt.Sprint(instance["InstanceID"]))
+			}
+		}
+		if len(heldIds) > 0 {
+			return WrapError(Error("the account already holds this value added service in %s as instance %s. "+
+				kmsValueAddedServiceAlreadyHeldMsg, client.RegionId, strings.Join(heldIds, ", ")))
+		}
+	}
+
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPostWithEndpoint("BssOpenApi", "2017-12-14", action, query, request, true, endpoint)
@@ -145,9 +195,34 @@ func resourceAliCloudKmsValueAddedServiceCreate(d *schema.ResourceData, meta int
 		return WrapErrorf(err, DefaultErrorMsg, "alicloud_kms_value_added_service", action, AlibabaCloudSdkGoERROR)
 	}
 
-	id, _ := jsonpath.Get("$.Data.InstanceId", response)
-	d.SetId(fmt.Sprint(id))
+	// BssOpenApi reports business failures in the response body with a 200 status code, so err alone
+	// does not tell whether the order succeeded.
+	if fmt.Sprint(response["Success"]) != "true" {
+		return WrapError(Error("%s failed, response: %v", action, response))
+	}
 
+	id, _ := jsonpath.Get("$.Data.InstanceId", response)
+	if id == nil || fmt.Sprint(id) == "" {
+		return WrapError(Error("%s did not return an instance id, response: %v", action, response))
+	}
+
+	// A duplicate order for a service the account already holds is accepted and then refunded, and the
+	// refunded instance stays in Creating and later drops out of the available instance list, which would
+	// make Read clear the id and the next plan order yet another refunded instance. Waiting for the
+	// instance to actually become effective is what keeps that loop from starting, and it stays as the
+	// backstop for whatever the prefix pre-flight above cannot see: a service ordered under a different
+	// code, or a concurrent create in the same region.
+	//
+	// The wait runs on the ordered id rather than d.Id(), which is only set once the instance is known to
+	// be effective, so a refunded order never reaches the state and leaves nothing to taint.
+	orderedId := fmt.Sprint(id)
+	refresh := kmsValueAddedServiceRefundedRefreshFunc(kmsServiceV2.KmsValueAddedServiceStateRefreshFunc(orderedId, "$.Status", []string{}))
+	stateConf := BuildStateConf([]string{}, []string{kmsValueAddedServiceEffectiveStatus}, d.Timeout(schema.TimeoutCreate), 5*time.Second, refresh)
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapError(Error("The ordered value added service %s did not become effective: %s. "+kmsValueAddedServiceAlreadyHeldMsg, orderedId, err))
+	}
+
+	d.SetId(orderedId)
 	return resourceAliCloudKmsValueAddedServiceRead(d, meta)
 }
 
@@ -168,7 +243,11 @@ func resourceAliCloudKmsValueAddedServiceRead(d *schema.ResourceData, meta inter
 	d.Set("create_time", objectRaw["CreateTime"])
 	d.Set("payment_type", objectRaw["SubscriptionType"])
 	d.Set("region_id", objectRaw["Region"])
-	d.Set("renew_period", formatInt(convertKmsValueAddedServiceDataInstanceListRenewalDurationResponse(objectRaw["RenewalDuration"])))
+	// RenewalDuration is omitted unless the instance is automatically renewed, and formatInt panics on
+	// the missing value, so keep whatever the state already holds.
+	if v, ok := objectRaw["RenewalDuration"]; ok && v != nil {
+		d.Set("renew_period", formatInt(convertKmsValueAddedServiceDataInstanceListRenewalDurationResponse(v)))
+	}
 	d.Set("renew_status", objectRaw["RenewStatus"])
 	d.Set("status", objectRaw["Status"])
 
@@ -303,6 +382,58 @@ func resourceAliCloudKmsValueAddedServiceDelete(d *schema.ResourceData, meta int
 	}
 
 	return nil
+}
+
+// kmsValueAddedServiceRefundedRefreshFunc wraps a state refresh so that an instance which disappears
+// after having been listed is reported as an error instead of being waited out. An automatically
+// refunded order leaves exactly that trace: the instance is listed as Creating for a few minutes, then
+// drops out once the refund settles, and it never reaches Normal. Failing on the disappearance keeps a
+// create from sitting on the timeout for an outcome that is already decided, which matters because
+// BssOpenApi gives no bound on how long a genuine order takes to become effective, so that timeout has
+// to stay generous.
+//
+// The instance has to have been seen first. An id that is not listed yet right after the order is
+// indistinguishable from one that never will be, and treating that as failure would break a create
+// whose instance simply takes a moment to appear.
+// kmsValueAddedServiceInEffect reports whether a listed instance holds the service right now. Status is
+// not enough on its own: BssOpenApi keeps listing an instance after its subscription lapses, so an
+// expired one can still read as Normal, and treating that as held would refuse a create the account is
+// entitled to make. The subscription end has to be a real timestamp in the future as well.
+//
+// An EndTime that is absent or unparseable counts as not in effect. That direction is deliberate: it
+// can cost at most a duplicate order, which the create wait catches and which BssOpenApi refunds by
+// itself, whereas the opposite would block the create with nothing the user can do about it.
+func kmsValueAddedServiceInEffect(instance map[string]interface{}, now time.Time) bool {
+	if fmt.Sprint(instance["Status"]) != kmsValueAddedServiceEffectiveStatus {
+		return false
+	}
+	endTime, ok := instance["EndTime"]
+	if !ok || endTime == nil || fmt.Sprint(endTime) == "" {
+		log.Printf("[WARN] alicloud_kms_value_added_service instance %v reports no EndTime, treating it as not in effect", instance["InstanceID"])
+		return false
+	}
+	// EndTime arrives as RFC3339, for example 2027-08-04T16:00:00Z.
+	end, err := time.Parse(time.RFC3339, fmt.Sprint(endTime))
+	if err != nil {
+		log.Printf("[WARN] alicloud_kms_value_added_service could not parse the EndTime %v of instance %v, treating it as not in effect: %s", endTime, instance["InstanceID"], err)
+		return false
+	}
+	return end.After(now)
+}
+
+func kmsValueAddedServiceRefundedRefreshFunc(refresh resource.StateRefreshFunc) resource.StateRefreshFunc {
+	listed := false
+	return func() (interface{}, string, error) {
+		object, state, err := refresh()
+		if err != nil || state != "" {
+			listed = listed || state != ""
+			return object, state, err
+		}
+		if listed {
+			return object, state, WrapError(Error("the instance is no longer available, which means its order was refunded"))
+		}
+		return object, state, nil
+	}
 }
 
 func convertKmsValueAddedServiceDataInstanceListRenewalDurationResponse(source interface{}) interface{} {

--- a/alicloud/resource_alicloud_kms_value_added_service_test.go
+++ b/alicloud/resource_alicloud_kms_value_added_service_test.go
@@ -1,13 +1,16 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 // Test Kms ValueAddedService. >>> Resource test cases, automatically generated.
@@ -90,11 +93,327 @@ var AlicloudKmsValueAddedServiceMap11636 = map[string]string{
 func AlicloudKmsValueAddedServiceBasicDependence11636(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
-    default = "%s"
-}
-
-
-`, name)
+  default = "%s"
+}`, name)
 }
 
 // Test Kms ValueAddedService. <<< Resource test cases, automatically generated.
+
+// TestAccAliCloudKmsValueAddedService_duplicateOrder reproduces the recreate-on-every-plan report. The
+// loop needs the account to already hold the service, so it cannot be reached from a single resource on
+// a clean account: it takes a second resource with the same config, which is what a duplicate order
+// actually looks like.
+//
+// Both resources are declared in one config with no dependency between them, so Terraform creates them
+// concurrently and either guard may be the one that fires - the pre-flight, if the first order is
+// already effective by the time the second one checks, or the create wait, if both checks run before
+// either order lands and the loser's order is refunded. Whichever it is, the create has to fail with
+// the shared already-held message instead of writing the refunded instance into state, which is what
+// used to start the loop. Asserting on the message the two guards share is what keeps that stable.
+func TestAccAliCloudKmsValueAddedService_duplicateOrder(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKmsValueAddedServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccKmsValueAddedServiceDuplicateConfig(),
+				ExpectError: regexp.MustCompile("This account may already hold this value added service"),
+			},
+		},
+	})
+}
+
+func testAccKmsValueAddedServiceConfig() string {
+	return `
+resource "alicloud_kms_value_added_service" "default" {
+  value_added_service = "2"
+  payment_type        = "Subscription"
+  period              = "1"
+  renew_period        = "1"
+  renew_status        = "AutoRenewal"
+}
+`
+}
+
+func testAccKmsValueAddedServiceDuplicateConfig() string {
+	return testAccKmsValueAddedServiceConfig() + `
+resource "alicloud_kms_value_added_service" "duplicate" {
+  value_added_service = "2"
+  payment_type        = "Subscription"
+  period              = "1"
+  renew_period        = "1"
+  renew_status        = "AutoRenewal"
+}
+`
+}
+
+// TestUnitKmsValueAddedServiceInEffect pins which listed instances count as holding the service. The
+// cases that matter are the ones that must NOT count: refusing a create over any of them would leave
+// the user with no way to proceed, while letting a duplicate order through only costs an order that
+// BssOpenApi refunds by itself and that the create wait already catches.
+func TestUnitKmsValueAddedServiceInEffect(t *testing.T) {
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name     string
+		instance map[string]interface{}
+		expected bool
+	}{
+		{
+			name:     "effective with a future end",
+			instance: map[string]interface{}{"InstanceID": "dkr-1", "Status": "Normal", "EndTime": "2027-08-04T16:00:00Z"},
+			expected: true,
+		},
+		{
+			name:     "end exactly one second away still counts",
+			instance: map[string]interface{}{"InstanceID": "dkr-2", "Status": "Normal", "EndTime": "2026-08-04T12:00:01Z"},
+			expected: true,
+		},
+		{
+			name:     "end exactly at now has lapsed",
+			instance: map[string]interface{}{"InstanceID": "dkr-8", "Status": "Normal", "EndTime": "2026-08-04T12:00:00Z"},
+			expected: false,
+		},
+		{
+			name:     "expired subscription still reported as Normal",
+			instance: map[string]interface{}{"InstanceID": "dkr-3", "Status": "Normal", "EndTime": "2025-08-04T16:00:00Z"},
+			expected: false,
+		},
+		{
+			name:     "refunded order lingering in Creating",
+			instance: map[string]interface{}{"InstanceID": "dkr-4", "Status": "Creating", "EndTime": "2999-09-08T16:00:00Z"},
+			expected: false,
+		},
+		{
+			name:     "no EndTime reported",
+			instance: map[string]interface{}{"InstanceID": "dkr-5", "Status": "Normal"},
+			expected: false,
+		},
+		{
+			name:     "nil EndTime",
+			instance: map[string]interface{}{"InstanceID": "dkr-6", "Status": "Normal", "EndTime": nil},
+			expected: false,
+		},
+		{
+			name:     "unparseable EndTime",
+			instance: map[string]interface{}{"InstanceID": "dkr-7", "Status": "Normal", "EndTime": "not a timestamp"},
+			expected: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := kmsValueAddedServiceInEffect(c.instance, now); got != c.expected {
+				t.Errorf("kmsValueAddedServiceInEffect(%v) = %v, want %v", c.instance, got, c.expected)
+			}
+		})
+	}
+}
+
+// TestAccAliCloudKmsValueAddedService_alreadyHeld covers the already-held pre-flight. The second step
+// adds a second resource for the same value added service in the same region, and because steps run
+// sequentially the first instance is already effective when the second create starts, so the prefix
+// pre-flight has to recognise it and refuse instead of placing an order that would only be refunded.
+func TestAccAliCloudKmsValueAddedService_alreadyHeld(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKmsValueAddedServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsValueAddedServiceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKmsValueAddedServiceExists("alicloud_kms_value_added_service.default"),
+					resource.TestCheckResourceAttr("alicloud_kms_value_added_service.default", "status", "Normal"),
+					resource.TestCheckResourceAttrSet("alicloud_kms_value_added_service.default", "create_time"),
+					resource.TestCheckResourceAttrSet("alicloud_kms_value_added_service.default", "region_id"),
+				),
+			},
+			{
+				Config:      testAccKmsValueAddedServiceAlreadyHeldConfig(),
+				ExpectError: regexp.MustCompile("already holds this value added service"),
+			},
+		},
+	})
+}
+
+func testAccKmsValueAddedServiceAlreadyHeldConfig() string {
+	return testAccKmsValueAddedServiceConfig() + `
+resource "alicloud_kms_value_added_service" "duplicate" {
+  depends_on          = [alicloud_kms_value_added_service.default]
+  value_added_service = "2"
+  payment_type        = "Subscription"
+  period              = "1"
+  renew_period        = "1"
+  renew_status        = "AutoRenewal"
+}
+`
+}
+
+// TestAccAliCloudKmsValueAddedService_twoRegions covers the confirmed per-region uniqueness of the
+// service: two providers pinned to different regions each order the same value added service (code 2)
+// and both succeed independently, because the service is scoped per region. That also pins the
+// already-held pre-flight to the right scope - it filters QueryAvailableInstances on the response
+// Region, so the cn-hangzhou instance must not make the cn-shanghai create refuse.
+//
+// Two same-region resources in one apply are deliberately not exercised: Terraform creates them
+// concurrently, so both pre-flights can run before either order lands and the race is not fixable
+// from inside the resource.
+func TestAccAliCloudKmsValueAddedService_twoRegions(t *testing.T) {
+	var providers []*schema.Provider
+	providerFactories := map[string]terraform.ResourceProviderFactory{
+		"alicloud": func() (terraform.ResourceProvider, error) {
+			p := Provider()
+			providers = append(providers, p.(*schema.Provider))
+			return p, nil
+		},
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou", "cn-shanghai"})
+			testAccPreCheck(t)
+		},
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckKmsValueAddedServiceDestroyWithProviders(&providers),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKmsValueAddedServiceTwoRegionsConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKmsValueAddedServiceExistsWithProviders("alicloud_kms_value_added_service.hz", &providers),
+					testAccCheckKmsValueAddedServiceExistsWithProviders("alicloud_kms_value_added_service.sh", &providers),
+					resource.TestCheckResourceAttr("alicloud_kms_value_added_service.hz", "region_id", "cn-hangzhou"),
+					resource.TestCheckResourceAttr("alicloud_kms_value_added_service.sh", "region_id", "cn-shanghai"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKmsValueAddedServiceTwoRegionsConfig() string {
+	return `
+provider "alicloud" {
+  alias  = "hz"
+  region = "cn-hangzhou"
+}
+
+provider "alicloud" {
+  alias  = "sh"
+  region = "cn-shanghai"
+}
+
+resource "alicloud_kms_value_added_service" "hz" {
+  provider            = alicloud.hz
+  value_added_service = "2"
+  payment_type        = "Subscription"
+  period              = "1"
+  renew_period        = "1"
+  renew_status        = "AutoRenewal"
+}
+
+resource "alicloud_kms_value_added_service" "sh" {
+  provider            = alicloud.sh
+  value_added_service = "2"
+  payment_type        = "Subscription"
+  period              = "1"
+  renew_period        = "1"
+  renew_status        = "AutoRenewal"
+}
+`
+}
+
+func testAccCheckKmsValueAddedServiceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No KMS value added service ID is set")
+		}
+		client := testAccProvider.Meta().(*connectivity.AliyunClient)
+		kmsServiceV2 := KmsServiceV2{client}
+		if _, err := kmsServiceV2.DescribeKmsValueAddedService(rs.Primary.ID); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func testAccCheckKmsValueAddedServiceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+	kmsServiceV2 := KmsServiceV2{client}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_kms_value_added_service" {
+			continue
+		}
+		_, err := kmsServiceV2.DescribeKmsValueAddedService(rs.Primary.ID)
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return err
+		}
+		return fmt.Errorf("KMS value added service %s still exists", rs.Primary.ID)
+	}
+	return nil
+}
+
+func testAccCheckKmsValueAddedServiceExistsWithProviders(n string, providers *[]*schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No KMS value added service ID is set")
+		}
+		for _, provider := range *providers {
+			// Ignore if Meta is empty, this can happen for validation providers.
+			if provider.Meta() == nil {
+				continue
+			}
+			client := provider.Meta().(*connectivity.AliyunClient)
+			kmsServiceV2 := KmsServiceV2{client}
+			if _, err := kmsServiceV2.DescribeKmsValueAddedService(rs.Primary.ID); err != nil {
+				if NotFoundError(err) {
+					continue
+				}
+				return err
+			}
+			return nil
+		}
+		return fmt.Errorf("KMS value added service %s not found in any provider", rs.Primary.ID)
+	}
+}
+
+func testAccCheckKmsValueAddedServiceDestroyWithProviders(providers *[]*schema.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, provider := range *providers {
+			if provider.Meta() == nil {
+				continue
+			}
+			client := provider.Meta().(*connectivity.AliyunClient)
+			kmsServiceV2 := KmsServiceV2{client}
+			for _, rs := range s.RootModule().Resources {
+				if rs.Type != "alicloud_kms_value_added_service" {
+					continue
+				}
+				_, err := kmsServiceV2.DescribeKmsValueAddedService(rs.Primary.ID)
+				if err != nil {
+					if NotFoundError(err) {
+						continue
+					}
+					return err
+				}
+				return fmt.Errorf("KMS value added service %s still exists", rs.Primary.ID)
+			}
+		}
+		return nil
+	}
+}

--- a/alicloud/service_alicloud_kms_v2.go
+++ b/alicloud/service_alicloud_kms_v2.go
@@ -768,6 +768,86 @@ func (s *KmsServiceV2) DescribeKmsValueAddedService(id string) (object map[strin
 	return v.([]interface{})[0].(map[string]interface{}), nil
 }
 
+// ListKmsValueAddedServiceInstancesByPrefix returns the KMS instances in the client's region whose id
+// carries the given prefix. Each value added service mints its instance ids with a prefix of its own,
+// so for a service whose prefix is not shared with another KMS product the prefix is the only way to
+// tell from a read which service an instance belongs to: QueryAvailableInstances reports no service
+// field, and QueryInstanceBill names it only as locale-dependent display text that lags hours behind
+// the purchase.
+//
+// The instances are returned whole rather than as ids because a prefix match alone says nothing about
+// whether the service is in effect. The list also carries instances that hold nothing - a refunded
+// order lingers in Creating for minutes, and an expired one is still listed - so callers that mean
+// "does the account hold this" have to filter on status themselves.
+//
+// Region is deliberately not sent - BssOpenApi resolves it against the account's station and silently
+// returns an empty list when it disagrees, so the region is applied to the response instead. PageSize
+// is capped server-side regardless of what is asked for, hence the paging.
+func (s *KmsServiceV2) ListKmsValueAddedServiceInstancesByPrefix(prefix string) (instances []map[string]interface{}, err error) {
+	client := s.client
+	var response map[string]interface{}
+	var endpoint string
+	action := "QueryAvailableInstances"
+
+	request := map[string]interface{}{
+		"ProductCode": "kms",
+		"PageNum":     1,
+		"PageSize":    PageSizeLarge,
+	}
+
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPostWithEndpoint("BssOpenApi", "2017-12-14", action, nil, request, true, endpoint)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				if !client.IsInternationalAccount() && IsExpectedErrors(err, []string{"NotApplicable"}) {
+					endpoint = connectivity.BssOpenAPIEndpointInternational
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return nil, WrapErrorf(err, DefaultErrorMsg, "alicloud_kms_value_added_service", action, AlibabaCloudSdkGoERROR)
+		}
+
+		// BssOpenApi reports business failures in the response body with a 200 status code.
+		if fmt.Sprint(response["Success"]) != "true" {
+			return nil, WrapError(Error("%s failed, response: %v", action, response))
+		}
+
+		v, err := jsonpath.Get("$.Data.InstanceList", response)
+		if err != nil {
+			return nil, WrapErrorf(err, FailedGetAttributeMsg, action, "$.Data.InstanceList", response)
+		}
+		result, _ := v.([]interface{})
+		for _, item := range result {
+			instance, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if fmt.Sprint(instance["Region"]) != client.RegionId {
+				continue
+			}
+			if strings.HasPrefix(fmt.Sprint(instance["InstanceID"]), prefix) {
+				instances = append(instances, instance)
+			}
+		}
+		if len(result) < request["PageSize"].(int) {
+			break
+		}
+		request["PageNum"] = request["PageNum"].(int) + 1
+	}
+
+	return instances, nil
+}
+
 func (s *KmsServiceV2) KmsValueAddedServiceStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
 	return s.KmsValueAddedServiceStateRefreshFuncWithApi(id, field, failStates, s.DescribeKmsValueAddedService)
 }

--- a/website/docs/r/kms_value_added_service.html.markdown
+++ b/website/docs/r/kms_value_added_service.html.markdown
@@ -16,6 +16,8 @@ For information about KMS Value Added Service and how to use it, see [What is Va
 
 -> **NOTE:** Available since v1.267.0.
 
+-> **NOTE:** A value added service can be purchased only once per region while it is in effect. If the account already holds it, for example because it was purchased in the console, a duplicate order is charged and then refunded automatically and its instance never becomes effective, so creating this resource fails rather than tracking an instance that does not work. Import the existing service instead of creating it.
+
 ## Example Usage
 
 Basic Usage
@@ -65,9 +67,10 @@ The following arguments are supported:
   - AutoRenewal: The instance is automatically renewed.
   - ManualRenewal: The instance is manually renewed.
   - NotRenewal: The instance is not renewed.
-* `value_added_service` - (Optional) value added service type, Instance Backup 1 default key rotation 2 Expert service 3
+* `value_added_service` - (Optional) The value added service type. Valid values:
+  - `2`: Default key rotation.
 
--> **NOTE:** The parameter is immutable after resource creation. It only applies during resource creation and has no effect when modified post-creation.
+  -> **NOTE:** The parameter is immutable after resource creation. It only applies during resource creation and has no effect when modified post-creation.
 
 
 ## Attributes Reference
@@ -81,9 +84,9 @@ The following attributes are exported:
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
-* `create` - (Defaults to 5 mins) Used when create the Value Added Service.
-* `delete` - (Defaults to 5 mins) Used when delete the Value Added Service.
-* `update` - (Defaults to 5 mins) Used when update the Value Added Service.
+* `create` - (Defaults to 10 mins) Used when create the Value Added Service.
+* `delete` - (Defaults to 10 mins) Used when delete the Value Added Service.
+* `update` - (Defaults to 10 mins) Used when update the Value Added Service.
 
 ## Import
 


### PR DESCRIPTION
### Problem

`alicloud_kms_value_added_service` recreates the resource on every plan.

A duplicate `CreateInstance` for a value added service the account already holds is **accepted** and then refunded automatically, rather than rejected. The ordered instance never activates — it stays in `Creating` and later drops out of the `InstanceIDs`-filtered `QueryAvailableInstances` result once the refund settles. `Read` then cleared the id, and the next plan ordered another instance that would only be refunded again.

### Fix

- `Create` waits for the ordered instance to actually reach `Normal`, and fails when it disappears after having been listed — the trace an automatic refund leaves. `d.SetId` runs only once the instance is known to be effective, so a refunded order never reaches the state.
- A pre-flight recognises an already-held *default key rotation* instance by its `dkr-` id prefix and refuses before ordering, turning a duplicate into an immediate, actionable failure that points at `terraform import`.
- Only an instance genuinely in effect counts: `Status` must be `Normal` and `EndTime` must be in the future, so a refunded instance lingering in `Creating`, or an expired one, does not block a create the account is entitled to make. That direction is deliberate — a false "not held" costs at most one auto-refunded order, which the create wait catches, whereas a false "held" would block the create with no workaround.
- `ListKmsValueAddedServiceInstancesByPrefix` pages through `QueryAvailableInstances` and filters on the **response** `Region` field. `Region` is deliberately not sent as a request parameter, because BssOpenApi then resolves the wrong station and silently returns an empty list.
- Create/update/delete timeouts raised from 5 to 10 minutes to give the new waits headroom.
- Docs: restrict the documented `value_added_service` values to `2`. The prefix check is limited to that code on purpose — expert service shares the `kst-` prefix with `alicloud_kms_instance`, so matching there could refuse a create over an unrelated KMS instance.

### Acceptance tests

```
PASS: TestAccAliCloudKmsValueAddedService_basic11636 (84.16s)
PASS: TestAccAliCloudKmsValueAddedService_twoRegions (83.71s)
PASS: TestAccAliCloudKmsValueAddedService_alreadyHeld (77.33s)
PASS: TestAccAliCloudKmsValueAddedService_duplicateOrder (115.94s)

PASS=4 FAIL=0 SKIP=0
```

Each new case exercises a distinct guard, confirmed from the debug log:

- `_alreadyHeld` (sequential, via `depends_on`) — the **pre-flight** refuses the second order.
- `_duplicateOrder` (concurrent, no dependency) — both pre-flights pass, and the **create wait** catches the refunded order.
- `_twoRegions` — two providers in different regions both create successfully, confirming the service is unique per region and that the response-`Region` filter scopes correctly.

Note that these cases need an account that does not already hold default key rotation in the test region; the pre-flight correctly refuses otherwise.

`TestUnitKmsValueAddedServiceInEffect` is a pure table test over the `Status` / `EndTime` boundaries. It is a unit test rather than an acceptance test, so it is not part of the run above.
