### PR TITLE
resource/alicloud_actiontrail_global_events_storage_region: validate storage_region enum

### DIFF
--- a/alicloud/resource_alicloud_actiontrail_global_events_storage_region.go
+++ b/alicloud/resource_alicloud_actiontrail_global_events_storage_region.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAlicloudActiontrailGlobalEventsStorageRegion() *schema.Resource {
@@ -24,6 +25,10 @@ func resourceAlicloudActiontrailGlobalEventsStorageRegion() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				Type:     schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ap-southeast-1",
+					"cn-hangzhou",
+				}, false),
 			},
 		},
 	}
@@ -84,6 +89,24 @@ func resourceAlicloudActiontrailGlobalEventsStorageRegionUpdate(d *schema.Resour
 		})
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		// GetGlobalEventsStorageRegion is eventually consistent: immediately after
+		// a successful UpdateGlobalEventsStorageRegion it can still report the
+		// previous StorageRegion, so poll until the API returns the newly
+		// configured region before refreshing state.
+		actiontrailService := ActiontrailService{client}
+		stateConf := BuildStateConf([]string{}, []string{fmt.Sprint(d.Get("storage_region"))}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, func() (interface{}, string, error) {
+			object, err := actiontrailService.DescribeActiontrailGlobalEventsStorageRegion(d.Id())
+			if err != nil {
+				if NotFoundError(err) {
+					return object, "", nil
+				}
+				return nil, "", WrapError(err)
+			}
+			return object, fmt.Sprint(object["StorageRegion"]), nil
+		})
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
 		}
 	}
 

--- a/alicloud/resource_alicloud_actiontrail_global_events_storage_region_test.go
+++ b/alicloud/resource_alicloud_actiontrail_global_events_storage_region_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -9,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAlicloudActiontrailGlobalEventsStorageRegion_basic0(t *testing.T) {
+func TestAccAliCloudActiontrailGlobalEventsStorageRegion_basic0(t *testing.T) {
 	var v map[string]interface{}
 	checkoutSupportedRegions(t, true, connectivity.ActiontrailGlobalEventsStorageRegionSupportRegions)
 	resourceId := "alicloud_actiontrail_global_events_storage_region.default"
@@ -30,21 +31,57 @@ func TestAccAlicloudActiontrailGlobalEventsStorageRegion_basic0(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  nil,
 		Steps: []resource.TestStep{
-			{
-				Config: testAccConfig(map[string]interface{}{}),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheck(map[string]string{
-						"storage_region": CHECKSET,
-					}),
-				),
-			},
+			// Step1: create/update to cn-hangzhou (valid enum). If the singleton
+			// residual differs (e.g. ap-southeast-1 from a prior run), this toggles
+			// the value and exercises the UpdateGlobalEventsStorageRegion API plus
+			// the Read eventual-consistency polling path.
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"storage_region": defaultRegionToTest,
+					"storage_region": "cn-hangzhou",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"storage_region": defaultRegionToTest,
+						"storage_region": "cn-hangzhou",
+					}),
+				),
+			},
+			// Step2: update to ap-southeast-1 (the other valid enum). The toggle
+			// from cn-hangzhou forces HasChange -> Update API -> Read polling
+			// convergence; state settles on ap-southeast-1.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"storage_region": "ap-southeast-1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"storage_region": "ap-southeast-1",
+					}),
+				),
+			},
+			// Step3: an invalid storage_region must be rejected by ValidateFunc at
+			// plan/validate time. state is unchanged (still ap-southeast-1).
+			// NB: this ExpectError step MUST NOT be the last step, because the
+			// SDK (terraform-plugin-sdk v1.17.2) derives the auto-destroy config
+			// from the last step's Config, which would re-trigger ValidateFunc and
+			// fail destroy with "config is invalid".
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"storage_region": "us-east-1",
+				}),
+				ExpectError: regexp.MustCompile(`expected storage_region to be one of`),
+			},
+			// Step4: a legal config as the last step. state is already
+			// ap-southeast-1, so apply is a no-op, but being the last step means
+			// the SDK auto-destroy reuses this (valid) config and passes
+			// ValidateFunc. The Check also confirms Step3's failed plan left
+			// state untouched.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"storage_region": "ap-southeast-1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"storage_region": "ap-southeast-1",
 					}),
 				),
 			},
@@ -61,4 +98,25 @@ variable "name" {
 }
 
 `, name)
+}
+
+func TestUnitAlicloudActiontrailGlobalEventsStorageRegionStorageRegionValidation(t *testing.T) {
+	schemaMap := resourceAlicloudActiontrailGlobalEventsStorageRegion().Schema
+	s, ok := schemaMap["storage_region"]
+	if !ok {
+		t.Fatal("storage_region schema is missing")
+	}
+	if s.ValidateFunc == nil {
+		t.Fatal("storage_region ValidateFunc is not configured")
+	}
+	for _, region := range []string{"ap-southeast-1", "cn-hangzhou"} {
+		if _, errs := s.ValidateFunc(region, "storage_region"); len(errs) != 0 {
+			t.Fatalf("expected storage_region %q to pass validation, got: %v", region, errs)
+		}
+	}
+	for _, region := range []string{"us-east-1", "cn-beijing", "eu-central-1"} {
+		if _, errs := s.ValidateFunc(region, "storage_region"); len(errs) == 0 {
+			t.Fatalf("expected storage_region %q to be rejected by validation", region)
+		}
+	}
 }

--- a/website/docs/r/actiontrail_global_events_storage_region.html.markdown
+++ b/website/docs/r/actiontrail_global_events_storage_region.html.markdown
@@ -35,7 +35,7 @@ resource "alicloud_actiontrail_global_events_storage_region" "foo" {
 
 The following arguments are supported:
 
-* `storage_region` - (Optional) Global Events Storage Region.
+* `storage_region` - (Optional) Global Events Storage Region. Valid values: `ap-southeast-1`, `cn-hangzhou`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Problem

The `storage_region` argument of `alicloud_actiontrail_global_events_storage_region` accepted arbitrary strings and only failed at apply time, when the `UpdateGlobalEventsStorageRegion` API rejected the value. The API only supports `ap-southeast-1` (Singapore) and `cn-hangzhou` (China Hangzhou).

### Fix

Add `validation.StringInSlice` to the `storage_region` schema so invalid values are rejected at plan/validate time, and document the valid values in the resource docs.

### Test

- `TestUnitAlicloudActiontrailGlobalEventsStorageRegionStorageRegionValidation` directly exercises the schema ValidateFunc: valid values (`ap-southeast-1`, `cn-hangzhou`) pass, invalid values (`us-east-1`, `cn-beijing`, `eu-central-1`) are rejected. Runs without `TF_ACC`.
- An acceptance test step (gated by `TF_ACC`) asserts that an invalid `storage_region` produces `expected storage_region to be one of` at plan time.
