### PR TITLE
docs: fix http_api_name and type descriptions for apig_http_api

### DIFF
--- a/website/docs/r/apig_http_api.html.markdown
+++ b/website/docs/r/apig_http_api.html.markdown
@@ -79,19 +79,20 @@ The following arguments are supported:
 
 -> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
 
-* `http_api_name` - (Required, ForceNew) Perform an exact search by name.
+* `http_api_name` - (Required, ForceNew) The name of the HTTP API.
 * `model_category` - (Optional, Available since v1.285.0) AI model category
 
 -> **NOTE:** This parameter is immutable. Changing it after creation has no effect.
 
 * `protocols` - (Required, List) List of API access protocols. Valid values: `HTTP`, `HTTPS`.
 * `resource_group_id` - (Optional, Computed) The ID of the resource group. It can be modified to migrate the resource to another resource group.
-* `type` - (Required, ForceNew) The type of the HTTP API. Multiple types are supported and must be separated by commas (,).
+* `type` - (Required, ForceNew) The type of the HTTP API. Valid values: `Http`, `Rest`, `WebSocket`, `HttpIngress`, `LLM`, `Agent`.
   - Http
-  - Rest  
-  - LLM  
-  - WebSocket  
-  - HttpIngress  
+  - Rest
+  - LLM
+  - WebSocket
+  - HttpIngress
+  - Agent
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Fixes two description issues in the `alicloud_apig_http_api` resource documentation:

- **`http_api_name`**: the description read as an exact-match search ("Perform an exact search by name."), which is incorrect; it now reads as the API name ("The name of the HTTP API.").
- **`type`**: the description claimed "Multiple types are supported and must be separated by commas (,)", but the schema is a single `schema.TypeString` and the example uses a single value (`type = "Rest"`). The description now lists the valid enum values and adds the previously missing `Agent` value.

The descriptions are aligned with the backing OpenAPI (APIG `CreateHttpApi`) parameter documentation. No schema, type, constraint, or CRUD changes — docs only.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] Any dependent changes have been merged and published in downstream modules