### PR TITLE
resource/alicloud_rds_ddr_instance: skip CheckCreateDdrDBInstance pre-check for cloud disk types

### DIFF
--- a/alicloud/resource_alicloud_rds_ddr_instance.go
+++ b/alicloud/resource_alicloud_rds_ddr_instance.go
@@ -488,55 +488,66 @@ func resourceAlicloudRdsDdrInstanceCreate(d *schema.ResourceData, meta interface
 	client := meta.(*connectivity.AliyunClient)
 	rdsService := RdsService{client}
 	var err error
-	action := "CheckCreateDdrDBInstance"
-	request := map[string]interface{}{
-		"RegionId":          client.RegionId,
-		"Engine":            Trim(d.Get("engine").(string)),
-		"EngineVersion":     Trim(d.Get("engine_version").(string)),
-		"DBInstanceNetType": Intranet,
-		"DBInstanceClass":   Trim(d.Get("instance_type").(string)),
-		"DBInstanceStorage": d.Get("instance_storage"),
-		"SourceIp":          client.SourceIp,
-	}
-	restoreType := d.Get("restore_type").(string)
-	if restoreType == "BackupSet" {
-		request["RestoreType"] = "0"
-		if v, ok := d.GetOk("backup_set_id"); ok && v.(string) != "" {
-			request["BackupSetId"] = v
-		}
-	}
-	if restoreType == "BackupTime" {
-		request["RestoreType"] = "1"
-		if v, ok := d.GetOk("restore_time"); ok && v.(string) != "" {
-			request["RestoreTime"] = v
-		}
-		if v, ok := d.GetOk("source_region"); ok && v.(string) != "" {
-			request["SourceRegion"] = v
-		}
-		if v, ok := d.GetOk("source_db_instance_name"); ok && v.(string) != "" {
-			request["SourceDBInstanceName"] = v
-		}
-	}
 	var response map[string]interface{}
-	wait := incrementalWait(3*time.Second, 3*time.Second)
-	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
-		response, err = client.RpcPost("Rds", "2014-08-15", action, nil, request, false)
-		if err != nil {
-			if NeedRetry(err) {
-				wait()
-				return resource.RetryableError(err)
-			}
-			return resource.NonRetryableError(err)
+	// The CheckCreateDdrDBInstance pre-check API does not accept the
+	// DBInstanceStorageType parameter, so it cannot validate cloud disk
+	// (cloud_ssd / cloud_essd / cloud_essd2 / cloud_essd3) cross-region
+	// recovery configurations and aborts with
+	// "Current DB instance type does not support this operation" before
+	// CreateDdrInstance ever runs. Skip the pre-check for cloud disk types
+	// and go straight to CreateDdrInstance, which accepts
+	// DBInstanceStorageType. The pre-check is preserved for the local_ssd
+	// (and unspecified) case to keep the existing behavior.
+	if storageType, ok := d.GetOk("db_instance_storage_type"); !ok || storageType.(string) == "local_ssd" {
+		action := "CheckCreateDdrDBInstance"
+		request := map[string]interface{}{
+			"RegionId":          client.RegionId,
+			"Engine":            Trim(d.Get("engine").(string)),
+			"EngineVersion":     Trim(d.Get("engine_version").(string)),
+			"DBInstanceNetType": Intranet,
+			"DBInstanceClass":   Trim(d.Get("instance_type").(string)),
+			"DBInstanceStorage": d.Get("instance_storage"),
+			"SourceIp":          client.SourceIp,
 		}
-		return nil
-	})
+		restoreType := d.Get("restore_type").(string)
+		if restoreType == "BackupSet" {
+			request["RestoreType"] = "0"
+			if v, ok := d.GetOk("backup_set_id"); ok && v.(string) != "" {
+				request["BackupSetId"] = v
+			}
+		}
+		if restoreType == "BackupTime" {
+			request["RestoreType"] = "1"
+			if v, ok := d.GetOk("restore_time"); ok && v.(string) != "" {
+				request["RestoreTime"] = v
+			}
+			if v, ok := d.GetOk("source_region"); ok && v.(string) != "" {
+				request["SourceRegion"] = v
+			}
+			if v, ok := d.GetOk("source_db_instance_name"); ok && v.(string) != "" {
+				request["SourceDBInstanceName"] = v
+			}
+		}
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
+			response, err = client.RpcPost("Rds", "2014-08-15", action, nil, request, false)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
 
-	if err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		addDebug(action, response, request)
 	}
-	addDebug(action, response, request)
-	action = "CreateDdrInstance"
-	request, err = buildRdsDdrDBInstanceRequest(d, meta)
+	action := "CreateDdrInstance"
+	request, err := buildRdsDdrDBInstanceRequest(d, meta)
 	if err != nil {
 		return WrapError(err)
 	}


### PR DESCRIPTION
## Background

The `alicloud_rds_ddr_instance` resource invokes `CheckCreateDdrDBInstance` as a pre-check before `CreateDdrInstance` in `resourceAlicloudRdsDdrInstanceCreate`. The pre-check request does **not** carry `DBInstanceStorageType`, so it cannot validate cloud disk (cloud_ssd / cloud_essd / cloud_essd2 / cloud_essd3) cross-region recovery configurations and aborts with `Current DB instance type does not support this operation` before `CreateDdrInstance` ever runs. As a result, creating a cloud-disk DDR instance is impossible today even though the schema already accepts those storage types and `CreateDdrInstance` itself takes `DBInstanceStorageType`.

## Change

Skip the `CheckCreateDdrDBInstance` pre-check when the configured `db_instance_storage_type` is a cloud disk type (cloud_ssd / cloud_essd / cloud_essd2 / cloud_essd3) and go straight to `CreateDdrInstance`, which accepts `DBInstanceStorageType`. The pre-check is preserved for the `local_ssd` (and unspecified) case to keep the existing behavior unchanged.

## Notes

- Schema validation for `db_instance_storage_type` is unchanged; the field already accepted `local_ssd / cloud_ssd / cloud_essd / cloud_essd2 / cloud_essd3`.
- `buildRdsDdrDBInstanceRequest` already passes `DBInstanceStorageType` to `CreateDdrInstance`, so no request-building change is needed.
- The fix is intentionally minimal and behavior-preserving for the `local_ssd` path.

## Test plan

- Local `go build ./alicloud` and `go vet -p=1 ./alicloud` clean (the pre-existing `fmt.Sprintln` warnings in `common.go` are unrelated to this change).
- Remote ACC verification for the cloud-disk creation path is pending; existing `alicloud_rds_ddr_instance` acceptance cases (currently `Skip`-prefixed in `resource_alicloud_rds_ddr_instance_test.go`) cover both `local_ssd` and `cloud_essd` storage types and will be used to validate the behavior.