### PR TITLE
resource/alicloud_vswitch: validate ipv6_cidr_block_mask as IntBetween(0, 4095)

### DIFF
--- a/alicloud/resource_alicloud_vswitch.go
+++ b/alicloud/resource_alicloud_vswitch.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAliCloudVpcVswitch() *schema.Resource {
@@ -53,9 +54,10 @@ func resourceAliCloudVpcVswitch() *schema.Resource {
 				Computed: true,
 			},
 			"ipv6_cidr_block_mask": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 4095),
 			},
 			"is_default": {
 				Type:     schema.TypeBool,

--- a/website/docs/r/vswitch.html.markdown
+++ b/website/docs/r/vswitch.html.markdown
@@ -132,6 +132,9 @@ The following arguments are supported:
   - When the VPC IPv6 address mask is `52`: `0` to `4095`.
   - When the VPC IPv6 address mask is `56`: `0` to `255`.
   - When the VPC IPv6 address mask is `60`: `0` to `15`.
+
+-> **NOTE:** The schema validates `ipv6_cidr_block_mask` as an integer in `0`-`4095` (the maximum documented range, for a VPC IPv6 mask of `52`); values outside this range are rejected at plan time. The effective valid range for a given VPC is narrower and determined by the VPC IPv6 address mask, as listed above.
+
 * `tags` - (Optional, Map, Available since v1.55.3) The tags of VSwitch.
 * `vswitch_name` - (Optional, Available since v1.119.0) The name of the VSwitch. The name must be `1` to `128` characters in length, and cannot start with `http://` or `https://`.
 * `vpc_id` - (Optional, ForceNew) The VPC ID. **NOTE:** From version 1.233.0, if you do not set `is_default`, or set `is_default` to `false`, `vpc_id` is required.


### PR DESCRIPTION
### What this PR does

Adds a `ValidateFunc` to the `ipv6_cidr_block_mask` argument of the `alicloud_vswitch` resource so that out-of-range values are rejected at `terraform plan` time rather than failing later at `apply` time against the backing VPC API.

### Why

Before this change, `ipv6_cidr_block_mask` had no schema-level validation: negative values, values above the documented maximum, and non-integers all passed `plan` and only failed when the VPC `CreateVSwitch` / `ModifyVSwitchAttribute` API rejected them. The resource documentation already states that the valid range depends on the VPC IPv6 address mask (`/52` -> `0`-`4095`, `/56` -> `0`-`255`, `/60` -> `0`-`15`). This PR enforces the outer bound (`0`-`4095`) so the worst out-of-range inputs are caught client-side.

### How

- `alicloud/resource_alicloud_vswitch.go`: import `helper/validation` and set `ValidateFunc: validation.IntBetween(0, 4095)` on `ipv6_cidr_block_mask`.
- `website/docs/r/vswitch.html.markdown`: add a NOTE documenting that the schema validates the field as `0`-`4095` (the maximum documented range) and that the effective valid range for a given VPC is narrower and determined by the VPC IPv6 address mask, as listed above.

### Notes

- The `0`-`4095` bound is the maximum documented range (a VPC IPv6 mask of `/52`); narrower ranges for `/56` and `/60` VPCs are still enforced by the backing API, so this is a non-breaking superset guard.
- Additive change: existing configurations with values inside `0`-`4095` are unaffected; values outside the range now fail at `plan` instead of at `apply`.

### Validation

- `gofmt` on the changed Go file: clean.
- `go vet -p=1 ./alicloud` (package-scoped gate): no issues introduced by this change (the only `go vet` output on the branch is two pre-existing `fmt.Sprintln` warnings in `alicloud/common.go`, present on `master` and unrelated to this change).
- Remote acceptance test verification for the `alicloud_vswitch` IPv6 behavior (including IntBetween boundary values: `0`, `255`, `256`, `4095`, `4096`, `-1`) will follow CI.
