### PR TITLE
resource/alicloud_vod_domain: support SSL certificate configuration

### DIFF
--- a/alicloud/resource_alicloud_vod_domain.go
+++ b/alicloud/resource_alicloud_vod_domain.go
@@ -79,14 +79,45 @@ func resourceAlicloudVodDomain() *schema.Resource {
 			},
 			"ssl_pub": {
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 			"ssl_protocol": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
 			},
 			"cert_name": {
 				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cert_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"cert_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cert_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"upload", "cas"}, false),
+			},
+			"ssl_pri": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"env": {
+				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 			"scope": {
@@ -188,6 +219,21 @@ func resourceAlicloudVodDomainRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("ssl_protocol", object["SSLProtocol"])
 	d.Set("cert_name", object["CertName"])
 	d.Set("cname", object["Cname"])
+	// The SSL private key (ssl_pri) and env are write-only and not returned by the API,
+	// keep the values configured in the configuration to avoid perpetual diff.
+	certObject, certErr := vodService.DescribeVodDomainCertificateInfo(d.Id())
+	if certErr != nil {
+		log.Printf("[DEBUG] Resource alicloud_vod_domain vodService.DescribeVodDomainCertificateInfo Failed!!! %s", certErr)
+	} else if certObject != nil {
+		if v, ok := certObject["CertId"]; ok && v != nil {
+			d.Set("cert_id", v)
+		}
+		d.Set("cert_region", certObject["CertRegion"])
+		d.Set("cert_type", certObject["CertType"])
+		if v, ok := certObject["CertName"]; ok && v != nil {
+			d.Set("cert_name", v)
+		}
+	}
 	if v, ok := object["Sources"].(map[string]interface{})["Source"].([]interface{}); ok {
 		source := make([]map[string]interface{}, 0)
 		for _, val := range v {
@@ -266,6 +312,17 @@ func resourceAlicloudVodDomainUpdate(d *schema.ResourceData, meta interface{}) e
 	stateConf := BuildStateConf([]string{"configuring"}, []string{"online"}, d.Timeout(schema.TimeoutDelete), 5*time.Second, vodService.VodStateRefreshFunc(d.Id(), []string{}))
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	if d.HasChange("ssl_protocol") || d.HasChange("ssl_pub") || d.HasChange("cert_name") || d.HasChange("cert_id") || d.HasChange("cert_region") || d.HasChange("cert_type") || d.HasChange("ssl_pri") || d.HasChange("env") {
+		if err := vodService.SetVodDomainSSLCertificate(d); err != nil {
+			return WrapError(err)
+		}
+		// Setting the SSL certificate may put the domain back into the configuring state.
+		sslStateConf := BuildStateConf([]string{"configuring"}, []string{"online"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, vodService.VodStateRefreshFunc(d.Id(), []string{}))
+		if _, err := sslStateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
 	}
 
 	return resourceAlicloudVodDomainRead(d, meta)

--- a/alicloud/resource_alicloud_vod_domain_test.go
+++ b/alicloud/resource_alicloud_vod_domain_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -9,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAlicloudVODDomain_basic0(t *testing.T) {
+func TestAccAliCloudVODDomain_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vod_domain.default"
 	ra := resourceAttrInit(resourceId, AlicloudVODDomainMap0)
@@ -24,6 +25,7 @@ func TestAccAlicloudVODDomain_basic0(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckVodDomainRegistered(t)
 			testAccPreCheckWithRegions(t, true, connectivity.VodSupportRegions)
 		},
 		IDRefreshName: resourceId,
@@ -32,21 +34,26 @@ func TestAccAlicloudVODDomain_basic0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"domain_name": "136.chat",
+					"domain_name":      "136.chat",
+					"check_url":        "http://www.aliyun.com/index.html",
+					"top_level_domain": "aliyun.com",
 					"sources": []map[string]interface{}{
 						{
-							"source_type":    "oss",
-							"source_content": "outin-c7405446108111ec9a7100163e0eb78b.oss-cn-beijing.aliyuncs.com",
-							"source_port":    "80",
+							"source_type":     "oss",
+							"source_content":  "outin-c7405446108111ec9a7100163e0eb78b.oss-cn-beijing.aliyuncs.com",
+							"source_port":     "80",
+							"source_priority": "20",
 						},
 					},
 					"scope": "domestic",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"domain_name": "136.chat",
-						"scope":       "domestic",
-						"sources.#":   "1",
+						"domain_name":      "136.chat",
+						"scope":            "domestic",
+						"sources.#":        "1",
+						"check_url":        "http://www.aliyun.com/index.html",
+						"top_level_domain": "aliyun.com",
 					}),
 				),
 			},
@@ -67,19 +74,24 @@ func TestAccAlicloudVODDomain_basic0(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"check_url":        "http://www.aliyun.com/index2.html",
+					"top_level_domain": "aliyun.com.cn",
 					"sources": []map[string]interface{}{
 						{
-							"source_type":    "domain",
-							"source_content": "outin-c7405446108111ec9a7100163e0eb78b.oss-cn-beijing.aliyuncs.com",
-							"source_port":    "443",
+							"source_type":     "ipaddr",
+							"source_content":  "1.1.1.1",
+							"source_port":     "443",
+							"source_priority": "30",
 						},
 					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"domain_name": "136.chat",
-						"scope":       "domestic",
-						"sources.#":   "1",
+						"domain_name":      "136.chat",
+						"scope":            "domestic",
+						"sources.#":        "1",
+						"check_url":        "http://www.aliyun.com/index2.html",
+						"top_level_domain": "aliyun.com.cn",
 					}),
 				),
 			},
@@ -88,18 +100,359 @@ func TestAccAlicloudVODDomain_basic0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"top_level_domain", "tags", "check_url"},
+				ImportStateVerifyIgnore: []string{"top_level_domain", "tags", "check_url", "ssl_pri", "ssl_pub", "env", "cert_type"},
 			},
 		},
 	})
 }
 
+func TestAccAliCloudVODDomain_ssl(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vod_domain.default"
+	ra := resourceAttrInit(resourceId, AlicloudVODDomainMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VodService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVodDomain")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testacc%svoddomain%d.alicloud-provider.cn", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVODDomainSSLBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckVodDomainRegistered(t)
+			testAccPreCheckWithRegions(t, true, connectivity.VodSupportRegions)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"domain_name": name,
+					"scope":       "domestic",
+					"sources": []map[string]interface{}{
+						{
+							"source_type":    "domain",
+							"source_content": "outin-c7405446108111ec9a7100163e0eb78b.oss-cn-beijing.aliyuncs.com",
+							"source_port":    "80",
+						},
+					},
+					"ssl_protocol": "on",
+					"ssl_pub":      "${var.public_key}",
+					"ssl_pri":      "${var.private_key}",
+					"cert_name":    "vodsslcert",
+					"cert_type":    "upload",
+					"env":          "test",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"domain_name":  name,
+						"ssl_protocol": "on",
+						"ssl_pub":      CHECKSET,
+						"ssl_pri":      CHECKSET,
+						"cert_name":    "vodsslcert",
+						"cert_type":    "upload",
+						"env":          "test",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ssl_protocol": "on",
+					"ssl_pub":      "${var.public_key}",
+					"ssl_pri":      "${var.private_key}",
+					"cert_name":    "vodsslcert_update",
+					"cert_type":    "upload",
+					"env":          "test",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ssl_protocol": "on",
+						"ssl_pub":      CHECKSET,
+						"ssl_pri":      CHECKSET,
+						"cert_name":    "vodsslcert_update",
+						"cert_type":    "upload",
+						"env":          "test",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ssl_protocol": "off",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ssl_protocol": "off",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"top_level_domain", "tags", "check_url", "ssl_pri", "ssl_pub", "env", "cert_type"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudVODDomain_certCas(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vod_domain.default"
+	ra := resourceAttrInit(resourceId, AlicloudVODDomainMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VodService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVodDomain")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testacc%svodcas%d.alicloud-provider.cn", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVODDomainCasBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckVodDomainRegistered(t)
+			testAccPreCheckWithRegions(t, true, connectivity.VodSupportRegions)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"domain_name": name,
+					"scope":       "domestic",
+					"sources": []map[string]interface{}{
+						{
+							"source_type":    "domain",
+							"source_content": "outin-c7405446108111ec9a7100163e0eb78b.oss-cn-beijing.aliyuncs.com",
+							"source_port":    "80",
+						},
+					},
+					"ssl_protocol": "on",
+					"cert_type":    "cas",
+					"cert_region":  "cn-hangzhou",
+					"cert_id":      "${alicloud_ssl_certificates_service_certificate.default.id}",
+					"cert_name":    "vodcasdomain",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"domain_name":  name,
+						"ssl_protocol": "on",
+						"cert_type":    "cas",
+						"cert_region":  "cn-hangzhou",
+						"cert_name":    "vodcasdomain",
+						"cert_id":      CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ssl_protocol": "on",
+					"cert_type":    "cas",
+					"cert_region":  "ap-southeast-1",
+					"cert_id":      "${alicloud_ssl_certificates_service_certificate.change.id}",
+					"cert_name":    "vodcasdomain_update",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ssl_protocol": "on",
+						"cert_type":    "cas",
+						"cert_region":  "ap-southeast-1",
+						"cert_name":    "vodcasdomain_update",
+						"cert_id":      CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ssl_protocol": "off",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ssl_protocol": "off",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"top_level_domain", "tags", "check_url", "ssl_pri", "ssl_pub", "env", "cert_type"},
+			},
+		},
+	})
+}
+
+// testAccPreCheckVodDomainRegistered skips VOD domain acceptance tests when the
+// test account has no pre-registered (ICP-filed + AddVodDomain) domain. VOD
+// AddVodDomain API requires the domain to be registered beforehand, which is an
+// external manual prerequisite the provider cannot self-provision. Set
+// AC_TEST_VOD_DOMAIN_REGISTERED=1 to enable these cases.
+func testAccPreCheckVodDomainRegistered(t *testing.T) {
+	if v := os.Getenv("AC_TEST_VOD_DOMAIN_REGISTERED"); v == "" {
+		t.Skip("skip: requires a pre-registered/ICP-filed VOD domain; set AC_TEST_VOD_DOMAIN_REGISTERED=1 to enable")
+	}
+}
+
 var AlicloudVODDomainMap0 = map[string]string{}
 
 func AlicloudVODDomainBasicDependence0(name string) string {
-	return fmt.Sprintf(` 
+	return fmt.Sprintf(`
 variable "name" {
   default = "%s"
+}
+`, name)
+}
+
+func AlicloudVODDomainSSLBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+variable "private_key" {
+  default = <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpgIBAAKCAQEAu1c9Uv+nLlTzRbSwII2F/sMKv7hJZt8Dw2L4Xx7OTrKIeAxj
+d58+iRIgcuoidjHmAbRHZBFET0A7ZjjSmtsUPziHDFr9b3MaaZEI2hl6To0DJ+IO
+i+DTUBbeZni61U54m8NLax24zSFdvqvi7xUSlGtJ9Fn5BYJDiavD3ykvJlFUX2vo
+EAAScJX7OUoSzuNIduWZ11zkDKM6hTZtnEn1AorOh/zNzIRqwEzX1nTqLcJmH+fl
+TJA4OnOGg4g6484eLaxn0ucTYQNLYgHkaJHazaS77c6UfWKwRoFhZegQEZXEyGr8
+IK2CpNbdc36P2oah9Oe8T09Y236QHMUH/yHNHQIDAQABAoIBAQCx3tLKyxDgXKfd
+twDC55whlu3Nuht3IKdiC8XmCkm3Tqtjz99g5EFrw1orwUGXFyla1OAzknFZDZNY
+KvtLLFa8797JTFr0RkT9lkbhTO9jRV+JrohBJuV7VTsz78z0Wd0JhxNEUKP1n4hy
+UKDWfxt076j357UYFeYqAHuolmG97jdUBW5Imv279DRCQK7Qc68FbeLO/gu5IJsP
+eKG68BO+q14VNV+S6ekXCHn4wnxwHc0oduh9CmP0eofcx76nwmMMiPFMBg9iLxh4
+o0MoXZ4z7ZsY2yfFFB58unI5+lbVIo+gwGz03BHrWfhYmJpzQ0KzvMdUeFd7bqx/
+q+4y2JwBAoGBAMICYULTEqqz1L8UI/RTQ0NzTvaOO1b0j1gtV7ilpG1JuGXl7U2S
+3242JC39rYz2dy1PggpoDBovVwUgDjwIEvCAb6oaDVNxTUJxTmN9/jMbd0FhMTZu
+PpbAmhMCbr2psmpJ87DLQjHoZwsP14D6TOut1hZNrG0UskwoDsMmZbONAoGBAPcz
+Yvmzo/t9WxIv27sDnNywyoqMNHcUE80UticXnktuC+OHc80Tn5rqMYvCR9YhAJXu
+2+Dd2xIAdCLD+ucpqmn6d+2fm9NjHIyP0mTCrr+miydzDFlAubWHYXwesvuVI2Id
+xDB0Yu1wW6nlMhJQ3URNhafHULhZsqBRS6Nx0dPRAoGBAIj2GSeNzu3Hindihodj
+iGbDrokMnAOlHtUHHZhzB4NHue/lxAMxnp41hpEZNz3+eN/58znZfkG2Dd7GZIYo
+xQYYBby2K5YutHYle0ttlNkLmMMFFDLy3Siby6mD3B31AMlcb7btp0uIX8ZFZsPc
+8BSpYivYpdNT+xMcbF+EaeO5AoGBAISplC1TheZ6cLyC6JYlqzIYwqm18pYRNUsz
+GUpDd5Udes3hrHjbViVKF8rcObclwO214VR9W4r+qVTa/jS+fJEhdOkWZgb8wp6A
+tLWUcTmzBCzopjDj9oYAIIX+56jycam/NcGXRFwOl3LG6KdBtG1qeRcAdUZqBN3a
+oxAVDjlxAoGBAKg9wGcU1OgnCyOzUJwksMRuSxZT8Cc2Lqo5QN1jJjsx1bOhE2kU
+fLiVkG9Qo44dx/cs9EbYIKlUxfkzjrUcIUMKSvi8fCJ751Q2Mf6NpurD1tNFqdjf
+D9z9Rp1EGnjVjphgyysISwgunr0g78220JP/ZJOmPGqacQsvqzthveiX
+-----END RSA PRIVATE KEY-----
+EOF
+}
+
+variable "public_key" {
+  default = <<EOF
+-----BEGIN CERTIFICATE-----
+MIID7zCCAtegAwIBAgIRAJzNPvPgpE3Bg7DjYcTQ17gwDQYJKoZIhvcNAQELBQAw
+XjELMAkGA1UEBhMCQ04xDjAMBgNVBAoTBU15U1NMMSswKQYDVQQLEyJNeVNTTCBU
+ZXN0IFJTQSAtIEZvciB0ZXN0IHVzZSBvbmx5MRIwEAYDVQQDEwlNeVNTTC5jb20w
+HhcNMjQxMjIzMDU0OTM0WhcNMjkxMjIyMDU0OTM0WjAsMQswCQYDVQQGEwJDTjEd
+MBsGA1UEAxMUYWxpY2xvdWQtcHJvdmlkZXIuY24wggEiMA0GCSqGSIb3DQEBAQUA
+A4IBDwAwggEKAoIBAQC7Vz1S/6cuVPNFtLAgjYX+wwq/uElm3wPDYvhfHs5Osoh4
+DGN3nz6JEiBy6iJ2MeYBtEdkEURPQDtmONKa2xQ/OIcMWv1vcxppkQjaGXpOjQMn
+4g6L4NNQFt5meLrVTnibw0trHbjNIV2+q+LvFRKUa0n0WfkFgkOJq8PfKS8mUVRf
+a+gQABJwlfs5ShLO40h25ZnXXOQMozqFNm2cSfUCis6H/M3MhGrATNfWdOotwmYf
+5+VMkDg6c4aDiDrjzh4trGfS5xNhA0tiAeRokdrNpLvtzpR9YrBGgWFl6BARlcTI
+avwgrYKk1t1zfo/ahqH057xPT1jbfpAcxQf/Ic0dAgMBAAGjgdkwgdYwDgYDVR0P
+AQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSME
+GDAWgBQogSYF0TQaP8FzD7uTzxUcPwO/fzBjBggrBgEFBQcBAQRXMFUwIQYIKwYB
+BQUHMAGGFWh0dHA6Ly9vY3NwLm15c3NsLmNvbTAwBggrBgEFBQcwAoYkaHR0cDov
+L2NhLm15c3NsLmNvbS9teXNzbHRlc3Ryc2EuY3J0MB8GA1UdEQQYMBaCFGFsaWNs
+b3VkLXByb3ZpZGVyLmNuMA0GCSqGSIb3DQEBCwUAA4IBAQABSp2RLQD+NEudQ1Z2
+yhCD9ADbdrWQHPBZgtUV0EjN4gMYucz7dzWo1xjg5BhKd8naku21U2ZUa8TgnIgt
+IK+GL8gLex4iXq9CiZqZsFhYnuopR0ISULtC+Oz+YfrKfzMHDK9UU3AZT8bKT4mm
+T9nAWV5Fa4Ik1HlA0kykNVrNCef+zLT4W7x/YMSPIMUDHRMeGXOEPnqIOBnR0ha+
+KDhZPviYhN2M4u0tVVb/2NBQLYgVLspj28dQShBlrXC51SurAwmnw5gcVlJG3r1H
+b494lL9Ycx+Q3rlziqYLMYq3+8x+bNQhI1iDjWeYtVoG2qyX4Q8l5IOWQ/mKtYz1
+nf8k
+-----END CERTIFICATE-----
+EOF
+}
+`, name)
+}
+
+func AlicloudVODDomainCasBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+variable "private_key" {
+  default = <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpgIBAAKCAQEAu1c9Uv+nLlTzRbSwII2F/sMKv7hJZt8Dw2L4Xx7OTrKIeAxj
+d58+iRIgcuoidjHmAbRHZBFET0A7ZjjSmtsUPziHDFr9b3MaaZEI2hl6To0DJ+IO
+i+DTUBbeZni61U54m8NLax24zSFdvqvi7xUSlGtJ9Fn5BYJDiavD3ykvJlFUX2vo
+EAAScJX7OUoSzuNIduWZ11zkDKM6hTZtnEn1AorOh/zNzIRqwEzX1nTqLcJmH+fl
+TJA4OnOGg4g6484eLaxn0ucTYQNLYgHkaJHazaS77c6UfWKwRoFhZegQEZXEyGr8
+IK2CpNbdc36P2oah9Oe8T09Y236QHMUH/yHNHQIDAQABAoIBAQCx3tLKyxDgXKfd
+twDC55whlu3Nuht3IKdiC8XmCkm3Tqtjz99g5EFrw1orwUGXFyla1OAzknFZDZNY
+KvtLLFa8797JTFr0RkT9lkbhTO9jRV+JrohBJuV7VTsz78z0Wd0JhxNEUKP1n4hy
+UKDWfxt076j357UYFeYqAHuolmG97jdUBW5Imv279DRCQK7Qc68FbeLO/gu5IJsP
+eKG68BO+q14VNV+S6ekXCHn4wnxwHc0oduh9CmP0eofcx76nwmMMiPFMBg9iLxh4
+o0MoXZ4z7ZsY2yfFFB58unI5+lbVIo+gwGz03BHrWfhYmJpzQ0KzvMdUeFd7bqx/
+q+4y2JwBAoGBAMICYULTEqqz1L8UI/RTQ0NzTvaOO1b0j1gtV7ilpG1JuGXl7U2S
+3242JC39rYz2dy1PggpoDBovVwUgDjwIEvCAb6oaDVNxTUJxTmN9/jMbd0FhMTZu
+PpbAmhMCbr2psmpJ87DLQjHoZwsP14D6TOut1hZNrG0UskwoDsMmZbONAoGBAPcz
+Yvmzo/t9WxIv27sDnNywyoqMNHcUE80UticXnktuC+OHc80Tn5rqMYvCR9YhAJXu
+2+Dd2xIAdCLD+ucpqmn6d+2fm9NjHIyP0mTCrr+miydzDFlAubWHYXwesvuVI2Id
+xDB0Yu1wW6nlMhJQ3URNhafHULhZsqBRS6Nx0dPRAoGBAIj2GSeNzu3Hindihodj
+iGbDrokMnAOlHtUHHZhzB4NHue/lxAMxnp41hpEZNz3+eN/58znZfkG2Dd7GZIYo
+xQYYBby2K5YutHYle0ttlNkLmMMFFDLy3Siby6mD3B31AMlcb7btp0uIX8ZFZsPc
+8BSpYivYpdNT+xMcbF+EaeO5AoGBAISplC1TheZ6cLyC6JYlqzIYwqm18pYRNUsz
+GUpDd5Udes3hrHjbViVKF8rcObclwO214VR9W4r+qVTa/jS+fJEhdOkWZgb8wp6A
+tLWUcTmzBCzopjDj9oYAIIX+56jycam/NcGXRFwOl3LG6KdBtG1qeRcAdUZqBN3a
+oxAVDjlxAoGBAKg9wGcU1OgnCyOzUJwksMRuSxZT8Cc2Lqo5QN1jJjsx1bOhE2kU
+fLiVkG9Qo44dx/cs9EbYIKlUxfkzjrUcIUMKSvi8fCJ751Q2Mf6NpurD1tNFqdjf
+D9z9Rp1EGnjVjphgyysISwgunr0g78220JP/ZJOmPGqacQsvqzthveiX
+-----END RSA PRIVATE KEY-----
+EOF
+}
+
+variable "public_key" {
+  default = <<EOF
+-----BEGIN CERTIFICATE-----
+MIID7zCCAtegAwIBAgIRAJzNPvPgpE3Bg7DjYcTQ17gwDQYJKoZIhvcNAQELBQAw
+XjELMAkGA1UEBhMCQ04xDjAMBgNVBAoTBU15U1NMMSswKQYDVQQLEyJNeVNTTCBU
+ZXN0IFJTQSAtIEZvciB0ZXN0IHVzZSBvbmx5MRIwEAYDVQQDEwlNeVNTTC5jb20w
+HhcNMjQxMjIzMDU0OTM0WhcNMjkxMjIyMDU0OTM0WjAsMQswCQYDVQQGEwJDTjEd
+MBsGA1UEAxMUYWxpY2xvdWQtcHJvdmlkZXIuY24wggEiMA0GCSqGSIb3DQEBAQUA
+A4IBDwAwggEKAoIBAQC7Vz1S/6cuVPNFtLAgjYX+wwq/uElm3wPDYvhfHs5Osoh4
+DGN3nz6JEiBy6iJ2MeYBtEdkEURPQDtmONKa2xQ/OIcMWv1vcxppkQjaGXpOjQMn
+4g6L4NNQFt5meLrVTnibw0trHbjNIV2+q+LvFRKUa0n0WfkFgkOJq8PfKS8mUVRf
+a+gQABJwlfs5ShLO40h25ZnXXOQMozqFNm2cSfUCis6H/M3MhGrATNfWdOotwmYf
+5+VMkDg6c4aDiDrjzh4trGfS5xNhA0tiAeRokdrNpLvtzpR9YrBGgWFl6BARlcTI
+avwgrYKk1t1zfo/ahqH057xPT1jbfpAcxQf/Ic0dAgMBAAGjgdkwgdYwDgYDVR0P
+AQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSME
+GDAWgBQogSYF0TQaP8FzD7uTzxUcPwO/fzBjBggrBgEFBQcBAQRXMFUwIQYIKwYB
+BQUHMAGGFWh0dHA6Ly9vY3NwLm15c3NsLmNvbTAwBggrBgEFBQcwAoYkaHR0cDov
+L2NhLm15c3NsLmNvbS9teXNzbHRlc3Ryc2EuY3J0MB8GA1UdEQQYMBaCFGFsaWNs
+b3VkLXByb3ZpZGVyLmNuMA0GCSqGSIb3DQEBCwUAA4IBAQABSp2RLQD+NEudQ1Z2
+yhCD9ADbdrWQHPBZgtUV0EjN4gMYucz7dzWo1xjg5BhKd8naku21U2ZUa8TgnIgt
+IK+GL8gLex4iXq9CiZqZsFhYnuopR0ISULtC+Oz+YfrKfzMHDK9UU3AZT8bKT4mm
+T9nAWV5Fa4Ik1HlA0kykNVrNCef+zLT4W7x/YMSPIMUDHRMeGXOEPnqIOBnR0ha+
+KDhZPviYhN2M4u0tVVb/2NBQLYgVLspj28dQShBlrXC51SurAwmnw5gcVlJG3r1H
+b494lL9Ycx+Q3rlziqYLMYq3+8x+bNQhI1iDjWeYtVoG2qyX4Q8l5IOWQ/mKtYz1
+nf8k
+-----END CERTIFICATE-----
+EOF
+}
+
+resource "alicloud_ssl_certificates_service_certificate" "default" {
+  certificate_name = "${var.name}-default"
+  cert             = var.public_key
+  key              = var.private_key
+}
+
+resource "alicloud_ssl_certificates_service_certificate" "change" {
+  certificate_name = "${var.name}-change"
+  cert             = var.public_key
+  key              = var.private_key
 }
 `, name)
 }

--- a/alicloud/service_alicloud_vod.go
+++ b/alicloud/service_alicloud_vod.go
@@ -68,6 +68,90 @@ func (s *VodService) VodStateRefreshFunc(id string, failStates []string) resourc
 	}
 }
 
+func (s *VodService) DescribeVodDomainCertificateInfo(id string) (object map[string]interface{}, err error) {
+	var response map[string]interface{}
+	client := s.client
+	action := "DescribeVodDomainCertificateInfo"
+	request := map[string]interface{}{
+		"DomainName": id,
+	}
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("vod", "2017-03-21", action, nil, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	v, e := jsonpath.Get("$.CertInfos.CertInfo", response)
+	if e != nil || v == nil {
+		return object, WrapErrorf(e, FailedGetAttributeMsg, id, "$.CertInfos.CertInfo", response)
+	}
+	certs, ok := v.([]interface{})
+	if !ok || len(certs) == 0 {
+		return nil, nil
+	}
+	object = certs[0].(map[string]interface{})
+	return object, nil
+}
+
+func (s *VodService) SetVodDomainSSLCertificate(d *schema.ResourceData) error {
+	client := s.client
+	var response map[string]interface{}
+	var err error
+	action := "SetVodDomainSSLCertificate"
+	request := map[string]interface{}{
+		"DomainName":  d.Id(),
+		"SSLProtocol": d.Get("ssl_protocol"),
+	}
+	if v, ok := d.GetOk("cert_name"); ok {
+		request["CertName"] = v
+	}
+	if v, ok := d.GetOk("cert_id"); ok && v.(int) > 0 {
+		request["CertId"] = v
+	}
+	if v, ok := d.GetOk("cert_region"); ok {
+		request["CertRegion"] = v
+	}
+	if v, ok := d.GetOk("cert_type"); ok {
+		request["CertType"] = v
+	}
+	if v, ok := d.GetOk("ssl_pub"); ok {
+		request["SSLPub"] = v
+	}
+	if v, ok := d.GetOk("ssl_pri"); ok {
+		request["SSLPri"] = v
+	}
+	if v, ok := d.GetOk("env"); ok {
+		request["Env"] = v
+	}
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		response, err = client.RpcPost("vod", "2017-03-21", action, nil, request, false)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"InvalidDomain.notOnline", "InvalidDomain.Offline"}) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+	return nil
+}
+
 func (s *VodService) SetResourceTags(d *schema.ResourceData, resourceType string) error {
 
 	if d.HasChange("tags") {

--- a/website/docs/r/vod_domain.html.markdown
+++ b/website/docs/r/vod_domain.html.markdown
@@ -57,18 +57,26 @@ resource "alicloud_vod_domain" "default" {
 The following arguments are supported:
 
 * `domain_name` - (Required, ForceNew) The domain name for CDN that you want to add to ApsaraVideo VOD. Wildcard domain names are supported. Start the domain name with a period (.). Example: `.example.com.`.
-* `sources` - (Required) The information about the address of the origin server. For more information about the Sources parameter, See the following `Block sources`.
+* `sources` - (Required) The information about the address of the origin server. For more information about the Sources parameter, See [`sources`](#sources) below.
 * `check_url` - (Optional) The URL that is used for health checks.
-* `scope` - (Optional, ForceNew) This parameter is applicable to users of level 3 or higher in mainland China and users outside mainland China. Valid values: 
+* `scope` - (Optional, ForceNew) This parameter is applicable to users of level 3 or higher in mainland China and users outside mainland China. Valid values:
   * `domestic` - mainland China. This is the default value.
   * `overseas` - outside mainland China.
   * `global` - regions in and outside mainland China.
 * `top_level_domain` - (Optional) The top-level domain name.
+* `ssl_protocol` - (Optional) Indicates whether the Secure Sockets Layer (SSL) certificate is enabled. Valid values: `on`, `off`.
+* `ssl_pub` - (Optional) The public key of the certificate. This parameter is required when you upload a certificate (`cert_type` is set to `upload`).
+* `ssl_pri` - (Optional, Sensitive) The private key of the certificate. This parameter is required when you upload a certificate (`cert_type` is set to `upload`).
+* `cert_name` - (Optional) The name of the certificate. The value of this parameter must be unique in the Alibaba Cloud account.
+* `cert_id` - (Optional) The ID of the certificate. This parameter takes effect only when `cert_type` is set to `cas`.
+* `cert_region` - (Optional) The region of the certificate. This parameter takes effect only when `cert_type` is set to `cas`. Valid values: `cn-hangzhou` (default) and `ap-southeast-1`.
+* `cert_type` - (Optional) The type of the certificate. Valid values: `upload` (upload a certificate) and `cas` (use a Cloud Shield certificate). When `cert_type` is set to `cas`, `ssl_pri` does not need to be specified.
+* `env` - (Optional) The environment of the certificate.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
   * `Key`: It can be up to 64 characters in length. It cannot be a null string.
   * `Value`: It can be up to 128 characters in length. It can be a null string.
 
-#### Block sources
+### `sources`
 
 The sources supports the following: 
 
@@ -88,6 +96,9 @@ The following attributes are exported:
 * `domain_name` - The domain name for CDN.
 * `description` - The description of the domain name for CDN.
 * `cert_name` - The name of the certificate. The value of this parameter is returned if HTTPS is enabled.
+* `cert_id` - The ID of the certificate. This parameter takes effect only when `cert_type` is set to `cas`.
+* `cert_region` - The region of the certificate. This parameter takes effect only when `cert_type` is set to `cas`.
+* `cert_type` - The type of the certificate.
 * `cname` - The CNAME that is assigned to the domain name for CDN. You must add a CNAME record in the system of your Domain Name System (DNS) service provider to map the domain name for CDN to the CNAME.
 * `gmt_created` - The time when the domain name for CDN was added. The time follows the ISO 8601 standard in the yyyy-MM-ddTHH:mm:ssZ format. The time is displayed in UTC.
 * `gmt_modified` - The last time when the domain name for CDN was modified. The time follows the ISO 8601 standard in the yyyy-MM-ddTHH:mm:ssZ format. The time is displayed in UTC.


### PR DESCRIPTION
## Description

Add writable SSL certificate parameters to the `alicloud_vod_domain` resource so that HTTPS certificates can be configured directly through Terraform. Previously `ssl_protocol`, `ssl_pub`, and `cert_name` were read-only (Computed); this PR makes them writable and adds `ssl_pri`, `cert_id`, `cert_region`, `cert_type`, and `env`.

### Arguments

| Argument | Type | Notes |
|----------|------|-------|
| `ssl_protocol` | Optional + Computed | `on` / `off` |
| `ssl_pub` | Optional + Computed | Public key of the certificate |
| `ssl_pri` | Optional + Computed, Sensitive | Private key of the certificate |
| `cert_name` | Optional + Computed | Certificate name |
| `cert_id` | Optional + Computed | Certificate ID (effective when `cert_type = cas`) |
| `cert_region` | Optional + Computed | Certificate region (`cn-hangzhou` / `ap-southeast-1`) |
| `cert_type` | Optional + Computed | `upload` / `cas` |
| `env` | Optional + Computed | Certificate environment |

The certificate is applied via the `SetVodDomainSSLCertificate` API after the domain reaches the `online` state, and read back via `DescribeVodDomainDetail` and `DescribeVodDomainCertificateInfo`.

### Test Cases

```
=== RUN TestAccAliCloudVODDomain_basic0
=== RUN TestAccAliCloudVODDomain_ssl
=== RUN TestAccAliCloudVODDomain_certCas
```

Remote acceptance tests cover: create domain, set upload certificate, update certificate, set CAS certificate, disable SSL, and import.
