### PR TITLE
New Data Source: alicloud_cms_metric_list

### DIFF
--- a/alicloud/data_source_alicloud_cms_metric_list.go
+++ b/alicloud/data_source_alicloud_cms_metric_list.go
@@ -1,0 +1,245 @@
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// data source alicloud_cms_metric_list wraps the DescribeMetricList RPC
+// (Cms/2019-01-01). It returns the metric datapoints of the given metric
+// name and namespace within a time range. The result is paginated by
+// NextToken and Datapoints is a JSON string that must be unmarshalled.
+
+const cmsDescribeMetricListDefaultLength = 1000
+
+func dataSourceAlicloudCmsMetricList() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudCmsMetricListRead,
+		Schema: map[string]*schema.Schema{
+			"metric_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"metric_namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"dimensions": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"start_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"end_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"period": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"express": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"length": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"next_token": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"datapoints": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"metric_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"timestamp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"average": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"sum": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"maximum": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"minimum": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"count": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"user_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"actual_period": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudCmsMetricListRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "DescribeMetricList"
+	request := make(map[string]interface{})
+	request["MetricName"] = d.Get("metric_name")
+	request["Namespace"] = d.Get("metric_namespace")
+	if v, ok := d.GetOk("dimensions"); ok {
+		request["Dimensions"] = v
+	}
+	if v, ok := d.GetOk("start_time"); ok {
+		request["StartTime"] = v
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		request["EndTime"] = v
+	}
+	if v, ok := d.GetOk("period"); ok {
+		request["Period"] = v
+	}
+	if v, ok := d.GetOk("express"); ok {
+		request["Express"] = v
+	}
+	if v, ok := d.GetOk("length"); ok {
+		request["Length"] = v.(int)
+	}
+	if v, ok := d.GetOk("next_token"); ok {
+		request["NextToken"] = v
+	}
+	if _, ok := request["Length"]; !ok {
+		request["Length"] = cmsDescribeMetricListDefaultLength
+	}
+
+	var objects []map[string]interface{}
+	var response map[string]interface{}
+	var err error
+	currentToken := fmt.Sprint(request["NextToken"])
+	for {
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPost("Cms", "2019-01-01", action, nil, request, false)
+			if err != nil {
+				if IsExpectedErrors(err, []string{"InternalError", "BadRequest"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			// DescribeMetricList returns error 10002 ("the metric ... is not
+			// exist") when the requested metric name does not exist for the
+			// given namespace. For this query-only data source that is a valid
+			// empty result, so set the id and return instead of surfacing the
+			// error.
+			if IsExpectedErrors(err, []string{"10002"}) || IsExpectedErrorsMessage(err, "is not exist") {
+				d.SetId(dataResourceIdHash([]string{d.Get("metric_name").(string), d.Get("metric_namespace").(string)}))
+				return nil
+			}
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_cms_metric_list", action, AlibabaCloudSdkGoERROR)
+		}
+		if code, ok := response["Code"].(string); ok && code != "" && code != "200" {
+			msg := fmt.Sprint(response["Message"])
+			return WrapError(fmt.Errorf("%s failed, code: %s, message: %s", action, code, msg))
+		}
+
+		datapointsStr, ok := response["Datapoints"].(string)
+		var datapoints []map[string]interface{}
+		if ok && datapointsStr != "" {
+			if jsonErr := json.Unmarshal([]byte(datapointsStr), &datapoints); jsonErr != nil {
+				return WrapErrorf(jsonErr, "unmarshal Datapoints for %s", action)
+			}
+		}
+		objects = append(objects, datapoints...)
+
+		nextToken, ok := response["NextToken"].(string)
+		if !ok || nextToken == "" || nextToken == currentToken {
+			break
+		}
+		currentToken = nextToken
+		request["NextToken"] = nextToken
+	}
+
+	s := make([]map[string]interface{}, 0)
+	ids := make([]string, 0)
+	for _, dp := range objects {
+		item := map[string]interface{}{
+			"uuid":        fmt.Sprint(dp["uuid"]),
+			"metric_name": fmt.Sprint(dp["MetricName"]),
+			"timestamp":   fmt.Sprint(dp["Timestamp"]),
+			"average":     dp["Average"],
+			"sum":         dp["Sum"],
+			"maximum":     dp["Maximum"],
+			"minimum":     dp["Minimum"],
+			"count":       dp["Count"],
+			"user_id":     fmt.Sprint(dp["userId"]),
+			"instance_id": fmt.Sprint(dp["instanceId"]),
+		}
+		s = append(s, item)
+		if id := fmt.Sprint(dp["uuid"]); id != "" && id != "<nil>" {
+			ids = append(ids, id)
+		}
+	}
+
+	d.SetId(dataResourceIdHash([]string{d.Get("metric_name").(string), d.Get("metric_namespace").(string)}))
+	if err := d.Set("datapoints", s); err != nil {
+		return WrapError(err)
+	}
+	if v, ok := response["NextToken"]; ok {
+		if err := d.Set("next_token", fmt.Sprint(v)); err != nil {
+			return WrapError(err)
+		}
+	}
+	if v, ok := response["Period"]; ok {
+		if err := d.Set("actual_period", fmt.Sprint(v)); err != nil {
+			return WrapError(err)
+		}
+	}
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+
+	return nil
+}

--- a/alicloud/data_source_alicloud_cms_metric_list_test.go
+++ b/alicloud/data_source_alicloud_cms_metric_list_test.go
@@ -1,0 +1,93 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+// TestAccAlicloudCmsMetricListDataSource verifies the data source that wraps
+// DescribeMetricList (Cms/2019-01-01). It queries the read-only
+// acs_ecs_dashboard CPUUtilization metric within the last 1-2 hours so the
+// test does not depend on any provisioned resource. The "exist" config uses
+// a real metric name (expecting a non-empty response when the account has
+// ECS instances, otherwise still a valid empty list), while the "fake" config
+// queries a non-existent metric name and expects an empty datapoints list.
+func TestAccAlicloudCmsMetricListDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+
+	basicConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsMetricListDataSourceName(rand, map[string]string{
+			"metric_name":      `"CPUUtilization"`,
+			"metric_namespace": `"acs_ecs_dashboard"`,
+			"period":           `"60"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsMetricListDataSourceName(rand, map[string]string{
+			"metric_name":      `"FakeMetricNotExist"`,
+			"metric_namespace": `"acs_ecs_dashboard"`,
+			"period":           `"60"`,
+		}),
+	}
+
+	periodConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsMetricListDataSourceName(rand, map[string]string{
+			"metric_name":      `"CPUUtilization"`,
+			"metric_namespace": `"acs_ecs_dashboard"`,
+			"period":           `"300"`,
+			"length":           "100",
+		}),
+		fakeConfig: testAccCheckAlicloudCmsMetricListDataSourceName(rand, map[string]string{
+			"metric_name":      `"FakeMetricNotExist"`,
+			"metric_namespace": `"acs_ecs_dashboard"`,
+			"period":           `"300"`,
+			"length":           "100",
+		}),
+	}
+
+	var existAlicloudCmsMetricListDataSourceNameMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"datapoints.#":  CHECKSET,
+			"actual_period": CHECKSET,
+		}
+	}
+	var fakeAlicloudCmsMetricListDataSourceNameMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"datapoints.#": "0",
+		}
+	}
+	var alicloudCmsMetricListCheckInfo = dataSourceAttr{
+		resourceId:   "data.alicloud_cms_metric_list.default",
+		existMapFunc: existAlicloudCmsMetricListDataSourceNameMapFunc,
+		fakeMapFunc:  fakeAlicloudCmsMetricListDataSourceNameMapFunc,
+	}
+
+	preCheck := func() {
+		testAccPreCheck(t)
+	}
+	alicloudCmsMetricListCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, basicConf, periodConf)
+}
+
+func testAccCheckAlicloudCmsMetricListDataSourceName(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+
+	// Use a dynamic time window (1h-2h ago to 1h ago) so the test stays valid
+	// over time. CMS DescribeMetricList accepts ISO 8601 timestamps.
+	now := time.Now()
+	start := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	end := now.Add(-1 * time.Hour).Format(time.RFC3339)
+
+	config := fmt.Sprintf(`
+data "alicloud_cms_metric_list" "default" {
+	start_time = "%s"
+	end_time = "%s"
+	%s
+}
+`, start, end, strings.Join(pairs, " \n "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -866,6 +866,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cen_transit_router_cidrs":                         dataSourceAlicloudCenTransitRouterCidrs(),
 			"alicloud_ga_basic_accelerators":                            dataSourceAliCloudGaBasicAccelerators(),
 			"alicloud_cms_metric_rule_black_lists":                      dataSourceAlicloudCmsMetricRuleBlackLists(),
+			"alicloud_cms_metric_list":                                  dataSourceAlicloudCmsMetricList(),
 			"alicloud_cloud_firewall_vpc_firewall_cens":                 dataSourceAlicloudCloudFirewallVpcFirewallCens(),
 			"alicloud_cloud_firewall_vpc_firewalls":                     dataSourceAlicloudCloudFirewallVpcFirewalls(),
 			"alicloud_cloud_firewall_instance_members":                  dataSourceAlicloudCloudFirewallInstanceMembers(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -1044,6 +1044,9 @@
                             <a href="/docs/providers/alicloud/d/cms_hybrid_monitor_fc_tasks.html">alicloud_cms_hybrid_monitor_fc_tasks</a>
                           </li>
                           <li>
+                            <a href="/docs/providers/alicloud/d/cms_metric_list.html">alicloud_cms_metric_list</a>
+                          </li>
+                          <li>
                             <a href="/docs/providers/alicloud/d/cms_metric_rule_black_lists.html">alicloud_cms_metric_rule_black_lists</a>
                          </li>
                           <li>

--- a/website/docs/d/cms_metric_list.html.markdown
+++ b/website/docs/d/cms_metric_list.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "Cloud Monitor Service"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_metric_list"
+sidebar_current: "docs-alicloud-datasource-cms-metric-list"
+description: |-
+  Provides the datapoints of a specified Cloud Monitor metric to the user.
+---
+
+# alicloud_cms_metric_list
+
+This data source provides the datapoints of a specified Cloud Monitor Service (CMS) metric within a time range. It wraps the `DescribeMetricList` API (Cms/2019-01-01) and paginates by `NextToken`.
+
+-> **NOTE:** Available since v1.289.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+data "alicloud_cms_metric_list" "example" {
+  metric_name      = "CPUUtilization"
+  metric_namespace = "acs_ecs_dashboard"
+  dimensions       = "{\"instanceId\":\"i-bp1example\"}"
+  start_time       = "2026-08-01 00:00:00"
+  end_time         = "2026-08-01 01:00:00"
+  period           = "60"
+}
+
+output "first_datapoint_average" {
+  value = data.alicloud_cms_metric_list.example.datapoints.0.average
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `metric_name` - (Required) The name of the monitoring metric.
+* `metric_namespace` - (Required) The namespace of the monitoring metric. For example, `acs_ecs_dashboard` for ECS and `acs_rds_dashboard` for RDS.
+* `dimensions` - (Optional) The dimensions that classify the monitoring metric. The value is a JSON string that contains key-value pairs. For example, `{"instanceId":"i-bp1example"}`.
+* `start_time` - (Optional) The beginning of the time range to query. Specify the time in the `YYYY-MM-DD HH:mm:ss` format or as a Unix timestamp in milliseconds. This value must be earlier than the end time.
+* `end_time` - (Optional) The end of the time range to query. Specify the time in the `YYYY-MM-DD HH:mm:ss` format or as a Unix timestamp in milliseconds.
+* `period` - (Optional) The interval at which monitoring data is collected. Unit: seconds. Valid values: `60`, `300`, `900`.
+* `express` - (Optional) The aggregation method that is used to display the monitoring data. The value is a JSON string. For example, `{"downsample":"avg"}`.
+* `length` - (Optional) The maximum number of entries that are returned in a single query. If you do not specify this parameter, the default value `1000` is used.
+* `next_token` - (Optional) The pagination token that is used in the next request to retrieve more datapoints.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The ID of the data source. It is computed from the metric name and namespace.
+* `datapoints` - A list of Cms Metric Datapoints. Each element contains the following attributes:
+  * `uuid` - The unique identifier of the datapoint.
+  * `metric_name` - The name of the monitoring metric.
+  * `timestamp` - The timestamp that indicates when the metric value was collected.
+  * `average` - The average of the metric values within the statistical period.
+  * `sum` - The sum of the metric values within the statistical period.
+  * `maximum` - The maximum metric value within the statistical period.
+  * `minimum` - The minimum metric value within the statistical period.
+  * `count` - The number of times that the metric value is collected within the statistical period.
+  * `user_id` - The ID of the Alibaba Cloud user.
+  * `instance_id` - The ID of the instance.
+* `actual_period` - The actual period at which monitoring data is collected. This value is returned by the server.
+* `next_token` - The pagination token that can be used in the next request to retrieve more datapoints.


### PR DESCRIPTION
### New Data Source: alicloud_cms_metric_list

This adds a read-only data source `alicloud_cms_metric_list` that wraps the `DescribeMetricList` RPC (Cms/2019-01-01). It returns Cloud Monitor metric datapoints for a given metric name and namespace within a time range.

#### Schema

Inputs:

- `metric_name` (required) — the metric name, e.g. `CPUUtilization`.
- `metric_namespace` (required) — the namespace, e.g. `acs_ecs_dashboard`.
- `dimensions` (optional) — the dimensions JSON string used to filter the metric.
- `start_time` / `end_time` (optional) — the time range (ISO 8601 or epoch ms).
- `period` (optional) — the aggregation period, e.g. `60`, `300`, `900`.
- `express` (optional) — the downstream data aggregation method.
- `length` (optional) — the maximum number of datapoints returned per page.
- `next_token` (optional) — the pagination cursor for subsequent calls.

Outputs:

- `datapoints` — list of datapoints, each with `uuid`, `metric_name`, `timestamp`, `average`, `sum`, `maximum`, `minimum`, `count`, `user_id`, `instance_id`.
- `actual_period` — the period the server applied to the response.
- `next_token` — the pagination cursor for the next page.
- `output_file` — save the datapoints list to a file.

#### Behavior

- Paginates via `NextToken` until exhausted (with a guard against the server returning the same token twice).
- Parses the `Datapoints` JSON string returned by the API into structured output.
- Retries on `InternalError` / `BadRequest` and on retryable errors.

#### Tests

`TestAccAlicloudCmsMetricListDataSource` covers two configurations:

- `period=60` against `acs_ecs_dashboard` / `CPUUtilization`.
- `period=300` with `length=100` against the same metric.

Both configs query a dynamic 1–2 hour-ago time window of the read-only `acs_ecs_dashboard` `CPUUtilization` metric, so the test does not provision any resource. The `exist` config asserts the response is well-formed (`datapoints.#` set, `actual_period` set); the `fake` config queries a non-existent metric name and asserts an empty `datapoints` list.
