### PR TITLE
docs: db_backup_policy; resource/alicloud_db_backup_policy: fix backup_retention_period being ignored when set to 7

### DIFF
--- a/alicloud/resource_alicloud_db_backup_policy_test.go
+++ b/alicloud/resource_alicloud_db_backup_policy_test.go
@@ -531,6 +531,18 @@ func TestAccAliCloudRdsDBBackupPolicyPostgreSQL(t *testing.T) {
 						"backup_interval":             "60",
 					}),
 				),
+			},
+			// 7 is the schema default of backup_retention_period, and a configured 7 used to be
+			// discarded in favour of the deprecated retention_period, which made this a silent no-op
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"backup_retention_period": "7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"backup_retention_period": "7",
+					}),
+				),
 			}},
 	})
 }

--- a/alicloud/service_alicloud_rds.go
+++ b/alicloud/service_alicloud_rds.go
@@ -846,9 +846,7 @@ func (s *RdsService) ModifyDBBackupPolicy(d *schema.ResourceData, updateForData,
 	}
 
 	retentionPeriod := "7"
-	if v, ok := d.GetOk("backup_retention_period"); ok && v.(int) != 7 {
-		retentionPeriod = strconv.Itoa(v.(int))
-	} else if v, ok := d.GetOk("retention_period"); ok && v.(int) != 0 {
+	if v, ok := d.GetOk("backup_retention_period"); ok {
 		retentionPeriod = strconv.Itoa(v.(int))
 	}
 

--- a/website/docs/r/db_backup_policy.html.markdown
+++ b/website/docs/r/db_backup_policy.html.markdown
@@ -65,59 +65,73 @@ resource "alicloud_db_backup_policy" "policy" {
 
 The following arguments are supported:
 
-* `instance_id` - (Required, ForceNew) The Id of instance that can run database.
-* `backup_period` - (Deprecated) It has been deprecated from version 1.69.0, and use field 'preferred_backup_period' instead.
-* `preferred_backup_period` - (Optional, Available since v1.69.0) DB Instance backup period. Please set at least two days to ensure backing up at least twice a week. Valid values: [Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday].
-* `backup_time` - (Deprecated) It has been deprecated from version 1.69.0, and use field 'preferred_backup_time' instead.
-* `preferred_backup_time` - (Optional, Available since v1.69.0) DB instance backup time, in the format of HH:mmZ- HH:mmZ. Time setting interval is one hour. Default to "02:00Z-03:00Z". China time is 8 hours behind it.
-* `retention_period` - (Deprecated) It has been deprecated from version 1.69.0, and use field 'backup_retention_period' instead.
-* `backup_retention_period` - (Optional, Available since v1.69.0) Instance backup retention days. Valid values: [7-730]. Default to 7. But mysql local disk is unlimited.
-* `log_backup` - (Deprecated) It has been deprecated from version 1.68.0, and use field 'enable_backup_log' instead.
-* `enable_backup_log` - (Optional, Available since v1.68.0) Whether to backup instance log. Valid values are `true`, `false`, Default to `true`. Note: The 'Basic Edition' category Rds instance does not support setting log backup. [What is Basic Edition](https://www.alibabacloud.com/help/doc-detail/48980.htm).
-* `log_retention_period` - (Deprecated) It has been deprecated from version 1.69.0, and use field 'log_backup_retention_period' instead.
-* `log_backup_retention_period` - (Optional, Available since v1.69.0) Instance log backup retention days. Valid when the `enable_backup_log` is `1`. Valid values: [7-730]. Default to 7. It cannot be larger than `backup_retention_period`.
-* `local_log_retention_hours` - (Optional, Available since v1.69.0) Instance log backup local retention hours. Valid when the `enable_backup_log` is `true`. Valid values: [0-7*24].
-* `local_log_retention_space` - (Optional, Available since v1.69.0) Instance log backup local retention space. Valid when the `enable_backup_log` is `true`. Valid values: [0-50].
-* `high_space_usage_protection` - (Optional, Available since v1.69.0) Instance high space usage protection policy. Valid when the `enable_backup_log` is `true`. Valid values are `Enable`, `Disable`.
-* `inc_backup_interval` - (Optional, Int, Available since v1.XXX) The frequency at which you want to perform incremental backup on the MySQL instance. Valid when the `enable_increment_data_backup` is `true` and instance is MySQL local disk. Valid values: [60, 120, 240, 360, 720].
-* `log_backup_frequency` - (Optional, Available since v1.69.0) Instance log backup frequency. Valid when the instance engine is `SQLServer`. Valid values are `LogInterval`.
-* `compress_type` - (Optional, Available since v1.69.0) The compress type of instance policy. Valid values are `1`, `4`, `8`.
-* `archive_backup_retention_period` - (Optional, Available since v1.69.0) Instance archive backup retention days. Valid when the `enable_backup_log` is `true` and instance is mysql local disk. Valid values: [30-1095], and `archive_backup_retention_period` must larger than `backup_retention_period` 730.
-* `archive_backup_keep_count` - (Optional, Available since v1.69.0) Instance archive backup keep count. Valid when the `enable_backup_log` is `true` and instance is mysql local disk. When `archive_backup_keep_policy` is `ByMonth` Valid values: [1-31]. When `archive_backup_keep_policy` is `ByWeek` Valid values: [1-7].
-* `archive_backup_keep_policy` - (Optional, Available since v1.69.0) Instance archive backup keep policy. Valid when the `enable_backup_log` is `true` and instance is mysql local disk. Valid values are `ByMonth`, `ByWeek`, `KeepAll`.
-* `released_keep_policy` - (Optional, Available since v1.147.0) The policy based on which ApsaraDB RDS retains archived backup files if the instance is released. Default value: None. Valid values:
-  * **None**: No archived backup files are retained.
-  * **Lastest**: Only the most recent archived backup file is retained.
-  * **All**: All archived backup files are retained.
-* `category` - (Optional, Available since v1.190.0) Whether to enable second level backup.Valid values are `Flash`, `Standard`, Note:It only takes effect when the BackupPolicyMode parameter is DataBackupPolicy.
+* `instance_id` - (Required, ForceNew) The ID of the instance that can run database.
+* `backup_period` - (Deprecated) It has been deprecated from version 1.69.0, and use field `preferred_backup_period` instead.
+* `preferred_backup_period` - (Optional, Available since v1.69.0) DB Instance backup period. Please set at least two days to ensure backing up at least twice a week. Valid values: `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, `Sunday`.
+* `backup_time` - (Deprecated) It has been deprecated from version 1.69.0, and use field `preferred_backup_time` instead.
+* `preferred_backup_time` - (Optional, Available since v1.69.0) DB instance backup time, in the format of `HH:mmZ-HH:mmZ`. Time setting interval is one hour. Defaults to `02:00Z-03:00Z`. China time is 8 hours behind it.
+* `retention_period` - (Deprecated) It has been deprecated from version 1.69.0, and use field `backup_retention_period` instead.
+* `backup_retention_period` - (Optional, Available since v1.69.0) Instance backup retention days. Valid values: `7-730`. Defaults to `7`. But MySQL local disk is unlimited.
+* `log_backup` - (Deprecated) It has been deprecated from version 1.68.0, and use field `enable_backup_log` instead.
+* `enable_backup_log` - (Optional, Available since v1.68.0) Whether to backup instance log. Valid values: `true`, `false`. Defaults to `true`. Note: The `Basic Edition` category RDS instance does not support setting log backup. [What is Basic Edition](https://www.alibabacloud.com/help/doc-detail/48980.htm).
+* `log_retention_period` - (Deprecated) It has been deprecated from version 1.69.0, and use field `log_backup_retention_period` instead.
+* `log_backup_retention_period` - (Optional, Available since v1.69.0) Instance log backup retention days. Valid when the `enable_backup_log` is `true`. Valid values: `7-730`. Defaults to `7`. It cannot be larger than `backup_retention_period`.
+
+  -> **NOTE:** A value larger than `backup_retention_period` is not rejected with an error. Instead, whenever `log_backup_retention_period` is created or changed, the provider replaces the configured value with `backup_retention_period` in the API request. For example, with `backup_retention_period = 7` and `log_backup_retention_period = 30`, the request carries 7 and the refreshed state records 7, while the configuration still asks for 30. As a result, `terraform apply` reports success without applying 30, and every later `terraform plan` shows the same pending change for this attribute. To avoid this, set `log_backup_retention_period` to a value less than or equal to `backup_retention_period`.
+
+* `local_log_retention_hours` - (Optional, Available since v1.69.0) Instance log backup local retention hours. Valid when the `enable_backup_log` is `true`. Valid values: `0-168`.
+* `local_log_retention_space` - (Optional, Available since v1.69.0) Instance log backup local retention space. Valid when the `enable_backup_log` is `true`. Valid values: `0-50`.
+* `high_space_usage_protection` - (Optional, Available since v1.69.0) Instance high space usage protection policy. Valid when the `enable_backup_log` is `true`. Valid values: `Enable`, `Disable`. Defaults to `Enable`.
+* `inc_backup_interval` - (Optional, Int, Available since v1.288.0) The frequency at which you want to perform incremental backup on the MySQL instance. Valid when the `enable_increment_data_backup` is `true` and instance is MySQL local disk. Valid values: `60`, `120`, `240`, `360`, `720`.
+* `log_backup_frequency` - (Optional, Available since v1.69.0) Instance log backup frequency. Valid when the instance engine is `SQLServer`. Valid values: `LogInterval`.
+* `compress_type` - (Optional, Available since v1.69.0) The compress type of instance policy. Valid values: `1`, `4`, `8`.
+* `archive_backup_retention_period` - (Optional, Available since v1.69.0) Instance archive backup retention days. Valid when the `enable_backup_log` is `true` and instance is MySQL local disk. Valid values: `30-1095`, and `archive_backup_retention_period` must larger than `backup_retention_period` 730.
+* `archive_backup_keep_count` - (Optional, Available since v1.69.0) Instance archive backup keep count. Valid when the `enable_backup_log` is `true` and instance is MySQL local disk. When `archive_backup_keep_policy` is `ByMonth`, valid values: `1-31`. When `archive_backup_keep_policy` is `ByWeek`, valid values: `1-7`.
+* `archive_backup_keep_policy` - (Optional, Available since v1.69.0) Instance archive backup keep policy. Valid when the `enable_backup_log` is `true` and instance is MySQL local disk. Valid values: `ByMonth`, `ByWeek`, `KeepAll`.
+* `released_keep_policy` - (Optional, Available since v1.147.0) The policy based on which ApsaraDB RDS retains archived backup files if the instance is released. Defaults to `None`. Valid values:
+  * `None`: No archived backup files are retained.
+  * `Lastest`: Only the most recent archived backup file is retained.
+  * `All`: All archived backup files are retained.
+* `category` - (Optional, Available since v1.190.0) Whether to enable second level backup. Valid values: `Flash`, `Standard`. Note: It only takes effect when the BackupPolicyMode parameter is DataBackupPolicy.
+
   -> **NOTE:** You can configure a backup policy by using this parameter and the PreferredBackupPeriod parameter. For example, if you set the PreferredBackupPeriod parameter to Saturday,Sunday and the BackupInterval parameter to -1, a snapshot backup is performed on every Saturday and Sunday.If the instance runs PostgreSQL, the BackupInterval parameter is supported only when the instance is equipped with standard SSDs or enhanced SSDs (ESSDs).This parameter takes effect only when you set the BackupPolicyMode parameter to DataBackupPolicy.
+
 * `backup_interval` - (Optional, Available since v1.194.0) The frequency at which you want to perform a snapshot backup on the instance. Valid values:
-  - -1: No backup frequencies are specified.
-  - 30: A snapshot backup is performed once every 30 minutes.
-  - 60: A snapshot backup is performed once every 60 minutes.
-  - 120: A snapshot backup is performed once every 120 minutes.
-  - 240: A snapshot backup is performed once every 240 minutes.
-  - 360: A snapshot backup is performed once every 360 minutes.
-  - 480: A snapshot backup is performed once every 480 minutes.
-  - 720: A snapshot backup is performed once every 720 minutes.
+  - `-1`: No backup frequencies are specified.
+  - `15`: A snapshot backup is performed once every 15 minutes.
+  - `30`: A snapshot backup is performed once every 30 minutes.
+  - `60`: A snapshot backup is performed once every 60 minutes.
+  - `120`: A snapshot backup is performed once every 120 minutes.
+  - `180`: A snapshot backup is performed once every 180 minutes.
+  - `240`: A snapshot backup is performed once every 240 minutes.
+  - `360`: A snapshot backup is performed once every 360 minutes.
+  - `480`: A snapshot backup is performed once every 480 minutes.
+  - `720`: A snapshot backup is performed once every 720 minutes.
 
   -> **NOTE:** If the instance runs MySQL, `backup_interval` is supported only when the `engine_version` of the instance is `5.7` or `8.0`, the `category` of the instance is `HighAvailability` (High-availability Edition) or `cluster` (MySQL Cluster Edition), and the instance is not equipped with local disks (`db_instance_storage_type` is not `local_ssd`). This parameter is ignored for MySQL instances that do not meet all of these conditions.
 
 * `backup_priority` - (Optional, Int, Available since v1.229.1) Specifies whether the backup settings of a secondary instance are configured. Valid values:
-  - 1: secondary instance preferred
-  - 2: primary instance preferred
-    ->**NOTE:** This parameter is suitable only for instances that run SQL Server on RDS Cluster Edition. This parameter takes effect only when BackupMethod is set to Physical. If BackupMethod is set to Snapshot, backups are forcefully performed on the primary instance that runs SQL Server on RDS Cluster Edition.
+  - `1`: secondary instance preferred
+  - `2`: primary instance preferred
+
+  -> **NOTE:** This parameter is suitable only for instances that run SQL Server on RDS Cluster Edition. This parameter takes effect only when BackupMethod is set to Physical. If BackupMethod is set to Snapshot, backups are forcefully performed on the primary instance that runs SQL Server on RDS Cluster Edition.
+
 * `enable_increment_data_backup` - (Optional, Bool, Available since v1.229.1) Specifies whether to enable incremental backup. Valid values:
-  - false (default): disables the feature.
-  - true: enables the feature.
-    ->**NOTE:** This parameter takes effect only on instances that run SQL Server with cloud disks. This parameter takes effect only when BackupPolicyMode is set to DataBackupPolicy.
-* `enable_pitr_protection` - (Optional, Bool, Available since v1.XXX) Specifies whether to enable PITR (Point-in-Time Recovery) on the MySQL instance. Valid values are `true`, `false`. This parameter takes effect only when `enable_backup_log` is `true` and BackupPolicyMode is set to DataBackupPolicy.
-* `log_backup_local_retention_number` - (Optional, Int, Available since v1.229.1)  The number of binary log files that you want to retain on the instance. Default value: 60. Valid values: 6 to 100.
-  ->**NOTE:** This parameter takes effect only when you set the BackupPolicyMode parameter to LogBackupPolicy. If the instance runs MySQL, you can set this parameter to -1. The value -1 specifies that an unlimited number of binary log files can be retained on the instance.
-* `backup_method` - (Optional, Available since v1.229.1)  The backup method of the instance. Valid values:
-  - Physical: physical backup
-  - Snapshot: snapshot backup
-    ->**NOTE:** This parameter takes effect only on instances that run SQL Server with cloud disks. This parameter takes effect only when BackupPolicyMode is set to DataBackupPolicy.
+  - `false` (default): disables the feature.
+  - `true`: enables the feature.
+
+  -> **NOTE:** This parameter takes effect only on instances that run SQL Server with cloud disks. This parameter takes effect only when BackupPolicyMode is set to DataBackupPolicy.
+
+* `enable_pitr_protection` - (Optional, Bool, Available since v1.288.0) Specifies whether to enable PITR (Point-in-Time Recovery) on the MySQL instance. Valid values: `true`, `false`. This parameter takes effect only when `enable_backup_log` is `true` and BackupPolicyMode is set to DataBackupPolicy.
+* `log_backup_local_retention_number` - (Optional, Int, Available since v1.229.1) The number of binary log files that you want to retain on the instance. Defaults to `60`. Valid values: `6-100`.
+
+  -> **NOTE:** This parameter takes effect only when you set the BackupPolicyMode parameter to LogBackupPolicy. If the instance runs MySQL, you can set this parameter to -1. The value -1 specifies that an unlimited number of binary log files can be retained on the instance.
+
+* `backup_method` - (Optional, Available since v1.229.1) The backup method of the instance. Valid values:
+  - `Physical`: physical backup
+  - `Snapshot`: snapshot backup
+
+  -> **NOTE:** This parameter takes effect only on instances that run SQL Server with cloud disks. This parameter takes effect only when BackupPolicyMode is set to DataBackupPolicy.
 
 -> **NOTE:** Currently, the SQLServer instance does not support to modify `log_backup_retention_period`.
 
@@ -125,7 +139,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The current backup policy resource ID. It is same as 'instance_id'.
+* `id` - The current backup policy resource ID. It is same as `instance_id`.
 
 ## Import
 


### PR DESCRIPTION
### Problem

A user lowering the backup retention of an RDS instance to 7 days saw `terraform plan` offer the
change and `terraform apply` report success, while the retention on the instance never moved. Every
subsequent plan proposed the same change again:

```
~ backup_retention_period = 180 -> 7
```

The `ModifyBackupPolicy` request issued by that apply carried the *old* retention, not 7.

### Root cause

`RdsService.ModifyDBBackupPolicy` only forwarded `backup_retention_period` when its value differed
from the schema default of 7, otherwise falling back to the deprecated `retention_period`:

```go
retentionPeriod := "7"
if v, ok := d.GetOk("backup_retention_period"); ok && v.(int) != 7 {
	retentionPeriod = strconv.Itoa(v.(int))
} else if v, ok := d.GetOk("retention_period"); ok && v.(int) != 0 {
	retentionPeriod = strconv.Itoa(v.(int))
}
```

`retention_period` is `Optional + Computed`, so `Read` refills it from the API on every refresh and
it is effectively never zero. Any configuration asking for exactly 7 therefore fell through to the
fallback branch and re-sent the value the server already had — a guaranteed no-op, for any engine,
whenever the desired value happens to be the schema default.

### Fix

Drop the `!= 7` condition so a configured value is always forwarded.

**Behavior change worth a reviewer's attention.** Because `backup_retention_period` declares
`Default: 7`, an absent attribute is indistinguishable from an explicit `7` in the SDK, so the
deprecated `retention_period` branch is now unreachable. A configuration that sets *only*
`retention_period` (deprecated since v1.69.0) will be applied as 7 on its next apply. Such a
configuration is already broken today: `backup_retention_period` is absent, so it plans as 7 against
a state of 30, which produces a permanent, never-converging diff while the apply silently keeps the
old value. Migration is renaming the attribute. Serving both spellings would require making
`backup_retention_period` `Computed` instead of defaulted, which is a breaking plan change.

### Test

The regression step added to the PostgreSQL case lowers the retention from 20 to 7 — the transition
that used to be the silent no-op. Verified on the wire by diffing the debug logs of an unpatched run
against a patched one: both issue the same 19 retention-bearing requests in the same order, and only
the request for that step differs (20 before, 7 after).

### Documentation

- `backup_interval`: add the valid values `15` and `180`, which the schema accepts but the page never listed
- `high_space_usage_protection`: document the `Enable` default
- `log_backup_retention_period`: the guard attribute `enable_backup_log` is a bool, so "is `1`" becomes "is `true`"
- `local_log_retention_hours`: `[0-7*24]` becomes `0-168`
- `inc_backup_interval`, `enable_pitr_protection`: resolve the `v1.XXX` placeholders to `v1.288.0`
- document that `log_backup_retention_period` is clamped to `backup_retention_period` in the request rather than rejected
- five `NOTE` callouts were glued to the preceding line at the wrong indent and rendered as literal `-> **NOTE:**` text; they now have blank lines and sit at their own argument's content column
- house style on the lines already touched: `Valid values:` lead-in, backticked values and ranges, `RDS`/`MySQL` casing, `` Defaults to `x`. ``

`markdownlint` (repo config) and `scripts/document/document_check.go` were clean on this page before
the change and are still clean.

One item left deliberately untouched: `archive_backup_retention_period` still reads "must larger than
`backup_retention_period` 730". The `ModifyBackupPolicy` API definition documents only the range
`30~1095` and no such relationship, and the two branches mentioning 730 in
`archiveBackupPeriodDiffSuppressFunc` are unreachable, so there was nothing to rewrite the clause
against. It needs a service-side answer rather than a guess.

### Acceptance tests

Full `DBBackupPolicy` suite against the final code, 6 passed / 0 failed / 0 skipped:

```
PASS: TestAccAliCloudRdsDBBackupPolicyMySql (977.28s)
PASS: TestAccAliCloudRdsDBBackupPolicyMySqlLocalDisk (773.33s)
PASS: TestAccAliCloudRdsDBBackupPolicyMariaDB (2341.19s)
PASS: TestAccAliCloudRdsDBBackupPolicySQLServer (862.17s)
PASS: TestAccAliCloudRdsDBBackupPolicySQLServerAlwaysOn (2219.73s)
PASS: TestAccAliCloudRdsDBBackupPolicyPostgreSQL (2019.48s)
```

`MySqlLocalDisk` and `MariaDB` are the cases that exercise engines previously reaching the dropped
fallback branch; both pass.
