### PR TITLE
resource/alicloud_ens_nat_gateway_snat_entry: new resource and data source; New Resource: alicloud_ens_nat_gateway_snat_entry, New Data Source: alicloud_ens_nat_gateway_snat_entries; resource/alicloud_ens_eip: support ip_address

### DIFF
--- a/alicloud/data_source_alicloud_ens_nat_gateway_snat_entries.go
+++ b/alicloud/data_source_alicloud_ens_nat_gateway_snat_entries.go
@@ -1,0 +1,220 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudEnsNatGatewaySnatEntries() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudEnsNatGatewaySnatEntryRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"snat_entry_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"snat_entry_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"snat_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"source_cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"nat_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"entries": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"eip_affinity": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"idle_timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"isp_affinity": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"nat_gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"snat_entry_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"snat_entry_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"snat_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_cidr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"standby_snat_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"standby_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudEnsNatGatewaySnatEntryRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeSnatTableEntries"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if v, ok := d.GetOk("snat_entry_id"); ok {
+		request["SnatEntryId"] = v
+	}
+	if v, ok := d.GetOk("snat_entry_name"); ok {
+		request["SnatEntryName"] = v
+	}
+	if v, ok := d.GetOk("snat_ip"); ok {
+		request["SnatIp"] = v
+	}
+	if v, ok := d.GetOk("source_cidr"); ok {
+		request["SourceCIDR"] = v
+	}
+	request["NatGatewayId"] = d.Get("nat_gateway_id")
+	request["PageSize"] = PageSizeLarge
+	request["PageNumber"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.SnatTableEntries[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["SnatEntryId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["SnatEntryId"]
+
+		mapping["eip_affinity"] = objectRaw["EipAffinity"]
+		mapping["idle_timeout"] = formatInt(objectRaw["IdleTimeout"])
+		mapping["isp_affinity"] = objectRaw["IspAffinity"]
+		mapping["nat_gateway_id"] = objectRaw["NatGatewayId"]
+		mapping["snat_entry_name"] = objectRaw["SnatEntryName"]
+		mapping["snat_ip"] = objectRaw["SnatIp"]
+		mapping["source_cidr"] = objectRaw["SourceCIDR"]
+		mapping["standby_snat_ip"] = objectRaw["StandbySnatIp"]
+		mapping["standby_status"] = objectRaw["StandbyStatus"]
+		mapping["status"] = objectRaw["Status"]
+		mapping["snat_entry_id"] = objectRaw["SnatEntryId"]
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("entries", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_ens_nat_gateway_snat_entries_test.go
+++ b/alicloud/data_source_alicloud_ens_nat_gateway_snat_entries_test.go
@@ -1,0 +1,209 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudEnsNatGatewaySnatEntryDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ens_nat_gateway_snat_entry.default.id}_fake"]`,
+		}),
+	}
+
+	SnatIpConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":     `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"snat_ip": `"${alicloud_ens_eip.defaultiUbwh0.ip_address}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":     `["${alicloud_ens_nat_gateway_snat_entry.default.id}_fake"]`,
+			"snat_ip": `"${alicloud_ens_eip.defaultiUbwh0.ip_address}_fake"`,
+		}),
+	}
+	SnatEntryNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":             `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"snat_entry_name": `"测试用例-snat"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":             `["${alicloud_ens_nat_gateway_snat_entry.default.id}_fake"]`,
+			"snat_entry_name": `"测试用例-snat_fake"`,
+		}),
+	}
+	NatGatewayIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_ens_nat_gateway_snat_entry.default.id}_fake"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.default2Kn0nu.id}_fake"`,
+		}),
+	}
+	SourceCidrConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"source_cidr": `"10.0.0.0/8"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":         `["${alicloud_ens_nat_gateway_snat_entry.default.id}_fake"]`,
+			"source_cidr": `"10.0.0.0/8_fake"`,
+		}),
+	}
+	SnatEntryIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":           `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"snat_entry_id": `"${alicloud_ens_nat_gateway_snat_entry.default.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":           `["${alicloud_ens_nat_gateway_snat_entry.default.id}_fake"]`,
+			"snat_entry_id": `"${alicloud_ens_nat_gateway_snat_entry.default.id}_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":             `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"snat_ip":         `"${alicloud_ens_eip.defaultiUbwh0.ip_address}"`,
+			"snat_entry_name": `"测试用例-snat"`,
+			"nat_gateway_id":  `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+			"source_cidr":     `"10.0.0.0/8"`,
+			"snat_entry_id":   `"${alicloud_ens_nat_gateway_snat_entry.default.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":             `["${alicloud_ens_nat_gateway_snat_entry.default.id}_fake"]`,
+			"snat_ip":         `"${alicloud_ens_eip.defaultiUbwh0.ip_address}_fake"`,
+			"snat_entry_name": `"测试用例-snat_fake"`,
+			"nat_gateway_id":  `"${alicloud_ens_nat_gateway.default2Kn0nu.id}_fake"`,
+			"source_cidr":     `"10.0.0.0/8_fake"`,
+			"snat_entry_id":   `"${alicloud_ens_nat_gateway_snat_entry.default.id}_fake"`,
+		}),
+	}
+
+	EnsNatGatewaySnatEntryCheckInfo.dataSourceTestCheck(t, rand, idsConf, SnatIpConf, SnatEntryNameConf, NatGatewayIdConf, SourceCidrConf, SnatEntryIdConf, allConf)
+}
+
+var existEnsNatGatewaySnatEntryMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"entries.#":                 "1",
+		"entries.0.status":          CHECKSET,
+		"entries.0.eip_affinity":    CHECKSET,
+		"entries.0.idle_timeout":    CHECKSET,
+		"entries.0.isp_affinity":    CHECKSET,
+		"entries.0.snat_entry_id":   CHECKSET,
+		"entries.0.snat_entry_name": CHECKSET,
+		"entries.0.snat_ip":         CHECKSET,
+		"entries.0.source_cidr":     CHECKSET,
+		"entries.0.nat_gateway_id":  CHECKSET,
+		"entries.0.standby_snat_ip": CHECKSET,
+		"entries.0.standby_status":  CHECKSET,
+	}
+}
+
+var fakeEnsNatGatewaySnatEntryMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"entries.#": "0",
+	}
+}
+
+var EnsNatGatewaySnatEntryCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_ens_nat_gateway_snat_entries.default",
+	existMapFunc: existEnsNatGatewaySnatEntryMapFunc,
+	fakeMapFunc:  fakeEnsNatGatewaySnatEntryMapFunc,
+}
+
+func testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccEnsNatGatewaySnatEntry%d"
+}
+variable "ens_region_id" {
+  default = "cn-hangzhou-44"
+}
+
+resource "alicloud_ens_network" "defaultXqhlfk" {
+  network_name  = "测试用例-snat"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "defaultzkXvut" {
+  cidr_block    = "10.0.0.0/24"
+  vswitch_name  = "测试用例-snat"
+  ens_region_id = alicloud_ens_network.defaultXqhlfk.ens_region_id
+  network_id    = alicloud_ens_network.defaultXqhlfk.id
+}
+
+resource "alicloud_ens_eip" "defaultiUbwh0" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = alicloud_ens_vswitch.defaultzkXvut.ens_region_id
+  eip_name             = "测试用例-snat"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_nat_gateway" "default2Kn0nu" {
+  vswitch_id    = alicloud_ens_vswitch.defaultzkXvut.id
+  ens_region_id = alicloud_ens_vswitch.defaultzkXvut.ens_region_id
+  network_id    = alicloud_ens_vswitch.defaultzkXvut.network_id
+  instance_type = "enat.default"
+  nat_name      = "测试用例-snat"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultlI0M0t" {
+  instance_id   = alicloud_ens_nat_gateway.default2Kn0nu.id
+  allocation_id = alicloud_ens_eip.defaultiUbwh0.id
+  instance_type = "Nat"
+  standby       = false
+}
+
+resource "alicloud_ens_eip" "eip2" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "测试用例-snat2"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultbMMEpj" {
+  instance_id   = alicloud_ens_nat_gateway.default2Kn0nu.id
+  allocation_id = alicloud_ens_eip.eip2.id
+  instance_type = "Nat"
+  standby       = false
+}
+
+
+
+resource "alicloud_ens_nat_gateway_snat_entry" "default" {
+  snat_entry_name = "测试用例-snat"
+  source_cidr     = "10.0.0.0/8"
+  snat_ip         = alicloud_ens_eip.defaultiUbwh0.ip_address
+  nat_gateway_id  = alicloud_ens_nat_gateway.default2Kn0nu.id
+  idle_timeout    = "50"
+  isp_affinity    = false
+  eip_affinity    = false
+}
+
+data "alicloud_ens_nat_gateway_snat_entries" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -174,6 +174,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"alicloud_ens_load_balancer_udp_listeners":                dataSourceAliCloudEnsLoadBalancerUdpListeners(),
 			"alicloud_ecd_desktop_groups":                             dataSourceAliCloudEcdDesktopGroups(),
+			"alicloud_ens_nat_gateway_snat_entries":                   dataSourceAliCloudEnsNatGatewaySnatEntries(),
 			"alicloud_redis_global_security_ip_groups":                dataSourceAliCloudRedisGlobalSecurityIpGroups(),
 			"alicloud_cr_artifact_subscription_rules":                 dataSourceAliCloudCrArtifactSubscriptionRules(),
 			"alicloud_cms_event_notify_policies":                      dataSourceAliCloudCmsEventNotifyPolicies(),
@@ -968,6 +969,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ens_load_balancer_udp_listener":                       resourceAliCloudEnsLoadBalancerUdpListener(),
 			"alicloud_gpdb_db_extension":                                    resourceAliCloudGpdbDbExtension(),
 			"alicloud_ecd_desktop_group":                                    resourceAliCloudEcdDesktopGroup(),
+			"alicloud_ens_nat_gateway_snat_entry":                           resourceAliCloudEnsNatGatewaySnatEntry(),
 			"alicloud_redis_global_security_ip_group":                       resourceAliCloudRedisGlobalSecurityIpGroup(),
 			"alicloud_cr_artifact_subscription_rule":                        resourceAliCloudCrArtifactSubscriptionRule(),
 			"alicloud_cms_event_notify_policy":                              resourceAliCloudCmsEventNotifyPolicy(),

--- a/alicloud/resource_alicloud_ens_eip.go
+++ b/alicloud/resource_alicloud_ens_eip.go
@@ -54,6 +54,10 @@ func resourceAliCloudEnsEip() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: StringInSlice([]string{"95BandwidthByMonth"}, false),
 			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"isp": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -151,6 +155,7 @@ func resourceAliCloudEnsEipRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("eip_name", objectRaw["Name"])
 	d.Set("ens_region_id", objectRaw["EnsRegionId"])
 	d.Set("internet_charge_type", objectRaw["InternetChargeType"])
+	d.Set("ip_address", objectRaw["IpAddress"])
 	d.Set("isp", objectRaw["Isp"])
 	d.Set("payment_type", convertEnsEipAddressesEipAddressChargeTypeResponse(objectRaw["ChargeType"]))
 	d.Set("status", objectRaw["Status"])

--- a/alicloud/resource_alicloud_ens_nat_gateway_snat_entry.go
+++ b/alicloud/resource_alicloud_ens_nat_gateway_snat_entry.go
@@ -1,0 +1,295 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudEnsNatGatewaySnatEntry() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudEnsNatGatewaySnatEntryCreate,
+		Read:   resourceAliCloudEnsNatGatewaySnatEntryRead,
+		Update: resourceAliCloudEnsNatGatewaySnatEntryUpdate,
+		Delete: resourceAliCloudEnsNatGatewaySnatEntryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dest_cidr": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"eip_affinity": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"idle_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: IntBetween(1, 86400),
+			},
+			"isp_affinity": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"nat_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"snat_entry_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"snat_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"source_cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"source_network_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"source_vswitch_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"standby_snat_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"standby_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudEnsNatGatewaySnatEntryCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateSnatEntry"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["NatGatewayId"] = d.Get("nat_gateway_id")
+	request["SnatIp"] = d.Get("snat_ip")
+	if v, ok := d.GetOk("snat_entry_name"); ok {
+		request["SnatEntryName"] = v
+	}
+	if v, ok := d.GetOk("source_cidr"); ok {
+		request["SourceCIDR"] = v
+	}
+	if v, ok := d.GetOkExists("idle_timeout"); ok {
+		request["IdleTimeout"] = v
+	}
+	if v, ok := d.GetOkExists("isp_affinity"); ok {
+		request["IspAffinity"] = v
+	}
+	if v, ok := d.GetOkExists("eip_affinity"); ok {
+		request["EipAffinity"] = v
+	}
+	if v, ok := d.GetOk("source_vswitch_id"); ok {
+		request["SourceVSwitchId"] = v
+	}
+	if v, ok := d.GetOk("source_network_id"); ok {
+		request["SourceNetworkId"] = v
+	}
+	if v, ok := d.GetOk("standby_snat_ip"); ok {
+		request["StandbySnatIp"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ens_nat_gateway_snat_entry", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["SnatEntryId"]))
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, ensServiceV2.EnsNatGatewaySnatEntryStateRefreshFunc(d.Id(), "Status", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return resourceAliCloudEnsNatGatewaySnatEntryRead(d, meta)
+}
+
+func resourceAliCloudEnsNatGatewaySnatEntryRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ensServiceV2 := EnsServiceV2{client}
+
+	objectRaw, err := ensServiceV2.DescribeEnsNatGatewaySnatEntry(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ens_nat_gateway_snat_entry DescribeEnsNatGatewaySnatEntry Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("eip_affinity", objectRaw["EipAffinity"])
+	d.Set("idle_timeout", formatInt(objectRaw["IdleTimeout"]))
+	d.Set("isp_affinity", objectRaw["IspAffinity"])
+	d.Set("nat_gateway_id", objectRaw["NatGatewayId"])
+	d.Set("snat_entry_name", objectRaw["SnatEntryName"])
+	d.Set("snat_ip", objectRaw["SnatIp"])
+	d.Set("source_cidr", objectRaw["SourceCIDR"])
+	d.Set("standby_snat_ip", objectRaw["StandbySnatIp"])
+	d.Set("standby_status", objectRaw["StandbyStatus"])
+	d.Set("type", objectRaw["Type"])
+	d.Set("creation_time", objectRaw["CreationTime"])
+	d.Set("dest_cidr", objectRaw["DestCIDR"])
+	d.Set("status", objectRaw["Status"])
+
+	return nil
+}
+
+func resourceAliCloudEnsNatGatewaySnatEntryUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "ModifySnatEntry"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["SnatEntryId"] = d.Id()
+
+	if d.HasChange("snat_entry_name") {
+		update = true
+		request["SnatEntryName"] = d.Get("snat_entry_name")
+	}
+
+	if d.HasChange("isp_affinity") {
+		update = true
+		request["IspAffinity"] = d.Get("isp_affinity")
+	}
+
+	if d.HasChange("eip_affinity") {
+		update = true
+		request["EipAffinity"] = d.Get("eip_affinity")
+	}
+
+	if d.HasChange("snat_ip") {
+		update = true
+	}
+	request["SnatIp"] = d.Get("snat_ip")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		ensServiceV2 := EnsServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ensServiceV2.EnsNatGatewaySnatEntryStateRefreshFunc(d.Id(), "Status", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+
+	return resourceAliCloudEnsNatGatewaySnatEntryRead(d, meta)
+}
+
+func resourceAliCloudEnsNatGatewaySnatEntryDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteSnatEntry"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["SnatEntryId"] = d.Id()
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"InvalidParameter.SnatNotFound"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 5*time.Second, ensServiceV2.EnsNatGatewaySnatEntryStateRefreshFunc(d.Id(), "$.SnatEntryId", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ens_nat_gateway_snat_entry_test.go
+++ b/alicloud/resource_alicloud_ens_nat_gateway_snat_entry_test.go
@@ -1,0 +1,166 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Ens NatGatewaySnatEntry. >>> Resource test cases, automatically generated.
+// Case Snat_20241218 9626
+func TestAccAliCloudEnsNatGatewaySnatEntry_basic9626(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_nat_gateway_snat_entry.default"
+	ra := resourceAttrInit(resourceId, AlicloudEnsNatGatewaySnatEntryMap9626)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsNatGatewaySnatEntry")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccens%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudEnsNatGatewaySnatEntryBasicDependence9626)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"snat_entry_name":   "测试用例-snat",
+					"source_cidr":       "10.0.0.0/8",
+					"snat_ip":           "${alicloud_ens_eip.defaultiUbwh0.ip_address}",
+					"nat_gateway_id":    "${alicloud_ens_nat_gateway.default2Kn0nu.id}",
+					"idle_timeout":      "50",
+					"isp_affinity":      "false",
+					"eip_affinity":      "false",
+					"source_vswitch_id": "${alicloud_ens_vswitch.defaultzkXvut.id}",
+					"source_network_id": "${alicloud_ens_network.defaultXqhlfk.id}",
+					"standby_snat_ip":   "${alicloud_ens_eip.eip2.ip_address}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"snat_entry_name":   "测试用例-snat",
+						"source_cidr":       "10.0.0.0/8",
+						"snat_ip":           CHECKSET,
+						"nat_gateway_id":    CHECKSET,
+						"idle_timeout":      "50",
+						"isp_affinity":      "false",
+						"eip_affinity":      "false",
+						"source_vswitch_id": CHECKSET,
+						"source_network_id": CHECKSET,
+						"standby_snat_ip":   CHECKSET,
+						"standby_status":    CHECKSET,
+						"type":              CHECKSET,
+						"creation_time":     CHECKSET,
+						"dest_cidr":         CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"snat_entry_name": "测试用例-snat2",
+					"snat_ip":         "${alicloud_ens_eip.eip2.ip_address}",
+					"isp_affinity":    "true",
+					"eip_affinity":    "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"snat_entry_name": "测试用例-snat2",
+						"snat_ip":         CHECKSET,
+						"isp_affinity":    "true",
+						"eip_affinity":    "true",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudEnsNatGatewaySnatEntryMap9626 = map[string]string{
+	"status":         CHECKSET,
+	"standby_status": CHECKSET,
+	"type":           CHECKSET,
+	"creation_time":  CHECKSET,
+	"dest_cidr":      CHECKSET,
+}
+
+func AlicloudEnsNatGatewaySnatEntryBasicDependence9626(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-44"
+}
+
+resource "alicloud_ens_network" "defaultXqhlfk" {
+  network_name  = "测试用例-snat"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "defaultzkXvut" {
+  cidr_block    = "10.0.0.0/24"
+  vswitch_name  = "测试用例-snat"
+  ens_region_id = alicloud_ens_network.defaultXqhlfk.ens_region_id
+  network_id    = alicloud_ens_network.defaultXqhlfk.id
+}
+
+resource "alicloud_ens_eip" "defaultiUbwh0" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = alicloud_ens_vswitch.defaultzkXvut.ens_region_id
+  eip_name             = "测试用例-snat"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_nat_gateway" "default2Kn0nu" {
+  vswitch_id    = alicloud_ens_vswitch.defaultzkXvut.id
+  ens_region_id = alicloud_ens_vswitch.defaultzkXvut.ens_region_id
+  network_id    = alicloud_ens_vswitch.defaultzkXvut.network_id
+  instance_type = "enat.default"
+  nat_name      = "测试用例-snat"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultlI0M0t" {
+  instance_id   = alicloud_ens_nat_gateway.default2Kn0nu.id
+  allocation_id = alicloud_ens_eip.defaultiUbwh0.id
+  instance_type = "Nat"
+  standby       = false
+}
+
+resource "alicloud_ens_eip" "eip2" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "测试用例-snat2"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultbMMEpj" {
+  instance_id   = alicloud_ens_nat_gateway.default2Kn0nu.id
+  allocation_id = alicloud_ens_eip.eip2.id
+  instance_type = "Nat"
+  standby       = false
+}
+
+
+`, name)
+}
+
+// Test Ens NatGatewaySnatEntry. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_ens_v2.go
+++ b/alicloud/service_alicloud_ens_v2.go
@@ -1568,3 +1568,74 @@ func (s *EnsServiceV2) EnsLoadBalancerUdpListenerStateRefreshFuncWithApi(id stri
 }
 
 // DescribeEnsLoadBalancerUdpListener >>> Encapsulated.
+
+// DescribeEnsNatGatewaySnatEntry <<< Encapsulated get interface for Ens NatGatewaySnatEntry.
+
+func (s *EnsServiceV2) DescribeEnsNatGatewaySnatEntry(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["SnatEntryId"] = id
+
+	action := "DescribeSnatAttribute"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"InvalidParameter.SnatNotFound"}) {
+			return object, WrapErrorf(NotFoundErr("NatGatewaySnatEntry", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *EnsServiceV2) EnsNatGatewaySnatEntryStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.EnsNatGatewaySnatEntryStateRefreshFuncWithApi(id, field, failStates, s.DescribeEnsNatGatewaySnatEntry)
+}
+
+func (s *EnsServiceV2) EnsNatGatewaySnatEntryStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeEnsNatGatewaySnatEntry >>> Encapsulated.

--- a/website/docs/d/ens_nat_gateway_snat_entries.html.markdown
+++ b/website/docs/d/ens_nat_gateway_snat_entries.html.markdown
@@ -1,0 +1,134 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_nat_gateway_snat_entries"
+sidebar_current: "docs-alicloud-datasource-ens-nat-gateway-snat-entries"
+description: |-
+  Provides a list of ENS Nat Gateway Snat Entry owned by an Alibaba Cloud account.
+---
+
+# alicloud_ens_nat_gateway_snat_entries
+
+This data source provides ENS Nat Gateway Snat Entry available to the user.[What is Nat Gateway Snat Entry](https://next.api.alibabacloud.com/document/Ens/2017-11-10/CreateSnatEntry)
+
+-> **NOTE:** Available since v1.289.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = ""
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-44"
+}
+
+resource "alicloud_ens_network" "defaultXqhlfk" {
+  network_name  = "example-snat"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "defaultzkXvut" {
+  cidr_block    = "10.0.0.0/24"
+  vswitch_name  = "example-snat"
+  ens_region_id = alicloud_ens_network.defaultXqhlfk.ens_region_id
+  network_id    = alicloud_ens_network.defaultXqhlfk.id
+}
+
+resource "alicloud_ens_eip" "defaultiUbwh0" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = alicloud_ens_vswitch.defaultzkXvut.ens_region_id
+  eip_name             = "example-snat"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_nat_gateway" "default2Kn0nu" {
+  vswitch_id    = alicloud_ens_vswitch.defaultzkXvut.id
+  ens_region_id = alicloud_ens_vswitch.defaultzkXvut.ens_region_id
+  network_id    = alicloud_ens_vswitch.defaultzkXvut.network_id
+  instance_type = "enat.default"
+  nat_name      = "example-snat"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultlI0M0t" {
+  instance_id   = alicloud_ens_nat_gateway.default2Kn0nu.id
+  allocation_id = alicloud_ens_eip.defaultiUbwh0.id
+  instance_type = "Nat"
+  standby       = false
+}
+
+resource "alicloud_ens_eip" "eip2" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "example-snat2"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultbMMEpj" {
+  instance_id   = alicloud_ens_nat_gateway.default2Kn0nu.id
+  allocation_id = alicloud_ens_eip.eip2.id
+  instance_type = "Nat"
+  standby       = false
+}
+
+
+resource "alicloud_ens_nat_gateway_snat_entry" "default" {
+  snat_entry_name = "example-snat"
+  source_cidr     = "10.0.0.0/8"
+  snat_ip         = alicloud_ens_eip.defaultiUbwh0.ip_address
+  nat_gateway_id  = alicloud_ens_nat_gateway.default2Kn0nu.id
+  idle_timeout    = "50"
+  isp_affinity    = false
+  eip_affinity    = false
+}
+
+data "alicloud_ens_nat_gateway_snat_entries" "default" {
+  ids             = ["${alicloud_ens_nat_gateway_snat_entry.default.id}"]
+  snat_ip         = alicloud_ens_eip.defaultiUbwh0.ip_address
+  snat_entry_name = "example-snat"
+  source_cidr     = "10.0.0.0/8"
+  nat_gateway_id  = alicloud_ens_nat_gateway.default2Kn0nu.id
+}
+
+output "alicloud_ens_nat_gateway_snat_entry_example_id" {
+  value = data.alicloud_ens_nat_gateway_snat_entries.default.entries.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `snat_entry_id` - (Optional) The ID of the SNAT entry.
+* `snat_entry_name` - (Optional) The name of the SNAT entry.
+* `snat_ip` - (Optional) The EIPs in the SNAT entry. Separate multiple EIPs with commas (,).
+* `source_cidr` - (Optional) The source CIDR block of the SNAT entry.
+* `nat_gateway_id` - (Required) The ID of the NAT gateway.
+* `ids` - (Optional, Computed) A list of Nat Gateway Snat Entry IDs.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Nat Gateway Snat Entry IDs.
+* `entries` - A list of Nat Gateway Snat Entry Entries. Each element contains the following attributes:
+  * `eip_affinity` - Whether to enable IP affinity.
+  * `idle_timeout` - The idle timeout. Valid values: 1 to 86400. Unit: seconds.
+  * `isp_affinity` - Whether to open the operator affinity.
+  * `nat_gateway_id` - The ID of the NAT gateway.
+  * `snat_entry_id` - The ID of the SNAT entry.
+  * `snat_entry_name` - The name of the SNAT entry.
+  * `snat_ip` - The EIPs in the SNAT entry.
+  * `source_cidr` - The source CIDR block of the SNAT entry.
+  * `standby_snat_ip` - The standby EIPs in the SNAT entry.
+  * `standby_status` - The status of the standby EIP.
+  * `status` - SNAT entry status.
+  * `id` - The ID of the resource supplied above.

--- a/website/docs/r/ens_eip.html.markdown
+++ b/website/docs/r/ens_eip.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 The following attributes are exported:
 * `id` - The ID of the resource supplied above.
 * `create_time` - The creation time of the EIP instance.
+* `ip_address` - The elastic IP address of the EIP.
 * `status` - The status of the EIP.
 
 ## Timeouts

--- a/website/docs/r/ens_nat_gateway_snat_entry.html.markdown
+++ b/website/docs/r/ens_nat_gateway_snat_entry.html.markdown
@@ -1,0 +1,139 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_nat_gateway_snat_entry"
+description: |-
+  Provides a Alicloud ENS Nat Gateway Snat Entry resource.
+---
+
+# alicloud_ens_nat_gateway_snat_entry
+
+Provides a ENS Nat Gateway Snat Entry resource.
+
+
+
+For information about ENS Nat Gateway Snat Entry and how to use it, see [What is Nat Gateway Snat Entry](https://next.api.alibabacloud.com/document/Ens/2017-11-10/CreateSnatEntry).
+
+-> **NOTE:** Available since v1.289.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = ""
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-44"
+}
+
+resource "alicloud_ens_network" "defaultXqhlfk" {
+  network_name  = "example-snat"
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "defaultzkXvut" {
+  cidr_block    = "10.0.0.0/24"
+  vswitch_name  = "example-snat"
+  ens_region_id = alicloud_ens_network.defaultXqhlfk.ens_region_id
+  network_id    = alicloud_ens_network.defaultXqhlfk.id
+}
+
+resource "alicloud_ens_eip" "defaultiUbwh0" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = alicloud_ens_vswitch.defaultzkXvut.ens_region_id
+  eip_name             = "example-snat"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_nat_gateway" "default2Kn0nu" {
+  vswitch_id    = alicloud_ens_vswitch.defaultzkXvut.id
+  ens_region_id = alicloud_ens_vswitch.defaultzkXvut.ens_region_id
+  network_id    = alicloud_ens_vswitch.defaultzkXvut.network_id
+  instance_type = "enat.default"
+  nat_name      = "example-snat"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultlI0M0t" {
+  instance_id   = alicloud_ens_nat_gateway.default2Kn0nu.id
+  allocation_id = alicloud_ens_eip.defaultiUbwh0.id
+  instance_type = "Nat"
+  standby       = false
+}
+
+resource "alicloud_ens_eip" "eip2" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = var.ens_region_id
+  eip_name             = "example-snat2"
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultbMMEpj" {
+  instance_id   = alicloud_ens_nat_gateway.default2Kn0nu.id
+  allocation_id = alicloud_ens_eip.eip2.id
+  instance_type = "Nat"
+  standby       = false
+}
+
+
+resource "alicloud_ens_nat_gateway_snat_entry" "default" {
+  snat_entry_name = "example-snat"
+  source_cidr     = "10.0.0.0/8"
+  snat_ip         = alicloud_ens_eip.defaultiUbwh0.ip_address
+  nat_gateway_id  = alicloud_ens_nat_gateway.default2Kn0nu.id
+  idle_timeout    = "50"
+  isp_affinity    = false
+  eip_affinity    = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `eip_affinity` - (Optional) Whether to enable IP affinity.
+* `idle_timeout` - (Optional, ForceNew, Int) The idle timeout. Valid values: 1 to 86400. Unit: seconds.
+* `isp_affinity` - (Optional) Whether to enable the operator affinity. Valid values:
+false: disable operator affinity.
+true: enable operator affinity.
+* `nat_gateway_id` - (Required, ForceNew) The ID of the NAT gateway.
+* `snat_entry_name` - (Optional) The name of the SNAT entry.
+* `snat_ip` - (Required) The EIPs in the SNAT entry. Separate multiple EIPs with commas (,).
+* `source_cidr` - (Optional, ForceNew) The source CIDR block of the SNAT entry.
+* `source_network_id` - (Optional, ForceNew) The ID of the network. All ENS instances in the network can access the Internet through SNAT rules.
+* `source_vswitch_id` - (Optional, ForceNew) The ID of the vSwitch that needs to access the Internet. All ENS instances in the vSwitch can access the Internet through SNAT rules.
+* `standby_snat_ip` - (Optional, ForceNew) The standby EIPs in the SNAT entry. Separate multiple standby EIPs with commas (,).
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+* `creation_time` - The creation time, in UTC.
+* `dest_cidr` - The destination CIDR block. Only requests destined for this CIDR block are processed by this rule.
+* `standby_snat_ip` - The standby EIPs in the SNAT entry.
+* `standby_status` - The status of the standby EIP. Valid values: Running, Stopping, Stopped, Starting.
+* `status` - SNAT entry status.
+* `type` - The NAT type. An empty value indicates symmetric NAT. FullCone: full cone NAT.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Nat Gateway Snat Entry.
+* `delete` - (Defaults to 5 mins) Used when delete the Nat Gateway Snat Entry.
+* `update` - (Defaults to 5 mins) Used when update the Nat Gateway Snat Entry.
+
+## Import
+
+ENS Nat Gateway Snat Entry can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ens_nat_gateway_snat_entry.example <snat_entry_id>
+```


### PR DESCRIPTION
Adds the `alicloud_ens_nat_gateway_snat_entry` resource and the `alicloud_ens_nat_gateway_snat_entries` data source for the ENS (Edge Node Service) NAT Gateway SNAT Entry API.

## What

- New resource `alicloud_ens_nat_gateway_snat_entry` backed by the ENS `CreateSnatEntry` / `ModifySnatEntry` / `DeleteSnatEntry` / `DescribeSnatAttribute` APIs.
- New data source `alicloud_ens_nat_gateway_snat_entries` backed by the ENS `DescribeSnatTableEntries` list API.
- Resource and data source documentation.

## Schema

The resource schema exposes the following arguments and attributes:

| Argument | Type | Required/Optional | Notes |
| --- | --- | --- | --- |
| `nat_gateway_id` | string | Required, ForceNew | ID of the NAT gateway. |
| `snat_ip` | string | Required | EIP(s) used in the SNAT entry. Multiple EIPs are separated by commas. |
| `snat_entry_name` | string | Optional | Name of the SNAT entry. |
| `source_cidr` | string | Optional, ForceNew | Source CIDR block of the SNAT entry. |
| `idle_timeout` | int | Optional, ForceNew | Idle timeout in seconds, range 0~86400. |
| `isp_affinity` | bool | Optional | Whether to enable operator affinity. |
| `eip_affinity` | bool | Optional | Whether to enable IP affinity. |
| `status` | string | Computed | SNAT entry status. |

The resource supports import via the SNAT entry ID.

## Test plan

Acceptance tests are queued to run remotely via ACube. The passing test list will be appended to this PR body once the run completes.

```
=== RUN TestAccAliCloudEnsNatGatewaySnatEntry_basic9626
--- PASS: TestAccAliCloudEnsNatGatewaySnatEntry_basic9626 (pending)

=== RUN TestAccAlicloudEnsNatGatewaySnatEntryDataSource
--- PASS: TestAccAlicloudEnsNatGatewaySnatEntryDataSource (pending)
```
