### PR TITLE
resource/alicloud_ens_security_group: add permissions support and New Data Source: alicloud_ens_security_groups

### DIFF
--- a/alicloud/data_source_alicloud_ens_security_groups.go
+++ b/alicloud/data_source_alicloud_ens_security_groups.go
@@ -1,0 +1,319 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudEnsSecurityGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudEnsSecurityGroupRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"security_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"security_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"permissions": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"policy": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"port_range": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"description": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"source_port_range": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"priority": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"source_cidr_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"creation_time": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ip_protocol": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"dest_cidr_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ipv6_source_cidr_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"ipv6_dest_cidr_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"direction": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"security_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"security_group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudEnsSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeSecurityGroups"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if v, ok := d.GetOk("security_group_id"); ok {
+		request["SecurityGroupId"] = v
+	}
+	if v, ok := d.GetOk("security_group_id"); ok {
+		request["SecurityGroupId"] = v
+	}
+	if v, ok := d.GetOk("security_group_name"); ok {
+		request["SecurityGroupName"] = v
+	}
+	request["MaxResults"] = PageSizeLarge
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.SecurityGroups.SecurityGroup[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["SecurityGroupName"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["SecurityGroupId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if nextToken, ok := response["NextToken"].(string); ok && nextToken != "" {
+			request["NextToken"] = nextToken
+		} else {
+			break
+		}
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["SecurityGroupId"]
+
+		mapping["description"] = objectRaw["Description"]
+		mapping["security_group_name"] = objectRaw["SecurityGroupName"]
+		mapping["create_time"] = objectRaw["CreationTime"]
+		mapping["instance_count"] = objectRaw["InstanceCount"]
+		mapping["security_group_id"] = objectRaw["SecurityGroupId"]
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			names = append(names, objectRaw["SecurityGroupName"])
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["SecurityGroupId"])
+		mapping, err = dataSourceAliCloudEnsSecurityGroupReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["SecurityGroupName"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("groups", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudEnsSecurityGroupReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	ensServiceV2 := EnsServiceV2{client}
+	getResp, err := ensServiceV2.DescribeEnsSecurityGroup(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["description"] = objectRaw["Description"]
+	mapping["security_group_name"] = objectRaw["SecurityGroupName"]
+	mapping["security_group_id"] = objectRaw["SecurityGroupId"]
+
+	permissionRaw, _ := jsonpath.Get("$.Permissions.Permission", objectRaw)
+	permissionsMaps := make([]map[string]interface{}, 0)
+	if permissionRaw != nil {
+		for _, permissionChildRaw := range convertToInterfaceArray(permissionRaw) {
+			permissionsMap := make(map[string]interface{})
+			permissionChildRaw := permissionChildRaw.(map[string]interface{})
+			permissionsMap["creation_time"] = permissionChildRaw["CreationTime"]
+			permissionsMap["description"] = permissionChildRaw["Description"]
+			permissionsMap["dest_cidr_ip"] = permissionChildRaw["DestCidrIp"]
+			permissionsMap["direction"] = permissionChildRaw["Direction"]
+			permissionsMap["ip_protocol"] = permissionChildRaw["IpProtocol"]
+			permissionsMap["ipv6_dest_cidr_ip"] = permissionChildRaw["Ipv6DestCidrIp"]
+			permissionsMap["ipv6_source_cidr_ip"] = permissionChildRaw["Ipv6SourceCidrIp"]
+			permissionsMap["policy"] = permissionChildRaw["Policy"]
+			permissionsMap["port_range"] = permissionChildRaw["PortRange"]
+			permissionsMap["priority"] = permissionChildRaw["Priority"]
+			permissionsMap["source_cidr_ip"] = permissionChildRaw["SourceCidrIp"]
+			permissionsMap["source_port_range"] = permissionChildRaw["SourcePortRange"]
+
+			permissionsMaps = append(permissionsMaps, permissionsMap)
+		}
+	}
+	mapping["permissions"] = permissionsMaps
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_ens_security_groups_test.go
+++ b/alicloud/data_source_alicloud_ens_security_groups_test.go
@@ -1,0 +1,85 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudEnsSecurityGroupsDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsSecurityGroupsSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_ens_security_group.default.security_group_name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsSecurityGroupsSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_ens_security_group.default.security_group_name}_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsSecurityGroupsSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_ens_security_group.default.security_group_name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsSecurityGroupsSourceConfig(rand, map[string]string{
+			"name_regex": `"TestAccAlicloudEnsSecurityGroupsDataSource_fake"`,
+		}),
+	}
+
+	EnsSecurityGroupCheckInfo.dataSourceTestCheck(t, rand, nameRegexConf, allConf)
+}
+
+func testAccCheckAlicloudEnsSecurityGroupsSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+    default = "tf-testAccEnsSecurityGroupsDataSource%d"
+}
+
+resource "alicloud_ens_security_group" "default" {
+  security_group_name = var.name
+  description         = var.name
+  permissions {
+    direction      = "ingress"
+    ip_protocol    = "TCP"
+    port_range     = "80/80"
+    policy         = "Accept"
+    priority       = 1
+    source_cidr_ip = "0.0.0.0/0"
+    dest_cidr_ip   = "0.0.0.0/0"
+  }
+}
+
+data "alicloud_ens_security_groups" "default" {
+  enable_details = true
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}
+
+var existEnsSecurityGroupMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"groups.#":                     "1",
+		"groups.0.security_group_name": fmt.Sprintf("tf-testAccEnsSecurityGroupsDataSource%d", rand),
+		"groups.0.permissions.#":       "1",
+	}
+}
+
+var fakeEnsSecurityGroupMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"groups.#": "0",
+	}
+}
+
+var EnsSecurityGroupCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_ens_security_groups.default",
+	existMapFunc: existEnsSecurityGroupMapFunc,
+	fakeMapFunc:  fakeEnsSecurityGroupMapFunc,
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -616,6 +616,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_hbr_restore_jobs":                                 dataSourceAlicloudHbrRestoreJobs(),
 			"alicloud_alb_listeners":                                    dataSourceAlicloudAlbListeners(),
 			"alicloud_ens_key_pairs":                                    dataSourceAlicloudEnsKeyPairs(),
+			"alicloud_ens_security_groups":                             dataSourceAliCloudEnsSecurityGroups(),
 			"alicloud_sae_applications":                                 dataSourceAlicloudSaeApplications(),
 			"alicloud_alb_rules":                                        dataSourceAliCloudAlbRules(),
 			"alicloud_cms_metric_rule_templates":                        dataSourceAlicloudCmsMetricRuleTemplates(),

--- a/alicloud/resource_alicloud_ens_security_group.go
+++ b/alicloud/resource_alicloud_ens_security_group.go
@@ -2,10 +2,12 @@
 package alicloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"time"
 
+	"github.com/PaesslerAG/jsonpath"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -30,6 +32,73 @@ func resourceAliCloudEnsSecurityGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"permissions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Set:      ensSecurityGroupPermissionHash,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"policy": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: StringInSlice([]string{"Accept", "Drop"}, false),
+						},
+						"port_range": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"source_port_range": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"priority": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: IntBetween(0, 100),
+						},
+						"source_cidr_ip": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ip_protocol": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: StringInSlice([]string{"TCP", "UDP", "ICMP", "ALL"}, false),
+						},
+						"dest_cidr_ip": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ipv6_source_cidr_ip": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ipv6_dest_cidr_ip": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"direction": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: StringInSlice([]string{"ingress", "egress"}, false),
+						},
+					},
+				},
+			},
 			"security_group_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -49,16 +118,32 @@ func resourceAliCloudEnsSecurityGroupCreate(d *schema.ResourceData, meta interfa
 	var err error
 	request = make(map[string]interface{})
 
-	if v, ok := d.GetOk("security_group_name"); ok {
-		request["SecurityGroupName"] = v
-	}
 	if v, ok := d.GetOk("description"); ok {
 		request["Description"] = v
+	}
+	if v, ok := d.GetOk("permissions"); ok {
+		permissionsMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(v) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := buildEnsPermissionMap(dataLoopTmp)
+			if desc := dataLoopTmp["description"].(string); desc != "" {
+				dataLoopMap["Description"] = desc
+			}
+			permissionsMapsArray = append(permissionsMapsArray, dataLoopMap)
+		}
+		permissionsMapsJson, err := json.Marshal(permissionsMapsArray)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["Permissions"] = string(permissionsMapsJson)
+	}
+
+	if v, ok := d.GetOk("security_group_name"); ok {
+		request["SecurityGroupName"] = v
 	}
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
-
 		if err != nil {
 			if NeedRetry(err) {
 				wait()
@@ -66,9 +151,9 @@ func resourceAliCloudEnsSecurityGroupCreate(d *schema.ResourceData, meta interfa
 			}
 			return resource.NonRetryableError(err)
 		}
-		addDebug(action, response, request)
 		return nil
 	})
+	addDebug(action, response, request)
 
 	if err != nil {
 		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ens_security_group", action, AlibabaCloudSdkGoERROR)
@@ -102,6 +187,32 @@ func resourceAliCloudEnsSecurityGroupRead(d *schema.ResourceData, meta interface
 	d.Set("description", objectRaw["Description"])
 	d.Set("security_group_name", objectRaw["SecurityGroupName"])
 
+	permissionRaw, _ := jsonpath.Get("$.Permissions.Permission", objectRaw)
+	permissionsMaps := make([]map[string]interface{}, 0)
+	if permissionRaw != nil {
+		for _, permissionChildRaw := range convertToInterfaceArray(permissionRaw) {
+			permissionsMap := make(map[string]interface{})
+			permissionChildRaw := permissionChildRaw.(map[string]interface{})
+			permissionsMap["creation_time"] = permissionChildRaw["CreationTime"]
+			permissionsMap["description"] = permissionChildRaw["Description"]
+			permissionsMap["dest_cidr_ip"] = permissionChildRaw["DestCidrIp"]
+			permissionsMap["direction"] = permissionChildRaw["Direction"]
+			permissionsMap["ip_protocol"] = permissionChildRaw["IpProtocol"]
+			permissionsMap["ipv6_dest_cidr_ip"] = permissionChildRaw["Ipv6DestCidrIp"]
+			permissionsMap["ipv6_source_cidr_ip"] = permissionChildRaw["Ipv6SourceCidrIp"]
+			permissionsMap["policy"] = permissionChildRaw["Policy"]
+			permissionsMap["port_range"] = permissionChildRaw["PortRange"]
+			permissionsMap["priority"] = permissionChildRaw["Priority"]
+			permissionsMap["source_cidr_ip"] = permissionChildRaw["SourceCidrIp"]
+			permissionsMap["source_port_range"] = permissionChildRaw["SourcePortRange"]
+
+			permissionsMaps = append(permissionsMaps, permissionsMap)
+		}
+	}
+	if err := d.Set("permissions", permissionsMaps); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -111,26 +222,29 @@ func resourceAliCloudEnsSecurityGroupUpdate(d *schema.ResourceData, meta interfa
 	var response map[string]interface{}
 	var query map[string]interface{}
 	update := false
-	action := "ModifySecurityGroupAttribute"
+
 	var err error
+	action := "ModifySecurityGroupAttribute"
 	request = make(map[string]interface{})
 	query = make(map[string]interface{})
-	query["SecurityGroupId"] = d.Id()
-	if d.HasChange("security_group_name") {
-		update = true
-		request["SecurityGroupName"] = d.Get("security_group_name")
-	}
+	request["SecurityGroupId"] = d.Id()
 
 	if d.HasChange("description") {
 		update = true
-		request["Description"] = d.Get("description")
 	}
-
+	if v, ok := d.GetOk("description"); ok || d.HasChange("description") {
+		request["Description"] = v
+	}
+	if d.HasChange("security_group_name") {
+		update = true
+	}
+	if v, ok := d.GetOk("security_group_name"); ok || d.HasChange("security_group_name") {
+		request["SecurityGroupName"] = v
+	}
 	if update {
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
-
 			if err != nil {
 				if NeedRetry(err) {
 					wait()
@@ -138,11 +252,90 @@ func resourceAliCloudEnsSecurityGroupUpdate(d *schema.ResourceData, meta interfa
 				}
 				return resource.NonRetryableError(err)
 			}
-			addDebug(action, response, request)
 			return nil
 		})
+		addDebug(action, response, request)
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	if d.HasChange("permissions") {
+		oldEntry, newEntry := d.GetChange("permissions")
+		oldEntrySet := oldEntry.(*schema.Set)
+		newEntrySet := newEntry.(*schema.Set)
+		removed := oldEntrySet.Difference(newEntrySet)
+		added := newEntrySet.Difference(oldEntrySet)
+
+		if removed.Len() > 0 {
+			action := "DeleteSecurityGroupPermissions"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["SecurityGroupId"] = d.Id()
+			permissionsMapsArray := make([]interface{}, 0)
+			for _, dataLoop := range removed.List() {
+				dataLoopTmp := dataLoop.(map[string]interface{})
+				dataLoopMap := buildEnsPermissionMap(dataLoopTmp)
+				permissionsMapsArray = append(permissionsMapsArray, dataLoopMap)
+			}
+			permissionsMapsJson, err := json.Marshal(permissionsMapsArray)
+			if err != nil {
+				return WrapError(err)
+			}
+			request["Permissions"] = string(permissionsMapsJson)
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+		}
+
+		if added.Len() > 0 {
+			action := "CreateSecurityGroupPermissions"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["SecurityGroupId"] = d.Id()
+			permissionsMapsArray := make([]interface{}, 0)
+			for _, dataLoop := range added.List() {
+				dataLoopTmp := dataLoop.(map[string]interface{})
+				dataLoopMap := buildEnsPermissionMap(dataLoopTmp)
+				if desc := dataLoopTmp["description"].(string); desc != "" {
+					dataLoopMap["Description"] = desc
+				}
+				permissionsMapsArray = append(permissionsMapsArray, dataLoopMap)
+			}
+			permissionsMapsJson, err := json.Marshal(permissionsMapsArray)
+			if err != nil {
+				return WrapError(err)
+			}
+			request["Permissions"] = string(permissionsMapsJson)
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
 		}
 	}
 
@@ -158,12 +351,11 @@ func resourceAliCloudEnsSecurityGroupDelete(d *schema.ResourceData, meta interfa
 	query := make(map[string]interface{})
 	var err error
 	request = make(map[string]interface{})
-	query["SecurityGroupId"] = d.Id()
+	request["SecurityGroupId"] = d.Id()
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
-
 		if err != nil {
 			if NeedRetry(err) {
 				wait()
@@ -171,11 +363,14 @@ func resourceAliCloudEnsSecurityGroupDelete(d *schema.ResourceData, meta interfa
 			}
 			return resource.NonRetryableError(err)
 		}
-		addDebug(action, response, request)
 		return nil
 	})
+	addDebug(action, response, request)
 
 	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 
@@ -185,4 +380,67 @@ func resourceAliCloudEnsSecurityGroupDelete(d *schema.ResourceData, meta interfa
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
 	return nil
+}
+
+// buildEnsPermissionMap builds the permission payload for ENS SecurityGroup
+// permission actions, skipping optional string fields that are empty. The
+// ENS API rejects requests with InvalidParameter when an unset permission
+// attribute is sent as an empty string (for example a v4-only rule leaves
+// Ipv6SourceCidrIp/Ipv6DestCidrIp empty), so only set fields are forwarded.
+// Description is intentionally not included here because the
+// DeleteSecurityGroupPermissions action does not accept it; callers that
+// need Description add it after invoking this helper.
+func buildEnsPermissionMap(dataLoopTmp map[string]interface{}) map[string]interface{} {
+	dataLoopMap := make(map[string]interface{})
+	if priority, ok := dataLoopTmp["priority"].(int); ok && priority > 0 {
+		dataLoopMap["Priority"] = priority
+	}
+	if v := dataLoopTmp["dest_cidr_ip"].(string); v != "" {
+		dataLoopMap["DestCidrIp"] = v
+	}
+	if v := dataLoopTmp["direction"].(string); v != "" {
+		dataLoopMap["Direction"] = v
+	}
+	if v := dataLoopTmp["ip_protocol"].(string); v != "" {
+		dataLoopMap["IpProtocol"] = v
+	}
+	if v := dataLoopTmp["ipv6_dest_cidr_ip"].(string); v != "" {
+		dataLoopMap["Ipv6DestCidrIp"] = v
+	}
+	if v := dataLoopTmp["ipv6_source_cidr_ip"].(string); v != "" {
+		dataLoopMap["Ipv6SourceCidrIp"] = v
+	}
+	if v := dataLoopTmp["policy"].(string); v != "" {
+		dataLoopMap["Policy"] = v
+	}
+	if v := dataLoopTmp["port_range"].(string); v != "" {
+		dataLoopMap["PortRange"] = v
+	}
+	if v := dataLoopTmp["source_cidr_ip"].(string); v != "" {
+		dataLoopMap["SourceCidrIp"] = v
+	}
+	if v := dataLoopTmp["source_port_range"].(string); v != "" {
+		dataLoopMap["SourcePortRange"] = v
+	}
+	return dataLoopMap
+}
+
+// ensSecurityGroupPermissionHash computes the set identity hash for an ENS
+// security group permission rule. It intentionally excludes creation_time
+// (a server-populated Computed field) and source_port_range (Optional+Computed,
+// defaulted by the API when the user leaves it unset) so that a rule written
+// in config without those fields still hashes identically to the same rule
+// read back from the API. Without this the TypeSet would show a perpetual
+// diff, because the default schema.HashResource hashes Computed fields that
+// are empty in config but populated in state. The remaining identity fields
+// are sufficient to uniquely distinguish a permission within one security
+// group.
+func ensSecurityGroupPermissionHash(i interface{}) int {
+	m, ok := i.(map[string]interface{})
+	if !ok {
+		return 0
+	}
+	return schema.HashString(fmt.Sprintf("%s|%s|%s|%s|%v|%s|%s|%s|%s|%s",
+		m["direction"], m["ip_protocol"], m["port_range"], m["policy"], m["priority"],
+		m["source_cidr_ip"], m["dest_cidr_ip"], m["ipv6_source_cidr_ip"], m["ipv6_dest_cidr_ip"], m["description"]))
 }

--- a/alicloud/resource_alicloud_ens_security_group_test.go
+++ b/alicloud/resource_alicloud_ens_security_group_test.go
@@ -148,4 +148,126 @@ func TestAccAliCloudEnsSecurityGroup_basic5107_twin(t *testing.T) {
 	})
 }
 
+// Case 5108
+func TestAccAliCloudEnsSecurityGroup_permissions5108(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_security_group.default"
+	ra := resourceAttrInit(resourceId, AlicloudEnsSecurityGroupMap5108)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsSecurityGroup")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%senssecuritygroup%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudEnsSecurityGroupBasicDependence5107)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"security_group_name": name,
+					"permissions": []map[string]interface{}{
+						{
+							"direction":         "ingress",
+							"ip_protocol":       "TCP",
+							"port_range":        "80/80",
+							"policy":            "Accept",
+							"priority":          1,
+							"source_cidr_ip":    "10.0.0.0/8",
+							"dest_cidr_ip":      "0.0.0.0/0",
+							"source_port_range": "80/80",
+							"description":       "test ingress v4 rule",
+						},
+						{
+							"direction":           "ingress",
+							"ip_protocol":         "TCP",
+							"port_range":          "80/80",
+							"policy":              "Accept",
+							"priority":            1,
+							"ipv6_source_cidr_ip": "2001:db8::/32",
+							"ipv6_dest_cidr_ip":   "::/0",
+							"source_port_range":   "80/80",
+							"description":         "test ingress v6 rule",
+						},
+						{
+							"direction":      "egress",
+							"ip_protocol":    "TCP",
+							"port_range":     "443/443",
+							"policy":         "Drop",
+							"priority":       2,
+							"source_cidr_ip": "0.0.0.0/0",
+							"dest_cidr_ip":   "0.0.0.0/0",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_group_name": name,
+						"permissions.#":       "3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"security_group_name": name,
+					"permissions": []map[string]interface{}{
+						{
+							"direction":         "egress",
+							"ip_protocol":       "UDP",
+							"port_range":        "53/53",
+							"policy":            "Accept",
+							"priority":          1,
+							"source_cidr_ip":    "0.0.0.0/0",
+							"dest_cidr_ip":      "192.168.0.0/16",
+							"source_port_range": "53/53",
+							"description":       "updated egress v4 rule",
+						},
+						{
+							"direction":           "egress",
+							"ip_protocol":         "UDP",
+							"port_range":          "53/53",
+							"policy":              "Accept",
+							"priority":            1,
+							"ipv6_source_cidr_ip": "::/0",
+							"ipv6_dest_cidr_ip":   "2001:db8:abcd::/48",
+							"source_port_range":   "53/53",
+							"description":         "updated egress v6 rule",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"permissions.#": "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"security_group_name": name,
+					"permissions":         REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"permissions.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudEnsSecurityGroupMap5108 = map[string]string{}
+
 // Test Ens SecurityGroup. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_ens_v2.go
+++ b/alicloud/service_alicloud_ens_v2.go
@@ -614,7 +614,7 @@ func (s *EnsServiceV2) DescribeEnsSecurityGroup(id string) (object map[string]in
 	})
 
 	if err != nil {
-		if IsExpectedErrors(err, []string{"ens.interface.error"}) {
+		if IsExpectedErrors(err, []string{"ens.interface.error", "InvalidSecurityGroupId.NotFound"}) {
 			return object, WrapErrorf(NotFoundErr("SecurityGroup", id), NotFoundMsg, response)
 		}
 		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)

--- a/website/docs/d/ens_security_groups.html.markdown
+++ b/website/docs/d/ens_security_groups.html.markdown
@@ -1,0 +1,74 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_security_groups"
+sidebar_current: "docs-alicloud-datasource-ens-security-groups"
+description: |-
+  Provides a list of ENS Security Groups to the user.
+---
+
+# alicloud\_ens\_security_groups
+
+This data source provides the ENS Security Groups of the current Alibaba Cloud user.
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+data "alicloud_ens_security_groups" "default" {
+  security_group_name = "tf-example"
+  ids                 = ["sg-xxx"]
+}
+output "first_group_id" {
+  value = data.alicloud_ens_security_groups.default.groups.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `enable_details` - (Optional) Default to `false`. Set it to `true` to get more details of the security groups.
+* `ids` - (Optional, ForceNew) A list of Security Group IDs.
+* `name_regex` - (Optional, ForceNew) A regex string to filter results by Security Group name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `security_group_id` - (Optional, ForceNew) The ID of the Security Group.
+* `security_group_name` - (Optional, ForceNew) The name of the Security Group.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `ids` - A list of Security Group IDs.
+* `names` - A list of Security Group names.
+* `groups` - A list of Security Groups.
+
+### `groups`
+
+The groups supports the following attributes:
+* `create_time` - Creation time of the security group, UTC time.
+* `description` - Security group description information.
+* `id` - The ID of the Security Group.
+* `instance_count` - Number of instances associated with a security group.
+* `permissions` - A collection of rules for a security group instance.
+* `security_group_id` - The ID of the Security Group.
+* `security_group_name` - Security group name.
+
+### `groups.permissions`
+
+The permissions supports the following attributes:
+* `creation_time` - Creation time, UTC time.
+* `description` - Rule description information.
+* `dest_cidr_ip` - Destination IP address segment for outbound authorization.
+* `direction` - Authorized direction.
+* `ip_protocol` - IP protocol.
+* `ipv6_dest_cidr_ip` - The target IPv6 address segment.
+* `ipv6_source_cidr_ip` - The source IPv6 address segment.
+* `policy` - Authorization Policy.
+* `port_range` - Source end port range.
+* `priority` - Rule Priority.
+* `source_cidr_ip` - Source IP address segment, used for inbound authorization.
+* `source_port_range` - The port range of the source security group.

--- a/website/docs/r/ens_security_group.html.markdown
+++ b/website/docs/r/ens_security_group.html.markdown
@@ -8,7 +8,9 @@ description: |-
 
 # alicloud_ens_security_group
 
-Provides a ENS Security Group resource. 
+Provides a ENS Security Group resource.
+
+
 
 For information about ENS Security Group and how to use it, see [What is Security Group](https://www.alibabacloud.com/help/en/ens/developer-reference/api-createsnapshot).
 
@@ -17,12 +19,6 @@ For information about ENS Security Group and how to use it, see [What is Securit
 ## Example Usage
 
 Basic Usage
-
-<div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
-  <a href="https://api.aliyun.com/terraform?resource=alicloud_ens_security_group&exampleId=b5a40fc7-1e42-e096-f7a2-0e286603674b1fd46a98&activeTab=example&spm=docs.r.ens_security_group.0.b5a40fc71e&intl_lang=EN_US" target="_blank">
-    <img alt="Open in AliCloud" src="https://img.alicdn.com/imgextra/i1/O1CN01hjjqXv1uYUlY56FyX_!!6000000006049-55-tps-254-36.svg" style="max-height: 44px; max-width: 100%;">
-  </a>
-</div></div>
 
 ```terraform
 variable "name" {
@@ -35,13 +31,36 @@ resource "alicloud_ens_security_group" "default" {
 }
 ```
 
-📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_ens_security_group&spm=docs.r.ens_security_group.example&intl_lang=EN_US)
-
 ## Argument Reference
 
 The following arguments are supported:
-* `description` - (Optional) Security group description informationIt must be 2 to 256 characters in length and must start with a letter or Chinese, but cannot start with `http://` or `https://`.
-* `security_group_name` - (Optional) Security group nameThe security group name. The length is 2~128 English or Chinese characters. It must start with an uppercase or lowcase letter or a Chinese character and cannot start with `http://` or `https`. Can contain digits, colons (:), underscores (_), or hyphens (-).
+* `description` - (Optional) Security group description information
+It must be 2 to 256 characters in length and must start with a letter or Chinese, but cannot start with http:// or https://
+* `permissions` - (Optional, List, Available since v1.287.0) A collection of rules for a security group instance See [`permissions`](#permissions) below.
+* `security_group_name` - (Optional) Security group name
+The security group name. The length is 2~128 English or Chinese characters. It must start with an uppercase or lowcase letter or a Chinese character and cannot start with http:// or https. Can contain digits, colons (:), underscores (_), or hyphens (-)
+
+### `permissions`
+
+The permissions supports the following:
+* `creation_time` - (Computed, Available since v1.287.0) Creation time, UTC time.
+* `description` - (Optional, Available since v1.287.0) Rule description information
+* `dest_cidr_ip` - (Optional, Available since v1.287.0) Destination IP address segment for outbound authorization
+Example value: 0.0.0.0/0
+* `direction` - (Optional, Available since v1.287.0) Authorized direction
+Example value: ingress
+* `ip_protocol` - (Optional, Computed, Available since v1.287.0) IP protocol
+Example value: TCP
+* `ipv6_dest_cidr_ip` - (Optional, Available since v1.287.0) The target IPv6 address segment.
+* `ipv6_source_cidr_ip` - (Optional, Available since v1.287.0) The source IPv6 address segment.
+* `policy` - (Optional, Computed, Available since v1.287.0) Authorization Policy
+Example value: Accept
+* `port_range` - (Optional, Computed, Available since v1.287.0) Source end port range.
+* `priority` - (Optional, Computed, Int, Available since v1.287.0) Rule Priority
+Example value: 1
+* `source_cidr_ip` - (Optional, Computed, Available since v1.287.0) Source IP address segment, used for inbound authorization
+Example value: 0.0.0.0/0
+* `source_port_range` - (Optional, Computed, Available since v1.287.0) The port range of the source security group.
 
 ## Attributes Reference
 
@@ -60,5 +79,5 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 ENS Security Group can be imported using the id, e.g.
 
 ```shell
-$ terraform import alicloud_ens_security_group.example <id>
+$ terraform import alicloud_ens_security_group.example <security_group_id>
 ```


### PR DESCRIPTION
### Description

Add `permissions` support to `alicloud_ens_security_group` and introduce the `alicloud_ens_security_groups` data source.

### New Attributes

- `permissions` (Optional, TypeSet): A collection of security group rules. Each rule supports:
  - `direction` (Required) - Authorized direction. Valid values: `ingress`, `egress`.
  - `ip_protocol` - IP protocol. Valid values: `TCP`, `UDP`, `ICMP`, `ALL`.
  - `port_range` - Source end port range.
  - `policy` - Authorization Policy. Valid values: `Accept`, `Drop`. Default: `Accept`.
  - `priority` - Rule Priority. Valid values: 1-100. Default: `1`.
  - `source_cidr_ip` - Source IP address segment, used for inbound authorization.
  - `dest_cidr_ip` - Destination IP address segment for outbound authorization.
  - `source_port_range` - The port range of the source security group.
  - `description` - Rule description information.
  - `ipv6_source_cidr_ip` - The source IPv6 address segment.
  - `ipv6_dest_cidr_ip` - The target IPv6 address segment.
  - `creation_time` (Computed) - Creation time, UTC time.

Permissions are sent on Create via `CreateSecurityGroup` and updated incrementally via `CreateSecurityGroupPermissions` (ADD) and `DeleteSecurityGroupPermissions` (REMOVE).

### New Data Source

- `alicloud_ens_security_groups`: queries ENS Security Groups with the same `permissions` block as a computed attribute. Supports `ids`, `name_regex`, `security_group_id`, `security_group_name` and `output_file` arguments.

### Test Cases

Remote acceptance tests will be run and the passing list appended here.