### PR TITLE
resource/alicloud_ens_instance: support spot_duration, schedule_id and order_detail

### DIFF
--- a/alicloud/resource_alicloud_ens_instance.go
+++ b/alicloud/resource_alicloud_ens_instance.go
@@ -162,6 +162,10 @@ func resourceAliCloudEnsInstance() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"order_detail": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"password": {
 				Type:      schema.TypeString,
 				Optional:  true,
@@ -199,6 +203,10 @@ func resourceAliCloudEnsInstance() *schema.Resource {
 				Required:     true,
 				ValidateFunc: StringMatch(regexp.MustCompile("^[A-Za-z0-9_-]+$"), "Scheduling level, through which node-level scheduling or area scheduling is performed. Optional values:-Node-level scheduling: Region-Regional scheduling: Big (region),Middle (province),Small (city)"),
 			},
+			"schedule_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"scheduling_price_strategy": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -213,6 +221,12 @@ func resourceAliCloudEnsInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+			},
+			"spot_duration": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
 			},
 			"spot_strategy": {
 				Type:     schema.TypeString,
@@ -400,6 +414,9 @@ func resourceAliCloudEnsInstanceCreate(d *schema.ResourceData, meta interface{})
 	if v, ok := d.GetOk("spot_strategy"); ok {
 		request["SpotStrategy"] = v
 	}
+	if v, ok := d.GetOk("spot_duration"); ok {
+		request["SpotDuration"] = v
+	}
 	if v, ok := d.GetOk("tags"); ok {
 		tagsMap := ConvertTags(v.(map[string]interface{}))
 		request = expandTagsToMap(request, tagsMap)
@@ -481,6 +498,15 @@ func resourceAliCloudEnsInstanceRead(d *schema.ResourceData, meta interface{}) e
 	}
 	if objectRaw["SpotStrategy"] != nil {
 		d.Set("spot_strategy", objectRaw["SpotStrategy"])
+	}
+	if objectRaw["SpotDuration"] != nil {
+		d.Set("spot_duration", objectRaw["SpotDuration"])
+	}
+	if objectRaw["ScheduleId"] != nil {
+		d.Set("schedule_id", objectRaw["ScheduleId"])
+	}
+	if objectRaw["OrderDetail"] != nil {
+		d.Set("order_detail", objectRaw["OrderDetail"])
 	}
 	if objectRaw["Status"] != nil {
 		d.Set("status", objectRaw["Status"])

--- a/alicloud/resource_alicloud_ens_instance_test.go
+++ b/alicloud/resource_alicloud_ens_instance_test.go
@@ -606,7 +606,7 @@ func TestAccAliCloudEnsInstance_basic5654(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
+				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "order_detail", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "schedule_id", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
 			},
 		},
 	})
@@ -714,7 +714,7 @@ func TestAccAliCloudEnsInstance_basic5654_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
+				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "order_detail", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "schedule_id", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
 			},
 		},
 	})
@@ -846,7 +846,7 @@ func TestAccAliCloudEnsInstance_basic5657(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
+				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "order_detail", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "schedule_id", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
 			},
 		},
 	})
@@ -1102,7 +1102,7 @@ func TestAccAliCloudEnsInstance_basic5608(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
+				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "order_detail", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "schedule_id", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
 			},
 		},
 	})
@@ -1220,7 +1220,7 @@ func TestAccAliCloudEnsInstance_basic5657_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
+				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "order_detail", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "schedule_id", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
 			},
 		},
 	})
@@ -1322,7 +1322,7 @@ func TestAccAliCloudEnsInstance_basic5608_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
+				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "order_detail", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "schedule_id", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
 			},
 		},
 	})
@@ -1436,7 +1436,7 @@ func TestAccAliCloudEnsInstance_basic7639(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
+				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "order_detail", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "schedule_id", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
 			},
 		},
 	})
@@ -1506,6 +1506,7 @@ func TestAccAliCloudEnsInstance_basic7627(t *testing.T) {
 					"payment_type":               "PayAsYouGo",
 					"instance_type":              "ens.pfv.cg72g2",
 					"spot_strategy":              "SpotAsPriceGo",
+					"spot_duration":              "1",
 					"password":                   "12345678abcABC",
 					"status":                     "Running",
 					"amount":                     "1",
@@ -1543,7 +1544,7 @@ func TestAccAliCloudEnsInstance_basic7627(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
+				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "order_detail", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "schedule_id", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
 			},
 		},
 	})
@@ -1730,7 +1731,7 @@ func TestAccAliCloudEnsInstance_basic5608_raw(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
+				ImportStateVerifyIgnore: []string{"amount", "auto_renew", "auto_use_coupon", "billing_cycle", "carrier", "force_stop", "include_data_disks", "instance_charge_strategy", "internet_charge_type", "ip_type", "net_district_code", "order_detail", "password", "password_inherit", "period", "period_unit", "public_ip_identification", "schedule_area_level", "schedule_id", "scheduling_price_strategy", "scheduling_strategy", "unique_suffix", "user_data"},
 			},
 		},
 	})

--- a/website/docs/r/ens_instance.html.markdown
+++ b/website/docs/r/ens_instance.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
   - false (default): non-mandatory
 
 * `host_name` - (Optional, Computed, Available since v1.208.0) The host name of the instance. Example value: test-HostName
-* `image_id` - (Optional, ForceNew, Available since v1.208.0) The image ID of the instance. The arm version card cannot be filled in. Other specifications are required. Example value: m-5si16wo6simkt267p8b7h * * * *
+* `image_id` - (Optional, ForceNew, Available since v1.208.0) The image ID of the instance. The arm version card cannot be filled in. Other specifications are required. Example value: m-5si16wo6simkt267p8b7h \* \* \* \*
 * `include_data_disks` - (Optional) Whether the Payment type of the disk created with the instance is converted.
 * `instance_charge_strategy` - (Optional, Available since v1.208.0) The instance billing policy. Optional values:
   - instance: instance granularity (the subscription method does not support instance)
@@ -126,6 +126,7 @@ The following arguments are supported:
 -> **NOTE:**  At least one of `Password`, `KeyPairName`, and **PasswordInherit.
 * `net_district_code` - (Optional, Available since v1.208.0) The area code. Example value: 350000. Required for regional-level scheduling, invalid for node-level scheduling
 * `net_work_id` - (Optional, ForceNew) The network ID of the instance. Can only be used in node-level scheduling
+* `order_detail` - (Computed) The order details.
 * `password` - (Optional, Available since v1.208.0) The instance password. At least one of Password, KeyPairName, and PasswordInherit
 * `password_inherit` - (Optional, Available since v1.208.0) Whether to use image preset password prompt: Password and KeyPairNamePasswordInherit must be passed
 * `payment_type` - (Required, Available since v1.208.0) Instance payment method. Since v1.230.0, you can modify payment_type. Optional values:
@@ -144,6 +145,7 @@ The following arguments are supported:
 * `schedule_area_level` - (Required, Available since v1.208.0) Scheduling level, through which node-level scheduling or area scheduling is performed. Optional values:
   - Node-level scheduling: Region
   - Regional scheduling: Big (region),Middle (province),Small (city)
+* `schedule_id` - (Computed) The pre-scheduling ID.
 * `scheduling_price_strategy` - (Optional, Available since v1.208.0) Scheduling price policy. If it is not filled in, the default priority is low price. Value:
   - PriceLowPriority
   - PriceLowPriority (priority low price)
@@ -151,6 +153,7 @@ The following arguments are supported:
   - Concentrate for node-level scheduling
   - For regional scheduling, Concentrate, Disperse
 * `security_id` - (Optional, ForceNew) ID of the security group to which the instance belongs.
+* `spot_duration` - (Optional, ForceNew, Computed, Int) The protection period of the preemptible instance. Unit: hours. Value range: 0, 1.
 * `spot_strategy` - (Optional, ForceNew, Available since v1.230.0) The bidding strategy for pay-as-you-go instances. It takes effect when the value of the 'InstanceChargeType' parameter is set to 'PostPaid. Value range:
   - NoSpot: normal pay-as-you-go instance (default)
   - SpotAsPriceGo: The system automatically bids, following the actual price in the current market.
@@ -159,7 +162,7 @@ The following arguments are supported:
 * `tags` - (Optional, ForceNew, Map, Available since v1.230.0) The tag bound to the instance
 * `unique_suffix` - (Optional, Available since v1.208.0) Indicates whether to add an ordered suffix to HostName and InstanceName. The ordered suffix starts from 001 and cannot exceed 999.
 * `user_data` - (Optional, Available since v1.208.0) User-defined data, maximum support 16KB. You can pass in the UserData information. The UserData is encoded in Base64 format.
-* `vswitch_id` - (Optional, ForceNew) The ID of the vSwitch to which the instance belongs. Can only be used in node-level scheduling
+* `vswitch_id` - (Optional, ForceNew, Computed) The ID of the vSwitch to which the instance belongs. Can only be used in node-level scheduling. Required when the scheduling strategy is regional scheduling (ScheduleAreaLevel is Big, Middle, or Small); optional when the scheduling strategy is node-level scheduling (ScheduleAreaLevel is Region).
 
 ### `data_disk`
 


### PR DESCRIPTION
This change adds three new attributes to the `alicloud_ens_instance` resource:

- `spot_duration` (Optional, ForceNew, Computed, Int): The protection period of the preemptible instance. Unit: hours. Value range: 0, 1.
- `schedule_id` (Computed): The pre-scheduling ID.
- `order_detail` (Computed): The order details.

The `spot_duration` parameter is passed to the RunInstances API during creation. The `schedule_id` and `order_detail` fields are read back from the DescribeInstances API response.

The `vswitch_id` documentation has also been updated to include the ScheduleAreaLevel restriction context.

### Test result

Acceptance tests for `alicloud_ens_instance` require real ENS instance resources. Test configs and ImportStateVerifyIgnore have been updated to cover the new `spot_duration` attribute. Full ACC verification will be performed via CI.
