### PR TITLE
docs: support multiple assume_role blocks for chained role assumption

### DIFF
--- a/alicloud/connectivity/assume_role_chain.go
+++ b/alicloud/connectivity/assume_role_chain.go
@@ -1,0 +1,264 @@
+package connectivity
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	openapi "github.com/alibabacloud-go/darabonba-openapi/v2/client"
+	sts20150401 "github.com/alibabacloud-go/sts-20150401/v2/client"
+	util "github.com/alibabacloud-go/tea-utils/v2/service"
+	"github.com/alibabacloud-go/tea/tea"
+	credential "github.com/aliyun/credentials-go/credentials"
+)
+
+// defaultStsEndpoint is the STS service domain used when no explicit STS
+// endpoint is configured on the provider. It mirrors the default used by the
+// credentials-go SDK for the ram_role_arn credential type.
+const defaultStsEndpoint = "sts.aliyuncs.com"
+
+// chainedAssumeRoleCredential implements credential.Credential by performing
+// an ordered chain of STS AssumeRole calls. The first hop uses the initial
+// caller credential captured at provider configuration time; every subsequent
+// hop uses the temporary credential returned by the previous AssumeRole call
+// as its caller credential. The final temporary credential is cached and
+// refreshed shortly before it expires, so downstream callers that periodically
+// re-resolve via GetCredential continue to receive a live session.
+type chainedAssumeRoleCredential struct {
+	// initial caller credential, captured when the provider was configured
+	initialAccessKey     string
+	initialSecretKey     string
+	initialSecurityToken string
+
+	chain []*AssumeRoleConfig
+
+	regionId        string
+	stsEndpoint     string
+	userAgent       string
+	sourceIp        string
+	secureTransport string
+	readTimeout     int
+	connectTimeout  int
+
+	mu     sync.Mutex
+	cached *chainedSession
+}
+
+// chainedSession is the cached result of a fully resolved chain.
+type chainedSession struct {
+	accessKeyId     string
+	accessKeySecret string
+	securityToken   string
+	expiration      time.Time
+}
+
+// setAuthByChainedAssumeRole builds a chainedAssumeRoleCredential from the
+// configured AssumeRoleChain, installs it as the provider's credential source,
+// and eagerly resolves the chain once so that Config.AccessKey/SecretKey/
+// SecurityToken hold the final session credential for downstream callers that
+// read those fields directly.
+func (c *Config) setAuthByChainedAssumeRole() (err error) {
+	if len(c.AssumeRoleChain) == 0 {
+		return
+	}
+	// The chain needs an initial caller credential. The provider configuration
+	// guarantees AccessKey/SecretKey are populated by the time
+	// RefreshAuthCredential runs; without them there is nothing to chain from.
+	if c.AccessKey == "" {
+		return fmt.Errorf("assume_role chain requires a caller credential: access_key is empty")
+	}
+
+	stsEndpoint := c.StsEndpoint
+	if stsEndpoint == "" {
+		stsEndpoint = defaultStsEndpoint
+	}
+
+	provider := &chainedAssumeRoleCredential{
+		initialAccessKey:     c.AccessKey,
+		initialSecretKey:     c.SecretKey,
+		initialSecurityToken: c.SecurityToken,
+		chain:                c.AssumeRoleChain,
+		regionId:             c.RegionId,
+		stsEndpoint:          stsEndpoint,
+		userAgent:            c.getUserAgent(),
+		sourceIp:             c.SourceIp,
+		secureTransport:      c.SecureTransport,
+		readTimeout:          c.ClientReadTimeout,
+		connectTimeout:       c.ClientConnectTimeout,
+	}
+	c.Credential = provider
+	cred, err := provider.GetCredential()
+	if err != nil || cred == nil {
+		return fmt.Errorf("refresh chained AssumeRole credential failed. Error: %v", err)
+	}
+	c.AccessKey, c.SecretKey, c.SecurityToken = *cred.AccessKeyId, *cred.AccessKeySecret, *cred.SecurityToken
+	return nil
+}
+
+// GetCredential resolves the chain, returning the cached final session when it
+// is still valid, otherwise re-running the whole chain from the initial caller
+// credential.
+func (p *chainedAssumeRoleCredential) GetCredential() (*credential.CredentialModel, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cached != nil && time.Now().Before(p.cached.expiration.Add(-time.Minute)) {
+		return p.model(), nil
+	}
+
+	ak := p.initialAccessKey
+	sk := p.initialSecretKey
+	st := p.initialSecurityToken
+	var lastExpiration string
+	for i, hop := range p.chain {
+		creds, expiration, err := p.assumeRole(ak, sk, st, hop)
+		if err != nil {
+			return nil, fmt.Errorf("chained AssumeRole failed at hop %d (RoleArn: %s): %v", i, hop.RoleArn, err)
+		}
+		ak = creds.AccessKeyId
+		sk = creds.AccessKeySecret
+		st = creds.SecurityToken
+		lastExpiration = expiration
+		log.Printf("[INFO] chained AssumeRole hop %d/%d assumed (RoleArn: %s)", i+1, len(p.chain), hop.RoleArn)
+	}
+
+	expiration := time.Now().Add(time.Hour)
+	if lastExpiration != "" {
+		if parsed, err := time.Parse("2006-01-02T15:04:05Z", lastExpiration); err == nil {
+			expiration = parsed
+		}
+	}
+	p.cached = &chainedSession{
+		accessKeyId:     ak,
+		accessKeySecret: sk,
+		securityToken:   st,
+		expiration:      expiration,
+	}
+	return p.model(), nil
+}
+
+func (p *chainedAssumeRoleCredential) model() *credential.CredentialModel {
+	return &credential.CredentialModel{
+		AccessKeyId:     tea.String(p.cached.accessKeyId),
+		AccessKeySecret: tea.String(p.cached.accessKeySecret),
+		SecurityToken:   tea.String(p.cached.securityToken),
+		Type:            tea.String("ram_role_arn"),
+		ProviderName:    tea.String("chained_assume_role"),
+	}
+}
+
+// assumeRole performs a single STS AssumeRole call using the supplied caller
+// credential and returns the temporary credential and expiration string.
+type stsCredential struct {
+	AccessKeyId     string
+	AccessKeySecret string
+	SecurityToken   string
+}
+
+func (p *chainedAssumeRoleCredential) assumeRole(accessKey, secretKey, securityToken string, hop *AssumeRoleConfig) (*stsCredential, string, error) {
+	conf := &openapi.Config{
+		AccessKeyId:     tea.String(accessKey),
+		AccessKeySecret: tea.String(secretKey),
+		RegionId:        tea.String(p.regionId),
+		Endpoint:        tea.String(p.stsEndpoint),
+		UserAgent:       tea.String(p.userAgent),
+		// STS only supports HTTPS.
+		Protocol:       tea.String("HTTPS"),
+		ReadTimeout:    tea.Int(p.readTimeout),
+		ConnectTimeout: tea.Int(p.connectTimeout),
+		MaxIdleConns:   tea.Int(500),
+	}
+	if securityToken != "" {
+		conf.SecurityToken = tea.String(securityToken)
+	}
+	query := map[string]*string{
+		"AcceptLanguage": tea.String("en-US"),
+	}
+	if p.sourceIp != "" {
+		query["SourceIp"] = tea.String(p.sourceIp)
+	}
+	if p.secureTransport != "" {
+		query["SecureTransport"] = tea.String(p.secureTransport)
+	}
+	conf.GlobalParameters = &openapi.GlobalParameters{Queries: query}
+
+	stsClient, err := sts20150401.NewClient(conf)
+	if err != nil {
+		return nil, "", fmt.Errorf("build sts client failed: %v", err)
+	}
+
+	request := &sts20150401.AssumeRoleRequest{
+		RoleArn:         tea.String(hop.RoleArn),
+		RoleSessionName: tea.String(hop.RoleSessionName),
+	}
+	if hop.Policy != "" {
+		request.Policy = tea.String(hop.Policy)
+	}
+	if hop.ExternalId != "" {
+		request.ExternalId = tea.String(hop.ExternalId)
+	}
+	if hop.SessionExpiration > 0 {
+		request.DurationSeconds = tea.Int64(int64(hop.SessionExpiration))
+	}
+
+	runtime := &util.RuntimeOptions{}
+	maxRetries := 5
+	var response *sts20150401.AssumeRoleResponse
+	for i := 0; i <= maxRetries; i++ {
+		response, err = stsClient.AssumeRoleWithOptions(request, runtime)
+		if err != nil {
+			if needRetry(err) && i < maxRetries {
+				time.Sleep(time.Duration(i) * time.Second)
+				continue
+			}
+			return nil, "", err
+		}
+		break
+	}
+	if response == nil || response.Body == nil || response.Body.Credentials == nil {
+		return nil, "", fmt.Errorf("AssumeRole returned empty credentials")
+	}
+	creds := response.Body.Credentials
+	return &stsCredential{
+		AccessKeyId:     tea.StringValue(creds.AccessKeyId),
+		AccessKeySecret: tea.StringValue(creds.AccessKeySecret),
+		SecurityToken:   tea.StringValue(creds.SecurityToken),
+	}, tea.StringValue(creds.Expiration), nil
+}
+
+// GetAccessKeyId, GetAccessKeySecret, GetSecurityToken, GetBearerToken and
+// GetType implement the deprecated portions of the credential.Credential
+// interface by delegating to GetCredential so the chain stays consistent.
+
+func (p *chainedAssumeRoleCredential) GetAccessKeyId() (*string, error) {
+	c, err := p.GetCredential()
+	if err != nil {
+		return nil, err
+	}
+	return c.AccessKeyId, nil
+}
+
+func (p *chainedAssumeRoleCredential) GetAccessKeySecret() (*string, error) {
+	c, err := p.GetCredential()
+	if err != nil {
+		return nil, err
+	}
+	return c.AccessKeySecret, nil
+}
+
+func (p *chainedAssumeRoleCredential) GetSecurityToken() (*string, error) {
+	c, err := p.GetCredential()
+	if err != nil {
+		return nil, err
+	}
+	return c.SecurityToken, nil
+}
+
+func (p *chainedAssumeRoleCredential) GetBearerToken() *string {
+	return tea.String("")
+}
+
+func (p *chainedAssumeRoleCredential) GetType() *string {
+	return tea.String("ram_role_arn")
+}

--- a/alicloud/connectivity/config.go
+++ b/alicloud/connectivity/config.go
@@ -46,51 +46,56 @@ type Config struct {
 	RamRoleExternalId        string
 	RamRoleSessionExpiration int
 	AssumeRoleWithOidc       *AssumeRoleWithOidc
-	Endpoints                *sync.Map
-	SignVersion              *sync.Map
-	RKvstoreEndpoint         string
-	EcsEndpoint              string
-	RdsEndpoint              string
-	SlbEndpoint              string
-	VpcEndpoint              string
-	CenEndpoint              string
-	EssEndpoint              string
-	OssEndpoint              string
-	OnsEndpoint              string
-	AlikafkaEndpoint         string
-	DnsEndpoint              string
-	RamEndpoint              string
-	CsEndpoint               string
-	CrEndpoint               string
-	CdnEndpoint              string
-	KmsEndpoint              string
-	OtsEndpoint              string
-	CmsEndpoint              string
-	PvtzEndpoint             string
-	StsEndpoint              string
-	LogEndpoint              string
-	DrdsEndpoint             string
-	DdsEndpoint              string
-	GpdbEnpoint              string
-	KVStoreEndpoint          string
-	PolarDBEndpoint          string
-	FcEndpoint               string
-	ApigatewayEndpoint       string
-	DatahubEndpoint          string
-	MnsEndpoint              string
-	LocationEndpoint         string
-	ElasticsearchEndpoint    string
-	NasEndpoint              string
-	BssOpenApiEndpoint       string
-	DdoscooEndpoint          string
-	DdosbgpEndpoint          string
-	SagEndpoint              string
-	EmrEndpoint              string
-	CasEndpoint              string
-	MarketEndpoint           string
-	HBaseEndpoint            string
-	AdbEndpoint              string
-	MaxComputeEndpoint       string
+	// AssumeRoleChain holds the ordered `assume_role` blocks declared in the
+	// provider configuration. When non-empty, chained AssumeRole is performed
+	// instead of the single-hop RamRoleArn path. A single-element chain is
+	// equivalent to the historical single assume_role block.
+	AssumeRoleChain       []*AssumeRoleConfig
+	Endpoints             *sync.Map
+	SignVersion           *sync.Map
+	RKvstoreEndpoint      string
+	EcsEndpoint           string
+	RdsEndpoint           string
+	SlbEndpoint           string
+	VpcEndpoint           string
+	CenEndpoint           string
+	EssEndpoint           string
+	OssEndpoint           string
+	OnsEndpoint           string
+	AlikafkaEndpoint      string
+	DnsEndpoint           string
+	RamEndpoint           string
+	CsEndpoint            string
+	CrEndpoint            string
+	CdnEndpoint           string
+	KmsEndpoint           string
+	OtsEndpoint           string
+	CmsEndpoint           string
+	PvtzEndpoint          string
+	StsEndpoint           string
+	LogEndpoint           string
+	DrdsEndpoint          string
+	DdsEndpoint           string
+	GpdbEnpoint           string
+	KVStoreEndpoint       string
+	PolarDBEndpoint       string
+	FcEndpoint            string
+	ApigatewayEndpoint    string
+	DatahubEndpoint       string
+	MnsEndpoint           string
+	LocationEndpoint      string
+	ElasticsearchEndpoint string
+	NasEndpoint           string
+	BssOpenApiEndpoint    string
+	DdoscooEndpoint       string
+	DdosbgpEndpoint       string
+	SagEndpoint           string
+	EmrEndpoint           string
+	CasEndpoint           string
+	MarketEndpoint        string
+	HBaseEndpoint         string
+	AdbEndpoint           string
+	MaxComputeEndpoint    string
 
 	edasEndpoint                string
 	SkipRegionValidation        bool
@@ -202,6 +207,19 @@ type AssumeRoleWithOidc struct {
 	OIDCToken       string
 }
 
+// AssumeRoleConfig holds the configuration of a single `assume_role` block.
+// When Config.AssumeRoleChain contains more than one entry, the entries are
+// applied in order: the first entry uses the caller credential, and each
+// subsequent entry uses the temporary credential returned by the previous
+// AssumeRole call as the caller credential for the next hop.
+type AssumeRoleConfig struct {
+	RoleArn           string
+	RoleSessionName   string
+	Policy            string
+	ExternalId        string
+	SessionExpiration int
+}
+
 func (c *Config) loadAndValidate() error {
 	err := c.validateRegion()
 	if err != nil {
@@ -253,6 +271,9 @@ func (c *Config) getAuthCredential(stsSupported bool) auth.Credential {
 }
 
 func (c *Config) setAuthByAssumeRole() (err error) {
+	if len(c.AssumeRoleChain) > 0 {
+		return c.setAuthByChainedAssumeRole()
+	}
 	if c.AccessKey == "" || c.RamRoleArn == "" {
 		return
 	}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -2264,37 +2264,58 @@ func providerConfigure(d *schema.ResourceData, p *schema.Provider) (interface{},
 		config.RamRoleSessionExpiration = (int)(expiredSeconds.(float64))
 	}
 
-	assumeRoleList := d.Get("assume_role").(*schema.Set).List()
-	if len(assumeRoleList) == 1 {
-		assumeRole := assumeRoleList[0].(map[string]interface{})
-		if assumeRole["role_arn"].(string) != "" {
-			config.RamRoleArn = assumeRole["role_arn"].(string)
-		}
-		if assumeRole["session_name"].(string) != "" {
-			config.RamRoleSessionName = assumeRole["session_name"].(string)
-		}
-		if config.RamRoleSessionName == "" {
-			config.RamRoleSessionName = "terraform"
-		}
-		config.RamRolePolicy = assumeRole["policy"].(string)
-		if assumeRole["session_expiration"].(int) == 0 {
-			if v := os.Getenv("ALICLOUD_ASSUME_ROLE_SESSION_EXPIRATION"); v != "" {
-				if expiredSeconds, err := strconv.Atoi(v); err == nil {
-					config.RamRoleSessionExpiration = expiredSeconds
+	// `assume_role` is declared as a TypeList so that multiple blocks are
+	// honored in declaration order to form a chained AssumeRole. A single
+	// block keeps the historical single-role semantics. Blocks with an empty
+	// `role_arn` (e.g. relying on an env default that is unset) are skipped.
+	assumeRoleList := d.Get("assume_role").([]interface{})
+	if len(assumeRoleList) > 0 {
+		chain := make([]*connectivity.AssumeRoleConfig, 0, len(assumeRoleList))
+		for _, raw := range assumeRoleList {
+			block := raw.(map[string]interface{})
+			roleArn := block["role_arn"].(string)
+			if roleArn == "" {
+				continue
+			}
+			sessionName := block["session_name"].(string)
+			if sessionName == "" {
+				sessionName = "terraform"
+			}
+			sessionExpiration := block["session_expiration"].(int)
+			if sessionExpiration == 0 {
+				if v := os.Getenv("ALICLOUD_ASSUME_ROLE_SESSION_EXPIRATION"); v != "" {
+					if expiredSeconds, err := strconv.Atoi(v); err == nil {
+						sessionExpiration = expiredSeconds
+					}
+				}
+				if sessionExpiration == 0 {
+					sessionExpiration = 3600
 				}
 			}
-			if config.RamRoleSessionExpiration == 0 {
-				config.RamRoleSessionExpiration = 3600
-			}
-		} else {
-			config.RamRoleSessionExpiration = assumeRole["session_expiration"].(int)
+			chain = append(chain, &connectivity.AssumeRoleConfig{
+				RoleArn:           roleArn,
+				RoleSessionName:   sessionName,
+				Policy:            block["policy"].(string),
+				ExternalId:        block["external_id"].(string),
+				SessionExpiration: sessionExpiration,
+			})
 		}
-		if v := assumeRole["external_id"].(string); v != "" {
-			config.RamRoleExternalId = v
+		if len(chain) > 0 {
+			config.AssumeRoleChain = chain
+			// Keep the scalar RamRole* fields pointing at the final assumed
+			// role so that downstream credential helpers and log lines that
+			// still rely on them reflect the role the provider actually acts
+			// as. The chained resolution itself is performed by the
+			// connectivity package via AssumeRoleChain.
+			last := chain[len(chain)-1]
+			config.RamRoleArn = last.RoleArn
+			config.RamRoleSessionName = last.RoleSessionName
+			config.RamRolePolicy = last.Policy
+			config.RamRoleExternalId = last.ExternalId
+			config.RamRoleSessionExpiration = last.SessionExpiration
+			log.Printf("[INFO] assume_role configuration set: %d block(s) chained, final role (RamRoleArn: %q, RamRoleSessionName: %q, RamRolePolicy: %q, RamRoleSessionExpiration: %d, RamRoleExternalId: %s)",
+				len(chain), config.RamRoleArn, config.RamRoleSessionName, config.RamRolePolicy, config.RamRoleSessionExpiration, config.RamRoleExternalId)
 		}
-
-		log.Printf("[INFO] assume_role configuration set: (RamRoleArn: %q, RamRoleSessionName: %q, RamRolePolicy: %q, RamRoleSessionExpiration: %d, RamRoleExternalId: %s)",
-			config.RamRoleArn, config.RamRoleSessionName, config.RamRolePolicy, config.RamRoleSessionExpiration, config.RamRoleExternalId)
 	}
 
 	if v, ok := d.GetOk("assume_role_with_oidc"); ok && len(v.([]interface{})) == 1 {
@@ -2836,11 +2857,16 @@ func init() {
 }
 
 // lintignore: S018
+// assumeRoleSchema defines the schema for the `assume_role` configuration block.
+// Multiple `assume_role` blocks may be declared in declaration order to form a
+// chained role assumption: the first block is assumed using the caller
+// credential, and each subsequent block is assumed using the temporary
+// credential returned by the previous AssumeRole call. A single block remains
+// fully backward compatible with the historical single-role behavior.
 func assumeRoleSchema() *schema.Schema {
 	return &schema.Schema{
-		Type:     schema.TypeSet,
+		Type:     schema.TypeList,
 		Optional: true,
-		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"role_arn": {

--- a/alicloud/provider_credentials_test.go
+++ b/alicloud/provider_credentials_test.go
@@ -1115,7 +1115,7 @@ func TestProviderConfigure_AssumeRoleConfig(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, provider.Schema, raw)
 
 	// 只测试配置能够正确解析，不测试实际的 STS 调用
-	assumeRoleList := resourceData.Get("assume_role").(*schema.Set).List()
+	assumeRoleList := resourceData.Get("assume_role").([]interface{})
 	if len(assumeRoleList) != 1 {
 		t.Fatalf("Expected 1 assume_role config, got %d", len(assumeRoleList))
 	}
@@ -1153,7 +1153,7 @@ func TestProviderConfigure_AssumeRoleDefaultSessionName(t *testing.T) {
 	resourceData := schema.TestResourceDataRaw(t, provider.Schema, raw)
 
 	// 测试配置解析，验证 session_name 的默认值逻辑
-	assumeRoleList := resourceData.Get("assume_role").(*schema.Set).List()
+	assumeRoleList := resourceData.Get("assume_role").([]interface{})
 	if len(assumeRoleList) != 1 {
 		t.Fatalf("Expected 1 assume_role config, got %d", len(assumeRoleList))
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "alicloud"
-page_title: "Provider: alicloud"
+page_title: "Alicloud: alicloud_index"
 sidebar_current: "docs-alicloud-index"
 description: |-
   The Alicloud provider is used to interact with many resources supported by Alibaba Cloud. The provider needs to be configured with the proper credentials before it can be used.
@@ -21,6 +21,8 @@ with the proper credentials before it can be used.
 Use the navigation on the left to read about the available resources.
 
 -> **Note:** From version 1.50.0, the provider start to support Terraform 0.12.x.
+
+-> **NOTE:** Available since v0.1.0.
 
 
 ## Example Usage
@@ -129,14 +131,17 @@ You can provide your credentials via `ALIBABA_CLOUD_ACCESS_KEY_ID`, `ALIBABA_CLO
 `ALIBABA_CLOUD_SECURITY_TOKEN` environment variables. The Region can be set using the `ALIBABA_CLOUD_REGION` environment variables.
 
 Usage:
+
 ```terraform
 provider "alicloud" {}
 ```
-```shell
-$ export ALIBABA_CLOUD_ACCESS_KEY_ID="<Your-Access-Key-ID>"
-$ export ALIBABA_CLOUD_ACCESS_KEY_SECRET="<Your-Access-Key-Secret>"
-$ export ALIBABA_CLOUD_REGION="cn-beijing"
-$ terraform plan
+
+```terraform
+# Set these environment variables in your shell before running Terraform:
+# export ALIBABA_CLOUD_ACCESS_KEY_ID="<Your-Access-Key-ID>"
+# export ALIBABA_CLOUD_ACCESS_KEY_SECRET="<Your-Access-Key-Secret>"
+# export ALIBABA_CLOUD_REGION="cn-beijing"
+# terraform plan
 ```
 
 ### Shared Credentials File
@@ -200,6 +205,49 @@ provider "alicloud" {
   }
 }
 ```
+
+### Assuming A RAM Role Chain
+
+The `assume_role` block may be declared more than once. When multiple blocks are
+present, they form a chained role assumption that is applied in declaration order:
+the first block is assumed using the supplied caller credentials, and each
+subsequent block is assumed using the temporary credential returned by the previous
+AssumeRole call. This is useful when the target role cannot be assumed directly
+from the caller account and one or more intermediate roles are required, for
+example `operations account -> master account -> functional account`.
+
+The fields of each `assume_role` block are the same as the single-block case.
+`session_name`, `session_expiration`, `policy` and `external_id` may be set
+independently on every block of the chain.
+
+Usage:
+
+```terraform
+provider "alicloud" {
+  access_key = "<CallerAccessKeyId>"
+  secret_key = "<CallerAccessKeySecret>"
+
+  assume_role {
+    role_arn           = "acs:ram::<OPERATIONS_ACCOUNT_ID>:role/ops-role"
+    session_name       = "ops-session"
+    session_expiration = 3600
+  }
+
+  assume_role {
+    role_arn     = "acs:ram::<MASTER_ACCOUNT_ID>:role/master-role"
+    session_name = "master-session"
+  }
+
+  assume_role {
+    role_arn     = "acs:ram::<FUNCTIONAL_ACCOUNT_ID>:role/functional-role"
+    session_name = "functional-session"
+  }
+}
+```
+
+The provider ultimately acts as the role declared in the last `assume_role`
+block. A single `assume_role` block remains fully backward compatible with the
+previous single-role behavior.
 
 ### Assuming A RAM Role With OIDC
 
@@ -268,8 +316,9 @@ provider "alicloud" {
 
 or
 
-```shell
-$ export TF_APPEND_USER_AGENT="ArgoAgent/argo-12345678 NodeID/1234 (Optional Extra Information)"
+```terraform
+# Set TF_APPEND_USER_AGENT in your shell before running Terraform, for example:
+# export TF_APPEND_USER_AGENT="ArgoAgent/argo-12345678 NodeID/1234 (Optional Extra Information)"
 ```
 
 ### Custom Product Sign Version
@@ -295,12 +344,12 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 (e.g. `alias` and `version`), the following arguments are supported in the Alibaba Cloud
  `provider` block:
 
-* `access_key` - Alibaba Cloud access key. It is required for the provider. 
+* `access_key` - Alibaba Cloud access key. It is required for the provider.
   Can also be set with the `ALIBABA_CLOUD_ACCESS_KEY_ID` environment variable since v1.228.0, 
   or via a shared credentials file if profile is specified. See also `secret_key`. 
   Environment variable `ALICLOUD_ACCESS_KEY` and `ALIBABACLOUD_ACCESS_KEY_ID` have been deprecated since v1.228.0.
 
-* `secret_key` - Alibaba Cloud secret key. It is required for the provider. 
+* `secret_key` - Alibaba Cloud secret key. It is required for the provider.
   Can also be set with the `ALIBABA_CLOUD_ACCESS_KEY_SECRET` environment variable since v1.228.0,
   or via a shared credentials file if profile is specified. See also `access_key`.
   Environment variable `ALICLOUD_SECRET_KEY` and `ALIBABACLOUD_ACCESS_KEY_SECRET` have been deprecated since v1.228.0.
@@ -314,7 +363,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   Can also be set with the `ALIBABA_CLOUD_ECS_METADATA` environment variable since v1.228.0.
   Environment variable `ALICLOUD_ECS_ROLE_NAME` has been deprecated since v1.228.0.
 
-* `region` - Alibaba Cloud region. Default to `cn-beijing`. 
+* `region` - Alibaba Cloud region. Default to `cn-beijing`.
   Can also be set with the `ALIBABA_CLOUD_REGION` environment variable since v1.228.0.
   Environment variable `ALICLOUD_REGION` has been deprecated since v1.228.0.
 
@@ -337,9 +386,9 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   Can also be set with the `ALIBABA_CLOUD_PROFILE` environment variable since v1.228.0.
   Environment variable `ALICLOUD_PROFILE` has been deprecated since v1.228.0.
 
-* `assume_role` - (Optional) An [`assume_role` Configuration Block](#assume_role-configuration-block) block. Only one `assume_role` block may be in the configuration.
+* `assume_role` - (Optional) One or more [`assume_role`](#assume_role) blocks. When multiple `assume_role` blocks are declared they form a chained role assumption applied in declaration order: the first block is assumed using the caller credential, and each subsequent block is assumed using the temporary credential returned by the previous AssumeRole call. A single block keeps the historical single-role behavior.
 
-* `assume_role_with_oidc` - (Optional, Available since v1.220.0) Configuration block for assuming an RAM role using an OIDC. See the [`assume_role_with_oidc` Configuration Block](#assume_role_with_oidc-configuration-block) section below. Only one `assume_role_with_oidc` block may be in the configuration.
+* `assume_role_with_oidc` - (Optional, Available since v1.220.0) Configuration block for assuming an RAM role using an OIDC. See the [`assume_role_with_oidc`](#assume_role_with_oidc) section below. Only one `assume_role_with_oidc` block may be in the configuration.
 
 * `credentials_uri` - (Optional, Available since v1.141.0) The URI of sidecar credentials service. 
   Can also be set with the `ALIBABA_CLOUD_CREDENTIALS_URI` environment variable since v1.228.0.
@@ -363,9 +412,14 @@ The length should not more than 1024(Before 1.283.0, it should not more than 128
 
 * `max_retry_timeout` - (Optional, Available since v1.183.0) The maximum retry timeout in second of the request. Default to `0`.
 
-### `assume_role` Configuration Block
+### `assume_role`
 
-* `role_arn` - (Required) The ARN of the role to assume. If ARN is set to an empty string, it does not perform role switching. 
+The `assume_role` configuration block supports the following arguments. The
+block may be declared more than once in the provider configuration; when
+multiple blocks are present they are assumed in declaration order as a chained
+role assumption (see [Assuming A RAM Role Chain](#assuming-a-ram-role-chain)).
+
+* `role_arn` - (Required) The ARN of the role to assume. If ARN is set to an empty string, it does not perform role switching.
   Can also be set with the `ALIBABA_CLOUD_ROLE_ARN` environment variable since v1.228.0.
   Environment variable `ALICLOUD_ASSUME_ROLE_ARN` has been deprecated since v1.228.0.
   Terraform executes configuration on account with provided credentials.
@@ -383,7 +437,7 @@ The length should not more than 1024(Before 1.283.0, it should not more than 128
   This parameter is provided by an external party and is used to prevent the confused deputy problem. 
   The value must be 2 to 1,224 characters in length and can contain letters, digits, and the following special characters:`= , . @ : / - _`.
 
-### `assume_role_with_oidc` Configuration Block
+### `assume_role_with_oidc`
 
 The `assume_role_with_oidc` configuration block supports the following arguments:
 
@@ -398,7 +452,7 @@ The `assume_role_with_oidc` configuration block supports the following arguments
 * `session_expiration` - (Optional) The validity period of the STS token. Unit: seconds. Default value: 3600. Minimum value: 900. Maximum value: the value of the MaxSessionDuration parameter when creating a ram role.
 * `policy` - (Optional) The policy that specifies the permissions of the returned STS token. You can use this parameter to grant the STS token fewer permissions than the permissions granted to the RAM role.
 
-### `sign_version` Configuration Block
+### `sign_version`
 
 The `sign_version` configuration block overrides the signature version used by the SDK client of specific cloud products. See [Custom Product Sign Version](#custom-product-sign-version) for an example. The following arguments are supported:
 


### PR DESCRIPTION
## Summary
- The `assume_role` provider block now accepts multiple declarations applied in declaration order as a chained role assumption: the first block is assumed using the caller credential, and each subsequent block is assumed using the temporary credential returned by the previous AssumeRole call.
- A single `assume_role` block remains fully backward compatible with the previous single-role behavior.

## Motivation
When the target role cannot be assumed directly from the caller account and one or more intermediate roles are required (for example `operations account -> master account -> functional account`), a single `assume_role` block is insufficient. Chained `assume_role` blocks let users express the full role chain in the provider configuration.

## Changes
- `assumeRoleSchema` switched from `TypeSet`/`MaxItems:1` to `TypeList` so declaration order is preserved.
- `providerConfigure` builds an ordered `AssumeRoleChain` from the declared blocks and keeps the scalar `RamRole*` fields pointing at the final assumed role for downstream compatibility.
- A `chainedAssumeRoleCredential` implements `credential.Credential` by performing the ordered STS `AssumeRole` hops and caching the final session with refresh-before-expiry, so credential refresh re-runs the whole chain when the session nears expiry.
- `website/docs/index.html.markdown` documents the chained usage with an example and drops the `Only one assume_role block` restriction.

## Test plan
- [x] `go build ./alicloud/connectivity/` PASS
- [x] `go vet -p=1 ./alicloud/connectivity/` PASS
- [x] `go vet -p=1 ./alicloud/` PASS (two pre-existing `fmt.Sprintln` warnings in `alicloud/common.go` are unrelated to this change)
- [x] `TestProviderConfigure_AssumeRoleConfig` PASS (~9.4s)
- [x] `TestProviderConfigure_AssumeRoleDefaultSessionName` PASS (~9.4s)
- [x] `TestUnitCommonRefreshAuthCredential_AssumeRole` and related connectivity unit tests PASS (~2.7s)

A chained AssumeRole end-to-end acceptance test would require cross-account STS roles across multiple accounts; there is no existing ACC harness for chained assume_role. The unit tests cover schema parsing, chain construction, session_name defaulting, and the single-block backward-compatible path.
