### PR TITLE
resource/alicloud_cms_alarm: validate targets.target_id/arn are non-empty in expand

### DIFF
--- a/alicloud/resource_alicloud_cms_alarm.go
+++ b/alicloud/resource_alicloud_cms_alarm.go
@@ -597,6 +597,45 @@ func resourceAliCloudCmsAlarmRead(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
+// expandCmsAlarmTargets builds the Targets list sent to PutMetricRuleTargets.
+// The API marks Targets[].Id and Targets[].Arn as required, so when a targets
+// block is declared, target_id and arn must be non-empty. An empty value is
+// rejected here with a clear validation error instead of being silently sent
+// to the API, which would reject it with an opaque error. target_id and arn
+// remain Optional in the schema to avoid a breaking change (the provider's
+// BreakingChange CI gate blocks Optional->Required promotion), but the expand
+// path enforces the API contract at apply time.
+func expandCmsAlarmTargets(targetsList []interface{}) ([]map[string]interface{}, error) {
+	targetsMaps := make([]map[string]interface{}, 0)
+	for _, targets := range targetsList {
+		targetsMap := map[string]interface{}{}
+		targetsArg := targets.(map[string]interface{})
+
+		id, _ := targetsArg["target_id"].(string)
+		if id == "" {
+			return nil, fmt.Errorf("targets.target_id is required by the PutMetricRuleTargets API and must not be empty")
+		}
+		targetsMap["Id"] = id
+
+		if jsonParams, ok := targetsArg["json_params"]; ok {
+			targetsMap["JsonParams"] = jsonParams
+		}
+
+		if level, ok := targetsArg["level"]; ok {
+			targetsMap["Level"] = level
+		}
+
+		arn, _ := targetsArg["arn"].(string)
+		if arn == "" {
+			return nil, fmt.Errorf("targets.arn is required by the PutMetricRuleTargets API and must not be empty")
+		}
+		targetsMap["Arn"] = arn
+
+		targetsMaps = append(targetsMaps, targetsMap)
+	}
+	return targetsMaps, nil
+}
+
 func resourceAliCloudCmsAlarmUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	cmsService := CmsService{client}
@@ -922,30 +961,10 @@ func resourceAliCloudCmsAlarmUpdate(d *schema.ResourceData, meta interface{}) er
 		update = true
 	}
 	if v, ok := d.GetOk("targets"); ok {
-		targetsMaps := make([]map[string]interface{}, 0)
-		for _, targets := range v.(*schema.Set).List() {
-			targetsMap := map[string]interface{}{}
-			targetsArg := targets.(map[string]interface{})
-
-			if id, ok := targetsArg["target_id"]; ok {
-				targetsMap["Id"] = id
-			}
-
-			if jsonParams, ok := targetsArg["json_params"]; ok {
-				targetsMap["JsonParams"] = jsonParams
-			}
-
-			if level, ok := targetsArg["level"]; ok {
-				targetsMap["Level"] = level
-			}
-
-			if arn, ok := targetsArg["arn"]; ok {
-				targetsMap["Arn"] = arn
-			}
-
-			targetsMaps = append(targetsMaps, targetsMap)
+		targetsMaps, err := expandCmsAlarmTargets(v.(*schema.Set).List())
+		if err != nil {
+			return WrapError(err)
 		}
-
 		putMetricRuleTargetsReq["Targets"] = targetsMaps
 	}
 

--- a/alicloud/resource_alicloud_cms_alarm_test.go
+++ b/alicloud/resource_alicloud_cms_alarm_test.go
@@ -1409,3 +1409,67 @@ func AliCloudCmsAlarmBasicDependence0(name string) string {
 	}
 `, name)
 }
+
+// TestUnitExpandCmsAlarmTargetsRequiresIdAndArn locks the regression for the
+// PutMetricRuleTargets required-Id/Arn alignment. The API marks Targets[].Id
+// and Targets[].Arn as required, but the provider schema keeps target_id and
+// arn Optional to avoid a breaking change (the BreakingChange CI gate blocks
+// Optional->Required promotion). Previously, when a targets block omitted
+// target_id or arn, the expand path silently sent an empty Id/Arn that the
+// API rejected at apply time with an opaque error. expandCmsAlarmTargets now
+// validates non-empty values and returns a clear error before the API call.
+// This test fails on the old silent-expand behavior and passes after the fix.
+func TestUnitExpandCmsAlarmTargetsRequiresIdAndArn(t *testing.T) {
+	// Case 1: empty target_id -> error (the regression being locked)
+	_, err := expandCmsAlarmTargets([]interface{}{
+		map[string]interface{}{"target_id": "", "arn": "acs:mns:cn-hangzhou:123:/queues/q/message"},
+	})
+	if err == nil {
+		t.Fatal("expected error when target_id is empty, got nil — expand must reject empty Id before the API call")
+	}
+
+	// Case 2: empty arn -> error
+	_, err = expandCmsAlarmTargets([]interface{}{
+		map[string]interface{}{"target_id": "1", "arn": ""},
+	})
+	if err == nil {
+		t.Fatal("expected error when arn is empty, got nil — expand must reject empty Arn before the API call")
+	}
+
+	// Case 3: both fields set -> ok, Id/Arn/JsonParams/Level populated
+	maps, err := expandCmsAlarmTargets([]interface{}{
+		map[string]interface{}{
+			"target_id":   "1",
+			"arn":         "acs:mns:cn-hangzhou:123:/queues/q/message",
+			"json_params": `{"key":"value"}`,
+			"level":       "Critical",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error when both target_id and arn are set, got %v", err)
+	}
+	if len(maps) != 1 {
+		t.Fatalf("expected 1 target map, got %d", len(maps))
+	}
+	if maps[0]["Id"] != "1" {
+		t.Fatalf("expected Id=1, got %v", maps[0]["Id"])
+	}
+	if maps[0]["Arn"] != "acs:mns:cn-hangzhou:123:/queues/q/message" {
+		t.Fatalf("expected Arn set, got %v", maps[0]["Arn"])
+	}
+	if maps[0]["JsonParams"] != `{"key":"value"}` {
+		t.Fatalf("expected JsonParams set, got %v", maps[0]["JsonParams"])
+	}
+	if maps[0]["Level"] != "Critical" {
+		t.Fatalf("expected Level=Critical, got %v", maps[0]["Level"])
+	}
+
+	// Case 4: empty list -> empty maps, no error (preserve no-targets behavior)
+	maps, err = expandCmsAlarmTargets([]interface{}{})
+	if err != nil {
+		t.Fatalf("expected no error for empty targets list, got %v", err)
+	}
+	if len(maps) != 0 {
+		t.Fatalf("expected empty maps for empty targets list, got %d", len(maps))
+	}
+}

--- a/website/docs/r/cms_alarm.html.markdown
+++ b/website/docs/r/cms_alarm.html.markdown
@@ -174,10 +174,10 @@ The prometheus supports the following:
 
 The targets supports the following:
 
-* `target_id` - (Optional) The ID of the resource for which alerts are triggered. For more information about how to obtain the ID of the resource for which alerts are triggered, see [DescribeMetricRuleTargets](https://www.alibabacloud.com/help/en/cms/developer-reference/api-describemetricruletargets) .
+* `target_id` - (Optional) The ID of the resource for which alerts are triggered. For more information about how to obtain the ID of the resource for which alerts are triggered, see [DescribeMetricRuleTargets](https://www.alibabacloud.com/help/en/cms/developer-reference/api-describemetricruletargets) . **NOTE:** Although this field is marked Optional in the schema, the PutMetricRuleTargets API requires `Id` to be non-empty; if a `targets` block is declared, omitting `target_id` (or leaving it empty) causes `apply` to fail with a clear validation error instead of an opaque API rejection.
 * `json_params` - (Optional) The parameters of the alert callback. The parameters are in the JSON format.
 * `level` - (Optional) The level of the alert. Valid values: `Critical`, `Warn`, `Info`.
-* `arn` - (Optional) The Alibaba Cloud Resource Name (ARN) of the resource. Simple Message Queue (formerly MNS) (SMQ), Auto Scaling, Simple Log Service, and Function Compute are supported:
+* `arn` - (Optional) The Alibaba Cloud Resource Name (ARN) of the resource. Simple Message Queue (formerly MNS) (SMQ), Auto Scaling, Simple Log Service, and Function Compute are supported: **NOTE:** Although this field is marked Optional in the schema, the PutMetricRuleTargets API requires `Arn` to be non-empty; if a `targets` block is declared, omitting `arn` (or leaving it empty) causes `apply` to fail with a clear validation error instead of an opaque API rejection.
   - SMQ: `acs:mns:{regionId}:{userId}:/{Resource type}/{Resource name}/message`. {regionId}: the region ID of the SMQ queue or topic. {userId}: the ID of the Alibaba Cloud account that owns the resource. {Resource type}: the type of the resource for which alerts are triggered. Valid values:queues, topics. {Resource name}: the resource name. If the resource type is queues, the resource name is the queue name. If the resource type is topics, the resource name is the topic name.
   - Auto Scaling: `acs:ess:{regionId}:{userId}:scalingGroupId/{Scaling group ID}:scalingRuleId/{Scaling rule ID}`
   - Simple Log Service: `acs:log:{regionId}:{userId}:project/{Project name}/logstore/{Logstore name}`


### PR DESCRIPTION
### Background

The `PutMetricRuleTargets` API marks `Targets[].Id` and `Targets[].Arn` as **required**. The provider schema for `alicloud_cms_alarm` marks `targets.target_id` and `targets.arn` as `Optional` (promoting them to `Required` is blocked by the provider's `BreakingChange` CI gate, which rejects Optional->Required as a breaking change). Previously, when a `targets` block omitted `target_id` or `arn`, the expand path silently sent an empty `Id`/`Arn` that the API rejected at `apply` time with an opaque error.

### Changes

- Extract `expandCmsAlarmTargets` from the inline expand in `resourceAliCloudCmsAlarmUpdate`. The new helper validates that `target_id` and `arn` are non-empty when a `targets` block is declared, returning a clear validation error (`targets.target_id is required by the PutMetricRuleTargets API and must not be empty`) before the API call instead of silently sending an empty `Id`/`Arn`.
- `targets.target_id` and `targets.arn` remain `Optional` in the schema to avoid a breaking change. The API contract is enforced at apply time via the expand helper.
- Docs (`website/docs/r/cms_alarm.html.markdown`) updated with a NOTE on `target_id` and `arn` explaining that although the fields are Optional in the schema, the PutMetricRuleTargets API requires non-empty `Id`/`Arn`, and omitting them (or leaving them empty) in a `targets` block causes `apply` to fail with a clear validation error.

### Regression test

`TestUnitExpandCmsAlarmTargetsRequiresIdAndArn` is a unit test that calls `expandCmsAlarmTargets` with:
- an empty `target_id` -> expects an error
- an empty `arn` -> expects an error
- both fields set -> expects a populated Targets map with `Id`/`Arn`/`JsonParams`/`Level`
- an empty list -> expects no error and no maps (preserves the no-targets behavior)

It fails on the old silent-expand behavior (which sent empty `Id`/`Arn` to the API) and passes after the fix, locking the API-contract enforcement.

### Remote ACC

Existing acceptance cases already provide both `target_id` and `arn` in every `targets` block, so they continue to pass. Remote ACC covers the create + update + import lifecycle with both fields provided.

### Why not Required?

Promoting `target_id`/`arn` from `Optional` to `Required` would be the most direct fix, but the provider's `BreakingChange` CI gate (`scripts/compatibility/breaking_change_check.go`) hard-blocks Optional->Required field promotion. Keeping the fields `Optional` and enforcing non-empty at expand time achieves the same API alignment without a breaking schema change.

```release-note:bug-fix
resource/alicloud_cms_alarm: `targets.target_id` and `targets.arn` are now validated as non-empty in the expand path to align with the `PutMetricRuleTargets` API, which marks `Id` and `Arn` as required; omitting them in a `targets` block previously caused `apply` to fail with an opaque API rejection and now fails with a clear validation error.
```
