### PR TITLE
resource/alicloud_route_entry: serialize create/delete and stop abandoned retry from creating after failure

### DIFF
--- a/alicloud/resource_alicloud_route_entry.go
+++ b/alicloud/resource_alicloud_route_entry.go
@@ -3,6 +3,8 @@ package alicloud
 import (
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
@@ -64,6 +66,21 @@ func resourceAliyunRouteEntry() *schema.Resource {
 	}
 }
 
+// routeEntryTaskLock serializes CreateRouteEntry/DeleteRouteEntry calls made
+// by this provider process. The VPC service handles route entry operations as
+// serialized asynchronous tasks and rejects concurrent submissions with
+// "TaskConflict" ("The operation is too frequent"). Without client-side
+// serialization, a plan that creates several route entries in parallel makes
+// every resource burn its own retry budget on rejections caused by its
+// siblings; when the retry window is short (e.g. the provider-level
+// "max_retry_timeout" is set), the budget runs out while the server is still
+// busy and the apply fails with a spurious TaskConflict. Queueing on this
+// mutex happens before the retry loop starts, so waiting for a sibling
+// operation does not consume the resource's own retry budget. TaskConflict
+// remains in the retryable lists below because other actors (a second
+// Terraform run, the console, other tools) can still trigger it.
+var routeEntryTaskLock sync.Mutex
+
 func resourceAliyunRouteEntryCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	vpcService := VpcService{client}
@@ -102,14 +119,35 @@ func resourceAliyunRouteEntryCreate(d *schema.ResourceData, meta interface{}) er
 		request.Description = v.(string)
 	}
 
+	// Serialize with every other route entry create/delete in this process
+	// before the retry clock starts, so sibling operations do not eat into
+	// this resource's retry budget by triggering TaskConflict rejections.
+	routeEntryTaskLock.Lock()
+	defer routeEntryTaskLock.Unlock()
+
 	// retry 10 min to create lots of entries concurrently
 	var raw interface{}
 	attempt := 0
+	var abandoned atomic.Bool
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
 		attempt++
 		if err := vpcService.WaitForAllRouteEntriesAvailable(rtId, DefaultTimeout); err != nil {
 			return resource.NonRetryableError(err)
+		}
+
+		// resource.Retry does not cancel an in-flight callback when its
+		// deadline expires: it returns the last error to Terraform and leaves
+		// the callback goroutine running. If that goroutine was blocked in
+		// WaitForAllRouteEntriesAvailable above when the deadline fired, it
+		// would - without this guard - still send CreateRouteEntry afterwards
+		// and could succeed on the cloud long after this apply already
+		// reported the resource as failed, leaving a route that exists
+		// server-side with no record in state (the next apply then fails
+		// with Duplicated.VpcNextHop). Skip the call once the loop has been
+		// abandoned so no request is sent whose outcome nobody records.
+		if abandoned.Load() {
+			return resource.NonRetryableError(Error("the retry deadline of creating route entry has expired; skip sending CreateRouteEntry"))
 		}
 
 		args := *request
@@ -135,6 +173,10 @@ func resourceAliyunRouteEntryCreate(d *schema.ResourceData, meta interface{}) er
 		}
 		return nil
 	})
+	// Mark the loop abandoned before acting on its result, so a callback that
+	// outlived the deadline (see the guard above) cannot create the route
+	// after the outcome has been decided here.
+	abandoned.Store(true)
 
 	// Compute the resource id from the request parameters (all known up-front).
 	// The id is recorded into state only after CreateRouteEntry has been
@@ -268,6 +310,11 @@ func resourceAliyunRouteEntryDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	request.RegionId = client.RegionId
+
+	// Serialize with every other route entry create/delete in this process
+	// before the retry clock starts; see routeEntryTaskLock.
+	routeEntryTaskLock.Lock()
+	defer routeEntryTaskLock.Unlock()
 
 	var raw interface{}
 	retryTimes := 7


### PR DESCRIPTION
## Summary

Fixes two related failure modes of `alicloud_route_entry` under concurrent creation (multiple route entries in one plan, e.g. VBR + RouterInterface topologies), both reproduced locally with `TF_LOG=DEBUG` evidence:

1. **Spurious final `TaskConflict` failure.** The VPC service processes route entry operations as serialized asynchronous tasks and rejects concurrent submissions with `TaskConflict` ("The operation is too frequent"). Concurrent sibling resources burn each other's retry budget on these rejections; when the retry window is short (e.g. the provider-level `max_retry_timeout` is set), the budget runs out while the server is still busy and the apply fails even though nothing is actually wrong.

2. **Hidden create after reported failure (root cause of `Duplicated.VpcNextHop` on the next apply).** `helper/resource.Retry` does not cancel an in-flight callback when its deadline expires. A callback blocked in `WaitForAllRouteEntriesAvailable` keeps running after Terraform has already reported the resource as failed, then sends `CreateRouteEntry` (same ClientToken) which can succeed on the cloud - leaving a route that exists server-side with no record in state. Reproduced: attempt 1 returned `TaskConflict` and the apply failed; the abandoned callback sent attempt 2 with the same ClientToken **64 seconds later** and received 200 OK; the route existed on the cloud while absent from state, so the next apply failed with `Duplicated.VpcNextHop`.

## Changes

- Add a process-wide mutex (`routeEntryTaskLock`) serializing `CreateRouteEntry`/`DeleteRouteEntry` calls. Queueing happens before the retry loop starts, so waiting for a sibling operation does not consume the resource's own retry budget. `TaskConflict` stays in the retryable lists because other actors (a second Terraform run, the console, other tools) can still trigger it.
- Add an `abandoned` guard (atomic flag set right after `resource.Retry` returns, checked in the callback between `WaitForAllRouteEntriesAvailable` and `CreateRouteEntry`), so a callback that outlives the retry deadline can no longer create the route after the outcome has been decided.

## Verification

- Repro before fix (v1.288.0, template with several route entries, `max_retry_timeout = 10`, `-parallelism=10`): apply failed with final `TaskConflict` on one route entry; TF_LOG shows the abandoned attempt 2 succeeding 64s after the failure was reported, route present on cloud but not in state.
- Same template with this patch (dev_overrides build): `Apply complete! Resources: 24 added, 0 changed, 0 destroyed.`; all 5 route entries created on attempt 1 with zero `TaskConflict` responses; all present in state.
- `go build ./alicloud/...`, `go vet`, `gofmt` clean; existing unit tests pass:
  `go test ./alicloud -run 'TestUnit(IsRouteEntryWaitTimeout|BuildRouteEntryResourceId)$'`
