### PR TITLE
New Data Source: alicloud_sae_application_instances

### DIFF
--- a/alicloud/data_source_alicloud_sae_application_instances.go
+++ b/alicloud/data_source_alicloud_sae_application_instances.go
@@ -1,0 +1,232 @@
+package alicloud
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAlicloudSaeApplicationInstances() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudSaeApplicationInstancesRead,
+		Schema: map[string]*schema.Schema{
+			"application_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_container_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_container_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_health_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"main_container_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"image_url": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"package_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vswitch_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudSaeApplicationInstancesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	appId := d.Get("application_id").(string)
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	groupIds := make([]string, 0)
+	if v, ok := d.GetOk("group_id"); ok {
+		groupIds = append(groupIds, v.(string))
+	} else {
+		action := "/pop/v1/sam/app/describeApplicationGroups"
+		request := map[string]*string{
+			"AppId":       StringPointer(appId),
+			"PageSize":    StringPointer(strconv.Itoa(PageSizeLarge)),
+			"CurrentPage": StringPointer("1"),
+		}
+		var response map[string]interface{}
+		var err error
+		for {
+			wait := incrementalWait(3*time.Second, 3*time.Second)
+			err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+				response, err = client.RoaGet("sae", "2019-05-06", action, request, nil, nil)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_sae_application_instances", "GET "+action, AlibabaCloudSdkGoERROR)
+			}
+			resp, err := jsonpath.Get("$.Data", response)
+			if err != nil {
+				return WrapErrorf(err, FailedGetAttributeMsg, action, "$.Data", response)
+			}
+			result, _ := resp.([]interface{})
+			for _, v := range result {
+				item := v.(map[string]interface{})
+				groupIds = append(groupIds, fmt.Sprint(item["GroupId"]))
+			}
+			if len(result) < PageSizeLarge {
+				break
+			}
+			currentPage, err := strconv.Atoi(*request["CurrentPage"])
+			if err != nil {
+				return WrapError(err)
+			}
+			request["CurrentPage"] = StringPointer(strconv.Itoa(currentPage + 1))
+		}
+	}
+
+	action := "/pop/v1/sam/app/describeApplicationInstances"
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, groupId := range groupIds {
+		request := map[string]*string{
+			"AppId":       StringPointer(appId),
+			"GroupId":     StringPointer(groupId),
+			"PageSize":    StringPointer(strconv.Itoa(PageSizeLarge)),
+			"CurrentPage": StringPointer("1"),
+		}
+		var response map[string]interface{}
+		var err error
+		for {
+			wait := incrementalWait(3*time.Second, 3*time.Second)
+			err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+				response, err = client.RoaGet("sae", "2019-05-06", action, request, nil, nil)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_sae_application_instances", "GET "+action, AlibabaCloudSdkGoERROR)
+			}
+			resp, err := jsonpath.Get("$.Data.Instances", response)
+			if err != nil {
+				return WrapErrorf(err, FailedGetAttributeMsg, action, "$.Data.Instances", response)
+			}
+			result, _ := resp.([]interface{})
+			for _, v := range result {
+				item := v.(map[string]interface{})
+				if len(idsMap) > 0 {
+					if _, ok := idsMap[fmt.Sprint(item["InstanceId"])]; !ok {
+						continue
+					}
+				}
+				mapping := map[string]interface{}{
+					"id":                        fmt.Sprint(item["InstanceId"]),
+					"instance_id":               item["InstanceId"],
+					"group_id":                  item["GroupId"],
+					"instance_container_ip":     item["InstanceContainerIp"],
+					"instance_container_status": item["InstanceContainerStatus"],
+					"instance_health_status":    item["InstanceHealthStatus"],
+					"main_container_status":     item["MainContainerStatus"],
+					"image_url":                 item["ImageUrl"],
+					"package_version":           item["PackageVersion"],
+					"vswitch_id":                item["VSwitchId"],
+				}
+				ids = append(ids, fmt.Sprint(mapping["id"]))
+				s = append(s, mapping)
+			}
+			if len(result) < PageSizeLarge {
+				break
+			}
+			currentPage, err := strconv.Atoi(*request["CurrentPage"])
+			if err != nil {
+				return WrapError(err)
+			}
+			request["CurrentPage"] = StringPointer(strconv.Itoa(currentPage + 1))
+		}
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("instances", s); err != nil {
+		return WrapError(err)
+	}
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+
+	return nil
+}

--- a/alicloud/data_source_alicloud_sae_application_instances_test.go
+++ b/alicloud/data_source_alicloud_sae_application_instances_test.go
@@ -1,0 +1,89 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudSAEApplicationInstancesDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(1, 1000)
+	checkoutSupportedRegions(t, true, connectivity.SaeSupportRegions)
+	appIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudSaeApplicationInstancesDataSourceName(rand, map[string]string{
+			"application_id": `"${alicloud_sae_application.default.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudSaeApplicationInstancesDataSourceName(rand, map[string]string{
+			"application_id": `"${alicloud_sae_application.default.id}"`,
+			"ids":            `["fake"]`,
+		}),
+	}
+	var existAlicloudSaeApplicationInstancesDataSourceNameMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":                              "2",
+			"instances.#":                        "2",
+			"instances.0.instance_id":            CHECKSET,
+			"instances.0.group_id":               CHECKSET,
+			"instances.0.instance_container_ip":  CHECKSET,
+			"instances.0.instance_health_status": CHECKSET,
+			"instances.0.image_url":              CHECKSET,
+			"instances.0.package_version":        CHECKSET,
+		}
+	}
+	var fakeAlicloudSaeApplicationInstancesDataSourceNameMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":       "0",
+			"instances.#": "0",
+		}
+	}
+	var alicloudSaeApplicationInstancesCheckInfo = dataSourceAttr{
+		resourceId:   "data.alicloud_sae_application_instances.default",
+		existMapFunc: existAlicloudSaeApplicationInstancesDataSourceNameMapFunc,
+		fakeMapFunc:  fakeAlicloudSaeApplicationInstancesDataSourceNameMapFunc,
+	}
+	alicloudSaeApplicationInstancesCheckInfo.dataSourceTestCheck(t, rand, appIdConf)
+}
+
+func testAccCheckAlicloudSaeApplicationInstancesDataSourceName(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tftestaccsaeinstance%d"
+}
+data "alicloud_vpcs" "default"	{
+	name_regex = "default-NODELETING"
+}
+data "alicloud_vswitches" "default" {
+  vpc_id = "${data.alicloud_vpcs.default.ids.0}"
+}
+resource "alicloud_sae_namespace" "default" {
+	namespace_description = var.name
+	namespace_id = "%s:tftestacc%d"
+	namespace_name = var.name
+}
+resource "alicloud_sae_application" "default" {
+  app_description= var.name
+  app_name=        var.name
+  namespace_id=    alicloud_sae_namespace.default.namespace_id
+  image_url=     "registry-vpc.cn-hangzhou.aliyuncs.com/lxepoo/apache-php5"
+  package_type=    "Image"
+  jdk=             "Open JDK 8"
+  vswitch_id=      data.alicloud_vswitches.default.ids.0
+  vpc_id          = data.alicloud_vpcs.default.ids.0
+  timezone = "Asia/Shanghai"
+  replicas=        "2"
+  cpu=             "500"
+  memory =          "2048"
+}
+data "alicloud_sae_application_instances" "default" {
+	%s
+}
+`, rand, defaultRegionToTest, rand, strings.Join(pairs, " \n "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -616,6 +616,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_alb_listeners":                                    dataSourceAlicloudAlbListeners(),
 			"alicloud_ens_key_pairs":                                    dataSourceAlicloudEnsKeyPairs(),
 			"alicloud_sae_applications":                                 dataSourceAlicloudSaeApplications(),
+			"alicloud_sae_application_instances":                        dataSourceAlicloudSaeApplicationInstances(),
 			"alicloud_alb_rules":                                        dataSourceAliCloudAlbRules(),
 			"alicloud_cms_metric_rule_templates":                        dataSourceAlicloudCmsMetricRuleTemplates(),
 			"alicloud_iot_device_groups":                                dataSourceAlicloudIotDeviceGroups(),

--- a/website/alicloud.erb
+++ b/website/alicloud.erb
@@ -4746,6 +4746,9 @@
                             <a href="/docs/providers/alicloud/d/sae_applications.html">alicloud_sae_applications</a>
                          </li>
                           <li>
+                            <a href="/docs/providers/alicloud/d/sae_application_instances.html">alicloud_sae_application_instances</a>
+                         </li>
+                          <li>
                             <a href="/docs/providers/alicloud/d/sae_service.html">alicloud_sae_service</a>
                           </li>
                           <li>

--- a/website/docs/d/sae_application_instances.html.markdown
+++ b/website/docs/d/sae_application_instances.html.markdown
@@ -1,0 +1,63 @@
+---
+subcategory: "Serverless App Engine (SAE)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_sae_application_instances"
+sidebar_current: "docs-alicloud-datasource-sae-application-instances"
+description: |-
+  Provides a list of SAE application instances to the user.
+---
+
+# alicloud\_sae\_application\_instances
+
+This data source provides the instances of an SAE application, including the ENI IP (`instance_container_ip`) of each instance.
+
+-> **NOTE:** Available in v1.289.0+.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+data "alicloud_sae_application_instances" "default" {
+  application_id = "47a14017-2587-4db1-80f1-3285453f7459"
+}
+
+output "sae_instance_ips" {
+  value = data.alicloud_sae_application_instances.default.instances.*.instance_container_ip
+}
+```
+
+Filter by instance ids:
+
+```terraform
+data "alicloud_sae_application_instances" "default" {
+  application_id = "47a14017-2587-4db1-80f1-3285453f7459"
+  ids            = ["ai-gateway-litellm-test-47a14017-2587-4db1-3285-qc4rh"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `application_id` - (Required) The ID of the SAE application.
+* `group_id` - (Optional) The ID of the instance group. If not set, instances of all groups of the application are returned.
+* `ids` - (Optional) A list of instance IDs to filter results.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `ids` - A list of instance IDs.
+* `instances` - A list of instances. Each element contains the following attributes:
+    * `id` - The ID of the instance.
+    * `instance_id` - The ID of the instance.
+    * `group_id` - The ID of the group the instance belongs to.
+    * `instance_container_ip` - The ENI IP address of the instance container.
+    * `instance_container_status` - The status of the instance container.
+    * `instance_health_status` - The health status of the instance.
+    * `main_container_status` - The status of the main container.
+    * `image_url` - The image address the instance is running.
+    * `package_version` - The package version the instance is running.
+    * `vswitch_id` - The vSwitch ID of the ENI of the instance.


### PR DESCRIPTION
Implements #10152.

## What

Adds a new data source `alicloud_sae_application_instances` that lists the instances of an SAE application, exposing per-instance ENI IP (`instance_container_ip`), container/health status, `image_url`, `package_version` and `vswitch_id`.

Implementation:
- `group_id` unset → all groups are enumerated via `GET /pop/v1/sam/app/describeApplicationGroups`; `group_id` set → only that group.
- Instances are read via `GET /pop/v1/sam/app/describeApplicationInstances` with pagination (`PageSize`/`CurrentPage`) and the standard retry wrapper.
- Optional client-side `ids` filtering, `output_file`, and `ids` export, following the conventions of `alicloud_sae_applications`.
- Documentation page + sidebar entry (website/alicloud.erb) + acceptance test included.

## Why

SAE reassigns ENI IPs on every rolling deployment. Downstream IP-based resources (e.g. a self-managed `alicloud_alb_server_group` fronting an SAE app, needed when listener timeouts beyond the SAE-managed CLB defaults are required) currently have no way to track the new IPs declaratively. Because the `alicloud_sae_application` update with `deploy = true` already waits for the ChangeOrder to complete, `depends_on` lets the data source read the post-deploy IPs within a single apply:

```terraform
data "alicloud_sae_application_instances" "app" {
  application_id = alicloud_sae_application.app.id
  depends_on     = [alicloud_sae_application.app]
}

resource "alicloud_alb_server_group" "app" {
  server_group_type = "Ip"
  dynamic "servers" {
    for_each = toset(data.alicloud_sae_application_instances.app.instances.*.instance_container_ip)
    content {
      server_id   = servers.value
      server_ip   = servers.value
      server_type = "Ip"
      port        = 4000
    }
  }
}
```

## Testing

- `go build ./alicloud/` and `go vet ./alicloud/` pass (the two `fmt.Sprintln` vet notes in `alicloud/common.go` are pre-existing upstream).
- Acceptance test `TestAccAlicloudSAEApplicationInstancesDataSource` added following the existing SAE data source test pattern (exist: application_id; fake: ids filter). It requires an Alibaba Cloud account to run, so it has not been executed here — happy to adjust if maintainers hit issues running it.