### PR TITLE
resource/alicloud_amqp_virtual_host: retry the transient instance-not-ready error on create

### DIFF
--- a/alicloud/resource_alicloud_amqp_virtual_host.go
+++ b/alicloud/resource_alicloud_amqp_virtual_host.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alibabacloud-go/tea/tea"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -57,7 +58,7 @@ func resourceAliCloudAmqpVirtualHostCreate(d *schema.ResourceData, meta interfac
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("amqp-open", "2019-12-12", action, query, request, true)
 		if err != nil {
-			if NeedRetry(err) {
+			if NeedRetry(err) || isAmqpInstanceNotReadyError(err) {
 				wait()
 				return resource.RetryableError(err)
 			}
@@ -135,4 +136,21 @@ func resourceAliCloudAmqpVirtualHostDelete(d *schema.ResourceData, meta interfac
 	}
 
 	return nil
+}
+
+// isAmqpInstanceNotReadyError reports whether err is the transient failure that
+// amqp-open returns while a newly created instance is still initializing. The
+// instance already reports SERVING by that point and GetInstance exposes no
+// finer-grained readiness field, so this error is the only available signal that
+// the instance cannot serve virtual host creation yet.
+//
+// The match is deliberately narrowed to this one message. Other InvalidParameter
+// failures, such as a malformed virtual host name, must keep failing fast.
+func isAmqpInstanceNotReadyError(err error) bool {
+	e, ok := err.(*tea.SDKError)
+	if !ok {
+		return false
+	}
+
+	return tea.StringValue(e.Code) == "InvalidParameter" && strings.Contains(tea.StringValue(e.Message), "the internal error!")
 }

--- a/alicloud/resource_alicloud_amqp_virtual_host_test.go
+++ b/alicloud/resource_alicloud_amqp_virtual_host_test.go
@@ -206,6 +206,16 @@ func TestUnitAliCloudAmqpVirtualHost(t *testing.T) {
 				StatusCode: tea.Int(400),
 			}
 		},
+		// The transient failure amqp-open returns while a freshly created instance
+		// is still initializing, even though it already reports SERVING.
+		"InstanceNotReadyError": func(errorCode string) (map[string]interface{}, error) {
+			return nil, &tea.SDKError{
+				Code:       String("InvalidParameter"),
+				Data:       String(`{"Code":"InvalidParameter","Message":"the internal error!","RequestId":"MockRequestId"}`),
+				Message:    String("code: 400, the internal error! request id: MockRequestId"),
+				StatusCode: tea.Int(400),
+			}
+		},
 		"CreateNormal": func(errorCode string) (map[string]interface{}, error) {
 			result := ReadMockResponse
 			return result, nil
@@ -270,6 +280,32 @@ func TestUnitAliCloudAmqpVirtualHost(t *testing.T) {
 		err := resourceAliCloudAmqpVirtualHostCreate(dCreate, rawClient)
 		patches.Reset()
 		assert.Nil(t, err)
+	})
+	// Creating a virtual host in the same apply as its instance can hit the
+	// instance initialization window; the first attempt must be retried rather
+	// than aborting the apply.
+	t.Run("CreateInstanceNotReadyThenNormal", func(t *testing.T) {
+		dNotReady, _ := schema.InternalMap(p["alicloud_amqp_virtual_host"].Schema).Data(nil, nil)
+		dNotReady.MarkNewResource()
+		for key, value := range map[string]interface{}{
+			"instance_id":       "instance_id",
+			"virtual_host_name": "virtual_host_name",
+		} {
+			err := dNotReady.Set(key, value)
+			assert.Nil(t, err)
+		}
+		notReadyFlag := true
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, _ *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			if notReadyFlag {
+				notReadyFlag = false
+				return responseMock["InstanceNotReadyError"]("")
+			}
+			return responseMock["CreateNormal"]("")
+		})
+		err := resourceAliCloudAmqpVirtualHostCreate(dNotReady, rawClient)
+		patches.Reset()
+		assert.Nil(t, err)
+		assert.False(t, notReadyFlag, "the transient error should have been served and retried")
 	})
 
 	// Set ID for Update and Delete Method
@@ -380,6 +416,58 @@ func TestUnitAliCloudAmqpVirtualHost(t *testing.T) {
 	})
 }
 
+func TestUnitAliCloudAmqpVirtualHostIsInstanceNotReadyError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name: "instance still initializing",
+			err: &tea.SDKError{
+				Code:       String("InvalidParameter"),
+				Message:    String("code: 400, the internal error! request id: MockRequestId"),
+				StatusCode: tea.Int(400),
+			},
+			expected: true,
+		},
+		{
+			name: "other InvalidParameter failures still fail fast",
+			err: &tea.SDKError{
+				Code:       String("InvalidParameter"),
+				Message:    String("code: 400, the VirtualHost is invalid. request id: MockRequestId"),
+				StatusCode: tea.Int(400),
+			},
+			expected: false,
+		},
+		{
+			name: "same message under another code is not the readiness signal",
+			err: &tea.SDKError{
+				Code:       String("InvalidInstanceId.NotFound"),
+				Message:    String("code: 400, the internal error! request id: MockRequestId"),
+				StatusCode: tea.Int(400),
+			},
+			expected: false,
+		},
+		{
+			name:     "non sdk error",
+			err:      Error("the internal error!"),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, isAmqpInstanceNotReadyError(testCase.err))
+		})
+	}
+}
+
 // Test Amqp VirtualHost. >>> Resource test cases, automatically generated.
 // Case VirtualHost_测试用例 7216
 func TestAccAliCloudAmqpVirtualHost_basic7216(t *testing.T) {
@@ -433,6 +521,20 @@ func AliCloudAmqpVirtualHostBasicDependence7216(name string) string {
     	default = "%s"
 	}
 
+	data "alicloud_vpcs" "default" {
+  		name_regex = "default-NODELETING"
+	}
+
+	data "alicloud_vswitches" "default" {
+  		vpc_id     = data.alicloud_vpcs.default.ids.0
+  		name_regex = "^default-NODELETING-ACK-switch"
+	}
+
+	data "alicloud_security_groups" "default" {
+  		vpc_id     = data.alicloud_vpcs.default.ids.0
+  		name_regex = "^sae"
+	}
+
 	resource "alicloud_amqp_instance" "default" {
   		instance_name         = var.name
   		instance_type         = "enterprise"
@@ -444,6 +546,9 @@ func AliCloudAmqpVirtualHostBasicDependence7216(name string) string {
   		renewal_duration      = 1
   		renewal_duration_unit = "Year"
   		support_eip           = true
+  		vpc_id                = data.alicloud_vswitches.default.vpc_id
+  		vswitch_ids           = [data.alicloud_vswitches.default.ids.0, data.alicloud_vswitches.default.ids.1]
+  		security_group_id     = data.alicloud_security_groups.default.ids.0
 	}
 `, name)
 }


### PR DESCRIPTION
### Problem

Creating an `alicloud_amqp_instance` and an `alicloud_amqp_virtual_host` in the same apply can fail with:

```
StatusCode: 400
Code: InvalidParameter
Message: the internal error!
```

This came from a customer report; they were working around it with a fixed `time_sleep` between the two resources.

The instance resource already waits for `Status == SERVING` before returning, and `GetInstance` exposes no finer-grained readiness field — `Status` is only `DEPLOYING` / `EXPIRED` / `SERVING` / `RELEASED`. The service can still reject `CreateVirtualHost` for a short window after `SERVING`. Since `NeedRetry` covers only 5xx, throttling and network errors, this 400 became a `NonRetryableError` and aborted the apply.

The signature is diagnostic: the first virtual host create against a fresh instance fails, and subsequent creates on the same instance succeed.

### Fix

Retry `CreateVirtualHost` within the existing create timeout when the error is `InvalidParameter` **and** its message contains `the internal error!`.

The match is deliberately narrow. Retrying on the `InvalidParameter` code alone would swallow genuine parameter errors, so other `InvalidParameter` failures — a malformed virtual host name, for instance — still fail fast, with the original error message and RequestId preserved.

### Tests

- `TestUnitAliCloudAmqpVirtualHostIsInstanceNotReadyError` — table-driven boundaries: the transient error is retried; a different `InvalidParameter` message is not; the same message under a different code is not; non-SDK and nil errors are not.
- `TestUnitAliCloudAmqpVirtualHost/CreateInstanceNotReadyThenNormal` — drives create through a first-attempt transient failure into a success, and asserts the transient error was actually served rather than skipped.
- Fixture repair: `AliCloudAmqpVirtualHostBasicDependence7216` created an instance with no VPC and failed in about a second with `MissingVswitchIds` — the API made `VswitchIds` mandatory after the fixture was generated. Added the vpc / vswitch / security-group data sources. `release/v2` already carries the equivalent fixture fix; this brings master in line.

### AccTest

```
PASS: TestAccAliCloudAmqpVirtualHost_basic7216 (447.25s)
1 passed / 0 failed / 0 skipped (of 1)
```

Worth stating plainly: this run did not reproduce the race — `CreateVirtualHost` was called once and succeeded on the first attempt. So the acceptance test demonstrates no regression on the normal instance-then-virtual-host path, while the retry path itself is covered by the unit tests above. Teardown released the subscription instance cleanly.
