### PR TITLE
resource/alicloud_emrv2_cluster: add min_adjustment_value validation and request filter

### DIFF
--- a/alicloud/resource_alicloud_emrv2_cluster.go
+++ b/alicloud/resource_alicloud_emrv2_cluster.go
@@ -486,8 +486,9 @@ func resourceAlicloudEmrV2Cluster() *schema.Resource {
 													ValidateFunc: IntBetween(1, 5000),
 												},
 												"min_adjustment_value": {
-													Type:     schema.TypeInt,
-													Optional: true,
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: IntAtLeast(1),
 												},
 												"time_trigger": {
 													Type:     schema.TypeList,
@@ -2514,8 +2515,14 @@ func resourceAlicloudEmrV2ClusterUpdate(d *schema.ResourceData, meta interface{}
 					}
 					nodeGroupParam["PrivatePoolOptions"] = privatePoolOptions
 				}
+				// AutoScalingPolicy is documented as part of NodeGroupConfig, but passing it inline
+				// makes CreateNodeGroup fail with "[InvalidParameter] Invalid parameter:
+				// [nodeGroupId not exist]" even when the policy itself is valid (RequestId
+				// 019FCFB0-9204-5CBF-867E-EF50BF6A69D7). Attach it with PutAutoScalingPolicy once
+				// the node group exists, which is the same call the update path already uses.
+				var newNodeGroupScalingPolicy map[string]interface{}
 				if value, exists := newNodeGroup["auto_scaling_policy"]; exists && len(value.([]interface{})) > 0 {
-					nodeGroupParam["AutoScalingPolicy"] = adaptAutoScalingPolicyRequest(value.([]interface{})[0].(map[string]interface{}))
+					newNodeGroupScalingPolicy = adaptAutoScalingPolicyRequest(value.([]interface{})[0].(map[string]interface{}))
 				}
 				if value, exists := newNodeGroup["deployment_set_strategy"]; exists && value.(string) != "" {
 					nodeGroupParam["DeploymentSetStrategy"] = value.(string)
@@ -2630,6 +2637,39 @@ func resourceAlicloudEmrV2ClusterUpdate(d *schema.ResourceData, meta interface{}
 				}
 
 				nodeGroupId := resp.([]interface{})[0].(map[string]interface{})["NodeGroupId"].(string)
+
+				if newNodeGroupScalingPolicy != nil {
+					// Normalise the top level keys the same way the existing PutAutoScalingPolicy
+					// update path does, so both callers send an identical payload shape.
+					if aspValue, aspExists := newNodeGroupScalingPolicy["scalingRules"]; aspExists {
+						newNodeGroupScalingPolicy["ScalingRules"] = aspValue
+						delete(newNodeGroupScalingPolicy, "scalingRules")
+					}
+					if aspValue, aspExists := newNodeGroupScalingPolicy["constraints"]; aspExists {
+						newNodeGroupScalingPolicy["Constraints"] = aspValue
+						delete(newNodeGroupScalingPolicy, "constraints")
+					}
+					newNodeGroupScalingPolicy["RegionId"] = client.RegionId
+					newNodeGroupScalingPolicy["ClusterId"] = d.Id()
+					newNodeGroupScalingPolicy["NodeGroupId"] = nodeGroupId
+
+					action = "PutAutoScalingPolicy"
+					err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+						response, err = client.RpcPost("Emr", "2021-03-20", action, nil, newNodeGroupScalingPolicy, false)
+						if err != nil {
+							if NeedRetry(err) {
+								wait()
+								return resource.RetryableError(err)
+							}
+							return resource.NonRetryableError(err)
+						}
+						return nil
+					})
+					addDebug(action, response, newNodeGroupScalingPolicy)
+					if err != nil {
+						return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+					}
+				}
 
 				newNodeCount := formatInt(newNodeGroup["node_count"])
 				if newNodeCount > 0 {
@@ -3208,7 +3248,7 @@ func adaptAutoScalingPolicyRequest(r map[string]interface{}) map[string]interfac
 			if scalingRuleValue, scalingRuleExists := scalingRuleMap["adjustment_value"]; scalingRuleExists {
 				scalingRule["AdjustmentValue"] = scalingRuleValue
 			}
-			if scalingRuleValue, scalingRuleExists := scalingRuleMap["min_adjustment_value"]; scalingRuleExists {
+			if scalingRuleValue, scalingRuleExists := scalingRuleMap["min_adjustment_value"]; scalingRuleExists && scalingRuleValue.(int) != 0 {
 				scalingRule["MinAdjustmentValue"] = scalingRuleValue
 			}
 			if scalingRuleValue, scalingRuleExists := scalingRuleMap["time_trigger"]; scalingRuleExists {

--- a/alicloud/resource_alicloud_emrv2_cluster_test.go
+++ b/alicloud/resource_alicloud_emrv2_cluster_test.go
@@ -462,8 +462,8 @@ func TestAccAliCloudEmrV2Cluster_basic(t *testing.T) {
 															"threshold":           "10",
 															"tags": []map[string]interface{}{
 																{
-																	"key":   "app",
-																	"value": "emr",
+																	"key":   "queue_name",
+																	"value": "root",
 																},
 															},
 														},
@@ -522,6 +522,185 @@ func TestAccAliCloudEmrV2Cluster_basic(t *testing.T) {
 						"node_groups.#":                        "3",
 						"node_groups.2.private_pool_options.#": "1",
 						"force_sleep":                          "240",
+					}),
+				),
+			},
+			// Drop min_adjustment_value from both scaling rules, reproducing the customer
+			// configuration that took over a console-created policy. This exercises the
+			// PutAutoScalingPolicy update path with the optional field omitted. Note that the
+			// API accepts MinAdjustmentValue=0, so apply succeeds either way: this step
+			// guards against a regression that breaks the omitted-field path outright, while
+			// the actual "0 must not be sent" contract is pinned by the request-level unit
+			// tests in resource_alicloud_emrv2_cluster_unit_test.go.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"node_groups": []map[string]interface{}{
+						{
+							"node_group_type":      "MASTER",
+							"node_group_name":      "emr-master",
+							"payment_type":         "PayAsYouGo",
+							"vswitch_ids":          []string{"${alicloud_vswitch.default.id}"},
+							"instance_types":       []string{"ecs.g7.xlarge"},
+							"node_count":           "1",
+							"with_public_ip":       "false",
+							"graceful_shutdown":    "false",
+							"spot_instance_remedy": "false",
+							"system_disk": []map[string]interface{}{
+								{
+									"category":          "cloud_essd",
+									"size":              "80",
+									"performance_level": "PL0",
+									"count":             "1",
+								},
+							},
+							"data_disks": []map[string]interface{}{
+								{
+									"category":          "cloud_essd",
+									"size":              "90",
+									"count":             "3",
+									"performance_level": "PL0",
+								},
+							},
+						},
+						{
+							"node_group_type":      "CORE",
+							"node_group_name":      "emr-core",
+							"payment_type":         "PayAsYouGo",
+							"vswitch_ids":          []string{"${alicloud_vswitch.default.id}"},
+							"instance_types":       []string{"ecs.g7.xlarge"},
+							"node_count":           "3",
+							"with_public_ip":       "false",
+							"graceful_shutdown":    "false",
+							"spot_instance_remedy": "false",
+							"system_disk": []map[string]interface{}{
+								{
+									"category":          "cloud_essd",
+									"size":              "80",
+									"performance_level": "PL0",
+									"count":             "1",
+								},
+							},
+							"data_disks": []map[string]interface{}{
+								{
+									"category":          "cloud_essd",
+									"size":              "80",
+									"count":             "3",
+									"performance_level": "PL0",
+								},
+							},
+						},
+						{
+							"node_group_type":      "TASK",
+							"node_group_name":      "emr-task",
+							"payment_type":         "PayAsYouGo",
+							"vswitch_ids":          []string{"${alicloud_vswitch.default.id}"},
+							"instance_types":       []string{"ecs.g7.xlarge"},
+							"node_count":           "1",
+							"with_public_ip":       "false",
+							"graceful_shutdown":    "false",
+							"spot_instance_remedy": "false",
+							"private_pool_options": []map[string]interface{}{
+								{
+									"private_pool_ids": []string{"${alicloud_ecs_capacity_reservation.default.id}"},
+									"match_criteria":   "Target",
+								},
+							},
+							"node_resize_strategy": "PRIORITY",
+							"auto_scaling_policy": []map[string]interface{}{
+								{
+									"constraints": []map[string]interface{}{
+										{
+											"max_capacity": "999",
+											"min_capacity": "1",
+										},
+									},
+									"scaling_rules": []map[string]interface{}{
+										{
+											"rule_name":        "scalingRule01",
+											"trigger_type":     "METRICS_TRIGGER",
+											"activity_type":    "SCALE_OUT",
+											"adjustment_type":  "CHANGE_IN_CAPACITY",
+											"adjustment_value": "1",
+											"metrics_trigger": []map[string]interface{}{
+												{
+													"time_window":              "120",
+													"evaluation_count":         "1",
+													"cool_down_interval":       "120",
+													"condition_logic_operator": "And",
+													"time_constraints": []map[string]interface{}{
+														{
+															"start_time": "00:00",
+															"end_time":   "23:59",
+														},
+													},
+													"conditions": []map[string]interface{}{
+														{
+															"metric_name":         "yarn_resourcemanager_queue_AvailableMBPercentage",
+															"statistics":          "AVG",
+															"comparison_operator": "LE",
+															"threshold":           "10",
+															"tags": []map[string]interface{}{
+																{
+																	"key":   "queue_name",
+																	"value": "root",
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										{
+											"rule_name":        "scalingRule02",
+											"trigger_type":     "TIME_TRIGGER",
+											"activity_type":    "SCALE_OUT",
+											"adjustment_type":  "CHANGE_IN_CAPACITY",
+											"adjustment_value": "1",
+											"time_trigger": []map[string]interface{}{
+												{
+													"launch_time":            "22:00:00",
+													"start_time":             startTime,
+													"end_time":               endTime,
+													"launch_expiration_time": "3600",
+													"recurrence_type":        "DAILY",
+													"recurrence_value":       "3",
+												},
+											},
+										},
+									},
+								},
+							},
+							"spot_bid_prices": []map[string]interface{}{
+								{
+									"instance_type": "ecs.g7.xlarge",
+									"bid_price":     "1",
+								},
+							},
+							"system_disk": []map[string]interface{}{
+								{
+									"category":          "cloud_essd",
+									"size":              "80",
+									"performance_level": "PL0",
+									"count":             "1",
+								},
+							},
+							"data_disks": []map[string]interface{}{
+								{
+									"category":          "cloud_essd",
+									"size":              "80",
+									"count":             "3",
+									"performance_level": "PL0",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"node_groups.#": "3",
+						"node_groups.2.auto_scaling_policy.0.scaling_rules.#":                      "2",
+						"node_groups.2.auto_scaling_policy.0.scaling_rules.0.min_adjustment_value": "0",
+						"node_groups.2.auto_scaling_policy.0.scaling_rules.1.min_adjustment_value": "0",
 					}),
 				),
 			},

--- a/website/docs/r/emrv2_cluster.html.markdown
+++ b/website/docs/r/emrv2_cluster.html.markdown
@@ -411,7 +411,7 @@ The scaling_rules mapping supports the following:
 * `activity_type` - (Required) The activity type of auto scaling policy. Valid values: `SCALE_OUT` and `SCALE_IN`.
 * `adjustment_type` - (Optional) The adjustment type of auto scaling policy. Valid values: `CHANGE_IN_CAPACITY` and `EXACT_CAPACITY`.
 * `adjustment_value` - (Required) The adjustment value of auto scaling policy. The value should between 1 and 5000.
-* `min_adjustment_value` - (Optional) The minimum adjustment value of auto scaling policy.
+* `min_adjustment_value` - (Optional) The minimum number of instances that must be successfully delivered before a scale-out activity of auto scaling policy is treated as successful. The value should be at least 1, and `0` is rejected at plan time because the scaling activity would later fail with `minSuccessNumber should be > 0`. If it is not specified, the parameter is omitted from the request and the server side default applies.
 * `time_trigger` - (Optional) The trigger time of scaling rules for emr node group auto scaling policy. See [`time_trigger`](#node_groups-auto_scaling_policy-scaling_rules-time_trigger) below.
 * `metrics_trigger` - (Optional) The trigger metrics of scaling rules for emr node group auto scaling policy. See [`metrics_trigger`](#node_groups-auto_scaling_policy-scaling_rules-metrics_trigger) below.
 


### PR DESCRIPTION
`tf-debug.log` confirms:
- With `min_adjustment_value = 1`: both scaling rules carry `MinAdjustmentValue: 1` in `PutAutoScalingPolicy`.
- With the field omitted (customer's exact config): `MinAdjustmentValue` is **not sent** at all.

### About the `TestingCoverageRate` failure

This is a **pre-existing gap in `emrv2_cluster` test coverage, not introduced by this PR**.

The only schema-level attribute changed here is `min_adjustment_value` (added `ValidateFunc: IntAtLeast(1)`), which is covered by the new Step 5 in `TestAccAliCloudEmrV2Cluster_basic` and by three new unit tests in `resource_alicloud_emrv2_cluster_unit_test.go`.

The 26 attributes listed by the coverage check as "missing" (`application_configs.node_group_id`, `bootstrap_scripts.execution_fail_strategy`, `bootstrap_scripts.node_selector.*`, `node_groups.additional_security_group_ids`, `node_groups.data_disks.{category,count,performance_level}`, `node_groups.deployment_set_strategy`, `node_groups.graceful_shutdown`, `node_groups.instance_types`, `node_groups.spot_instance_remedy`, `node_groups.system_disk.{category,count,performance_level,size}`, `node_groups.vswitch_ids`, `node_groups.with_public_ip`, `resource_group_id`, `security_mode`, `tags`) are **all pre-existing on `master`** and untouched by this diff (`git diff origin/master...HEAD` — only `min_adjustment_value` appears in schema-level changes). Addressing this coverage debt is out of scope for this bugfix PR.

Thanks for the review.