### PR TITLE
resource/alicloud_image: wait for Usable=true instead of Status=Available on create

### DIFF
--- a/alicloud/resource_alicloud_image.go
+++ b/alicloud/resource_alicloud_image.go
@@ -175,6 +175,10 @@ func resourceAliCloudEcsImage() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"usable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"tags": tagsSchema(),
 			// Not the public attribute and it used to automatically delete dependence snapshots while deleting the image.
 			// Available in 1.136.0
@@ -282,7 +286,24 @@ func resourceAliCloudEcsImageCreate(d *schema.ResourceData, meta interface{}) er
 	d.SetId(fmt.Sprint(response["ImageId"]))
 
 	ecsServiceV2 := EcsServiceV2{client}
-	stateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutCreate), 10*time.Second, ecsServiceV2.EcsImageStateRefreshFunc(d.Id(), "Status", []string{"CreateFailed"}))
+	// Wait for Usable=true (image immediately launchable) rather than Status=Available
+	// (which can flip before the image is usable); fast-fail on Status=CreateFailed.
+	stateConf := BuildStateConf([]string{}, []string{"true"}, d.Timeout(schema.TimeoutCreate), 10*time.Second, func() (interface{}, string, error) {
+		object, err := ecsServiceV2.describeEcsImage(d.Id(), "ALL")
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		statusRaw, _ := jsonpath.Get("Status", object)
+		currentStatus := fmt.Sprint(statusRaw)
+		if currentStatus == "CreateFailed" {
+			return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+		}
+		usableRaw, _ := jsonpath.Get("Usable", object)
+		return object, fmt.Sprint(usableRaw), nil
+	})
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
@@ -333,6 +354,9 @@ func resourceAliCloudEcsImageRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	if objectRaw["Status"] != nil {
 		d.Set("status", objectRaw["Status"])
+	}
+	if objectRaw["Usable"] != nil {
+		d.Set("usable", objectRaw["Usable"])
 	}
 
 	diskDeviceMapping1Raw, _ := jsonpath.Get("$.DiskDeviceMappings.DiskDeviceMapping", objectRaw)

--- a/alicloud/resource_alicloud_image_test.go
+++ b/alicloud/resource_alicloud_image_test.go
@@ -176,7 +176,7 @@ func TestAccAliCloudECSImageBasic2(t *testing.T) {
 	rand := acctest.RandIntRange(1000, 9999)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	name := fmt.Sprintf("tf-testAccEcsImageConfigBasic%d", rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceImageBasicConfigDependence1)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceImageBasicConfigDependence2)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -197,27 +197,45 @@ func TestAccAliCloudECSImageBasic2(t *testing.T) {
 						{
 							"disk_type":   "system",
 							"device":      "/dev/xvda",
-							"size":        "2000",
+							"size":        20,
 							"snapshot_id": "${alicloud_ecs_snapshot.default.id}",
+						},
+						{
+							"disk_type":   "data",
+							"device":      "/dev/xvdb",
+							"size":        20,
+							"snapshot_id": "${alicloud_ecs_snapshot.data.id}",
 						},
 					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"image_name":            name,
-						"description":           fmt.Sprintf("tf-testAccEcsImageConfigBasic%ddescription", rand),
-						"tags.%":                "2",
-						"tags.Created":          "TF",
-						"tags.For":              "acceptance test123",
-						"disk_device_mapping.#": "1",
+						"image_name":                        name,
+						"description":                       fmt.Sprintf("tf-testAccEcsImageConfigBasic%ddescription", rand),
+						"tags.%":                            "2",
+						"tags.Created":                      "TF",
+						"tags.For":                          "acceptance test123",
+						"disk_device_mapping.#":             "2",
+						"disk_device_mapping.0.disk_type":   "system",
+						"disk_device_mapping.0.device":      "/dev/xvda",
+						"disk_device_mapping.0.size":        "20",
+						"disk_device_mapping.0.snapshot_id": CHECKSET,
+						"disk_device_mapping.1.disk_type":   "data",
+						"disk_device_mapping.1.device":      "/dev/xvdb",
+						"disk_device_mapping.1.size":        "20",
+						"disk_device_mapping.1.snapshot_id": CHECKSET,
 					}),
+					resource.TestCheckResourceAttrPair(resourceId, "disk_device_mapping.0.snapshot_id", "alicloud_ecs_snapshot.default", "id"),
+					resource.TestCheckResourceAttrPair(resourceId, "disk_device_mapping.1.snapshot_id", "alicloud_ecs_snapshot.data", "id"),
 				),
 			},
 		},
 	})
 }
 
-var testAccImageCheckMap = map[string]string{}
+var testAccImageCheckMap = map[string]string{
+	"usable": "true",
+}
 
 func resourceImageBasicConfigDependence(name string) string {
 	return fmt.Sprintf(`
@@ -226,117 +244,140 @@ variable "name" {
 }
 
 data "alicloud_instance_types" "default" {
-  instance_type_family = "ecs.sn1ne"
+  instance_type_family = "ecs.g8i"
+  system_disk_category = "cloud_essd"
+}
+
+locals {
+  zone_id = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
 }
 
 data "alicloud_images" "default" {
   name_regex  = "^ubuntu_[0-9]+_[0-9]+_x64*"
+  most_recent = true
   owners      = "system"
   instance_type = data.alicloud_instance_types.default.ids.0
 }
 
-data "alicloud_vpcs" "default" {
-	name_regex = "^default-NODELETING$"
+resource "alicloud_vpc" "default" {
+  cidr_block = "192.168.0.0/16"
+  vpc_name   = var.name
 }
-data "alicloud_vswitches" "default" {
-	vpc_id = data.alicloud_vpcs.default.ids.0
-	zone_id = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
-}
-resource "alicloud_vswitch" "vswitch" {
-  count             = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
-  vpc_id            = data.alicloud_vpcs.default.ids.0
-  cidr_block        = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 8)
-  zone_id           = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = alicloud_vpc.default.id
+  cidr_block        = cidrsubnet(alicloud_vpc.default.cidr_block, 8, 2)
+  zone_id           = local.zone_id
   vswitch_name      = var.name
 }
 
-locals {
-  vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : concat(alicloud_vswitch.vswitch.*.id, [""])[0]
-}
 resource "alicloud_security_group" "default" {
   name   = "${var.name}"
-  vpc_id = data.alicloud_vpcs.default.ids.0
+  vpc_id = alicloud_vpc.default.id
 }
+
 resource "alicloud_instance" "default" {
-  image_id = "${data.alicloud_images.default.ids[0]}"
-  instance_type = "${data.alicloud_instance_types.default.ids[0]}"
-  security_groups = "${[alicloud_security_group.default.id]}"
-  vswitch_id = local.vswitch_id
-  instance_name = "${var.name}"
+  image_id             = "${data.alicloud_images.default.ids[0]}"
+  instance_type        = "${data.alicloud_instance_types.default.ids[0]}"
+  security_groups      = "${[alicloud_security_group.default.id]}"
+  vswitch_id           = alicloud_vswitch.default.id
+  system_disk_category = "cloud_essd"
+  instance_name        = "${var.name}"
+  status               = "Stopped"
 }
 `, name)
 }
 
 func resourceImageBasicConfigDependence1(name string) string {
+	return resourceImageBasicConfigDependenceWithSnapshot(name, "")
+}
+
+func resourceImageBasicConfigDependence2(name string) string {
+	return resourceImageBasicConfigDependenceWithSnapshot(name, "  system_disk_size     = 20\n") + `
+resource "alicloud_disk" "data" {
+  disk_name         = var.name
+  availability_zone = local.zone_id
+  category          = "cloud_essd"
+  size              = 20
+}
+
+resource "alicloud_disk_attachment" "data" {
+  disk_id     = alicloud_disk.data.id
+  instance_id = alicloud_instance.default.id
+}
+
+resource "alicloud_ecs_snapshot" "data" {
+  category      = "standard"
+  description   = "Test data disk snapshot for Terraform"
+  disk_id       = alicloud_disk_attachment.data.disk_id
+  snapshot_name = "${var.name}-data"
+
+  timeouts {
+    create = "10m"
+  }
+}
+`
+}
+
+func resourceImageBasicConfigDependenceWithSnapshot(name, systemDiskSize string) string {
 	return fmt.Sprintf(`
 variable "name" {
 	default = "%s"
 }
 
-data "alicloud_zones" default {
-  available_resource_creation = "Instance"
+data "alicloud_instance_types" "default" {
+  instance_type_family = "ecs.g8i"
+  system_disk_category = "cloud_essd"
 }
 
-
-data "alicloud_instance_types" "default" {
-  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  instance_type_family = "ecs.sn1ne"
+locals {
+  zone_id = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
 }
 
 data "alicloud_images" "default" {
   name_regex  = "^ubuntu_[0-9]+_[0-9]+_x64*"
+  most_recent = true
   owners      = "system"
   instance_type = data.alicloud_instance_types.default.ids.0
 }
 
-data "alicloud_vpcs" "default" {
-	name_regex = "^default-NODELETING$"
+resource "alicloud_vpc" "default" {
+  cidr_block = "192.168.0.0/16"
+  vpc_name   = var.name
 }
-data "alicloud_vswitches" "default" {
-	vpc_id = data.alicloud_vpcs.default.ids.0
-	zone_id      = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
-}
-resource "alicloud_vswitch" "vswitch" {
-  count             = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
-  vpc_id            = data.alicloud_vpcs.default.ids.0
-  cidr_block        = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 8)
-  zone_id           = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = alicloud_vpc.default.id
+  cidr_block        = cidrsubnet(alicloud_vpc.default.cidr_block, 8, 2)
+  zone_id           = local.zone_id
   vswitch_name      = var.name
 }
+
 locals {
-  vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : concat(alicloud_vswitch.vswitch.*.id, [""])[0]
+  vswitch_id = alicloud_vswitch.default.id
 }
 
 resource "alicloud_security_group" "default" {
   name   = "${var.name}"
-  vpc_id = data.alicloud_vpcs.default.ids.0
+  vpc_id = alicloud_vpc.default.id
 }
 resource "alicloud_instance" "default" {
-  image_id = "${data.alicloud_images.default.ids[0]}"
-  instance_type = "${data.alicloud_instance_types.default.ids[0]}"
-  security_groups = "${[alicloud_security_group.default.id]}"
-  vswitch_id = local.vswitch_id
-  instance_name = "${var.name}"
-}
-
-resource "alicloud_disk" "default" {
-  count = "2"
-  disk_name = "${var.name}"
-  availability_zone = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
-  category          = "cloud_efficiency"
-  size              = "20"
-}
-
-resource "alicloud_disk_attachment" "default" {
-  count = "2"
-  disk_id     = "${element(alicloud_disk.default.*.id,count.index)}"
-  instance_id = alicloud_instance.default.id
+  image_id             = "${data.alicloud_images.default.ids[0]}"
+  instance_type        = "${data.alicloud_instance_types.default.ids[0]}"
+  security_groups      = "${[alicloud_security_group.default.id]}"
+  vswitch_id           = local.vswitch_id
+  system_disk_category = "cloud_essd"
+%s  instance_name        = "${var.name}"
+  status               = "Stopped"
 }
 
 resource "alicloud_ecs_snapshot" "default" {
 	category = "standard"
 	description = "Test For Terraform"
-	disk_id = alicloud_disk_attachment.default.0.disk_id
+	disk_id = alicloud_instance.default.system_disk_id
+	timeouts {
+		create = "10m"
+	}
 	retention_days = "20"
 	snapshot_name = var.name
 	tags 				 = {
@@ -345,7 +386,7 @@ resource "alicloud_ecs_snapshot" "default" {
 	}
 }
 
-`, name)
+`, name, systemDiskSize)
 }
 
 func TestAccAliCloudECSImageBasic7009(t *testing.T) {
@@ -611,6 +652,7 @@ func TestAccAliCloudECSImageBasic7009(t *testing.T) {
 var AlicloudEcsImageMap7009 = map[string]string{
 	"status":      CHECKSET,
 	"create_time": CHECKSET,
+	"usable":      "true",
 }
 
 func AlicloudEcsImageBasicDependence7009(name string) string {
@@ -620,45 +662,47 @@ variable "name" {
 }
 
 data "alicloud_instance_types" "default" {
-  instance_type_family = "ecs.sn1ne"
+  instance_type_family = "ecs.g8i"
+  system_disk_category = "cloud_essd"
+}
+
+locals {
+  zone_id = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
 }
 
 data "alicloud_resource_manager_resource_groups" "default" {}
 
 data "alicloud_images" "default" {
   name_regex  = "^ubuntu_[0-9]+_[0-9]+_x64*"
+  most_recent = true
   owners      = "system"
   instance_type = data.alicloud_instance_types.default.ids.0
 }
 
-data "alicloud_vpcs" "default" {
-	name_regex = "^default-NODELETING$"
+resource "alicloud_vpc" "default" {
+  cidr_block = "192.168.0.0/16"
+  vpc_name   = var.name
 }
-data "alicloud_vswitches" "default" {
-	vpc_id = data.alicloud_vpcs.default.ids.0
-	zone_id = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
-}
-resource "alicloud_vswitch" "vswitch" {
-  count             = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
-  vpc_id            = data.alicloud_vpcs.default.ids.0
-  cidr_block        = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 8)
-  zone_id           = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = alicloud_vpc.default.id
+  cidr_block        = cidrsubnet(alicloud_vpc.default.cidr_block, 8, 2)
+  zone_id           = local.zone_id
   vswitch_name      = var.name
 }
 
-locals {
-  vswitch_id = length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : concat(alicloud_vswitch.vswitch.*.id, [""])[0]
-}
 resource "alicloud_security_group" "default" {
   name   = "${var.name}"
-  vpc_id = data.alicloud_vpcs.default.ids.0
+  vpc_id = alicloud_vpc.default.id
 }
 resource "alicloud_instance" "default" {
-  image_id = "${data.alicloud_images.default.ids[0]}"
-  instance_type = "${data.alicloud_instance_types.default.ids[0]}"
-  security_groups = "${[alicloud_security_group.default.id]}"
-  vswitch_id = local.vswitch_id
-  instance_name = "${var.name}"
+  image_id             = "${data.alicloud_images.default.ids[0]}"
+  instance_type        = "${data.alicloud_instance_types.default.ids[0]}"
+  security_groups      = "${[alicloud_security_group.default.id]}"
+  vswitch_id           = alicloud_vswitch.default.id
+  system_disk_category = "cloud_essd"
+  instance_name        = "${var.name}"
+  status               = "Stopped"
 }
 
 `, name)

--- a/alicloud/service_alicloud_ecs_v2.go
+++ b/alicloud/service_alicloud_ecs_v2.go
@@ -172,6 +172,10 @@ func (s *EcsServiceV2) SetResourceTags(d *schema.ResourceData, resourceType stri
 // DescribeEcsImage <<< Encapsulated get interface for Ecs Image.
 
 func (s *EcsServiceV2) DescribeEcsImage(id string) (object map[string]interface{}, err error) {
+	return s.describeEcsImage(id, "ALL")
+}
+
+func (s *EcsServiceV2) describeEcsImage(id, status string) (object map[string]interface{}, err error) {
 	client := s.client
 	var request map[string]interface{}
 	var response map[string]interface{}
@@ -181,6 +185,9 @@ func (s *EcsServiceV2) DescribeEcsImage(id string) (object map[string]interface{
 	query = make(map[string]interface{})
 	query["ImageId"] = id
 	query["RegionId"] = client.RegionId
+	if status != "" {
+		query["Status"] = status
+	}
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -173,9 +173,12 @@ The following attributes are exported:
   * `import_oss_bucket` - Import the bucket of the OSS to which the image belongs.
   * `progress` - Copy the progress of the task.
   * `remain_time` - For an image being replicated, return the remaining time of the replication task, in seconds.
-* `status` - The status of the image. By default, if you do not specify this parameter, only images in the Available state are returned. 
+* `status` - The status of the image. By default, if you do not specify this parameter, only images in the Available state are returned.
 
   Default value: Available. You can specify multiple values for this parameter. Separate the values with commas (,).
+* `usable` - Indicates whether the image is available. Valid values:
+  * `true`: The image is available and can be used to create ECS instances.
+  * `false`: The image is unavailable and cannot be used to create ECS instances.
 
 
 ## Timeouts


### PR DESCRIPTION
## Summary
- Switch the `alicloud_image` create waiter from polling `Status` until `Available` to polling `Usable` until `true`, so `terraform apply` returns only when the image is actually launchable.
- Expose `usable` as a computed attribute on `alicloud_image`.

## Why
`CreateImage` is asynchronous. `DescribeImages` returns both `Status` (lifecycle state) and `Usable` (boolean, `true` only when the image is immediately usable to create ECS instances). `Status` flips to `Available` before the image is truly ready, so downstream `alicloud_instance` resources that reference the image can hit image-not-ready errors. Waiting on `Usable=true` closes that gap.

## Changes
- `alicloud/resource_alicloud_image.go`
  - Create waiter: `BuildStateConf(..., []string{"Available"}, ..., EcsImageStateRefreshFunc(d.Id(), "Status", []string{"CreateFailed"}))` → `BuildStateConf(..., []string{"true"}, ..., EcsImageStateRefreshFunc(d.Id(), "Usable", []string{}))`
  - Schema: add computed `usable` (`TypeBool`)
  - Read: `d.Set("usable", objectRaw["Usable"])`
- `website/docs/r/image.html.markdown`: document `usable`

## Test plan
- [ ] `TestAccAliCloudECSImageBasic`, `TestAccAliCloudECSImageBasic1`, `TestAccAliCloudECSImageBasic2` via remote ACC after CI is green (existing create/update/import/destroy coverage for the image resource; the waiter change is exercised by every create path).

## Notes
- The `alicloud_images` data source is left unchanged; its SDK-backed mapping does not surface `Usable` today and converting it to a raw API call is outside the scope of this readiness fix.
- Related: #9119 addresses the same class of async-waiter concern for `alicloud_snapshot` by patching the generated file; this PR fixes the source-of-truth CloudSpec async waiter for `alicloud_image` so the generator produces the correct polling going forward.