### PR TITLE
data-source/alicloud_nas_file_systems: add file_system_type input filter; data-source/alicloud_nas_access_groups: add cpfs enum

### DIFF
--- a/alicloud/data_source_alicloud_nas_access_groups.go
+++ b/alicloud/data_source_alicloud_nas_access_groups.go
@@ -45,7 +45,7 @@ func dataSourceAlicloudNasAccessGroups() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "standard",
-				ValidateFunc: validation.StringInSlice([]string{"extreme", "standard"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"extreme", "standard", "cpfs"}, false),
 			},
 			"useutc_date_time": {
 				Type:     schema.TypeBool,

--- a/alicloud/data_source_alicloud_nas_file_systems.go
+++ b/alicloud/data_source_alicloud_nas_file_systems.go
@@ -30,6 +30,11 @@ func dataSourceAlicloudFileSystems() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringIsValidRegExp,
 			},
+			"file_system_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"standard", "extreme", "cpfs", "cpfsse"}, false),
+			},
 			"ids": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -114,6 +119,9 @@ func dataSourceAlicloudFileSystemsRead(d *schema.ResourceData, meta interface{})
 	request["RegionId"] = client.Region
 	request["PageSize"] = PageSizeLarge
 	request["PageNumber"] = 1
+	if v, ok := d.GetOk("file_system_type"); ok {
+		request["FileSystemType"] = v
+	}
 
 	var objects []map[string]interface{}
 	idsMap := make(map[string]string)

--- a/alicloud/data_source_alicloud_nas_file_systems_test.go
+++ b/alicloud/data_source_alicloud_nas_file_systems_test.go
@@ -38,6 +38,16 @@ func TestAccAlicloudNASFileSystem_DataSource(t *testing.T) {
 			"ids": `["${alicloud_nas_file_system.default.id}_fake"]`,
 		}),
 	}
+	fileSystemTypeConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudFileSystemDataSourceConfig(rand, map[string]string{
+			"file_system_type":  `"standard"`,
+			"description_regex": `"^${alicloud_nas_file_system.default.description}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudFileSystemDataSourceConfig(rand, map[string]string{
+			"file_system_type":  `"extreme"`,
+			"description_regex": `"^${alicloud_nas_file_system.default.description}"`,
+		}),
+	}
 	allConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudFileSystemDataSourceConfig(rand, map[string]string{
 			"storage_type":      `"${alicloud_nas_file_system.default.storage_type}"`,
@@ -52,7 +62,7 @@ func TestAccAlicloudNASFileSystem_DataSource(t *testing.T) {
 	}
 
 	fileSystemCheckInfo.dataSourceTestCheck(t, rand, storageTypeConf, protocolTypeConf,
-		descriptionConf, idsConf, allConf)
+		descriptionConf, idsConf, fileSystemTypeConf, allConf)
 }
 
 func testAccCheckAlicloudFileSystemDataSourceConfig(rand int, attrMap map[string]string) string {

--- a/website/docs/d/nas_access_groups.html.markdown
+++ b/website/docs/d/nas_access_groups.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 This data source provides user-available access groups. Use when you can create mount points
 
--> NOTE: Available in 1.35.0+
+-> **NOTE:** Available since v1.35.0+
 
 ## Example Usage
 
@@ -33,10 +33,10 @@ The following arguments are supported:
 
 * `name_regex` - (Optional, ForceNew) A regex string to filter AccessGroups by name. 
 * `type` - (Optional, ForceNew, Deprecated in v1.95.0+) Field `type` has been deprecated from version 1.95.0. Use `access_group_type` instead.
-* `access_group_type` - (Optional, ForceNew ,Available in 1.95.0+) Filter results by a specific AccessGroupType.
+* `access_group_type` - (Optional, ForceNew, Available in 1.95.0+) Filter results by a specific AccessGroupType.
 * `description` - (Optional, ForceNew) Filter results by a specific Description.
 * `access_group_name` - (Optional, ForceNew, Available in 1.95.0+) The name of access group.
-* `file_system_type` - (Optional, ForceNew, Available in 1.95.0+) The type of file system. Valid values: `standard` and `extreme`. Default to `standard`.
+* `file_system_type` - (Optional, ForceNew, Available in 1.95.0+) The type of file system. Valid values: `standard`, `extreme` and `cpfs`. Default to `standard`.
 * `useutc_date_time` - (Optional, ForceNew, Available in 1.95.0+) Specifies whether the time to return is in UTC. Valid values: true and false.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
@@ -47,10 +47,10 @@ The following attributes are exported in addition to the arguments listed above:
 * `ids` - A list of AccessGroup IDs, the value is set to `names`. After version 1.95.0 the item value as `<access_group_id>:<file_system_type>`. 
 * `names` - A list of AccessGroup names.
 * `groups` - A list of AccessGroups. Each element contains the following attributes:
- * `id` - This ID of this AccessGroup. It is formatted to ``<access_group_id>:<file_system_type>``. Before version 1.95.0, the value is `access_group_name`.
- * `rule_count` - RuleCount of the AccessGroup.
- * `type` - (Deprecated in v1.95.0+) AccessGroupType of the AccessGroup. The Field replace by `access_group_type` after version 1.95.0.
- * `mount_target_count` - MountTargetCount block of the AccessGroup
- * `description` - Description of the AccessGroup.
- * `access_group_name` - (Available in 1.95.0+) The name of the AccessGroup.
- * `access_group_type` - (Available in 1.95.0+) The type of the AccessGroup.
+  * `id` - This ID of this AccessGroup. It is formatted to ``<access_group_id>:<file_system_type>``. Before version 1.95.0, the value is `access_group_name`.
+  * `rule_count` - RuleCount of the AccessGroup.
+  * `type` - (Deprecated in v1.95.0+) AccessGroupType of the AccessGroup. The Field replace by `access_group_type` after version 1.95.0.
+  * `mount_target_count` - MountTargetCount block of the AccessGroup
+  * `description` - Description of the AccessGroup.
+  * `access_group_name` - (Available in 1.95.0+) The name of the AccessGroup.
+  * `access_group_type` - (Available in 1.95.0+) The type of the AccessGroup.

--- a/website/docs/d/nas_file_systems.html.markdown
+++ b/website/docs/d/nas_file_systems.html.markdown
@@ -11,13 +11,14 @@ description: |-
 
 This data source provides FileSystems available to the user.
 
--> **NOTE**: Available in 1.35.0+
+-> **NOTE:** Available since v1.35.0+
 
 ## Example Usage
 
 ```terraform
 data "alicloud_nas_file_systems" "fs" {
   protocol_type     = "NFS"
+  file_system_type  = "standard"
   description_regex = "${alicloud_nas_file_system.foo.description}"
 }
 
@@ -25,26 +26,29 @@ output "alicloud_nas_file_systems_id" {
   value = "${data.alicloud_nas_file_systems.fs.systems.0.id}"
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `ids` - (Optional) A list of FileSystemId.
-* `storage_type` - (Required, ForceNew) The storage type of the file system.
+* `storage_type` - (Optional, ForceNew) The storage type of the file system.
   * Valid values:
     * `Performance` (Available when the `file_system_type` is `standard`)
     * `Capacity` (Available when the `file_system_type` is `standard`)
     * `standard` (Available in v1.140.0+ and when the `file_system_type` is `extreme`)
     * `advance` (Available in v1.140.0+ and when the `file_system_type` is `extreme`)
-* `protocol_type` - (Required, ForceNew) The protocol type of the file system.
+* `protocol_type` - (Optional, ForceNew) The protocol type of the file system.
                                      Valid values:
                                            `NFS`,
                                            `SMB` (Available when the `file_system_type` is `standard`).
 * `description_regex` - (Optional) A regex string to filter the results by the ：FileSystem description.
-* `file_system_type` - (Optional, Available in v1.140.0+) The type of the file system.
+* `file_system_type` - (Optional, Available in v1.140.0+) The type of the file system. Filter file systems by the specified type. If not specified, all file system types are returned.
                                       Valid values:
-                                            `standard` (Default),
-                                            `extreme`.
+                                            `standard`,
+                                            `extreme`,
+                                            `cpfs`,
+                                            `cpfsse`.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
 ## Attributes Reference
@@ -64,13 +68,11 @@ The following attributes are exported in addition to the arguments listed above:
   * `capacity` - (Optional, Available in v1.140.0+) The capacity of the file system.
   * `file_system_type` - (Optional, Available in v1.140.0+) The type of the file system.
                             Valid values:
-                            `standard` (Default),
-                            `extreme`.
-  * `encrypt_type` - (Optional, Available in v1.121.2+) Whether the file system is encrypted. 
-    * Valid values:
-      * `0`: The file system is not encrypted.
-      * `1`: The file system is encrypted with a managed secret key.
-      * `2`: User management key.
+                            `standard`,
+                            `extreme`,
+                            `cpfs`,
+                            `cpfsse`.
+  * `encrypt_type` - (Optional, Available in v1.121.2+) Whether the file system is encrypted. Valid values: `0` (The file system is not encrypted), `1` (The file system is encrypted with a managed secret key), `2` (User management key).
   * `kms_key_id` - (Optional, Available in v1.140.0+) The id of the KMS key.
   * `zone_id` - (Optional, Available in v1.140.0+) The id of the zone. Each region consists of multiple isolated locations known as zones. Each zone has an independent power supply and network.
  


### PR DESCRIPTION
## Summary

The `alicloud_nas_file_systems` data source documented `file_system_type` as an input filter since v1.140.0+, but the schema only declared it as a Computed output — users could not actually filter NAS file systems by type. The sibling `alicloud_nas_access_groups` data source already accepted `file_system_type` but its `ValidateFunc` omitted the `cpfs` value that the OpenAPI `DescribeAccessGroups` action supports.

## Changes

### `alicloud_nas_file_systems`

- Add `file_system_type` as an Optional input field, validated against the OpenAPI `DescribeFileSystems` enum: `standard`, `extreme`, `cpfs`, `cpfsse`.
- In `Read`, forward `file_system_type` to the `FileSystemType` request parameter when set (mirrors the existing pattern in `alicloud_nas_access_groups`). When unset, `FileSystemType` is not sent and the API returns all file system types, preserving existing behavior.
- The existing Computed `systems[].file_system_type` output is unchanged.

### `alicloud_nas_access_groups`

- Add `cpfs` to the `file_system_type` `ValidateFunc` enum. OpenAPI `DescribeAccessGroups` accepts `standard`, `extreme`, `cpfs`.

### Docs

- `nas_file_systems.html.markdown`: update the argument and attribute enum to list `standard`, `extreme`, `cpfs`, `cpfsse`; clarify that when `file_system_type` is not specified, all file system types are returned; add `file_system_type` to the example usage.
- `nas_access_groups.html.markdown`: add `cpfs` to the `file_system_type` valid values.

### Tests

- `data_source_alicloud_nas_file_systems_test.go`: add a `fileSystemTypeConf` acceptance test case that exercises the new input filter (exist case filters by `standard` against the standard fixture; fake case filters by `extreme` and expects zero matches).

## Verification

- `gofmt` clean on changed Go files.
- `go vet -p=1 ./alicloud` passes (the two pre-existing `fmt.Sprintln` warnings in `common.go` are unrelated to this change).
- Remote ACC (`TestAccAlicloudNASFileSystem_DataSource`) will be run via the standard ACC pipeline.
