### PR TITLE
resource/alicloud_cloud_firewall_instance_v2: support business order parameters; resource/alicloud_cloud_firewall_instance: unsubscribe Subscription instances on destroy

### DIFF
--- a/alicloud/resource_alicloud_cloud_firewall_instance_v2.go
+++ b/alicloud/resource_alicloud_cloud_firewall_instance_v2.go
@@ -26,10 +26,46 @@ func resourceAliCloudCloudFirewallInstanceV2() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
+			"account_number": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntBetween(1, 1000),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if v, ok := d.GetOk("cfw_account"); ok && v.(bool) {
+						return false
+					}
+					return true
+				},
+			},
+			"auto_asset_protection": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"band_width": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntBetween(10, 15000),
+			},
+			"cfw_account": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"cfw_log": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
+			},
+			"cfw_log_storage": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntBetween(1000, 500000),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if v, ok := d.GetOk("cfw_log"); ok && v.(bool) && d.Get("payment_type").(string) == "Subscription" {
+						return false
+					}
+					return true
+				},
 			},
 			"create_time": {
 				Type:     schema.TypeString,
@@ -38,6 +74,33 @@ func resourceAliCloudCloudFirewallInstanceV2() *schema.Resource {
 			"end_time": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"fw_vpc_number": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: IntBetween(2, 500),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if v, ok := d.GetOk("spec"); ok && v.(string) == "premium_version" {
+						return true
+					}
+					return false
+				},
+			},
+			"instance_count": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntBetween(5, 5000),
+			},
+			"ip_number": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: IntBetween(20, 4000),
+			},
+			"logistics": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"modify_type": {
 				Type:         schema.TypeString,
@@ -91,7 +154,6 @@ func resourceAliCloudCloudFirewallInstanceV2() *schema.Resource {
 			"spec": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: StringInSlice([]string{"payg_version", "premium_version", "enterprise_version", "ultimate_version"}, false),
 			},
 			"status": {
@@ -152,11 +214,63 @@ func resourceAliCloudCloudFirewallInstanceV2Create(d *schema.ResourceData, meta 
 			})
 		}
 	}
+	if v, ok := d.GetOk("ip_number"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "IpNumber",
+			"Value": v,
+		})
+	}
+	if v, ok := d.GetOk("band_width"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "BandWidth",
+			"Value": v,
+		})
+	}
+	if v, ok := d.GetOk("cfw_log_storage"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "CfwLogStorage",
+			"Value": v,
+		})
+	}
+	if v, ok := d.GetOkExists("cfw_account"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "CfwAccount",
+			"Value": v,
+		})
+	}
+	if v, ok := d.GetOkExists("account_number"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "CfwAccountNum",
+			"Value": v,
+		})
+	}
+	if v, ok := d.GetOk("fw_vpc_number"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "FwVpcNumber",
+			"Value": v,
+		})
+	}
+	if v, ok := d.GetOk("instance_count"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "InstanceCount",
+			"Value": v,
+		})
+	}
+	if v, ok := d.GetOk("auto_asset_protection"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "AutoAssetProtection",
+			"Value": v,
+		})
+	}
 	request["Parameter"] = parameterMapList
 
 	request["ProductCode"] = d.Get("product_code")
 	request["SubscriptionType"] = d.Get("payment_type")
 	request["ProductType"] = d.Get("product_type")
+
+	if v, ok := d.GetOk("logistics"); ok {
+		request["Logistics"] = v
+	}
 
 	if v, ok := d.GetOk("renewal_status"); ok {
 		request["RenewalStatus"] = v
@@ -178,6 +292,14 @@ func resourceAliCloudCloudFirewallInstanceV2Create(d *schema.ResourceData, meta 
 			}
 			if !client.IsInternationalAccount() && IsExpectedErrors(err, []string{"NotApplicable", NotFoundArticle}) {
 				endpoint = connectivity.BssOpenAPIEndpointInternational
+				if _, ok := d.GetOkExists("account_number"); ok {
+					for _, v := range parameterMapList {
+						if fmt.Sprint(v["Code"]) == "CfwAccountNum" {
+							v["Code"] = "CfwAccountIntlNum"
+						}
+					}
+					request["Parameter"] = parameterMapList
+				}
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -236,6 +358,31 @@ func resourceAliCloudCloudFirewallInstanceV2Read(d *schema.ResourceData, meta in
 	d.Set("spec", convertCloudFirewallInstanceVersionResponse(objectRaw["Version"]))
 	d.Set("status", objectRaw["InstanceStatus"])
 	d.Set("user_status", fmt.Sprint(objectRaw["UserStatus"]))
+	// DescribeUserBuyVersion reports the purchased spec counts (IpNumber /
+	// VpcNumber / LogStorage) as 0 for Subscription instances even when
+	// InstanceStatus is normal, while PayAsYouGo returns the real values.
+	// Overwriting the user-configured counts with 0 produces a spurious diff
+	// on every plan, so these fields are only set when the API reports a
+	// non-zero value. Drift detection for these counts is therefore limited to
+	// instances where the API actually surfaces the value.
+	if v := objectRaw["LogStorage"]; v != nil && fmt.Sprint(v) != "0" {
+		d.Set("cfw_log_storage", v)
+	}
+	if v := objectRaw["VpcNumber"]; v != nil && fmt.Sprint(v) != "0" {
+		d.Set("fw_vpc_number", v)
+	}
+	if v := objectRaw["IpNumber"]; v != nil && fmt.Sprint(v) != "0" {
+		d.Set("ip_number", v)
+	}
+
+	assetStatistic, err := cloudFirewallServiceV2.DescribeInstanceDescribeAssetStatistic(d.Id())
+	if err != nil {
+		if !NotFoundError(err) {
+			return WrapError(err)
+		}
+	} else {
+		d.Set("auto_asset_protection", fmt.Sprint(assetStatistic["AutoResourceEnable"]))
+	}
 
 	return nil
 }
@@ -311,12 +458,104 @@ func resourceAliCloudCloudFirewallInstanceV2Update(d *schema.ResourceData, meta 
 
 	parameterMapList := make([]map[string]interface{}, 0)
 
+	// Append every order Parameter that has a value so ModifyInstance receives
+	// the complete component list; HasChange only gates the update trigger.
+	// Sending the full set (including unchanged specs) is required for BssOpenApi
+	// ModifyInstance to accept the Upgrade/Downgrade without
+	// UPDOWNGRADE_CONFIG_NO_CHANGE.
+	if !d.IsNewResource() && d.HasChange("cfw_account") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("cfw_account"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "CfwAccount",
+			"Value": v,
+		})
+	}
+
+	if !d.IsNewResource() && d.HasChange("account_number") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("account_number"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "CfwAccountNum",
+			"Value": v,
+		})
+	}
+
+	if !d.IsNewResource() && d.HasChange("fw_vpc_number") {
+		update = true
+	}
+	if v, ok := d.GetOk("fw_vpc_number"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "FwVpcNumber",
+			"Value": v,
+		})
+	}
+
+	if !d.IsNewResource() && d.HasChange("ip_number") {
+		update = true
+	}
+	if v, ok := d.GetOk("ip_number"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "IpNumber",
+			"Value": v,
+		})
+	}
+
 	if !d.IsNewResource() && d.HasChange("cfw_log") {
 		update = true
 	}
 	if v, ok := d.GetOkExists("cfw_log"); ok {
 		parameterMapList = append(parameterMapList, map[string]interface{}{
 			"Code":  "CfwLog",
+			"Value": v,
+		})
+	}
+
+	if !d.IsNewResource() && d.HasChange("cfw_log_storage") {
+		update = true
+	}
+	if v, ok := d.GetOk("cfw_log_storage"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "CfwLogStorage",
+			"Value": v,
+		})
+	}
+
+	if !d.IsNewResource() && d.HasChange("band_width") {
+		update = true
+	}
+	if v, ok := d.GetOk("band_width"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "BandWidth",
+			"Value": v,
+		})
+	}
+
+	if !d.IsNewResource() && d.HasChange("spec") {
+		update = true
+	}
+	if v, ok := d.GetOk("spec"); ok {
+		if d.Get("payment_type").(string) == "PayAsYouGo" {
+			parameterMapList = append(parameterMapList, map[string]interface{}{
+				"Code":  "spec",
+				"Value": convertCloudFirewallInstanceSpecRequest(v),
+			})
+		} else {
+			parameterMapList = append(parameterMapList, map[string]interface{}{
+				"Code":  "cfw_spec",
+				"Value": convertCloudFirewallInstanceSpecRequest(v),
+			})
+		}
+	}
+
+	if !d.IsNewResource() && d.HasChange("instance_count") {
+		update = true
+	}
+	if v, ok := d.GetOk("instance_count"); ok {
+		parameterMapList = append(parameterMapList, map[string]interface{}{
+			"Code":  "InstanceCount",
 			"Value": v,
 		})
 	}
@@ -334,6 +573,14 @@ func resourceAliCloudCloudFirewallInstanceV2Update(d *schema.ResourceData, meta 
 				}
 				if !client.IsInternationalAccount() && IsExpectedErrors(err, []string{"NotApplicable"}) {
 					endpoint = connectivity.BssOpenAPIEndpointInternational
+					if _, ok := d.GetOkExists("account_number"); ok {
+						for _, v := range parameterMapList {
+							if fmt.Sprint(v["Code"]) == "CfwAccountNum" {
+								v["Code"] = "CfwAccountIntlNum"
+							}
+						}
+						request["Parameter"] = parameterMapList
+					}
 					return resource.RetryableError(err)
 				}
 				return resource.NonRetryableError(err)
@@ -418,17 +665,111 @@ func resourceAliCloudCloudFirewallInstanceV2Update(d *schema.ResourceData, meta 
 		}
 	}
 
+	update = false
+	setAutoProtectNewAssetsRequest := make(map[string]interface{})
+	setAutoProtectNewAssetsQuery := make(map[string]interface{})
+
+	if !d.IsNewResource() && d.HasChange("auto_asset_protection") {
+		update = true
+	}
+	setAutoProtectNewAssetsRequest["AutoProtect"] = d.Get("auto_asset_protection")
+
+	if update {
+		action := "SetAutoProtectNewAssets"
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Cloudfw", "2017-12-07", action, setAutoProtectNewAssetsQuery, setAutoProtectNewAssetsRequest, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, setAutoProtectNewAssetsRequest)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		d.SetPartial("auto_asset_protection")
+	}
+
 	d.Partial(false)
 	return resourceAliCloudCloudFirewallInstanceV2Read(d, meta)
 }
 
 func resourceAliCloudCloudFirewallInstanceV2Delete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
 	if d.Get("payment_type").(string) == "Subscription" {
-		log.Printf("[WARN] Cannot destroy resourceAliCloudCloudFirewallInstance. Terraform will remove this resource from the state file, however resources may remain.")
+		// Prepaid (Subscription) Cloud Firewall instances cannot be released
+		// through Cloudfw ReleasePostInstance; unsubscribe them via BssOpenApi
+		// RefundInstance so that no cloud resource is left behind on destroy.
+		action := "RefundInstance"
+		request := map[string]interface{}{
+			"InstanceId":         d.Id(),
+			"ClientToken":        buildClientToken(action),
+			"ImmediatelyRelease": "1",
+			"ProductCode":        "vipcloudfw",
+			"ProductType":        "vipcloudfw",
+		}
+		if client.IsInternationalAccount() {
+			request["ProductCode"] = "cfw"
+			request["ProductType"] = "cfw_pre_intl"
+		}
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		var response map[string]interface{}
+		var err error
+		var endpoint string
+		err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+			response, err = client.RpcPostWithEndpoint("BssOpenApi", "2017-12-14", action, nil, request, true, endpoint)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				if !client.IsInternationalAccount() && IsExpectedErrors(err, []string{"NotApplicable"}) {
+					request["ProductCode"] = "cfw"
+					request["ProductType"] = "cfw_pre_intl"
+					endpoint = connectivity.BssOpenAPIEndpointInternational
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"ResourceNotExists"}) || NotFoundError(err) {
+				return nil
+			}
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		bssOpenApiService := BssOpenApiService{client}
+		bssWait := incrementalWait(10*time.Second, 10*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+			_, err = bssOpenApiService.QueryAvailableInstance(d.Id())
+			if err != nil {
+				if NotFoundError(err) {
+					return nil
+				}
+				if NeedRetry(err) {
+					bssWait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			bssWait()
+			return resource.RetryableError(fmt.Errorf("Cloud Firewall instance %s still exists", d.Id()))
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "WaitForRefundInstance", AlibabaCloudSdkGoERROR)
+		}
 		return nil
 	}
 
-	client := meta.(*connectivity.AliyunClient)
 	enableDelete := false
 	if v, ok := d.GetOkExists("payment_type"); ok {
 		if InArray(fmt.Sprint(v), []string{"PayAsYouGo"}) {

--- a/alicloud/resource_alicloud_cloud_firewall_instance_v2_test.go
+++ b/alicloud/resource_alicloud_cloud_firewall_instance_v2_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -35,27 +36,31 @@ func TestAccAliCloudCloudFirewallInstanceV2_basic11709(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"payment_type": "PayAsYouGo",
-					"product_code": "cfw",
-					"product_type": "cfw_elasticity_public_cn",
-					"spec":         "payg_version",
+					"payment_type":          "PayAsYouGo",
+					"product_code":          "cfw",
+					"product_type":          "cfw_elasticity_public_cn",
+					"spec":                  "payg_version",
+					"auto_asset_protection": "true",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"payment_type": "PayAsYouGo",
-						"product_code": "cfw",
-						"product_type": "cfw_elasticity_public_cn",
-						"spec":         "payg_version",
+						"payment_type":          "PayAsYouGo",
+						"product_code":          "cfw",
+						"product_type":          "cfw_elasticity_public_cn",
+						"spec":                  "payg_version",
+						"auto_asset_protection": "true",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"sdl": "true",
+					"sdl":                   "true",
+					"auto_asset_protection": "false",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"sdl": "true",
+						"sdl":                   "true",
+						"auto_asset_protection": "false",
 					}),
 				),
 			},
@@ -74,7 +79,7 @@ func TestAccAliCloudCloudFirewallInstanceV2_basic11709(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"modify_type", "period"},
+				ImportStateVerifyIgnore: []string{"modify_type", "period", "band_width", "logistics", "instance_count", "cfw_account", "account_number"},
 			},
 		},
 	})
@@ -126,7 +131,7 @@ func TestAccAliCloudCloudFirewallInstanceV2_basic11709_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"modify_type", "period"},
+				ImportStateVerifyIgnore: []string{"modify_type", "period", "band_width", "logistics", "instance_count", "cfw_account", "account_number"},
 			},
 		},
 	})
@@ -214,7 +219,7 @@ func TestAccAliCloudCloudFirewallInstanceV2_basic11710(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"modify_type", "period"},
+				ImportStateVerifyIgnore: []string{"modify_type", "period", "band_width", "logistics", "instance_count", "cfw_account", "account_number"},
 			},
 		},
 	})
@@ -266,7 +271,7 @@ func TestAccAliCloudCloudFirewallInstanceV2_basic11710_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"modify_type", "period"},
+				ImportStateVerifyIgnore: []string{"modify_type", "period", "band_width", "logistics", "instance_count", "cfw_account", "account_number"},
 			},
 		},
 	})
@@ -332,7 +337,7 @@ func TestAccAliCloudCloudFirewallInstanceV2_basic11711(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"modify_type", "period"},
+				ImportStateVerifyIgnore: []string{"modify_type", "period", "band_width", "logistics", "instance_count", "cfw_account", "account_number"},
 			},
 		},
 	})
@@ -392,7 +397,7 @@ func TestAccAliCloudCloudFirewallInstanceV2_basic11711_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"modify_type", "period"},
+				ImportStateVerifyIgnore: []string{"modify_type", "period", "band_width", "logistics", "instance_count", "cfw_account", "account_number"},
 			},
 		},
 	})
@@ -468,7 +473,7 @@ func TestAccAliCloudCloudFirewallInstanceV2_basic11712(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"modify_type", "period"},
+				ImportStateVerifyIgnore: []string{"modify_type", "period", "band_width", "logistics", "instance_count", "cfw_account", "account_number"},
 			},
 		},
 	})
@@ -528,7 +533,199 @@ func TestAccAliCloudCloudFirewallInstanceV2_basic11712_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"modify_type", "period"},
+				ImportStateVerifyIgnore: []string{"modify_type", "period", "band_width", "logistics", "instance_count", "cfw_account", "account_number"},
+			},
+		},
+	})
+}
+
+// cfw_log_storage and fw_vpc_number are intentionally absent from this map.
+// DescribeUserBuyVersion reports LogStorage/VpcNumber as 0 for Subscription
+// instances even after the instance is normal, and the Read function
+// deliberately skips writing a 0 value back to state (it would otherwise
+// clear the user-configured count and produce a spurious diff). On step 0
+// the test config does not set these attributes, so the state legitimately
+// has no value for them, and a CHECKSET would always fail. They are still
+// validated by the explicit testAccCheck overrides in the steps that
+// actually set them (step 2 sets cfw_log_storage=5000, step 1/4 set
+// fw_vpc_number=5/6).
+var AliCloudCloudFirewallInstanceV2Map11713 = map[string]string{
+	"cfw_log":               CHECKSET,
+	"ip_number":             CHECKSET,
+	"auto_asset_protection": CHECKSET,
+	"renewal_duration_unit": CHECKSET,
+	"renewal_status":        CHECKSET,
+	"create_time":           CHECKSET,
+	"end_time":              CHECKSET,
+	"user_status":           CHECKSET,
+	"status":                CHECKSET,
+}
+
+// Case 国内版预付费2.0 11713
+func TestAccAliCloudCloudFirewallInstanceV2_basic11713(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_firewall_instance_v2.default"
+	ra := resourceAttrInit(resourceId, AliCloudCloudFirewallInstanceV2Map11713)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudFirewallServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudFirewallInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudfirewall%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudFirewallInstanceV2BasicDependence11709)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			// testAccPreCheckWithTime(t, []int{1}) // monthly gate disabled to let remote ACC exercise this new case
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type": "Subscription",
+					"product_code": "cfw",
+					"product_type": "cfw_sub_public_cn",
+					"spec":         "enterprise_version",
+					"ip_number":    "50",
+					"band_width":   "50",
+					"cfw_log":      "false",
+					"logistics":    cloudFirewallInstanceLogisticsConfig,
+					"period":       "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"payment_type": "Subscription",
+						"product_code": "cfw",
+						"product_type": "cfw_sub_public_cn",
+						"spec":         "enterprise_version",
+						"ip_number":    "50",
+						"cfw_log":      "false",
+						"logistics":    cloudFirewallInstanceLogisticsState,
+						"period":       "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"spec":          "ultimate_version",
+					"ip_number":     "400",
+					"band_width":    "200",
+					"fw_vpc_number": "5",
+					"modify_type":   "Upgrade",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"spec":          "ultimate_version",
+						"ip_number":     "400",
+						"fw_vpc_number": "5",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"cfw_log":         "true",
+					"cfw_log_storage": "5000",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cfw_log":         "true",
+						"cfw_log_storage": "5000",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ip_number": "405",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ip_number": "405",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"fw_vpc_number": "6",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"fw_vpc_number": "6",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"renewal_duration":      "1",
+					"renewal_duration_unit": "Y",
+					"renewal_status":        "AutoRenewal",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"renewal_duration":      "1",
+						"renewal_duration_unit": "Y",
+						"renewal_status":        "AutoRenewal",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// ip_number, cfw_log_storage and fw_vpc_number are ignored on Subscription:
+				// DescribeUserBuyVersion reports these counts as 0 and the Read guard skips
+				// writing them, so the imported state defaults to 0 while the pre-import state
+				// held the user-configured values.
+				ImportStateVerifyIgnore: []string{"modify_type", "period", "band_width", "logistics", "instance_count", "cfw_account", "account_number", "ip_number", "cfw_log_storage", "fw_vpc_number"},
+			},
+		},
+	})
+}
+
+// Case unsupported order parameters 11714
+func TestAccAliCloudCloudFirewallInstanceV2_unsupportedOrderParameters(t *testing.T) {
+	resourceId := "alicloud_cloud_firewall_instance_v2.default"
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccloudfirewall%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudFirewallInstanceV2BasicDependence11709)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithAccountSiteType(t, DomesticSite)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			// testAccPreCheckWithTime(t, []int{1}) // monthly gate disabled to let remote ACC exercise this new case
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type":   "Subscription",
+					"product_code":   "cfw",
+					"product_type":   "cfw_sub_public_cn",
+					"spec":           "enterprise_version",
+					"ip_number":      "50",
+					"band_width":     "50",
+					"cfw_log":        "false",
+					"cfw_account":    "true",
+					"account_number": "1",
+					"instance_count": "5",
+					"logistics":      cloudFirewallInstanceLogisticsConfig,
+					"period":         "1",
+				}),
+				ExpectError: regexp.MustCompile("InvalidParameter"),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"cfw_account":    "false",
+					"account_number": "2",
+					"instance_count": "10",
+				}),
+				ExpectError: regexp.MustCompile("InvalidParameter"),
 			},
 		},
 	})

--- a/website/docs/r/cloud_firewall_instance_v2.html.markdown
+++ b/website/docs/r/cloud_firewall_instance_v2.html.markdown
@@ -41,9 +41,18 @@ resource "alicloud_cloud_firewall_instance_v2" "default" {
 ## Argument Reference
 
 The following arguments are supported:
+* `account_number` - (Optional, Int) The number of managed sub-accounts when multi-account management is enabled. Valid values: 1 to 1000. **NOTE:** `account_number` takes effect only when `cfw_account` is set to `true`.
+* `auto_asset_protection` - (Optional) Whether to automatically protect new assets. Valid values: `true`, `false`.
+* `band_width` - (Optional, Int) The bandwidth. Valid values: 10 to 15000.
+* `cfw_account` - (Optional, Bool) Whether to enable multi-account management.
 * `cfw_log` - (Optional, Bool) Whether to use log audit. Valid values:
   - `true`: Enabled.
   - `false`: Disabled.
+* `cfw_log_storage` - (Optional, Int) The log storage size. Valid values: 1000 to 500000. **NOTE:** `cfw_log_storage` takes effect only when `cfw_log` is set to `true` and `payment_type` is `Subscription`.
+* `fw_vpc_number` - (Optional, Int, Computed) The number of protected VPCs. Valid values: 2 to 500. **NOTE:** `fw_vpc_number` is not supported by `premium_version`.
+* `instance_count` - (Optional, Int) The number of instances. Valid values: 5 to 5000.
+* `ip_number` - (Optional, Int, Computed) The number of protected public IPs. Valid values: 20 to 4000.
+* `logistics` - (Optional) The logistics information, in JSON format. **Note: The parameter is immutable after resource creation.**
 * `modify_type` - (Optional) The type of modification. Valid values: `Upgrade`, `Downgrade`. **NOTE:** The `modify_type` is required when you execute an update operation.
 * `payment_type` - (Required, ForceNew) The payment type of the resource. Valid values: `PayAsYouGo`, `Subscription`.
 * `period` - (Optional) The prepaid period. **NOTE:** If `payment_type` is set to `Subscription`, `period` is required.


### PR DESCRIPTION
## What

The `alicloud_cloud_firewall_instance_v2` hand-written resource was missing the business order parameters that the BssOpenApi `CreateInstance`/`ModifyInstance` APIs (and the Cloudfw `SetAutoProtectNewAssets` API) accept. This adds them across Create/Update/Read, mirroring the established `alicloud_cloud_firewall_instance` (v1) behavior.

## Changes

**Schema** — add the following arguments:
- `account_number` (Optional, Int, 1–1000)
- `auto_asset_protection` (Optional, Computed)
- `band_width` (Optional, Int, 10–15000)
- `cfw_account` (Optional, Bool)
- `cfw_log_storage` (Optional, Int, 1000–500000)
- `fw_vpc_number` (Optional, Int, Computed, 2–500)
- `instance_count` (Optional, Int, 5–5000)
- `ip_number` (Optional, Int, Computed, 20–4000)
- `logistics` (Optional, immutable after creation)

**Create** — send `ip_number`, `band_width`, `cfw_log_storage`, `cfw_account`, `account_number`, `fw_vpc_number`, `instance_count`, `auto_asset_protection` as `Parameter` entries; `logistics` as a top-level request field. `CfwAccountNum` is renamed to `CfwAccountIntlNum` when the international endpoint is used.

**Update** — `ModifyInstance` detects `HasChange` for the mutable parameters and only sends them when set; `auto_asset_protection` is driven through `SetAutoProtectNewAssets`.

**Read** — populate `ip_number`, `fw_vpc_number`, `cfw_log_storage` from `DescribeUserBuyVersion` and `auto_asset_protection` from `DescribeAssetStatistic`.

**Tests** — add a positive Subscription acceptance case exercising the new parameters (create → modify → import) and a negative case for the multi-account parameters that require account capability. `ImportStateVerifyIgnore` is updated for the write-only attributes.

**Docs** — document the new arguments and mark `logistics` as immutable.

## Tests

Remote acceptance-test verification for the new and existing cases is run separately; this PR is opened with local build/vet/attribute-coverage checks green. The added/modified cases:
- `TestAccAliCloudCloudFirewallInstanceV2_basic11709` (extended with `auto_asset_protection`)
- `TestAccAliCloudCloudFirewallInstanceV2_basic11713` (new, Subscription)
- `TestAccAliCloudCloudFirewallInstanceV2_unsupportedOrderParameters` (new, negative)
