### PR TITLE
resource/alicloud_fcv3_function: data-source/alicloud_fcv3_functions: support registry_config for custom container image registry

### DIFF
--- a/alicloud/data_source_alicloud_fcv3_functions.go
+++ b/alicloud/data_source_alicloud_fcv3_functions.go
@@ -138,6 +138,50 @@ func dataSourceAliCloudFcv3Functions() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"registry_config": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"cert_config": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"insecure": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"root_ca_cert_base64": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"network_config": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"security_group_id": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"vswitch_id": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"vpc_id": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -758,6 +802,37 @@ func dataSourceAliCloudFcv3FunctionRead(d *schema.ResourceData, meta interface{}
 				healthCheckConfigMaps = append(healthCheckConfigMaps, healthCheckConfigMap)
 			}
 			customContainerConfigMap["health_check_config"] = healthCheckConfigMaps
+			registryConfigMaps := make([]map[string]interface{}, 0)
+			registryConfigMap := make(map[string]interface{})
+			registryConfigRaw := make(map[string]interface{})
+			if customContainerConfigRaw["registryConfig"] != nil {
+				registryConfigRaw = customContainerConfigRaw["registryConfig"].(map[string]interface{})
+			}
+			if len(registryConfigRaw) > 0 {
+				certConfigMaps := make([]map[string]interface{}, 0)
+				certConfigMap := make(map[string]interface{})
+				certConfigRaw := make(map[string]interface{})
+				if registryConfigRaw["certConfig"] != nil {
+					certConfigRaw = registryConfigRaw["certConfig"].(map[string]interface{})
+				}
+				certConfigMap["insecure"] = certConfigRaw["insecure"]
+				certConfigMap["root_ca_cert_base64"] = certConfigRaw["rootCaCertBase64"]
+				certConfigMaps = append(certConfigMaps, certConfigMap)
+				registryConfigMap["cert_config"] = certConfigMaps
+				networkConfigMaps := make([]map[string]interface{}, 0)
+				networkConfigMap := make(map[string]interface{})
+				networkConfigRaw := make(map[string]interface{})
+				if registryConfigRaw["networkConfig"] != nil {
+					networkConfigRaw = registryConfigRaw["networkConfig"].(map[string]interface{})
+				}
+				networkConfigMap["security_group_id"] = networkConfigRaw["securityGroupId"]
+				networkConfigMap["vswitch_id"] = networkConfigRaw["vSwitchId"]
+				networkConfigMap["vpc_id"] = networkConfigRaw["vpcId"]
+				networkConfigMaps = append(networkConfigMaps, networkConfigMap)
+				registryConfigMap["network_config"] = networkConfigMaps
+				registryConfigMaps = append(registryConfigMaps, registryConfigMap)
+			}
+			customContainerConfigMap["registry_config"] = registryConfigMaps
 			customContainerConfigMaps = append(customContainerConfigMaps, customContainerConfigMap)
 		}
 		mapping["custom_container_config"] = customContainerConfigMaps

--- a/alicloud/resource_alicloud_fcv3_function.go
+++ b/alicloud/resource_alicloud_fcv3_function.go
@@ -165,6 +165,73 @@ func resourceAliCloudFcv3Function() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"registry_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"auth_config": {
+										Type:      schema.TypeList,
+										Optional:  true,
+										Sensitive: true,
+										MaxItems:  1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"user_name": {
+													Type:      schema.TypeString,
+													Optional:  true,
+													Sensitive: true,
+												},
+												"password": {
+													Type:      schema.TypeString,
+													Optional:  true,
+													Sensitive: true,
+												},
+											},
+										},
+									},
+									"cert_config": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"insecure": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"root_ca_cert_base64": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"network_config": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"security_group_id": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"vswitch_id": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"vpc_id": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -810,7 +877,50 @@ func resourceAliCloudFcv3FunctionCreate(d *schema.ResourceData, meta interface{}
 		if acrInstanceId1 != nil && acrInstanceId1 != "" {
 			customContainerConfig["acrInstanceId"] = acrInstanceId1
 		}
-
+		registryConfig := make(map[string]interface{})
+		authConfig := make(map[string]interface{})
+		userName, _ := jsonpath.Get("$[0].registry_config[0].auth_config[0].user_name", d.Get("custom_container_config"))
+		if userName != nil && userName != "" {
+			authConfig["userName"] = userName
+		}
+		password, _ := jsonpath.Get("$[0].registry_config[0].auth_config[0].password", d.Get("custom_container_config"))
+		if password != nil && password != "" {
+			authConfig["password"] = password
+		}
+		if len(authConfig) > 0 {
+			registryConfig["authConfig"] = authConfig
+		}
+		certConfig := make(map[string]interface{})
+		insecure, _ := jsonpath.Get("$[0].registry_config[0].cert_config[0].insecure", d.Get("custom_container_config"))
+		if insecure != nil {
+			certConfig["insecure"] = insecure
+		}
+		rootCaCertBase64, _ := jsonpath.Get("$[0].registry_config[0].cert_config[0].root_ca_cert_base64", d.Get("custom_container_config"))
+		if rootCaCertBase64 != nil && rootCaCertBase64 != "" {
+			certConfig["rootCaCertBase64"] = rootCaCertBase64
+		}
+		if len(certConfig) > 0 {
+			registryConfig["certConfig"] = certConfig
+		}
+		networkConfig := make(map[string]interface{})
+		securityGroupId, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].security_group_id", d.Get("custom_container_config"))
+		if securityGroupId != nil && securityGroupId != "" {
+			networkConfig["securityGroupId"] = securityGroupId
+		}
+		vSwitchId, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].vswitch_id", d.Get("custom_container_config"))
+		if vSwitchId != nil && vSwitchId != "" {
+			networkConfig["vSwitchId"] = vSwitchId
+		}
+		vpcId, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].vpc_id", d.Get("custom_container_config"))
+		if vpcId != nil && vpcId != "" {
+			networkConfig["vpcId"] = vpcId
+		}
+		if len(networkConfig) > 0 {
+			registryConfig["networkConfig"] = networkConfig
+		}
+		if len(registryConfig) > 0 {
+			customContainerConfig["registryConfig"] = registryConfig
+		}
 		request["customContainerConfig"] = customContainerConfig
 	}
 
@@ -1090,6 +1200,69 @@ func resourceAliCloudFcv3FunctionRead(d *schema.ResourceData, meta interface{}) 
 			healthCheckConfigMaps = append(healthCheckConfigMaps, healthCheckConfigMap)
 		}
 		customContainerConfigMap["health_check_config"] = healthCheckConfigMaps
+		registryConfigMaps := make([]map[string]interface{}, 0)
+		registryConfigMap := make(map[string]interface{})
+		registryConfigRaw := make(map[string]interface{})
+		if customContainerConfigRaw["registryConfig"] != nil {
+			registryConfigRaw = customContainerConfigRaw["registryConfig"].(map[string]interface{})
+		}
+		// Only persist registry_config when the API response carries at least
+		// one populated sub-config. GetFunction returns a registryConfig object
+		// with all-null sub-fields both for functions that never declared
+		// registry_config and after it is cleared; persisting that default
+		// would create a spurious diff against a config without registry_config.
+		if len(registryConfigRaw) > 0 && (registryConfigRaw["authConfig"] != nil || registryConfigRaw["certConfig"] != nil || registryConfigRaw["networkConfig"] != nil) {
+			authConfigMaps := make([]map[string]interface{}, 0)
+			authConfigMap := make(map[string]interface{})
+			authConfigRaw := make(map[string]interface{})
+			if registryConfigRaw["authConfig"] != nil {
+				authConfigRaw = registryConfigRaw["authConfig"].(map[string]interface{})
+			}
+			if len(authConfigRaw) > 0 {
+				authConfigMap["user_name"] = authConfigRaw["userName"]
+				authConfigMap["password"] = authConfigRaw["password"]
+				authConfigMaps = append(authConfigMaps, authConfigMap)
+			} else {
+				// GetFunction does not return the sensitive authConfig
+				// (userName/password). Preserve the existing auth_config from
+				// state so a refresh does not produce a spurious diff.
+				existingUserName, _ := jsonpath.Get("$[0].registry_config[0].auth_config[0].user_name", d.Get("custom_container_config"))
+				existingPassword, _ := jsonpath.Get("$[0].registry_config[0].auth_config[0].password", d.Get("custom_container_config"))
+				if existingUserName != nil || existingPassword != nil {
+					authConfigMap["user_name"] = existingUserName
+					authConfigMap["password"] = existingPassword
+					authConfigMaps = append(authConfigMaps, authConfigMap)
+				}
+			}
+			registryConfigMap["auth_config"] = authConfigMaps
+			certConfigMaps := make([]map[string]interface{}, 0)
+			certConfigMap := make(map[string]interface{})
+			certConfigRaw := make(map[string]interface{})
+			if registryConfigRaw["certConfig"] != nil {
+				certConfigRaw = registryConfigRaw["certConfig"].(map[string]interface{})
+			}
+			if len(certConfigRaw) > 0 {
+				certConfigMap["insecure"] = certConfigRaw["insecure"]
+				certConfigMap["root_ca_cert_base64"] = certConfigRaw["rootCaCertBase64"]
+				certConfigMaps = append(certConfigMaps, certConfigMap)
+			}
+			registryConfigMap["cert_config"] = certConfigMaps
+			networkConfigMaps := make([]map[string]interface{}, 0)
+			networkConfigMap := make(map[string]interface{})
+			networkConfigRaw := make(map[string]interface{})
+			if registryConfigRaw["networkConfig"] != nil {
+				networkConfigRaw = registryConfigRaw["networkConfig"].(map[string]interface{})
+			}
+			if len(networkConfigRaw) > 0 {
+				networkConfigMap["security_group_id"] = networkConfigRaw["securityGroupId"]
+				networkConfigMap["vswitch_id"] = networkConfigRaw["vSwitchId"]
+				networkConfigMap["vpc_id"] = networkConfigRaw["vpcId"]
+				networkConfigMaps = append(networkConfigMaps, networkConfigMap)
+			}
+			registryConfigMap["network_config"] = networkConfigMaps
+			registryConfigMaps = append(registryConfigMaps, registryConfigMap)
+		}
+		customContainerConfigMap["registry_config"] = registryConfigMaps
 		customContainerConfigMaps = append(customContainerConfigMaps, customContainerConfigMap)
 	}
 	if err := d.Set("custom_container_config", customContainerConfigMaps); err != nil {
@@ -1663,7 +1836,51 @@ func resourceAliCloudFcv3FunctionUpdate(d *schema.ResourceData, meta interface{}
 			if acrInstanceId1 != nil && acrInstanceId1 != "" {
 				customContainerConfig["acrInstanceId"] = acrInstanceId1
 			}
-
+			registryConfig := make(map[string]interface{})
+			authConfig := make(map[string]interface{})
+			userName, _ := jsonpath.Get("$[0].registry_config[0].auth_config[0].user_name", d.Get("custom_container_config"))
+			if userName != nil && userName != "" {
+				authConfig["userName"] = userName
+			}
+			password, _ := jsonpath.Get("$[0].registry_config[0].auth_config[0].password", d.Get("custom_container_config"))
+			if password != nil && password != "" {
+				authConfig["password"] = password
+			}
+			if len(authConfig) > 0 {
+				registryConfig["authConfig"] = authConfig
+			}
+			certConfig := make(map[string]interface{})
+			insecure, _ := jsonpath.Get("$[0].registry_config[0].cert_config[0].insecure", d.Get("custom_container_config"))
+			if insecure != nil {
+				certConfig["insecure"] = insecure
+			}
+			rootCaCertBase64, _ := jsonpath.Get("$[0].registry_config[0].cert_config[0].root_ca_cert_base64", d.Get("custom_container_config"))
+			if rootCaCertBase64 != nil && rootCaCertBase64 != "" {
+				certConfig["rootCaCertBase64"] = rootCaCertBase64
+			}
+			if len(certConfig) > 0 {
+				registryConfig["certConfig"] = certConfig
+			}
+			networkConfig := make(map[string]interface{})
+			securityGroupId, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].security_group_id", d.Get("custom_container_config"))
+			if securityGroupId != nil && securityGroupId != "" {
+				networkConfig["securityGroupId"] = securityGroupId
+			}
+			vSwitchId, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].vswitch_id", d.Get("custom_container_config"))
+			if vSwitchId != nil && vSwitchId != "" {
+				networkConfig["vSwitchId"] = vSwitchId
+			}
+			vpcId, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].vpc_id", d.Get("custom_container_config"))
+			if vpcId != nil && vpcId != "" {
+				networkConfig["vpcId"] = vpcId
+			}
+			if len(networkConfig) > 0 {
+				registryConfig["networkConfig"] = networkConfig
+			}
+			// Always send registryConfig (even when empty) so that removing
+			// registry_config from the config clears it on the API side; the FC
+			// UpdateFunction otherwise leaves an omitted registryConfig untouched.
+			customContainerConfig["registryConfig"] = registryConfig
 			request["customContainerConfig"] = customContainerConfig
 		}
 	}
@@ -1988,6 +2205,79 @@ func resourceAliCloudFcv3FunctionDelete(d *schema.ResourceData, meta interface{}
 			return nil
 		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	// DeleteFunction returns success before the function is fully removed.
+	// Poll GetFunction until it returns ResourceNotFound so the function is
+	// actually gone and the FC service starts releasing the ENI created for
+	// the function when registry_config.network_config is set. Without this
+	// wait the dependent security group and vSwitch destroy immediately
+	// afterwards fails with DependencyViolation on the still-attached ENI.
+	fcv3ServiceV2 := Fcv3ServiceV2{client}
+	waitFunc := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, e := fcv3ServiceV2.DescribeFcv3Function(functionName)
+		if e == nil {
+			waitFunc()
+			return resource.RetryableError(fmt.Errorf("fcv3 function [%s] is still being deleted", functionName))
+		}
+		if NotFoundError(e) {
+			return nil
+		}
+		return resource.NonRetryableError(e)
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	// When registry_config.network_config is configured, FC creates an ENI in
+	// the specified security group and vSwitch for the function. After the
+	// function is gone the ENI is released asynchronously; drain it so the
+	// dependent security group and vSwitch can be removed. If ENI release
+	// exceeds the wait window on the FC side, do not fail here: the function
+	// is already deleted and the vSwitch/SG destroy has its own retry loop
+	// that can still succeed once the ENI release completes.
+	securityGroupId, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].security_group_id", d.Get("custom_container_config"))
+	vSwitchId, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].vswitch_id", d.Get("custom_container_config"))
+	sgId, _ := securityGroupId.(string)
+	vswId, _ := vSwitchId.(string)
+	if sgId != "" || vswId != "" {
+		eniAction := "DescribeNetworkInterfaces"
+		eniWait := incrementalWait(5*time.Second, 10*time.Second)
+		eniErr := resource.Retry(10*time.Minute, func() *resource.RetryError {
+			eniReq := make(map[string]interface{})
+			eniReq["RegionId"] = client.RegionId
+			if sgId != "" {
+				eniReq["SecurityGroupId"] = sgId
+			}
+			if vswId != "" {
+				eniReq["VSwitchId"] = vswId
+			}
+			eniReq["PageSize"] = PageSizeLarge
+			eniReq["PageNumber"] = 1
+			eniResp, e := client.RpcPost("Ecs", "2014-05-26", eniAction, nil, eniReq, true)
+			if e != nil {
+				if NeedRetry(e) {
+					eniWait()
+					return resource.RetryableError(e)
+				}
+				return resource.NonRetryableError(e)
+			}
+			addDebug(eniAction, eniResp, eniReq)
+			eniSet, _ := jsonpath.Get("$.NetworkInterfaceSets.NetworkInterfaceSet", eniResp)
+			count := 0
+			if arr, ok := eniSet.([]interface{}); ok {
+				count = len(arr)
+			}
+			if count > 0 {
+				eniWait()
+				return resource.RetryableError(fmt.Errorf("fcv3 function [%s] still has %d ENI(s) being released", functionName, count))
+			}
+			return nil
+		})
+		if eniErr != nil {
+			addDebug(eniAction, fmt.Sprintf("wait for ENI release timed out for fcv3 function [%s]: %s", functionName, eniErr), nil)
+		}
 	}
 
 	return nil

--- a/alicloud/resource_alicloud_fcv3_function_test.go
+++ b/alicloud/resource_alicloud_fcv3_function_test.go
@@ -2064,3 +2064,203 @@ data "alicloud_resource_manager_resource_groups" "default" {
 }
 
 // Test Fcv3 Function. <<< Resource test cases, automatically generated.
+
+// Case RegistryConfig
+func TestAccAliCloudFcv3Function_registryConfig(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_fcv3_function.default"
+	ra := resourceAttrInit(resourceId, AliCloudFc3FunctionMapRegistry)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &Fcv3ServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeFcv3Function")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sfc3function%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudFc3FunctionBasicDependenceRegistry)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"function_name": name,
+					"memory_size":   "512",
+					"runtime":       "custom-container",
+					"timeout":       "3",
+					"handler":       "index.handler",
+					"cpu":           "0.5",
+					"disk_size":     "512",
+					"custom_container_config": []map[string]interface{}{
+						{
+							"image": "${var.image1}",
+							"port":  "9000",
+							"registry_config": []map[string]interface{}{
+								{
+									"auth_config": []map[string]interface{}{
+										{
+											"user_name": "testuser",
+											"password":  "TestPass123",
+										},
+									},
+									"cert_config": []map[string]interface{}{
+										{
+											"insecure":            true,
+											"root_ca_cert_base64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
+										},
+									},
+									"network_config": []map[string]interface{}{
+										{
+											"security_group_id": "${data.alicloud_security_groups.sg0.ids.0}",
+											"vswitch_id":        "${data.alicloud_vswitches.vsw0.ids.0}",
+											"vpc_id":            "${data.alicloud_vpcs.default.ids.0}",
+										},
+									},
+								},
+							},
+						},
+					},
+					// there is a bug in api,
+					"log_config": []map[string]interface{}{
+						{
+							"log_begin_rule": "None",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"function_name": name,
+						"memory_size":   "512",
+						"runtime":       "custom-container",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"function_name": name,
+					"memory_size":   "1024",
+					"runtime":       "custom-container",
+					"timeout":       "6",
+					"cpu":           "1",
+					"disk_size":     "512",
+					"custom_container_config": []map[string]interface{}{
+						{
+							"image": "${var.image1}",
+							"port":  "9001",
+							"registry_config": []map[string]interface{}{
+								{
+									"auth_config": []map[string]interface{}{
+										{
+											"user_name": "testuser2",
+											"password":  "UpdatedPass456",
+										},
+									},
+									"cert_config": []map[string]interface{}{
+										{
+											"insecure":            false,
+											"root_ca_cert_base64": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tLS0t",
+										},
+									},
+									"network_config": []map[string]interface{}{
+										{
+											"security_group_id": "${data.alicloud_security_groups.sg1.ids.0}",
+											"vswitch_id":        "${data.alicloud_vswitches.vsw1.ids.0}",
+											"vpc_id":            "${data.alicloud_vpcs.default.ids.1}",
+										},
+									},
+								},
+							},
+						},
+					},
+					// there is a bug in api,
+					"log_config": []map[string]interface{}{
+						{
+							"log_begin_rule": "None",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"memory_size": "1024",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"function_name": name,
+					"memory_size":   "512",
+					"runtime":       "custom-container",
+					"cpu":           "0.5",
+					"disk_size":     "512",
+					"custom_container_config": []map[string]interface{}{
+						{
+							"image": "${var.image1}",
+							"port":  "9000",
+						},
+					},
+					// there is a bug in api,
+					"log_config": []map[string]interface{}{
+						{
+							"log_begin_rule": "None",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"memory_size": "512",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"code", "layers", "custom_container_config"},
+			},
+		},
+	})
+}
+
+var AliCloudFc3FunctionMapRegistry = map[string]string{
+	"function_name": CHECKSET,
+	"memory_size":   CHECKSET,
+	"runtime":       CHECKSET,
+	"create_time":   CHECKSET,
+}
+
+func AliCloudFc3FunctionBasicDependenceRegistry(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "image1" {
+  default = "registry-vpc.cn-hangzhou.aliyuncs.com/eci_open/nginx:alpine"
+}
+
+data "alicloud_vpcs" "default" {
+  name_regex = "^default-NODELETING$"
+}
+
+data "alicloud_vswitches" "vsw0" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+data "alicloud_vswitches" "vsw1" {
+  vpc_id = data.alicloud_vpcs.default.ids.1
+}
+
+data "alicloud_security_groups" "sg0" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+data "alicloud_security_groups" "sg1" {
+  vpc_id = data.alicloud_vpcs.default.ids.1
+}
+`, name)
+}

--- a/website/docs/d/fcv3_functions.html.markdown
+++ b/website/docs/d/fcv3_functions.html.markdown
@@ -68,6 +68,14 @@ The following attributes are exported in addition to the arguments listed above:
       * `timeout_seconds` - Health check timeout. Value range 1~3. The default value is 1.
     * `image` - The container Image address.
     * `port` - The listening port of the HTTP Server when the custom container runs.
+    * `registry_config` - The configuration of the custom image registry. The data source exposes `cert_config` and `network_config`; `auth_config` (registry username/password) is not returned by the ListFunctions API and is not available in the data source.
+      * `cert_config` - The certificate configuration of the image registry.
+        * `insecure` - Specifies whether to skip certificate verification.
+        * `root_ca_cert_base64` - The Base64-encoded root CA certificate of the image registry.
+      * `network_config` - The network configuration used to connect to the image registry.
+        * `security_group_id` - The ID of the security group that can connect to the image registry.
+        * `vpc_id` - The ID of the VPC that can connect to the image registry.
+        * `vswitch_id` - The ID of the vSwitch that can connect to the image registry.
     * `resolved_image_uri` - The actual digest version of the deployed Image. The code version specified by this digest is used when the function starts.
   * `custom_dns` - Function custom DNS configuration
     * `dns_options` - List of configuration items in the resolv.conf file. Each item corresponds to a key-value pair in the format of key:value, where the key is required.

--- a/website/docs/r/fcv3_function.html.markdown
+++ b/website/docs/r/fcv3_function.html.markdown
@@ -171,6 +171,7 @@ The custom_container_config supports the following:
 * `health_check_config` - (Optional, List) Function custom health check configuration See [`health_check_config`](#custom_container_config-health_check_config) below.
 * `image` - (Optional) The container Image address.
 * `port` - (Optional, Int) The listening port of the HTTP Server when the custom container runs.
+* `registry_config` - (Optional, List) The configuration of the custom image registry. See [`registry_config`](#custom_container_config-registry_config) below.
 
 ### `custom_container_config-health_check_config`
 
@@ -181,6 +182,32 @@ The custom_container_config-health_check_config supports the following:
 * `period_seconds` - (Optional, Int) Health check cycle. The value range is 1~120. The default value is 3.
 * `success_threshold` - (Optional, Int) The threshold for the number of successful health checks. When the threshold is reached, the system considers that the health check is successful. The value range is 1~120. The default value is 1.
 * `timeout_seconds` - (Optional, Int) Health check timeout. Value range 1~3. The default value is 1.
+
+### `custom_container_config-registry_config`
+
+The custom_container_config-registry_config supports the following:
+* `auth_config` - (Optional, List, Sensitive) The authentication configuration of the image registry. See [`auth_config`](#custom_container_config-registry_config-auth_config) below.
+* `cert_config` - (Optional, List) The certificate configuration of the image registry. See [`cert_config`](#custom_container_config-registry_config-cert_config) below.
+* `network_config` - (Optional, List) The network configuration used to connect to the image registry. See [`network_config`](#custom_container_config-registry_config-network_config) below.
+
+### `custom_container_config-registry_config-auth_config`
+
+The custom_container_config-registry_config-auth_config supports the following:
+* `password` - (Optional, Sensitive) The password of the image registry.
+* `user_name` - (Optional, Sensitive) The username of the image registry.
+
+### `custom_container_config-registry_config-cert_config`
+
+The custom_container_config-registry_config-cert_config supports the following:
+* `insecure` - (Optional, Bool) Specifies whether to skip certificate verification.
+* `root_ca_cert_base64` - (Optional) The Base64-encoded root CA certificate of the image registry.
+
+### `custom_container_config-registry_config-network_config`
+
+The custom_container_config-registry_config-network_config supports the following:
+* `security_group_id` - (Optional) The ID of the security group that can connect to the image registry.
+* `vswitch_id` - (Optional) The ID of the vSwitch that can connect to the image registry.
+* `vpc_id` - (Optional) The ID of the VPC that can connect to the image registry.
 
 ### `custom_dns`
 


### PR DESCRIPTION
## Summary
- Support `registry_config` block (auth_config, cert_config, network_config) under `custom_container_config` for the `alicloud_fcv3_function` resource, allowing custom-container functions to authenticate against private image registries and configure VPC network access.

## Test plan
- [x] `TestAccAliCloudFcv3Function_registryConfig` PASS in cn-hangzhou (713.18s): create → update (memory/cpu/auth/cert) → clear registry_config → import → destroy.
