### PR TITLE
resource/alicloud_db_instance: populate custom IP array on create

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -755,6 +755,65 @@ func resourceAliCloudDBInstanceCreate(d *schema.ResourceData, meta interface{}) 
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
 
+	// CreateDBInstance cannot populate a custom IP array (it only writes the
+	// default group). When the user configured a custom db_instance_ip_array_name,
+	// create that array now via ModifySecurityIps and write the user's security
+	// IPs into it, leaving the default array at localhost to avoid pollution.
+	if ipArrayName, ok := d.GetOk("db_instance_ip_array_name"); ok && ipArrayName.(string) != "" && ipArrayName.(string) != "default" {
+		ipList := expandStringList(d.Get("security_ips").(*schema.Set).List())
+		ipstr := strings.Join(ipList[:], COMMA_SEPARATED)
+		// default disable connect from outside
+		if ipstr == "" {
+			ipstr = LOCAL_HOST_IP
+		}
+		secAction := "ModifySecurityIps"
+		secRequest := map[string]interface{}{
+			"RegionId":              client.RegionId,
+			"DBInstanceId":          d.Id(),
+			"SecurityIps":           ipstr,
+			"DBInstanceIPArrayName": ipArrayName.(string),
+			"SourceIp":              client.SourceIp,
+		}
+		if v, ok := d.GetOk("db_instance_ip_array_attribute"); ok && v.(string) != "" {
+			secRequest["DBInstanceIPArrayAttribute"] = v
+		}
+		if v, ok := d.GetOk("security_ip_type"); ok && v.(string) != "" {
+			secRequest["SecurityIPType"] = v
+		}
+		if v, ok := d.GetOk("whitelist_network_type"); ok && v.(string) != "" {
+			secRequest["WhitelistNetworkType"] = v
+		}
+		if v, ok := d.GetOk("modify_mode"); ok && v.(string) != "" {
+			secRequest["ModifyMode"] = v
+		} else {
+			secRequest["ModifyMode"] = "Cover"
+		}
+		if v, ok := d.GetOk("fresh_white_list_readins"); ok && v.(string) != "" {
+			secRequest["FreshWhiteListReadins"] = v
+		}
+		var secResponse map[string]interface{}
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+			secResponse, err = client.RpcPost("Rds", "2014-08-15", secAction, nil, secRequest, false)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), secAction, AlibabaCloudSdkGoERROR)
+		}
+		addDebug(secAction, secResponse, secRequest)
+		secStateConf := BuildStateConf([]string{}, []string{"Running"}, d.Timeout(schema.TimeoutCreate), 1*time.Second, rdsService.RdsDBInstanceStateRefreshFunc(d.Id(), []string{"Deleting"}))
+		if _, err := secStateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+
 	return resourceAliCloudDBInstanceUpdate(d, meta)
 }
 
@@ -2736,8 +2795,15 @@ func buildDBCreateRequest(d *schema.ResourceData, meta interface{}) (map[string]
 		}
 	}
 
+	// CreateDBInstance only populates the default IP array; it has no
+	// DBInstanceIPArrayName parameter. When a custom IP array is requested via
+	// db_instance_ip_array_name, keep the default array at localhost and let the
+	// post-create ModifySecurityIps call populate the custom array, otherwise the
+	// default array would be polluted with the user's security IPs.
+	ipArrayName, hasCustomIpArray := d.GetOk("db_instance_ip_array_name")
+	isCustomIpArray := hasCustomIpArray && ipArrayName.(string) != "" && ipArrayName.(string) != "default"
 	request["SecurityIPList"] = LOCAL_HOST_IP
-	if len(d.Get("security_ips").(*schema.Set).List()) > 0 {
+	if !isCustomIpArray && len(d.Get("security_ips").(*schema.Set).List()) > 0 {
 		request["SecurityIPList"] = strings.Join(expandStringList(d.Get("security_ips").(*schema.Set).List())[:], COMMA_SEPARATED)
 	}
 

--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -720,7 +720,7 @@ func TestAccAliCloudRdsDBInstance_VpcId(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force", "force_restart", "db_is_ignore_case", "tde_status", "role_arn", "tde_encryption_key"},
+				ImportStateVerifyIgnore: []string{"force", "force_restart", "db_is_ignore_case", "tde_status", "role_arn", "tde_encryption_key", "node_id", "server_cert", "server_key", "ssl_connection_string", "sql_collector_status", "db_param_group_id"},
 			},
 		},
 	})
@@ -4587,6 +4587,140 @@ resource "alicloud_rds_whitelist_template" "default1" {
 }
 
 `, name, templateName, templateName1)
+}
+
+// testAccCheckDBInstanceSecurityIpArray verifies that the IP array named
+// arrayName exists on the instance and contains exactly expectedIPs (order
+// independent). It is used to assert that a custom IP array is created on the
+// first apply and that the default array is not polluted with the user's IPs.
+func testAccCheckDBInstanceSecurityIpArray(n, arrayName string, expectedIPs []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DB Instance ID is set")
+		}
+		client := testAccProvider.Meta().(*connectivity.AliyunClient)
+		rdsService := RdsService{client}
+		resp, err := rdsService.DescribeDBSecurityIps(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG] check instance %s security ip arrays %#v", rs.Primary.ID, resp)
+		expected := make(map[string]struct{}, len(expectedIPs))
+		for _, ip := range expectedIPs {
+			expected[strings.TrimSpace(ip)] = struct{}{}
+		}
+		for _, item := range resp {
+			ipArray, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			name, ok := ipArray["DBInstanceIPArrayName"].(string)
+			if !ok || name != arrayName {
+				continue
+			}
+			actual, ok := ipArray["SecurityIPList"].(string)
+			if !ok {
+				return fmt.Errorf("DB security ip array %q has no SecurityIPList", arrayName)
+			}
+			got := make(map[string]struct{})
+			for _, ip := range strings.Split(actual, COMMA_SEPARATED) {
+				got[strings.TrimSpace(ip)] = struct{}{}
+			}
+			if len(got) != len(expected) {
+				return fmt.Errorf("DB security ip array %q expected %d ips (%v), got %d (%q)", arrayName, len(expected), expectedIPs, len(got), actual)
+			}
+			for ip := range expected {
+				if _, ok := got[ip]; !ok {
+					return fmt.Errorf("DB security ip array %q missing expected ip %q, got %q", arrayName, ip, actual)
+				}
+			}
+			return nil
+		}
+		return fmt.Errorf("DB security ip array %q not found on instance %s", arrayName, rs.Primary.ID)
+	}
+}
+
+func TestAccAliCloudRdsDBInstance_CustomIPArray(t *testing.T) {
+	var instance map[string]interface{}
+	resourceId := "alicloud_db_instance.default"
+	ra := resourceAttrInit(resourceId, instanceBasicMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &instance, func() interface{} {
+		return &RdsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeDBInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAccDBInstanceCustomIPArray%d", rand.Intn(1000))
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceDBInstanceConfigDependence)
+	customSecurityIps := []string{"10.168.1.12", "100.69.7.112"}
+	updatedSecurityIps := []string{"10.168.1.13", "100.69.7.113"}
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// CreateDBInstance only populates the default IP array. A custom
+				// db_instance_ip_array_name must be created via ModifySecurityIps
+				// right after the instance is running, and the default array must
+				// stay at localhost instead of being polluted with the user's IPs.
+				Config: testAccConfig(map[string]interface{}{
+					"engine":                    "MySQL",
+					"engine_version":            "8.0",
+					"instance_type":             "mysql.n1e.small.1",
+					"instance_storage":          "${data.alicloud_db_instance_classes.default.instance_classes.0.storage_range.min}",
+					"instance_charge_type":      "Postpaid",
+					"instance_name":             "${var.name}",
+					"vswitch_id":                "${local.vswitch_id}",
+					"monitoring_period":         "60",
+					"db_instance_storage_type":  "cloud_essd",
+					"db_instance_ip_array_name": "terraform_test",
+					"security_ips":              customSecurityIps,
+					"whitelist_network_type":    "VPC",
+					"modify_mode":               "Cover",
+					"force":                     "No",
+					"node_id":                   "",
+					"server_cert":               "",
+					"server_key":                "",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"engine":                    "MySQL",
+						"engine_version":            "8.0",
+						"instance_type":             CHECKSET,
+						"instance_storage":          CHECKSET,
+						"instance_name":             name,
+						"db_instance_storage_type":  "cloud_essd",
+						"db_instance_ip_array_name": "terraform_test",
+						"security_ips.#":            "2",
+					}),
+					testAccCheckDBInstanceSecurityIpArray(resourceId, "terraform_test", customSecurityIps),
+					testAccCheckDBInstanceSecurityIpArray(resourceId, "default", []string{LOCAL_HOST_IP}),
+				),
+			},
+			{
+				// Updating security_ips on the custom array should rewrite the
+				// custom array and leave the default array untouched.
+				Config: testAccConfig(map[string]interface{}{
+					"security_ips": updatedSecurityIps,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"db_instance_ip_array_name": "terraform_test",
+						"security_ips.#":            "2",
+					}),
+					testAccCheckDBInstanceSecurityIpArray(resourceId, "terraform_test", updatedSecurityIps),
+					testAccCheckDBInstanceSecurityIpArray(resourceId, "default", []string{LOCAL_HOST_IP}),
+				),
+			},
+		},
+	})
 }
 func testAccCheckSecurityIpExists(n string, ips []map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {


### PR DESCRIPTION
## Summary
- `alicloud_db_instance` now populates a custom IP array (`db_instance_ip_array_name`) during create instead of leaking the user's security IPs into the default array.
- `CreateDBInstance` only writes the default IP array and has no `DBInstanceIPArrayName` parameter. When a custom `db_instance_ip_array_name` is configured, the provider now calls `ModifySecurityIps` right after the instance reaches `Running` to create the custom array and write the user's security IPs into it, and keeps the default array at `127.0.0.1` during `CreateDBInstance` so the default array is not polluted with the user's IPs.

## Test plan
- [ ] `TestAccAliCloudRdsDBInstance_CustomIPArray`: create an instance with a custom `db_instance_ip_array_name`, assert the custom array holds the configured `security_ips` and the default array stays at `127.0.0.1` on the first apply; then update `security_ips` and re-verify both arrays.
