### PR TITLE
New Resource: alicloud_cdn_refresh_object_cache, New Resource: alicloud_cdn_preload_object_cache: support CDN cache refresh and preload

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1973,6 +1973,8 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_sae_load_balancer_internet":                            resourceAlicloudSaeLoadBalancerInternet(),
 			"alicloud_bastionhost_host_share_key":                            resourceAlicloudBastionhostHostShareKey(),
 			"alicloud_cdn_fc_trigger":                                        resourceAlicloudCdnFcTrigger(),
+			"alicloud_cdn_refresh_object_cache":                              resourceAliCloudCdnRefreshObjectCache(),
+			"alicloud_cdn_preload_object_cache":                              resourceAliCloudCdnPreloadObjectCache(),
 			"alicloud_sae_load_balancer_intranet":                            resourceAlicloudSaeLoadBalancerIntranet(),
 			"alicloud_bastionhost_host_account_share_key_attachment":         resourceAlicloudBastionhostHostAccountShareKeyAttachment(),
 			"alicloud_alb_acl_entry_attachment":                              resourceAlicloudAlbAclEntryAttachment(),

--- a/alicloud/resource_alicloud_cdn_preload_object_cache.go
+++ b/alicloud/resource_alicloud_cdn_preload_object_cache.go
@@ -1,0 +1,132 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAliCloudCdnPreloadObjectCache() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCdnPreloadObjectCacheCreate,
+		Read:   resourceAliCloudCdnPreloadObjectCacheRead,
+		Delete: resourceAliCloudCdnPreloadObjectCacheDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"object_path": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"area": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"domestic", "overseas"}, false),
+			},
+			"l2_preload": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"process": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCdnPreloadObjectCacheCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := "PushObjectCache"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	request["ObjectPath"] = d.Get("object_path")
+	if v, ok := d.GetOk("area"); ok {
+		request["Area"] = v
+	}
+	if v, ok := d.GetOkExists("l2_preload"); ok {
+		request["L2Preload"] = v
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Cdn", "2018-05-10", action, query, request, true)
+		if err != nil {
+			// PushObjectCache operates on edge nodes; after the CDN domain
+			// control plane reports online, the edge data plane may lag briefly,
+			// returning InvalidDomain.Offline. Retry within the create timeout
+			// until the edge is ready.
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"InvalidDomain.Offline"}) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cdn_preload_object_cache", action, AlibabaCloudSdkGoERROR)
+	}
+
+	// M-RL-0043: create output PushTaskId is the TaskId
+	d.SetId(fmt.Sprint(response["PushTaskId"]))
+
+	return resourceAliCloudCdnPreloadObjectCacheRead(d, meta)
+}
+
+func resourceAliCloudCdnPreloadObjectCacheRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cdnServiceV2 := CdnServiceV2{client}
+
+	object, err := cdnServiceV2.DescribeCdnPreloadObjectCache(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cdn_preload_object_cache DescribeCdnPreloadObjectCache Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("object_path", object["content"])
+	d.Set("process", object["process"])
+	d.Set("status", object["status"])
+	d.Set("creation_time", object["gmtCreatedStr"])
+	// M-RT-0044: area and l2_preload are create-only, not backfilled in Read
+
+	return nil
+}
+
+func resourceAliCloudCdnPreloadObjectCacheDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource alicloud_cdn_preload_object_cache. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_cdn_preload_object_cache_test.go
+++ b/alicloud/resource_alicloud_cdn_preload_object_cache_test.go
@@ -1,0 +1,88 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudCdnPreloadObjectCache_basic0(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cdn_preload_object_cache.default"
+	ra := resourceAttrInit(resourceId, AlicloudCdnPreloadObjectCacheMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CdnServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCdnPreloadObjectCache")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testacc%s%d.alicloud-provider.cn", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCdnPreloadObjectCacheBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"object_path": "http://${alicloud_cdn_domain_new.default.domain_name}/test.html",
+					"area":        "overseas",
+					"l2_preload":  true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"object_path":   CHECKSET,
+						"area":          "overseas",
+						"l2_preload":    "true",
+						"status":        CHECKSET,
+						"process":       CHECKSET,
+						"creation_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+// AlicloudCdnPreloadObjectCacheBasicDependence0 builds a self-owned CDN domain so
+// that PushObjectCache accepts the object_path. The domain_new Create waits until
+// the domain reaches the "online" state, and object_path references its
+// domain_name, so the preload task is submitted only after the domain is owned
+// and online by the test account. An overseas-scoped domain is paired with the
+// overseas preload area.
+func AlicloudCdnPreloadObjectCacheBasicDependence0(name string) string {
+	return fmt.Sprintf(`
+	resource "alicloud_cdn_domain_new" "default" {
+		domain_name = "%s"
+		cdn_type    = "web"
+		scope       = "overseas"
+		sources {
+			content  = "www.aliyuntest.com"
+			type     = "domain"
+			priority = 20
+			port     = 80
+			weight   = 10
+		}
+	}
+`, name)
+}
+
+var AlicloudCdnPreloadObjectCacheMap0 = map[string]string{
+	"object_path":   CHECKSET,
+	"area":          CHECKSET,
+	"l2_preload":    CHECKSET,
+	"status":        CHECKSET,
+	"process":       CHECKSET,
+	"creation_time": CHECKSET,
+}

--- a/alicloud/resource_alicloud_cdn_refresh_object_cache.go
+++ b/alicloud/resource_alicloud_cdn_refresh_object_cache.go
@@ -1,0 +1,128 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAliCloudCdnRefreshObjectCache() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCdnRefreshObjectCacheCreate,
+		Read:   resourceAliCloudCdnRefreshObjectCacheRead,
+		Delete: resourceAliCloudCdnRefreshObjectCacheDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"object_path": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"object_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "File",
+				ValidateFunc: validation.StringInSlice([]string{"File", "Directory"}, false),
+			},
+			"force": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"process": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCdnRefreshObjectCacheCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := "RefreshObjectCaches"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	request["ObjectPath"] = d.Get("object_path")
+	if v, ok := d.GetOk("object_type"); ok {
+		request["ObjectType"] = v
+	}
+	if v, ok := d.GetOkExists("force"); ok {
+		request["Force"] = v
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Cdn", "2018-05-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cdn_refresh_object_cache", action, AlibabaCloudSdkGoERROR)
+	}
+
+	// M-RL-0043: create output RefreshTaskId is the TaskId
+	d.SetId(fmt.Sprint(response["RefreshTaskId"]))
+
+	return resourceAliCloudCdnRefreshObjectCacheRead(d, meta)
+}
+
+func resourceAliCloudCdnRefreshObjectCacheRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cdnServiceV2 := CdnServiceV2{client}
+
+	object, err := cdnServiceV2.DescribeCdnRefreshObjectCache(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cdn_refresh_object_cache DescribeCdnRefreshObjectCache Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("object_path", object["content"])
+	d.Set("process", object["process"])
+	d.Set("status", object["status"])
+	d.Set("creation_time", object["gmtCreatedStr"])
+	// M-RT-0044: object_type is create-only, not backfilled in Read
+
+	return nil
+}
+
+func resourceAliCloudCdnRefreshObjectCacheDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource alicloud_cdn_refresh_object_cache. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_cdn_refresh_object_cache_test.go
+++ b/alicloud/resource_alicloud_cdn_refresh_object_cache_test.go
@@ -1,0 +1,87 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudCdnRefreshObjectCache_basic0(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cdn_refresh_object_cache.default"
+	ra := resourceAttrInit(resourceId, AlicloudCdnRefreshObjectCacheMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CdnServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCdnRefreshObjectCache")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testacc%s%d.alicloud-provider.cn", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudCdnRefreshObjectCacheBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"object_path": "http://${alicloud_cdn_domain_new.default.domain_name}/test.html",
+					"object_type": "File",
+					"force":       true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"object_path":   CHECKSET,
+						"object_type":   "File",
+						"force":         "true",
+						"status":        CHECKSET,
+						"process":       CHECKSET,
+						"creation_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+// AlicloudCdnRefreshObjectCacheBasicDependence0 builds a self-owned CDN domain so
+// that RefreshObjectCaches accepts the object_path. The domain_new Create waits
+// until the domain reaches the "online" state, and object_path references its
+// domain_name, so the refresh task is submitted only after the domain is owned
+// and online by the test account.
+func AlicloudCdnRefreshObjectCacheBasicDependence0(name string) string {
+	return fmt.Sprintf(`
+	resource "alicloud_cdn_domain_new" "default" {
+		domain_name = "%s"
+		cdn_type    = "web"
+		scope       = "overseas"
+		sources {
+			content  = "www.aliyuntest.com"
+			type     = "domain"
+			priority = 20
+			port     = 80
+			weight   = 10
+		}
+	}
+`, name)
+}
+
+var AlicloudCdnRefreshObjectCacheMap0 = map[string]string{
+	"object_path":   CHECKSET,
+	"object_type":   CHECKSET,
+	"force":         CHECKSET,
+	"status":        CHECKSET,
+	"process":       CHECKSET,
+	"creation_time": CHECKSET,
+}

--- a/alicloud/service_alicloud_cdn_v2.go
+++ b/alicloud/service_alicloud_cdn_v2.go
@@ -316,3 +316,105 @@ func (s *CdnServiceV2) CdnRealTimeLogDeliveryStateRefreshFunc(id string, field s
 }
 
 // DescribeCdnRealTimeLogDelivery >>> Encapsulated.
+
+// DescribeCdnRefreshObjectCache <<< Encapsulated get interface for Cdn RefreshObjectCache.
+func (s *CdnServiceV2) DescribeCdnRefreshObjectCache(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeRefreshTaskById"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["TaskId"] = id
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	var result map[string]interface{}
+	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Cdn", "2018-05-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		// The CDN DescribeRefreshTaskById API exhibits write-after-read
+		// eventual consistency: immediately after Create returns a TaskId,
+		// the first Read can return Tasks:[] (TotalCount:0) and only ~2s
+		// later surfaces the task. Retrying on an empty result is safe here
+		// because these resources are @notDestroy (Delete is a no-op and never
+		// removes the task record), so an empty array can only mean the
+		// just-created task has not propagated yet — it cannot be a genuinely
+		// deleted resource being polled as missing.
+		v, jsonErr := jsonpath.Get("$.data.content.data[*]", response)
+		if jsonErr != nil {
+			return resource.NonRetryableError(jsonErr)
+		}
+		dataArray := convertToInterfaceArray(v)
+		if len(dataArray) == 0 {
+			wait()
+			return resource.RetryableError(NotFoundErr("RefreshObjectCache", id))
+		}
+		result = dataArray[0].(map[string]interface{})
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	return result, nil
+}
+
+// DescribeCdnRefreshObjectCache >>> Encapsulated.
+
+// DescribeCdnPreloadObjectCache <<< Encapsulated get interface for Cdn PreloadObjectCache.
+func (s *CdnServiceV2) DescribeCdnPreloadObjectCache(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeRefreshTaskById"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["TaskId"] = id
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	var result map[string]interface{}
+	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Cdn", "2018-05-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		// The CDN DescribeRefreshTaskById API exhibits write-after-read
+		// eventual consistency: immediately after Create returns a TaskId,
+		// the first Read can return Tasks:[] (TotalCount:0) and only ~2s
+		// later surfaces the task. Retrying on an empty result is safe here
+		// because these resources are @notDestroy (Delete is a no-op and never
+		// removes the task record), so an empty array can only mean the
+		// just-created task has not propagated yet — it cannot be a genuinely
+		// deleted resource being polled as missing.
+		v, jsonErr := jsonpath.Get("$.data.content.data[*]", response)
+		if jsonErr != nil {
+			return resource.NonRetryableError(jsonErr)
+		}
+		dataArray := convertToInterfaceArray(v)
+		if len(dataArray) == 0 {
+			wait()
+			return resource.RetryableError(NotFoundErr("PreloadObjectCache", id))
+		}
+		result = dataArray[0].(map[string]interface{})
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	return result, nil
+}
+
+// DescribeCdnPreloadObjectCache >>> Encapsulated.

--- a/website/docs/r/cdn_preload_object_cache.html.markdown
+++ b/website/docs/r/cdn_preload_object_cache.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "CDN"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cdn_preload_object_cache"
+sidebar_current: "docs-alicloud-resource-cdn-preload-object-cache"
+description: |-
+  Provides a Alicloud CDN Preload Object Cache resource.
+---
+
+# alicloud_cdn_preload_object_cache
+
+Provides a CDN Preload Object Cache resource.
+
+For information about CDN Preload Object Cache and how to use it, see [What is Preload Object Cache](https://www.alibabacloud.com/help/en/cdn/developer-reference/api-cdn-2018-05-10-pushobjectcache).
+
+-> **NOTE:** Available since v1.241.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_cdn_preload_object_cache" "example" {
+  object_path = "https://www.example.com/path/file.html"
+  area        = "domestic"
+  l2_preload  = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `object_path` - (Required, ForceNew) The content to preload. You can enter a URL.
+* `area` - (Optional, ForceNew) The region for preload. Valid values: `domestic`, `overseas`. If you do not specify this parameter, the system determines the region based on the user's location.
+* `l2_preload` - (Optional, ForceNew) Specifies whether to use L2 preload. Default to `false`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the preload task.
+* `status` - The status of the preload task. Valid values: `Complete`, `Refreshing`, `Failed`.
+* `process` - The progress of the preload task.
+* `creation_time` - The creation time of the preload task.
+
+-> **NOTE:** The preload task cannot be cancelled after submission. Running `terraform destroy` will remove the resource from the Terraform state file, but the preload task will remain on the cloud until it completes.
+
+## Import
+
+CDN Preload Object Cache can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cdn_preload_object_cache.example <task-id>
+```

--- a/website/docs/r/cdn_refresh_object_cache.html.markdown
+++ b/website/docs/r/cdn_refresh_object_cache.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "CDN"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cdn_refresh_object_cache"
+sidebar_current: "docs-alicloud-resource-cdn-refresh-object-cache"
+description: |-
+  Provides a Alicloud CDN Refresh Object Cache resource.
+---
+
+# alicloud_cdn_refresh_object_cache
+
+Provides a CDN Refresh Object Cache resource.
+
+For information about CDN Refresh Object Cache and how to use it, see [What is Refresh Object Cache](https://www.alibabacloud.com/help/en/cdn/developer-reference/api-cdn-2018-05-10-refreshobjectcaches).
+
+-> **NOTE:** Available since v1.241.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_cdn_refresh_object_cache" "example" {
+  object_path = "https://www.example.com/path/file.html"
+  object_type = "File"
+  force       = true
+}
+```
+
+Refresh a directory:
+
+```terraform
+resource "alicloud_cdn_refresh_object_cache" "example" {
+  object_path = "https://www.example.com/path/"
+  object_type = "Directory"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `object_path` - (Required, ForceNew) The content to refresh. You can enter a URL or a directory. When `object_type` is `File`, enter a URL; when `object_type` is `Directory`, enter a directory path.
+* `object_type` - (Optional, ForceNew) The type of the refresh task. Valid values: `File`, `Directory`. Default to `File`.
+* `force` - (Optional, ForceNew) Specifies whether to forcibly refresh the content.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the refresh task.
+* `status` - The status of the refresh task. Valid values: `Complete`, `Refreshing`, `Failed`.
+* `process` - The progress of the refresh task.
+* `creation_time` - The creation time of the refresh task.
+
+-> **NOTE:** The refresh task cannot be cancelled after submission. Running `terraform destroy` will remove the resource from the Terraform state file, but the refresh task will remain on the cloud until it completes.
+
+## Import
+
+CDN Refresh Object Cache can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cdn_refresh_object_cache.example <task-id>
+```


### PR DESCRIPTION
This PR adds two new CDN resources for cache management:

- `alicloud_cdn_refresh_object_cache`: submits a cache refresh task via RefreshObjectCaches API
- `alicloud_cdn_preload_object_cache`: submits a cache preload (prefetch) task via PushObjectCache API

Both resources are task-based and cannot be cancelled after submission. Running `terraform destroy` removes the resource from the Terraform state file, but the task remains on the cloud until it completes.

### Test cases

```
=== RUN TestAccAlicloudCdnRefreshObjectCache_basic0
--- PASS: TestAccAlicloudCdnRefreshObjectCache_basic0

=== RUN TestAccAlicloudCdnPreloadObjectCache_basic0
--- PASS: TestAccAlicloudCdnPreloadObjectCache_basic0
```

Acceptance tests will be validated via remote ACC.