### PR TITLE
resource/alicloud_oss_bucket_object: rebuild after out-of-band delete

### DIFF
--- a/alicloud/resource_alicloud_oss_bucket_object.go
+++ b/alicloud/resource_alicloud_oss_bucket_object.go
@@ -285,8 +285,15 @@ func resourceAlicloudOssBucketObjectRead(d *schema.ResourceData, meta interface{
 	object, err := bucket.GetObjectDetailedMeta(d.Get("key").(string), options...)
 	if err != nil {
 		if IsExpectedErrors(err, []string{"404 Not Found", "NoSuchKey"}) {
+			// The object was removed out-of-band (e.g. via the OSS console or
+			// CLI) and no longer exists. SetId("") asks Terraform to drop it
+			// from state; return nil so the SDK commits that update during
+			// refresh. A subsequent plan then reports "1 to add" and apply
+			// recreates the object. Returning an error here would discard the
+			// SetId("") change and abort the refresh/plan, leaving the
+			// resource stuck in state and blocking further automation.
 			d.SetId("")
-			return WrapError(Error("To get the Object: %#v but it is not exist in the specified bucket %s.", d.Get("key").(string), d.Get("bucket").(string)))
+			return nil
 		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), "GetObjectDetailedMeta", AliyunOssGoSdk)
 	}

--- a/alicloud/resource_alicloud_oss_bucket_object_test.go
+++ b/alicloud/resource_alicloud_oss_bucket_object_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccAlicloudOssBucketObject_basic(t *testing.T) {
+func TestAccAliCloudOssBucketObject_basic(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "tf-oss-object-test-acc-source")
 	if err != nil {
 		t.Fatal(err)
@@ -48,31 +48,52 @@ func TestAccAlicloudOssBucketObject_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"bucket":       "${alicloud_oss_bucket_public_access_block.default.bucket}",
-					"key":          "test-object-source-key",
-					"source":       tmpFile.Name(),
-					"content_type": "binary/octet-stream",
+					"bucket":              "${alicloud_oss_bucket_public_access_block.default.bucket}",
+					"key":                 "test-object-source-key",
+					"source":              tmpFile.Name(),
+					"content_type":        "binary/octet-stream",
+					"cache_control":       "max-age=3600",
+					"content_disposition": "attachment",
+					"content_encoding":    "identity",
+					"content_md5":         "ewBv9NcPaMxlBhrPL4Aubw==",
+					"expires":             "Mon, 01 Jan 2035 00:00:00 GMT",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudOssBucketObjectExists(
 						"alicloud_oss_bucket_object.default", name, v),
 					testAccCheck(map[string]string{
-						"bucket": name,
-						"source": tmpFile.Name(),
+						"bucket":              name,
+						"source":              tmpFile.Name(),
+						"content_type":        "binary/octet-stream",
+						"cache_control":       "max-age=3600",
+						"content_disposition": "attachment",
+						"content_encoding":    "identity",
+						"expires":             "Mon, 01 Jan 2035 00:00:00 GMT",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"source":  REMOVEKEY,
-					"content": "some words for test oss object content",
+					"source":              REMOVEKEY,
+					"content":             "some words for test oss object content",
+					"content_type":        "text/plain",
+					"cache_control":       "no-cache",
+					"content_disposition": "inline",
+					"content_encoding":    "gzip",
+					"content_md5":         "DLbtZmJKNYFp4DtLY9hZDw==",
+					"expires":             "Tue, 02 Jan 2035 00:00:00 GMT",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlicloudOssBucketObjectExists(
 						"alicloud_oss_bucket_object.default", name, v),
 					testAccCheck(map[string]string{
-						"source":  REMOVEKEY,
-						"content": "some words for test oss object content",
+						"source":              REMOVEKEY,
+						"content":             "some words for test oss object content",
+						"content_type":        "text/plain",
+						"cache_control":       "no-cache",
+						"content_disposition": "inline",
+						"content_encoding":    "gzip",
+						"expires":             "Tue, 02 Jan 2035 00:00:00 GMT",
 					}),
 				),
 			},
@@ -103,6 +124,7 @@ func TestAccAlicloudOssBucketObject_basic(t *testing.T) {
 					"key":                    "test-object-source-key",
 					"content":                REMOVEKEY,
 					"source":                 tmpFile.Name(),
+					"content_md5":            "ewBv9NcPaMxlBhrPL4Aubw==",
 					"content_type":           "binary/octet-stream",
 					"acl":                    REMOVEKEY,
 				}),
@@ -123,7 +145,7 @@ func TestAccAlicloudOssBucketObject_basic(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudOssBucketObject_worm(t *testing.T) {
+func TestAccAliCloudOssBucketObject_worm(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("", "tf-oss-object-worm-source")
 	if err != nil {
 		t.Fatal(err)
@@ -220,6 +242,96 @@ func TestAccAlicloudOssBucketObject_worm(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccAliCloudOssBucketObject_outOfBandDeleteRebuild verifies that when an
+// OSS object is deleted out-of-band (e.g. through the OSS console or CLI,
+// bypassing Terraform), the provider Read drops the resource from state so a
+// subsequent plan reports "1 to add" and apply recreates the object, instead
+// of erroring out and blocking automation.
+func TestAccAliCloudOssBucketObject_outOfBandDeleteRebuild(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "tf-oss-object-oob-delete")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if err := ioutil.WriteFile(tmpFile.Name(), []byte("out-of-band delete rebuild coverage"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var v http.Header
+	resourceId := "alicloud_oss_bucket_object.default"
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testacc-object-oob-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceOssBucketObjectConfigDependence)
+	cfg := testAccConfig(map[string]interface{}{
+		"bucket":       "${alicloud_oss_bucket_public_access_block.default.bucket}",
+		"key":          "test-object-oob-delete-key",
+		"source":       tmpFile.Name(),
+		"content_type": "binary/octet-stream",
+	})
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAlicloudOssBucketObjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             cfg,
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudOssBucketObjectExists(resourceId, name, v),
+					// Delete the object directly through the OSS API. This step
+					// explicitly expects its mandatory post-Check refresh to plan a
+					// recreate. Before the fix, Read returned an error instead.
+					testAccCheckAlicloudOssBucketObjectDeleteOutOfBand(resourceId, name),
+				),
+			},
+			{
+				// Re-apply the same config: the object is recreated, proving the
+				// out-of-band delete is self-healing.
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlicloudOssBucketObjectExists(resourceId, name, v),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckAlicloudOssBucketObjectDeleteOutOfBand removes the OSS object
+// backing the resource via the OSS SDK directly, simulating a delete issued
+// from the console or CLI that Terraform did not observe.
+func testAccCheckAlicloudOssBucketObjectDeleteOutOfBand(n, bucket string) resource.TestCheckFunc {
+	providers := []*schema.Provider{testAccProvider}
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		for _, provider := range providers {
+			if provider.Meta() == nil {
+				continue
+			}
+			client := provider.Meta().(*connectivity.AliyunClient)
+			raw, err := client.WithOssClient(func(ossClient *oss.Client) (interface{}, error) {
+				return ossClient.Bucket(bucket)
+			})
+			if err != nil {
+				return fmt.Errorf("Error getting bucket: %#v", err)
+			}
+			buck, _ := raw.(*oss.Bucket)
+			if err := buck.DeleteObject(rs.Primary.ID); err != nil {
+				return fmt.Errorf("Out-of-band DeleteObject failed: %#v", err)
+			}
+			log.Printf("[INFO] out-of-band deleted oss object %q to simulate console/CLI deletion", rs.Primary.ID)
+			return nil
+		}
+		return fmt.Errorf("No provider with Meta available")
+	}
 }
 
 func resourceOssBucketObjectConfigDependence(name string) string {

--- a/website/docs/r/oss_bucket_object.html.markdown
+++ b/website/docs/r/oss_bucket_object.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Provides a resource to put a object(content or file) to a oss bucket.
 
+-> **NOTE:** Available since v0.1.1.
+
 ## Example Usage
 
 ### Uploading a file to a bucket
@@ -95,7 +97,7 @@ The following arguments are supported:
 * `expires` - (Optional) Specifies expire date for the the request/response. Read [RFC2616 Expires](https://www.ietf.org/rfc/rfc2616.txt) for further details.
 * `server_side_encryption` - (Optional) Specifies server-side encryption of the object in OSS. Valid values are `AES256`, `KMS`. Default value is `AES256`.
 * `kms_key_id` - (Optional, Available in 1.62.1+) Specifies the primary key managed by KMS. This parameter is valid when the value of `server_side_encryption` is set to KMS.
-* `object_worm_mode` - (Optional, Available in 1.278.0+) The retention mode of the object worm policy. Valid value: `COMPLIANCE`. Must be set together with `object_worm_retain_until_date`. The bucket must have object worm enabled. Updating only this attribute (or `object_worm_retain_until_date`) calls `PutObjectRetention` and does not re-upload the object.
+* `object_worm_mode` - (Optional, Available in 1.278.0+) The retention mode of the object worm policy. Valid value: `COMPLIANCE`. Must be set together with `object_worm_retain_until_date`. The bucket must have object worm enabled. **Note: The parameter is immutable after resource creation.** Updating `object_worm_retain_until_date` calls `PutObjectRetention` and does not re-upload the object.
 * `object_worm_retain_until_date` - (Optional, Available in 1.278.0+) The UTC time at which the object retention expires, in ISO8601 format with millisecond precision (for example `2026-09-30T00:00:00.000Z`). Must be set together with `object_worm_mode`.
 
 -> **Note:** Either `source` or `content` must be provided to specify the bucket content. These two arguments are mutually-exclusive.


### PR DESCRIPTION
## Problem

When an OSS object is removed out-of-band (for example, via the OSS console or CLI) while it is still tracked by `alicloud_oss_bucket_object` in Terraform state, running `terraform plan` / `terraform refresh` aborts with an error instead of detecting the drift and planning a recreate.

## Root cause

`resourceAlicloudOssBucketObjectRead` matched the `404 Not Found` / `NoSuchKey` branch and called `d.SetId("")` (correctly asking Terraform to drop the resource from state), but then returned an error:

```go
if IsExpectedErrors(err, []string{"404 Not Found", "NoSuchKey"}) {
    d.SetId("")
    return WrapError(Error("To get the Object: ... not exist ...")) // aborts refresh
}
```

Under the Terraform plugin SDK, returning an error from `Read` discards the pending `SetId("")` state update and aborts the refresh/plan. The resource stays stuck in state and Terraform cannot recover without manual state removal.

## Fix

Return `nil` on the not-found branch so the SDK commits `SetId("")` during refresh. A subsequent plan then reports `1 to add` and `apply` recreates the object. Other errors still propagate as before.

## Acceptance test

Adds `TestAccAliCloudOssBucketObject_outOfBandDeleteRebuild`:

1. Create a bucket and object through Terraform.
2. Delete the object directly through the OSS API during the test check, simulating a console or CLI deletion.
3. Mark the step with `ExpectNonEmptyPlan: true`; the SDK's mandatory follow-up refresh must drop the object from state and plan a recreate. Before the fix, this refresh returns an error.
4. Re-apply the same configuration and verify the object is recreated.

The existing acceptance-test names are normalized to `TestAccAliCloud...`, and their configuration now covers the object header attributes required by the testing-coverage check. The documentation also clarifies that `object_worm_mode` is immutable because its only supported value is `COMPLIANCE`.
