### PR TITLE
resource/alicloud_config_rule: support governance scope attributes

### DIFF
--- a/alicloud/resource_alicloud_config_rule.go
+++ b/alicloud/resource_alicloud_config_rule.go
@@ -80,6 +80,60 @@ func resourceAliCloudConfigRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"exclude_region_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"exclude_resource_group_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"exclude_tags_scope": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"tag_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"extend_content": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tag_key_logic_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags_scope": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"tag_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 			// lintignore: S006
 			"input_parameters": {
 				Type:     schema.TypeMap,
@@ -223,6 +277,35 @@ func resourceAlicloudConfigRuleCreate(d *schema.ResourceData, meta interface{}) 
 	if v, ok := d.GetOk("exclude_resource_ids_scope"); ok {
 		request["ExcludeResourceIdsScope"] = v
 	}
+	if v, ok := d.GetOk("exclude_region_ids_scope"); ok {
+		request["ExcludeRegionIdsScope"] = v
+	}
+	if v, ok := d.GetOk("exclude_resource_group_ids_scope"); ok {
+		request["ExcludeResourceGroupIdsScope"] = v
+	}
+	if v, ok := d.GetOk("exclude_tags_scope"); ok {
+		for i, dataLoop := range v.([]interface{}) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			request[fmt.Sprintf("ExcludeTagsScope.%d.TagKey", i+1)] = dataLoopTmp["tag_key"]
+			request[fmt.Sprintf("ExcludeTagsScope.%d.TagValue", i+1)] = dataLoopTmp["tag_value"]
+		}
+	}
+	if v, ok := d.GetOk("extend_content"); ok {
+		request["ExtendContent"] = v
+	}
+	if v, ok := d.GetOk("resource_ids_scope"); ok {
+		request["ResourceIdsScope"] = v
+	}
+	if v, ok := d.GetOk("tag_key_logic_scope"); ok {
+		request["TagKeyLogicScope"] = v
+	}
+	if v, ok := d.GetOk("tags_scope"); ok {
+		for i, dataLoop := range v.([]interface{}) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			request[fmt.Sprintf("TagsScope.%d.TagKey", i+1)] = dataLoopTmp["tag_key"]
+			request[fmt.Sprintf("TagsScope.%d.TagValue", i+1)] = dataLoopTmp["tag_value"]
+		}
+	}
 	if v, ok := d.GetOk("input_parameters"); ok {
 		request["InputParameters"] = convertMapToJsonStringIgnoreError(v.(map[string]interface{}))
 	}
@@ -286,6 +369,37 @@ func resourceAlicloudConfigRuleRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("create_time", objectRaw["CreateTimestamp"])
 	d.Set("description", objectRaw["Description"])
 	d.Set("exclude_resource_ids_scope", objectRaw["ExcludeResourceIdsScope"])
+	d.Set("exclude_region_ids_scope", objectRaw["ExcludeRegionIdsScope"])
+	d.Set("exclude_resource_group_ids_scope", objectRaw["ExcludeResourceGroupIdsScope"])
+	if v, ok := objectRaw["ExcludeTagsScope"].([]interface{}); ok {
+		excludeTagsScopeList := make([]map[string]interface{}, 0)
+		for _, val := range v {
+			item := val.(map[string]interface{})
+			excludeTagsScopeList = append(excludeTagsScopeList, map[string]interface{}{
+				"tag_key":   item["TagKey"],
+				"tag_value": item["TagValue"],
+			})
+		}
+		if err := d.Set("exclude_tags_scope", excludeTagsScopeList); err != nil {
+			return WrapError(err)
+		}
+	}
+	d.Set("extend_content", objectRaw["ExtendContent"])
+	d.Set("resource_ids_scope", objectRaw["ResourceIdsScope"])
+	d.Set("tag_key_logic_scope", objectRaw["TagKeyLogicScope"])
+	if v, ok := objectRaw["TagsScope"].([]interface{}); ok {
+		tagsScopeList := make([]map[string]interface{}, 0)
+		for _, val := range v {
+			item := val.(map[string]interface{})
+			tagsScopeList = append(tagsScopeList, map[string]interface{}{
+				"tag_key":   item["TagKey"],
+				"tag_value": item["TagValue"],
+			})
+		}
+		if err := d.Set("tags_scope", tagsScopeList); err != nil {
+			return WrapError(err)
+		}
+	}
 	d.Set("input_parameters", objectRaw["InputParameters"])
 	d.Set("maximum_execution_frequency", objectRaw["MaximumExecutionFrequency"])
 	d.Set("modified_timestamp", objectRaw["ModifiedTimestamp"])
@@ -402,6 +516,52 @@ func resourceAlicloudConfigRuleUpdate(d *schema.ResourceData, meta interface{}) 
 			request["ExcludeResourceIdsScope"] = v
 		}
 	}
+	if !d.IsNewResource() && d.HasChange("exclude_region_ids_scope") {
+		update = true
+		if v, ok := d.GetOk("exclude_region_ids_scope"); ok {
+			request["ExcludeRegionIdsScope"] = v
+		}
+	}
+	if !d.IsNewResource() && d.HasChange("exclude_resource_group_ids_scope") {
+		update = true
+		if v, ok := d.GetOk("exclude_resource_group_ids_scope"); ok {
+			request["ExcludeResourceGroupIdsScope"] = v
+		}
+	}
+	if !d.IsNewResource() && d.HasChange("exclude_tags_scope") {
+		update = true
+		for i, dataLoop := range d.Get("exclude_tags_scope").([]interface{}) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			request[fmt.Sprintf("ExcludeTagsScope.%d.TagKey", i+1)] = dataLoopTmp["tag_key"]
+			request[fmt.Sprintf("ExcludeTagsScope.%d.TagValue", i+1)] = dataLoopTmp["tag_value"]
+		}
+	}
+	if !d.IsNewResource() && d.HasChange("extend_content") {
+		update = true
+		if v, ok := d.GetOk("extend_content"); ok {
+			request["ExtendContent"] = v
+		}
+	}
+	if !d.IsNewResource() && d.HasChange("resource_ids_scope") {
+		update = true
+		if v, ok := d.GetOk("resource_ids_scope"); ok {
+			request["ResourceIdsScope"] = v
+		}
+	}
+	if !d.IsNewResource() && d.HasChange("tag_key_logic_scope") {
+		update = true
+		if v, ok := d.GetOk("tag_key_logic_scope"); ok {
+			request["TagKeyLogicScope"] = v
+		}
+	}
+	if !d.IsNewResource() && d.HasChange("tags_scope") {
+		update = true
+		for i, dataLoop := range d.Get("tags_scope").([]interface{}) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			request[fmt.Sprintf("TagsScope.%d.TagKey", i+1)] = dataLoopTmp["tag_key"]
+			request[fmt.Sprintf("TagsScope.%d.TagValue", i+1)] = dataLoopTmp["tag_value"]
+		}
+	}
 	if !d.IsNewResource() && d.HasChange("risk_level") {
 		update = true
 		if v, ok := d.GetOk("risk_level"); ok {
@@ -467,6 +627,13 @@ func resourceAlicloudConfigRuleUpdate(d *schema.ResourceData, meta interface{}) 
 		d.SetPartial("region_ids_scope")
 		d.SetPartial("resource_group_ids_scope")
 		d.SetPartial("exclude_resource_ids_scope")
+		d.SetPartial("exclude_region_ids_scope")
+		d.SetPartial("exclude_resource_group_ids_scope")
+		d.SetPartial("exclude_tags_scope")
+		d.SetPartial("extend_content")
+		d.SetPartial("resource_ids_scope")
+		d.SetPartial("tag_key_logic_scope")
+		d.SetPartial("tags_scope")
 		d.SetPartial("risk_level")
 		d.SetPartial("config_rule_trigger_types")
 		d.SetPartial("input_parameters")

--- a/alicloud/resource_alicloud_config_rule_test.go
+++ b/alicloud/resource_alicloud_config_rule_test.go
@@ -1392,3 +1392,104 @@ func TestUnitAliCloudConfigRule(t *testing.T) {
 	}
 
 }
+
+func TestAccAliCloudConfigRule_scope(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_config_rule.default"
+	ra := resourceAttrInit(resourceId, AliCloudConfigRuleMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ConfigService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeConfigRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccConfigRuleScope%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudConfigRuleBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, connectivity.CloudConfigSupportedRegions)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rule_name":                        name,
+					"risk_level":                       "1",
+					"resource_types_scope":             []string{"ACS::ECS::Instance"},
+					"config_rule_trigger_types":        "ConfigurationItemChangeNotification",
+					"maximum_execution_frequency":      "One_Hour",
+					"source_identifier":                "ecs-instances-in-vpc",
+					"source_owner":                     "ALIYUN",
+					"exclude_region_ids_scope":         "cn-hangzhou",
+					"exclude_resource_group_ids_scope": "${data.alicloud_resource_manager_resource_groups.default.groups.0.id}",
+					"extend_content":                   "{\\\"fixedHour\\\":\\\"13\\\"}",
+					"tag_key_logic_scope":              "AND",
+					"tags_scope": []map[string]interface{}{
+						{"tag_key": "tfTestTagKey", "tag_value": "tfTestTagValue"},
+					},
+					"exclude_tags_scope": []map[string]interface{}{
+						{"tag_key": "tfTestExcludeKey", "tag_value": "tfTestExcludeValue"},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rule_name":                        name,
+						"resource_types_scope.#":           "1",
+						"config_rule_trigger_types":        "ConfigurationItemChangeNotification",
+						"exclude_region_ids_scope":         "cn-hangzhou",
+						"exclude_resource_group_ids_scope": CHECKSET,
+						"extend_content":                   CHECKSET,
+						"tag_key_logic_scope":              "AND",
+						"tags_scope.#":                     "1",
+						"tags_scope.0.tag_key":             "tfTestTagKey",
+						"tags_scope.0.tag_value":           "tfTestTagValue",
+						"exclude_tags_scope.#":             "1",
+						"exclude_tags_scope.0.tag_key":     "tfTestExcludeKey",
+						"exclude_tags_scope.0.tag_value":   "tfTestExcludeValue",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"config_rule_trigger_types":        "ScheduledNotification",
+					"maximum_execution_frequency":      "Three_Hours",
+					"resource_ids_scope":               "${alicloud_instance.default.id}",
+					"exclude_region_ids_scope":         "cn-beijing",
+					"exclude_resource_group_ids_scope": "${data.alicloud_resource_manager_resource_groups.default.groups.1.id}",
+					"extend_content":                   "{\\\"fixedHour\\\":\\\"14\\\"}",
+					"tag_key_logic_scope":              "OR",
+					"tags_scope": []map[string]interface{}{
+						{"tag_key": "tfTestTagKeyUpdated", "tag_value": "tfTestTagValueUpdated"},
+					},
+					"exclude_tags_scope": []map[string]interface{}{
+						{"tag_key": "tfTestExcludeKeyUpdated", "tag_value": "tfTestExcludeValueUpdated"},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"config_rule_trigger_types":        "ScheduledNotification",
+						"maximum_execution_frequency":      "Three_Hours",
+						"resource_ids_scope":               CHECKSET,
+						"exclude_region_ids_scope":         "cn-beijing",
+						"exclude_resource_group_ids_scope": CHECKSET,
+						"extend_content":                   CHECKSET,
+						"tag_key_logic_scope":              "OR",
+						"tags_scope.#":                     "1",
+						"tags_scope.0.tag_key":             "tfTestTagKeyUpdated",
+						"tags_scope.0.tag_value":           "tfTestTagValueUpdated",
+						"exclude_tags_scope.#":             "1",
+						"exclude_tags_scope.0.tag_key":     "tfTestExcludeKeyUpdated",
+						"exclude_tags_scope.0.tag_value":   "tfTestExcludeValueUpdated",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}

--- a/website/docs/r/config_rule.html.markdown
+++ b/website/docs/r/config_rule.html.markdown
@@ -58,6 +58,17 @@ The following arguments are supported:
 * `config_rule_trigger_types` - (Optional, Required) The trigger type of the rule. Valid values:  `ConfigurationItemChangeNotification`: The rule is triggered upon configuration changes. `ScheduledNotification`: The rule is triggered as scheduled.
 * `description` - (Optional) The description of the rule.
 * `exclude_resource_ids_scope` - (Optional) The rule monitors excluded resource IDs, multiple of which are separated by commas, only applies to rules created based on managed rules, , custom rule this field is empty.
+* `exclude_region_ids_scope` - (Optional) The rule monitors excluded region IDs, multiple of which are separated by commas, only applies to rules created based on managed rules.
+* `exclude_resource_group_ids_scope` - (Optional) The rule monitors excluded resource group IDs, multiple of which are separated by commas, only applies to rules created based on managed rules.
+* `exclude_tags_scope` - (Optional) The tags that the rule excludes from monitoring. Each element contains the following:
+  * `tag_key` - (Optional) The key of the tag excluded from monitoring.
+  * `tag_value` - (Optional) The value of the tag excluded from monitoring.
+* `extend_content` - (Optional) The extended content of the rule.
+* `resource_ids_scope` - (Optional) The rule monitors resource IDs, multiple of which are separated by commas, only applies to rules created based on managed rules.
+* `tag_key_logic_scope` - (Optional) The logical relationship of the tag keys that the rule monitors. Valid values: `AND`, `OR`.
+* `tags_scope` - (Optional) The tags that the rule monitors. Each element contains the following:
+  * `tag_key` - (Optional) The key of the tag monitored by the rule.
+  * `tag_value` - (Optional) The value of the tag monitored by the rule.
 * `input_parameters` - (Optional, Map) The settings of the input parameters for the rule.
 * `maximum_execution_frequency` - (Optional) The frequency of the compliance evaluations, it is required if the ConfigRuleTriggerTypes value is ScheduledNotification. Valid values:  `One_Hour`, `Three_Hours`, `Six_Hours`, `Twelve_Hours`, `TwentyFour_Hours`.
 * `region_ids_scope` - (Optional) The rule monitors region IDs, separated by commas, only applies to rules created based on managed rules.


### PR DESCRIPTION
### What this PR does

Adds governance scope attributes to the `alicloud_config_rule` resource, wiring them through Create, Read and Update against the Config 2020-09-07 `CreateConfigRule`, `GetConfigRule` and `UpdateConfigRule` operations:

- `resource_ids_scope` (string)
- `exclude_region_ids_scope` (string)
- `exclude_resource_group_ids_scope` (string)
- `extend_content` (string)
- `tag_key_logic_scope` (string)
- `tags_scope` (list of { `tag_key`, `tag_value` })
- `exclude_tags_scope` (list of { `tag_key`, `tag_value` })

Nested tag scopes are flattened with the existing RPC list pattern (e.g. `TagsScope.<n>.TagKey`), consistent with `alicloud_config_aggregate_config_rule`. None of these attributes require resource recreation, so no `ForceNew` is set.

### Tests

Acceptance test `TestAccAliCloudConfigRule_scope` covers the create -> update -> import lifecycle for all new attributes. Remote ACC verification is pending.

### Doc

`website/docs/r/config_rule.html.markdown` updated with the new arguments.
