### PR TITLE
resource/alicloud_alb_rule: fix remove_header_config being dropped on create

### DIFF
--- a/alicloud/resource_alicloud_alb_rule.go
+++ b/alicloud/resource_alicloud_alb_rule.go
@@ -619,7 +619,7 @@ func resourceAliCloudAlbRuleCreate(d *schema.ResourceData, meta interface{}) err
 		removeHeaderConfigMap := map[string]interface{}{}
 		for _, removeHeaderConfig := range ruleActionsArg["remove_header_config"].(*schema.Set).List() {
 			removeHeaderConfigArg := removeHeaderConfig.(map[string]interface{})
-			insertHeaderConfigMap["Key"] = removeHeaderConfigArg["key"]
+			removeHeaderConfigMap["Key"] = removeHeaderConfigArg["key"]
 			ruleActionsMap["RemoveHeaderConfig"] = removeHeaderConfigMap
 		}
 

--- a/alicloud/resource_alicloud_alb_rule_test.go
+++ b/alicloud/resource_alicloud_alb_rule_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func init() {
@@ -877,6 +878,146 @@ func TestAccAliCloudALBRule_basic2(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccAliCloudALBRule_removeHeader covers RemoveHeader on the create path.
+// TestAccAliCloudALBRule_basic0 only adds a RemoveHeader action at an update
+// step, which is why the create path stayed broken. A rule must carry exactly
+// one final action executed last, so RemoveHeader is declared next to a
+// ForwardGroup with a larger order.
+func TestAccAliCloudALBRule_removeHeader(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alb_rule.default"
+	ra := resourceAttrInit(resourceId, AliCloudALBRuleMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlbService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlbRule", []string{"direction"}...)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%salbrule%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudALBRuleBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"listener_id": "${alicloud_alb_listener.default.id}",
+					"rule_name":   name,
+					"priority":    "666",
+					"rule_conditions": []map[string]interface{}{
+						{
+							"host_config": []map[string]interface{}{
+								{
+									"values": []string{"www.test.com"},
+								},
+							},
+							"type": "Host",
+						},
+					},
+					"rule_actions": []map[string]interface{}{
+						{
+							"remove_header_config": []map[string]interface{}{
+								{
+									"key": "tf-remove-header",
+								},
+							},
+							"order": "3",
+							"type":  "RemoveHeader",
+						},
+						{
+							"forward_group_config": []map[string]interface{}{
+								{
+									"server_group_tuples": []map[string]interface{}{
+										{
+											"server_group_id": "${alicloud_alb_server_group.default.id}",
+										},
+									},
+								},
+							},
+							"order": "9",
+							"type":  "ForwardGroup",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"listener_id":       CHECKSET,
+						"rule_name":         name,
+						"priority":          "666",
+						"rule_actions.#":    "2",
+						"rule_conditions.#": "1",
+					}),
+					checkAlbRuleRemoveHeaderKey(resourceId, "tf-remove-header"),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rule_actions": []map[string]interface{}{
+						{
+							"remove_header_config": []map[string]interface{}{
+								{
+									"key": "tf-remove-header-update",
+								},
+							},
+							"order": "3",
+							"type":  "RemoveHeader",
+						},
+						{
+							"forward_group_config": []map[string]interface{}{
+								{
+									"server_group_tuples": []map[string]interface{}{
+										{
+											"server_group_id": "${alicloud_alb_server_group.default.id}",
+										},
+									},
+								},
+							},
+							"order": "9",
+							"type":  "ForwardGroup",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rule_actions.#": "2",
+					}),
+					checkAlbRuleRemoveHeaderKey(resourceId, "tf-remove-header-update"),
+				),
+			},
+		},
+	})
+}
+
+// checkAlbRuleRemoveHeaderKey asserts the rule carries exactly one
+// remove_header_config block holding the expected key. rule_actions and
+// remove_header_config are both schema.TypeSet, so their state indexes are
+// hashes and cannot be addressed with resource.TestCheckResourceAttr.
+func checkAlbRuleRemoveHeaderKey(resourceID, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceID]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceID)
+		}
+
+		got := make([]string, 0)
+		for k, v := range rs.Primary.Attributes {
+			if strings.Contains(k, ".remove_header_config.") && strings.HasSuffix(k, ".key") {
+				got = append(got, v)
+			}
+		}
+
+		if len(got) != 1 || got[0] != expected {
+			return fmt.Errorf("%s: remove_header_config keys expected [%s], got %v", resourceID, expected, got)
+		}
+
+		return nil
+	}
 }
 
 func TestAccAliCloudALBRule_trafficMirror(t *testing.T) {

--- a/website/docs/r/alb_rule.html.markdown
+++ b/website/docs/r/alb_rule.html.markdown
@@ -131,6 +131,42 @@ resource "alicloud_alb_rule" "default" {
 }
 ```
 
+Removing a request header before forwarding
+
+A forwarding rule must contain exactly one final action (`ForwardGroup`, `Redirect` or `FixedResponse`), and that action is executed last, so the `RemoveHeader` extension action has to be declared with a smaller `order`. The example below reuses the listener and the server group created above.
+
+```terraform
+resource "alicloud_alb_rule" "remove_header" {
+  rule_name   = "${var.name}_remove_header"
+  listener_id = alicloud_alb_listener.default.id
+  priority    = "556"
+  rule_conditions {
+    host_config {
+      values = ["www.example.com"]
+    }
+    type = "Host"
+  }
+
+  rule_actions {
+    remove_header_config {
+      key = "X-Debug-Trace"
+    }
+    order = "1"
+    type  = "RemoveHeader"
+  }
+
+  rule_actions {
+    forward_group_config {
+      server_group_tuples {
+        server_group_id = alicloud_alb_server_group.default.id
+      }
+    }
+    order = "9"
+    type  = "ForwardGroup"
+  }
+}
+```
+
 📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_alb_rule&spm=docs.r.alb_rule.example&intl_lang=EN_US)
 
 ## Argument Reference
@@ -139,7 +175,10 @@ The following arguments are supported:
 
 * `listener_id` - (Required, ForceNew) The ID of the listener to which the forwarding rule belongs.
 * `rule_name` - (Required) The name of the forwarding rule. The name must be 2 to 128 characters in length, and can contain letters, digits, periods (.), underscores (_), and hyphens (-). The name must start with a letter.
-* `priority` - (Required, Int) The priority of the rule. Valid values: `1` to `10000`. A smaller value indicates a higher priority. **Note*:* The priority of each rule within the same listener must be unique.
+* `priority` - (Required, Int) The priority of the rule. Valid values: `1` to `10000`. A smaller value indicates a higher priority.
+
+  -> **NOTE:** The priority of each rule within the same listener must be unique.
+
 * `direction` - (Optional, ForceNew, Available since v1.205.0) The direction to which the forwarding rule is applied. Default value: `Request`. Valid values:
   - `Request`: The forwarding rule is applied to the client requests received by ALB.
   - `Response`: The forwarding rule is applied to the responses returned by backend servers.
@@ -152,14 +191,21 @@ The following arguments are supported:
 The rule_actions supports the following:
 
 * `order` - (Required, Int) The order of the forwarding rule actions. Valid values: `1` to `50000`. The actions are performed in ascending order. You cannot leave this parameter empty. Each value must be unique.
+
+  -> **NOTE:** The `ForwardGroup`, `Redirect` or `FixedResponse` action is performed last, so its `order` must be greater than the `order` of every other action in the same rule. Otherwise the rule is rejected with `IllegalParam.Order`.
+
 * `type` - (Required) The action type. Valid values: `ForwardGroup`, `Redirect`, `FixedResponse`, `Rewrite`, `InsertHeader`, `RemoveHeader`, `TrafficLimit`, `TrafficMirror` and `Cors`.
-  **Note:** The preceding actions can be classified into two types:  `FinalType`: A forwarding rule can contain only one `FinalType` action, which is executed last. This type of action can contain only one `ForwardGroup`, `Redirect` or `FixedResponse` action. `ExtType`: A forwarding rule can contain one or more `ExtType` actions, which are executed before `FinalType` actions and need to coexist with the `FinalType` actions. This type of action can contain multiple `InsertHeader` actions or one `Rewrite` action.
-  **NOTE:** The `TrafficLimit` and `TrafficMirror` option is available since 1.162.0.
-  **NOTE:** From version 1.205.0, `type` can be set to `Cors`.
+
+  -> **NOTE:** A forwarding rule must contain exactly one `ForwardGroup`, `Redirect` or `FixedResponse` action, which is performed last. Every other action is performed before it and can only be used together with it: a rule can contain multiple `InsertHeader` actions, but at most one `Rewrite` action.
+
+  -> **NOTE:** The `TrafficLimit` and `TrafficMirror` option is available since 1.162.0.
+
+  -> **NOTE:** From version 1.205.0, `type` can be set to `Cors`.
+
 * `fixed_response_config` - (Optional, Set) The configuration of the fixed response. See [`fixed_response_config`](#rule_actions-fixed_response_config) below.
 * `forward_group_config` - (Optional, Set) The forward response action within ALB. See [`forward_group_config`](#rule_actions-forward_group_config) below.
 * `insert_header_config` - (Optional, Set) The configuration of the inserted header field. See [`insert_header_config`](#rule_actions-insert_header_config) below.
-* `remove_header_config` - (Optional, Set) The configuration of the inserted header field. See [`remove_header_config`](#rule_actions-remove_header_config) below.
+* `remove_header_config` - (Optional, Set) The configuration of the removed header field. See [`remove_header_config`](#rule_actions-remove_header_config) below.
 * `redirect_config` - (Optional, Set) The configuration of the external redirect action. See [`redirect_config`](#rule_actions-redirect_config) below.
 * `rewrite_config` - (Optional, Set) The redirect action within ALB. See [`rewrite_config`](#rule_actions-rewrite_config) below.
 * `traffic_limit_config` - (Optional, Set, Available since v1.162.0) The Flow speed limit. See [`traffic_limit_config`](#rule_actions-traffic_limit_config) below.
@@ -187,7 +233,8 @@ The server_group_tuples supports the following:
 
 * `server_group_id` - (Optional) The ID of the destination server group to which requests are forwarded.
 * `weight` - (Optional, Int, Available since v1.162.0) The Weight of server group. Default value: `100`. Valid values: `0` to `100`.
-**NOTE:** `weight` is required when the number of `server_group_tuples` is greater than 2. From version 1.264.0, `weight` can be set to `0`.
+
+  -> **NOTE:** `weight` is required when the number of `server_group_tuples` is greater than 2. From version 1.264.0, `weight` can be set to `0`.
 
 ### `rule_actions-forward_group_config-server_group_sticky_session`
 
@@ -200,7 +247,10 @@ The server_group_sticky_session supports the following:
 
 The insert_header_config supports the following:
 
-* `key` - (Optional) The name of the inserted header field. The name must be 1 to 40 characters in length, and can contain letters, digits, underscores (_), and hyphens (-). You cannot use the same name in InsertHeader. Note You cannot use Cookie or Host in the name.
+* `key` - (Optional) The name of the inserted header field. The name must be 1 to 40 characters in length, and can contain letters, digits, underscores (_), and hyphens (-). You cannot use the same name in InsertHeader.
+
+  -> **NOTE:** The header name cannot be set to the following fields (case insensitive): slb-id, slb-ip, x-forwarded-for, x-forwarded-proto, x-forwarded-eip, x-forwarded-port, x-forwarded-client-srcport, connection, upgrade, content-length, transfer-encoding, keep-alive, te, host, cookie, remoteip, authority, and x-forwarded-host.
+
 * `value` - (Optional) The content of the inserted header field. Valid values:
   * If the `value_type` is set to `SystemDefined`, the following values are used:
     - `ClientSrcPort`: the port of the client.
@@ -220,7 +270,7 @@ The insert_header_config supports the following:
 The remove_header_config supports the following:
 
 * `key` - (Optional) The name of the removed header field. It can be 1 to 40 characters in length and supports upper and lower case letters a to z, numbers, underscores (_), and dashes (-). Header field names cannot be used repeatedly in RemoveHeader. 
-  * Request Direction: The header name cannot be set to the following fields (case insensitive):slb-id, slb-ip, x-forwarded-for, x-forwarded-proto, x-forwarded-eip, x-forwarded-port, x-forwarded-client-srcport, connection, upgrade, content-length, transfer-encoding, keep-alive, te, host, cookie, remoteip, and authority. 
+  * Request Direction: The header name cannot be set to the following fields (case insensitive):slb-id, slb-ip, x-forwarded-for, x-forwarded-proto, x-forwarded-eip, x-forwarded-port, x-forwarded-client-srcport, connection, upgrade, content-length, transfer-encoding, keep-alive, te, host, cookie, remoteip, authority, and x-forwarded-host.
   * Response Direction: The header name cannot be set to the following fields (case insensitive):connection, upgrade, content-length, transfer-encoding.
 
 ### `rule_actions-redirect_config`
@@ -231,7 +281,10 @@ The redirect_config supports the following:
 * `http_code` - (Optional) The redirect method. Valid values: `301`, `302`, `303`, `307`, and `308`.
 * `path` - (Optional) The path of the destination to which requests are directed. Valid values: The path must be `1` to `128` characters in length, and start with a forward slash (/). The path can contain letters, digits, asterisks (*), question marks (?) and the following special characters: $ - _ . + / & ~ @ :. It cannot contain the following special characters: " % # ; ! ( ) [ ] ^ , ”. The path is case-sensitive. Default value: ${path}. You can also reference ${host}, ${protocol}, and ${port}. Each variable can appear at most once. You can use the preceding variables at the same time, or use them with a valid string.
 * `port` - (Optional) The port of the destination to which requests are redirected. Valid values: `1` to `63335`. Default value: ${port}. You cannot use this value together with other characters at the same time.
-* `protocol` - (Optional) The protocol of the requests to be redirected. Valid values: `HTTP` and `HTTPS`. Default value: `${protocol}`. You cannot use this value together with other characters at the same time. Note HTTPS listeners can redirect only HTTPS requests.
+* `protocol` - (Optional) The protocol of the requests to be redirected. Valid values: `HTTP` and `HTTPS`. Default value: `${protocol}`. You cannot use this value together with other characters at the same time.
+
+  -> **NOTE:** HTTPS listeners can redirect only HTTPS requests.
+
 * `query` - (Optional) The query string of the request to be redirected. The query string must be `1` to `128` characters in length, can contain letters and printable characters. It cannot contain the following special characters: # [ ] { } \ | < > &. Default value: ${query}. You can also reference ${host}, ${protocol}, and ${port}. Each variable can appear at most once. You can use the preceding variables at the same time, or use them together with a valid string.
 
 ### `rule_actions-rewrite_config`
@@ -247,7 +300,9 @@ The rewrite_config supports the following:
 The traffic_limit_config supports the following:
 
 * `qps` - (Optional, Int) The Number of requests per second. Valid values: `1` to `100000`.
-* `per_ip_qps` - (Optional, Int) The number of requests per second for a single IP address. Value range: 1~1000000. Note: If the QPS parameter is also configured, the value of the PerIpQps parameter must be smaller than the value of the QPS parameter.
+* `per_ip_qps` - (Optional, Int) The number of requests per second for a single IP address. Value range: 1~1000000.
+
+  -> **NOTE:** If `qps` is also configured, the value of `per_ip_qps` must be smaller than the value of `qps`.
 
 ### `rule_actions-traffic_mirror_config`
 
@@ -290,10 +345,13 @@ The rule_conditions supports the following:
   - `QueryString`: Requests are forwarded based on the query string.
   - `Method`: Request are forwarded based on the request method.
   - `Cookie`: Requests are forwarded based on the cookie.
-  - `SourceIp`: Requests are forwarded based on the source ip. **NOTE:** The `SourceIp` option is available since 1.162.0.
-  - `ResponseHeader`: Response header. **NOTE:** The `SourceIp` option is available since 1.213.1.
-  - `ResponseStatusCode`: Response status code. **NOTE:** The `SourceIp` option is available since 1.213.1.
-* `cookie_config` - (Optional, Set) The configuration of the cookie. See See [`cookie_config`](#rule_conditions-cookie_config) below.
+  - `SourceIp`: Requests are forwarded based on the source ip.
+  - `ResponseHeader`: Response header.
+  - `ResponseStatusCode`: Response status code.
+
+  -> **NOTE:** `SourceIp` is available since v1.162.0. `ResponseHeader` and `ResponseStatusCode` are available since v1.213.1.
+
+* `cookie_config` - (Optional, Set) The configuration of the cookie. See [`cookie_config`](#rule_conditions-cookie_config) below.
 * `header_config` - (Optional, Set) The configuration of the header field. See [`header_config`](#rule_conditions-header_config) below.
 * `response_header_config` - (Optional, Set) The configuration of the header field. See [`response_header_config`](#rule_conditions-response_header_config) below.
 * `response_status_code_config` - (Optional, Set) The configuration of the header field. See [`response_status_code_config`](#rule_conditions-response_status_code_config) below.
@@ -340,7 +398,9 @@ The response_status_code_config supports the following:
 
 The host_config supports the following:
 
-* `values` - (Optional, List) The name of the host. **Note: ** The host name must meet the following rules: The hostname must be 3 to 128 characters in length, and can contain lowercase letters, digits, hyphens (-), periods (.), asterisks (*), and question marks (?). The host name must contain at least one period (.), and cannot start or end with a period (.). The rightmost field can contain only letters and wildcards, and cannot contain digits or hyphens (-). Other fields cannot start or end with a hyphen (-). You can enter asterisks (*) and question marks (?) anywhere in a field.
+* `values` - (Optional, List) The name of the host.
+
+  -> **NOTE:** The host name must meet the following rules: The hostname must be 3 to 128 characters in length, and can contain lowercase letters, digits, hyphens (-), periods (.), asterisks (*), and question marks (?). The host name must contain at least one period (.), and cannot start or end with a period (.). The rightmost field can contain only letters and wildcards, and cannot contain digits or hyphens (-). Other fields cannot start or end with a hyphen (-). You can enter asterisks (*) and question marks (?) anywhere in a field.
 
 ### `rule_conditions-method_config`
 


### PR DESCRIPTION
### Problem

`remove_header_config` on `alicloud_alb_rule` never takes effect when the rule is created.

`resourceAliCloudAlbRuleCreate` builds `removeHeaderConfigMap`, but assigns the key into
`insertHeaderConfigMap` instead, so `RemoveHeaderConfig` goes out as an empty object:

```go
removeHeaderConfigMap := map[string]interface{}{}
for _, removeHeaderConfig := range ruleActionsArg["remove_header_config"].(*schema.Set).List() {
    removeHeaderConfigArg := removeHeaderConfig.(map[string]interface{})
-   insertHeaderConfigMap["Key"] = removeHeaderConfigArg["key"]
+   removeHeaderConfigMap["Key"] = removeHeaderConfigArg["key"]
    ruleActionsMap["RemoveHeaderConfig"] = removeHeaderConfigMap
}
```

`CreateRule` accepts the request and stores nothing, so the effect is silent and persistent:

1. the header is never actually removed by the rule;
2. `ListRules` returns `"RemoveHeaderConfig": {}`, Read finds no key and drops the whole
   action from state;
3. every subsequent plan shows the same diff, and every apply is discarded the same way.

`Update` already assigned into the right map, so the argument works if you apply it a second
time as a change — which is why this went unnoticed. Reported via an internal ticket.

### Changes

- `resource_alicloud_alb_rule.go`: assign the key into `removeHeaderConfigMap` on create.
- `resource_alicloud_alb_rule_test.go`: add `TestAccAliCloudALBRule_removeHeader`, covering
  `remove_header_config` next to a `forward_group_config` final action and asserting the key
  on both create and update. Nested `TypeSet` elements are hash-indexed, so the key is
  asserted with a check function walking the instance attributes rather than an indexed path.
- `website/docs/r/alb_rule.html.markdown`: add an example combining `remove_header_config`
  with a `forward_group_config` final action, and describe `remove_header_config` as the
  removed header field rather than the inserted one.
- also repair the notes on that docs page, which the markdown lint forced into scope:
  `markdownlint` runs over the whole changed file, and `host_config.values` carried
  `**Note: **`, tripping `MD037/no-space-in-emphasis`. The notes on `priority`,
  `rule_actions.type`, `weight`, `insert_header_config.key`, `redirect_config.protocol`,
  `per_ip_qps` and the `rule_conditions.type` sublist had a second problem: with no blank
  line before them, CommonMark absorbs each into the preceding bullet as a lazy
  continuation, so they render as literal `**NOTE:**` text. They are now blank-line
  separated `-> **NOTE:**` blocks indented to their parent's content column. The
  `rule_conditions.type` sublist also claimed "The `SourceIp` option is available since
  1.213.1" on both `ResponseHeader` and `ResponseStatusCode`; its three notes are merged
  into one that names each value.
- while in those notes, two content gaps: the ordering constraint on `rule_actions.order`
  was only implied, and was phrased in the service's `FinalType`/`ExtType` vocabulary
  rather than in terms of the configuration — the `ForwardGroup` / `Redirect` /
  `FixedResponse` action runs last, so its `order` must be greater than every other
  action's in the same rule, or the rule is rejected with `IllegalParam.Order`. And the
  forbidden header names were incomplete: `insert_header_config.key` listed only `Cookie`
  and `Host` out of the eighteen the service rejects, and `remove_header_config.key` was
  missing `x-forwarded-host`.

### Acceptance tests

Whole `TestAccAliCloudALBRule*` suite, cn-beijing:

```
PASS: TestAccAliCloudALBRule_basic2 (192.91s)
FAIL: TestAccAliCloudALBRule_removeHeader (159.96s)          <- destroy hook only, see below
FAIL: TestAccAliCloudALBRule_basic0 (527.01s)
FAIL: TestAccAliCloudALBRule_basic0_twin (157.44s)
FAIL: TestAccAliCloudALBRule_basic1 (542.31s)
FAIL: TestAccAliCloudALBRule_trafficMirror (160.65s)
FAIL: TestAccAliCloudALBRule_basicStickySession (534.35s)
FAIL: TestAccAliCloudALBRulesDataSource (172.22s)
--- PASS=1 FAIL=7 SKIP=0
```

Re-run of the three cases that had failed on `DeleteLoadBalancer`, plus `basicStickySession`,
in cn-hangzhou:

```
FAIL: TestAccAliCloudALBRule_removeHeader (155.55s)          <- destroy hook only, see below
FAIL: TestAccAliCloudALBRule_basic0_twin (507.62s)
FAIL: TestAccAliCloudALBRule_trafficMirror (533.39s)
FAIL: TestAccAliCloudALBRule_basicStickySession (541.75s)
--- PASS=0 FAIL=4 SKIP=0
```

All four failed in the post-test destroy hook (`testing.go:766`) with no step error and no
check error, so all four test bodies passed. `basic0_twin` and `trafficMirror` got past
`DeleteLoadBalancer` this time and failed one step further on, at `DeleteVpc`; their dangling
state holds nothing but the VPC, every other resource having been destroyed cleanly.

`TestAccAliCloudALBRule_removeHeader` has no step error and no check error: both applies and
every check passed, including the key assertion on create and on update. Its only failure is
the post-test destroy hook (`testing.go:766`), where `DeleteLoadBalancer` returns
`IncorrectStatus.LoadBalancer` on its single attempt, seconds after the listener's
asynchronous delete job completes. The debug log confirms the fix end to end: the create request carries
`"RemoveHeaderConfig":{"Key":"..."}`, the update carries the new key, and `ListRules` reads
both back alongside the rule's `ForwardGroup` action. On master the same request carries
`"RemoveHeaderConfig":{}`. The case was re-run twice afterwards, in a second region: three runs,
three green bodies, and a red destroy hook every time — twice on `DeleteLoadBalancer` as above
and once one step further on, at `DeleteVpc` with the security group described below.

The other failures are pre-existing and unrelated to this change. Five of the seven are in the
post-test destroy hook only, with the test body fully green; `ALBRulesDataSource` fails in its
body only; `basic0` fails in both places:

- `basic0_twin`, `trafficMirror` fail in the destroy hook only, same
  `IncorrectStatus.LoadBalancer` as above. `DeleteLoadBalancer` is the only call in
  `resource_alicloud_alb_load_balancer.go` that omits `IncorrectStatus.LoadBalancer` from its
  retry list, while nine other calls in that same file include it, so a 400 here is treated as
  non-retryable and the 5-minute delete budget goes unused. The error itself does not name the
  status it objects to — the message fills both of its slots with the instance ID — and the
  delete path reads no load balancer status of its own. Worth a separate fix, though on
  re-run both cases got past the load balancer and then hit the security group below instead,
  so that fix alone will not turn them green.
- `basic1`, `basicStickySession` fail in the destroy hook only, on `DeleteVpc` with
  `DependencyViolation.SecurityGroup`. The test account auto-creates a default security group
  inside every new VPC a couple of minutes after the VPC appears. Terraform does not manage it,
  so it is never in the destroy graph, and `resourceAliCloudVpcDelete` spends its whole
  5-minute budget retrying a dependency that will never clear. Whether a case beats the
  automation is a race: across two runs the same test case produced either this error or a
  clean VPC delete, and the cases that tore down fastest were the ones that got through.
- `basic0` is the only case that fails inside its body: step 4 apply fails with `-21013
  LbStatusNotSupport` on `UpdateRuleAttribute`, then the destroy hook fails on the same
  security group as above. The `-21013` is the same class of gap as the load balancer one —
  `resourceAliCloudAlbRuleUpdate` retries only on `ResourceInConfiguring.Listener`, so a
  transient load balancer status is non-retryable there even though the Delete path already
  lists `-21013`. It did not reproduce when the case was re-run on its own, where only the
  destroy hook failed.
- `ALBRulesDataSource` fails at its first apply with `IllegalParam.Order` on `CreateRule`, a
  fixture defect in a file this PR does not touch; it reproduces on `release/v2` too. Its
  destroy hook is the one that passed.
