### PR TITLE
feat: serve a terraform-plugin-framework provider alongside SDK v2

### DIFF
--- a/CHANGELOG-v2.md
+++ b/CHANGELOG-v2.md
@@ -1,3 +1,10 @@
+## 2.0.0-beta3 (Unreleased)
+
+FEATURES:
+
+- **Terraform Plugin Framework:** the provider binary now serves a `terraform-plugin-framework` provider alongside the existing `terraform-plugin-sdk/v2` one, muxed behind `tf5muxserver`. Protocol version, provider address and provider schema are unchanged; new resources and data sources can be authored framework-native, and the framework-only concept types (ephemeral resources, provider functions, list resources, actions) become available for the first time.
+- **New Data Source:** `alicloud_ims_default_domain` — the default domain of the Alibaba Cloud account, backed by the Ims `GetDefaultDomain` API. Served by the framework provider.
+
 ## 2.0.0-beta2 (August 4, 2026)
 
 This beta rolls up every change merged from the 1.x line since v2.0.0-beta1 — see the `1.287.0` section of [CHANGELOG.md](CHANGELOG.md) — plus the v2-only fix below.

--- a/alicloud/acctest/acctest.go
+++ b/alicloud/acctest/acctest.go
@@ -1,0 +1,51 @@
+package acctest
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/framework"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+)
+
+func ProtoV5ProviderFactories(names ...string) map[string]func() (tfprotov5.ProviderServer, error) {
+	if len(names) == 0 {
+		names = []string{"alicloud"}
+	}
+
+	factories := make(map[string]func() (tfprotov5.ProviderServer, error), len(names))
+	for _, name := range names {
+		factories[name] = func() (tfprotov5.ProviderServer, error) {
+			serverFactory, err := framework.ProtoV5ProviderServerFactory(context.Background(), alicloud.Provider())
+			if err != nil {
+				return nil, err
+			}
+
+			return serverFactory(), nil
+		}
+	}
+
+	return factories
+}
+
+// PreCheck is the exported form of the suite's testAccPreCheck: it fails the test unless
+// credentials are in the environment, and defaults the region the way the suite does.
+//
+// It does not set package alicloud's defaultRegionToTest, which is unexported and only
+// read by tests in that package. Read the region back from ALICLOUD_REGION if a test in a
+// service package needs it.
+func PreCheck(t *testing.T) {
+	if v := os.Getenv("ALICLOUD_ACCESS_KEY"); v == "" {
+		t.Fatal("ALICLOUD_ACCESS_KEY must be set for acceptance tests")
+	}
+	if v := os.Getenv("ALICLOUD_SECRET_KEY"); v == "" {
+		t.Fatal("ALICLOUD_SECRET_KEY must be set for acceptance tests")
+	}
+	if v := os.Getenv("ALICLOUD_REGION"); v == "" {
+		log.Println("[INFO] Test: Using cn-beijing as test region")
+		os.Setenv("ALICLOUD_REGION", "cn-beijing")
+	}
+}

--- a/alicloud/provider/framework/factory.go
+++ b/alicloud/provider/framework/factory.go
@@ -1,0 +1,26 @@
+package framework
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	sdkschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func ProtoV5ProviderServerFactory(ctx context.Context, primary *sdkschema.Provider) (func() tfprotov5.ProviderServer, error) {
+	secondary := NewProvider(primary)
+
+	servers := []func() tfprotov5.ProviderServer{
+		primary.GRPCProvider,
+		providerserver.NewProtocol5(secondary),
+	}
+
+	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
+	if err != nil {
+		return nil, err
+	}
+
+	return muxServer.ProviderServer, nil
+}

--- a/alicloud/provider/framework/factory_test.go
+++ b/alicloud/provider/framework/factory_test.go
@@ -1,0 +1,32 @@
+package framework_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/framework"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+)
+
+// TestUnitFrameworkProviderSchemaMatchesSDK muxes the two provider servers exactly as
+// main.go does and asks the result for its schema.
+func TestUnitFrameworkProviderSchemaMatchesSDK(t *testing.T) {
+	ctx := context.Background()
+
+	serverFactory, err := framework.ProtoV5ProviderServerFactory(ctx, alicloud.Provider())
+	if err != nil {
+		t.Fatalf("muxing the SDK v2 and framework providers: %s", err)
+	}
+
+	resp, err := serverFactory().GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema on the muxed provider: %s", err)
+	}
+
+	for _, d := range resp.Diagnostics {
+		if d.Severity == tfprotov5.DiagnosticSeverityError {
+			t.Errorf("GetProviderSchema on the muxed provider: %s: %s", d.Summary, d.Detail)
+		}
+	}
+}

--- a/alicloud/provider/framework/provider.go
+++ b/alicloud/provider/framework/provider.go
@@ -1,0 +1,85 @@
+package framework
+
+import (
+	"context"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/service/ims"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	sdkschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var (
+	_ provider.Provider                       = &alicloudProvider{}
+	_ provider.ProviderWithEphemeralResources = &alicloudProvider{}
+	_ provider.ProviderWithFunctions          = &alicloudProvider{}
+	_ provider.ProviderWithListResources      = &alicloudProvider{}
+	_ provider.ProviderWithActions            = &alicloudProvider{}
+)
+
+type alicloudProvider struct {
+	primary *sdkschema.Provider
+}
+
+// NewProvider returns the framework provider to be muxed with the SDK v2 provider.
+func NewProvider(primary *sdkschema.Provider) provider.Provider {
+	return &alicloudProvider{
+		primary: primary,
+	}
+}
+
+func (p *alicloudProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "alicloud"
+}
+
+func (p *alicloudProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
+	schema, diags := ProviderSchema(p.primary.Schema)
+
+	resp.Schema = schema
+	resp.Diagnostics.Append(diags...)
+}
+
+func (p *alicloudProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	// The provider's parsed configuration is available through the primary provider's
+	// Meta method: tf5muxserver configures its servers in the order they were passed to
+	// NewMuxServer, and the SDK v2 one goes first. Credential resolution lives in
+	// alicloud.providerConfigure and is not duplicated here.
+	meta := p.primary.Meta()
+
+	resp.ResourceData = meta
+	resp.DataSourceData = meta
+	resp.EphemeralResourceData = meta
+	resp.ListResourceData = meta
+	resp.ActionData = meta
+}
+
+func (p *alicloudProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
+	return []func() datasource.DataSource{
+		ims.NewDefaultDomainDataSource,
+	}
+}
+
+func (p *alicloudProvider) Resources(ctx context.Context) []func() resource.Resource {
+	return []func() resource.Resource{}
+}
+
+func (p *alicloudProvider) EphemeralResources(ctx context.Context) []func() ephemeral.EphemeralResource {
+	return []func() ephemeral.EphemeralResource{}
+}
+
+func (p *alicloudProvider) Functions(ctx context.Context) []func() function.Function {
+	return []func() function.Function{}
+}
+
+func (p *alicloudProvider) ListResources(ctx context.Context) []func() list.ListResource {
+	return []func() list.ListResource{}
+}
+
+func (p *alicloudProvider) Actions(ctx context.Context) []func() action.Action {
+	return []func() action.Action{}
+}

--- a/alicloud/provider/framework/schema.go
+++ b/alicloud/provider/framework/schema.go
@@ -1,0 +1,184 @@
+package framework
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	fwschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	sdkschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ProviderSchema derives the terraform-plugin-framework provider schema from the
+// terraform-plugin-sdk/v2 provider schema map.
+//
+// tf5muxserver refuses to serve providers whose provider schemas differ once
+// converted to tfprotov5 (see tf5muxserver.schemaEquals), so the two schemas must
+// stay byte-identical over the protocol. The SDK v2 schema has 27 top-level
+// attributes and an "endpoints" block that alone carries ~160 fields and grows with
+// every new product, so the framework side is derived from it rather than
+// hand-written: a hand-written mirror would break GetProviderSchema for every user
+// the first time someone added an endpoint to only one of the two copies.
+//
+// Constructs the framework cannot express identically produce an error diagnostic
+// instead of a silently divergent schema. That turns future drift into a failing
+// unit test rather than a runtime "Invalid Provider Server Combination" for users.
+func ProviderSchema(sdk map[string]*sdkschema.Schema) (fwschema.Schema, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	attributes, blocks := convertSchemaMap(sdk, "", &diags)
+
+	return fwschema.Schema{
+		Attributes: attributes,
+		Blocks:     blocks,
+	}, diags
+}
+
+// convertSchemaMap splits an SDK v2 schema map into framework attributes and blocks,
+// mirroring the attribute/block routing in schemaMap.CoreConfigSchema.
+func convertSchemaMap(sdk map[string]*sdkschema.Schema, prefix string, diags *diag.Diagnostics) (map[string]fwschema.Attribute, map[string]fwschema.Block) {
+	attributes := make(map[string]fwschema.Attribute, len(sdk))
+	blocks := make(map[string]fwschema.Block)
+
+	for name, s := range sdk {
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+
+		if s.ConfigMode != sdkschema.SchemaConfigModeAuto {
+			addUnsupportedError(diags, path, "ConfigMode is set; only SchemaConfigModeAuto is supported")
+			continue
+		}
+
+		if s.Elem == nil {
+			if attribute, ok := convertAttribute(s, path, diags); ok {
+				attributes[name] = attribute
+			}
+			continue
+		}
+
+		elem, ok := s.Elem.(*sdkschema.Resource)
+		if !ok {
+			addUnsupportedError(diags, path, fmt.Sprintf("Elem is %T; only *schema.Resource is supported", s.Elem))
+			continue
+		}
+
+		if block, ok := convertBlock(s, elem, path, diags); ok {
+			blocks[name] = block
+		}
+	}
+
+	return attributes, blocks
+}
+
+// convertAttribute converts a primitive SDK v2 schema into a framework attribute.
+func convertAttribute(s *sdkschema.Schema, path string, diags *diag.Diagnostics) (fwschema.Attribute, bool) {
+	// Framework provider schema attributes have no Computed or WriteOnly field, so
+	// either one would convert to a proto attribute that differs from the SDK v2 one.
+	if s.Computed {
+		addUnsupportedError(diags, path, "Computed is not expressible in a framework provider schema")
+		return nil, false
+	}
+	if s.WriteOnly {
+		addUnsupportedError(diags, path, "WriteOnly is not expressible in a framework provider schema")
+		return nil, false
+	}
+
+	required, optional := requiredOptional(s)
+
+	// Description is deliberately used in place of MarkdownDescription: SDK v2 emits
+	// tfprotov5.StringKindPlain unless the global schema.DescriptionKind is switched,
+	// and MarkdownDescription would emit StringKindMarkdown and fail the mux
+	// comparison.
+	switch s.Type {
+	case sdkschema.TypeString:
+		return fwschema.StringAttribute{
+			Required:           required,
+			Optional:           optional,
+			Sensitive:          s.Sensitive,
+			Description:        s.Description,
+			DeprecationMessage: s.Deprecated,
+		}, true
+	case sdkschema.TypeInt:
+		return fwschema.Int64Attribute{
+			Required:           required,
+			Optional:           optional,
+			Sensitive:          s.Sensitive,
+			Description:        s.Description,
+			DeprecationMessage: s.Deprecated,
+		}, true
+	case sdkschema.TypeBool:
+		return fwschema.BoolAttribute{
+			Required:           required,
+			Optional:           optional,
+			Sensitive:          s.Sensitive,
+			Description:        s.Description,
+			DeprecationMessage: s.Deprecated,
+		}, true
+	}
+
+	addUnsupportedError(diags, path, fmt.Sprintf("type %s is not supported; only TypeString, TypeInt and TypeBool are", s.Type))
+
+	return nil, false
+}
+
+// convertBlock converts an SDK v2 schema whose Elem is a *schema.Resource into a
+// framework nested block.
+//
+// MinItems and MaxItems are dropped: the framework cannot express them, and
+// tf5muxserver ignores both fields when comparing schemas.
+func convertBlock(s *sdkschema.Schema, elem *sdkschema.Resource, path string, diags *diag.Diagnostics) (fwschema.Block, bool) {
+	// coreConfigSchemaBlock lifts the outer schema's description and deprecation
+	// onto the nested block itself, so they belong on the block here rather than
+	// anywhere inside NestedObject.
+	nested := fwschema.NestedBlockObject{}
+	nested.Attributes, nested.Blocks = convertSchemaMap(elem.Schema, path, diags)
+
+	switch s.Type {
+	case sdkschema.TypeList:
+		return fwschema.ListNestedBlock{
+			NestedObject:       nested,
+			Description:        s.Description,
+			DeprecationMessage: s.Deprecated,
+		}, true
+	case sdkschema.TypeSet:
+		return fwschema.SetNestedBlock{
+			NestedObject:       nested,
+			Description:        s.Description,
+			DeprecationMessage: s.Deprecated,
+		}, true
+	}
+
+	addUnsupportedError(diags, path, fmt.Sprintf("type %s with a *schema.Resource Elem is not supported; only TypeList and TypeSet are", s.Type))
+
+	return nil, false
+}
+
+// requiredOptional mirrors the required-ness demotion in
+// (*schema.Schema).coreConfigSchemaAttribute: SDK v2 reports a Required attribute
+// that also has a DefaultFunc as Optional whenever that DefaultFunc yields a value,
+// because Terraform core has no concept of conditional required-ness. The framework
+// has no equivalent, so the same sniff has to be applied here or the two schemas
+// disagree — for example assume_role.role_arn flips to Optional as soon as
+// ALICLOUD_ASSUME_ROLE_ARN is set in the environment.
+func requiredOptional(s *sdkschema.Schema) (required, optional bool) {
+	required, optional = s.Required, s.Optional
+
+	if required && s.DefaultFunc != nil {
+		v, err := s.DefaultFunc()
+		if err != nil || v != nil {
+			required, optional = false, true
+		}
+	}
+
+	return required, optional
+}
+
+func addUnsupportedError(diags *diag.Diagnostics, path, detail string) {
+	diags.AddError(
+		"Unsupported Provider Schema Construct",
+		fmt.Sprintf("The framework provider schema could not be derived from the SDK v2 provider schema at %q: %s.\n\n"+
+			"This is a bug in the provider: alicloud/provider/framework/schema.go needs to learn this construct, "+
+			"otherwise the muxed provider servers would expose differing provider schemas.", path, detail),
+	)
+}

--- a/alicloud/provider/framework/schema_test.go
+++ b/alicloud/provider/framework/schema_test.go
@@ -1,0 +1,199 @@
+package framework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	sdkschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var schemaCmpOptions = []cmp.Option{
+	cmpopts.SortSlices(func(i, j *tfprotov5.SchemaAttribute) bool { return i.Name < j.Name }),
+	cmpopts.SortSlices(func(i, j *tfprotov5.SchemaNestedBlock) bool { return i.TypeName < j.TypeName }),
+	cmpopts.IgnoreFields(tfprotov5.SchemaNestedBlock{}, "MinItems", "MaxItems"),
+}
+
+func TestUnitProviderSchema(t *testing.T) {
+	testCases := map[string]map[string]*sdkschema.Schema{
+		"primitives": {
+			"a_string": {Type: sdkschema.TypeString, Optional: true},
+			"an_int":   {Type: sdkschema.TypeInt, Optional: true},
+			"a_bool":   {Type: sdkschema.TypeBool, Optional: true},
+		},
+		"required": {
+			"a_string": {Type: sdkschema.TypeString, Required: true},
+		},
+		"sensitive": {
+			"a_string": {Type: sdkschema.TypeString, Optional: true, Sensitive: true},
+		},
+		"described": {
+			"a_string": {Type: sdkschema.TypeString, Optional: true, Description: "what it does"},
+		},
+		"deprecated": {
+			"a_string": {Type: sdkschema.TypeString, Optional: true, Deprecated: "use something else"},
+		},
+		// A Required attribute with a DefaultFunc that yields a value is reported as
+		// Optional by the SDK v2, because Terraform has no conditional required-ness.
+		"required with a default func that yields a value": {
+			"a_string": {
+				Type:        sdkschema.TypeString,
+				Required:    true,
+				DefaultFunc: func() (interface{}, error) { return "value", nil },
+			},
+		},
+		// ... while one that yields nothing stays Required.
+		"required with a default func that yields nothing": {
+			"a_string": {
+				Type:        sdkschema.TypeString,
+				Required:    true,
+				DefaultFunc: func() (interface{}, error) { return nil, nil },
+			},
+		},
+		"set block": {
+			"a_block": {
+				Type:     sdkschema.TypeSet,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &sdkschema.Resource{
+					Schema: map[string]*sdkschema.Schema{
+						"a_string": {Type: sdkschema.TypeString, Required: true},
+						"an_int":   {Type: sdkschema.TypeInt, Optional: true},
+					},
+				},
+			},
+		},
+		"list block": {
+			"a_block": {
+				Type:        sdkschema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "a described block",
+				Deprecated:  "a deprecated block",
+				Elem: &sdkschema.Resource{
+					Schema: map[string]*sdkschema.Schema{
+						"a_string": {Type: sdkschema.TypeString, Optional: true},
+					},
+				},
+			},
+		},
+		"nested blocks": {
+			"a_block": {
+				Type:     sdkschema.TypeSet,
+				Optional: true,
+				Elem: &sdkschema.Resource{
+					Schema: map[string]*sdkschema.Schema{
+						"a_nested_block": {
+							Type:     sdkschema.TypeList,
+							Optional: true,
+							Elem: &sdkschema.Resource{
+								Schema: map[string]*sdkschema.Schema{
+									"a_string": {Type: sdkschema.TypeString, Optional: true},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, sdk := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+
+			expected := sdkProtoSchema(ctx, t, sdk)
+			actual := frameworkProtoSchema(ctx, t, sdk)
+
+			if diff := cmp.Diff(expected, actual, schemaCmpOptions...); diff != "" {
+				t.Errorf("unexpected difference between the SDK v2 and framework provider schemas (-sdk +framework):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUnitProviderSchemaUnsupported(t *testing.T) {
+	testCases := map[string]map[string]*sdkschema.Schema{
+		"map": {
+			"a_map": {Type: sdkschema.TypeMap, Optional: true},
+		},
+		"float": {
+			"a_float": {Type: sdkschema.TypeFloat, Optional: true},
+		},
+		"list of primitives": {
+			"a_list": {
+				Type:     sdkschema.TypeList,
+				Optional: true,
+				Elem:     &sdkschema.Schema{Type: sdkschema.TypeString},
+			},
+		},
+		"computed": {
+			"a_string": {Type: sdkschema.TypeString, Optional: true, Computed: true},
+		},
+		"config mode": {
+			"a_block": {
+				Type:       sdkschema.TypeList,
+				Optional:   true,
+				ConfigMode: sdkschema.SchemaConfigModeAttr,
+				Elem: &sdkschema.Resource{
+					Schema: map[string]*sdkschema.Schema{
+						"a_string": {Type: sdkschema.TypeString, Optional: true},
+					},
+				},
+			},
+		},
+		"unsupported field nested in a block": {
+			"a_block": {
+				Type:     sdkschema.TypeSet,
+				Optional: true,
+				Elem: &sdkschema.Resource{
+					Schema: map[string]*sdkschema.Schema{
+						"a_float": {Type: sdkschema.TypeFloat, Optional: true},
+					},
+				},
+			},
+		},
+	}
+
+	for name, sdk := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if _, diags := ProviderSchema(sdk); !diags.HasError() {
+				t.Error("expected an error diagnostic, got none")
+			}
+		})
+	}
+}
+
+func sdkProtoSchema(ctx context.Context, t *testing.T, sdk map[string]*sdkschema.Schema) *tfprotov5.Schema {
+	t.Helper()
+
+	provider := &sdkschema.Provider{Schema: sdk}
+
+	resp, err := provider.GRPCProvider().GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema on the SDK v2 provider: %s", err)
+	}
+
+	return resp.Provider
+}
+
+func frameworkProtoSchema(ctx context.Context, t *testing.T, sdk map[string]*sdkschema.Schema) *tfprotov5.Schema {
+	t.Helper()
+
+	server := providerserver.NewProtocol5(NewProvider(&sdkschema.Provider{Schema: sdk}))()
+
+	resp, err := server.GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema on the framework provider: %s", err)
+	}
+	for _, d := range resp.Diagnostics {
+		if d.Severity == tfprotov5.DiagnosticSeverityError {
+			t.Fatalf("GetProviderSchema on the framework provider: %s: %s", d.Summary, d.Detail)
+		}
+	}
+
+	return resp.Provider
+}

--- a/alicloud/service/ims/data_source_default_domain.go
+++ b/alicloud/service/ims/data_source_default_domain.go
@@ -1,0 +1,94 @@
+package ims
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const defaultDomainTypeName = "alicloud_ims_default_domain"
+
+var (
+	_ datasource.DataSource              = &defaultDomainDataSource{}
+	_ datasource.DataSourceWithConfigure = &defaultDomainDataSource{}
+)
+
+func NewDefaultDomainDataSource() datasource.DataSource {
+	return &defaultDomainDataSource{}
+}
+
+type defaultDomainDataSource struct {
+	client *connectivity.AliyunClient
+}
+
+type defaultDomainModel struct {
+	Id            types.String `tfsdk:"id"`
+	DefaultDomain types.String `tfsdk:"default_domain"`
+}
+
+func (d *defaultDomainDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = defaultDomainTypeName
+}
+
+func (d *defaultDomainDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides the default domain of the Alibaba Cloud account, which is the suffix of every RAM user's logon name.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The default domain, same as `default_domain`.",
+			},
+			"default_domain": schema.StringAttribute{
+				Computed:    true,
+				Description: "The default domain of the Alibaba Cloud account.",
+			},
+		},
+	}
+}
+
+func (d *defaultDomainDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*connectivity.AliyunClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *connectivity.AliyunClient, got %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+func (d *defaultDomainDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	const action = "GetDefaultDomain"
+
+	response, err := d.client.RpcPost("Ims", "2019-08-15", action, nil, map[string]interface{}{}, true)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Reading %s: calling %s", defaultDomainTypeName, action), err.Error())
+		return
+	}
+
+	domain, _ := response["DefaultDomainName"].(string)
+	if domain == "" {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Reading %s: calling %s", defaultDomainTypeName, action),
+			fmt.Sprintf("The response carried no DefaultDomainName: %v", response),
+		)
+		return
+	}
+
+	state := defaultDomainModel{
+		Id:            types.StringValue(domain),
+		DefaultDomain: types.StringValue(domain),
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}

--- a/alicloud/service/ims/data_source_default_domain_test.go
+++ b/alicloud/service/ims/data_source_default_domain_test.go
@@ -1,0 +1,32 @@
+package ims_test
+
+import (
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAliCloudImsDefaultDomainDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAliCloudImsDefaultDomainDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.alicloud_ims_default_domain.default", "id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_ims_default_domain.default", "default_domain"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAliCloudImsDefaultDomainDataSourceConfig() string {
+	return `
+data "alicloud_ims_default_domain" "default" {
+}`
+}

--- a/go.mod
+++ b/go.mod
@@ -33,10 +33,14 @@ require (
 	github.com/blues/jsonata-go v1.5.4
 	github.com/deckarep/golang-set v1.8.0
 	github.com/denverdino/aliyungo v0.0.0-20220929054937-e3c8bf5ad947
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-uuid v1.0.3
+	github.com/hashicorp/terraform-plugin-framework v1.19.0
+	github.com/hashicorp/terraform-plugin-go v0.31.0
+	github.com/hashicorp/terraform-plugin-mux v0.23.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/keybase/go-crypto v0.0.0-20190416182011-b785b22cc757
 	github.com/mitchellh/go-homedir v1.1.0
@@ -93,7 +97,7 @@ require (
 	github.com/dennwc/varint v1.0.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 // indirect
-	github.com/fatih/color v1.16.0 // indirect
+	github.com/fatih/color v1.18.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
@@ -108,7 +112,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/flatbuffers v23.5.26+incompatible // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grafana/regexp v0.0.0-20221005093135-b4c2bcb0a4b6 // indirect
@@ -125,7 +128,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.2 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.31.0 // indirect
 	github.com/hashicorp/terraform-plugin-log v0.10.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
@@ -136,7 +138,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.8 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,8 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqL
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
 github.com/frankban/quicktest v1.14.5/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
@@ -418,10 +420,14 @@ github.com/hashicorp/terraform-exec v0.25.1 h1:PRutYRGM8pixV3B8812NYoBK5O+yuf3qc
 github.com/hashicorp/terraform-exec v0.25.1/go.mod h1:+izOYrs9sKMQK4OYvGDnrSSJHY/pm4e4eXFqSL2Q5mA=
 github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoKST/tRDBJKU=
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
+github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
+github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=
 github.com/hashicorp/terraform-plugin-log v0.10.0/go.mod h1:/9RR5Cv2aAbrqcTSdNmY1NRHP4E3ekrXRGjqORpXyB0=
+github.com/hashicorp/terraform-plugin-mux v0.23.1 h1:B93b4hEj8cPKh24WJH2dJJAS3a5lxZANykrz4Or3fgo=
+github.com/hashicorp/terraform-plugin-mux v0.23.1/go.mod h1:IwuivHNfDVeuDbVvg6fnAYEEEVx881STwJHsl/00UkQ=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1 h1:2yPUd7esMOpuTaG3y1iEla1iw+tla+3ZEkkBnmOAre4=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1/go.mod h1:sq8qsxh+PwdvTQFcd17kfCoBgQo46ADNMvCpKE7t/gY=
 github.com/hashicorp/terraform-registry-address v0.4.0 h1:S1yCGomj30Sao4l5BMPjTGZmCNzuv7/GDTDX99E9gTk=
@@ -491,6 +497,8 @@ github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=

--- a/main.go
+++ b/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"log"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/framework"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
 )
 
 func main() {
@@ -15,11 +17,19 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	plugin.Serve(&plugin.ServeOpts{
-		Debug:        debug,
-		ProviderAddr: "registry.terraform.io/aliyun/alicloud",
-		ProviderFunc: func() *schema.Provider {
-			return alicloud.Provider()
-		},
-	})
+	ctx := context.Background()
+
+	serverFactory, err := framework.ProtoV5ProviderServerFactory(ctx, alicloud.Provider())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var serveOpts []tf5server.ServeOpt
+	if debug {
+		serveOpts = append(serveOpts, tf5server.WithManagedDebug())
+	}
+
+	if err := tf5server.Serve("registry.terraform.io/aliyun/alicloud", serverFactory, serveOpts...); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/website/docs/d/ims_default_domain.html.markdown
+++ b/website/docs/d/ims_default_domain.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "IMS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ims_default_domain"
+sidebar_current: "docs-alicloud-datasource-ims-default-domain"
+description: |-
+    Provides the default domain of the Alibaba Cloud account.
+---
+
+# alicloud_ims_default_domain
+
+This data source provides the default domain of the Alibaba Cloud account. Every RAM user's
+logon name is `<user_principal_name>@<default_domain>`.
+
+-> **NOTE:** Available since v2.0.0-beta3.
+
+## Example Usage
+
+```terraform
+data "alicloud_ims_default_domain" "default" {
+}
+
+output "default_domain" {
+  value = data.alicloud_ims_default_domain.default.default_domain
+}
+```
+
+## Argument Reference
+
+This data source takes no arguments.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The default domain, same as `default_domain`.
+* `default_domain` - The default domain of the Alibaba Cloud account, for example `examplecompany.onaliyun.com`.


### PR DESCRIPTION
## What

Mux a `terraform-plugin-framework` provider with the existing `terraform-plugin-sdk/v2` one behind `tf5muxserver`, so new types can be authored framework-native without migrating the ~1130 SDK v2 resources and ~740 data sources. Protocol version, provider address and provider schema are unchanged, and `Provider()` itself is untouched.

This also makes the framework-only concept types — ephemeral resources, provider functions, list resources, actions — reachable for the first time.

## How

- **`alicloud/provider/framework`** — plumbing only: the framework provider, the mux factory, and a converter that derives the framework provider schema from the SDK v2 schema map at runtime. Deriving it is not a convenience: `tf5muxserver` refuses to serve providers whose provider schemas differ, and `endpointsSchema()` alone contributes 160 fields that would drift out of a hand-written mirror on the first new endpoint. Anything the converter has not been taught raises an error diagnostic rather than producing a silently divergent schema.
- **Server order is load-bearing.** The SDK v2 server is passed to `NewMuxServer` first, so its `ConfigureContextFunc` has built the `*connectivity.AliyunClient` by the time the framework `Configure` runs; the client is handed over through `(*schema.Provider).Meta()`. Credential resolution is not duplicated.
- **`alicloud/service/ims`** — the first framework-served type, `alicloud_ims_default_domain`. Framework types live in per-product service packages, never in the plumbing package: a service package may import `alicloud/connectivity` and nothing else of the provider, because `package alicloud`'s own tests reach `framework` and the reverse edge would not compile.
- **`alicloud/acctest`** — `ProtoV5ProviderFactories` and `PreCheck`: the exported test support a `<product>_test` package needs in order to reach a framework-served type.
- All six registration methods are declared, so registering the first ephemeral resource, list resource, action or provider function is a one-line change.

## Compatibility

No user-facing change. A plugin binary exposes type names over gRPC, not Go symbols — and here the provider schema is *derived* from the SDK v2 one and asserted equal by a unit test, the provider address and protocol version are unchanged, and no existing resource or data source is modified.

## Tests

Acceptance test for the new data source:

```
=== RUN   TestAccAliCloudImsDefaultDomainDataSource
--- PASS: TestAccAliCloudImsDefaultDomainDataSource (4.20s)
PASS
ok      github.com/aliyun/terraform-provider-alicloud/alicloud/service/ims      6.201s
```

**1 passed / 0 failed / 0 skipped.**

Unit tests added, covering the part most likely to break silently — the schema derivation:

- `TestUnitFrameworkProviderSchemaMatchesSDK` — the derived framework provider schema is served without `tf5muxserver` rejecting it
- `TestUnitProviderSchema` — per-field mapping from the SDK v2 schema
- `TestUnitProviderSchemaUnsupported` — an untaught construct raises a diagnostic instead of being dropped
