### PR TITLE
resource/alicloud_cms_group_metric_rule: support in-place update of category

### DIFF
--- a/alicloud/resource_alicloud_cms_group_metric_rule.go
+++ b/alicloud/resource_alicloud_cms_group_metric_rule.go
@@ -551,6 +551,13 @@ func resourceAliCloudCmsGroupMetricRuleUpdate(d *schema.ResourceData, meta inter
 	}
 	request["MetricName"] = d.Get("metric_name")
 
+	if !d.IsNewResource() && d.HasChange("category") {
+		update = true
+	}
+	if v, ok := d.GetOk("category"); ok {
+		request["Category"] = v
+	}
+
 	if !d.IsNewResource() && d.HasChange("contact_groups") {
 		update = true
 	}
@@ -717,6 +724,7 @@ func resourceAliCloudCmsGroupMetricRuleUpdate(d *schema.ResourceData, meta inter
 		d.SetPartial("group_id")
 		d.SetPartial("group_metric_rule_name")
 		d.SetPartial("metric_name")
+		d.SetPartial("category")
 		d.SetPartial("contact_groups")
 		d.SetPartial("dimensions")
 		d.SetPartial("email_subject")

--- a/alicloud/resource_alicloud_cms_group_metric_rule_test.go
+++ b/alicloud/resource_alicloud_cms_group_metric_rule_test.go
@@ -172,6 +172,26 @@ func TestAccAliCloudCmsGroupMetricRule_basic0(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"category": "ecs",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"category": "ecs",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"category": "rds",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"category": "rds",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"contact_groups": "${alicloud_cms_monitor_group.default.id}",
 				}),
 				Check: resource.ComposeTestCheckFunc(

--- a/website/docs/r/cms_group_metric_rule.html.markdown
+++ b/website/docs/r/cms_group_metric_rule.html.markdown
@@ -81,6 +81,8 @@ The following arguments are supported:
 * `metric_name` - (Required) The name of the metric.
 * `namespace` - (Required, ForceNew) The namespace of the service.
 * `category` - (Optional) The abbreviation of the service name.
+
+  -> **NOTE:** The API used to read the alert rule does not return this attribute, so Terraform cannot detect its drift. The state value always reflects the last applied configuration, and the attribute is not restored by `terraform import`.
 * `contact_groups` - (Optional) Alarm contact group.
 * `dimensions` - (Optional) The dimensions that specify the resources to be associated with the alert rule.
 * `email_subject` - (Optional) The subject of the alert notification email.


### PR DESCRIPTION
## Summary

- The `category` argument of `alicloud_cms_group_metric_rule` is declared updatable (no `ForceNew`), and the `PutGroupMetricRule` API accepts `Category` on both create and update, but the update handler never sent it. As a result, in-place changes to `category` were silently ignored. This change includes `Category` in the update request whenever it is set, marks it in the partial state, and triggers the update call when it changes.
- The read API (`DescribeMetricRuleList`) does not return this attribute (it only exposes `ProductCategory`, which is derived from the rule namespace rather than from the stored `Category` value), so the attribute is intentionally not refreshed from the remote state. The documentation now notes that drift of this attribute cannot be detected and that it is not restored by `terraform import`.

## Changes

- `alicloud/resource_alicloud_cms_group_metric_rule.go`: send `Category` in the `PutGroupMetricRule` update request (following the same pattern as the sibling updatable arguments) and add `category` to the partial state list.
- `alicloud/resource_alicloud_cms_group_metric_rule_test.go`: extend `TestAccAliCloudCmsGroupMetricRule_basic0` with steps that set `category` and then change it in place.
- `website/docs/r/cms_group_metric_rule.html.markdown`: add a note documenting the read-back limitation of `category`.

## Test plan

- [x] `TestAccAliCloudCmsGroupMetricRule_basic0` PASS in cn-beijing (81.43s): create → update group/name/metric → set `category` → change `category` in place → update contact groups/dimensions/email/interval/period/silence/webhook/targets/escalations → import → destroy. The debug trace confirms `Category` is sent in the update requests (`ecs`, then the in-place change to `rds`) and preserved by the subsequent updates.
- `TestAccAliCloudCmsGroupMetricRule_basic0_twin` fails on `ImportStateVerify` for `contact_groups` (the configuration passes a monitor group ID where the API expects alarm contact group names, and the API asynchronously normalizes the stored value). This failure is pre-existing: it reproduces identically on the unmodified base commit in the same environment, and this PR does not touch `contact_groups` handling.
