### PR TITLE
resource/alicloud_oss_bucket: add Deprecated annotation to policy/referer_config and align docs for alidns_custom_line, alidns_cloud_gtm_monitor_template

### DIFF
--- a/alicloud/resource_alicloud_oss_bucket.go
+++ b/alicloud/resource_alicloud_oss_bucket.go
@@ -119,8 +119,9 @@ func resourceAlicloudOssBucket() *schema.Resource {
 			},
 
 			"referer_config": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:       schema.TypeList,
+				Optional:   true,
+				Deprecated: "Field 'referer_config' has been deprecated since provider version 1.220.0. New resource 'alicloud_oss_bucket_referer' instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"allow_empty": {
@@ -347,8 +348,9 @@ func resourceAlicloudOssBucket() *schema.Resource {
 			},
 
 			"policy": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "Field 'policy' has been deprecated since provider version 1.220.0. New resource 'alicloud_oss_bucket_policy' instead.",
 			},
 			"creation_date": {
 				Type:     schema.TypeString,

--- a/website/docs/r/alidns_cloud_gtm_monitor_template.html.markdown
+++ b/website/docs/r/alidns_cloud_gtm_monitor_template.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 * `interval` - (Required) The interval between consecutive probes, in seconds. Valid values: `15`, `60`, `300`, `900`, `1800`, `3600`. The `15` seconds interval is only available for Flagship Edition instances.
 * `timeout` - (Required) Probe request timeout, in milliseconds. Probe packets that do not return within this duration are treated as timeouts. Valid values: `2000`, `3000`, `5000`, `10000`.
 * `evaluation_count` - (Required, Int) The number of retries after a probe failure. A service is marked abnormal only after this many consecutive failures, preventing transient network fluctuations from triggering false alarms. Valid values: `0`, `1`, `2`, `3`.
-* `failure_rate` - (Required, Int) The failure-rate threshold (%) among selected probe nodes. If the percentage of failing nodes exceeds this value, the service address is marked as abnormal. Valid values: `0`, `20`, `50`, `80`, `100`.
+* `failure_rate` - (Required, Int) The failure-rate threshold (%) among selected probe nodes. If the percentage of failing nodes exceeds this value, the service address is marked as abnormal. Valid values: `20`, `50`, `80`, `100`.
 * `isp_city_nodes` - (Required, Set) The set of monitoring nodes that this template will probe from. Use the [ListCloudGtmMonitorNodes](https://help.aliyun.com/document_detail/2797349.html) API to look up available `city_code` / `isp_code` combinations. See [`isp_city_nodes`](#isp_city_nodes) below.
 * `extend_info` - (Optional, Computed) A JSON string containing protocol-specific probe configuration. The supported keys depend on `protocol`. See [`extend_info`](#extend_info) below.
 * `remark` - (Optional) The remark of the monitor template. Passing an empty value clears the existing remark.
@@ -94,13 +94,13 @@ The `extend_info` argument takes a JSON-encoded string. The supported keys depen
 
 Keys for `http` / `https`:
 
-| Key              | Description                                                                                                                                                                                                                         |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `host`           | The value of the `Host` header carried in the HTTP(S) request. Defaults to the primary domain of the target. Set this when the target site requires a specific Host header.                                                        |
-| `path`           | The URL path to probe. Defaults to `/`.                                                                                                                                                                                             |
+| Key              | Description                                                                                                                                                                                                                            |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `host`           | The value of the `Host` header carried in the HTTP(S) request. Defaults to the primary domain of the target. Set this when the target site requires a specific Host header.                                                            |
+| `path`           | The URL path to probe. Defaults to `/`.                                                                                                                                                                                                |
 | `code`           | HTTP response-code threshold used to classify the service as abnormal. Valid values: `400` (Bad Request — use when the probe URL includes parameters and you want to detect invalid-request responses), `500` (Server Error, default). |
-| `sni`            | Whether to enable Server Name Indication during the TLS handshake (HTTPS only). Valid values: `true`, `false`.                                                                                                                      |
-| `followRedirect` | Whether to follow HTTP 3XX redirects (`301`, `302`, `303`, `307`, `308`). Valid values: `true`, `false`.                                                                                                                             |
+| `sni`            | Whether to enable Server Name Indication during the TLS handshake (HTTPS only). Valid values: `true`, `false`.                                                                                                                         |
+| `followRedirect` | Whether to follow HTTP 3XX redirects (`301`, `302`, `303`, `307`, `308`). Valid values: `true`, `false`.                                                                                                                               |
 
 Keys for `ping`:
 

--- a/website/docs/r/alidns_custom_line.html.markdown
+++ b/website/docs/r/alidns_custom_line.html.markdown
@@ -50,8 +50,8 @@ The following arguments are supported:
 
 The ip_segment_list supports the following:
 
-* `start_ip` - (Required) The start IP address of the CIDR block.
-* `end_ip` - (Required) The end IP address of the CIDR block.
+* `start_ip` - (Required) The start IP address of an IP range pair. Each entry in `ip_segment_list` is a `start_ip`-`end_ip` contiguous IP range pair (e.g. `192.0.2.1` and `192.0.2.125`), not a CIDR block.
+* `end_ip` - (Required) The end IP address of an IP range pair. Must be greater than or equal to `start_ip`.
 
 
 ## Attributes Reference


### PR DESCRIPTION
## Summary
Three consistency fixes found by cross-checking TF docs, OpenAPI, and provider source. No schema/CRUD behavior changes.

1. **alicloud_alidns_custom_line** (doc only): `start_ip`/`end_ip` were documented as a "CIDR block", but the backing `AddCustomLine`/`UpdateCustomLine` APIs take `IpSegment.N.StartIp`/`EndIp` as an IP range pair (OpenAPI description: "IP段列表。IP与IP之间用中横线间隔"). Corrected the prose to describe a `start_ip`-`end_ip` contiguous IP range pair.

2. **alicloud_oss_bucket** (source schema): the `acl` field already carries a `Deprecated` annotation pointing to `alicloud_oss_bucket_acl` since provider 1.220.0. The doc also marks `policy` and `referer_config` as deprecated since 1.220.0 (pointing to `alicloud_oss_bucket_policy` and `alicloud_oss_bucket_referer`), but the source schema was missing the `Deprecated` annotation on both. Added the annotation to align with `acl` and the documentation.

3. **alicloud_alidns_cloud_gtm_monitor_template** (doc only): `failure_rate` doc listed valid values `0,20,50,80,100`, but the schema `ValidateFunc` is `IntInSlice([]int{20,50,80,100})` (no `0`) and the `CreateCloudGtmMonitorTemplate` OpenAPI description is "20, 50, 80, 100". Removed the invalid `0` from the doc.

## Test plan
No ACC tests added — changes 1 and 3 are pure doc prose, and change 2 is a schema `Deprecated` annotation that emits a plan-time deprecation warning (Terraform SDK deterministic behavior, no CRUD path change). Existing `alicloud_oss_bucket` ACC tests continue to cover the resource lifecycle.

- `gofmt` clean on `resource_alicloud_oss_bucket.go`
- No forbidden info in diff (pre-push-sanitize clean)
- Single commit per repo convention
