### PR TITLE
resource/alicloud_ens_network: align with DescribeNetworkAttribute API and add computed relation fields

### DIFF
--- a/alicloud/resource_alicloud_ens_network.go
+++ b/alicloud/resource_alicloud_ens_network.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/PaesslerAG/jsonpath"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -48,9 +49,18 @@ func resourceAliCloudEnsNetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"router_table_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"vswitch_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}
@@ -124,7 +134,11 @@ func resourceAliCloudEnsNetworkRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("description", objectRaw["Description"])
 	d.Set("ens_region_id", objectRaw["EnsRegionId"])
 	d.Set("network_name", objectRaw["NetworkName"])
+	d.Set("router_table_id", objectRaw["RouterTableId"])
 	d.Set("status", objectRaw["Status"])
+
+	vSwitchIdRaw, _ := jsonpath.Get("$.VSwitchIds.VSwitchId", objectRaw)
+	d.Set("vswitch_ids", vSwitchIdRaw)
 
 	return nil
 }
@@ -142,12 +156,16 @@ func resourceAliCloudEnsNetworkUpdate(d *schema.ResourceData, meta interface{}) 
 	query["NetworkId"] = d.Id()
 	if d.HasChange("network_name") {
 		update = true
-		request["NetworkName"] = d.Get("network_name")
+	}
+	if v, ok := d.GetOk("network_name"); ok || d.HasChange("network_name") {
+		request["NetworkName"] = v
 	}
 
 	if d.HasChange("description") {
 		update = true
-		request["Description"] = d.Get("description")
+	}
+	if v, ok := d.GetOk("description"); ok || d.HasChange("description") {
+		request["Description"] = v
 	}
 
 	if update {
@@ -200,6 +218,9 @@ func resourceAliCloudEnsNetworkDelete(d *schema.ResourceData, meta interface{}) 
 	})
 
 	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 

--- a/alicloud/resource_alicloud_ens_network_test.go
+++ b/alicloud/resource_alicloud_ens_network_test.go
@@ -112,8 +112,9 @@ func TestAccAliCloudEnsNetwork_basic5077(t *testing.T) {
 }
 
 var AlicloudEnsNetworkMap5077 = map[string]string{
-	"status":      CHECKSET,
-	"create_time": CHECKSET,
+	"status":          CHECKSET,
+	"create_time":     CHECKSET,
+	"router_table_id": CHECKSET,
 }
 
 func AlicloudEnsNetworkBasicDependence5077(name string) string {

--- a/alicloud/service_alicloud_ens_v2.go
+++ b/alicloud/service_alicloud_ens_v2.go
@@ -310,7 +310,7 @@ func (s *EnsServiceV2) DescribeEnsNetwork(id string) (object map[string]interfac
 	var request map[string]interface{}
 	var response map[string]interface{}
 	var query map[string]interface{}
-	action := "DescribeNetworks"
+	action := "DescribeNetworkAttribute"
 	request = make(map[string]interface{})
 	query = make(map[string]interface{})
 	query["NetworkId"] = id
@@ -331,19 +331,13 @@ func (s *EnsServiceV2) DescribeEnsNetwork(id string) (object map[string]interfac
 	})
 
 	if err != nil {
+		if IsExpectedErrors(err, []string{"NetworkNotFound", "InvalidNetworkId.NotFound"}) {
+			return object, WrapErrorf(NotFoundErr("Network", id), NotFoundMsg, response)
+		}
 		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
 	}
 
-	v, err := jsonpath.Get("$.Networks.Network[*]", response)
-	if err != nil {
-		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Networks.Network[*]", response)
-	}
-
-	if len(v.([]interface{})) == 0 {
-		return object, WrapErrorf(NotFoundErr("Network", id), NotFoundMsg, response)
-	}
-
-	return v.([]interface{})[0].(map[string]interface{}), nil
+	return response, nil
 }
 
 func (s *EnsServiceV2) EnsNetworkStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {


### PR DESCRIPTION
## Changes

- Read uses `DescribeNetworkAttribute` (the canonical Get API for ENS Network) instead of `DescribeNetworks` list-and-filter, returning the single network object directly.
- Add computed `router_table_id` and `vswitch_ids` schema fields — these readOnly relation fields are returned by `DescribeNetworkAttribute` and let users reference the associated route table and VSwitches.
- Delete returns nil on NotFound for idempotent destroy.
- Update sends field values even when clearing (`ok || HasChange`) so clearing `network_name` / `description` reaches the `ModifyNetworkAttribute` API instead of being silently dropped.
- Service: handle `NetworkNotFound` / `InvalidNetworkId.NotFound` as NotFound.

## Testing

- `TestAccAliCloudEnsNetwork_basic5077`
- `TestAccAliCloudEnsNetwork_basic5077_twin`
- TestingCoverageRate: 100% (local pre-check passed)

Remote ACC verification is in progress.