### PR TITLE
New Resource: alicloud_cr_artifact_subscription_rule and New Data Source: alicloud_cr_artifact_subscription_rules

### DIFF
--- a/alicloud/data_source_alicloud_cr_artifact_subscription_rules.go
+++ b/alicloud/data_source_alicloud_cr_artifact_subscription_rules.go
@@ -1,0 +1,277 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudCrArtifactSubscriptionRules() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudCrArtifactSubscriptionRuleRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"namespace_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"repo_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"accelerate": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"artifact_subscription_rule_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"modified_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"namespace_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"override": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"platform": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"repo_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_domain": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_namespace_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_provider": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_repo_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tag_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"tag_regexp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudCrArtifactSubscriptionRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListArtifactSubscriptionRule"
+	var err error
+	query = make(map[string]interface{})
+	query["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("instance_id"); ok {
+		query["InstanceId"] = v.(string)
+	}
+
+	query["PageSize"] = PageSizeLarge
+	query["PageNo"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcGet("cr", "2018-12-01", action, query, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, query)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.Rules[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["InstanceId"], ":", item["RuleId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		query["PageNo"] = query["PageNo"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(objectRaw["InstanceId"], ":", objectRaw["RuleId"])
+
+		mapping["accelerate"] = objectRaw["Accelerate"]
+		mapping["create_time"] = fmt.Sprintf("%v", objectRaw["CreateTime"])
+		mapping["modified_time"] = fmt.Sprintf("%v", objectRaw["ModifiedTime"])
+		mapping["namespace_name"] = objectRaw["NamespaceName"]
+		mapping["override"] = objectRaw["Override"]
+		mapping["platform"] = objectRaw["Platform"]
+		mapping["repo_name"] = objectRaw["RepoName"]
+		mapping["source_domain"] = objectRaw["SourceDomain"]
+		mapping["source_namespace_name"] = objectRaw["SourceNamespaceName"]
+		mapping["source_provider"] = objectRaw["SourceProvider"]
+		mapping["source_repo_name"] = objectRaw["SourceRepoName"]
+		mapping["tag_count"] = objectRaw["TagCount"]
+		mapping["tag_regexp"] = objectRaw["TagRegexp"]
+		mapping["artifact_subscription_rule_id"] = objectRaw["RuleId"]
+		mapping["instance_id"] = objectRaw["InstanceId"]
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["InstanceId"], ":", objectRaw["RuleId"])
+		mapping, err = dataSourceAliCloudCrArtifactSubscriptionRuleReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("rules", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudCrArtifactSubscriptionRuleReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	crServiceV2 := CrServiceV2{client}
+	getResp, err := crServiceV2.DescribeCrArtifactSubscriptionRule(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["accelerate"] = objectRaw["Accelerate"]
+	mapping["create_time"] = fmt.Sprintf("%v", objectRaw["CreateTime"])
+	mapping["modified_time"] = fmt.Sprintf("%v", objectRaw["ModifiedTime"])
+	mapping["namespace_name"] = objectRaw["NamespaceName"]
+	mapping["override"] = objectRaw["Override"]
+	mapping["platform"] = objectRaw["Platform"]
+	mapping["region_id"] = objectRaw["RegionId"]
+	mapping["repo_name"] = objectRaw["RepoName"]
+	mapping["source_domain"] = objectRaw["SourceDomain"]
+	mapping["source_namespace_name"] = objectRaw["SourceNamespaceName"]
+	mapping["source_provider"] = objectRaw["SourceProvider"]
+	mapping["source_repo_name"] = objectRaw["SourceRepoName"]
+	mapping["tag_count"] = objectRaw["TagCount"]
+	mapping["tag_regexp"] = objectRaw["TagRegexp"]
+	mapping["artifact_subscription_rule_id"] = objectRaw["RuleId"]
+	mapping["instance_id"] = objectRaw["InstanceId"]
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_cr_artifact_subscription_rules_test.go
+++ b/alicloud/data_source_alicloud_cr_artifact_subscription_rules_test.go
@@ -1,0 +1,87 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceAlicloudCrArtifactSubscriptionRules_basic(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccr%d", rand)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAlicloudCrArtifactSubscriptionRulesConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.alicloud_cr_artifact_subscription_rules.default", "rules.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAlicloudCrArtifactSubscriptionRulesConfig(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_cr_ee_instance" "default" {
+  default_oss_bucket = "true"
+  instance_name      = var.name
+  renewal_status     = "ManualRenewal"
+  image_scanner      = "ACR"
+  period             = "1"
+  payment_type       = "Subscription"
+  instance_type      = "Standard"
+
+  timeouts {
+    create = "30m"
+  }
+}
+
+resource "alicloud_cr_ee_namespace" "default" {
+  instance_id        = alicloud_cr_ee_instance.default.id
+  name               = var.name
+  auto_create        = false
+  default_visibility = "PRIVATE"
+}
+
+resource "alicloud_cr_ee_repo" "default" {
+  instance_id = alicloud_cr_ee_instance.default.id
+  namespace   = alicloud_cr_ee_namespace.default.name
+  name        = var.name
+  repo_type   = "PRIVATE"
+  summary     = "test repository for artifact subscription rule"
+}
+
+resource "alicloud_cr_artifact_subscription_rule" "default" {
+  instance_id           = alicloud_cr_ee_instance.default.id
+  source_provider       = "DOCKER_HUB"
+  source_namespace_name = "library"
+  source_repo_name      = "alpine"
+  namespace_name        = alicloud_cr_ee_namespace.default.name
+  repo_name             = alicloud_cr_ee_repo.default.name
+  tag_regexp            = ".*"
+  tag_count             = 1
+  override              = true
+  accelerate            = false
+  platform              = ["linux/amd64"]
+}
+
+data "alicloud_cr_artifact_subscription_rules" "default" {
+  instance_id    = alicloud_cr_ee_instance.default.id
+  enable_details  = true
+  ids             = [alicloud_cr_artifact_subscription_rule.default.id]
+}
+`, name)
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -171,6 +171,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"alicloud_redis_global_security_ip_groups":                dataSourceAliCloudRedisGlobalSecurityIpGroups(),
+			"alicloud_cr_artifact_subscription_rules":                 dataSourceAliCloudCrArtifactSubscriptionRules(),
 			"alicloud_apig_ai_model_providers":                        dataSourceAliCloudApigAiModelProviders(),
 			"alicloud_apig_services":                                  dataSourceAliCloudApigServices(),
 			"alicloud_apig_gateways":                                  dataSourceAliCloudApigGateways(),
@@ -952,6 +953,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_redis_global_security_ip_group":                       resourceAliCloudRedisGlobalSecurityIpGroup(),
+			"alicloud_cr_artifact_subscription_rule":                        resourceAliCloudCrArtifactSubscriptionRule(),
 			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),
 			"alicloud_apig_ai_model_provider":                               resourceAliCloudApigAiModelProvider(),
 			"alicloud_apig_service":                                         resourceAliCloudApigService(),

--- a/alicloud/resource_alicloud_cr_artifact_subscription_rule.go
+++ b/alicloud/resource_alicloud_cr_artifact_subscription_rule.go
@@ -1,0 +1,407 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudCrArtifactSubscriptionRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCrArtifactSubscriptionRuleCreate,
+		Read:   resourceAliCloudCrArtifactSubscriptionRuleRead,
+		Update: resourceAliCloudCrArtifactSubscriptionRuleUpdate,
+		Delete: resourceAliCloudCrArtifactSubscriptionRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"accelerate": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"artifact_subscription_rule_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"modified_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"namespace_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"override": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"platform": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"repo_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"source_domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_namespace_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"source_provider": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"source_repo_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tag_count": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"tag_regexp": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCrArtifactSubscriptionRuleCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateArtifactSubscriptionRule"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("instance_id"); ok {
+		request["InstanceId"] = v
+	}
+	request["RegionId"] = client.RegionId
+
+	request["SourceProvider"] = d.Get("source_provider")
+	if v, ok := d.GetOkExists("override"); ok {
+		request["Override"] = v
+	}
+	request["TagRegexp"] = d.Get("tag_regexp")
+	request["SourceRepoName"] = d.Get("source_repo_name")
+	if v, ok := d.GetOkExists("accelerate"); ok {
+		request["Accelerate"] = v
+	}
+	request["NamespaceName"] = d.Get("namespace_name")
+	request["RepoName"] = d.Get("repo_name")
+	request["TagCount"] = d.Get("tag_count")
+	if v, ok := d.GetOk("source_namespace_name"); ok {
+		request["SourceNamespaceName"] = v
+	}
+	if v, ok := d.GetOk("platform"); ok {
+		request["Platform"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("cr", "2018-12-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cr_artifact_subscription_rule", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", request["InstanceId"], response["RuleId"]))
+
+	return resourceAliCloudCrArtifactSubscriptionRuleUpdate(d, meta)
+}
+
+func resourceAliCloudCrArtifactSubscriptionRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	crServiceV2 := CrServiceV2{client}
+
+	objectRaw, err := crServiceV2.DescribeCrArtifactSubscriptionRule(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cr_artifact_subscription_rule DescribeCrArtifactSubscriptionRule Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+	if objectRaw["RuleId"] == nil || objectRaw["RuleId"] == "" {
+		if !d.IsNewResource() {
+			log.Printf("[DEBUG] Resource alicloud_cr_artifact_subscription_rule not found with id %s", d.Id())
+			d.SetId("")
+			return nil
+		}
+	}
+	d.Set("accelerate", objectRaw["Accelerate"])
+	d.Set("create_time", fmt.Sprintf("%v", objectRaw["CreateTime"]))
+	d.Set("modified_time", fmt.Sprintf("%v", objectRaw["ModifiedTime"]))
+	d.Set("namespace_name", objectRaw["NamespaceName"])
+	d.Set("override", objectRaw["Override"])
+	d.Set("platform", objectRaw["Platform"])
+	d.Set("repo_name", objectRaw["RepoName"])
+	d.Set("source_domain", objectRaw["SourceDomain"])
+	d.Set("source_namespace_name", objectRaw["SourceNamespaceName"])
+	d.Set("source_provider", objectRaw["SourceProvider"])
+	d.Set("source_repo_name", objectRaw["SourceRepoName"])
+	d.Set("tag_count", objectRaw["TagCount"])
+	d.Set("tag_regexp", objectRaw["TagRegexp"])
+	d.Set("artifact_subscription_rule_id", objectRaw["RuleId"])
+	d.Set("instance_id", objectRaw["InstanceId"])
+
+	return nil
+}
+
+func resourceAliCloudCrArtifactSubscriptionRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	action := "UpdateArtifactSubscriptionRule"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RuleId"] = parts[1]
+	request["InstanceId"] = parts[0]
+	request["RegionId"] = client.RegionId
+	if !d.IsNewResource() && d.HasChange("source_provider") {
+		update = true
+	}
+	request["SourceProvider"] = d.Get("source_provider")
+	if !d.IsNewResource() && d.HasChange("override") {
+		update = true
+	}
+	request["Override"] = d.Get("override")
+
+	if !d.IsNewResource() && d.HasChange("tag_regexp") {
+		update = true
+	}
+	request["TagRegexp"] = d.Get("tag_regexp")
+	if !d.IsNewResource() && d.HasChange("source_repo_name") {
+		update = true
+	}
+	request["SourceRepoName"] = d.Get("source_repo_name")
+	if !d.IsNewResource() && d.HasChange("accelerate") {
+		update = true
+	}
+	request["Accelerate"] = d.Get("accelerate")
+
+	if !d.IsNewResource() && d.HasChange("namespace_name") {
+		update = true
+	}
+	request["NamespaceName"] = d.Get("namespace_name")
+	if !d.IsNewResource() && d.HasChange("repo_name") {
+		update = true
+	}
+	request["RepoName"] = d.Get("repo_name")
+	if !d.IsNewResource() && d.HasChange("tag_count") {
+		update = true
+	}
+	request["TagCount"] = d.Get("tag_count")
+	if !d.IsNewResource() && d.HasChange("source_namespace_name") {
+		update = true
+	}
+	request["SourceNamespaceName"] = d.Get("source_namespace_name")
+	request["Platform"] = d.Get("platform")
+	if !d.IsNewResource() && d.HasChange("platform") {
+		update = true
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("cr", "2018-12-01", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		// UpdateArtifactSubscriptionRule is asynchronous on the server side:
+		// the RPC returns success before the changed fields are observable
+		// through GetArtifactSubscriptionRule. Poll until every field that
+		// was changed in this Update reflects the requested value, otherwise
+		// the subsequent Read picks up stale values and ImportStateVerify
+		// drifts. Only d.HasChange fields are compared so that Optional
+		// fields left untouched do not produce false mismatches on empty
+		// values.
+		crServiceV2 := CrServiceV2{client}
+		waitField := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			object, e := crServiceV2.DescribeCrArtifactSubscriptionRule(d.Id())
+			if e != nil {
+				if NotFoundError(e) {
+					return resource.NonRetryableError(WrapError(e))
+				}
+				waitField()
+				return resource.RetryableError(e)
+			}
+			if !crArtifactSubscriptionRuleFieldsConverged(d, object) {
+				waitField()
+				return resource.RetryableError(fmt.Errorf("waiting for cr artifact subscription rule to converge"))
+			}
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "UpdateArtifactSubscriptionRule", AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudCrArtifactSubscriptionRuleRead(d, meta)
+}
+
+func resourceAliCloudCrArtifactSubscriptionRuleDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := "DeleteArtifactSubscriptionRule"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["InstanceId"] = parts[0]
+	request["RuleId"] = parts[1]
+	request["RegionId"] = client.RegionId
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("cr", "2018-12-01", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}
+
+// crArtifactSubscriptionRuleScalarFields maps mutable Terraform field names
+// (no ForceNew, scalar types) to the response keys returned by
+// GetArtifactSubscriptionRule.
+var crArtifactSubscriptionRuleScalarFields = map[string]string{
+	"source_provider":       "SourceProvider",
+	"source_repo_name":      "SourceRepoName",
+	"source_namespace_name": "SourceNamespaceName",
+	"tag_regexp":            "TagRegexp",
+	"tag_count":             "TagCount",
+	"override":              "Override",
+	"accelerate":            "Accelerate",
+	"namespace_name":        "NamespaceName",
+	"repo_name":             "RepoName",
+}
+
+// crArtifactSubscriptionRuleFieldsConverged reports whether the asynchronous
+// UpdateArtifactSubscriptionRule RPC has settled: every field changed in this
+// Update must already reflect the requested value in the freshly-read API
+// object. Only d.HasChange fields are compared so Optional fields left
+// untouched do not produce false mismatches on empty values.
+func crArtifactSubscriptionRuleFieldsConverged(d *schema.ResourceData, object map[string]interface{}) bool {
+	for tfField, apiField := range crArtifactSubscriptionRuleScalarFields {
+		if !d.HasChange(tfField) {
+			continue
+		}
+		if !crArtifactSubscriptionRuleValueEqual(d.Get(tfField), object[apiField]) {
+			return false
+		}
+	}
+	if d.HasChange("platform") {
+		if !crArtifactSubscriptionRulePlatformEqual(d.Get("platform").([]interface{}), object["Platform"]) {
+			return false
+		}
+	}
+	return true
+}
+
+// crArtifactSubscriptionRuleValueEqual compares a Terraform-side scalar value
+// with the corresponding value from the API response. nil and empty
+// representations are treated as equivalent to tolerate Optional fields that
+// the API omits when unset.
+func crArtifactSubscriptionRuleValueEqual(expected interface{}, actual interface{}) bool {
+	expectedStr := fmt.Sprintf("%v", expected)
+	actualStr := fmt.Sprintf("%v", actual)
+	if expectedStr == "" || expectedStr == "<nil>" {
+		return actualStr == "" || actualStr == "<nil>"
+	}
+	return expectedStr == actualStr
+}
+
+// crArtifactSubscriptionRulePlatformEqual compares the configured platform
+// list with the API response, order-insensitively.
+func crArtifactSubscriptionRulePlatformEqual(expected []interface{}, actual interface{}) bool {
+	actualList, ok := actual.([]interface{})
+	if !ok {
+		return fmt.Sprintf("%v", expected) == fmt.Sprintf("%v", actual)
+	}
+	if len(expected) != len(actualList) {
+		return false
+	}
+	seen := make(map[string]bool, len(expected))
+	for _, e := range expected {
+		seen[fmt.Sprintf("%v", e)] = true
+	}
+	for _, a := range actualList {
+		if !seen[fmt.Sprintf("%v", a)] {
+			return false
+		}
+	}
+	return true
+}

--- a/alicloud/resource_alicloud_cr_artifact_subscription_rule_test.go
+++ b/alicloud/resource_alicloud_cr_artifact_subscription_rule_test.go
@@ -1,0 +1,274 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudCrArtifactSubscriptionRule_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cr_artifact_subscription_rule.default"
+	ra := resourceAttrInit(resourceId, AlicloudCrArtifactSubscriptionRuleMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCrArtifactSubscriptionRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCrArtifactSubscriptionRuleBasicDependence)
+
+	// baselineConfig returns the step1 (create) values for every attribute.
+	baselineConfig := func() map[string]interface{} {
+		return map[string]interface{}{
+			"instance_id":           "${alicloud_cr_ee_instance.default.id}",
+			"source_provider":       "DOCKER_HUB",
+			"source_namespace_name": "library",
+			"source_repo_name":      "alpine",
+			"namespace_name":        "${alicloud_cr_ee_namespace.default.name}",
+			"repo_name":             "${alicloud_cr_ee_repo.default.name}",
+			"tag_regexp":            ".*",
+			"tag_count":             "1",
+			"override":              "true",
+			"accelerate":            "false",
+			"platform":              []string{"linux/amd64", "linux/arm64"},
+		}
+	}
+
+	// secondValue is the alternate value each mutable attribute is flipped
+	// to, one attribute per step, so the single-attribute Update path
+	// (d.HasChange -> request -> RPC -> field-match waiter -> Read) is
+	// exercised in isolation for every attribute.
+	secondValue := map[string]interface{}{
+		"source_provider":       "QUAY",
+		"source_repo_name":      "busybox",
+		"source_namespace_name": "public",
+		"tag_regexp":            "v.*",
+		"tag_count":             "2",
+		"override":              "false",
+		"accelerate":            "true",
+		"platform":              []string{"linux/amd64"},
+		"namespace_name":        "${alicloud_cr_ee_namespace.second.name}",
+		"repo_name":             "${alicloud_cr_ee_repo.second.name}",
+	}
+
+	// singleAttrOrder lists the attributes flipped one per step in the
+	// accumulating config: stepConfig(k) is the baseline with the first k
+	// attributes already flipped, so step k+1 differs from step k in exactly
+	// one attribute and d.HasChange fires for that single attribute only.
+	singleAttrOrder := []string{
+		"source_provider",
+		"source_repo_name",
+		"source_namespace_name",
+		"tag_regexp",
+		"tag_count",
+		"override",
+		"accelerate",
+		"platform",
+	}
+	stepConfig := func(k int) map[string]interface{} {
+		cfg := baselineConfig()
+		for i := 0; i < k; i++ {
+			cfg[singleAttrOrder[i]] = secondValue[singleAttrOrder[i]]
+		}
+		return cfg
+	}
+	// pairConfig flips namespace_name and repo_name together as the final
+	// update step: the target repo must exist in the target namespace, so the
+	// two are advanced to the "second" namespace/repo pair in one step rather
+	// than producing an invalid intermediate state.
+	pairConfig := func() map[string]interface{} {
+		cfg := stepConfig(len(singleAttrOrder))
+		cfg["namespace_name"] = secondValue["namespace_name"]
+		cfg["repo_name"] = secondValue["repo_name"]
+		return cfg
+	}
+
+	// secondName is the resolved name of the "second" namespace and repo
+	// resources, both named "<name>-second" in the dependence.
+	secondName := fmt.Sprintf("%s-second", name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// step1: create the rule with the baseline configuration.
+			{
+				Config: testAccConfig(stepConfig(0)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_id":           CHECKSET,
+						"source_provider":       "DOCKER_HUB",
+						"source_namespace_name": "library",
+						"source_repo_name":      "alpine",
+						"tag_regexp":            ".*",
+						"tag_count":             "1",
+						"override":              "true",
+						"accelerate":            "false",
+						"platform.#":            "2",
+					}),
+				),
+			},
+			// step2: update source_provider only.
+			{
+				Config: testAccConfig(stepConfig(1)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"source_provider": "QUAY",
+					}),
+				),
+			},
+			// step3: update source_repo_name only.
+			{
+				Config: testAccConfig(stepConfig(2)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"source_repo_name": "busybox",
+					}),
+				),
+			},
+			// step4: update source_namespace_name only.
+			{
+				Config: testAccConfig(stepConfig(3)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"source_namespace_name": "public",
+					}),
+				),
+			},
+			// step5: update tag_regexp only.
+			{
+				Config: testAccConfig(stepConfig(4)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tag_regexp": "v.*",
+					}),
+				),
+			},
+			// step6: update tag_count only.
+			{
+				Config: testAccConfig(stepConfig(5)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tag_count": "2",
+					}),
+				),
+			},
+			// step7: update override only.
+			{
+				Config: testAccConfig(stepConfig(6)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"override": "false",
+					}),
+				),
+			},
+			// step8: update accelerate only.
+			{
+				Config: testAccConfig(stepConfig(7)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"accelerate": "true",
+					}),
+				),
+			},
+			// step9: update platform only (list value).
+			{
+				Config: testAccConfig(stepConfig(8)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"platform.#": "1",
+					}),
+					resource.TestCheckResourceAttr(resourceId, "platform.0", "linux/amd64"),
+				),
+			},
+			// step10: update namespace_name and repo_name together to the
+			// "second" namespace/repo pair (the target repo must live in the
+			// target namespace, so the two are flipped in one step).
+			{
+				Config: testAccConfig(pairConfig()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"namespace_name": secondName,
+						"repo_name":      secondName,
+					}),
+				),
+			},
+			// step11: import and verify the final state.
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudCrArtifactSubscriptionRuleMap = map[string]string{
+	"create_time":                   CHECKSET,
+	"modified_time":                 CHECKSET,
+	"artifact_subscription_rule_id": CHECKSET,
+	"source_domain":                 CHECKSET,
+}
+
+func AlicloudCrArtifactSubscriptionRuleBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_cr_ee_instance" "default" {
+  default_oss_bucket = "true"
+  instance_name      = var.name
+  renewal_status     = "ManualRenewal"
+  image_scanner      = "ACR"
+  period             = "1"
+  payment_type       = "Subscription"
+  instance_type      = "Standard"
+
+  timeouts {
+    create = "30m"
+  }
+}
+
+resource "alicloud_cr_ee_namespace" "default" {
+  instance_id        = alicloud_cr_ee_instance.default.id
+  name               = var.name
+  auto_create        = false
+  default_visibility = "PRIVATE"
+}
+
+resource "alicloud_cr_ee_namespace" "second" {
+  instance_id        = alicloud_cr_ee_instance.default.id
+  name               = "${var.name}-second"
+  auto_create        = false
+  default_visibility = "PRIVATE"
+}
+
+resource "alicloud_cr_ee_repo" "default" {
+  instance_id = alicloud_cr_ee_instance.default.id
+  namespace   = alicloud_cr_ee_namespace.default.name
+  name        = var.name
+  repo_type   = "PRIVATE"
+  summary     = "test repository for artifact subscription rule"
+}
+
+resource "alicloud_cr_ee_repo" "second" {
+  instance_id = alicloud_cr_ee_instance.default.id
+  namespace   = alicloud_cr_ee_namespace.second.name
+  name        = "${var.name}-second"
+  repo_type   = "PRIVATE"
+  summary     = "test repository second for artifact subscription rule"
+}
+`, name)
+}

--- a/alicloud/service_alicloud_cr_v2.go
+++ b/alicloud/service_alicloud_cr_v2.go
@@ -745,3 +745,79 @@ func (s *CrServiceV2) SetResourceTags(d *schema.ResourceData, resourceType strin
 }
 
 // SetResourceTags >>> tag function encapsulated.
+// DescribeCrArtifactSubscriptionRule <<< Encapsulated get interface for Cr ArtifactSubscriptionRule.
+
+func (s *CrServiceV2) DescribeCrArtifactSubscriptionRule(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	query["RuleId"] = parts[1]
+	query["InstanceId"] = parts[0]
+	query["RegionId"] = client.RegionId
+	action := "GetArtifactSubscriptionRule"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcGet("cr", "2018-12-01", action, query, request)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"INSTANCE_NOT_EXIST"}) {
+			return object, WrapErrorf(NotFoundErr("ArtifactSubscriptionRule", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *CrServiceV2) CrArtifactSubscriptionRuleStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.CrArtifactSubscriptionRuleStateRefreshFuncWithApi(id, field, failStates, s.DescribeCrArtifactSubscriptionRule)
+}
+
+func (s *CrServiceV2) CrArtifactSubscriptionRuleStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeCrArtifactSubscriptionRule >>> Encapsulated.

--- a/website/docs/d/cr_artifact_subscription_rules.html.markdown
+++ b/website/docs/d/cr_artifact_subscription_rules.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "Container Registry (CR)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cr_artifact_subscription_rules"
+sidebar_current: "docs-alicloud-datasource-cr-artifact-subscription-rules"
+description: |-
+  Provides a list of Cr Artifact Subscription Rule owned by an Alibaba Cloud account.
+---
+
+# alicloud_cr_artifact_subscription_rules
+
+This data source provides Cr Artifact Subscription Rule available to the user.[What is Artifact Subscription Rule](https://next.api.alibabacloud.com/document/cr/2018-12-01/CreateArtifactSubscriptionRule)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+data "alicloud_cr_artifact_subscription_rules" "example" {
+  instance_id    = "cri-xxx"
+  enable_details = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `instance_id` - (Required, ForceNew) Instance ID
+* `namespace_name` - (ForceNew, Optional) Namespace name
+* `repo_name` - (ForceNew, Optional) Repository name
+* `ids` - (Optional, Computed) A list of Artifact Subscription Rule IDs. The value is formulated as `<instance_id>:<artifact_subscription_rule_id>`.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Artifact Subscription Rule IDs.
+* `rules` - A list of Artifact Subscription Rule Entries. Each element contains the following attributes:
+  * `accelerate` - Whether to enable acceleration.
+  * `artifact_subscription_rule_id` - The first ID of the resource.
+  * `create_time` - Creation time.
+  * `instance_id` - Instance ID.
+  * `modified_time` - Modification time.
+  * `namespace_name` - Namespace name.
+  * `override` - Whether to override existing tags.
+  * `platform` - Subscription platform list.
+  * `region_id` - **NOTE:** This field is only available when `enable_details` is `true`. The region ID of the resource.
+  * `repo_name` - Repository name.
+  * `source_domain` - Source domain.
+  * `source_namespace_name` - Source namespace name.
+  * `source_provider` - Source image registry provider, e.
+  * `source_repo_name` - Source repository name.
+  * `tag_count` - Number of tags to subscribe.
+  * `tag_regexp` - Regular expression for subscribing tags.
+  * `id` - The ID of the resource supplied above.

--- a/website/docs/r/cr_artifact_subscription_rule.html.markdown
+++ b/website/docs/r/cr_artifact_subscription_rule.html.markdown
@@ -1,0 +1,101 @@
+---
+subcategory: "Container Registry (CR)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cr_artifact_subscription_rule"
+description: |-
+  Provides a Alicloud cr Artifact Subscription Rule resource.
+---
+
+# alicloud_cr_artifact_subscription_rule
+
+Provides a cr Artifact Subscription Rule resource.
+
+Artifact subscription rule.
+
+For information about cr Artifact Subscription Rule and how to use it, see [What is Artifact Subscription Rule](https://next.api.alibabacloud.com/document/cr/2018-12-01/CreateArtifactSubscriptionRule).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_cr_ee_instance" "example" {
+  default_oss_bucket = "true"
+  instance_name      = "tf-demo-cr-instance"
+  renewal_status     = "ManualRenewal"
+  image_scanner      = "DISABLE"
+  period             = "1"
+  payment_type       = "Subscription"
+  instance_type      = "Economy"
+}
+
+resource "alicloud_cr_ee_namespace" "example" {
+  instance_id        = alicloud_cr_ee_instance.example.id
+  name               = "tf-demo-cr-namespace"
+  auto_create        = false
+  default_visibility = "PRIVATE"
+}
+
+resource "alicloud_cr_ee_repo" "example" {
+  instance_id = alicloud_cr_ee_instance.example.id
+  namespace   = alicloud_cr_ee_namespace.example.name
+  name        = "tf-demo-cr-repo"
+  repo_type   = "PRIVATE"
+  summary     = "demo repository"
+}
+
+resource "alicloud_cr_artifact_subscription_rule" "example" {
+  instance_id           = alicloud_cr_ee_instance.example.id
+  source_provider       = "DOCKER_HUB"
+  source_namespace_name = "library"
+  source_repo_name      = "alpine"
+  namespace_name        = alicloud_cr_ee_namespace.example.name
+  repo_name             = alicloud_cr_ee_repo.example.name
+  tag_regexp            = ".*"
+  tag_count             = 10
+  override              = true
+  accelerate            = false
+  platform              = ["linux/amd64", "linux/arm64"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `accelerate` - (Optional) Whether to enable acceleration
+* `instance_id` - (Required, ForceNew) Instance ID
+* `namespace_name` - (Required) Namespace name
+* `override` - (Optional) Whether to override existing tags
+* `platform` - (Required, List) Subscription platform list
+* `repo_name` - (Required) Repository name
+* `source_namespace_name` - (Optional) Source namespace name
+* `source_provider` - (Required) Source image registry provider, e.g. DOCKER_HUB, GCR, QUAY
+* `source_repo_name` - (Required) Source repository name
+* `tag_count` - (Required, Int) Number of tags to subscribe
+* `tag_regexp` - (Required) Regular expression for subscribing tags
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<instance_id>:<artifact_subscription_rule_id>`.
+* `artifact_subscription_rule_id` - The first ID of the resource.
+* `create_time` - Creation time.
+* `modified_time` - Modification time.
+* `source_domain` - Source domain.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Artifact Subscription Rule.
+* `delete` - (Defaults to 5 mins) Used when delete the Artifact Subscription Rule.
+* `update` - (Defaults to 5 mins) Used when update the Artifact Subscription Rule.
+
+## Import
+
+cr Artifact Subscription Rule can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cr_artifact_subscription_rule.example <instance_id>:<artifact_subscription_rule_id>
+```


### PR DESCRIPTION
### New Resource: alicloud_cr_artifact_subscription_rule

Add the `alicloud_cr_artifact_subscription_rule` resource and the `alicloud_cr_artifact_subscription_rules` data source to support ACR (Container Registry) enterprise edition artifact subscription. This subscribes overseas source images (Docker Hub, GCR, Quay) to enterprise instance repositories.

### Example Usage

```hcl
resource "alicloud_cr_artifact_subscription_rule" "example" {
  instance_id           = "cri-xxx"
  source_provider       = "DOCKER_HUB"
  source_namespace_name = "library"
  source_repo_name      = "alpine"
  namespace_name        = "my-namespace"
  repo_name             = "my-repo"
  tag_regexp            = ".*"
  tag_count             = 10
  override              = true
  accelerate            = false
  platform              = ["CENTOS", "UBUNTU"]
}

data "alicloud_cr_artifact_subscription_rules" "example" {
  instance_id    = "cri-xxx"
  enable_details = true
}
```

### Argument Reference

The following arguments are supported for `alicloud_cr_artifact_subscription_rule`:

* `instance_id` - (Required, ForceNew) The ID of the ACR enterprise instance.
* `source_provider` - (Required) The source image registry provider. Valid values: `DOCKER_HUB`, `GCR`, `QUAY`.
* `source_namespace_name` - (Optional) The source namespace name.
* `source_repo_name` - (Required) The source repository name.
* `namespace_name` - (Required) The target namespace name on the enterprise instance.
* `repo_name` - (Required) The target repository name on the enterprise instance.
* `tag_regexp` - (Required) The regular expression for subscribing tags.
* `tag_count` - (Required) The number of tags to subscribe. Valid values: 1-30.
* `override` - (Optional) Whether to override existing tags.
* `accelerate` - (Optional) Whether to enable acceleration.
* `platform` - (Required) The subscription platform list.

The following attributes are exported:

* `artifact_subscription_rule_id` - The ID of the artifact subscription rule.
* `create_time` - The creation time of the rule.
* `modified_time` - The modification time of the rule.
* `source_domain` - The source domain.

### Test Cases

- `TestAccAliCloudCrArtifactSubscriptionRule_basic`
- `TestAccDataSourceAlicloudCrArtifactSubscriptionRules_basic`

Remote acceptance test results will be appended once verified.