### PR TITLE
fix: stop d.Partial from discarding successful updates

### DIFF
--- a/alicloud/resource_alicloud_api_gateway_app.go
+++ b/alicloud/resource_alicloud_api_gateway_app.go
@@ -112,7 +112,6 @@ func resourceAliyunApigatewayAppUpdate(d *schema.ResourceData, meta interface{})
 		return WrapError(err)
 	}
 	if d.IsNewResource() {
-		d.Partial(false)
 		return resourceAliyunApigatewayAppRead(d, meta)
 	}
 	if d.HasChange("name") || d.HasChange("description") {

--- a/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
+++ b/alicloud/resource_alicloud_cs_kubernetes_node_pool.go
@@ -3130,6 +3130,7 @@ func resourceAliCloudAckNodepoolUpdate(d *schema.ResourceData, meta interface{})
 			}
 			// The removal of a node is logically independent.
 			// The removal of a node should not involve parameter changes.
+			d.Partial(false)
 			return resourceAliCloudAckNodepoolRead(d, meta)
 		}
 		update = true

--- a/alicloud/resource_alicloud_dts_migration_instance.go
+++ b/alicloud/resource_alicloud_dts_migration_instance.go
@@ -178,7 +178,6 @@ func resourceAlicloudDtsMigrationInstanceRead(d *schema.ResourceData, meta inter
 func resourceAlicloudDtsMigrationInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	dtsService := DtsService{client}
-	d.Partial(false)
 
 	if d.HasChange("tags") {
 		if err := dtsService.SetResourceTags(d, "ALIYUN::DTS::INSTANCE"); err != nil {

--- a/alicloud/resource_alicloud_dts_migration_job.go
+++ b/alicloud/resource_alicloud_dts_migration_job.go
@@ -404,7 +404,6 @@ func resourceAlicloudDtsMigrationJobUpdate(d *schema.ResourceData, meta interfac
 	client := meta.(*connectivity.AliyunClient)
 	dtsService := DtsService{client}
 	var response map[string]interface{}
-	d.Partial(false)
 
 	if d.HasChange("status") {
 		object, err := dtsService.DescribeDtsMigrationJob(d.Id())

--- a/alicloud/resource_alicloud_ecs_instance_set.go
+++ b/alicloud/resource_alicloud_ecs_instance_set.go
@@ -735,7 +735,6 @@ func resourceAliCloudEcsInstanceSetRead(d *schema.ResourceData, meta interface{}
 func resourceAliCloudEcsInstanceSetUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	ecsService := EcsService{client}
-	d.Partial(false)
 
 	if d.HasChange("tags") {
 		instanceIds := make([]string, 0)

--- a/alicloud/resource_alicloud_emr_cluster.go
+++ b/alicloud/resource_alicloud_emr_cluster.go
@@ -664,12 +664,10 @@ func resourceAlicloudEmrClusterCreate(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(fmt.Sprint(response["ClusterId"]))
 
-	d.Partial(true)
 	emrService := EmrService{client}
 	if err := emrService.setEmrClusterTags(d); err != nil {
 		return WrapError(err)
 	}
-	d.Partial(false)
 
 	stateConf := BuildStateConf([]string{"CREATING"}, []string{"IDLE"}, d.Timeout(schema.TimeoutCreate), 6*time.Minute, emrService.EmrClusterStateRefreshFunc(d.Id(), []string{"CREATE_FAILED"}))
 	stateConf.PollInterval = 10 * time.Second

--- a/alicloud/resource_alicloud_polardb_endpoint_address.go
+++ b/alicloud/resource_alicloud_polardb_endpoint_address.go
@@ -188,7 +188,6 @@ func resourceAlicloudPolarDBEndpointAddressUpdate(d *schema.ResourceData, meta i
 	}
 
 	if d.IsNewResource() {
-		d.Partial(false)
 		return resourceAlicloudPolarDBEndpointAddressRead(d, meta)
 	}
 

--- a/alicloud/resource_alicloud_rds_db_proxy_public.go
+++ b/alicloud/resource_alicloud_rds_db_proxy_public.go
@@ -121,7 +121,6 @@ func resourceAliCloudRdsDBProxyPublicUpdate(d *schema.ResourceData, meta interfa
 	client := meta.(*connectivity.AliyunClient)
 	rdsService := RdsService{client}
 	if d.IsNewResource() {
-		d.Partial(false)
 		return resourceAliCloudRdsDBProxyPublicRead(d, meta)
 	}
 

--- a/alicloud/resource_alicloud_reserved_instance.go
+++ b/alicloud/resource_alicloud_reserved_instance.go
@@ -335,6 +335,7 @@ func resourceAliCloudReservedInstanceUpdate(d *schema.ResourceData, meta interfa
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
+	d.Partial(false)
 
 	return resourceAliCloudReservedInstanceRead(d, meta)
 }

--- a/alicloud/resource_alicloud_service_mesh_user_permission.go
+++ b/alicloud/resource_alicloud_service_mesh_user_permission.go
@@ -225,7 +225,6 @@ func resourceAliCloudServiceMeshUserPermissionUpdate(d *schema.ResourceData, met
 func resourceAliCloudServiceMeshUserPermissionDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	var response map[string]interface{}
-	d.Partial(true)
 	var err error
 
 	request := map[string]interface{}{

--- a/alicloud/resource_alicloud_slb_listener.go
+++ b/alicloud/resource_alicloud_slb_listener.go
@@ -773,8 +773,6 @@ func resourceAliCloudSlbListenerUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	d.Partial(false)
-
 	return resourceAliCloudSlbListenerRead(d, meta)
 }
 

--- a/alicloud/resource_alicloud_slb_server_certificate.go
+++ b/alicloud/resource_alicloud_slb_server_certificate.go
@@ -183,7 +183,6 @@ func resourceAlicloudSlbServerCertificateUpdate(d *schema.ResourceData, meta int
 		return WrapError(err)
 	}
 	if d.IsNewResource() {
-		d.Partial(false)
 		return resourceAlicloudSlbServerCertificateRead(d, meta)
 	}
 	if !d.IsNewResource() && d.HasChange("name") {


### PR DESCRIPTION
### Why

SDK v2 removed `helper/schema.ResourceData.SetPartial` in `2.0.0-rc.1` but deliberately kept
`Partial` (restored in `2.0.0-rc.2`). The v1 → v2 migration dropped the `SetPartial` calls — the
*whitelist* half of the v1 partial-state mechanism — and left the `Partial(true)` *flag* half in
place.

In `terraform-plugin-sdk/v2@v2.40.1` there is no whitelist left to filter. `ResourceData` carries a
single `partial bool`, and `State()` reads:

```go
source := getSourceSet
if d.partial {
    source = getSourceState
}
raw := d.get([]string{k}, source)
```

`get()` maps `getSourceState` to `level = "state"`, which never reaches the `"set"` level where
`d.Set` writes. So with the flag on, *every* schema key comes from prior state. The flag's meaning
inverted from **"persist only these keys"** to **"persist nothing"**.

That is harmless wherever the window closes before the success return, which is the case in 279 of
the 281 affected files. Two resources return successfully while it is still open.

### The two defects

**`alicloud_reserved_instance`** — `Update` opens the window at the top and never closes it, so a
successful `description` / `reserved_instance_name` / `renewal_status` update persisted stale
state.

**`alicloud_cs_kubernetes_node_pool`** — the `node_count` scale-down path returns early, bypassing
the close on the main path. On SDK v1 this was correct: `removeNodePoolNodes` ended with
`SetPartial("node_count")`, whitelisting exactly the key that path changes, which is what the
existing comment ("the removal of a node should not involve parameter changes") describes. With the
whitelist gone, `node_count` became the one value discarded — so scaling a pool down removed the
nodes, reported success, kept the old count in state, and re-planned the same diff on the next run.

Both are fixed by closing the window before the success return rather than deleting the
`Partial(true)`. That keeps the error-path behaviour the SDK upgrade guide describes for the
remaining returns, and matches the idiom already present in both files.

One caveat stated plainly: this is not a restoration of the v1 semantics. v1 persisted only the
whitelisted key; this persists everything `Read` observed. `SetPartial` no longer exists, so the
narrow form is not available — and the broader form is what the rest of the provider already does.

### Eleven calls that could not do anything

Removed, with no behaviour change:

- `alicloud_service_mesh_user_permission` — `Partial(true)` in `Delete`, where state is dropped
  regardless. Its `Update` window is correct and is left alone.
- `alicloud_emr_cluster` — a `true`/`false` pair inside `Create`; there is no prior state to fall
  back to, so the window is pointless by construction.
- Eight files carrying a `Partial(false)` with no `Partial(true)` anywhere in the file. `partial`
  defaults to false and `ResourceData` is per-operation, so these were unconditional no-ops:
  `alicloud_api_gateway_app`, `alicloud_dts_migration_instance`, `alicloud_dts_migration_job`,
  `alicloud_ecs_instance_set`, `alicloud_polardb_endpoint_address`, `alicloud_rds_db_proxy_public`,
  `alicloud_slb_listener`, `alicloud_slb_server_certificate`.

Each enclosing block was checked to retain a statement after deletion; none collapses.

### Why this targets `release/v2` and not `master`

`master` is still on `terraform-plugin-sdk v1.17.2`, where the mechanism is intact — both files
there pair `Partial(true)` with the matching `SetPartial` calls, which is correct v1 behaviour.
**`master` needs no fix**, the defect is `release/v2`-only, created by the migration, and a
forward-merge from `master` will not undo this change.

### Verification

- `go vet ./alicloud/...` — exit 0.
- `gofmt -l` on all 12 touched files — empty. One deletion left a double blank line in
  `resource_alicloud_slb_listener.go`; the file was gofmt-clean beforehand, so `gofmt -w` corrected
  only that (hence 2 deletions in that file rather than 1).
- Files calling `d.Partial(`: 287 → 279, exactly the eight fully drained.
- `d.SetPartial(` — still absent provider-wide; nothing reintroduced.
- Layout unchanged in every touched file: `const`/`var` above all funcs, CRUD ordering intact.

### Acceptance tests

**Not yet run — this PR is a draft until they are.** Recording that explicitly rather than omitting
it.

Required, because the point of the two fixes is that a successful apply now persists fresh state:

- `TestAccAliCloudReservedInstanceBasic`, `TestAccAliCloudReservedInstanceBasic1`
- `TestAccAliCloudCSKubernetesNodePoolWithNodeCount_basic` — exercises the scale-down path that
  returns early
- `TestAccAliCloudCSKubernetesNodePool_basic`
- `TestAccAliCloudServiceMeshUserPermission_basic0`
- `TestAccAlicloudEmrCluster_basic`

The eight no-op removals need no case of their own: `partial` defaults to false, so deleting a
`Partial(false)` that has no matching `Partial(true)` cannot change any code path. Saying so here
rather than leaving the gap unexplained.
