### PR TITLE
resource/alicloud_data_works_project_member: retry throttling error code 9990040003

### DIFF
--- a/alicloud/resource_alicloud_data_works_project_member.go
+++ b/alicloud/resource_alicloud_data_works_project_member.go
@@ -101,7 +101,7 @@ func resourceAliCloudDataWorksProjectMemberCreate(d *schema.ResourceData, meta i
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("dataworks-public", "2024-05-18", action, query, request, true)
 		if err != nil {
-			if NeedRetry(err) {
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"9990040003"}) {
 				wait()
 				return resource.RetryableError(err)
 			}
@@ -205,7 +205,7 @@ func resourceAliCloudDataWorksProjectMemberUpdate(d *schema.ResourceData, meta i
 			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 				response, err = client.RpcPost("dataworks-public", "2024-05-18", action, query, request, true)
 				if err != nil {
-					if NeedRetry(err) {
+					if NeedRetry(err) || IsExpectedErrors(err, []string{"9990040003"}) {
 						wait()
 						return resource.RetryableError(err)
 					}
@@ -248,7 +248,7 @@ func resourceAliCloudDataWorksProjectMemberUpdate(d *schema.ResourceData, meta i
 			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 				response, err = client.RpcPost("dataworks-public", "2024-05-18", action, query, request, true)
 				if err != nil {
-					if NeedRetry(err) {
+					if NeedRetry(err) || IsExpectedErrors(err, []string{"9990040003"}) {
 						wait()
 						return resource.RetryableError(err)
 					}
@@ -287,7 +287,7 @@ func resourceAliCloudDataWorksProjectMemberDelete(d *schema.ResourceData, meta i
 		response, err = client.RpcPost("dataworks-public", "2024-05-18", action, query, request, true)
 
 		if err != nil {
-			if NeedRetry(err) {
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"9990040003"}) {
 				wait()
 				return resource.RetryableError(err)
 			}

--- a/alicloud/service_alicloud_data_works_v2.go
+++ b/alicloud/service_alicloud_data_works_v2.go
@@ -190,7 +190,7 @@ func (s *DataWorksServiceV2) DescribeDataWorksProjectMember(id string) (object m
 		response, err = client.RpcPost("dataworks-public", "2024-05-18", action, query, request, true)
 
 		if err != nil {
-			if NeedRetry(err) || IsExpectedErrors(err, []string{"9990020002"}) {
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"9990020002", "9990040003"}) {
 				wait()
 				return resource.RetryableError(err)
 			}
@@ -666,8 +666,8 @@ func (s *DataWorksServiceV2) DescribeDataWorksDwResourceGroup(id string) (object
 	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
 		response, err = client.RpcGet("dataworks-public", "2024-05-18", action, query, nil)
 
-		if err != nil || IsExpectedErrors(err, []string{"9990040003"}) {
-			if NeedRetry(err) {
+		if err != nil {
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"9990040003"}) {
 				wait()
 				return resource.RetryableError(err)
 			}


### PR DESCRIPTION
### Problem

DataWorks answers with HTTP 400 and code `9990040003` (`Throttling.Resource`) when a request is
rate limited. `NeedRetry` does not catch it: it matches `Throttling` against the error **code**,
which is numeric here, and `^code: 5[\d]{2}` against the message, which starts with `code: 400`.
That is why the code lists `9990040003` explicitly where it is already handled — in
`DescribeDataWorksProject` and in the create of `alicloud_data_works_project`.

`alicloud_data_works_project_member` misses it on every path, so a throttled request fails the
apply instead of being retried:

```
Error: ... GetProjectMember Failed!!! [SDK alibaba-cloud-sdk-go ERROR]:
   StatusCode: 400
   Code: 9990040003
   Message: code: 400, Throttling.Resource
```

This showed up while running the acceptance test of the resource several times in one region: the
throttled `GetProjectMember` broke both a test step and the refresh during destroy.

### Change

- `alicloud_data_works_project_member`: `9990040003` is now retried in create, in both update
  calls, in delete and in `DescribeDataWorksProjectMember`, matching what
  `alicloud_data_works_project` already does for the same code.
- `DescribeDataWorksDwResourceGroup`: the same code was listed as
  `if err != nil || IsExpectedErrors(err, []string{"9990040003"})`, where the second operand can
  never contribute — it is only reached when `err` is `nil`, and `IsExpectedErrors(nil, ...)`
  returns false. The code therefore read as if throttling were retried, while the retry was in
  fact decided by `NeedRetry` alone, which does not match this code. Moved into the retry
  condition so it takes effect.

### Test

No dedicated test accompanies this change: the error is a server-side rate limit that cannot be
provoked on demand, and every touched line is an error branch that leaves the success path
untouched. The retry condition is the one already used for this code elsewhere in the same
product.
