### PR TITLE
resource/alicloud_instance: support replace_instance_on_image_update

### DIFF
--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -31,6 +31,7 @@ func resourceAliCloudInstance() *schema.Resource {
 			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
+		CustomizeDiff: resourceAliCloudInstanceCustomizeDiff,
 		Schema: map[string]*schema.Schema{
 			"availability_zone": {
 				Type:     schema.TypeString,
@@ -43,6 +44,11 @@ func resourceAliCloudInstance() *schema.Resource {
 				AtLeastOneOf: []string{"image_id", "launch_template_id", "launch_template_name"},
 				Optional:     true,
 				Computed:     true,
+			},
+			"replace_instance_on_image_update": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
 			"instance_type": {
 				Type:         schema.TypeString,
@@ -2684,6 +2690,37 @@ func resourceAliCloudInstanceDelete(d *schema.ResourceData, meta interface{}) er
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
 	return nil
+}
+
+func resourceAliCloudInstanceCustomizeDiff(diff *schema.ResourceDiff, v interface{}) error {
+	// Nothing to force on create. This also terminates the second, state-less diff pass that
+	// ForceNew triggers, where Id() is empty and RequiresNew has already been carried over.
+	if diff.Id() == "" {
+		return nil
+	}
+	// replace_instance_on_image_update is the switch: it guides what an image_id change means. Left off,
+	// the change keeps its default behaviour of replacing the system disk of the running instance in place.
+	if !diff.Get("replace_instance_on_image_update").(bool) {
+		return nil
+	}
+	// ForceNew reports an error when there is no change for the given key, so image_id is the only
+	// key the replacement can be anchored on, and only while it is actually changing.
+	if !diff.HasChange("image_id") {
+		return nil
+	}
+	// A value that is not yet known at plan time cannot be compared meaningfully.
+	if !diff.NewValueKnown("image_id") {
+		return nil
+	}
+	// image_id is Optional and Computed: with no value in the configuration it is filled in from
+	// the API, so an empty or an unchanged side is not user intent and must not destroy anything.
+	oldRaw, newRaw := diff.GetChange("image_id")
+	oldImageId, _ := oldRaw.(string)
+	newImageId, _ := newRaw.(string)
+	if oldImageId == "" || newImageId == "" || oldImageId == newImageId {
+		return nil
+	}
+	return diff.ForceNew("image_id")
 }
 
 func modifyInstanceChargeType(d *schema.ResourceData, meta interface{}, forceDelete bool) error {

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func init() {
@@ -4788,6 +4789,152 @@ func AliCloudEcsInstancePrivatePool(name string) string {
   		vpc_id = alicloud_vpc.vpc.id
 	}
 `, name)
+}
+
+func TestAccAliCloudECSInstanceReplaceOnImageUpdate(t *testing.T) {
+	var v ecs.Instance
+	resourceId := "alicloud_instance.default"
+	ra := resourceAttrInit(resourceId, testAccInstanceCheckMap)
+	serviceFunc := func() interface{} {
+		return &EcsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(1000, 9999)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAccEcsInstanceReplaceOnImageUpdate%d", rand)
+	// Both images are pinned rather than looked up by index, so that every step is guaranteed to
+	// differ in image_id from the one before it. They are plain x86_64 20G Linux system images, so one
+	// instance type serves both. The instance type itself is left to alicloud_instance_types, which
+	// filters out sold out types, so that a stock shortage cannot fail this test spuriously.
+	imageIdBefore := "ubuntu_24_04_x64_20G_alibase_20260720.vhd"
+	imageIdAfter := "ubuntu_22_04_x64_20G_alibase_20260723.vhd"
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, func(name string) string {
+		return resourceInstanceReplaceOnImageUpdateDependence(name, imageIdBefore)
+	})
+
+	// replace_instance_on_image_update is a switch over what an image_id change means, so the test has
+	// to pin down both of its positions. The instance id is the evidence: ReplaceSystemDisk keeps it,
+	// while a destroy and create hands out a new one.
+	instanceId := ""
+	recordInstanceId := func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceId]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceId)
+		}
+		instanceId = rs.Primary.ID
+		return nil
+	}
+	checkInstanceKept := func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceId]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceId)
+		}
+		if rs.Primary.ID != instanceId {
+			return fmt.Errorf("the instance was replaced (%s -> %s), but changing image_id with replace_instance_on_image_update disabled should have replaced its system disk in place", instanceId, rs.Primary.ID)
+		}
+		return nil
+	}
+	checkInstanceReplaced := func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceId]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceId)
+		}
+		if rs.Primary.ID == instanceId {
+			return fmt.Errorf("the instance was updated in place, but changing image_id with replace_instance_on_image_update enabled should have replaced it")
+		}
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.TestSalveRegions)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"image_id":                         imageIdBefore,
+					"replace_instance_on_image_update": "false",
+					"security_groups":                  []string{"${alicloud_security_group.default.id}"},
+					"instance_type":                    "${data.alicloud_instance_types.default.instance_types.0.id}",
+					"availability_zone":                "${data.alicloud_instance_types.default.instance_types.0.availability_zones.0}",
+					"system_disk_category":             "cloud_efficiency",
+					"instance_name":                    "${var.name}",
+					"spot_strategy":                    "NoSpot",
+					"spot_price_limit":                 "0",
+					"user_data":                        "I_am_user_data",
+					"vswitch_id":                       "${alicloud_vswitch.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_name":                    name,
+						"image_id":                         imageIdBefore,
+						"replace_instance_on_image_update": "false",
+					}),
+					recordInstanceId,
+				),
+			},
+			// Switch off: the image change falls through to ReplaceSystemDisk and the instance survives.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"image_id": imageIdAfter,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"image_id": imageIdAfter,
+					}),
+					checkInstanceKept,
+				),
+			},
+			// Switch on: the same kind of image change now destroys and creates the instance.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"image_id":                         imageIdBefore,
+					"replace_instance_on_image_update": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"image_id":                         imageIdBefore,
+						"replace_instance_on_image_update": "true",
+					}),
+					checkInstanceReplaced,
+				),
+			},
+		},
+	})
+}
+
+func resourceInstanceReplaceOnImageUpdateDependence(name, imageId string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_instance_types" "default" {
+  image_id = "%s"
+}
+
+resource "alicloud_vpc" "default" {
+  cidr_block = "192.168.0.0/16"
+  vpc_name   = var.name
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id       = alicloud_vpc.default.id
+  cidr_block   = cidrsubnet(alicloud_vpc.default.cidr_block, 8, 2)
+  zone_id      = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
+  vswitch_name = var.name
+}
+
+resource "alicloud_security_group" "default" {
+  security_group_name   = var.name
+  vpc_id = alicloud_vpc.default.id
+}
+`, name, imageId)
 }
 
 var tags0 = map[string]string{

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -104,7 +104,8 @@ to create several ECS instances one-click.
 
 The following arguments are supported:
 
-* `image_id` - (Optional) The Image to use for the instance. ECS instance's image can be replaced via changing `image_id`. When it is changed, the instance will reboot to make the change take effect. If you do not use `launch_template_id` or `launch_template_name` to specify a launch template, you must specify `image_id`.
+* `image_id` - (Optional) The Image to use for the instance. ECS instance's image can be replaced via changing `image_id`. When it is changed, the instance will reboot to make the change take effect. If you do not use `launch_template_id` or `launch_template_name` to specify a launch template, you must specify `image_id`. See also `replace_instance_on_image_update`, which controls whether such a change is applied in place or by replacing the instance.
+
 * `instance_type` - (Optional) The type of instance to start. When it is changed, the instance will reboot to make the change take effect. If you do not use `launch_template_id` or `launch_template_name` to specify a launch template, you must specify `instance_type`.
 * `io_optimized` - (Removed) It has been deprecated on instance resource. All the launched alicloud instances will be I/O optimized.
 * `is_outdated` - (Optional) Whether to use outdated instance type.
@@ -264,6 +265,12 @@ The following arguments are supported:
 
 * `image_options` - (Optional, Set, Available since v1.237.0) The options of images. See [`image_options`](#image_options) below.
 * `cpu_options` - (Optional, Set, Available since v1.267.0) The options of cpu. See [`cpu_options`](#cpu_options) below.
+* `replace_instance_on_image_update` - (Optional, Bool, Available since v1.289.0) Whether to replace the instance when `image_id` is updated, instead of updating it in place. Default value: `false`. Valid values:
+  - `false`: The system disk of the existing instance is replaced with the new image and the instance ID is retained.
+  - `true`: The instance is destroyed and created again, and `terraform plan` reports the change as `forces replacement`.
+
+  -> **NOTE:** Setting `replace_instance_on_image_update` to `true` changes how an `image_id` update is applied: the instance is destroyed and created again, so its instance ID, its private IP address and the data on all of its disks are lost. Make sure the instance can actually be destroyed before applying such a change, because the destroy fails if `deletion_protection` is `true`, or if `instance_charge_type` is `PrePaid` and `force_delete` is not `true`, and it is rejected at plan time if the resource has a `prevent_destroy` lifecycle rule. Replacement is only forced when both the old and the new `image_id` are known and not empty, so an instance whose image is supplied by a launch template instead of by the configuration is not affected.
+
 * `allocate_public_ip` - (Optional, Bool, Deprecated since v1.7.0) Field `allocate_public_ip` has been deprecated from provider version 1.7.0. Setting  `internet_max_bandwidth_out` larger than 0 will allocate public ip for instance.
 * `internet_max_bandwidth_in` - (Optional, Int, Deprecated since v1.121.2) Maximum incoming bandwidth from the public network, measured in Mbps (Mega bit per second). Value range: [1, 200]. If this value is not specified, then automatically sets it to 200 Mbps.
 * `role_name` - (Optional, Deprecated since v1.275.0) The name of the Resource Access Management (RAM) role. **NOTE:** From version 1.250.0, If you want to use `role_name`, We recommend you to use the resource [alicloud_ecs_ram_role_attachment](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ecs_ram_role_attachment). Field `role_name` has been deprecated from provider version 1.275.0. New resource [alicloud_ecs_ram_role_attachment](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ecs_ram_role_attachment) instead. From version 1.276.0, `role_name` can be modified.


### PR DESCRIPTION
### Summary

Adds `replace_instance_on_image_update` to `alicloud_instance`, a boolean switch over what a change to `image_id` means:

| Value | Behaviour on an `image_id` change |
|---|---|
| `false` (default, unchanged behaviour) | `ReplaceSystemDisk` — the system disk is reinstalled from the new image and the instance ID, its private IP address and its data disks are kept. |
| `true` | The instance is destroyed and created again; `terraform plan` reports the change as `# forces replacement`. |

Some images cannot be applied to a running instance in place (a different OS family or architecture, a change of boot mode), and some users simply want a clean instance from the new image rather than a reinstalled system disk. Terraform has no way to express that from the configuration today: `ForceNew` on `image_id` is a schema-level decision, and the `replace_triggered_by` lifecycle meta-argument cannot reference an attribute of the resource it belongs to.

### Implementation

The switch is honoured in a `CustomizeDiff` on the resource:

```go
func resourceAliCloudInstanceCustomizeDiff(diff *schema.ResourceDiff, v interface{}) error {
	if diff.Id() == "" {
		return nil
	}
	if !diff.Get("replace_instance_on_image_update").(bool) {
		return nil
	}
	if !diff.HasChange("image_id") {
		return nil
	}
	...
	return diff.ForceNew("image_id")
}
```

Notes on the guards, in the order they run:

* **`Id() == ""`** — nothing to force on create. This also terminates the second, state-less diff pass that `ForceNew` itself triggers, in which `Id()` is empty and `RequiresNew` has already been carried over.
* **the switch** — off is the default, and it falls straight through to the existing in-place path, so behaviour for existing configurations does not change.
* **`HasChange("image_id")`** — `ResourceDiff.ForceNew` returns an error for a key with no diff, so `image_id` is the only key the replacement can be anchored on, and only while it is actually changing. Anchoring there is also what makes the plan print `# forces replacement` on the line the user edited.
* **`NewValueKnown`, and both sides non-empty and different** — `image_id` is `Optional` and `Computed`, so with no value in the configuration it is filled in from the API. An empty or unchanged side is not user intent and must not destroy anything; an instance whose image comes from a launch template is therefore unaffected.

### Documentation

The new argument is documented with the two positions of the switch and a note that replacement loses the instance ID, the private IP address and the data on all disks, that the destroy fails under `deletion_protection` or under `PrePaid` without `force_delete`, and that it is rejected at plan time by a `prevent_destroy` lifecycle rule. `image_id` gained a cross-reference to it.

### Acceptance test

`TestAccAliCloudECSInstanceReplaceOnImageUpdate` pins both positions of the switch in one run and uses the instance ID as the evidence, since `ReplaceSystemDisk` keeps it while a destroy and create hands out a new one:

1. create with the switch off,
2. change `image_id` with the switch still off — assert the instance ID is unchanged,
3. change `image_id` with the switch on — assert the instance ID is different.

Both images are pinned rather than looked up by index so that each step is guaranteed to differ from the one before it; the instance type is left to `alicloud_instance_types`, which filters out sold-out types, so a stock shortage cannot fail the test spuriously.

```
=== RUN   TestAccAliCloudECSInstanceReplaceOnImageUpdate
--- PASS: TestAccAliCloudECSInstanceReplaceOnImageUpdate (263.75s)
PASS
统计: PASS=1 FAIL=0 SKIP=0
```

The API call sequence in the debug log confirms the assertions actually discriminate between the two paths rather than passing trivially: `RunInstances` (create) → `ReplaceSystemDisk` (step 2, switch off) → `DeleteInstance` + `RunInstances` back to back (step 3, switch on) → `DeleteInstance` (teardown).
