### PR TITLE
resource/alicloud_ens_gateway_qos: support ENS Gateway Qos resource and data source

### DIFF
--- a/alicloud/data_source_alicloud_ens_gateway_qos.go
+++ b/alicloud/data_source_alicloud_ens_gateway_qos.go
@@ -1,0 +1,302 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudEnsGatewayQos() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudEnsGatewayQosRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"ens_region_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"gateway_qos_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"gateway_qos_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"gateway_qos_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instances": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"qos": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bandwidth_in": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"bandwidth_out": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ens_region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_qos_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_qos_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gateway_qos_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instances": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"instance_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"instance_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudEnsGatewayQosRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeEnsGatewayQoses"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if v, ok := d.GetOk("gateway_qos_id"); ok {
+		request["GatewayQosId"] = v
+	}
+	if v, ok := d.GetOk("ens_region_id"); ok {
+		request["EnsRegionId"] = v
+	}
+	if v, ok := d.GetOk("gateway_qos_id"); ok {
+		request["GatewayQosId"] = v
+	}
+	if v, ok := d.GetOk("gateway_qos_name"); ok {
+		request["GatewayQosName"] = v
+	}
+	request["GatewayQosType"] = d.Get("gateway_qos_type")
+	if v, ok := d.GetOk("instances"); ok && v.(*schema.Set).Len() > 0 {
+		for _, dataLoop := range v.(*schema.Set).List() {
+			if dataLoopTmp, ok := dataLoop.(map[string]interface{}); ok {
+				if instanceId, ok := dataLoopTmp["instance_id"].(string); ok && instanceId != "" {
+					request["InstanceId"] = instanceId
+					break
+				}
+			}
+		}
+	}
+	request["NetworkId"] = d.Get("network_id")
+	request["PageSize"] = PageSizeLarge
+	request["PageNumber"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.GatewayQoses.GatewayQos[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["GatewayQosName"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["GatewayQosId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["GatewayQosId"]
+
+		mapping["bandwidth_in"] = objectRaw["BandwidthIn"]
+		mapping["bandwidth_out"] = objectRaw["BandwidthOut"]
+		mapping["creation_time"] = objectRaw["CreationTime"]
+		mapping["ens_region_id"] = objectRaw["EnsRegionId"]
+		mapping["gateway_qos_name"] = objectRaw["GatewayQosName"]
+		mapping["gateway_qos_type"] = objectRaw["GatewayQosType"]
+		mapping["network_id"] = objectRaw["NetworkId"]
+		mapping["status"] = objectRaw["Status"]
+		mapping["gateway_qos_id"] = objectRaw["GatewayQosId"]
+
+		instanceRaw, _ := jsonpath.Get("$.Instances.Instance", objectRaw)
+		instancesMaps := make([]map[string]interface{}, 0)
+		if instanceRaw != nil {
+			for _, instanceChildRaw := range convertToInterfaceArray(instanceRaw) {
+				instancesMap := make(map[string]interface{})
+				instanceChildRaw := instanceChildRaw.(map[string]interface{})
+				instancesMap["instance_id"] = instanceChildRaw["InstanceId"]
+				instancesMap["instance_type"] = instanceChildRaw["InstanceType"]
+				instancesMap["status"] = instanceChildRaw["Status"]
+
+				instancesMaps = append(instancesMaps, instancesMap)
+			}
+		}
+		mapping["instances"] = instancesMaps
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["GatewayQosName"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("qos", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_ens_gateway_qos_test.go
+++ b/alicloud/data_source_alicloud_ens_gateway_qos_test.go
@@ -1,0 +1,173 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudEnsGatewayQosDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsGatewayQosSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ens_gateway_qos.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsGatewayQosSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ens_gateway_qos.default.id}_fake"]`,
+		}),
+	}
+
+	GatewayQosTypeConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsGatewayQosSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_gateway_qos.default.id}"]`,
+			"gateway_qos_type": `"Nat"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsGatewayQosSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_gateway_qos.default.id}_fake"]`,
+			"gateway_qos_type": `"Nat_fake"`,
+		}),
+	}
+	GatewayQosNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsGatewayQosSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_gateway_qos.default.id}"]`,
+			"gateway_qos_name": `"${var.name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsGatewayQosSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_gateway_qos.default.id}_fake"]`,
+			"gateway_qos_name": `"${var.name}_fake"`,
+		}),
+	}
+	NetworkIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsGatewayQosSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_ens_gateway_qos.default.id}"]`,
+			"network_id": `"${alicloud_ens_network.defaultC7YqlT.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsGatewayQosSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_ens_gateway_qos.default.id}_fake"]`,
+			"network_id": `"${alicloud_ens_network.defaultC7YqlT.id}_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsGatewayQosSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_gateway_qos.default.id}"]`,
+			"gateway_qos_type": `"Nat"`,
+
+			"gateway_qos_name": `"${var.name}"`,
+
+			"network_id": `"${alicloud_ens_network.defaultC7YqlT.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsGatewayQosSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_gateway_qos.default.id}_fake"]`,
+			"gateway_qos_type": `"Nat_fake"`,
+
+			"gateway_qos_name": `"${var.name}_fake"`,
+
+			"network_id": `"${alicloud_ens_network.defaultC7YqlT.id}_fake"`,
+		}),
+	}
+
+	EnsGatewayQosCheckInfo.dataSourceTestCheck(t, rand, idsConf, GatewayQosTypeConf, GatewayQosNameConf, NetworkIdConf, allConf)
+}
+
+var existEnsGatewayQosMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"qos.#":                  "1",
+		"qos.0.status":           CHECKSET,
+		"qos.0.gateway_qos_name": CHECKSET,
+		"qos.0.bandwidth_in":     CHECKSET,
+		"qos.0.gateway_qos_type": CHECKSET,
+		"qos.0.network_id":       CHECKSET,
+		"qos.0.bandwidth_out":    CHECKSET,
+		"qos.0.gateway_qos_id":   CHECKSET,
+		"qos.0.creation_time":    CHECKSET,
+		"qos.0.ens_region_id":    CHECKSET,
+	}
+}
+
+var fakeEnsGatewayQosMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"qos.#": "0",
+	}
+}
+
+var EnsGatewayQosCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_ens_gateway_qos.default",
+	existMapFunc: existEnsGatewayQosMapFunc,
+	fakeMapFunc:  fakeEnsGatewayQosMapFunc,
+}
+
+func testAccCheckAlicloudEnsGatewayQosSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccEnsGatewayQos%d"
+}
+variable "ens_region_id" {
+  default = "cn-hangzhou-63"
+}
+
+resource "alicloud_ens_network" "defaultC7YqlT" {
+  network_name  = "镇元-网关限速测试使用"
+  cidr_block    = "10.0.0.0/10"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default5giQWR" {
+  cidr_block    = "10.0.8.0/24"
+  vswitch_name  = "镇元-网关限速测试"
+  ens_region_id = var.ens_region_id
+  network_id    = alicloud_ens_network.defaultC7YqlT.id
+}
+
+resource "alicloud_ens_instance" "defaultvuczsY" {
+  amount      = "1"
+  period_unit = "Month"
+  auto_renew  = false
+  system_disk {
+    size = "20"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.small"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  vswitch_id                 = alicloud_ens_vswitch.default5giQWR.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "镇元-网关限速测试"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+}
+
+
+
+resource "alicloud_ens_gateway_qos" "default" {
+  gateway_qos_name = "test"
+  bandwidth_in     = "10"
+  gateway_qos_type = "Nat"
+  network_id       = alicloud_ens_network.defaultC7YqlT.id
+  bandwidth_out    = "20"
+}
+
+data "alicloud_ens_gateway_qos" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -614,6 +614,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_sddp_configs":                                     dataSourceAlicloudSddpConfigs(),
 			"alicloud_hbr_restore_jobs":                                 dataSourceAlicloudHbrRestoreJobs(),
 			"alicloud_alb_listeners":                                    dataSourceAlicloudAlbListeners(),
+			"alicloud_ens_gateway_qos":                                  dataSourceAliCloudEnsGatewayQos(),
 			"alicloud_ens_key_pairs":                                    dataSourceAlicloudEnsKeyPairs(),
 			"alicloud_sae_applications":                                 dataSourceAlicloudSaeApplications(),
 			"alicloud_alb_rules":                                        dataSourceAliCloudAlbRules(),
@@ -949,6 +950,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_ens_gateway_qos":                                      resourceAliCloudEnsGatewayQos(),
 			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),
 			"alicloud_apig_ai_model_provider":                               resourceAliCloudApigAiModelProvider(),
 			"alicloud_apig_service":                                         resourceAliCloudApigService(),

--- a/alicloud/resource_alicloud_ens_gateway_qos.go
+++ b/alicloud/resource_alicloud_ens_gateway_qos.go
@@ -1,0 +1,368 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudEnsGatewayQos() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudEnsGatewayQosCreate,
+		Read:   resourceAliCloudEnsGatewayQosRead,
+		Update: resourceAliCloudEnsGatewayQosUpdate,
+		Delete: resourceAliCloudEnsGatewayQosDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"bandwidth_in": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"bandwidth_out": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ens_region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"gateway_qos_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"gateway_qos_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"instances": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudEnsGatewayQosCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateEnsGatewayQos"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["GatewayQosType"] = d.Get("gateway_qos_type")
+	if v, ok := d.GetOkExists("bandwidth_in"); ok {
+		request["BandwidthIn"] = v
+	}
+	if v, ok := d.GetOk("instances"); ok && v.(*schema.Set).Len() > 0 {
+		instancesMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range v.(*schema.Set).List() {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := make(map[string]interface{})
+			dataLoopMap["InstanceId"] = dataLoopTmp["instance_id"]
+			dataLoopMap["InstanceType"] = dataLoopTmp["instance_type"]
+			instancesMapsArray = append(instancesMapsArray, dataLoopMap)
+		}
+		request["Instances"] = instancesMapsArray
+	}
+
+	if v, ok := d.GetOk("gateway_qos_name"); ok {
+		request["GatewayQosName"] = v
+	}
+	if v, ok := d.GetOkExists("bandwidth_out"); ok {
+		request["BandwidthOut"] = v
+	}
+	request["NetworkId"] = d.Get("network_id")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ens_gateway_qos", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["GatewayQosId"]))
+
+	return resourceAliCloudEnsGatewayQosRead(d, meta)
+}
+
+func resourceAliCloudEnsGatewayQosRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ensServiceV2 := EnsServiceV2{client}
+
+	objectRaw, err := ensServiceV2.DescribeEnsGatewayQos(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ens_gateway_qos DescribeEnsGatewayQos Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("bandwidth_in", objectRaw["BandwidthIn"])
+	d.Set("bandwidth_out", objectRaw["BandwidthOut"])
+	d.Set("creation_time", objectRaw["CreationTime"])
+	d.Set("ens_region_id", objectRaw["EnsRegionId"])
+	d.Set("gateway_qos_name", objectRaw["GatewayQosName"])
+	d.Set("gateway_qos_type", objectRaw["GatewayQosType"])
+	d.Set("network_id", objectRaw["NetworkId"])
+	d.Set("status", objectRaw["Status"])
+
+	instanceRaw, _ := jsonpath.Get("$.Instances.Instance", objectRaw)
+	instancesMaps := make([]map[string]interface{}, 0)
+	if instanceRaw != nil {
+		for _, instanceChildRaw := range convertToInterfaceArray(instanceRaw) {
+			instancesMap := make(map[string]interface{})
+			instanceChildRaw := instanceChildRaw.(map[string]interface{})
+			instancesMap["instance_id"] = instanceChildRaw["InstanceId"]
+			instancesMap["instance_type"] = instanceChildRaw["InstanceType"]
+			instancesMap["status"] = instanceChildRaw["Status"]
+
+			instancesMaps = append(instancesMaps, instancesMap)
+		}
+	}
+	if err := d.Set("instances", instancesMaps); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAliCloudEnsGatewayQosUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "UpdateEnsGatewayQos"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["GatewayQosId"] = d.Id()
+
+	if d.HasChange("bandwidth_in") {
+		update = true
+		request["BandwidthIn"] = d.Get("bandwidth_in")
+	}
+
+	if d.HasChange("gateway_qos_name") {
+		update = true
+		request["GatewayQosName"] = d.Get("gateway_qos_name")
+	}
+
+	if d.HasChange("bandwidth_out") {
+		update = true
+		request["BandwidthOut"] = d.Get("bandwidth_out")
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		ensServiceV2 := EnsServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ensServiceV2.EnsGatewayQosStateRefreshFunc(d.Id(), "Status", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+
+	if d.HasChange("instances") {
+		var err error
+		oldEntry, newEntry := d.GetChange("instances")
+		oldEntrySet := oldEntry.(*schema.Set)
+		newEntrySet := newEntry.(*schema.Set)
+		removed := oldEntrySet.Difference(newEntrySet)
+		added := newEntrySet.Difference(oldEntrySet)
+
+		if removed.Len() > 0 {
+			action := "DeleteEnsGatewayQosInstances"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["GatewayQosId"] = d.Id()
+
+			localData := removed.List()
+			instancesMapsArray := make([]interface{}, 0)
+			for _, dataLoop := range localData {
+				dataLoopTmp := dataLoop.(map[string]interface{})
+				dataLoopMap := make(map[string]interface{})
+				dataLoopMap["InstanceId"] = dataLoopTmp["instance_id"]
+				dataLoopMap["InstanceType"] = dataLoopTmp["instance_type"]
+				instancesMapsArray = append(instancesMapsArray, dataLoopMap)
+			}
+			request["Instances"] = instancesMapsArray
+
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+			ensServiceV2 := EnsServiceV2{client}
+			stateConf := BuildStateConf([]string{}, []string{"[]"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ensServiceV2.EnsGatewayQosStateRefreshFunc(d.Id(), "", []string{}))
+			if _, err := stateConf.WaitForState(); err != nil {
+				return WrapErrorf(err, IdMsg, d.Id())
+			}
+
+		}
+
+		if added.Len() > 0 {
+			action := "AddEnsGatewayQosInstances"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["GatewayQosId"] = d.Id()
+
+			localData := added.List()
+			instancesMapsArray := make([]interface{}, 0)
+			for _, dataLoop := range localData {
+				dataLoopTmp := dataLoop.(map[string]interface{})
+				dataLoopMap := make(map[string]interface{})
+				dataLoopMap["InstanceId"] = dataLoopTmp["instance_id"]
+				dataLoopMap["InstanceType"] = dataLoopTmp["instance_type"]
+				instancesMapsArray = append(instancesMapsArray, dataLoopMap)
+			}
+			request["Instances"] = instancesMapsArray
+
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+
+		}
+
+	}
+	return resourceAliCloudEnsGatewayQosRead(d, meta)
+}
+
+func resourceAliCloudEnsGatewayQosDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteEnsGatewayQos"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["GatewayQosId"] = d.Id()
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"GatewayQosNotFound"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 5*time.Second, ensServiceV2.EnsGatewayQosStateRefreshFunc(d.Id(), "$.GatewayQosId", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ens_gateway_qos_test.go
+++ b/alicloud/resource_alicloud_ens_gateway_qos_test.go
@@ -1,0 +1,364 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Ens GatewayQos. >>> Resource test cases, automatically generated.
+// Case 网关限速_20250620_添加、移除实例 10964
+func TestAccAliCloudEnsGatewayQos_basic10964(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_gateway_qos.default"
+	ra := resourceAttrInit(resourceId, AlicloudEnsGatewayQosMap10964)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsGatewayQos")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccens%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudEnsGatewayQosBasicDependence10964)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"gateway_qos_name": name,
+					"bandwidth_in":     "10",
+					"gateway_qos_type": "Nat",
+					"network_id":       "${alicloud_ens_network.defaultC7YqlT.id}",
+					"bandwidth_out":    "20",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"gateway_qos_name": name,
+						"bandwidth_in":     "10",
+						"gateway_qos_type": "Nat",
+						"network_id":       CHECKSET,
+						"bandwidth_out":    "20",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"gateway_qos_name": name + "_update",
+					"bandwidth_in":     "20",
+					"instances": []map[string]interface{}{
+						{
+							"status":        "Available",
+							"instance_id":   "${alicloud_ens_instance.defaultvuczsY.id}",
+							"instance_type": "ens",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"gateway_qos_name": name + "_update",
+						"bandwidth_in":     "20",
+						"instances.#":      "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instances": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instances.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudEnsGatewayQosMap10964 = map[string]string{
+	"status":        CHECKSET,
+	"creation_time": CHECKSET,
+	"ens_region_id": CHECKSET,
+}
+
+func AlicloudEnsGatewayQosBasicDependence10964(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-63"
+}
+
+resource "alicloud_ens_network" "defaultC7YqlT" {
+  network_name  = "镇元-网关限速测试使用"
+  cidr_block    = "10.0.0.0/10"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default5giQWR" {
+  cidr_block    = "10.0.8.0/24"
+  vswitch_name  = "镇元-网关限速测试"
+  ens_region_id = var.ens_region_id
+  network_id    = alicloud_ens_network.defaultC7YqlT.id
+}
+
+resource "alicloud_ens_instance" "defaultvuczsY" {
+  amount      = "1"
+  period_unit = "Month"
+  auto_renew  = false
+  system_disk {
+    size = "20"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.small"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  vswitch_id                 = alicloud_ens_vswitch.default5giQWR.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "镇元-网关限速测试"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+}
+
+
+`, name)
+}
+
+// Case 网关限速_无实例z_修改名称、带宽_20250619 10966
+func TestAccAliCloudEnsGatewayQos_basic10966(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_gateway_qos.default"
+	ra := resourceAttrInit(resourceId, AlicloudEnsGatewayQosMap10966)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsGatewayQos")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccens%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudEnsGatewayQosBasicDependence10966)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"gateway_qos_name": name,
+					"bandwidth_in":     "10",
+					"gateway_qos_type": "Nat",
+					"network_id":       "${alicloud_ens_network.defaultC7YqlT.id}",
+					"bandwidth_out":    "10",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"gateway_qos_name": name,
+						"bandwidth_in":     "10",
+						"gateway_qos_type": "Nat",
+						"network_id":       CHECKSET,
+						"bandwidth_out":    "10",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"gateway_qos_name": name + "_update",
+					"bandwidth_in":     "20",
+					"bandwidth_out":    "20",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"gateway_qos_name": name + "_update",
+						"bandwidth_in":     "20",
+						"bandwidth_out":    "20",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudEnsGatewayQosMap10966 = map[string]string{
+	"status":        CHECKSET,
+	"creation_time": CHECKSET,
+	"ens_region_id": CHECKSET,
+}
+
+func AlicloudEnsGatewayQosBasicDependence10966(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-63"
+}
+
+resource "alicloud_ens_network" "defaultC7YqlT" {
+  network_name  = "镇元-网关限速测试使用"
+  cidr_block    = "10.0.0.0/10"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default5giQWR" {
+  cidr_block    = "10.0.8.0/24"
+  vswitch_name  = "镇元-网关限速测试"
+  ens_region_id = var.ens_region_id
+  network_id    = alicloud_ens_network.defaultC7YqlT.id
+}
+
+
+`, name)
+}
+
+// Case 网关限速_创建带实例_20250619 10960
+func TestAccAliCloudEnsGatewayQos_basic10960(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_gateway_qos.default"
+	ra := resourceAttrInit(resourceId, AlicloudEnsGatewayQosMap10960)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsGatewayQos")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccens%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudEnsGatewayQosBasicDependence10960)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instances": []map[string]interface{}{
+						{
+							"status":        "Available",
+							"instance_id":   "${alicloud_ens_instance.defaultvuczsY.id}",
+							"instance_type": "ens",
+						},
+					},
+					"gateway_qos_name": name,
+					"bandwidth_in":     "10",
+					"gateway_qos_type": "Nat",
+					"network_id":       "${alicloud_ens_network.defaultC7YqlT.id}",
+					"bandwidth_out":    "10",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instances.#":      "1",
+						"gateway_qos_name": name,
+						"bandwidth_in":     "10",
+						"gateway_qos_type": "Nat",
+						"network_id":       CHECKSET,
+						"bandwidth_out":    "10",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudEnsGatewayQosMap10960 = map[string]string{
+	"status":        CHECKSET,
+	"creation_time": CHECKSET,
+	"ens_region_id": CHECKSET,
+}
+
+func AlicloudEnsGatewayQosBasicDependence10960(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-63"
+}
+
+resource "alicloud_ens_network" "defaultC7YqlT" {
+  network_name  = "镇元-网关限速测试使用"
+  cidr_block    = "10.0.0.0/10"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default5giQWR" {
+  cidr_block    = "10.0.8.0/24"
+  vswitch_name  = "镇元-网关限速测试"
+  ens_region_id = var.ens_region_id
+  network_id    = alicloud_ens_network.defaultC7YqlT.id
+}
+
+resource "alicloud_ens_instance" "defaultvuczsY" {
+  amount      = "1"
+  period_unit = "Month"
+  auto_renew  = false
+  system_disk {
+    size = "20"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.small"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  vswitch_id                 = alicloud_ens_vswitch.default5giQWR.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "镇元-网关限速测试"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+}
+
+
+`, name)
+}
+
+// Test Ens GatewayQos. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_ens_v2.go
+++ b/alicloud/service_alicloud_ens_v2.go
@@ -1168,3 +1168,85 @@ func (s *EnsServiceV2) SetResourceTags(d *schema.ResourceData, resourceType stri
 }
 
 // SetResourceTags >>> tag function encapsulated.
+
+// DescribeEnsGatewayQos <<< Encapsulated get interface for Ens GatewayQos.
+
+func (s *EnsServiceV2) DescribeEnsGatewayQos(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["GatewayQosId"] = id
+
+	action := "DescribeEnsGatewayQoses"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.GatewayQoses.GatewayQos[*]", response)
+	if err != nil {
+		return object, WrapErrorf(NotFoundErr("GatewayQos", id), NotFoundMsg, response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("GatewayQos", id), NotFoundMsg, response)
+	}
+
+	currentStatus := v.([]interface{})[0].(map[string]interface{})["GatewayQosId"]
+	if currentStatus == nil {
+		return object, WrapErrorf(NotFoundErr("GatewayQos", id), NotFoundMsg, response)
+	}
+
+	return v.([]interface{})[0].(map[string]interface{}), nil
+}
+
+func (s *EnsServiceV2) EnsGatewayQosStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.EnsGatewayQosStateRefreshFuncWithApi(id, field, failStates, s.DescribeEnsGatewayQos)
+}
+
+func (s *EnsServiceV2) EnsGatewayQosStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeEnsGatewayQos >>> Encapsulated.

--- a/website/docs/d/ens_gateway_qos.html.markdown
+++ b/website/docs/d/ens_gateway_qos.html.markdown
@@ -1,0 +1,128 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_gateway_qos"
+sidebar_current: "docs-alicloud-datasource-ens-gateway-qos"
+description: |-
+  Provides a list of ENS Gateway Qos owned by an Alibaba Cloud account.
+---
+
+# alicloud_ens_gateway_qos
+
+This data source provides ENS Gateway Qos available to the user.[What is Gateway Qos](https://next.api.alibabacloud.com/document/Ens/2017-11-10/CreateEnsGatewayQos)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-63"
+}
+
+resource "alicloud_ens_network" "defaultC7YqlT" {
+  network_name  = "镇元-网关限速测试使用"
+  cidr_block    = "10.0.0.0/10"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default5giQWR" {
+  cidr_block    = "10.0.8.0/24"
+  vswitch_name  = "镇元-网关限速测试"
+  ens_region_id = var.ens_region_id
+  network_id    = alicloud_ens_network.defaultC7YqlT.id
+}
+
+resource "alicloud_ens_instance" "defaultvuczsY" {
+  amount      = "1"
+  period_unit = "Month"
+  auto_renew  = false
+  system_disk {
+    size = "20"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.small"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  vswitch_id                 = alicloud_ens_vswitch.default5giQWR.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "镇元-网关限速测试"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+}
+
+
+resource "alicloud_ens_gateway_qos" "default" {
+  gateway_qos_name = var.name
+  bandwidth_in     = "10"
+  gateway_qos_type = "Nat"
+  network_id       = alicloud_ens_network.defaultC7YqlT.id
+  bandwidth_out    = "20"
+}
+
+data "alicloud_ens_gateway_qos" "default" {
+  ids              = ["${alicloud_ens_gateway_qos.default.id}"]
+  name_regex       = alicloud_ens_gateway_qos.default.gateway_qos_name
+  gateway_qos_name = var.name
+  gateway_qos_type = "Nat"
+  network_id       = alicloud_ens_network.defaultC7YqlT.id
+}
+
+output "alicloud_ens_gateway_qos_example_id" {
+  value = data.alicloud_ens_gateway_qos.default.qos.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `ens_region_id` - (Optional) The ID of the ENS node.
+* `gateway_qos_id` - (Optional) The first ID of the resource
+* `gateway_qos_name` - (Optional) The name of the resource
+* `gateway_qos_type` - (Optional) Speed limit type.
+* `instances` - (Optional) The instance under the Gateway speed limit. See [`instances`](#instances) below.
+* `network_id` - (Optional) The ID of the network where the Gateway speed limit is located.
+* `ids` - (Optional, Computed) A list of Gateway Qos IDs.
+* `name_regex` - (Optional) A regex string to filter results by Group Metric Rule name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+### `instances`
+
+The instances supports the following:
+* `instance_id` - (Optional) The business ID of the instance.
+* `instance_type` - (Optional) The instance type.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Gateway Qos IDs.
+* `names` - A list of name of Gateway Qoss.
+* `qos` - A list of Gateway Qos Entries. Each element contains the following attributes:
+    * `bandwidth_in` - Inbound bandwidth speed limit, unit: Mbps, range: 0-10000.
+    * `bandwidth_out` - Outbound bandwidth speed limit, unit: Mbps, range: 0-10000.
+    * `creation_time` - The creation time of the resource.
+    * `ens_region_id` - The ID of the ENS node.
+    * `gateway_qos_id` - The first ID of the resource.
+    * `gateway_qos_name` - The name of the resource.
+    * `gateway_qos_type` - Speed limit type.
+    * `instances` - The instance under the Gateway speed limit.
+      * `status` - The speed limit status of the instance-bound gateway.
+    * `network_id` - The ID of the network where the Gateway speed limit is located.
+    * `status` - The speed limit status of the Gateway.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/ens_gateway_qos.html.markdown
+++ b/website/docs/r/ens_gateway_qos.html.markdown
@@ -1,0 +1,124 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_gateway_qos"
+description: |-
+  Provides a Alicloud ENS Gateway Qos resource.
+---
+
+# alicloud_ens_gateway_qos
+
+Provides a ENS Gateway Qos resource.
+
+Gateway speed limit.
+
+For information about ENS Gateway Qos and how to use it, see [What is Gateway Qos](https://next.api.alibabacloud.com/document/Ens/2017-11-10/CreateEnsGatewayQos).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-63"
+}
+
+resource "alicloud_ens_network" "defaultC7YqlT" {
+  network_name  = "镇元-网关限速example使用"
+  cidr_block    = "10.0.0.0/10"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default5giQWR" {
+  cidr_block    = "10.0.8.0/24"
+  vswitch_name  = "镇元-网关限速example"
+  ens_region_id = var.ens_region_id
+  network_id    = alicloud_ens_network.defaultC7YqlT.id
+}
+
+resource "alicloud_ens_instance" "defaultvuczsY" {
+  amount      = "1"
+  period_unit = "Month"
+  auto_renew  = false
+  system_disk {
+    size = "20"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.small"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  vswitch_id                 = alicloud_ens_vswitch.default5giQWR.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "镇元-网关限速example"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+}
+
+
+resource "alicloud_ens_gateway_qos" "default" {
+  gateway_qos_name = "example"
+  bandwidth_in     = "10"
+  gateway_qos_type = "Nat"
+  network_id       = alicloud_ens_network.defaultC7YqlT.id
+  bandwidth_out    = "20"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `bandwidth_in` - (Optional, Int) Inbound bandwidth speed limit, unit: Mbps, range: 0-10000
+* `bandwidth_out` - (Optional, Int) Outbound bandwidth speed limit, unit: Mbps, range: 0-10000.
+* `gateway_qos_name` - (Optional) The name of the resource
+* `gateway_qos_type` - (Required, ForceNew) Speed limit type.
+* `instances` - (Optional, List) The instance under the Gateway speed limit. See [`instances`](#instances) below.
+* `network_id` - (Required, ForceNew) The ID of the network where the Gateway speed limit is located.
+
+### `instances`
+
+The instances supports the following:
+* `instance_id` - (Required) The business ID of the instance.
+* `instance_type` - (Required) The instance type.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+* `creation_time` - The creation time of the resource.
+* `ens_region_id` - The ID of the ENS node.
+* `instances` - The instance under the Gateway speed limit.
+  * `status` - The speed limit status of the instance-bound gateway.
+* `status` - The speed limit status of the Gateway.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Gateway Qos.
+* `delete` - (Defaults to 5 mins) Used when delete the Gateway Qos.
+* `update` - (Defaults to 5 mins) Used when update the Gateway Qos.
+
+## Import
+
+ENS Gateway Qos can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ens_gateway_qos.example <gateway_qos_id>
+```


### PR DESCRIPTION
Adds the `alicloud_ens_gateway_qos` resource and data source for ENS Gateway Qos (speed limit).

## Resource

`alicloud_ens_gateway_qos` manages an ENS Gateway Qos with:
- `bandwidth_in` / `bandwidth_out` — inbound/outbound bandwidth limit (Mbps, 0-10000)
- `gateway_qos_type` — speed limit type (ForceNew)
- `gateway_qos_name` — QoS name
- `network_id` — the network where the Gateway Qos is located (ForceNew)
- `instances` — set of `{instance_id, instance_type}` bound to the gateway QoS; added/removed via AddEnsGatewayQosInstances / DeleteEnsGatewayQosInstances

Import supported: `terraform import alicloud_ens_gateway_qos.example <gateway_qos_id>`

## Data Source

`alicloud_ens_gateway_qos` lists existing Gateway Qos entries with filtering by `ids`, `gateway_qos_id`, `gateway_qos_name`, `gateway_qos_type`, `network_id`, `ens_region_id`, `name_regex`, `output_file`.

## Backing APIs

CreateEnsGatewayQos, DescribeEnsGatewayQoses, UpdateEnsGatewayQos, DeleteEnsGatewayQos, AddEnsGatewayQosInstances, DeleteEnsGatewayQosInstances (Ens 2017-11-10).

## Test Cases

```
TestAccAliCloudEnsGatewayQos_basic10964
TestAccAliCloudEnsGatewayQos_basic10966
TestAccAliCloudEnsGatewayQos_basic10960
TestAccAlicloudEnsGatewayQosDataSource
```

Remote ACC verification pending; passing results will be appended once all cases pass.
