### PR TITLE
New Resource: alicloud_realtime_compute_session_cluster; New Data Source: alicloud_realtime_compute_session_clusters

### DIFF
--- a/alicloud/data_source_alicloud_realtime_compute_session_clusters.go
+++ b/alicloud/data_source_alicloud_realtime_compute_session_clusters.go
@@ -1,0 +1,642 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudRealtimeComputeSessionClusters() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudRealtimeComputeSessionClusterRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"workspace": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"clusters": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"basic_resource_setting": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"taskmanager_resource_setting_spec": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"memory": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"cpu": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"parallelism": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"jobmanager_resource_setting_spec": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"memory": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"cpu": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"created_at": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"creator": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creator_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"deployment_target_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"engine_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"flink_conf": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"labels": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"logging": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"log4j2_configuration_template": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"logging_profile": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"log4j_loggers": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"logger_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"logger_level": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"log_reserve_policy": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"open_history": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"expiration_days": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"modified_at": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"modifier": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"modifier_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"namespace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"session_cluster_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"session_cluster_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"running": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"last_update_time": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"reference_deployment_ids": {
+													Type:     schema.TypeSet,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"started_at": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"current_session_cluster_status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"failure": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"message": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"failed_at": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"reason": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"workspace": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudRealtimeComputeSessionClusterRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var header map[string]*string
+	namespace := d.Get("namespace")
+	// ListSessionClusters
+	action := fmt.Sprintf("/api/v2/namespaces/%s/sessionclusters", namespace)
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	header = make(map[string]*string)
+	header["workspace"] = StringPointer(d.Get("workspace").(string))
+	request["namespace"] = namespace
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+		response, err = client.RoaGet("ververica", "2022-07-18", action, query, header, nil)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	resp, _ := jsonpath.Get("$.data[*]", response)
+
+	result, _ := resp.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["name"])) {
+			continue
+		}
+		if len(idsMap) > 0 {
+			if _, ok := idsMap[fmt.Sprint(item["workspace"], ":", item["namespace"], ":", item["name"])]; !ok {
+				continue
+			}
+		}
+		objects = append(objects, item)
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(objectRaw["workspace"], ":", objectRaw["namespace"], ":", objectRaw["name"])
+
+		mapping["created_at"] = objectRaw["createdAt"]
+		mapping["creator"] = objectRaw["creator"]
+		mapping["creator_name"] = objectRaw["creatorName"]
+		mapping["deployment_target_name"] = objectRaw["deploymentTargetName"]
+		mapping["engine_version"] = objectRaw["engineVersion"]
+		mapping["flink_conf"] = objectRaw["flinkConf"]
+		mapping["labels"] = objectRaw["labels"]
+		mapping["modified_at"] = objectRaw["modifiedAt"]
+		mapping["modifier"] = objectRaw["modifier"]
+		mapping["modifier_name"] = objectRaw["modifierName"]
+		mapping["session_cluster_id"] = objectRaw["sessionClusterId"]
+		mapping["namespace"] = objectRaw["namespace"]
+		mapping["session_cluster_name"] = objectRaw["name"]
+		mapping["workspace"] = objectRaw["workspace"]
+
+		basicResourceSettingMaps := make([]map[string]interface{}, 0)
+		basicResourceSettingMap := make(map[string]interface{})
+		basicResourceSettingRaw := make(map[string]interface{})
+		if objectRaw["basicResourceSetting"] != nil {
+			basicResourceSettingRaw = objectRaw["basicResourceSetting"].(map[string]interface{})
+		}
+		if len(basicResourceSettingRaw) > 0 {
+			basicResourceSettingMap["parallelism"] = basicResourceSettingRaw["parallelism"]
+
+			jobmanagerResourceSettingSpecMaps := make([]map[string]interface{}, 0)
+			jobmanagerResourceSettingSpecMap := make(map[string]interface{})
+			jobmanagerResourceSettingSpecRaw := make(map[string]interface{})
+			if basicResourceSettingRaw["jobmanagerResourceSettingSpec"] != nil {
+				jobmanagerResourceSettingSpecRaw = basicResourceSettingRaw["jobmanagerResourceSettingSpec"].(map[string]interface{})
+			}
+			if len(jobmanagerResourceSettingSpecRaw) > 0 {
+				jobmanagerResourceSettingSpecMap["cpu"] = jobmanagerResourceSettingSpecRaw["cpu"]
+				jobmanagerResourceSettingSpecMap["memory"] = jobmanagerResourceSettingSpecRaw["memory"]
+
+				jobmanagerResourceSettingSpecMaps = append(jobmanagerResourceSettingSpecMaps, jobmanagerResourceSettingSpecMap)
+			}
+			basicResourceSettingMap["jobmanager_resource_setting_spec"] = jobmanagerResourceSettingSpecMaps
+			taskmanagerResourceSettingSpecMaps := make([]map[string]interface{}, 0)
+			taskmanagerResourceSettingSpecMap := make(map[string]interface{})
+			taskmanagerResourceSettingSpecRaw := make(map[string]interface{})
+			if basicResourceSettingRaw["taskmanagerResourceSettingSpec"] != nil {
+				taskmanagerResourceSettingSpecRaw = basicResourceSettingRaw["taskmanagerResourceSettingSpec"].(map[string]interface{})
+			}
+			if len(taskmanagerResourceSettingSpecRaw) > 0 {
+				taskmanagerResourceSettingSpecMap["cpu"] = taskmanagerResourceSettingSpecRaw["cpu"]
+				taskmanagerResourceSettingSpecMap["memory"] = taskmanagerResourceSettingSpecRaw["memory"]
+
+				taskmanagerResourceSettingSpecMaps = append(taskmanagerResourceSettingSpecMaps, taskmanagerResourceSettingSpecMap)
+			}
+			basicResourceSettingMap["taskmanager_resource_setting_spec"] = taskmanagerResourceSettingSpecMaps
+			basicResourceSettingMaps = append(basicResourceSettingMaps, basicResourceSettingMap)
+		}
+		mapping["basic_resource_setting"] = basicResourceSettingMaps
+		loggingMaps := make([]map[string]interface{}, 0)
+		loggingMap := make(map[string]interface{})
+		loggingRaw := make(map[string]interface{})
+		if objectRaw["logging"] != nil {
+			loggingRaw = objectRaw["logging"].(map[string]interface{})
+		}
+		if len(loggingRaw) > 0 {
+			loggingMap["log4j2_configuration_template"] = loggingRaw["log4j2ConfigurationTemplate"]
+			loggingMap["logging_profile"] = loggingRaw["loggingProfile"]
+
+			log4jLoggersRaw := loggingRaw["log4jLoggers"]
+			log4JLoggersMaps := make([]map[string]interface{}, 0)
+			if log4jLoggersRaw != nil {
+				for _, log4jLoggersChildRaw := range convertToInterfaceArray(log4jLoggersRaw) {
+					log4JLoggersMap := make(map[string]interface{})
+					log4jLoggersChildRaw := log4jLoggersChildRaw.(map[string]interface{})
+					log4JLoggersMap["logger_level"] = log4jLoggersChildRaw["loggerLevel"]
+					log4JLoggersMap["logger_name"] = log4jLoggersChildRaw["loggerName"]
+
+					log4JLoggersMaps = append(log4JLoggersMaps, log4JLoggersMap)
+				}
+			}
+			loggingMap["log4j_loggers"] = log4JLoggersMaps
+			logReservePolicyMaps := make([]map[string]interface{}, 0)
+			logReservePolicyMap := make(map[string]interface{})
+			logReservePolicyRaw := make(map[string]interface{})
+			if loggingRaw["logReservePolicy"] != nil {
+				logReservePolicyRaw = loggingRaw["logReservePolicy"].(map[string]interface{})
+			}
+			if len(logReservePolicyRaw) > 0 {
+				logReservePolicyMap["expiration_days"] = logReservePolicyRaw["expirationDays"]
+				logReservePolicyMap["open_history"] = logReservePolicyRaw["openHistory"]
+
+				logReservePolicyMaps = append(logReservePolicyMaps, logReservePolicyMap)
+			}
+			loggingMap["log_reserve_policy"] = logReservePolicyMaps
+			loggingMaps = append(loggingMaps, loggingMap)
+		}
+		mapping["logging"] = loggingMaps
+		statusMaps := make([]map[string]interface{}, 0)
+		statusMap := make(map[string]interface{})
+		statusRaw := make(map[string]interface{})
+		if objectRaw["status"] != nil {
+			statusRaw = objectRaw["status"].(map[string]interface{})
+		}
+		if len(statusRaw) > 0 {
+			statusMap["current_session_cluster_status"] = statusRaw["currentSessionClusterStatus"]
+
+			statusMaps = append(statusMaps, statusMap)
+		}
+		mapping["status"] = statusMaps
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			names = append(names, objectRaw["name"])
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["workspace"], ":", objectRaw["namespace"], ":", objectRaw["name"])
+		mapping, err = dataSourceAliCloudRealtimeComputeSessionClusterReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["name"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("clusters", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudRealtimeComputeSessionClusterReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	realtimeComputeServiceV2 := RealtimeComputeServiceV2{client}
+	getResp, err := realtimeComputeServiceV2.DescribeRealtimeComputeSessionCluster(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["created_at"] = objectRaw["createdAt"]
+	mapping["creator"] = objectRaw["creator"]
+	mapping["creator_name"] = objectRaw["creatorName"]
+	mapping["deployment_target_name"] = objectRaw["deploymentTargetName"]
+	mapping["engine_version"] = objectRaw["engineVersion"]
+	mapping["flink_conf"] = objectRaw["flinkConf"]
+	mapping["labels"] = objectRaw["labels"]
+	mapping["modified_at"] = objectRaw["modifiedAt"]
+	mapping["modifier"] = objectRaw["modifier"]
+	mapping["modifier_name"] = objectRaw["modifierName"]
+	mapping["session_cluster_id"] = objectRaw["sessionClusterId"]
+	mapping["namespace"] = objectRaw["namespace"]
+	mapping["session_cluster_name"] = objectRaw["name"]
+	mapping["workspace"] = objectRaw["workspace"]
+
+	basicResourceSettingMaps := make([]map[string]interface{}, 0)
+	basicResourceSettingMap := make(map[string]interface{})
+	basicResourceSettingRaw := make(map[string]interface{})
+	if objectRaw["basicResourceSetting"] != nil {
+		basicResourceSettingRaw = objectRaw["basicResourceSetting"].(map[string]interface{})
+	}
+	if len(basicResourceSettingRaw) > 0 {
+		basicResourceSettingMap["parallelism"] = basicResourceSettingRaw["parallelism"]
+
+		jobmanagerResourceSettingSpecMaps := make([]map[string]interface{}, 0)
+		jobmanagerResourceSettingSpecMap := make(map[string]interface{})
+		jobmanagerResourceSettingSpecRaw := make(map[string]interface{})
+		if basicResourceSettingRaw["jobmanagerResourceSettingSpec"] != nil {
+			jobmanagerResourceSettingSpecRaw = basicResourceSettingRaw["jobmanagerResourceSettingSpec"].(map[string]interface{})
+		}
+		if len(jobmanagerResourceSettingSpecRaw) > 0 {
+			jobmanagerResourceSettingSpecMap["cpu"] = jobmanagerResourceSettingSpecRaw["cpu"]
+			jobmanagerResourceSettingSpecMap["memory"] = jobmanagerResourceSettingSpecRaw["memory"]
+
+			jobmanagerResourceSettingSpecMaps = append(jobmanagerResourceSettingSpecMaps, jobmanagerResourceSettingSpecMap)
+		}
+		basicResourceSettingMap["jobmanager_resource_setting_spec"] = jobmanagerResourceSettingSpecMaps
+		taskmanagerResourceSettingSpecMaps := make([]map[string]interface{}, 0)
+		taskmanagerResourceSettingSpecMap := make(map[string]interface{})
+		taskmanagerResourceSettingSpecRaw := make(map[string]interface{})
+		if basicResourceSettingRaw["taskmanagerResourceSettingSpec"] != nil {
+			taskmanagerResourceSettingSpecRaw = basicResourceSettingRaw["taskmanagerResourceSettingSpec"].(map[string]interface{})
+		}
+		if len(taskmanagerResourceSettingSpecRaw) > 0 {
+			taskmanagerResourceSettingSpecMap["cpu"] = taskmanagerResourceSettingSpecRaw["cpu"]
+			taskmanagerResourceSettingSpecMap["memory"] = taskmanagerResourceSettingSpecRaw["memory"]
+
+			taskmanagerResourceSettingSpecMaps = append(taskmanagerResourceSettingSpecMaps, taskmanagerResourceSettingSpecMap)
+		}
+		basicResourceSettingMap["taskmanager_resource_setting_spec"] = taskmanagerResourceSettingSpecMaps
+		basicResourceSettingMaps = append(basicResourceSettingMaps, basicResourceSettingMap)
+	}
+	mapping["basic_resource_setting"] = basicResourceSettingMaps
+	loggingMaps := make([]map[string]interface{}, 0)
+	loggingMap := make(map[string]interface{})
+	loggingRaw := make(map[string]interface{})
+	if objectRaw["logging"] != nil {
+		loggingRaw = objectRaw["logging"].(map[string]interface{})
+	}
+	if len(loggingRaw) > 0 {
+		loggingMap["log4j2_configuration_template"] = loggingRaw["log4j2ConfigurationTemplate"]
+		loggingMap["logging_profile"] = loggingRaw["loggingProfile"]
+
+		log4jLoggersRaw := loggingRaw["log4jLoggers"]
+		log4JLoggersMaps := make([]map[string]interface{}, 0)
+		if log4jLoggersRaw != nil {
+			for _, log4jLoggersChildRaw := range convertToInterfaceArray(log4jLoggersRaw) {
+				log4JLoggersMap := make(map[string]interface{})
+				log4jLoggersChildRaw := log4jLoggersChildRaw.(map[string]interface{})
+				log4JLoggersMap["logger_level"] = log4jLoggersChildRaw["loggerLevel"]
+				log4JLoggersMap["logger_name"] = log4jLoggersChildRaw["loggerName"]
+
+				log4JLoggersMaps = append(log4JLoggersMaps, log4JLoggersMap)
+			}
+		}
+		loggingMap["log4j_loggers"] = log4JLoggersMaps
+		logReservePolicyMaps := make([]map[string]interface{}, 0)
+		logReservePolicyMap := make(map[string]interface{})
+		logReservePolicyRaw := make(map[string]interface{})
+		if loggingRaw["logReservePolicy"] != nil {
+			logReservePolicyRaw = loggingRaw["logReservePolicy"].(map[string]interface{})
+		}
+		if len(logReservePolicyRaw) > 0 {
+			logReservePolicyMap["expiration_days"] = logReservePolicyRaw["expirationDays"]
+			logReservePolicyMap["open_history"] = logReservePolicyRaw["openHistory"]
+
+			logReservePolicyMaps = append(logReservePolicyMaps, logReservePolicyMap)
+		}
+		loggingMap["log_reserve_policy"] = logReservePolicyMaps
+		loggingMaps = append(loggingMaps, loggingMap)
+	}
+	mapping["logging"] = loggingMaps
+	statusMaps := make([]map[string]interface{}, 0)
+	statusMap := make(map[string]interface{})
+	statusRaw := make(map[string]interface{})
+	if objectRaw["status"] != nil {
+		statusRaw = objectRaw["status"].(map[string]interface{})
+	}
+	if len(statusRaw) > 0 {
+		statusMap["current_session_cluster_status"] = statusRaw["currentSessionClusterStatus"]
+
+		failureMaps := make([]map[string]interface{}, 0)
+		failureMap := make(map[string]interface{})
+		failureRaw := make(map[string]interface{})
+		if statusRaw["failure"] != nil {
+			failureRaw = statusRaw["failure"].(map[string]interface{})
+		}
+		if len(failureRaw) > 0 {
+			failureMap["failed_at"] = failureRaw["failedAt"]
+			failureMap["message"] = failureRaw["message"]
+			failureMap["reason"] = failureRaw["reason"]
+
+			failureMaps = append(failureMaps, failureMap)
+		}
+		statusMap["failure"] = failureMaps
+		runningMaps := make([]map[string]interface{}, 0)
+		runningMap := make(map[string]interface{})
+		runningRaw := make(map[string]interface{})
+		if statusRaw["running"] != nil {
+			runningRaw = statusRaw["running"].(map[string]interface{})
+		}
+		if len(runningRaw) > 0 {
+			runningMap["last_update_time"] = runningRaw["lastUpdateTime"]
+			runningMap["started_at"] = runningRaw["startedAt"]
+
+			referenceDeploymentIdsRaw := make([]interface{}, 0)
+			if runningRaw["referenceDeploymentIds"] != nil {
+				referenceDeploymentIdsRaw = convertToInterfaceArray(runningRaw["referenceDeploymentIds"])
+			}
+
+			runningMap["reference_deployment_ids"] = referenceDeploymentIdsRaw
+			runningMaps = append(runningMaps, runningMap)
+		}
+		statusMap["running"] = runningMaps
+		statusMaps = append(statusMaps, statusMap)
+	}
+	mapping["status"] = statusMaps
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_realtime_compute_session_clusters_test.go
+++ b/alicloud/data_source_alicloud_realtime_compute_session_clusters_test.go
@@ -1,0 +1,122 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudRealtimeComputeSessionClusterDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+	rand := acctest.RandIntRange(10000, 99999)
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudRealtimeComputeSessionClusterSourceConfig(rand),
+		fakeConfig:  "",
+	}
+
+	RealtimeComputeSessionClusterCheckInfo.dataSourceTestCheck(t, rand, allConf)
+}
+
+var existRealtimeComputeSessionClusterMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"ids.#":                                              "1",
+		"names.#":                                            "1",
+		"clusters.#":                                         "1",
+		"clusters.0.id":                                      CHECKSET,
+		"clusters.0.workspace":                               CHECKSET,
+		"clusters.0.namespace":                               CHECKSET,
+		"clusters.0.session_cluster_name":                    CHECKSET,
+		"clusters.0.session_cluster_id":                      CHECKSET,
+		"clusters.0.engine_version":                          CHECKSET,
+		"clusters.0.deployment_target_name":                  CHECKSET,
+		"clusters.0.basic_resource_setting.#":                "1",
+		"clusters.0.basic_resource_setting.0.parallelism":    CHECKSET,
+		"clusters.0.status.#":                                "1",
+		"clusters.0.status.0.current_session_cluster_status": CHECKSET,
+	}
+}
+
+var fakeRealtimeComputeSessionClusterMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"ids.#":      "0",
+		"names.#":    "0",
+		"clusters.#": "0",
+	}
+}
+
+var RealtimeComputeSessionClusterCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_realtime_compute_session_clusters.default",
+	existMapFunc: existRealtimeComputeSessionClusterMapFunc,
+	fakeMapFunc:  fakeRealtimeComputeSessionClusterMapFunc,
+}
+
+func testAccCheckAlicloudRealtimeComputeSessionClusterSourceConfig(rand int) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "tfaccrealtimecompute%d"
+}
+
+resource "alicloud_vpc" "default" {
+  is_default = false
+  cidr_block = "172.16.0.0/16"
+  vpc_name   = "test-tf-vpc-session-cluster-ds"
+}
+
+resource "alicloud_vswitch" "default" {
+  is_default   = false
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-beijing-g"
+  cidr_block   = "172.16.0.0/24"
+  vswitch_name = "test-tf-vswitch-session-cluster-ds"
+}
+
+resource "alicloud_oss_bucket" "default" {
+}
+
+resource "alicloud_realtime_compute_vvp_instance" "default" {
+  vvp_instance_name = var.name
+  storage {
+    oss {
+      bucket = alicloud_oss_bucket.default.id
+    }
+  }
+  vpc_id      = alicloud_vpc.default.id
+  vswitch_ids = ["${alicloud_vswitch.default.id}"]
+  resource_spec {
+    cpu       = "4"
+    memory_gb = "16"
+  }
+  payment_type = "PayAsYouGo"
+  zone_id     = alicloud_vswitch.default.zone_id
+}
+
+resource "alicloud_realtime_compute_session_cluster" "default" {
+  workspace              = alicloud_realtime_compute_vvp_instance.default.resource_id
+  namespace              = "${alicloud_realtime_compute_vvp_instance.default.vvp_instance_name}-default"
+  session_cluster_name   = var.name
+  deployment_target_name = "default-queue"
+  engine_version         = "vvr-8.0.11-flink-1.17"
+  basic_resource_setting {
+    parallelism = 1
+    jobmanager_resource_setting_spec {
+      cpu    = 1
+      memory = "1Gi"
+    }
+    taskmanager_resource_setting_spec {
+      cpu    = 1
+      memory = "1Gi"
+    }
+  }
+}
+
+data "alicloud_realtime_compute_session_clusters" "default" {
+  workspace      = alicloud_realtime_compute_vvp_instance.default.resource_id
+  namespace      = "${alicloud_realtime_compute_vvp_instance.default.vvp_instance_name}-default"
+  ids            = [alicloud_realtime_compute_session_cluster.default.id]
+  enable_details = true
+}
+`, rand)
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -170,6 +170,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_realtime_compute_session_clusters":              dataSourceAliCloudRealtimeComputeSessionClusters(),
 			"alicloud_redis_global_security_ip_groups":                dataSourceAliCloudRedisGlobalSecurityIpGroups(),
 			"alicloud_apig_ai_model_providers":                        dataSourceAliCloudApigAiModelProviders(),
 			"alicloud_apig_services":                                  dataSourceAliCloudApigServices(),
@@ -616,7 +617,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_hbr_restore_jobs":                                 dataSourceAlicloudHbrRestoreJobs(),
 			"alicloud_alb_listeners":                                    dataSourceAlicloudAlbListeners(),
 			"alicloud_ens_key_pairs":                                    dataSourceAlicloudEnsKeyPairs(),
-			"alicloud_ens_security_groups":                             dataSourceAliCloudEnsSecurityGroups(),
+			"alicloud_ens_security_groups":                              dataSourceAliCloudEnsSecurityGroups(),
 			"alicloud_sae_applications":                                 dataSourceAlicloudSaeApplications(),
 			"alicloud_alb_rules":                                        dataSourceAliCloudAlbRules(),
 			"alicloud_cms_metric_rule_templates":                        dataSourceAlicloudCmsMetricRuleTemplates(),
@@ -951,6 +952,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_realtime_compute_session_cluster":                     resourceAliCloudRealtimeComputeSessionCluster(),
 			"alicloud_redis_global_security_ip_group":                       resourceAliCloudRedisGlobalSecurityIpGroup(),
 			"alicloud_message_service_account_logging":                      resourceAliCloudMessageServiceAccountLogging(),
 			"alicloud_apig_ai_model_provider":                               resourceAliCloudApigAiModelProvider(),

--- a/alicloud/resource_alicloud_realtime_compute_session_cluster.go
+++ b/alicloud/resource_alicloud_realtime_compute_session_cluster.go
@@ -1,0 +1,755 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudRealtimeComputeSessionCluster() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudRealtimeComputeSessionClusterCreate,
+		Read:   resourceAliCloudRealtimeComputeSessionClusterRead,
+		Update: resourceAliCloudRealtimeComputeSessionClusterUpdate,
+		Delete: resourceAliCloudRealtimeComputeSessionClusterDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"basic_resource_setting": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"taskmanager_resource_setting_spec": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"memory": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"cpu": {
+										Type:     schema.TypeFloat,
+										Required: true,
+									},
+								},
+							},
+						},
+						"parallelism": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"jobmanager_resource_setting_spec": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"memory": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"cpu": {
+										Type:     schema.TypeFloat,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"created_at": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"creator": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creator_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"deployment_target_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"flink_conf": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"labels": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"logging": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"log4j2_configuration_template": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"logging_profile": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"log4j_loggers": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"logger_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"logger_level": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"log_reserve_policy": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"open_history": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Computed: true,
+									},
+									"expiration_days": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"modified_at": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"modifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modifier_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"namespace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"session_cluster_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"session_cluster_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"running": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"last_update_time": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"reference_deployment_ids": {
+										Type:     schema.TypeSet,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"started_at": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"current_session_cluster_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"failure": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"message": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"failed_at": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"reason": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"workspace": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudRealtimeComputeSessionClusterCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	namespace := d.Get("namespace")
+	action := fmt.Sprintf("/api/v2/namespaces/%s/sessionclusters", namespace)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	header := make(map[string]*string)
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	header["workspace"] = StringPointer(d.Get("workspace").(string))
+	// The CreateSessionCluster API validates the SessionCluster body structure
+	// and requires workspace and namespace in the body, in addition to the
+	// workspace header and the namespace path segment.
+	request["workspace"] = d.Get("workspace")
+	request["namespace"] = d.Get("namespace")
+	if v, ok := d.GetOk("session_cluster_name"); ok {
+		request["name"] = v
+	}
+
+	basicResourceSetting := make(map[string]interface{})
+
+	if v := d.Get("basic_resource_setting"); v != nil {
+		taskmanagerResourceSettingSpec := make(map[string]interface{})
+		cpu1, _ := jsonpath.Get("$[0].taskmanager_resource_setting_spec[0].cpu", d.Get("basic_resource_setting"))
+		if cpu1 != nil && cpu1 != "" {
+			taskmanagerResourceSettingSpec["cpu"] = cpu1
+		}
+		memory1, _ := jsonpath.Get("$[0].taskmanager_resource_setting_spec[0].memory", d.Get("basic_resource_setting"))
+		if memory1 != nil && memory1 != "" {
+			taskmanagerResourceSettingSpec["memory"] = memory1
+		}
+
+		if len(taskmanagerResourceSettingSpec) > 0 {
+			basicResourceSetting["taskmanagerResourceSettingSpec"] = taskmanagerResourceSettingSpec
+		}
+		jobmanagerResourceSettingSpec := make(map[string]interface{})
+		cpu3, _ := jsonpath.Get("$[0].jobmanager_resource_setting_spec[0].cpu", d.Get("basic_resource_setting"))
+		if cpu3 != nil && cpu3 != "" {
+			jobmanagerResourceSettingSpec["cpu"] = cpu3
+		}
+		memory3, _ := jsonpath.Get("$[0].jobmanager_resource_setting_spec[0].memory", d.Get("basic_resource_setting"))
+		if memory3 != nil && memory3 != "" {
+			jobmanagerResourceSettingSpec["memory"] = memory3
+		}
+
+		if len(jobmanagerResourceSettingSpec) > 0 {
+			basicResourceSetting["jobmanagerResourceSettingSpec"] = jobmanagerResourceSettingSpec
+		}
+		parallelism1, _ := jsonpath.Get("$[0].parallelism", v)
+		if parallelism1 != nil && parallelism1 != "" {
+			basicResourceSetting["parallelism"] = parallelism1
+		}
+
+		request["basicResourceSetting"] = basicResourceSetting
+	}
+
+	if v, ok := d.GetOk("flink_conf"); ok {
+		request["flinkConf"] = v
+	}
+	logging := make(map[string]interface{})
+
+	if v := d.Get("logging"); !IsNil(v) {
+		logReservePolicy := make(map[string]interface{})
+		expirationDays1, _ := jsonpath.Get("$[0].log_reserve_policy[0].expiration_days", d.Get("logging"))
+		if expirationDays1 != nil && expirationDays1 != "" {
+			logReservePolicy["expirationDays"] = expirationDays1
+		}
+		openHistory1, _ := jsonpath.Get("$[0].log_reserve_policy[0].open_history", d.Get("logging"))
+		if openHistory1 != nil && openHistory1 != "" {
+			logReservePolicy["openHistory"] = openHistory1
+		}
+
+		if len(logReservePolicy) > 0 {
+			logging["logReservePolicy"] = logReservePolicy
+		}
+		if v, ok := d.GetOk("logging"); ok {
+			localData, err := jsonpath.Get("$[0].log4j_loggers", v)
+			if err != nil {
+				localData = make([]interface{}, 0)
+			}
+			localMaps := make([]interface{}, 0)
+			for _, dataLoop := range convertToInterfaceArray(localData) {
+				dataLoopTmp := make(map[string]interface{})
+				if dataLoop != nil {
+					dataLoopTmp = dataLoop.(map[string]interface{})
+				}
+				dataLoopMap := make(map[string]interface{})
+				dataLoopMap["loggerLevel"] = dataLoopTmp["logger_level"]
+				dataLoopMap["loggerName"] = dataLoopTmp["logger_name"]
+				localMaps = append(localMaps, dataLoopMap)
+			}
+			logging["log4jLoggers"] = localMaps
+		}
+
+		loggingProfile1, _ := jsonpath.Get("$[0].logging_profile", v)
+		if loggingProfile1 != nil && loggingProfile1 != "" {
+			logging["loggingProfile"] = loggingProfile1
+		}
+		log4J2ConfigurationTemplate, _ := jsonpath.Get("$[0].log4j2_configuration_template", v)
+		if log4J2ConfigurationTemplate != nil && log4J2ConfigurationTemplate != "" {
+			logging["log4j2ConfigurationTemplate"] = log4J2ConfigurationTemplate
+		}
+
+		request["logging"] = logging
+	} else {
+		// The CreateSessionCluster API requires the logging parameter,
+		// fall back to the default logging profile when it is not specified.
+		request["logging"] = map[string]interface{}{
+			"loggingProfile": "default",
+		}
+	}
+
+	if v, ok := d.GetOk("labels"); ok {
+		request["labels"] = v
+	}
+	request["deploymentTargetName"] = d.Get("deployment_target_name")
+	request["engineVersion"] = d.Get("engine_version")
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("ververica", "2022-07-18", action, query, header, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_realtime_compute_session_cluster", action, AlibabaCloudSdkGoERROR)
+	}
+
+	dataworkspaceVar, _ := jsonpath.Get("$.data.workspace", response)
+	datanamespaceVar, _ := jsonpath.Get("$.data.namespace", response)
+	datanameVar, _ := jsonpath.Get("$.data.name", response)
+	d.SetId(fmt.Sprintf("%v:%v:%v", dataworkspaceVar, datanamespaceVar, datanameVar))
+
+	return resourceAliCloudRealtimeComputeSessionClusterRead(d, meta)
+}
+
+func resourceAliCloudRealtimeComputeSessionClusterRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	realtimeComputeServiceV2 := RealtimeComputeServiceV2{client}
+
+	objectRaw, err := realtimeComputeServiceV2.DescribeRealtimeComputeSessionCluster(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_realtime_compute_session_cluster DescribeRealtimeComputeSessionCluster Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("created_at", objectRaw["createdAt"])
+	d.Set("creator", objectRaw["creator"])
+	d.Set("creator_name", objectRaw["creatorName"])
+	d.Set("deployment_target_name", objectRaw["deploymentTargetName"])
+	d.Set("engine_version", objectRaw["engineVersion"])
+	d.Set("flink_conf", objectRaw["flinkConf"])
+	d.Set("labels", objectRaw["labels"])
+	d.Set("modified_at", objectRaw["modifiedAt"])
+	d.Set("modifier", objectRaw["modifier"])
+	d.Set("modifier_name", objectRaw["modifierName"])
+	d.Set("session_cluster_id", objectRaw["sessionClusterId"])
+	d.Set("namespace", objectRaw["namespace"])
+	d.Set("session_cluster_name", objectRaw["name"])
+	d.Set("workspace", objectRaw["workspace"])
+
+	basicResourceSettingMaps := make([]map[string]interface{}, 0)
+	basicResourceSettingMap := make(map[string]interface{})
+	basicResourceSettingRaw := make(map[string]interface{})
+	if objectRaw["basicResourceSetting"] != nil {
+		basicResourceSettingRaw = objectRaw["basicResourceSetting"].(map[string]interface{})
+	}
+	if len(basicResourceSettingRaw) > 0 {
+		basicResourceSettingMap["parallelism"] = basicResourceSettingRaw["parallelism"]
+
+		jobmanagerResourceSettingSpecMaps := make([]map[string]interface{}, 0)
+		jobmanagerResourceSettingSpecMap := make(map[string]interface{})
+		jobmanagerResourceSettingSpecRaw := make(map[string]interface{})
+		if basicResourceSettingRaw["jobmanagerResourceSettingSpec"] != nil {
+			jobmanagerResourceSettingSpecRaw = basicResourceSettingRaw["jobmanagerResourceSettingSpec"].(map[string]interface{})
+		}
+		if len(jobmanagerResourceSettingSpecRaw) > 0 {
+			jobmanagerResourceSettingSpecMap["cpu"] = jobmanagerResourceSettingSpecRaw["cpu"]
+			jobmanagerResourceSettingSpecMap["memory"] = jobmanagerResourceSettingSpecRaw["memory"]
+
+			jobmanagerResourceSettingSpecMaps = append(jobmanagerResourceSettingSpecMaps, jobmanagerResourceSettingSpecMap)
+		}
+		basicResourceSettingMap["jobmanager_resource_setting_spec"] = jobmanagerResourceSettingSpecMaps
+		taskmanagerResourceSettingSpecMaps := make([]map[string]interface{}, 0)
+		taskmanagerResourceSettingSpecMap := make(map[string]interface{})
+		taskmanagerResourceSettingSpecRaw := make(map[string]interface{})
+		if basicResourceSettingRaw["taskmanagerResourceSettingSpec"] != nil {
+			taskmanagerResourceSettingSpecRaw = basicResourceSettingRaw["taskmanagerResourceSettingSpec"].(map[string]interface{})
+		}
+		if len(taskmanagerResourceSettingSpecRaw) > 0 {
+			taskmanagerResourceSettingSpecMap["cpu"] = taskmanagerResourceSettingSpecRaw["cpu"]
+			taskmanagerResourceSettingSpecMap["memory"] = taskmanagerResourceSettingSpecRaw["memory"]
+
+			taskmanagerResourceSettingSpecMaps = append(taskmanagerResourceSettingSpecMaps, taskmanagerResourceSettingSpecMap)
+		}
+		basicResourceSettingMap["taskmanager_resource_setting_spec"] = taskmanagerResourceSettingSpecMaps
+		basicResourceSettingMaps = append(basicResourceSettingMaps, basicResourceSettingMap)
+	}
+	if err := d.Set("basic_resource_setting", basicResourceSettingMaps); err != nil {
+		return err
+	}
+	loggingMaps := make([]map[string]interface{}, 0)
+	loggingMap := make(map[string]interface{})
+	loggingRaw := make(map[string]interface{})
+	if objectRaw["logging"] != nil {
+		loggingRaw = objectRaw["logging"].(map[string]interface{})
+	}
+	if len(loggingRaw) > 0 {
+		loggingMap["log4j2_configuration_template"] = loggingRaw["log4j2ConfigurationTemplate"]
+		loggingMap["logging_profile"] = loggingRaw["loggingProfile"]
+
+		log4jLoggersRaw := loggingRaw["log4jLoggers"]
+		log4JLoggersMaps := make([]map[string]interface{}, 0)
+		if log4jLoggersRaw != nil {
+			for _, log4jLoggersChildRaw := range convertToInterfaceArray(log4jLoggersRaw) {
+				log4JLoggersMap := make(map[string]interface{})
+				log4jLoggersChildRaw := log4jLoggersChildRaw.(map[string]interface{})
+				log4JLoggersMap["logger_level"] = log4jLoggersChildRaw["loggerLevel"]
+				log4JLoggersMap["logger_name"] = log4jLoggersChildRaw["loggerName"]
+
+				log4JLoggersMaps = append(log4JLoggersMaps, log4JLoggersMap)
+			}
+		}
+		loggingMap["log4j_loggers"] = log4JLoggersMaps
+		logReservePolicyMaps := make([]map[string]interface{}, 0)
+		logReservePolicyMap := make(map[string]interface{})
+		logReservePolicyRaw := make(map[string]interface{})
+		if loggingRaw["logReservePolicy"] != nil {
+			logReservePolicyRaw = loggingRaw["logReservePolicy"].(map[string]interface{})
+		}
+		if len(logReservePolicyRaw) > 0 {
+			logReservePolicyMap["expiration_days"] = logReservePolicyRaw["expirationDays"]
+			logReservePolicyMap["open_history"] = logReservePolicyRaw["openHistory"]
+
+			logReservePolicyMaps = append(logReservePolicyMaps, logReservePolicyMap)
+		}
+		loggingMap["log_reserve_policy"] = logReservePolicyMaps
+		loggingMaps = append(loggingMaps, loggingMap)
+	}
+	if err := d.Set("logging", loggingMaps); err != nil {
+		return err
+	}
+	statusMaps := make([]map[string]interface{}, 0)
+	statusMap := make(map[string]interface{})
+	statusRaw := make(map[string]interface{})
+	if objectRaw["status"] != nil {
+		statusRaw = objectRaw["status"].(map[string]interface{})
+	}
+	if len(statusRaw) > 0 {
+		statusMap["current_session_cluster_status"] = statusRaw["currentSessionClusterStatus"]
+
+		failureMaps := make([]map[string]interface{}, 0)
+		failureMap := make(map[string]interface{})
+		failureRaw := make(map[string]interface{})
+		if statusRaw["failure"] != nil {
+			failureRaw = statusRaw["failure"].(map[string]interface{})
+		}
+		if len(failureRaw) > 0 {
+			failureMap["failed_at"] = failureRaw["failedAt"]
+			failureMap["message"] = failureRaw["message"]
+			failureMap["reason"] = failureRaw["reason"]
+
+			failureMaps = append(failureMaps, failureMap)
+		}
+		statusMap["failure"] = failureMaps
+		runningMaps := make([]map[string]interface{}, 0)
+		runningMap := make(map[string]interface{})
+		runningRaw := make(map[string]interface{})
+		if statusRaw["running"] != nil {
+			runningRaw = statusRaw["running"].(map[string]interface{})
+		}
+		if len(runningRaw) > 0 {
+			runningMap["last_update_time"] = runningRaw["lastUpdateTime"]
+			runningMap["started_at"] = runningRaw["startedAt"]
+
+			referenceDeploymentIdsRaw := make([]interface{}, 0)
+			if runningRaw["referenceDeploymentIds"] != nil {
+				referenceDeploymentIdsRaw = convertToInterfaceArray(runningRaw["referenceDeploymentIds"])
+			}
+
+			runningMap["reference_deployment_ids"] = referenceDeploymentIdsRaw
+			runningMaps = append(runningMaps, runningMap)
+		}
+		statusMap["running"] = runningMaps
+		statusMaps = append(statusMaps, statusMap)
+	}
+	if err := d.Set("status", statusMaps); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAliCloudRealtimeComputeSessionClusterUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var header map[string]*string
+	var body map[string]interface{}
+	update := false
+
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	namespace := parts[1]
+	sessionClusterName := parts[2]
+	action := fmt.Sprintf("/api/v2/namespaces/%s/sessionclusters/%s", namespace, sessionClusterName)
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	header = make(map[string]*string)
+	body = make(map[string]interface{})
+	header["workspace"] = StringPointer(parts[0])
+	// Keep the UpdateSessionCluster body consistent with the Create path: the
+	// backend validates the SessionCluster body structure, so include workspace
+	// and namespace alongside the workspace header and namespace path segment.
+	request["workspace"] = parts[0]
+	request["namespace"] = namespace
+
+	if d.HasChange("basic_resource_setting") {
+		update = true
+	}
+	basicResourceSetting := make(map[string]interface{})
+
+	if v := d.Get("basic_resource_setting"); v != nil {
+		taskmanagerResourceSettingSpec := make(map[string]interface{})
+		cpu1, _ := jsonpath.Get("$[0].taskmanager_resource_setting_spec[0].cpu", d.Get("basic_resource_setting"))
+		if cpu1 != nil && cpu1 != "" {
+			taskmanagerResourceSettingSpec["cpu"] = cpu1
+		}
+		memory1, _ := jsonpath.Get("$[0].taskmanager_resource_setting_spec[0].memory", d.Get("basic_resource_setting"))
+		if memory1 != nil && memory1 != "" {
+			taskmanagerResourceSettingSpec["memory"] = memory1
+		}
+
+		if len(taskmanagerResourceSettingSpec) > 0 {
+			basicResourceSetting["taskmanagerResourceSettingSpec"] = taskmanagerResourceSettingSpec
+		}
+		jobmanagerResourceSettingSpec := make(map[string]interface{})
+		cpu3, _ := jsonpath.Get("$[0].jobmanager_resource_setting_spec[0].cpu", d.Get("basic_resource_setting"))
+		if cpu3 != nil && cpu3 != "" {
+			jobmanagerResourceSettingSpec["cpu"] = cpu3
+		}
+		memory3, _ := jsonpath.Get("$[0].jobmanager_resource_setting_spec[0].memory", d.Get("basic_resource_setting"))
+		if memory3 != nil && memory3 != "" {
+			jobmanagerResourceSettingSpec["memory"] = memory3
+		}
+
+		if len(jobmanagerResourceSettingSpec) > 0 {
+			basicResourceSetting["jobmanagerResourceSettingSpec"] = jobmanagerResourceSettingSpec
+		}
+		parallelism1, _ := jsonpath.Get("$[0].parallelism", v)
+		if parallelism1 != nil && parallelism1 != "" {
+			basicResourceSetting["parallelism"] = parallelism1
+		}
+
+		request["basicResourceSetting"] = basicResourceSetting
+	}
+
+	if d.HasChange("flink_conf") {
+		update = true
+	}
+	if v, ok := d.GetOk("flink_conf"); ok || d.HasChange("flink_conf") {
+		request["flinkConf"] = v
+	}
+	if d.HasChange("logging") {
+		update = true
+	}
+	logging := make(map[string]interface{})
+
+	if v := d.Get("logging"); !IsNil(v) || d.HasChange("logging") {
+		logReservePolicy := make(map[string]interface{})
+		expirationDays1, _ := jsonpath.Get("$[0].log_reserve_policy[0].expiration_days", d.Get("logging"))
+		if expirationDays1 != nil && expirationDays1 != "" {
+			logReservePolicy["expirationDays"] = expirationDays1
+		}
+		openHistory1, _ := jsonpath.Get("$[0].log_reserve_policy[0].open_history", d.Get("logging"))
+		if openHistory1 != nil && openHistory1 != "" {
+			logReservePolicy["openHistory"] = openHistory1
+		}
+
+		if len(logReservePolicy) > 0 {
+			logging["logReservePolicy"] = logReservePolicy
+		}
+		if v, ok := d.GetOk("logging"); ok {
+			localData, err := jsonpath.Get("$[0].log4j_loggers", v)
+			if err != nil {
+				localData = make([]interface{}, 0)
+			}
+			localMaps := make([]interface{}, 0)
+			for _, dataLoop := range convertToInterfaceArray(localData) {
+				dataLoopTmp := make(map[string]interface{})
+				if dataLoop != nil {
+					dataLoopTmp = dataLoop.(map[string]interface{})
+				}
+				dataLoopMap := make(map[string]interface{})
+				dataLoopMap["loggerLevel"] = dataLoopTmp["logger_level"]
+				dataLoopMap["loggerName"] = dataLoopTmp["logger_name"]
+				localMaps = append(localMaps, dataLoopMap)
+			}
+			logging["log4jLoggers"] = localMaps
+		}
+
+		loggingProfile1, _ := jsonpath.Get("$[0].logging_profile", v)
+		if loggingProfile1 != nil && loggingProfile1 != "" {
+			logging["loggingProfile"] = loggingProfile1
+		}
+		log4J2ConfigurationTemplate, _ := jsonpath.Get("$[0].log4j2_configuration_template", v)
+		if log4J2ConfigurationTemplate != nil && log4J2ConfigurationTemplate != "" {
+			logging["log4j2ConfigurationTemplate"] = log4J2ConfigurationTemplate
+		}
+
+		request["logging"] = logging
+	}
+
+	if d.HasChange("labels") {
+		update = true
+	}
+	if v, ok := d.GetOk("labels"); ok || d.HasChange("labels") {
+		request["labels"] = v
+	}
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPatch("ververica", "2022-07-18", action, query, header, body, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudRealtimeComputeSessionClusterRead(d, meta)
+}
+
+func resourceAliCloudRealtimeComputeSessionClusterDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	namespace := parts[1]
+	sessionClusterName := parts[2]
+	action := fmt.Sprintf("/api/v2/namespaces/%s/sessionclusters/%s", namespace, sessionClusterName)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	header := make(map[string]*string)
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+	header["workspace"] = StringPointer(parts[0])
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("ververica", "2022-07-18", action, query, header, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"990301"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_realtime_compute_session_cluster_test.go
+++ b/alicloud/resource_alicloud_realtime_compute_session_cluster_test.go
@@ -1,0 +1,185 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test RealtimeCompute SessionCluster. >>> Resource test cases, automatically generated.
+// Case SessionCluster lifecycle test
+func TestAccAliCloudRealtimeComputeSessionCluster_basic0(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_realtime_compute_session_cluster.default"
+	ra := resourceAttrInit(resourceId, AlicloudRealtimeComputeSessionClusterMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RealtimeComputeServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRealtimeComputeSessionCluster")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccrealtimecompute%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRealtimeComputeSessionClusterBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"workspace":              "${alicloud_realtime_compute_vvp_instance.default.resource_id}",
+					"namespace":              "${alicloud_realtime_compute_vvp_instance.default.vvp_instance_name}-default",
+					"session_cluster_name":   name,
+					"deployment_target_name": "default-queue",
+					"engine_version":         "vvr-8.0.11-flink-1.17",
+					"basic_resource_setting": []map[string]interface{}{
+						{
+							"parallelism": "1",
+							"jobmanager_resource_setting_spec": []map[string]interface{}{
+								{
+									"cpu":    "1",
+									"memory": "1Gi",
+								},
+							},
+							"taskmanager_resource_setting_spec": []map[string]interface{}{
+								{
+									"cpu":    "1",
+									"memory": "1Gi",
+								},
+							},
+						},
+					},
+					"labels": map[string]interface{}{
+						"env": "test",
+					},
+					"flink_conf": map[string]interface{}{
+						"\"execution.checkpointing.interval\"": "180s",
+						"\"restart-strategy\"":                 "fixed-delay",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"session_cluster_name":   name,
+						"deployment_target_name": "default-queue",
+						"engine_version":         "vvr-8.0.11-flink-1.17",
+						"workspace":              CHECKSET,
+						"namespace":              CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"basic_resource_setting": []map[string]interface{}{
+						{
+							"parallelism": "2",
+							"jobmanager_resource_setting_spec": []map[string]interface{}{
+								{
+									"cpu":    "2",
+									"memory": "2Gi",
+								},
+							},
+							"taskmanager_resource_setting_spec": []map[string]interface{}{
+								{
+									"cpu":    "2",
+									"memory": "2Gi",
+								},
+							},
+						},
+					},
+					"labels": map[string]interface{}{
+						"env": "prod",
+					},
+					"flink_conf": map[string]interface{}{
+						"\"execution.checkpointing.interval\"": "300s",
+					},
+					"logging": []map[string]interface{}{
+						{
+							"logging_profile":               "default",
+							"log4j2_configuration_template": "test-template",
+							"log4j_loggers": []map[string]interface{}{
+								{
+									"logger_name":  "StdOut",
+									"logger_level": "DEBUG",
+								},
+							},
+							"log_reserve_policy": []map[string]interface{}{
+								{
+									"open_history":    "true",
+									"expiration_days": "7",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"logging.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudRealtimeComputeSessionClusterMap0 = map[string]string{
+	"session_cluster_id": CHECKSET,
+	"created_at":         CHECKSET,
+	"status.#":           "1",
+}
+
+func AlicloudRealtimeComputeSessionClusterBasicDependence0(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_vpc" "default" {
+  is_default = false
+  cidr_block = "172.16.0.0/16"
+  vpc_name   = "test-tf-vpc-session-cluster"
+}
+
+resource "alicloud_vswitch" "default" {
+  is_default   = false
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-beijing-g"
+  cidr_block   = "172.16.0.0/24"
+  vswitch_name = "test-tf-vswitch-session-cluster"
+}
+
+resource "alicloud_oss_bucket" "default" {
+}
+
+resource "alicloud_realtime_compute_vvp_instance" "default" {
+  vvp_instance_name = var.name
+  storage {
+    oss {
+      bucket = alicloud_oss_bucket.default.id
+    }
+  }
+  vpc_id      = alicloud_vpc.default.id
+  vswitch_ids = ["${alicloud_vswitch.default.id}"]
+  resource_spec {
+    cpu       = "4"
+    memory_gb = "16"
+  }
+  payment_type = "PayAsYouGo"
+  zone_id     = alicloud_vswitch.default.zone_id
+}
+`, name)
+}
+
+// Test RealtimeCompute SessionCluster. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_realtime_compute_v2.go
+++ b/alicloud/service_alicloud_realtime_compute_v2.go
@@ -341,3 +341,88 @@ func (s *RealtimeComputeServiceV2) RealtimeComputeJobStateRefreshFuncWithApi(id 
 }
 
 // DescribeRealtimeComputeJob >>> Encapsulated.
+
+// DescribeRealtimeComputeSessionCluster <<< Encapsulated get interface for RealtimeCompute SessionCluster.
+
+func (s *RealtimeComputeServiceV2) DescribeRealtimeComputeSessionCluster(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	var header map[string]*string
+	parts := strings.Split(id, ":")
+	if len(parts) != 3 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 3, len(parts)))
+		return nil, err
+	}
+	namespace := parts[1]
+	sessionClusterName := parts[2]
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	header = make(map[string]*string)
+	header["workspace"] = StringPointer(parts[0])
+
+	action := fmt.Sprintf("/api/v2/namespaces/%s/sessionclusters/%s", namespace, sessionClusterName)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RoaGet("ververica", "2022-07-18", action, query, header, nil)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"990301"}) {
+			return object, WrapErrorf(NotFoundErr("SessionCluster", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.data", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.data", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *RealtimeComputeServiceV2) RealtimeComputeSessionClusterStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.RealtimeComputeSessionClusterStateRefreshFuncWithApi(id, field, failStates, s.DescribeRealtimeComputeSessionCluster)
+}
+
+func (s *RealtimeComputeServiceV2) RealtimeComputeSessionClusterStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeRealtimeComputeSessionCluster >>> Encapsulated.

--- a/website/docs/d/realtime_compute_session_clusters.html.markdown
+++ b/website/docs/d/realtime_compute_session_clusters.html.markdown
@@ -1,0 +1,145 @@
+---
+subcategory: "Realtime Compute"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_realtime_compute_session_clusters"
+sidebar_current: "docs-alicloud-datasource-realtime-compute-session-clusters"
+description: |-
+  Provides a list of Realtime Compute Session Cluster owned by an Alibaba Cloud account.
+---
+
+# alicloud_realtime_compute_session_clusters
+
+This data source provides Realtime Compute Session Cluster available to the user.[What is Session Cluster](https://next.api.alibabacloud.com/document/ververica/2022-07-18/CreateSessionCluster)
+
+-> **NOTE:** Available since v1.289.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "tfexample-session-cluster"
+}
+
+resource "alicloud_vpc" "default" {
+  is_default = false
+  cidr_block = "172.16.0.0/16"
+  vpc_name   = var.name
+}
+
+resource "alicloud_vswitch" "default" {
+  is_default   = false
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-beijing-g"
+  cidr_block   = "172.16.0.0/24"
+  vswitch_name = var.name
+}
+
+resource "alicloud_oss_bucket" "default" {
+}
+
+resource "alicloud_realtime_compute_vvp_instance" "default" {
+  vvp_instance_name = var.name
+  storage {
+    oss {
+      bucket = alicloud_oss_bucket.default.id
+    }
+  }
+  vpc_id      = alicloud_vpc.default.id
+  vswitch_ids = [alicloud_vswitch.default.id]
+  resource_spec {
+    cpu       = "4"
+    memory_gb = "16"
+  }
+  payment_type = "PayAsYouGo"
+  zone_id      = alicloud_vswitch.default.zone_id
+}
+
+resource "alicloud_realtime_compute_session_cluster" "default" {
+  workspace              = alicloud_realtime_compute_vvp_instance.default.resource_id
+  namespace              = "${alicloud_realtime_compute_vvp_instance.default.vvp_instance_name}-default"
+  session_cluster_name   = var.name
+  deployment_target_name = "default-queue"
+  engine_version         = "vvr-8.0.11-flink-1.17"
+  basic_resource_setting {
+    parallelism = 1
+    jobmanager_resource_setting_spec {
+      cpu    = 1
+      memory = "1Gi"
+    }
+    taskmanager_resource_setting_spec {
+      cpu    = 1
+      memory = "1Gi"
+    }
+  }
+}
+
+data "alicloud_realtime_compute_session_clusters" "default" {
+  workspace      = alicloud_realtime_compute_vvp_instance.default.resource_id
+  namespace      = "${alicloud_realtime_compute_vvp_instance.default.vvp_instance_name}-default"
+  enable_details = true
+}
+
+output "session_cluster_id" {
+  value = data.alicloud_realtime_compute_session_clusters.default.clusters.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `namespace` - (Required) The name of the namespace
+* `workspace` - (Required) The ID of the workspace
+* `ids` - (Optional, Computed) A list of Session Cluster IDs. The value is formulated as `<workspace>:<namespace>:<session_cluster_name>`.
+* `name_regex` - (Optional) A regex string to filter results by Session Cluster name.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Session Cluster IDs.
+* `names` - A list of name of Session Clusters.
+* `clusters` - A list of Session Cluster Entries. Each element contains the following attributes:
+  * `basic_resource_setting` - Basic resource setting.
+    * `jobmanager_resource_setting_spec` - JobManager resource setting.
+      * `cpu` - CPU.
+      * `memory` - Memory.
+    * `parallelism` - Parallelism.
+    * `taskmanager_resource_setting_spec` - TaskManager resource setting.
+      * `cpu` - CPU.
+      * `memory` - Memory.
+  * `created_at` - Creation time.
+  * `creator` - Creator.
+  * `creator_name` - Creator name.
+  * `deployment_target_name` - The name of the deployment target.
+  * `engine_version` - The engine version of the session cluster.
+  * `flink_conf` - Flink configurations.
+  * `labels` - The labels of the session cluster.
+  * `logging` - Logging config.
+    * `log4j2_configuration_template` - Custom log template.
+    * `log4j_loggers` - log4j config.
+      * `logger_level` - Logger level.
+      * `logger_name` - Class name of the output log.
+    * `log_reserve_policy` - Log reserve policy.
+      * `expiration_days` - Expiration days.
+      * `open_history` - Enable log saving.
+    * `logging_profile` - System log template.
+  * `modified_at` - Modification time.
+  * `modifier` - Modifier.
+  * `modifier_name` - Modifier name.
+  * `namespace` - The name of the namespace.
+  * `session_cluster_id` - The ID of the session cluster.
+  * `session_cluster_name` - The name of the session cluster.
+  * `status` - Status of the session cluster.
+    * `current_session_cluster_status` - Current status of the session cluster.
+    * `failure` - **NOTE:** This field is only available when `enable_details` is `true`. Failure info of the session cluster.
+      * `failed_at` - Failure time.
+      * `message` - Failure message.
+      * `reason` - Failure reason.
+    * `running` - **NOTE:** This field is only available when `enable_details` is `true`. Running info of the session cluster.
+      * `last_update_time` - Last update time.
+      * `reference_deployment_ids` - IDs of deployments running on the session cluster.
+      * `started_at` - Start time.
+  * `workspace` - The ID of the workspace.
+  * `id` - The ID of the resource supplied above.

--- a/website/docs/r/realtime_compute_session_cluster.html.markdown
+++ b/website/docs/r/realtime_compute_session_cluster.html.markdown
@@ -1,0 +1,169 @@
+---
+subcategory: "Realtime Compute"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_realtime_compute_session_cluster"
+description: |-
+  Provides a Alicloud Realtime Compute Session Cluster resource.
+---
+
+# alicloud_realtime_compute_session_cluster
+
+Provides a Realtime Compute Session Cluster resource.
+
+Session cluster of Realtime Compute for Apache Flink.
+
+For information about Realtime Compute Session Cluster and how to use it, see [What is Session Cluster](https://next.api.alibabacloud.com/document/ververica/2022-07-18/CreateSessionCluster).
+
+-> **NOTE:** Available since v1.289.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "tfexample-session-cluster"
+}
+
+resource "alicloud_vpc" "default" {
+  is_default = false
+  cidr_block = "172.16.0.0/16"
+  vpc_name   = var.name
+}
+
+resource "alicloud_vswitch" "default" {
+  is_default   = false
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = "cn-beijing-g"
+  cidr_block   = "172.16.0.0/24"
+  vswitch_name = var.name
+}
+
+resource "alicloud_oss_bucket" "default" {
+}
+
+resource "alicloud_realtime_compute_vvp_instance" "default" {
+  vvp_instance_name = var.name
+  storage {
+    oss {
+      bucket = alicloud_oss_bucket.default.id
+    }
+  }
+  vpc_id      = alicloud_vpc.default.id
+  vswitch_ids = [alicloud_vswitch.default.id]
+  resource_spec {
+    cpu       = "4"
+    memory_gb = "16"
+  }
+  payment_type = "PayAsYouGo"
+  zone_id      = alicloud_vswitch.default.zone_id
+}
+
+resource "alicloud_realtime_compute_session_cluster" "default" {
+  workspace              = alicloud_realtime_compute_vvp_instance.default.resource_id
+  namespace              = "${alicloud_realtime_compute_vvp_instance.default.vvp_instance_name}-default"
+  session_cluster_name   = var.name
+  deployment_target_name = "default-queue"
+  engine_version         = "vvr-8.0.11-flink-1.17"
+  basic_resource_setting {
+    parallelism = 1
+    jobmanager_resource_setting_spec {
+      cpu    = 1
+      memory = "1Gi"
+    }
+    taskmanager_resource_setting_spec {
+      cpu    = 1
+      memory = "1Gi"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `basic_resource_setting` - (Required, List) Basic resource setting See [`basic_resource_setting`](#basic_resource_setting) below.
+* `deployment_target_name` - (Required, ForceNew) The name of the deployment target
+* `engine_version` - (Required, ForceNew) The engine version of the session cluster
+* `flink_conf` - (Optional, Computed, Map) Flink configurations
+* `labels` - (Optional, Map) The labels of the session cluster
+* `logging` - (Optional, Computed, List) Logging config See [`logging`](#logging) below.
+* `namespace` - (Required, ForceNew) The name of the namespace
+* `session_cluster_name` - (Required, ForceNew) The name of the session cluster
+* `workspace` - (Optional, ForceNew, Computed) The ID of the workspace
+
+### `basic_resource_setting`
+
+The basic_resource_setting supports the following:
+* `jobmanager_resource_setting_spec` - (Required, List) JobManager resource setting See [`jobmanager_resource_setting_spec`](#basic_resource_setting-jobmanager_resource_setting_spec) below.
+* `parallelism` - (Required, Int) Parallelism
+* `taskmanager_resource_setting_spec` - (Required, List) TaskManager resource setting See [`taskmanager_resource_setting_spec`](#basic_resource_setting-taskmanager_resource_setting_spec) below.
+
+### `basic_resource_setting-jobmanager_resource_setting_spec`
+
+The basic_resource_setting-jobmanager_resource_setting_spec supports the following:
+* `cpu` - (Required, Float) CPU
+* `memory` - (Required) Memory
+
+### `basic_resource_setting-taskmanager_resource_setting_spec`
+
+The basic_resource_setting-taskmanager_resource_setting_spec supports the following:
+* `cpu` - (Required, Float) CPU
+* `memory` - (Required) Memory
+
+### `logging`
+
+The logging supports the following:
+* `log4j2_configuration_template` - (Optional, Computed) Custom log template
+* `log4j_loggers` - (Optional, Computed, Set) log4j config See [`log4j_loggers`](#logging-log4j_loggers) below.
+* `log_reserve_policy` - (Optional, Computed, List) Log reserve policy See [`log_reserve_policy`](#logging-log_reserve_policy) below.
+* `logging_profile` - (Optional, Computed) System log template
+
+### `logging-log4j_loggers`
+
+The logging-log4j_loggers supports the following:
+* `logger_level` - (Optional, Computed) Logger level
+* `logger_name` - (Optional, Computed) Class name of the output log
+
+### `logging-log_reserve_policy`
+
+The logging-log_reserve_policy supports the following:
+* `expiration_days` - (Optional, Computed, Int) Expiration days
+* `open_history` - (Optional, Computed) Enable log saving
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<workspace>:<namespace>:<session_cluster_name>`.
+* `created_at` - Creation time.
+* `creator` - Creator.
+* `creator_name` - Creator name.
+* `modified_at` - Modification time.
+* `modifier` - Modifier.
+* `modifier_name` - Modifier name.
+* `session_cluster_id` - The ID of the session cluster.
+* `status` - Status of the session cluster.
+  * `current_session_cluster_status` - Current status of the session cluster.
+  * `failure` - Failure info of the session cluster.
+    * `failed_at` - Failure time.
+    * `message` - Failure message.
+    * `reason` - Failure reason.
+  * `running` - Running info of the session cluster.
+    * `last_update_time` - Last update time.
+    * `reference_deployment_ids` - IDs of deployments running on the session cluster.
+    * `started_at` - Start time.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Session Cluster.
+* `delete` - (Defaults to 5 mins) Used when delete the Session Cluster.
+* `update` - (Defaults to 5 mins) Used when update the Session Cluster.
+
+## Import
+
+Realtime Compute Session Cluster can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_realtime_compute_session_cluster.example <workspace>:<namespace>:<session_cluster_name>
+```


### PR DESCRIPTION
## Summary
- Add `alicloud_realtime_compute_session_cluster` resource to manage Realtime Compute for Apache Flink session clusters (ververica 2022-07-18): create, update (`basic_resource_setting`, `flink_conf`, `logging`, `labels`), delete and import, backed by the CreateSessionCluster / GetSessionCluster / UpdateSessionCluster / DeleteSessionCluster APIs.
- Add `alicloud_realtime_compute_session_clusters` data source backed by ListSessionClusters, with `ids` / `name_regex` filters and an `enable_details` option.

## Test plan
- [ ] `TestAccAliCloudRealtimeComputeSessionCluster_basic0`: create -> update (basic_resource_setting / labels / flink_conf / logging) -> import (remote acceptance test submitted, result pending)
- [ ] `TestAccAliCloudRealtimeComputeSessionClusterDataSource`: exist filter with `enable_details` (remote acceptance test submitted, result pending)
