### PR TITLE
New Resource: alicloud_ens_nat_gateway_forward_entry; New Data Source: alicloud_ens_nat_gateway_forward_entries

### DIFF
--- a/alicloud/data_source_alicloud_ens_nat_gateway_forward_entries.go
+++ b/alicloud/data_source_alicloud_ens_nat_gateway_forward_entries.go
@@ -1,0 +1,221 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudEnsNatGatewayForwardEntries() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudEnsNatGatewayForwardEntryRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"external_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"forward_entry_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"forward_entry_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"internal_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ip_protocol": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"nat_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"entries": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"external_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"external_port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"forward_entry_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"forward_entry_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"health_check_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"internal_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"internal_port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"nat_gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudEnsNatGatewayForwardEntryRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeForwardTableEntries"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if v, ok := d.GetOk("forward_entry_id"); ok {
+		request["ForwardEntryId"] = v
+	}
+	request["ExternalIp"] = d.Get("external_ip")
+	if v, ok := d.GetOk("forward_entry_id"); ok {
+		request["ForwardEntryId"] = v
+	}
+	if v, ok := d.GetOk("forward_entry_name"); ok {
+		request["ForwardEntryName"] = v
+	}
+	request["InternalIp"] = d.Get("internal_ip")
+	if v, ok := d.GetOk("ip_protocol"); ok {
+		request["IpProtocol"] = v
+	}
+	request["NatGatewayId"] = d.Get("nat_gateway_id")
+	request["PageSize"] = PageSizeLarge
+	request["PageNumber"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.ForwardTableEntries[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["ForwardEntryId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["ForwardEntryId"]
+
+		mapping["external_ip"] = objectRaw["ExternalIp"]
+		mapping["external_port"] = objectRaw["ExternalPort"]
+		mapping["forward_entry_name"] = objectRaw["ForwardEntryName"]
+		mapping["health_check_port"] = formatInt(objectRaw["HealthCheckPort"])
+		mapping["internal_ip"] = objectRaw["InternalIp"]
+		mapping["internal_port"] = objectRaw["InternalPort"]
+		mapping["ip_protocol"] = objectRaw["IpProtocol"]
+		mapping["nat_gateway_id"] = objectRaw["NatGatewayId"]
+		mapping["status"] = objectRaw["Status"]
+		mapping["forward_entry_id"] = objectRaw["ForwardEntryId"]
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("entries", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_ens_nat_gateway_forward_entries.go
+++ b/alicloud/data_source_alicloud_ens_nat_gateway_forward_entries.go
@@ -161,6 +161,14 @@ func dataSourceAliCloudEnsNatGatewayForwardEntryRead(d *schema.ResourceData, met
 			return nil
 		})
 		if err != nil {
+			// When the queried NatGateway does not exist, the ENS API returns
+			// InvalidParameter.NatNotFound. A data source listing the forward
+			// entries of a non-existent nat gateway should return an empty
+			// list rather than erroring out, so break out of pagination and
+			// return zero entries.
+			if IsExpectedErrors(err, []string{"InvalidParameter.NatNotFound"}) {
+				break
+			}
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
 

--- a/alicloud/data_source_alicloud_ens_nat_gateway_forward_entries_test.go
+++ b/alicloud/data_source_alicloud_ens_nat_gateway_forward_entries_test.go
@@ -16,31 +16,37 @@ func TestAccAliCloudEnsNatGatewayForwardEntryDataSource(t *testing.T) {
 
 	idsConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
-			"ids": `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+			"ids":            `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
 		}),
 		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
-			"ids": `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+			"ids":            `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
 		}),
 	}
 
 	InternalIpConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
-			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
-			"internal_ip": `"${alicloud_ens_instance.defaulth6OQ3p.private_ip_address}"`,
+			"ids":            `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+			"internal_ip":    `"${alicloud_ens_instance.defaulth6OQ3p.private_ip_address}"`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
 		}),
 		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
-			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
-			"internal_ip": `"${alicloud_ens_instance.defaulth6OQ3p.private_ip_address}_fake"`,
+			"ids":            `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+			"internal_ip":    `"${alicloud_ens_instance.defaulth6OQ3p.private_ip_address}_fake"`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
 		}),
 	}
 	IpProtocolConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
-			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
-			"ip_protocol": `"TCP"`,
+			"ids":            `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+			"ip_protocol":    `"TCP"`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
 		}),
 		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
-			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
-			"ip_protocol": `"TCP_fake"`,
+			"ids":            `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+			"ip_protocol":    `"TCP_fake"`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
 		}),
 	}
 	NatGatewayIdConf := dataSourceTestAccConfig{
@@ -55,22 +61,26 @@ func TestAccAliCloudEnsNatGatewayForwardEntryDataSource(t *testing.T) {
 	}
 	ExternalIpConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
-			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
-			"external_ip": `"${alicloud_ens_eip.defaultLQgQB6.ip_address}"`,
+			"ids":            `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+			"external_ip":    `"${alicloud_ens_eip.defaultLQgQB6.ip_address}"`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
 		}),
 		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
-			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
-			"external_ip": `"${alicloud_ens_eip.defaultLQgQB6.ip_address}_fake"`,
+			"ids":            `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+			"external_ip":    `"${alicloud_ens_eip.defaultLQgQB6.ip_address}_fake"`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
 		}),
 	}
 	ForwardEntryNameConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
 			"ids":                `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
 			"forward_entry_name": `"测试用例-dnat"`,
+			"nat_gateway_id":     `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
 		}),
 		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
 			"ids":                `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
 			"forward_entry_name": `"测试用例-dnat_fake"`,
+			"nat_gateway_id":     `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
 		}),
 	}
 
@@ -142,7 +152,7 @@ variable "name" {
 	default = "tf-testAccEnsNatGatewayForwardEntry%d"
 }
 variable "ens_region_id" {
-  default = "cn-hangzhou-44"
+  default = "cn-chenzhou-telecom_unicom_cmcc"
 }
 
 resource "alicloud_ens_network" "default6T9qR2" {

--- a/alicloud/data_source_alicloud_ens_nat_gateway_forward_entries_test.go
+++ b/alicloud/data_source_alicloud_ens_nat_gateway_forward_entries_test.go
@@ -1,0 +1,269 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudEnsNatGatewayForwardEntryDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+		}),
+	}
+
+	InternalIpConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+			"internal_ip": `"${alicloud_ens_instance.defaulth6OQ3p.private_ip_address}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+			"internal_ip": `"${alicloud_ens_instance.defaulth6OQ3p.private_ip_address}_fake"`,
+		}),
+	}
+	IpProtocolConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+			"ip_protocol": `"TCP"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+			"ip_protocol": `"TCP_fake"`,
+		}),
+	}
+	NatGatewayIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}_fake"`,
+		}),
+	}
+	ExternalIpConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+			"external_ip": `"${alicloud_ens_eip.defaultLQgQB6.ip_address}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+			"external_ip": `"${alicloud_ens_eip.defaultLQgQB6.ip_address}_fake"`,
+		}),
+	}
+	ForwardEntryNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":                `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+			"forward_entry_name": `"测试用例-dnat"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":                `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+			"forward_entry_name": `"测试用例-dnat_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}"]`,
+			"internal_ip": `"${alicloud_ens_instance.defaulth6OQ3p.private_ip_address}"`,
+
+			"ip_protocol": `"TCP"`,
+
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}"`,
+
+			"external_ip": `"${alicloud_ens_eip.defaultLQgQB6.ip_address}"`,
+
+			"forward_entry_name": `"测试用例-dnat"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_nat_gateway_forward_entry.default.id}_fake"]`,
+			"internal_ip": `"${alicloud_ens_instance.defaulth6OQ3p.private_ip_address}_fake"`,
+
+			"ip_protocol": `"TCP_fake"`,
+
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.defaultlZ7YKl.id}_fake"`,
+
+			"external_ip": `"${alicloud_ens_eip.defaultLQgQB6.ip_address}_fake"`,
+
+			"forward_entry_name": `"测试用例-dnat_fake"`,
+		}),
+	}
+
+	EnsNatGatewayForwardEntryCheckInfo.dataSourceTestCheck(t, rand, idsConf, InternalIpConf, IpProtocolConf, NatGatewayIdConf, ExternalIpConf, ForwardEntryNameConf, allConf)
+}
+
+var existEnsNatGatewayForwardEntryMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"entries.#":                    "1",
+		"entries.0.status":             CHECKSET,
+		"entries.0.external_port":      CHECKSET,
+		"entries.0.external_ip":        CHECKSET,
+		"entries.0.forward_entry_id":   CHECKSET,
+		"entries.0.ip_protocol":        CHECKSET,
+		"entries.0.internal_port":      CHECKSET,
+		"entries.0.health_check_port":  CHECKSET,
+		"entries.0.forward_entry_name": CHECKSET,
+		"entries.0.nat_gateway_id":     CHECKSET,
+		"entries.0.internal_ip":        CHECKSET,
+	}
+}
+
+var fakeEnsNatGatewayForwardEntryMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"entries.#": "0",
+	}
+}
+
+var EnsNatGatewayForwardEntryCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_ens_nat_gateway_forward_entries.default",
+	existMapFunc: existEnsNatGatewayForwardEntryMapFunc,
+	fakeMapFunc:  fakeEnsNatGatewayForwardEntryMapFunc,
+}
+
+func testAccCheckAlicloudEnsNatGatewayForwardEntrySourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccEnsNatGatewayForwardEntry%d"
+}
+variable "ens_region_id" {
+  default = "cn-hangzhou-44"
+}
+
+resource "alicloud_ens_network" "default6T9qR2" {
+  network_name  = "测试用例_Dnat"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default5BAAN2" {
+  cidr_block    = "10.0.6.0/24"
+  vswitch_name  = "测试用例-dnat"
+  ens_region_id = alicloud_ens_network.default6T9qR2.ens_region_id
+  network_id    = alicloud_ens_network.default6T9qR2.id
+}
+
+resource "alicloud_ens_nat_gateway" "defaultlZ7YKl" {
+  vswitch_id    = alicloud_ens_vswitch.default5BAAN2.id
+  ens_region_id = alicloud_ens_vswitch.default5BAAN2.ens_region_id
+  network_id    = alicloud_ens_vswitch.default5BAAN2.network_id
+  instance_type = "enat.default"
+  nat_name      = "测试用例-dnat"
+}
+
+resource "alicloud_ens_eip" "defaultLQgQB6" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "测试用例-dnat"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultc19VZl" {
+  instance_id   = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+  allocation_id = alicloud_ens_eip.defaultLQgQB6.id
+  instance_type = "Nat"
+}
+
+resource "alicloud_ens_instance" "defaulth6OQ3p" {
+  auto_renew = false
+  system_disk {
+    size     = "20"
+    category = "cloud_efficiency"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.stiny"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  amount                     = "1"
+  vswitch_id                 = alicloud_ens_vswitch.default5BAAN2.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "测试用例-dnat"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+  period_unit                = "Month"
+}
+
+resource "alicloud_ens_eip" "eip2" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "测试用例-dnat2"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "default4Ph8bE" {
+  instance_id   = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+  allocation_id = alicloud_ens_eip.eip2.id
+  instance_type = "Nat"
+}
+
+resource "alicloud_ens_instance" "instance2" {
+  auto_renew = false
+  system_disk {
+    size     = "20"
+    category = "cloud_efficiency"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.stiny"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  amount                     = "1"
+  vswitch_id                 = alicloud_ens_vswitch.default5BAAN2.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "测试用例-dnat2"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+  period_unit                = "Month"
+}
+
+
+
+resource "alicloud_ens_nat_gateway_forward_entry" "default" {
+  external_port      = "100/200"
+  external_ip        = alicloud_ens_eip.defaultLQgQB6.ip_address
+  ip_protocol        = "TCP"
+  internal_port      = "100/200"
+  health_check_port  = "150"
+  nat_gateway_id     = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+  forward_entry_name = "测试用例-dnat"
+  internal_ip        = alicloud_ens_instance.defaulth6OQ3p.private_ip_address
+}
+
+data "alicloud_ens_nat_gateway_forward_entries" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -224,17 +224,17 @@ func NeedRetry(err error) bool {
 		if strings.Contains(*e.Message, "Client.Timeout") {
 			return true
 		}
-		if *e.Code == ServiceUnavailable || *e.Code == "Rejected.Throttling" || throttlingRegex.MatchString(*e.Code) || codeRegex.MatchString(*e.Message) {
+		if *e.Code == ServiceUnavailable || *e.Code == "Rejected.Throttling" || *e.Code == "InvalidIpStatus.HasBeenUsedByForwardEntry" || throttlingRegex.MatchString(*e.Code) || codeRegex.MatchString(*e.Message) {
 			return true
 		}
 	}
 
 	if e, ok := err.(*errors.ServerError); ok {
-		return e.ErrorCode() == ServiceUnavailable || e.ErrorCode() == "Rejected.Throttling" || throttlingRegex.MatchString(e.ErrorCode()) || codeRegex.MatchString(e.Message())
+		return e.ErrorCode() == ServiceUnavailable || e.ErrorCode() == "Rejected.Throttling" || e.ErrorCode() == "InvalidIpStatus.HasBeenUsedByForwardEntry" || throttlingRegex.MatchString(e.ErrorCode()) || codeRegex.MatchString(e.Message())
 	}
 
 	if e, ok := err.(*common.Error); ok {
-		return e.Code == ServiceUnavailable || e.Code == "Rejected.Throttling" || throttlingRegex.MatchString(e.Code) || codeRegex.MatchString(e.Message)
+		return e.Code == ServiceUnavailable || e.Code == "Rejected.Throttling" || e.Code == "InvalidIpStatus.HasBeenUsedByForwardEntry" || throttlingRegex.MatchString(e.Code) || codeRegex.MatchString(e.Message)
 	}
 
 	return false

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -224,17 +224,17 @@ func NeedRetry(err error) bool {
 		if strings.Contains(*e.Message, "Client.Timeout") {
 			return true
 		}
-		if *e.Code == ServiceUnavailable || *e.Code == "Rejected.Throttling" || *e.Code == "InvalidIpStatus.HasBeenUsedByForwardEntry" || throttlingRegex.MatchString(*e.Code) || codeRegex.MatchString(*e.Message) {
+		if *e.Code == ServiceUnavailable || *e.Code == "Rejected.Throttling" || *e.Code == "InvalidIpStatus.HasBeenUsedByForwardEntry" || *e.Code == "OrderFailed" || throttlingRegex.MatchString(*e.Code) || codeRegex.MatchString(*e.Message) {
 			return true
 		}
 	}
 
 	if e, ok := err.(*errors.ServerError); ok {
-		return e.ErrorCode() == ServiceUnavailable || e.ErrorCode() == "Rejected.Throttling" || e.ErrorCode() == "InvalidIpStatus.HasBeenUsedByForwardEntry" || throttlingRegex.MatchString(e.ErrorCode()) || codeRegex.MatchString(e.Message())
+		return e.ErrorCode() == ServiceUnavailable || e.ErrorCode() == "Rejected.Throttling" || e.ErrorCode() == "InvalidIpStatus.HasBeenUsedByForwardEntry" || e.ErrorCode() == "OrderFailed" || throttlingRegex.MatchString(e.ErrorCode()) || codeRegex.MatchString(e.Message())
 	}
 
 	if e, ok := err.(*common.Error); ok {
-		return e.Code == ServiceUnavailable || e.Code == "Rejected.Throttling" || e.Code == "InvalidIpStatus.HasBeenUsedByForwardEntry" || throttlingRegex.MatchString(e.Code) || codeRegex.MatchString(e.Message)
+		return e.Code == ServiceUnavailable || e.Code == "Rejected.Throttling" || e.Code == "InvalidIpStatus.HasBeenUsedByForwardEntry" || e.Code == "OrderFailed" || throttlingRegex.MatchString(e.Code) || codeRegex.MatchString(e.Message)
 	}
 
 	return false

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -170,6 +170,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_ens_nat_gateway_forward_entries":                dataSourceAliCloudEnsNatGatewayForwardEntries(),
 			"alicloud_apig_ai_model_providers":                        dataSourceAliCloudApigAiModelProviders(),
 			"alicloud_apig_services":                                  dataSourceAliCloudApigServices(),
 			"alicloud_apig_gateways":                                  dataSourceAliCloudApigGateways(),
@@ -949,6 +950,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_ens_nat_gateway_forward_entry":                        resourceAliCloudEnsNatGatewayForwardEntry(),
 			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),
 			"alicloud_apig_ai_model_provider":                               resourceAliCloudApigAiModelProvider(),
 			"alicloud_apig_service":                                         resourceAliCloudApigService(),

--- a/alicloud/resource_alicloud_ens_eip.go
+++ b/alicloud/resource_alicloud_ens_eip.go
@@ -43,6 +43,10 @@ func resourceAliCloudEnsEip() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"ens_region_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -149,6 +153,7 @@ func resourceAliCloudEnsEipRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("create_time", objectRaw["AllocationTime"])
 	d.Set("description", objectRaw["Description"])
 	d.Set("eip_name", objectRaw["Name"])
+	d.Set("ip_address", objectRaw["IpAddress"])
 	d.Set("ens_region_id", objectRaw["EnsRegionId"])
 	d.Set("internet_charge_type", objectRaw["InternetChargeType"])
 	d.Set("isp", objectRaw["Isp"])

--- a/alicloud/resource_alicloud_ens_nat_gateway_forward_entry.go
+++ b/alicloud/resource_alicloud_ens_nat_gateway_forward_entry.go
@@ -1,0 +1,262 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudEnsNatGatewayForwardEntry() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudEnsNatGatewayForwardEntryCreate,
+		Read:   resourceAliCloudEnsNatGatewayForwardEntryRead,
+		Update: resourceAliCloudEnsNatGatewayForwardEntryUpdate,
+		Delete: resourceAliCloudEnsNatGatewayForwardEntryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"external_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"external_port": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"forward_entry_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"health_check_port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"internal_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"internal_port": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ip_protocol": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"TCP", "UDP", "Any"}, false),
+			},
+			"nat_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudEnsNatGatewayForwardEntryCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateForwardEntry"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["ExternalIp"] = d.Get("external_ip")
+	request["ExternalPort"] = d.Get("external_port")
+	request["InternalIp"] = d.Get("internal_ip")
+	request["InternalPort"] = d.Get("internal_port")
+	if v, ok := d.GetOk("forward_entry_name"); ok {
+		request["ForwardEntryName"] = v
+	}
+	if v, ok := d.GetOk("ip_protocol"); ok {
+		request["IpProtocol"] = v
+	}
+	if v, ok := d.GetOkExists("health_check_port"); ok {
+		request["HealthCheckPort"] = v
+	}
+	request["NatGatewayId"] = d.Get("nat_gateway_id")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ens_nat_gateway_forward_entry", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["ForwardEntryId"]))
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, ensServiceV2.EnsNatGatewayForwardEntryStateRefreshFunc(d.Id(), "Status", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return resourceAliCloudEnsNatGatewayForwardEntryRead(d, meta)
+}
+
+func resourceAliCloudEnsNatGatewayForwardEntryRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ensServiceV2 := EnsServiceV2{client}
+
+	objectRaw, err := ensServiceV2.DescribeEnsNatGatewayForwardEntry(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ens_nat_gateway_forward_entry DescribeEnsNatGatewayForwardEntry Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("external_ip", objectRaw["ExternalIp"])
+	d.Set("external_port", objectRaw["ExternalPort"])
+	d.Set("forward_entry_name", objectRaw["ForwardEntryName"])
+	d.Set("health_check_port", formatInt(objectRaw["HealthCheckPort"]))
+	d.Set("internal_ip", objectRaw["InternalIp"])
+	d.Set("internal_port", objectRaw["InternalPort"])
+	d.Set("ip_protocol", objectRaw["IpProtocol"])
+	d.Set("nat_gateway_id", objectRaw["NatGatewayId"])
+	d.Set("status", objectRaw["Status"])
+
+	return nil
+}
+
+func resourceAliCloudEnsNatGatewayForwardEntryUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "ModifyForwardEntry"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ForwardEntryId"] = d.Id()
+
+	if d.HasChange("forward_entry_name") {
+		update = true
+		request["ForwardEntryName"] = d.Get("forward_entry_name")
+	}
+
+	if d.HasChange("health_check_port") {
+		update = true
+		request["HealthCheckPort"] = d.Get("health_check_port")
+	}
+
+	if d.HasChange("external_ip") {
+		update = true
+	}
+	request["ExternalIp"] = d.Get("external_ip")
+	if d.HasChange("external_port") {
+		update = true
+	}
+	request["ExternalPort"] = d.Get("external_port")
+	if d.HasChange("internal_ip") {
+		update = true
+	}
+	request["InternalIp"] = d.Get("internal_ip")
+	if d.HasChange("internal_port") {
+		update = true
+	}
+	request["InternalPort"] = d.Get("internal_port")
+	if d.HasChange("ip_protocol") {
+		update = true
+		request["IpProtocol"] = d.Get("ip_protocol")
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		ensServiceV2 := EnsServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ensServiceV2.EnsNatGatewayForwardEntryStateRefreshFunc(d.Id(), "Status", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+
+	return resourceAliCloudEnsNatGatewayForwardEntryRead(d, meta)
+}
+
+func resourceAliCloudEnsNatGatewayForwardEntryDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteForwardEntry"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["ForwardEntryId"] = d.Id()
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"InvalidParameter.DnatNotFound"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 5*time.Second, ensServiceV2.EnsNatGatewayForwardEntryStateRefreshFunc(d.Id(), "$.ForwardEntryId", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ens_nat_gateway_forward_entry_test.go
+++ b/alicloud/resource_alicloud_ens_nat_gateway_forward_entry_test.go
@@ -1,0 +1,222 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Ens NatGatewayForwardEntry. >>> Resource test cases, automatically generated.
+// Case Dnat规则_20241218_TCP 9627
+func TestAccAliCloudEnsNatGatewayForwardEntry_basic9627(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_nat_gateway_forward_entry.default"
+	ra := resourceAttrInit(resourceId, AlicloudEnsNatGatewayForwardEntryMap9627)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsNatGatewayForwardEntry")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccens%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudEnsNatGatewayForwardEntryBasicDependence9627)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"external_port":      "100/200",
+					"external_ip":        "${alicloud_ens_eip.defaultLQgQB6.ip_address}",
+					"ip_protocol":        "TCP",
+					"internal_port":      "100/200",
+					"health_check_port":  "150",
+					"nat_gateway_id":     "${alicloud_ens_nat_gateway.defaultlZ7YKl.id}",
+					"forward_entry_name": "测试用例-dnat",
+					"internal_ip":        "${alicloud_ens_instance.defaulth6OQ3p.private_ip_address}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"external_port":      "100/200",
+						"external_ip":        CHECKSET,
+						"ip_protocol":        "TCP",
+						"internal_port":      "100/200",
+						"health_check_port":  "150",
+						"nat_gateway_id":     CHECKSET,
+						"forward_entry_name": "测试用例-dnat",
+						"internal_ip":        CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"external_port":      "151/151",
+					"external_ip":        "${alicloud_ens_eip.eip2.ip_address}",
+					"ip_protocol":        "UDP",
+					"internal_port":      "151/151",
+					"health_check_port":  "151",
+					"forward_entry_name": "test2",
+					"internal_ip":        "${alicloud_ens_instance.instance2.private_ip_address}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"external_port":      "151/151",
+						"external_ip":        CHECKSET,
+						"ip_protocol":        "UDP",
+						"internal_port":      "151/151",
+						"health_check_port":  "151",
+						"forward_entry_name": "test2",
+						"internal_ip":        CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ip_protocol": "Any",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ip_protocol": "Any",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudEnsNatGatewayForwardEntryMap9627 = map[string]string{
+	"status": CHECKSET,
+}
+
+func AlicloudEnsNatGatewayForwardEntryBasicDependence9627(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-44"
+}
+
+resource "alicloud_ens_network" "default6T9qR2" {
+  network_name  = "测试用例_Dnat"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default5BAAN2" {
+  cidr_block    = "10.0.6.0/24"
+  vswitch_name  = "测试用例-dnat"
+  ens_region_id = alicloud_ens_network.default6T9qR2.ens_region_id
+  network_id    = alicloud_ens_network.default6T9qR2.id
+}
+
+resource "alicloud_ens_nat_gateway" "defaultlZ7YKl" {
+  vswitch_id    = alicloud_ens_vswitch.default5BAAN2.id
+  ens_region_id = alicloud_ens_vswitch.default5BAAN2.ens_region_id
+  network_id    = alicloud_ens_vswitch.default5BAAN2.network_id
+  instance_type = "enat.default"
+  nat_name      = "测试用例-dnat"
+}
+
+resource "alicloud_ens_eip" "defaultLQgQB6" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "测试用例-dnat"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultc19VZl" {
+  instance_id   = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+  allocation_id = alicloud_ens_eip.defaultLQgQB6.id
+  instance_type = "Nat"
+}
+
+resource "alicloud_ens_instance" "defaulth6OQ3p" {
+  auto_renew = false
+  system_disk {
+    size     = "20"
+    category = "cloud_efficiency"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.stiny"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  amount                     = "1"
+  vswitch_id                 = alicloud_ens_vswitch.default5BAAN2.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "测试用例-dnat"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+  period_unit                = "Month"
+}
+
+resource "alicloud_ens_eip" "eip2" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "测试用例-dnat2"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "default4Ph8bE" {
+  instance_id   = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+  allocation_id = alicloud_ens_eip.eip2.id
+  instance_type = "Nat"
+}
+
+resource "alicloud_ens_instance" "instance2" {
+  auto_renew = false
+  system_disk {
+    size     = "20"
+    category = "cloud_efficiency"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.stiny"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  amount                     = "1"
+  vswitch_id                 = alicloud_ens_vswitch.default5BAAN2.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "测试用例-dnat2"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+  period_unit                = "Month"
+}
+
+
+`, name)
+}
+
+// Test Ens NatGatewayForwardEntry. <<< Resource test cases, automatically generated.

--- a/alicloud/resource_alicloud_ens_nat_gateway_forward_entry_test.go
+++ b/alicloud/resource_alicloud_ens_nat_gateway_forward_entry_test.go
@@ -109,7 +109,7 @@ variable "name" {
 }
 
 variable "ens_region_id" {
-  default = "cn-hangzhou-44"
+  default = "cn-chenzhou-telecom_unicom_cmcc"
 }
 
 resource "alicloud_ens_network" "default6T9qR2" {

--- a/alicloud/service_alicloud_ens_v2.go
+++ b/alicloud/service_alicloud_ens_v2.go
@@ -1168,3 +1168,73 @@ func (s *EnsServiceV2) SetResourceTags(d *schema.ResourceData, resourceType stri
 }
 
 // SetResourceTags >>> tag function encapsulated.
+// DescribeEnsNatGatewayForwardEntry <<< Encapsulated get interface for Ens NatGatewayForwardEntry.
+
+func (s *EnsServiceV2) DescribeEnsNatGatewayForwardEntry(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ForwardEntryId"] = id
+
+	action := "DescribeForwardEntryAttribute"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"InvalidForwardEntryId.NotFound"}) {
+			return object, WrapErrorf(NotFoundErr("NatGatewayForwardEntry", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *EnsServiceV2) EnsNatGatewayForwardEntryStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.EnsNatGatewayForwardEntryStateRefreshFuncWithApi(id, field, failStates, s.DescribeEnsNatGatewayForwardEntry)
+}
+
+func (s *EnsServiceV2) EnsNatGatewayForwardEntryStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeEnsNatGatewayForwardEntry >>> Encapsulated.

--- a/website/docs/d/ens_nat_gateway_forward_entries.html.markdown
+++ b/website/docs/d/ens_nat_gateway_forward_entries.html.markdown
@@ -1,0 +1,191 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_nat_gateway_forward_entries"
+sidebar_current: "docs-alicloud-datasource-ens-nat-gateway-forward-entries"
+description: |-
+  Provides a list of ENS Nat Gateway Forward Entry owned by an Alibaba Cloud account.
+---
+
+# alicloud_ens_nat_gateway_forward_entries
+
+This data source provides ENS Nat Gateway Forward Entry available to the user.[What is Nat Gateway Forward Entry](https://next.api.alibabacloud.com/document/Ens/2017-11-10/CreateForwardEntry)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = ""
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-44"
+}
+
+resource "alicloud_ens_network" "default6T9qR2" {
+  network_name  = "测试用例_Dnat"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default5BAAN2" {
+  cidr_block    = "10.0.6.0/24"
+  vswitch_name  = "测试用例-dnat"
+  ens_region_id = alicloud_ens_network.default6T9qR2.ens_region_id
+  network_id    = alicloud_ens_network.default6T9qR2.id
+}
+
+resource "alicloud_ens_nat_gateway" "defaultlZ7YKl" {
+  vswitch_id    = alicloud_ens_vswitch.default5BAAN2.id
+  ens_region_id = alicloud_ens_vswitch.default5BAAN2.ens_region_id
+  network_id    = alicloud_ens_vswitch.default5BAAN2.network_id
+  instance_type = "enat.default"
+  nat_name      = "测试用例-dnat"
+}
+
+resource "alicloud_ens_eip" "defaultLQgQB6" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "测试用例-dnat"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultc19VZl" {
+  instance_id   = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+  allocation_id = alicloud_ens_eip.defaultLQgQB6.id
+  instance_type = "Nat"
+}
+
+resource "alicloud_ens_instance" "defaulth6OQ3p" {
+  auto_renew = false
+  system_disk {
+    size     = "20"
+    category = "cloud_efficiency"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.stiny"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  amount                     = "1"
+  vswitch_id                 = alicloud_ens_vswitch.default5BAAN2.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "测试用例-dnat"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+  period_unit                = "Month"
+}
+
+resource "alicloud_ens_eip" "eip2" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "测试用例-dnat2"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "default4Ph8bE" {
+  instance_id   = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+  allocation_id = alicloud_ens_eip.eip2.id
+  instance_type = "Nat"
+}
+
+resource "alicloud_ens_instance" "instance2" {
+  auto_renew = false
+  system_disk {
+    size     = "20"
+    category = "cloud_efficiency"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.stiny"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  amount                     = "1"
+  vswitch_id                 = alicloud_ens_vswitch.default5BAAN2.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "测试用例-dnat2"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+  period_unit                = "Month"
+}
+
+
+resource "alicloud_ens_nat_gateway_forward_entry" "default" {
+  external_port      = "100/200"
+  external_ip        = alicloud_ens_eip.defaultLQgQB6.ip_address
+  ip_protocol        = "TCP"
+  internal_port      = "100/200"
+  health_check_port  = "150"
+  nat_gateway_id     = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+  forward_entry_name = "测试用例-dnat"
+  internal_ip        = alicloud_ens_instance.defaulth6OQ3p.private_ip_address
+}
+
+data "alicloud_ens_nat_gateway_forward_entries" "default" {
+  ids                = ["${alicloud_ens_nat_gateway_forward_entry.default.id}"]
+  external_ip        = alicloud_ens_eip.defaultLQgQB6.ip_address
+  forward_entry_name = "测试用例-dnat"
+  internal_ip        = alicloud_ens_instance.defaulth6OQ3p.private_ip_address
+  ip_protocol        = "TCP"
+  nat_gateway_id     = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+}
+
+output "alicloud_ens_nat_gateway_forward_entry_example_id" {
+  value = data.alicloud_ens_nat_gateway_forward_entries.default.entries.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `external_ip` - (Optional) The elastic public IP address that provides public network access in the DNAT entry.
+* `forward_entry_id` - (Optional) The ID of the DNAT entry.
+* `forward_entry_name` - (Optional) The name of the DNAT entry.
+* `internal_ip` - (Optional) The private IP address of the instance that uses the DNAT entry for public network communication.
+* `ip_protocol` - (Optional) Protocol type, value:
+  - `TCP`: forwards TCP packets.
+  - `UDP`: forwards UDP packets.
+  - `Any`: Forward messages of all protocols.
+* `nat_gateway_id` - (Required) The ID of the NAT gateway.
+* `ids` - (Optional, Computed) A list of Nat Gateway Forward Entry IDs. 
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Nat Gateway Forward Entry IDs.
+* `entries` - A list of Nat Gateway Forward Entry Entries. Each element contains the following attributes:
+    * `external_ip` - The elastic public IP address that provides public network access in the DNAT entry.
+    * `external_port` - The external port or port segment for port forwarding.
+    * `forward_entry_id` - The ID of the DNAT entry.
+    * `forward_entry_name` - The name of the DNAT entry.
+    * `health_check_port` - The detection port of DNAT must be within the intranet port range.
+    * `internal_ip` - The private IP address of the instance that uses the DNAT entry for public network communication.
+    * `internal_port` - Internal port or port segment for port forwarding.
+    * `ip_protocol` - Protocol type, value:.
+    * `nat_gateway_id` - The ID of the NAT gateway.
+    * `status` - DNAT entry status, value:.
+    * `id` - The ID of the resource supplied above.

--- a/website/docs/r/ens_nat_gateway_forward_entry.html.markdown
+++ b/website/docs/r/ens_nat_gateway_forward_entry.html.markdown
@@ -1,0 +1,186 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_nat_gateway_forward_entry"
+description: |-
+  Provides a Alicloud ENS Nat Gateway Forward Entry resource.
+---
+
+# alicloud_ens_nat_gateway_forward_entry
+
+Provides a ENS Nat Gateway Forward Entry resource.
+
+
+
+For information about ENS Nat Gateway Forward Entry and how to use it, see [What is Nat Gateway Forward Entry](https://next.api.alibabacloud.com/document/Ens/2017-11-10/CreateForwardEntry).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-44"
+}
+
+resource "alicloud_ens_network" "default6T9qR2" {
+  network_name  = "example用例_Dnat"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default5BAAN2" {
+  cidr_block    = "10.0.6.0/24"
+  vswitch_name  = "example用例-dnat"
+  ens_region_id = alicloud_ens_network.default6T9qR2.ens_region_id
+  network_id    = alicloud_ens_network.default6T9qR2.id
+}
+
+resource "alicloud_ens_nat_gateway" "defaultlZ7YKl" {
+  vswitch_id    = alicloud_ens_vswitch.default5BAAN2.id
+  ens_region_id = alicloud_ens_vswitch.default5BAAN2.ens_region_id
+  network_id    = alicloud_ens_vswitch.default5BAAN2.network_id
+  instance_type = "enat.default"
+  nat_name      = "example用例-dnat"
+}
+
+resource "alicloud_ens_eip" "defaultLQgQB6" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "example用例-dnat"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultc19VZl" {
+  instance_id   = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+  allocation_id = alicloud_ens_eip.defaultLQgQB6.id
+  instance_type = "Nat"
+}
+
+resource "alicloud_ens_instance" "defaulth6OQ3p" {
+  auto_renew = false
+  system_disk {
+    size     = "20"
+    category = "cloud_efficiency"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.stiny"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  amount                     = "1"
+  vswitch_id                 = alicloud_ens_vswitch.default5BAAN2.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "example用例-dnat"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+  period_unit                = "Month"
+}
+
+resource "alicloud_ens_eip" "eip2" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "example用例-dnat2"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "default4Ph8bE" {
+  instance_id   = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+  allocation_id = alicloud_ens_eip.eip2.id
+  instance_type = "Nat"
+}
+
+resource "alicloud_ens_instance" "instance2" {
+  auto_renew = false
+  system_disk {
+    size     = "20"
+    category = "cloud_efficiency"
+  }
+  scheduling_strategy        = "Concentrate"
+  schedule_area_level        = "Region"
+  image_id                   = "centos_6_08_64_20G_alibase_20171208"
+  payment_type               = "Subscription"
+  instance_type              = "ens.sn1.stiny"
+  password_inherit           = false
+  password                   = "12345678abcABC"
+  status                     = "Running"
+  amount                     = "1"
+  vswitch_id                 = alicloud_ens_vswitch.default5BAAN2.id
+  internet_charge_type       = "95BandwidthByMonth"
+  instance_name              = "example用例-dnat2"
+  internet_max_bandwidth_out = "0"
+  unique_suffix              = false
+  auto_use_coupon            = "true"
+  public_ip_identification   = false
+  instance_charge_strategy   = "PriceHighPriority"
+  ens_region_id              = var.ens_region_id
+  period_unit                = "Month"
+}
+
+
+resource "alicloud_ens_nat_gateway_forward_entry" "default" {
+  external_port      = "100/200"
+  external_ip        = alicloud_ens_eip.defaultLQgQB6.ip_address
+  ip_protocol        = "TCP"
+  internal_port      = "100/200"
+  health_check_port  = "150"
+  nat_gateway_id     = alicloud_ens_nat_gateway.defaultlZ7YKl.id
+  forward_entry_name = "example用例-dnat"
+  internal_ip        = alicloud_ens_instance.defaulth6OQ3p.private_ip_address
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `external_ip` - (Required) The elastic public IP address that provides public network access in the DNAT entry.
+* `external_port` - (Required) The external port or port segment for port forwarding.
+* `forward_entry_name` - (Optional) The name of the DNAT entry.
+* `health_check_port` - (Optional, Int) The detection port of DNAT must be within the intranet port range. The default value is empty.
+* `internal_ip` - (Required) The private IP address of the instance that uses the DNAT entry for public network communication.
+* `internal_port` - (Required) Internal port or port segment for port forwarding.
+* `ip_protocol` - (Optional) Protocol type, value:
+  - `TCP`: forwards TCP packets.
+  - `UDP`: forwards UDP packets.
+  - `Any`: Forward messages of all protocols.
+* `nat_gateway_id` - (Required, ForceNew) The ID of the NAT gateway.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. 
+* `status` - DNAT entry status, value:.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Nat Gateway Forward Entry.
+* `delete` - (Defaults to 5 mins) Used when delete the Nat Gateway Forward Entry.
+* `update` - (Defaults to 5 mins) Used when update the Nat Gateway Forward Entry.
+
+## Import
+
+ENS Nat Gateway Forward Entry can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ens_nat_gateway_forward_entry.example <forward_entry_id>
+```


### PR DESCRIPTION
## Summary
- Support ENS (Edge Node Service) Nat Gateway Forward Entry (DNAT rule) resource and data source. Users can now create, update, import, and delete ENS DNAT forward entries via Terraform, and query existing entries through the data source.

## Test plan
- [ ] `TestAccAliCloudEnsNatGatewayForwardEntry_basic9627`: create -> update (external_ip, external_port, internal_ip, internal_port, ip_protocol, forward_entry_name, health_check_port) -> change ip_protocol to Any -> import -> destroy.
- [ ] `TestAccAlicloudEnsNatGatewayForwardEntryDataSource`: filter by ids, external_ip, forward_entry_name, internal_ip, ip_protocol, nat_gateway_id.
