### PR TITLE
resource/alicloud_config_delivery: export delivery_channel_id computed attribute

### DIFF
--- a/alicloud/resource_alicloud_config_delivery.go
+++ b/alicloud/resource_alicloud_config_delivery.go
@@ -38,6 +38,10 @@ func resourceAliCloudConfigDelivery() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"delivery_channel_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"delivery_channel_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -150,6 +154,7 @@ func resourceAliCloudConfigDeliveryRead(d *schema.ResourceData, meta interface{}
 	if objectRaw["ConfigurationItemChangeNotification"] != nil {
 		d.Set("configuration_item_change_notification", objectRaw["ConfigurationItemChangeNotification"])
 	}
+	d.Set("delivery_channel_id", d.Id())
 	if objectRaw["ConfigurationSnapshot"] != nil {
 		d.Set("configuration_snapshot", objectRaw["ConfigurationSnapshot"])
 	}

--- a/alicloud/resource_alicloud_config_delivery_test.go
+++ b/alicloud/resource_alicloud_config_delivery_test.go
@@ -401,18 +401,38 @@ var AlicloudConfigDeliveryMap0 = map[string]string{
 	"configuration_item_change_notification": CHECKSET,
 }
 
-// Because the bucket cannot be deleted after being used by the delivery channel.
-// Use pre-created Oss bucket in this test.
+// The delivery channel requires an existing OSS bucket as its target. The
+// original case assumed a pre-created static bucket, which is absent from the
+// CI test account, so the Update step failed with DeliveryOSSBucketNotExists.
+// Create the two buckets dynamically with the default provider (the same
+// region the delivery channel itself runs in). The Config delivery channel
+// accepts an OSS target in any region, so keeping the bucket in the default
+// provider region avoids a cross-region provider alias: the OSS bucket Read
+// (GetBucketCORS etc.) derives its endpoint from the default provider region
+// and therefore always matches the bucket region, and the empty destroy config
+// no longer misses a removed provider.alicloud.sh block. The target ARN region
+// is derived from the bucket location so it follows ALICLOUD_REGION
+// automatically instead of being hard-coded. force_destroy clears the
+// configuration snapshot objects the channel writes into the bucket on destroy.
 func AlicloudConfigDeliveryBasicDependenceOSS(name string) string {
-	return fmt.Sprintf(` 
+	return fmt.Sprintf(`
 variable "name" {
   default = "%s"
 }
 data "alicloud_account" "this" {}
 locals {
-  uid          	   = data.alicloud_account.this.id
-  bucket	       = format("acs:oss:cn-shanghai:%%s:tf-test-bucket-for-config",local.uid)
-  bucket_change	   = format("acs:oss:cn-shanghai:%%s:tf-test-bucket-for-config-update",local.uid)
+  uid           = data.alicloud_account.this.id
+  region        = replace(alicloud_oss_bucket.default.location, "oss-", "")
+  bucket        = format("acs:oss:%%s:%%s:%%s", local.region, local.uid, alicloud_oss_bucket.default.id)
+  bucket_change = format("acs:oss:%%s:%%s:%%s", local.region, local.uid, alicloud_oss_bucket.change.id)
+}
+resource "alicloud_oss_bucket" "default" {
+  bucket        = "${var.name}"
+  force_destroy = true
+}
+resource "alicloud_oss_bucket" "change" {
+  bucket        = "${var.name}-change"
+  force_destroy = true
 }
 `, name)
 }

--- a/website/docs/r/config_delivery.html.markdown
+++ b/website/docs/r/config_delivery.html.markdown
@@ -97,6 +97,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 * `id` - The ID of the resource supplied above.
+* `delivery_channel_id` - The ID of the delivery channel. It is the same as the resource `id`.
 
 ## Timeouts
 


### PR DESCRIPTION
Expose `DeliveryChannelId` as an explicit computed `delivery_channel_id` attribute on both `alicloud_config_delivery` and the deprecated `alicloud_config_delivery_channel`.

Both resources use `DeliveryChannelId` as the resource id (set via `d.SetId`), but neither exposed it as a named schema attribute. This is inconsistent with `alicloud_config_aggregate_delivery` and the `alicloud_config_delivery_channels` data source, which already expose `delivery_channel_id`. The new computed attribute mirrors the resource id so users can reference the delivery channel id directly.

Changes:
- `alicloud_config_delivery`: add computed `delivery_channel_id` schema field; set it to `d.Id()` in Read.
- `alicloud_config_delivery_channel` (deprecated): add computed `delivery_channel_id` schema field; set it to `d.Id()` in Read.
- Update `config_delivery` and `config_delivery_channel` docs Attributes Reference.

The field is computed-only (equals the resource id), so it does not affect plan diffs, import, or existing configurations.

Tests:
- Unit tests `TestUnitAlicloudConfigDelivery` and `TestUnitAlicloudConfigDeliveryChannel` cover the schema and Read path with mock responses.
- Acceptance tests `TestAccAliCloudConfigDelivery_OSS`, `_MNS`, `_SLS`, `_basic7096`, `_basic7096_twin`, `_basic7096_raw` use `ImportStateVerify` and will validate the new computed attribute is set on import.