### PR TITLE
resource/alicloud_cms_event_rule: clarify silence_time unit and contact_parameters.level enum

### DIFF
--- a/alicloud/resource_alicloud_cms_event_rule.go
+++ b/alicloud/resource_alicloud_cms_event_rule.go
@@ -34,8 +34,9 @@ func resourceAliCloudCloudMonitorServiceEventRule() *schema.Resource {
 				Optional: true,
 			},
 			"silence_time": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The silence time in seconds.",
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -94,8 +95,9 @@ func resourceAliCloudCloudMonitorServiceEventRule() *schema.Resource {
 							Optional: true,
 						},
 						"level": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The alert level and the corresponding notification methods. Valid values: 2 (phone, SMS, DingTalk, and email), 3 (SMS, DingTalk, and email), and 4 (DingTalk and email). International or partner accounts only support level 4.",
 						},
 					},
 				},

--- a/website/docs/r/cms_event_rule.html.markdown
+++ b/website/docs/r/cms_event_rule.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `rule_name` - (Required, ForceNew) The name of the event-triggered alert rule.
 * `group_id` - (Optional) The ID of the application group to which the event-triggered alert rule belongs.
-* `silence_time` - (Optional, Int) The silence time.
+* `silence_time` - (Optional, Int) The silence time in seconds.
 * `description` - (Optional) The description of the event-triggered alert rule.
 * `status` - (Optional) The status of the resource. Valid values: `ENABLED`, `DISABLED`.
 * `event_pattern` - (Required, Set) Event mode, used to describe the trigger conditions for this event. See [`event_pattern`](#event_pattern) below.
@@ -93,7 +93,10 @@ The contact_parameters supports the following:
 
 * `contact_parameters_id` (Optional) The ID of the recipient that receives alert notifications.
 * `contact_group_name` (Optional) The name of the alert contact group.
-* `level` (Optional) The alert level and the corresponding notification methods.
+* `level` (Optional) The alert level and the corresponding notification methods. Valid values:
+  - `2`: notify by phone, SMS, DingTalk, and email.
+  - `3`: notify by SMS, DingTalk, and email.
+  - `4`: notify by DingTalk and email. International or partner accounts only support this level.
 
 ### `webhook_parameters`
 


### PR DESCRIPTION
## What this PR does

Clarifies two documentation gaps in `alicloud_cms_event_rule`:

1. **`silence_time`**: documents the unit (seconds) for the silence time, both in the resource docs and in the schema `Description`. This aligns the Terraform description with the backing OpenAPI definition (`SilenceTime`, Long, whose description states the unit is seconds).

2. **`contact_parameters.level`**: documents the valid values (2, 3, 4) together with the notification methods each level enables:
   - `2`: phone, SMS, DingTalk, and email
   - `3`: SMS, DingTalk, and email
   - `4`: DingTalk and email (international / partner accounts only support this level)

   The schema `Description` is updated to mirror the documentation so that `terraform schema` and generated docs stay consistent.

## Why

Both fields previously had terse descriptions that left users to discover valid values and units by trial and error. The added detail is taken directly from the upstream OpenAPI definition and helps users configure alert notification levels correctly the first time.

## Scope / non-breaking

- Pure documentation + schema `Description` text enhancement.
- No new fields, no type changes, no `ValidateFunc` / enum constraints are introduced.
- The `level` field remains a free-form string to preserve existing behavior (existing configurations with any string value continue to work as before).
- No acceptance test changes are required because no runtime behavior changes.

## Verification

- `gofmt` on the changed Go file.
- `go vet -p=1 ./alicloud` (only pre-existing warnings in `common.go`, unrelated to this change).
- Remote PR CI will run the full `go vet ./...` and `go build ./...`.