### PR TITLE
resource/alicloud_gpdb_instance: backfill parameters on terraform import

### DIFF
--- a/alicloud/resource_alicloud_gpdb_instance.go
+++ b/alicloud/resource_alicloud_gpdb_instance.go
@@ -708,39 +708,62 @@ func resourceAliCloudGpdbDbInstanceRead(d *schema.ResourceData, meta interface{}
 
 	// DescribeParameters returns the full server-side parameter set, while the
 	// user typically declares only a subset of parameters in the configuration.
-	// Writing the full set back into state makes a config that declares a subset
-	// produce a permanent non-empty plan. Only refresh the parameters the user
-	// has actually declared, so state stays aligned with the configuration.
-	if documented, ok := d.GetOk("parameters"); ok {
-		parameterObject, err := gpdbService.DescribeParameters(d.Id())
-		if err != nil {
-			return WrapError(err)
-		}
-		if parameterList, ok := parameterObject["Parameters"].([]interface{}); ok && parameterList != nil {
-			apiParameters := make(map[string]map[string]interface{})
-			for _, parameterListItem := range parameterList {
-				if parameterListValueItemMap, ok := parameterListItem.(map[string]interface{}); ok {
-					name := fmt.Sprint(parameterListValueItemMap["ParameterName"])
-					apiParameters[name] = map[string]interface{}{
-						"name":                   parameterListValueItemMap["ParameterName"],
-						"value":                  parameterListValueItemMap["CurrentValue"],
-						"default_value":          parameterListValueItemMap["ParameterValue"],
-						"is_changeable_config":   parameterListValueItemMap["IsChangeableConfig"],
-						"force_restart_instance": parameterListValueItemMap["ForceRestartInstance"],
-						"optional_range":         parameterListValueItemMap["OptionalRange"],
-						"parameter_description":  parameterListValueItemMap["ParameterDescription"],
-					}
+	// Refresh behavior splits into two branches so that both `terraform import`
+	// and an ordinary refresh produce a usable, drift-free state:
+	//   - When the configuration declares a subset of parameters, only those
+	//     declared parameters are refreshed using their current server-side
+	//     values. Writing the full server-side set back into state in this case
+	//     would surface the extra parameters as removed elements on every plan,
+	//     producing a permanent non-empty plan.
+	//   - When no parameters are declared in the configuration (notably right
+	//     after `terraform import`, where ImportStatePassthrough seeds the state
+	//     with only the instance id), the full server-side parameter set is
+	//     written back into state so the imported state reflects the real
+	//     instance. Because `parameters` is Optional+Computed, a configuration
+	//     that omits it keeps the server-side value without producing a plan.
+	//     A subsequent configuration that declares a subset is reconciled by
+	//     the following plan/apply, which is the expected behavior.
+	documented, documentedOk := d.GetOk("parameters")
+	parameterObject, err := gpdbService.DescribeParameters(d.Id())
+	if err != nil {
+		return WrapError(err)
+	}
+	if parameterList, ok := parameterObject["Parameters"].([]interface{}); ok && parameterList != nil {
+		apiParameters := make(map[string]map[string]interface{})
+		for _, parameterListItem := range parameterList {
+			if parameterListValueItemMap, ok := parameterListItem.(map[string]interface{}); ok {
+				name := fmt.Sprint(parameterListValueItemMap["ParameterName"])
+				apiParameters[name] = map[string]interface{}{
+					"name":                   parameterListValueItemMap["ParameterName"],
+					"value":                  parameterListValueItemMap["CurrentValue"],
+					"default_value":          parameterListValueItemMap["ParameterValue"],
+					"is_changeable_config":   parameterListValueItemMap["IsChangeableConfig"],
+					"force_restart_instance": parameterListValueItemMap["ForceRestartInstance"],
+					"optional_range":         parameterListValueItemMap["OptionalRange"],
+					"parameter_description":  parameterListValueItemMap["ParameterDescription"],
 				}
 			}
-			parameterListMaps := make([]map[string]interface{}, 0)
+		}
+		parameterListMaps := make([]map[string]interface{}, 0)
+		if documentedOk {
+			// Configuration declared a subset: refresh only the declared
+			// parameters using their current server-side values to avoid a
+			// permanent diff from the extra server-side parameters.
 			for _, parameter := range documented.(*schema.Set).List() {
 				name := fmt.Sprint(parameter.(map[string]interface{})["name"])
 				if apiParameter, ok := apiParameters[name]; ok {
 					parameterListMaps = append(parameterListMaps, apiParameter)
 				}
 			}
-			d.Set("parameters", parameterListMaps)
+		} else {
+			// No parameters declared in the configuration (e.g. right after
+			// import, where the state only carries the instance id): write back
+			// the full server-side parameter set so state reflects the instance.
+			for _, apiParameter := range apiParameters {
+				parameterListMaps = append(parameterListMaps, apiParameter)
+			}
 		}
+		d.Set("parameters", parameterListMaps)
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_gpdb_instance_test.go
+++ b/alicloud/resource_alicloud_gpdb_instance_test.go
@@ -408,6 +408,85 @@ func TestAccAliCloudGPDBDBInstance_basic0(t *testing.T) {
 	})
 }
 
+// TestAccAliCloudGPDBDBInstance_importBackfillsParameters is a regression test for
+// `terraform import`. ImportStatePassthrough seeds the state with only the
+// instance id, so the previous Read guard `d.GetOk("parameters")` was false on
+// import and the DescribeParameters block was skipped entirely, leaving the
+// imported state with an empty `parameters` set. Read now writes the full
+// server-side parameter set back into state when no parameters are declared in
+// the configuration, so an imported instance reflects its real parameters.
+func TestAccAliCloudGPDBDBInstance_importBackfillsParameters(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_gpdb_instance.default"
+	ra := resourceAttrInit(resourceId, AliCloudGPDBDBInstanceMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GpdbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGpdbDbInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sgpdbdbinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudGPDBDBInstanceBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Create an instance without declaring any `parameters` block,
+				// mirroring the state shape `terraform import` starts from
+				// (state carries only the instance id).
+				Config: testAccConfig(map[string]interface{}{
+					"db_instance_category":  "HighAvailability",
+					"db_instance_class":     "gpdb.group.segsdx1",
+					"db_instance_mode":      "StorageElastic",
+					"engine":                "gpdb",
+					"engine_version":        "6.0",
+					"zone_id":               "${data.alicloud_gpdb_zones.default.ids.0}",
+					"instance_network_type": "VPC",
+					"instance_spec":         "2C16G",
+					"instance_group_count":  "2",
+					"payment_type":          "PayAsYouGo",
+					"seg_storage_type":      "cloud_essd",
+					"seg_node_num":          "4",
+					"storage_size":          "50",
+					"vpc_id":                "${data.alicloud_vpcs.default.ids.0}",
+					"vswitch_id":            "${local.vswitch_id}",
+					"create_sample_data":    "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"payment_type": "PayAsYouGo",
+					}),
+				),
+			},
+			{
+				// Import the instance. ImportStateVerify is intentionally left
+				// off because the configuration declares no `parameters`; the
+				// point is to assert that Read backfills the server-side
+				// parameter set into state instead of skipping it.
+				ResourceName: resourceId,
+				ImportState:  true,
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[resourceId]
+						if !ok {
+							return fmt.Errorf("resource not found in state: %s", resourceId)
+						}
+						count := rs.Primary.Attributes["parameters.#"]
+						if count == "" || count == "0" {
+							return fmt.Errorf("expected parameters to be backfilled after import, got parameters.#=%q", count)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 // TestAccAliCloudGPDBDBInstance_minorVersion covers the minor_version attribute.
 // GPDB instances are always provisioned with the latest minor version and
 // UpgradeDBVersion cannot downgrade, so a real upgrade to a higher version cannot


### PR DESCRIPTION
## Summary

`alicloud_gpdb_instance.parameters` was not backfilled into state after `terraform import`, so the imported state never reflected the server-side parameters of the instance.

## Root cause

The Read function refreshed `parameters` only inside a guard `if documented, ok := d.GetOk("parameters"); ok`. `terraform import` uses `ImportStatePassthrough`, which seeds state with only the instance id, so `d.GetOk("parameters")` was false on import and the entire `DescribeParameters` block was skipped.

The guard was intentional for ordinary refresh: `DescribeParameters` returns the full server-side parameter set, while the configuration typically declares only a subset. Writing the full set back into state in that case surfaces the extra parameters as removed elements on every plan, producing a permanent non-empty plan.

## Fix

Lift `DescribeParameters` out of the guard and split refresh into two branches:

- **Configuration declares a subset of parameters** — only those declared parameters are refreshed, using their current server-side values. This preserves the existing behavior that avoids a permanent diff from the extra server-side parameters.
- **No parameters declared in the configuration** (e.g. right after `terraform import`) — the full server-side parameter set is written back into state so the imported state reflects the real instance. Because `parameters` is `Optional` + `Computed`, a configuration that omits it keeps the server-side value without producing a plan; a subsequent configuration that declares a subset is reconciled by the following plan/apply.

## Testing

Added `TestAccAliCloudGPDBDBInstance_importBackfillsParameters`: creates an instance without declaring any `parameters`, imports it, and asserts `parameters.#` is non-empty after import (previously the imported state had an empty `parameters` set).
