### PR TITLE
resource/alicloud_ens_ha_vip: new resource and data source for ENS HaVip

### DIFF
--- a/alicloud/data_source_alicloud_ens_ha_vips.go
+++ b/alicloud/data_source_alicloud_ens_ha_vips.go
@@ -1,0 +1,262 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudEnsHaVips() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudEnsHaVipRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"ens_region_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ha_vip_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ha_vip_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vswitch_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vips": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ens_region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ha_vip_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ha_vip_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"network_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"vswitch_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudEnsHaVipRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeHaVips"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if v, ok := d.GetOk("ha_vip_id"); ok {
+		query["HaVipId"] = v
+	}
+	if v, ok := d.GetOk("ens_region_id"); ok {
+		query["EnsRegionId"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("ha_vip_id"); ok {
+		query["HaVipId"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("ha_vip_name"); ok {
+		query["Name"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("ip_address"); ok {
+		query["HaVipAddress"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("network_id"); ok {
+		query["NetworkId"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("status"); ok {
+		query["Status"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("vswitch_id"); ok {
+		query["VSwitchId"] = v.(string)
+	}
+
+	request["PageSize"] = PageSizeLarge
+	request["PageNumber"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcGet("Ens", "2017-11-10", action, query, request)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.HaVips[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["Name"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["HaVipId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["HaVipId"]
+
+		mapping["create_time"] = objectRaw["CreationTime"]
+		mapping["description"] = objectRaw["Description"]
+		mapping["ens_region_id"] = objectRaw["EnsRegionId"]
+		mapping["ha_vip_name"] = objectRaw["Name"]
+		mapping["ip_address"] = objectRaw["IpAddress"]
+		mapping["network_id"] = objectRaw["NetworkId"]
+		mapping["status"] = objectRaw["Status"]
+		mapping["vswitch_id"] = objectRaw["VSwitchId"]
+		mapping["ha_vip_id"] = objectRaw["HaVipId"]
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["Name"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("vips", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_ens_ha_vips_test.go
+++ b/alicloud/data_source_alicloud_ens_ha_vips_test.go
@@ -1,0 +1,146 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudEnsHaVipDataSource(t *testing.T) {
+	testAccPreCheck(t)
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsHaVipSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ens_ha_vip.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsHaVipSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ens_ha_vip.default.id}_fake"]`,
+		}),
+	}
+
+	IpAddressConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsHaVipSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_ens_ha_vip.default.id}"]`,
+			"ip_address": `"10.0.9.5"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsHaVipSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_ens_ha_vip.default.id}_fake"]`,
+			"ip_address": `"10.0.9.5_fake"`,
+		}),
+	}
+	HaVipNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsHaVipSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_ha_vip.default.id}"]`,
+			"ha_vip_name": `"${var.name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsHaVipSourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_ha_vip.default.id}_fake"]`,
+			"ha_vip_name": `"${var.name}_fake"`,
+		}),
+	}
+	VSwitchIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsHaVipSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_ens_ha_vip.default.id}"]`,
+			"vswitch_id": `"${alicloud_ens_vswitch.defaultcW3Eib.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsHaVipSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_ens_ha_vip.default.id}_fake"]`,
+			"vswitch_id": `"${alicloud_ens_vswitch.defaultcW3Eib.id}_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsHaVipSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_ens_ha_vip.default.id}"]`,
+			"ip_address": `"10.0.9.5"`,
+
+			"ha_vip_name": `"${var.name}"`,
+
+			"vswitch_id": `"${alicloud_ens_vswitch.defaultcW3Eib.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsHaVipSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_ens_ha_vip.default.id}_fake"]`,
+			"ip_address": `"10.0.9.5_fake"`,
+
+			"ha_vip_name": `"${var.name}_fake"`,
+
+			"vswitch_id": `"${alicloud_ens_vswitch.defaultcW3Eib.id}_fake"`,
+		}),
+	}
+
+	EnsHaVipCheckInfo.dataSourceTestCheck(t, rand, idsConf, IpAddressConf, HaVipNameConf, VSwitchIdConf, allConf)
+}
+
+var existEnsHaVipMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"vips.#":               "1",
+		"vips.0.status":        CHECKSET,
+		"vips.0.description":   CHECKSET,
+		"vips.0.create_time":   CHECKSET,
+		"vips.0.vswitch_id":    CHECKSET,
+		"vips.0.ha_vip_name":   CHECKSET,
+		"vips.0.ha_vip_id":     CHECKSET,
+		"vips.0.network_id":    CHECKSET,
+		"vips.0.ip_address":    CHECKSET,
+		"vips.0.ens_region_id": CHECKSET,
+	}
+}
+
+var fakeEnsHaVipMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"vips.#": "0",
+	}
+}
+
+var EnsHaVipCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_ens_ha_vips.default",
+	existMapFunc: existEnsHaVipMapFunc,
+	fakeMapFunc:  fakeEnsHaVipMapFunc,
+}
+
+func testAccCheckAlicloudEnsHaVipSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccEnsHaVip%d"
+}
+variable "ens_region_id" {
+  default = "cn-hangzhou-58"
+}
+
+resource "alicloud_ens_network" "default4wYgcV" {
+  network_name  = "tf-testAccEnsHaVip"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "defaultcW3Eib" {
+  cidr_block    = "10.0.9.0/24"
+  vswitch_name  = "tf-testAccEnsHaVip"
+  ens_region_id = var.ens_region_id
+  network_id    = alicloud_ens_network.default4wYgcV.id
+}
+
+
+
+resource "alicloud_ens_ha_vip" "default" {
+  description = "desc1"
+  vswitch_id  = alicloud_ens_vswitch.defaultcW3Eib.id
+  amount      = 1
+  ip_address  = "10.0.9.5"
+  ha_vip_name = var.name
+}
+
+data "alicloud_ens_ha_vips" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -170,6 +170,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_ens_ha_vips":                                    dataSourceAliCloudEnsHaVips(),
 			"alicloud_apig_ai_model_providers":                        dataSourceAliCloudApigAiModelProviders(),
 			"alicloud_apig_services":                                  dataSourceAliCloudApigServices(),
 			"alicloud_apig_gateways":                                  dataSourceAliCloudApigGateways(),
@@ -949,6 +950,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_ens_ha_vip":                                           resourceAliCloudEnsHaVip(),
 			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),
 			"alicloud_apig_ai_model_provider":                               resourceAliCloudApigAiModelProvider(),
 			"alicloud_apig_service":                                         resourceAliCloudApigService(),

--- a/alicloud/resource_alicloud_ens_ha_vip.go
+++ b/alicloud/resource_alicloud_ens_ha_vip.go
@@ -1,0 +1,246 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/tidwall/sjson"
+)
+
+func resourceAliCloudEnsHaVip() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudEnsHaVipCreate,
+		Read:   resourceAliCloudEnsHaVipRead,
+		Update: resourceAliCloudEnsHaVipUpdate,
+		Delete: resourceAliCloudEnsHaVipDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"amount": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      1,
+				ValidateFunc: IntBetween(1, 10),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"ens_region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ha_vip_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vswitch_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudEnsHaVipCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateHaVip"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	if v, ok := d.GetOk("ip_address"); ok {
+		request["IpAddress"] = v
+	}
+	if v, ok := d.GetOk("description"); ok {
+		request["Description"] = v
+	}
+	if v, ok := d.GetOk("ha_vip_name"); ok {
+		request["Name"] = v
+	}
+	if v, ok := d.GetOk("vswitch_id"); ok {
+		request["VSwitchId"] = v
+	}
+	if v, ok := d.GetOkExists("amount"); ok && v.(int) > 0 {
+		request["Amount"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ens_ha_vip", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.HaVipIds[0]", response)
+	d.SetId(fmt.Sprint(id))
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, ensServiceV2.EnsHaVipStateRefreshFunc(d.Id(), "Status", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return resourceAliCloudEnsHaVipRead(d, meta)
+}
+
+func resourceAliCloudEnsHaVipRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ensServiceV2 := EnsServiceV2{client}
+
+	objectRaw, err := ensServiceV2.DescribeEnsHaVip(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ens_ha_vip DescribeEnsHaVip Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("create_time", objectRaw["CreationTime"])
+	d.Set("description", objectRaw["Description"])
+	d.Set("ens_region_id", objectRaw["EnsRegionId"])
+	d.Set("ha_vip_name", objectRaw["Name"])
+	d.Set("ip_address", objectRaw["IpAddress"])
+	d.Set("network_id", objectRaw["NetworkId"])
+	d.Set("status", objectRaw["Status"])
+	d.Set("vswitch_id", objectRaw["VSwitchId"])
+
+	return nil
+}
+
+func resourceAliCloudEnsHaVipUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "ModifyHaVipAttribute"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["HaVipId"] = d.Id()
+
+	if d.HasChange("ha_vip_name") {
+		update = true
+	}
+	if v, ok := d.GetOk("ha_vip_name"); ok || d.HasChange("ha_vip_name") {
+		request["Name"] = v
+	}
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudEnsHaVipRead(d, meta)
+}
+
+func resourceAliCloudEnsHaVipDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteHaVips"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	jsonString := convertObjectToJsonString(request)
+	jsonString, _ = sjson.Set(jsonString, "HaVipIds.0", d.Id())
+	_ = json.Unmarshal([]byte(jsonString), &request)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 5*time.Second, ensServiceV2.EnsHaVipStateRefreshFunc(d.Id(), "$.HaVipId", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ens_ha_vip_test.go
+++ b/alicloud/resource_alicloud_ens_ha_vip_test.go
@@ -1,0 +1,172 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudEnsHaVip_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_ha_vip.default"
+	ra := resourceAttrInit(resourceId, AliCloudEnsHaVipMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsHaVip")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testaccenshavip%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEnsHaVipBasicDependence)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"vswitch_id":  "${alicloud_ens_vswitch.default.id}",
+					"amount":      1,
+					"description": "desc1",
+					"ip_address":  "10.0.9.5",
+					"ha_vip_name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"amount":        "1",
+						"description":   "desc1",
+						"ip_address":    "10.0.9.5",
+						"ha_vip_name":   name,
+						"vswitch_id":    CHECKSET,
+						"status":        CHECKSET,
+						"create_time":   CHECKSET,
+						"ens_region_id": CHECKSET,
+						"network_id":    CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"vswitch_id":  "${alicloud_ens_vswitch.default.id}",
+					"amount":      1,
+					"description": "desc1",
+					"ip_address":  "10.0.9.5",
+					"ha_vip_name": name + "_update",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ha_vip_name": name + "_update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"vswitch_id":  "${alicloud_ens_vswitch.default.id}",
+					"ip_address":  "10.0.9.5",
+					"ha_vip_name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ha_vip_name": name,
+						"vswitch_id":  CHECKSET,
+						"ip_address":  "10.0.9.5",
+						"status":      CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"amount"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudEnsHaVip_autoIpAddress(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_ha_vip.default"
+	ra := resourceAttrInit(resourceId, AliCloudEnsHaVipMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsHaVip")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testaccenshavip%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEnsHaVipBasicDependence)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"vswitch_id":  "${alicloud_ens_vswitch.default.id}",
+					"amount":      2,
+					"ha_vip_name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"amount":        "2",
+						"ha_vip_name":   name,
+						"vswitch_id":    CHECKSET,
+						"status":        CHECKSET,
+						"ip_address":    CHECKSET,
+						"create_time":   CHECKSET,
+						"ens_region_id": CHECKSET,
+						"network_id":    CHECKSET,
+					}),
+				),
+			},
+		},
+	})
+}
+
+var AliCloudEnsHaVipMap = map[string]string{
+	"status":        CHECKSET,
+	"create_time":   CHECKSET,
+	"ens_region_id": CHECKSET,
+	"network_id":    CHECKSET,
+	"ip_address":    CHECKSET,
+	"vswitch_id":    CHECKSET,
+	"ha_vip_name":   CHECKSET,
+	"description":   CHECKSET,
+}
+
+func AliCloudEnsHaVipBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-58"
+}
+
+resource "alicloud_ens_network" "default" {
+  network_name  = "%s"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default" {
+  cidr_block    = "10.0.9.0/24"
+  vswitch_name  = "%s"
+  ens_region_id = var.ens_region_id
+  network_id    = alicloud_ens_network.default.id
+}
+`, name, name, name)
+}

--- a/alicloud/service_alicloud_ens_v2.go
+++ b/alicloud/service_alicloud_ens_v2.go
@@ -1168,3 +1168,79 @@ func (s *EnsServiceV2) SetResourceTags(d *schema.ResourceData, resourceType stri
 }
 
 // SetResourceTags >>> tag function encapsulated.
+// DescribeEnsHaVip <<< Encapsulated get interface for Ens HaVip.
+
+func (s *EnsServiceV2) DescribeEnsHaVip(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	query["HaVipId"] = id
+
+	action := "DescribeHaVips"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcGet("Ens", "2017-11-10", action, query, request)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.HaVips[*]", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.HaVips[*]", response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("HaVip", id), NotFoundMsg, response)
+	}
+
+	return v.([]interface{})[0].(map[string]interface{}), nil
+}
+
+func (s *EnsServiceV2) EnsHaVipStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.EnsHaVipStateRefreshFuncWithApi(id, field, failStates, s.DescribeEnsHaVip)
+}
+
+func (s *EnsServiceV2) EnsHaVipStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeEnsHaVip >>> Encapsulated.

--- a/website/docs/d/ens_ha_vips.html.markdown
+++ b/website/docs/d/ens_ha_vips.html.markdown
@@ -1,0 +1,100 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_ha_vips"
+sidebar_current: "docs-alicloud-datasource-ens-ha-vips"
+description: |-
+  Provides a list of ENS Ha Vip owned by an Alibaba Cloud account.
+---
+
+# alicloud_ens_ha_vips
+
+This data source provides ENS Ha Vip available to the user.[What is Ha Vip](https://next.api.alibabacloud.com/document/Ens/2017-11-10/CreateHaVip)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-58"
+}
+
+resource "alicloud_ens_network" "default4wYgcV" {
+  network_name  = "tf-example"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "defaultcW3Eib" {
+  cidr_block    = "10.0.9.0/24"
+  vswitch_name  = "tf-example"
+  ens_region_id = var.ens_region_id
+  network_id    = alicloud_ens_network.default4wYgcV.id
+}
+
+
+resource "alicloud_ens_ha_vip" "default" {
+  description = "desc1"
+  vswitch_id  = alicloud_ens_vswitch.defaultcW3Eib.id
+  amount      = 1
+  ip_address  = "10.0.9.5"
+  ha_vip_name = "tf-example"
+}
+
+data "alicloud_ens_ha_vips" "default" {
+  ids         = ["${alicloud_ens_ha_vip.default.id}"]
+  name_regex  = alicloud_ens_ha_vip.default.ha_vip_name
+  ha_vip_name = "tf-example"
+  ip_address  = "10.0.9.5"
+  vswitch_id  = alicloud_ens_vswitch.defaultcW3Eib.id
+}
+
+output "alicloud_ens_ha_vip_example_id" {
+  value = data.alicloud_ens_ha_vips.default.vips.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `ens_region_id` - (Optional) The node ID of ENS.
+* `ha_vip_id` - (Optional) The ID of the HaVip.
+* `ha_vip_name` - (Optional) The name of the HaVip instance.
+* `ip_address` - (Optional) The IP address of the HaVip.
+* `network_id` - (Optional) The network ID.
+* `status` - (Optional) The HaVip status. Value:
+  - Creating: Creating.
+  - Available: Available.
+  - InUse: In use.
+  - Deleting: Deleting.
+* `vswitch_id` - (Optional) The vSwitch ID.
+* `ids` - (Optional, Computed) A list of HaVip IDs.
+* `name_regex` - (Optional) A regex string to filter results by HaVip name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Ha Vip IDs.
+* `names` - A list of name of Ha Vips.
+* `vips` - A list of Ha Vip Entries. Each element contains the following attributes:
+    * `create_time` - The creation time of the resource.
+    * `description` - The description of the HaVip instance.
+    * `ens_region_id` - The node ID of ENS.
+    * `ha_vip_id` - The first ID of the resource.
+    * `ha_vip_name` - The name of the HaVip instance.
+    * `ip_address` - The IP address of the AVIP.
+    * `network_id` - The network ID.
+    * `status` - The HaVip status.
+    * `vswitch_id` - The vSwitch ID.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/ens_ha_vip.html.markdown
+++ b/website/docs/r/ens_ha_vip.html.markdown
@@ -1,0 +1,91 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_ha_vip"
+description: |-
+  Provides a Alicloud ENS Ha Vip resource.
+---
+
+# alicloud_ens_ha_vip
+
+Provides a ENS Ha Vip resource.
+
+High-Availability Virtual IP Address.
+
+For information about ENS Ha Vip and how to use it, see [What is Ha Vip](https://next.api.alibabacloud.com/document/Ens/2017-11-10/CreateHaVip).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-58"
+}
+
+resource "alicloud_ens_network" "default4wYgcV" {
+  network_name  = "tf-example"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "defaultcW3Eib" {
+  cidr_block    = "10.0.9.0/24"
+  vswitch_name  = "tf-example"
+  ens_region_id = var.ens_region_id
+  network_id    = alicloud_ens_network.default4wYgcV.id
+}
+
+
+resource "alicloud_ens_ha_vip" "default" {
+  description = "desc1"
+  vswitch_id  = alicloud_ens_vswitch.defaultcW3Eib.id
+  amount      = 1
+  ip_address  = "10.0.9.5"
+  ha_vip_name = "tf-example"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `amount` - (Optional, ForceNew, Int) The number of highly available VIPs created. Value range: 1 to 10. When the specified IP address is created, the quantity can only be 1. Defaults to 1.
+* `description` - (Optional, Computed, ForceNew) The description of the HaVip instance.
+* `ha_vip_name` - (Optional, Computed) The name of the HaVip instance.
+* `ip_address` - (Optional, Computed, ForceNew) The IP address of the HaVip. If not specified, the system automatically assigns one from the vSwitch CIDR block.
+* `vswitch_id` - (Required, ForceNew) The vSwitch ID.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+* `create_time` - The creation time of the resource.
+* `ens_region_id` - The node ID of ENS.
+* `network_id` - The network ID.
+* `status` - The HaVip status.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Ha Vip.
+* `delete` - (Defaults to 5 mins) Used when delete the Ha Vip.
+* `update` - (Defaults to 5 mins) Used when update the Ha Vip.
+
+## Import
+
+ENS Ha Vip can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ens_ha_vip.example <ha_vip_id>
+```


### PR DESCRIPTION
This PR adds a new resource `alicloud_ens_ha_vip` and data source `alicloud_ens_ha_vips` for managing ENS (Edge Node Service) High-Availability Virtual IP (HaVip).

## Resource: alicloud_ens_ha_vip

### Argument Reference

**Required:**
- `vswitch_id` - (ForceNew) The vSwitch ID.

**Optional:**
- `amount` - (ForceNew, Int, Default: 1) Number of HaVips to create. Range: 1-10. When `ip_address` is specified, `amount` must be 1.
- `description` - (Computed, ForceNew) Description of the HaVip instance.
- `ha_vip_name` - (Computed) Name of the HaVip instance.
- `ip_address` - (Computed, ForceNew) IP address of the HaVip. If not specified, the system auto-assigns one from the vSwitch CIDR.

**Computed:**
- `create_time` - Creation time.
- `ens_region_id` - ENS node ID.
- `network_id` - Network ID.
- `status` - HaVip status (Creating/Available/InUse/Deleting).

### Timeouts
- Create/Update/Delete: 5 minutes each.

## Data Source: alicloud_ens_ha_vips

Provides a list of ENS HaVips filtered by `ens_region_id`, `ha_vip_id`, `ha_vip_name`, `ip_address`, `network_id`, `status`, `vswitch_id`, `ids`, `name_regex`.

## Test Cases

```
TestAccAliCloudEnsHaVip_basic
TestAccAliCloudEnsHaVip_autoIpAddress
TestAccAlicloudEnsHaVipDataSource
```