### PR TITLE
resource/alicloud_message_service_queue: support server-side encryption; resource/alicloud_message_service_topic: support server-side encryption

### DIFF
--- a/alicloud/resource_alicloud_message_service_queue.go
+++ b/alicloud/resource_alicloud_message_service_queue.go
@@ -59,6 +59,15 @@ func resourceAliCloudMessageServiceQueue() *schema.Resource {
 					},
 				},
 			},
+			"enable_sse": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"logging_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -92,6 +101,16 @@ func resourceAliCloudMessageServiceQueue() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: StringInSlice([]string{"normal", "fifo"}, false),
+			},
+			"sse_algorithm": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"sse_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"tags": tagsSchema(),
 			"visibility_timeout": {
@@ -133,6 +152,18 @@ func resourceAliCloudMessageServiceQueueCreate(d *schema.ResourceData, meta inte
 	}
 	if v, ok := d.GetOkExists("logging_enabled"); ok {
 		request["EnableLogging"] = v
+	}
+	if v, ok := d.GetOkExists("enable_sse"); ok {
+		request["EnableSSE"] = v
+	}
+	if v, ok := d.GetOkExists("kms_key_id"); ok {
+		request["KmsKeyId"] = v
+	}
+	if v, ok := d.GetOkExists("sse_algorithm"); ok {
+		request["SseAlgorithm"] = v
+	}
+	if v, ok := d.GetOkExists("sse_type"); ok {
+		request["SseType"] = v
 	}
 	if v, ok := d.GetOk("queue_type"); ok {
 		request["QueueType"] = v
@@ -205,11 +236,15 @@ func resourceAliCloudMessageServiceQueueRead(d *schema.ResourceData, meta interf
 
 	d.Set("create_time", objectRaw["CreateTime"])
 	d.Set("delay_seconds", objectRaw["DelaySeconds"])
+	d.Set("enable_sse", objectRaw["EnableSSE"])
+	d.Set("kms_key_id", objectRaw["KmsKeyId"])
 	d.Set("logging_enabled", objectRaw["LoggingEnabled"])
 	d.Set("maximum_message_size", objectRaw["MaximumMessageSize"])
 	d.Set("message_retention_period", objectRaw["MessageRetentionPeriod"])
 	d.Set("polling_wait_seconds", objectRaw["PollingWaitSeconds"])
 	d.Set("queue_type", objectRaw["QueueType"])
+	d.Set("sse_algorithm", objectRaw["SseAlgorithm"])
+	d.Set("sse_type", objectRaw["SseType"])
 	d.Set("visibility_timeout", objectRaw["VisibilityTimeout"])
 	d.Set("queue_name", objectRaw["QueueName"])
 
@@ -293,6 +328,38 @@ func resourceAliCloudMessageServiceQueueUpdate(d *schema.ResourceData, meta inte
 	}
 	if v, ok := d.GetOkExists("logging_enabled"); ok {
 		request["EnableLogging"] = v
+	}
+
+	if !d.IsNewResource() && d.HasChange("enable_sse") {
+		update = true
+
+		if v, ok := d.GetOkExists("enable_sse"); ok {
+			request["EnableSSE"] = v
+		}
+	}
+
+	if !d.IsNewResource() && d.HasChange("kms_key_id") {
+		update = true
+
+		if v, ok := d.GetOkExists("kms_key_id"); ok {
+			request["KmsKeyId"] = v
+		}
+	}
+
+	if !d.IsNewResource() && d.HasChange("sse_algorithm") {
+		update = true
+
+		if v, ok := d.GetOkExists("sse_algorithm"); ok {
+			request["SseAlgorithm"] = v
+		}
+	}
+
+	if !d.IsNewResource() && d.HasChange("sse_type") {
+		update = true
+
+		if v, ok := d.GetOkExists("sse_type"); ok {
+			request["SseType"] = v
+		}
 	}
 
 	if !d.IsNewResource() && d.HasChange("dlq_policy") {

--- a/alicloud/resource_alicloud_message_service_queue_test.go
+++ b/alicloud/resource_alicloud_message_service_queue_test.go
@@ -625,6 +625,91 @@ func TestAccAliCloudMessageServiceQueue_basic1_twin(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudMessageServiceQueue_sse(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_message_service_queue.default"
+	ra := resourceAttrInit(resourceId, AliCloudMessageServiceQueueMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &MessageServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeMessageServiceQueue")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccMessageServiceQueue-name%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudMessageServiceQueueSSEDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-shanghai"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"queue_name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"queue_name": name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_sse":    "true",
+					"sse_algorithm": "AES-256-GCM",
+					"kms_key_id":    "${alicloud_kms_key.default.id}",
+					"sse_type":      "SMQ",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"queue_name":    name,
+						"enable_sse":    "true",
+						"sse_algorithm": "AES-256-GCM",
+						"sse_type":      "SMQ",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_sse":    "false",
+					"sse_algorithm": REMOVEKEY,
+					"sse_type":      REMOVEKEY,
+					"kms_key_id":    REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"queue_name":    name,
+						"enable_sse":    "false",
+						"sse_algorithm": REMOVEKEY,
+						"sse_type":      REMOVEKEY,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func AliCloudMessageServiceQueueSSEDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "%s"
+}
+
+resource "alicloud_kms_key" "default" {
+  description             = "${var.name}-kms-key"
+  pending_window_in_days  = 7
+}
+`, name)
+}
+
 var AliCloudMessageServiceQueueMap0 = map[string]string{
 	"create_time":              CHECKSET,
 	"delay_seconds":            CHECKSET,
@@ -674,6 +759,10 @@ func TestUnitAliCloudMessageServiceQueue(t *testing.T) {
 		"visibility_timeout":       40,
 		"polling_wait_seconds":     3,
 		"logging_enabled":          false,
+		"enable_sse":               false,
+		"kms_key_id":               "",
+		"sse_algorithm":            "",
+		"sse_type":                 "",
 	}
 	for key, value := range attributes {
 		err := dInit.Set(key, value)
@@ -702,6 +791,10 @@ func TestUnitAliCloudMessageServiceQueue(t *testing.T) {
 			"VisibilityTimeout":      40,
 			"PollingWaitSeconds":     3,
 			"LoggingEnabled":         false,
+			"EnableSSE":              false,
+			"KmsKeyId":               "",
+			"SseAlgorithm":           "",
+			"SseType":                "",
 		},
 	}
 	CreateMockResponse := map[string]interface{}{}
@@ -792,6 +885,10 @@ func TestUnitAliCloudMessageServiceQueue(t *testing.T) {
 		"visibility_timeout":       30,
 		"polling_wait_seconds":     0,
 		"logging_enabled":          true,
+		"enable_sse":               true,
+		"kms_key_id":               "kms-test-key-id",
+		"sse_algorithm":            "AES-256-GCM",
+		"sse_type":                 "SMQ",
 	}
 	diff, err := newInstanceDiff("alicloud_message_service_queue", attributes, attributesDiff, dInit.State())
 	if err != nil {
@@ -808,6 +905,10 @@ func TestUnitAliCloudMessageServiceQueue(t *testing.T) {
 			"VisibilityTimeout":      30,
 			"PollingWaitSeconds":     0,
 			"LoggingEnabled":         true,
+			"EnableSSE":              true,
+			"KmsKeyId":               "kms-test-key-id",
+			"SseAlgorithm":           "AES-256-GCM",
+			"SseType":                "SMQ",
 		},
 	}
 	errorCodes = []string{"NonRetryableError", "Throttling", "nil"}

--- a/alicloud/resource_alicloud_message_service_topic.go
+++ b/alicloud/resource_alicloud_message_service_topic.go
@@ -35,11 +35,30 @@ func resourceAliCloudMessageServiceTopic() *schema.Resource {
 				Computed:      true,
 				ConflictsWith: []string{"logging_enabled"},
 			},
+			"enable_sse": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"max_message_size": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: IntBetween(1024, 65536),
+			},
+			"sse_algorithm": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"sse_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"tags": tagsSchema(),
 			"topic_name": {
@@ -80,6 +99,18 @@ func resourceAliCloudMessageServiceTopicCreate(d *schema.ResourceData, meta inte
 		request["EnableLogging"] = v
 	} else if v, ok := d.GetOkExists("logging_enabled"); ok {
 		request["EnableLogging"] = v
+	}
+	if v, ok := d.GetOkExists("enable_sse"); ok {
+		request["EnableSSE"] = v
+	}
+	if v, ok := d.GetOkExists("kms_key_id"); ok {
+		request["KmsKeyId"] = v
+	}
+	if v, ok := d.GetOkExists("sse_algorithm"); ok {
+		request["SseAlgorithm"] = v
+	}
+	if v, ok := d.GetOkExists("sse_type"); ok {
+		request["SseType"] = v
 	}
 	if v, ok := d.GetOkExists("max_message_size"); ok {
 		request["MaxMessageSize"] = v
@@ -131,7 +162,11 @@ func resourceAliCloudMessageServiceTopicRead(d *schema.ResourceData, meta interf
 
 	d.Set("create_time", objectRaw["CreateTime"])
 	d.Set("enable_logging", objectRaw["LoggingEnabled"])
+	d.Set("enable_sse", objectRaw["EnableSSE"])
+	d.Set("kms_key_id", objectRaw["KmsKeyId"])
 	d.Set("max_message_size", objectRaw["MaxMessageSize"])
+	d.Set("sse_algorithm", objectRaw["SseAlgorithm"])
+	d.Set("sse_type", objectRaw["SseType"])
 	d.Set("topic_name", objectRaw["TopicName"])
 	d.Set("topic_type", objectRaw["TopicType"])
 	d.Set("logging_enabled", objectRaw["LoggingEnabled"])
@@ -176,6 +211,38 @@ func resourceAliCloudMessageServiceTopicUpdate(d *schema.ResourceData, meta inte
 
 		if v, ok := d.GetOkExists("max_message_size"); ok {
 			request["MaxMessageSize"] = v
+		}
+	}
+
+	if d.HasChange("enable_sse") {
+		update = true
+
+		if v, ok := d.GetOkExists("enable_sse"); ok {
+			request["EnableSSE"] = v
+		}
+	}
+
+	if d.HasChange("kms_key_id") {
+		update = true
+
+		if v, ok := d.GetOkExists("kms_key_id"); ok {
+			request["KmsKeyId"] = v
+		}
+	}
+
+	if d.HasChange("sse_algorithm") {
+		update = true
+
+		if v, ok := d.GetOkExists("sse_algorithm"); ok {
+			request["SseAlgorithm"] = v
+		}
+	}
+
+	if d.HasChange("sse_type") {
+		update = true
+
+		if v, ok := d.GetOkExists("sse_type"); ok {
+			request["SseType"] = v
 		}
 	}
 

--- a/alicloud/resource_alicloud_message_service_topic_test.go
+++ b/alicloud/resource_alicloud_message_service_topic_test.go
@@ -450,6 +450,91 @@ func TestAccAliCloudMessageServiceTopic_basic9032_twin(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudMessageServiceTopic_sse(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_message_service_topic.default"
+	ra := resourceAttrInit(resourceId, AliCloudMessageServiceTopicMap9031)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &MessageServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeMessageServiceTopic")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccMessageServiceTopic-name%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudMessageServiceTopicSSEDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-shanghai"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"topic_name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"topic_name": name,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_sse":    "true",
+					"sse_algorithm": "AES-256-GCM",
+					"kms_key_id":    "${alicloud_kms_key.default.id}",
+					"sse_type":      "SMQ",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"topic_name":    name,
+						"enable_sse":    "true",
+						"sse_algorithm": "AES-256-GCM",
+						"sse_type":      "SMQ",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_sse":    "false",
+					"sse_algorithm": REMOVEKEY,
+					"sse_type":      REMOVEKEY,
+					"kms_key_id":    REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"topic_name":    name,
+						"enable_sse":    "false",
+						"sse_algorithm": REMOVEKEY,
+						"sse_type":      REMOVEKEY,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func AliCloudMessageServiceTopicSSEDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "%s"
+}
+
+resource "alicloud_kms_key" "default" {
+  description             = "${var.name}-kms-key"
+  pending_window_in_days  = 7
+}
+`, name)
+}
+
 var AliCloudMessageServiceTopicMap9031 = map[string]string{
 	"create_time":      CHECKSET,
 	"topic_type":       CHECKSET,
@@ -474,6 +559,10 @@ func TestUnitAliCloudMessageServiceTopic(t *testing.T) {
 		"topic_name":       "CreateMessageServiceTopicValue",
 		"max_message_size": 12357,
 		"logging_enabled":  false,
+		"enable_sse":       false,
+		"kms_key_id":       "",
+		"sse_algorithm":    "",
+		"sse_type":         "",
 	}
 	for key, value := range attributes {
 		err := dInit.Set(key, value)
@@ -498,6 +587,10 @@ func TestUnitAliCloudMessageServiceTopic(t *testing.T) {
 			"TopicName":      "CreateMessageServiceTopicValue",
 			"MaxMessageSize": 12357,
 			"LoggingEnabled": false,
+			"EnableSSE":      false,
+			"KmsKeyId":       "",
+			"SseAlgorithm":   "",
+			"SseType":        "",
 		},
 	}
 	CreateMockResponse := map[string]interface{}{}
@@ -584,6 +677,10 @@ func TestUnitAliCloudMessageServiceTopic(t *testing.T) {
 		"topic_name":       "CreateMessageServiceTopicValue",
 		"max_message_size": 65536,
 		"logging_enabled":  true,
+		"enable_sse":       true,
+		"kms_key_id":       "kms-test-key-id",
+		"sse_algorithm":    "AES-256-GCM",
+		"sse_type":         "SMQ",
 	}
 	diff, err := newInstanceDiff("alicloud_message_service_topic", attributes, attributesDiff, dInit.State())
 	if err != nil {
@@ -596,6 +693,10 @@ func TestUnitAliCloudMessageServiceTopic(t *testing.T) {
 			"TopicName":      "CreateMessageServiceTopicValue",
 			"MaxMessageSize": 65536,
 			"LoggingEnabled": true,
+			"EnableSSE":      true,
+			"KmsKeyId":       "kms-test-key-id",
+			"SseAlgorithm":   "AES-256-GCM",
+			"SseType":        "SMQ",
 		},
 	}
 	errorCodes = []string{"NonRetryableError", "Throttling", "nil"}

--- a/website/docs/r/message_service_queue.html.markdown
+++ b/website/docs/r/message_service_queue.html.markdown
@@ -48,6 +48,10 @@ resource "alicloud_message_service_queue" "default" {
 The following arguments are supported:
 * `delay_seconds` - (Optional, Int) The period after which all messages sent to the queue are consumed. Default value: `0`. Valid values: `0` to `604800`. Unit: seconds.
 * `dlq_policy` - (Optional, Set, Available since v1.244.0) The dead-letter queue policy. See [`dlq_policy`](#dlq_policy) below.
+* `enable_sse` - (Optional, Bool, Available since v1.299.0) Specifies whether to enable server-side encryption (SSE) for the queue. Default value: `false`. Valid values:
+  - `true`: Enable.
+  - `false`: Disable.
+* `kms_key_id` - (Optional, Available since v1.299.0) The ID of the KMS key. Optional; recorded by the server when `enable_sse` is `true` (the MNS-open API always applies the `AES-256-GCM` algorithm).
 * `logging_enabled` - (Optional, Bool) Specifies whether to enable the logging feature. Default value: `false`. Valid values:
   - `true`: Enable.
   - `false`: Disable.
@@ -58,6 +62,9 @@ The following arguments are supported:
 * `queue_type` - (Optional, ForceNew, Available since v1.283.0) The type of the queue. Default value: `normal`. Valid values:
   - `normal`: Standard queue.
   - `fifo`: FIFO queue.
+* `sse_algorithm` - (Optional, Available since v1.299.0) The server-side encryption algorithm. Valid value: `AES-256-GCM`.
+* `sse_type` - (Optional, Available since v1.299.0) The server-side encryption type. Valid value: `SMQ`.
+-> **NOTE:** The SSE attributes (`enable_sse`, `kms_key_id`, `sse_algorithm`, `sse_type`) are returned by the MNS-open `GetQueueAttributes` API only in some regions — for example, `cn-shanghai` returned them during testing — and are omitted from the response in other regions — for example, `cn-hangzhou` and `cn-beijing` did not return them during testing. This is a region deployment difference of the MNS-open API and does not affect `SetQueueAttributes`. In regions where these fields are not returned, the read-back value is empty, so a configured SSE block may show a plan diff; use `lifecycle.ignore_changes` on the SSE attributes if needed.
 * `tags` - (Optional, Map, Available since v1.241.0) A mapping of tags to assign to the resource.
 * `visibility_timeout` - (Optional, Int) The duration for which a message stays in the Inactive state after the message is received from the queue. Valid values: `1` to `43200`. Unit: seconds. Default value: `30`.
 

--- a/website/docs/r/message_service_topic.html.markdown
+++ b/website/docs/r/message_service_topic.html.markdown
@@ -46,7 +46,14 @@ The following arguments are supported:
 * `enable_logging` - (Optional, Bool, Available since v1.241.0) Specifies whether to enable the logging feature. Default value: `false`. Valid values:
   - `true`: Enable.
   - `false`: Disable.
+* `enable_sse` - (Optional, Bool, Available since v1.299.0) Specifies whether to enable server-side encryption (SSE) for the topic. Default value: `false`. Valid values:
+  - `true`: Enable.
+  - `false`: Disable.
+* `kms_key_id` - (Optional, Available since v1.299.0) The ID of the KMS key. Optional; recorded by the server when `enable_sse` is `true` (the MNS-open API always applies the `AES-256-GCM` algorithm).
 * `max_message_size` - (Optional, Int) The maximum length of the message that is sent to the topic. Default value: `65536`. Valid values: `1024` to `65536`. Unit: bytes.
+* `sse_algorithm` - (Optional, Available since v1.299.0) The server-side encryption algorithm. Valid value: `AES-256-GCM`.
+* `sse_type` - (Optional, Available since v1.299.0) The server-side encryption type. Valid value: `SMQ`.
+-> **NOTE:** The SSE attributes (`enable_sse`, `kms_key_id`, `sse_algorithm`, `sse_type`) are returned by the MNS-open `GetTopicAttributes` API only in some regions — for example, `cn-shanghai` returned them during testing — and are omitted from the response in other regions — for example, `cn-hangzhou` and `cn-beijing` did not return them during testing. This is a region deployment difference of the MNS-open API and does not affect `SetTopicAttributes`. In regions where these fields are not returned, the read-back value is empty, so a configured SSE block may show a plan diff; use `lifecycle.ignore_changes` on the SSE attributes if needed.
 * `tags` - (Optional, Map, Available since v1.241.0) A mapping of tags to assign to the resource.
 * `topic_name` - (Required, ForceNew) The name of the topic.
 * `topic_type` - (Optional, ForceNew, Computed, Available since v1.283.0) The type of the topic. Default value: `normal`. Valid values:


### PR DESCRIPTION
### What does this PR do?

Add server-side encryption (SSE) support to the `alicloud_message_service_queue` and `alicloud_message_service_topic` resources.

### New arguments

| Resource | Argument | Type | Notes |
|---|---|---|---|
| alicloud_message_service_queue | `enable_sse` | bool | Optional. Whether SSE is enabled for the queue. |
| alicloud_message_service_queue | `kms_key_id` | string | Optional/Computed. The KMS key id used for SSE. |
| alicloud_message_service_queue | `sse_algorithm` | string | Optional/Computed. The SSE algorithm. |
| alicloud_message_service_queue | `sse_type` | string | Optional/Computed. The SSE type. |
| alicloud_message_service_topic | `enable_sse` | bool | Optional. Whether SSE is enabled for the topic. |
| alicloud_message_service_topic | `kms_key_id` | string | Optional/Computed. The KMS key id used for SSE. |
| alicloud_message_service_topic | `sse_algorithm` | string | Optional/Computed. The SSE algorithm. |
| alicloud_message_service_topic | `sse_type` | string | Optional/Computed. The SSE type. |

The new arguments map to the `EnableSSE`, `KmsKeyId`, `SseAlgorithm` and `SseType`
parameters of the Mns-open (2022-01-19) `CreateQueue`, `SetQueueAttributes`,
`GetQueueAttributes`, `CreateTopic`, `SetTopicAttributes` and `GetTopicAttributes`
operations. They are sent on create and update, and read back during refresh.

### Example

```terraform
resource "alicloud_kms_key" "default" {
  key_name       = "tf-example-kms-key"
  pending_window = "5d"
}

resource "alicloud_message_service_queue" "default" {
  queue_name     = "tf-example-queue"
  enable_sse      = true
  sse_algorithm   = "KMS"
  kms_key_id      = alicloud_kms_key.default.id
}
```

### Tests

```
=== RUN TestAccAliCloudMessageServiceQueue_sse
=== RUN TestAccAliCloudMessageServiceTopic_sse
```

Remote acceptance tests for the new SSE arguments will be run on the ACube platform.
