### PR TITLE
New Resource: alicloud_ens_common_bandwidth_eip_attachment

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1242,6 +1242,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_gpdb_remote_adb_data_source":                          resourceAliCloudGpdbRemoteADBDataSource(),
 			"alicloud_ens_nat_gateway":                                      resourceAliCloudEnsNatGateway(),
 			"alicloud_ens_eip_instance_attachment":                          resourceAliCloudEnsEipInstanceAttachment(),
+			"alicloud_ens_common_bandwidth_eip_attachment":                  resourceAliCloudEnsCommonBandwidthEipAttachment(),
 			"alicloud_ddos_bgp_policy":                                      resourceAliCloudDdosBgpPolicy(),
 			"alicloud_cen_transit_router_ecr_attachment":                    resourceAliCloudCenTransitRouterEcrAttachment(),
 			"alicloud_alb_load_balancer_security_group_attachment":          resourceAliCloudAlbLoadBalancerSecurityGroupAttachment(),

--- a/alicloud/resource_alicloud_ens_common_bandwidth_eip_attachment.go
+++ b/alicloud/resource_alicloud_ens_common_bandwidth_eip_attachment.go
@@ -1,0 +1,138 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudEnsCommonBandwidthEipAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudEnsCommonBandwidthEipAttachmentCreate,
+		Read:   resourceAliCloudEnsCommonBandwidthEipAttachmentRead,
+		Delete: resourceAliCloudEnsCommonBandwidthEipAttachmentDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"bandwidth_package_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ip_instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudEnsCommonBandwidthEipAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "AddCommonBandwidthPackageIps"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("bandwidth_package_id"); ok {
+		request["BandwidthPackageId"] = v
+	}
+	if v, ok := d.GetOk("ip_instance_id"); ok {
+		request["IpInstanceIds.1"] = v
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ens_common_bandwidth_eip_attachment", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", d.Get("ip_instance_id"), d.Get("bandwidth_package_id")))
+
+	return resourceAliCloudEnsCommonBandwidthEipAttachmentRead(d, meta)
+}
+
+func resourceAliCloudEnsCommonBandwidthEipAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ensServiceV2 := EnsServiceV2{client}
+
+	objectRaw, err := ensServiceV2.DescribeEnsCommonBandwidthEipAttachment(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ens_common_bandwidth_eip_attachment DescribeEnsCommonBandwidthEipAttachment Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("bandwidth_package_id", objectRaw["BandwidthPackageId"])
+	d.Set("ip_instance_id", objectRaw["AllocationId"])
+
+	return nil
+}
+
+func resourceAliCloudEnsCommonBandwidthEipAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := "DeleteCommonBandwidthPackageIps"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["BandwidthPackageId"] = parts[1]
+	request["IpInstanceIds.1"] = parts[0]
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"IpInstanceId.NotInBandwidthPackage"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ens_common_bandwidth_eip_attachment_test.go
+++ b/alicloud/resource_alicloud_ens_common_bandwidth_eip_attachment_test.go
@@ -1,0 +1,167 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// testAccEnsCommonBandwidthRegion resolves the region used to build the
+// standalone client that provisions the backing ENS common bandwidth package.
+// The package-level defaultRegionToTest is initialized from
+// os.Getenv("ALICLOUD_REGION") at init time and is only re-assigned inside
+// testAccPreCheck when ALICLOUD_REGION is already set, so it stays empty in
+// remote AccTest runs that do not pre-set ALICLOUD_REGION. Both the Dependence
+// step (which runs before PreCheck while constructing the TestCase steps) and
+// CheckDestroy would therefore pass an empty region to sharedClientForRegion
+// and abort with "Invalid Alibaba Cloud region: .". Mirroring the gpdb /
+// resource-manager pattern, fall back to cn-beijing (the same default
+// testAccPreCheck sets) so the test reaches create/delete.
+func testAccEnsCommonBandwidthRegion() string {
+	region := os.Getenv("ALICLOUD_REGION")
+	if region == "" {
+		region = "cn-beijing"
+	}
+	return region
+}
+
+// The ENS common bandwidth package resource is not yet available in this
+// provider, so the acceptance test provisions the backing package through the
+// ENS OpenAPI directly and embeds the returned id into the Terraform config.
+var testAccEnsCommonBandwidthPackageId string
+
+func testAccEnsCreateCommonBandwidthPackage(client *connectivity.AliyunClient, ensRegionId, name string) (string, error) {
+	request := map[string]interface{}{
+		"EnsRegionId": ensRegionId,
+		"Bandwidth":   5,
+		"Name":        name,
+	}
+	query := make(map[string]interface{})
+	response, err := client.RpcPost("Ens", "2017-11-10", "CreateCommonBandwidthPackage", query, request, true)
+	if err != nil {
+		return "", fmt.Errorf("creating ENS common bandwidth package: %w", err)
+	}
+	if v, ok := response["BandwidthPackageId"]; ok && fmt.Sprint(v) != "" {
+		return fmt.Sprint(v), nil
+	}
+	return "", fmt.Errorf("BandwidthPackageId missing from CreateCommonBandwidthPackage response: %v", response)
+}
+
+func testAccEnsDeleteCommonBandwidthPackage(client *connectivity.AliyunClient, id string) error {
+	if id == "" {
+		return nil
+	}
+	request := map[string]interface{}{
+		"BandwidthPackageId": id,
+	}
+	query := make(map[string]interface{})
+	_, err := client.RpcPost("Ens", "2017-11-10", "DeleteCommonBandwidthPackage", query, request, true)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"InvalidBandwidthPackageId.NotFound", "NotFound"}) || NotFoundError(err) {
+			return nil
+		}
+		return fmt.Errorf("deleting ENS common bandwidth package %s: %w", id, err)
+	}
+	return nil
+}
+
+func TestAccAliCloudEnsCommonBandwidthEipAttachment_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_common_bandwidth_eip_attachment.default"
+	ra := resourceAttrInit(resourceId, AlicloudEnsCommonBandwidthEipAttachmentMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsCommonBandwidthEipAttachment")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc-ens-cbwp-eip-att-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudEnsCommonBandwidthEipAttachmentBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy: func(s *terraform.State) error {
+			if err := rac.checkResourceDestroy()(s); err != nil {
+				return err
+			}
+			rawClient, err := sharedClientForRegion(testAccEnsCommonBandwidthRegion())
+			if err != nil {
+				return fmt.Errorf("getting client for cleanup: %w", err)
+			}
+			client := rawClient.(*connectivity.AliyunClient)
+			if derr := testAccEnsDeleteCommonBandwidthPackage(client, testAccEnsCommonBandwidthPackageId); derr != nil {
+				return derr
+			}
+			testAccEnsCommonBandwidthPackageId = ""
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"bandwidth_package_id": "${local.bandwidth_package_id}",
+					"ip_instance_id":       "${alicloud_ens_eip.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"bandwidth_package_id": testAccEnsCommonBandwidthPackageId,
+						"ip_instance_id":       CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudEnsCommonBandwidthEipAttachmentMap = map[string]string{
+	"bandwidth_package_id": CHECKSET,
+	"ip_instance_id":       CHECKSET,
+}
+
+func AlicloudEnsCommonBandwidthEipAttachmentBasicDependence(name string) string {
+	rawClient, err := sharedClientForRegion(testAccEnsCommonBandwidthRegion())
+	if err != nil {
+		log.Fatalf("[ERROR] failed to build standalone Alicloud client for ENS common bandwidth package setup: %s", err)
+	}
+	client := rawClient.(*connectivity.AliyunClient)
+	packageId, err := testAccEnsCreateCommonBandwidthPackage(client, "cn-chenzhou-telecom_unicom_cmcc", name)
+	if err != nil {
+		log.Fatalf("[ERROR] %s", err)
+	}
+	testAccEnsCommonBandwidthPackageId = packageId
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+variable "ens_region_id" {
+  default = "cn-chenzhou-telecom_unicom_cmcc"
+}
+
+locals {
+  bandwidth_package_id = "%s"
+}
+
+resource "alicloud_ens_eip" "default" {
+  bandwidth            = "5"
+  eip_name             = var.name
+  ens_region_id        = var.ens_region_id
+  internet_charge_type = "95BandwidthByMonth"
+  payment_type         = "PayAsYouGo"
+}
+`, name, packageId)
+}

--- a/alicloud/service_alicloud_ens_v2.go
+++ b/alicloud/service_alicloud_ens_v2.go
@@ -1168,3 +1168,92 @@ func (s *EnsServiceV2) SetResourceTags(d *schema.ResourceData, resourceType stri
 }
 
 // SetResourceTags >>> tag function encapsulated.
+// DescribeEnsCommonBandwidthEipAttachment <<< Encapsulated get interface for Ens CommonBandwidthEipAttachment.
+
+func (s *EnsServiceV2) DescribeEnsCommonBandwidthEipAttachment(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["AllocationId"] = parts[0]
+
+	action := "DescribeEnsEipAddresses"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.EipAddresses.EipAddress[*]", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.EipAddresses.EipAddress[*]", response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("CommonBandwidthEipAttachment", id), NotFoundMsg, response)
+	}
+
+	result, _ := v.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		if fmt.Sprint(item["BandwidthPackageId"]) != parts[1] {
+			continue
+		}
+		return item, nil
+	}
+	return object, WrapErrorf(NotFoundErr("CommonBandwidthEipAttachment", id), NotFoundMsg, response)
+}
+
+func (s *EnsServiceV2) EnsCommonBandwidthEipAttachmentStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.EnsCommonBandwidthEipAttachmentStateRefreshFuncWithApi(id, field, failStates, s.DescribeEnsCommonBandwidthEipAttachment)
+}
+
+func (s *EnsServiceV2) EnsCommonBandwidthEipAttachmentStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeEnsCommonBandwidthEipAttachment >>> Encapsulated.

--- a/website/docs/r/ens_common_bandwidth_eip_attachment.html.markdown
+++ b/website/docs/r/ens_common_bandwidth_eip_attachment.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_common_bandwidth_eip_attachment"
+description: |-
+  Provides a Alicloud ENS Common Bandwidth Eip Attachment resource.
+---
+
+# alicloud_ens_common_bandwidth_eip_attachment
+
+Provides a ENS Common Bandwidth Eip Attachment resource.
+
+Bindings between shared bandwidth and EIP.
+
+For information about ENS Common Bandwidth Eip Attachment and how to use it, see [What is Common Bandwidth Eip Attachment](https://next.api.alibabacloud.com/document/Ens/2017-11-10/AddCommonBandwidthPackageIps).
+
+-> **NOTE:** Available since v1.289.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "tf-example"
+}
+
+variable "ens_region_id" {
+  default = "cn-chenzhou-telecom_unicom_cmcc"
+}
+
+resource "alicloud_ens_eip" "default" {
+  bandwidth            = "5"
+  eip_name             = var.name
+  ens_region_id        = var.ens_region_id
+  internet_charge_type = "95BandwidthByMonth"
+  payment_type         = "PayAsYouGo"
+}
+
+resource "alicloud_ens_common_bandwidth_eip_attachment" "default" {
+  bandwidth_package_id = "cbwp-xxxxx"
+  ip_instance_id       = alicloud_ens_eip.default.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `bandwidth_package_id` - (Required, ForceNew) The ID of the ENS common bandwidth package.
+* `ip_instance_id` - (Optional, ForceNew, Computed) The ID of the EIP (AllocationId) that is attached to the common bandwidth package.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<ip_instance_id>:<bandwidth_package_id>`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Common Bandwidth Eip Attachment.
+* `delete` - (Defaults to 5 mins) Used when delete the Common Bandwidth Eip Attachment.
+
+## Import
+
+ENS Common Bandwidth Eip Attachment can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ens_common_bandwidth_eip_attachment.example <ip_instance_id>:<bandwidth_package_id>
+```


### PR DESCRIPTION
This PR adds a new resource `alicloud_ens_common_bandwidth_eip_attachment` and its documentation.

## What

`alicloud_ens_common_bandwidth_eip_attachment` binds ENS EIPs to an ENS common bandwidth package. The resource is create-only against the ENS shared bandwidth and is removed on delete; there is no in-place update path because the backing API (`AddCommonBandwidthPackageIps` / `DeleteCommonBandwidthPackageIps`) only exposes attach/detach semantics.

## Schema

| Argument | Type | Required/Optional | ForceNew | Description |
|----------|------|-------------------|----------|-------------|
| `bandwidth_package_id` | string | Required | yes | The ID of the ENS common bandwidth package. |
| `ip_instance_id` | string | Optional, Computed | yes | The ID of the EIP (AllocationId) attached to the common bandwidth package. |

The resource id is formatted as `<ip_instance_id>:<bandwidth_package_id>` and the resource supports `terraform import`.

## Read path

Read is served by `DescribeEnsEipAddresses`, filtering the returned EIP set by `BandwidthPackageId` so the attachment reflects the EIP that is actually bound to the package.

## Tests

An acceptance test (`TestAccAliCloudEnsCommonBandwidthEipAttachment_basic`) is included covering create, read-back, and import-verify. Because the companion `alicloud_ens_common_bandwidth_package` resource is not yet available in this provider, the test provisions the backing common bandwidth package through the ENS OpenAPI directly and injects the returned id into the Terraform config.

## Hand-fixes applied to the generated output

- Fixed the resource id composition in `Create`: the generator built the id from a jsonpath lookup that could not resolve against the flat-keyed request map, which would produce an id with an empty `ip_instance_id` segment and break `Delete`/`Read` part-splitting. The id is now built directly from the schema values (`ip_instance_id:bandwidth_package_id`), matching the documented format and the `Delete`/`Describe` part order.
- Replaced the generator placeholder in the docs example with a real usage example and aligned the `Available since` note with the upcoming release.
- Enriched the argument descriptions to reference the backing API field semantics.
