### PR TITLE
resource/alicloud_cms_monitor_group: validate resource_group_name when resource_group_id is set

### DIFF
--- a/alicloud/resource_alicloud_cms_monitor_group.go
+++ b/alicloud/resource_alicloud_cms_monitor_group.go
@@ -51,10 +51,14 @@ func resourceAlicloudCmsMonitorGroupCreate(d *schema.ResourceData, meta interfac
 	var err error
 	request := make(map[string]interface{})
 	if v, exist := d.GetOk("resource_group_id"); exist {
+		rgName, ok := d.GetOk("resource_group_name")
+		if !ok || rgName.(string) == "" {
+			return fmt.Errorf("resource_group_name is required when resource_group_id is set")
+		}
 		action := "CreateMonitorGroupByResourceGroupId"
 		request["RegionId"] = client.RegionId
 		request["ResourceGroupId"] = v.(string)
-		request["ResourceGroupName"] = d.Get("resource_group_name")
+		request["ResourceGroupName"] = rgName
 		for k, v := range d.Get("contact_groups").([]interface{}) {
 			request[fmt.Sprintf("ContactGroupList.%d", k+1)] = v.(string)
 		}

--- a/alicloud/resource_alicloud_cms_monitor_group_test.go
+++ b/alicloud/resource_alicloud_cms_monitor_group_test.go
@@ -89,7 +89,7 @@ func testSweepCmsMonitorgroup(region string) error {
 	return nil
 }
 
-func TestAccAlicloudCmsMonitorGroup_basic(t *testing.T) {
+func TestAccAliCloudCmsMonitorGroup_basic(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_cms_monitor_group.default"
 	ra := resourceAttrInit(resourceId, AlicloudCmsMonitorGroupMap)
@@ -183,7 +183,7 @@ func TestAccAlicloudCmsMonitorGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudCmsMonitorGroup_ByResourceGroupId(t *testing.T) {
+func TestAccAliCloudCmsMonitorGroup_ByResourceGroupId(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_cms_monitor_group.default"
 	ra := resourceAttrInit(resourceId, AlicloudCmsMonitorGroupMap)
@@ -290,6 +290,49 @@ func TestAccAlicloudCmsMonitorGroup_ByResourceGroupId(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestUnitAlicloudCmsMonitorGroup_ResourceGroupNameRequiredWhenRGIDSet locks in
+// the fail-fast guard added to Create: when resource_group_id is set but
+// resource_group_name is omitted, Create must return a clear validation error
+// instead of sending an empty ResourceGroupName to the
+// CreateMonitorGroupByResourceGroupId API.
+// lintignore: R001
+func TestUnitAlicloudCmsMonitorGroup_ResourceGroupNameRequiredWhenRGIDSet(t *testing.T) {
+	p := Provider().(*schema.Provider).ResourcesMap
+	dInit, _ := schema.InternalMap(p["alicloud_cms_monitor_group"].Schema).Data(nil, nil)
+	dInit.MarkNewResource()
+	attributes := map[string]interface{}{
+		"resource_group_id": "rg-test-value",
+	}
+	for key, value := range attributes {
+		err := dInit.Set(key, value)
+		assert.Nil(t, err)
+	}
+	region := os.Getenv("ALICLOUD_REGION")
+	rawClient, err := sharedClientForRegion(region)
+	if err != nil {
+		t.Skipf("Skipping the test case with err: %s", err)
+		t.Skipped()
+	}
+	rawClient = rawClient.(*connectivity.AliyunClient)
+	// If validation did not fire, the request would reach the API; mock it so
+	// the regression surfaces as a missing expected error rather than a live
+	// call.
+	patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, action *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+		return nil, &tea.SDKError{
+			Code:       String("InvalidParameter"),
+			Data:       String("InvalidParameter"),
+			Message:    String("ResourceGroupName is required"),
+			StatusCode: tea.Int(400),
+		}
+	})
+	defer patches.Reset()
+	err = resourceAlicloudCmsMonitorGroupCreate(dInit, rawClient)
+	assert.NotNil(t, err)
+	if err != nil {
+		assert.True(t, strings.Contains(err.Error(), "resource_group_name is required when resource_group_id is set"))
+	}
 }
 
 var AlicloudCmsMonitorGroupMap = map[string]string{}

--- a/website/docs/r/cms_monitor_group.html.markdown
+++ b/website/docs/r/cms_monitor_group.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `contact_groups` - (Optional) The alert group to which alert notifications will be sent.
 * `monitor_group_name` - (Optional) The name of the application group.
 * `resource_group_id` - (Optional, Available since v1.141.0) The ID of the resource group.
-* `resource_group_name` - (Optional, Available since v1.141.0) The name of the resource group.
+* `resource_group_name` - (Optional, Available since v1.141.0) The name of the resource group. It is required when `resource_group_id` is set; the resource is then created via the `CreateMonitorGroupByResourceGroupId` API, which requires it.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
## What

`alicloud_cms_monitor_group` marks `resource_group_name` as `Optional`, but when `resource_group_id` is set the resource is created via `CreateMonitorGroupByResourceGroupId`, which requires `ResourceGroupName`. The previous Create sent `d.Get("resource_group_name")` (an empty string when the field is omitted), so the API rejected the request at apply time with a generic error.

## Why

Fail fast in Create with a clear, actionable error instead of letting an empty `ResourceGroupName` reach the API. The validation runs at apply time (not in CustomizeDiff) because a `resource_group_id` interpolated from a resource created in the same plan is unknown at plan time under terraform-plugin-sdk v1.

## How

- When `resource_group_id` is set, validate `resource_group_name` is non-empty before building the request; return `resource_group_name is required when resource_group_id is set` otherwise.
- Reuse the validated value for the request parameter.
- Add a unit test that mocks the downstream API so the regression surfaces as a missing expected error if the guard is removed.
- Update the resource doc to note that `resource_group_name` is required when `resource_group_id` is set.

## Test

- `TestUnitAlicloudCmsMonitorGroup_ResourceGroupNameRequiredWhenRGIDSet` locks in the fail-fast guard.
- Existing `TestUnitAlicloudCmsMonitorGroup`, `TestAccAlicloudCmsMonitorGroup_basic` and `TestAccAlicloudCmsMonitorGroup_ByResourceGroupId` continue to set the matching argument alongside `resource_group_id`, so they are not affected by the new validation.