### PR TITLE
resource/alicloud_instance: support replacing the instance when image_id changes

### DIFF
--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -74,6 +74,7 @@ import (
 	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
 	otsTunnel "github.com/aliyun/aliyun-tablestore-go-sdk/tunnel"
 	"github.com/aliyun/fc-go-sdk"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/features"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awscredentials "github.com/aws/aws-sdk-go-v2/credentials"
 	awsdynamodb "github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -159,6 +160,8 @@ type AliyunClient struct {
 	cmsConn                      *cms.Client
 	r_kvstoreConn                *r_kvstore.Client
 	maxcomputeConn               *maxcompute.Client
+
+	Features features.Features
 }
 
 type ApiVersion string
@@ -267,6 +270,7 @@ func (c *Config) Client() (*AliyunClient, error) {
 		otsTunnelConnByInstanceName:  make(map[string]otsTunnel.TunnelClient),
 		csprojectconnByKey:           make(map[string]*cs.ProjectClient),
 		skipRegionValidation:         c.SkipRegionValidation,
+		Features:                     c.Features,
 	}
 	if c.AccountType == "" {
 		c.AccountType = client.getAccountType()

--- a/alicloud/connectivity/config.go
+++ b/alicloud/connectivity/config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
 	credential "github.com/aliyun/credentials-go/credentials"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/features"
 )
 
 var securityCredURL = "http://100.100.100.200/latest/meta-data/ram/security-credentials/"
@@ -190,6 +191,9 @@ type Config struct {
 	OceanbaseEndpoint           string
 	BeebotEndpoint              string
 	ComputeNestEndpoint         string
+
+	// Features carries the provider's behaviour toggles. See the features package.
+	Features features.Features
 }
 
 type AssumeRoleWithOidc struct {

--- a/alicloud/features/features.go
+++ b/alicloud/features/features.go
@@ -1,0 +1,26 @@
+// Package features holds the provider arguments that change how a resource behaves, as opposed to
+// which account, region or endpoint the provider talks to. It is a leaf package: it imports
+// nothing, so a resource can read a toggle without pulling in connectivity.
+package features
+
+// Features mirrors the provider's features block.
+type Features struct {
+	EcsInstance EcsInstance
+}
+
+// EcsInstance holds the toggles of the features.ecs_instance block.
+type EcsInstance struct {
+	// ReplaceOnImageUpdate makes an image_id change plan as a replacement of the instance instead of
+	// an in-place replacement of its system disk.
+	ReplaceOnImageUpdate bool
+}
+
+// Default returns the behaviour of a provider that configures no features block at all. Defaults
+// live here as well as in the schema because an absent nested block contributes no schema default.
+func Default() Features {
+	return Features{
+		EcsInstance: EcsInstance{
+			ReplaceOnImageUpdate: false,
+		},
+	}
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aliyun/credentials-go/credentials"
 	"github.com/aliyun/credentials-go/credentials/providers"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/features"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/helper"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -112,6 +113,7 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("ALICLOUD_SKIP_REGION_VALIDATION", false),
 				Description: descriptions["skip_region_validation"],
 			},
+			"features": featuresSchema(),
 			"configuration_source": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -2229,6 +2231,7 @@ func providerConfigure(d *schema.ResourceData, p *schema.Provider) (interface{},
 		TerraformTraceId:     strings.Trim(uuid.New().String(), "-"),
 		TerraformVersion:     p.TerraformVersion,
 	}
+	config.Features = expandFeatures(d.Get("features").([]interface{}))
 	if credential != nil {
 		config.Credential = credential
 	}
@@ -2565,6 +2568,8 @@ func init() {
 		"assume_role_session_expiration": "The time after which the established session for assuming role expires. Valid value range: [900-3600] seconds. Default to 0 (in this case Alicloud use own default value).",
 
 		"skip_region_validation": "Skip static validation of region ID. Used by users of alternative AlibabaCloud-like APIs or users w/ access to regions that are not public (yet). It can also be sourced from the `ALICLOUD_SKIP_REGION_VALIDATION` environment variable.",
+
+		"features": "Customize the behaviour of certain resources. Every toggle it holds is optional, and leaving the block out keeps the provider's default behaviour.",
 
 		"configuration_source": "Use this to mark a terraform configuration file source.",
 
@@ -2956,6 +2961,55 @@ func signVersionSchema() *schema.Schema {
 			},
 		},
 	}
+}
+
+// featuresSchema returns the provider's features block. Grouping the behaviour toggles keeps the
+// next one from becoming another top level provider argument, at the cost of an environment
+// variable: a DefaultFunc on a nested field only runs when its block is present.
+func featuresSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"ecs_instance": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"replace_on_image_update": {
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Default:     false,
+								Description: "Whether a change to `image_id` on an `alicloud_instance` is planned as a replacement of the instance instead of an in-place replacement of its system disk.",
+							},
+						},
+					},
+					Description: "The behaviour toggles of the `alicloud_instance` resource.",
+				},
+			},
+		},
+		Description: descriptions["features"],
+	}
+}
+
+// expandFeatures reads the features block into the struct the client carries, starting from the
+// defaults because every level of the block is optional.
+func expandFeatures(featuresList []interface{}) features.Features {
+	expanded := features.Default()
+	if len(featuresList) == 0 || featuresList[0] == nil {
+		return expanded
+	}
+	featuresMap := featuresList[0].(map[string]interface{})
+	if ecsInstanceList, ok := featuresMap["ecs_instance"].([]interface{}); ok && len(ecsInstanceList) > 0 && ecsInstanceList[0] != nil {
+		ecsInstance := ecsInstanceList[0].(map[string]interface{})
+		if v, ok := ecsInstance["replace_on_image_update"].(bool); ok {
+			expanded.EcsInstance.ReplaceOnImageUpdate = v
+		}
+	}
+	return expanded
 }
 
 func endpointsSchema() *schema.Schema {

--- a/alicloud/provider_test.go
+++ b/alicloud/provider_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/aliyun/fc-go-sdk"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/features"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -71,6 +72,61 @@ func TestProviderSkipRegionValidation(t *testing.T) {
 			d := schema.TestResourceDataRaw(t, Provider().(*schema.Provider).Schema, testCase.raw)
 			if got := d.Get("skip_region_validation").(bool); got != testCase.expected {
 				t.Fatalf("skip_region_validation: expected %v, got %v", testCase.expected, got)
+			}
+		})
+	}
+}
+
+// TestProviderFeatures covers expandFeatures over the shapes the features block can take: every
+// level of it is optional, so a missing block or field has to fall back to features.Default.
+func TestProviderFeatures(t *testing.T) {
+	testCases := []struct {
+		name     string
+		features []interface{}
+		expected features.Features
+	}{
+		{
+			name:     "no features block at all",
+			features: []interface{}{},
+			expected: features.Default(),
+		},
+		{
+			name:     "a features block that is null",
+			features: []interface{}{nil},
+			expected: features.Default(),
+		},
+		{
+			name:     "a features block without the ecs_instance block",
+			features: []interface{}{map[string]interface{}{}},
+			expected: features.Default(),
+		},
+		{
+			name:     "an empty ecs_instance block",
+			features: []interface{}{map[string]interface{}{"ecs_instance": []interface{}{}}},
+			expected: features.Default(),
+		},
+		{
+			name: "replace_on_image_update enabled",
+			features: []interface{}{map[string]interface{}{
+				"ecs_instance": []interface{}{map[string]interface{}{"replace_on_image_update": true}},
+			}},
+			expected: features.Features{
+				EcsInstance: features.EcsInstance{ReplaceOnImageUpdate: true},
+			},
+		},
+		{
+			name: "replace_on_image_update disabled explicitly",
+			features: []interface{}{map[string]interface{}{
+				"ecs_instance": []interface{}{map[string]interface{}{"replace_on_image_update": false}},
+			}},
+			expected: features.Default(),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := expandFeatures(testCase.features); got != testCase.expected {
+				t.Fatalf("expandFeatures: expected %+v, got %+v", testCase.expected, got)
 			}
 		})
 	}

--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -31,6 +31,7 @@ func resourceAliCloudInstance() *schema.Resource {
 			Update: schema.DefaultTimeout(10 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
+		CustomizeDiff: resourceAliCloudInstanceCustomizeDiff,
 		Schema: map[string]*schema.Schema{
 			"availability_zone": {
 				Type:     schema.TypeString,
@@ -2684,6 +2685,36 @@ func resourceAliCloudInstanceDelete(d *schema.ResourceData, meta interface{}) er
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
 	return nil
+}
+
+// resourceAliCloudInstanceCustomizeDiff turns an image_id change into a replacement when the
+// provider is configured with features.ecs_instance.replace_on_image_update. Without it, such a
+// change is applied in place by modifyInstanceImage, which the plan can only describe as an update.
+func resourceAliCloudInstanceCustomizeDiff(diff *schema.ResourceDiff, meta interface{}) error {
+	client, ok := meta.(*connectivity.AliyunClient)
+	if !ok || client == nil || !client.Features.EcsInstance.ReplaceOnImageUpdate {
+		return nil
+	}
+	// Nothing to force on create. This also terminates the second, state-less diff pass that
+	// ForceNew triggers, where Id() is empty and RequiresNew has already been carried over.
+	if diff.Id() == "" {
+		return nil
+	}
+	// ForceNew reports an error when the key it is given is not changing. A new image_id that is only
+	// known at apply time cannot be compared either, so it is left to the in place path: a plan
+	// cannot report a replacement for a value it does not have yet.
+	if !diff.HasChange("image_id") || !diff.NewValueKnown("image_id") {
+		return nil
+	}
+	oldRaw, newRaw := diff.GetChange("image_id")
+	oldImageId, _ := oldRaw.(string)
+	newImageId, _ := newRaw.(string)
+	// image_id is Optional+Computed, so an empty side is a value the API filled in - for an instance
+	// created from a launch template, for example - rather than user intent.
+	if oldImageId == "" || newImageId == "" || oldImageId == newImageId {
+		return nil
+	}
+	return diff.ForceNew("image_id")
 }
 
 func modifyInstanceChargeType(d *schema.ResourceData, meta interface{}, forceDelete bool) error {

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/features"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func init() {
@@ -4788,6 +4790,307 @@ func AliCloudEcsInstancePrivatePool(name string) string {
   		vpc_id = alicloud_vpc.vpc.id
 	}
 `, name)
+}
+
+// TestAccAliCloudECSInstanceImageUpdateReplace covers
+// features.ecs_instance.replace_on_image_update enabled: an image_id change replaces the instance.
+func TestAccAliCloudECSInstanceImageUpdateReplace(t *testing.T) {
+	var v ecs.Instance
+	resourceId := "alicloud_instance.default"
+	ra := resourceAttrInit(resourceId, testAccInstanceImageUpdateCheckMap)
+	serviceFunc := func() interface{} {
+		return &EcsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAccEcsInstanceImageUpdateReplace%d", acctest.RandIntRange(1000, 9999))
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, func(name string) string {
+		return resourceInstanceImageUpdateDependence(name, true)
+	})
+	recordInstanceId, _, assertInstanceReplaced := instanceIdTracker(resourceId)
+	// The only test that lets the replacement path run, so the only one that has to clean up after it.
+	defer restoreInstanceImageIdForceNew()()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"image_id":             "${data.alicloud_images.default.images.0.id}",
+					"security_groups":      []string{"${alicloud_security_group.default.id}"},
+					"instance_type":        "${data.alicloud_instance_types.default.instance_types.0.id}",
+					"availability_zone":    "${data.alicloud_instance_types.default.instance_types.0.availability_zones.0}",
+					"system_disk_category": "cloud_essd",
+					"system_disk_size":     "40",
+					"instance_name":        "${var.name}",
+					"vswitch_id":           "${alicloud_vswitch.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_name": name,
+					}),
+					recordInstanceId,
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"image_id": "${data.alicloud_images.default.images.1.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(nil),
+					assertInstanceReplaced,
+				),
+			},
+		},
+	})
+}
+
+// TestAccAliCloudECSInstanceImageUpdateInPlace guards the default: with the toggle unset, an
+// image_id change still goes through ReplaceSystemDisk and the instance survives.
+func TestAccAliCloudECSInstanceImageUpdateInPlace(t *testing.T) {
+	var v ecs.Instance
+	resourceId := "alicloud_instance.default"
+	ra := resourceAttrInit(resourceId, testAccInstanceImageUpdateCheckMap)
+	serviceFunc := func() interface{} {
+		return &EcsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAccEcsInstanceImageUpdateInPlace%d", acctest.RandIntRange(1000, 9999))
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, func(name string) string {
+		return resourceInstanceImageUpdateDependence(name, false)
+	})
+	recordInstanceId, assertInstanceKept, _ := instanceIdTracker(resourceId)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"image_id":             "${data.alicloud_images.default.images.0.id}",
+					"security_groups":      []string{"${alicloud_security_group.default.id}"},
+					"instance_type":        "${data.alicloud_instance_types.default.instance_types.0.id}",
+					"availability_zone":    "${data.alicloud_instance_types.default.instance_types.0.availability_zones.0}",
+					"system_disk_category": "cloud_essd",
+					"system_disk_size":     "40",
+					"instance_name":        "${var.name}",
+					"vswitch_id":           "${alicloud_vswitch.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_name": name,
+					}),
+					recordInstanceId,
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"image_id": "${data.alicloud_images.default.images.1.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(nil),
+					assertInstanceKept,
+				),
+			},
+		},
+	})
+}
+
+// restoreInstanceImageIdForceNew restores the ForceNew flag of the shared alicloud_instance
+// image_id schema, which ResourceDiff.ForceNew sets and nothing unsets. Without it every later
+// alicloud_instance test in the same binary would plan an image_id change as a replacement too.
+func restoreInstanceImageIdForceNew() func() {
+	imageIdSchema := testAccProvider.ResourcesMap["alicloud_instance"].Schema["image_id"]
+	forceNew := imageIdSchema.ForceNew
+	return func() {
+		imageIdSchema.ForceNew = forceNew
+	}
+}
+
+// instanceIdTracker returns a check that records the instance id of resourceId, plus two checks
+// asserting that a later step kept or replaced it. The id is the evidence of what the plan decided:
+// ReplaceSystemDisk keeps it, a destroy and create hands out a new one.
+func instanceIdTracker(resourceId string) (record, assertKept, assertReplaced resource.TestCheckFunc) {
+	instanceId := ""
+	readId := func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceId]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceId)
+		}
+		return rs.Primary.ID, nil
+	}
+	record = func(s *terraform.State) error {
+		id, err := readId(s)
+		if err != nil {
+			return err
+		}
+		instanceId = id
+		return nil
+	}
+	assertKept = func(s *terraform.State) error {
+		id, err := readId(s)
+		if err != nil {
+			return err
+		}
+		if id != instanceId {
+			return fmt.Errorf("the instance was replaced, but with features.ecs_instance.replace_on_image_update disabled an image_id change should have replaced its system disk in place")
+		}
+		return nil
+	}
+	assertReplaced = func(s *terraform.State) error {
+		id, err := readId(s)
+		if err != nil {
+			return err
+		}
+		if id == instanceId {
+			return fmt.Errorf("the instance was updated in place, but with features.ecs_instance.replace_on_image_update enabled an image_id change should have replaced it")
+		}
+		return nil
+	}
+	return record, assertKept, assertReplaced
+}
+
+// resourceInstanceImageUpdateDependence sets the toggle in a provider block, the only place it can
+// be set. Credentials keep coming from the provider's own DefaultFuncs.
+func resourceInstanceImageUpdateDependence(name string, replaceOnImageUpdate bool) string {
+	return fmt.Sprintf(`
+provider "alicloud" {
+  features {
+    ecs_instance {
+      replace_on_image_update = %t
+    }
+  }
+}
+
+variable "name" {
+  default = "%s"
+}
+
+# Two images out of one query. The regex has to exclude the GPU driver and 100G variants: as the
+# second image, one of those is rejected by the instance type and outgrows the system disk.
+data "alicloud_images" "default" {
+  name_regex = "^ubuntu_2[0-9]_[0-9]+_x64_20G_alibase"
+  owners     = "system"
+}
+
+# Filtered by disk category on purpose: filtering by image alone hands back a first generation type,
+# and only the modern categories can restore the natively encrypted snapshot behind a Ubuntu image.
+data "alicloud_instance_types" "default" {
+  image_id             = data.alicloud_images.default.images.0.id
+  system_disk_category = "cloud_essd"
+  cpu_core_count       = 2
+  memory_size          = 4
+}
+
+resource "alicloud_vpc" "default" {
+  cidr_block = "192.168.0.0/16"
+  vpc_name   = var.name
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id       = alicloud_vpc.default.id
+  cidr_block   = cidrsubnet(alicloud_vpc.default.cidr_block, 8, 2)
+  zone_id      = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
+  vswitch_name = var.name
+}
+
+resource "alicloud_security_group" "default" {
+  security_group_name = var.name
+  vpc_id              = alicloud_vpc.default.id
+}
+`, replaceOnImageUpdate, name)
+}
+
+// testAccInstanceImageUpdateCheckMap leaves image_id to the instance id checks: both positions of
+// the toggle leave the same image_id in state.
+var testAccInstanceImageUpdateCheckMap = map[string]string{
+	"image_id":             CHECKSET,
+	"instance_type":        CHECKSET,
+	"availability_zone":    CHECKSET,
+	"security_groups.#":    "1",
+	"system_disk_category": "cloud_essd",
+	"system_disk_size":     "40",
+	"vswitch_id":           CHECKSET,
+	"status":               "Running",
+}
+
+// TestUnitAliCloudInstanceImageUpdateForcesNew exercises the diff decision without the API.
+func TestUnitAliCloudInstanceImageUpdateForcesNew(t *testing.T) {
+	testCases := []struct {
+		name            string
+		replaceEnabled  bool
+		stateImageId    string
+		configImageId   string
+		wantRequiresNew bool
+	}{
+		{
+			name:            "enabled forces a replacement",
+			replaceEnabled:  true,
+			stateImageId:    "image-before",
+			configImageId:   "image-after",
+			wantRequiresNew: true,
+		},
+		{
+			name:            "disabled keeps the update in place",
+			replaceEnabled:  false,
+			stateImageId:    "image-before",
+			configImageId:   "image-after",
+			wantRequiresNew: false,
+		},
+		{
+			// An instance created from a launch template has no image_id of its own, so there is no
+			// user chosen image being replaced.
+			name:            "an image_id that was empty in state is left alone",
+			replaceEnabled:  true,
+			stateImageId:    "",
+			configImageId:   "image-after",
+			wantRequiresNew: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// A fresh resource per case: ForceNew is recorded on the schema, so cases would
+			// otherwise leak into each other through a shared schema map.
+			instanceResource := resourceAliCloudInstance()
+			state := &terraform.InstanceState{
+				ID:         "i-unit-test",
+				Attributes: map[string]string{"image_id": testCase.stateImageId},
+			}
+			config := terraform.NewResourceConfigRaw(map[string]interface{}{
+				"image_id": testCase.configImageId,
+			})
+			client := &connectivity.AliyunClient{
+				Features: features.Features{
+					EcsInstance: features.EcsInstance{ReplaceOnImageUpdate: testCase.replaceEnabled},
+				},
+			}
+
+			diff, err := instanceResource.Diff(state, config, client)
+			if err != nil {
+				t.Fatalf("diff: %s", err)
+			}
+			attribute, ok := diff.Attributes["image_id"]
+			if !ok {
+				t.Fatalf("expected image_id to be part of the diff, got %#v", diff.Attributes)
+			}
+			if attribute.RequiresNew != testCase.wantRequiresNew {
+				t.Fatalf("image_id RequiresNew = %t, want %t", attribute.RequiresNew, testCase.wantRequiresNew)
+			}
+		})
+	}
 }
 
 var tags0 = map[string]string{

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -129,9 +129,11 @@ You can provide your credentials via `ALIBABA_CLOUD_ACCESS_KEY_ID`, `ALIBABA_CLO
 `ALIBABA_CLOUD_SECURITY_TOKEN` environment variables. The Region can be set using the `ALIBABA_CLOUD_REGION` environment variables.
 
 Usage:
+
 ```terraform
 provider "alicloud" {}
 ```
+
 ```shell
 $ export ALIBABA_CLOUD_ACCESS_KEY_ID="<Your-Access-Key-ID>"
 $ export ALIBABA_CLOUD_ACCESS_KEY_SECRET="<Your-Access-Key-Secret>"
@@ -295,12 +297,12 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 (e.g. `alias` and `version`), the following arguments are supported in the Alibaba Cloud
  `provider` block:
 
-* `access_key` - Alibaba Cloud access key. It is required for the provider. 
+* `access_key` - Alibaba Cloud access key. It is required for the provider.
   Can also be set with the `ALIBABA_CLOUD_ACCESS_KEY_ID` environment variable since v1.228.0, 
   or via a shared credentials file if profile is specified. See also `secret_key`. 
   Environment variable `ALICLOUD_ACCESS_KEY` and `ALIBABACLOUD_ACCESS_KEY_ID` have been deprecated since v1.228.0.
 
-* `secret_key` - Alibaba Cloud secret key. It is required for the provider. 
+* `secret_key` - Alibaba Cloud secret key. It is required for the provider.
   Can also be set with the `ALIBABA_CLOUD_ACCESS_KEY_SECRET` environment variable since v1.228.0,
   or via a shared credentials file if profile is specified. See also `access_key`.
   Environment variable `ALICLOUD_SECRET_KEY` and `ALIBABACLOUD_ACCESS_KEY_SECRET` have been deprecated since v1.228.0.
@@ -314,7 +316,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   Can also be set with the `ALIBABA_CLOUD_ECS_METADATA` environment variable since v1.228.0.
   Environment variable `ALICLOUD_ECS_ROLE_NAME` has been deprecated since v1.228.0.
 
-* `region` - Alibaba Cloud region. Default to `cn-beijing`. 
+* `region` - Alibaba Cloud region. Default to `cn-beijing`.
   Can also be set with the `ALIBABA_CLOUD_REGION` environment variable since v1.228.0.
   Environment variable `ALICLOUD_REGION` has been deprecated since v1.228.0.
 
@@ -323,7 +325,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   Can also be set with the `ALIBABA_CLOUD_ACCOUNT_ID` environment variable since v1.228.0.
   Environment variable `ALICLOUD_ACCOUNT_ID` has been deprecated since v1.228.0.
 
-* `account_type` - (Optional, Available since v1.240.0) Alibaba Cloud [Account Type](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/guides/getting-account). 
+* `account_type` - (Optional, Available since v1.240.0) Alibaba Cloud [Account Type](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/guides/getting-account).
   It used to indicate caller identity's account type. Can also be set with the `ALIBABA_CLOUD_ACCOUNT_TYPE` environment variable. Valid values:
   - `Domestic`(Default): China-Site Account.
   - `International`: International-Site Account.
@@ -337,11 +339,11 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
   Can also be set with the `ALIBABA_CLOUD_PROFILE` environment variable since v1.228.0.
   Environment variable `ALICLOUD_PROFILE` has been deprecated since v1.228.0.
 
-* `assume_role` - (Optional) An [`assume_role` Configuration Block](#assume_role-configuration-block) block. Only one `assume_role` block may be in the configuration.
+* `assume_role` - (Optional) An [`assume_role`](#assume_role) block. Only one `assume_role` block may be in the configuration.
 
-* `assume_role_with_oidc` - (Optional, Available since v1.220.0) Configuration block for assuming an RAM role using an OIDC. See the [`assume_role_with_oidc` Configuration Block](#assume_role_with_oidc-configuration-block) section below. Only one `assume_role_with_oidc` block may be in the configuration.
+* `assume_role_with_oidc` - (Optional, Available since v1.220.0) Configuration block for assuming an RAM role using an OIDC. See the [`assume_role_with_oidc`](#assume_role_with_oidc) section below. Only one `assume_role_with_oidc` block may be in the configuration.
 
-* `credentials_uri` - (Optional, Available since v1.141.0) The URI of sidecar credentials service. 
+* `credentials_uri` - (Optional, Available since v1.141.0) The URI of sidecar credentials service.
   Can also be set with the `ALIBABA_CLOUD_CREDENTIALS_URI` environment variable since v1.228.0.
   Environment variable `ALICLOUD_CREDENTIALS_URI` has been deprecated since v1.228.0.
 
@@ -352,10 +354,12 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 * `skip_region_validation` - (Optional, Available since v1.52.0) Skip static validation of region ID. Used by users of alternative AlibabaCloud-like APIs or users w/ access to regions that are not public (yet).
   Can also be set with the `ALICLOUD_SKIP_REGION_VALIDATION` environment variable since v1.287.0.
 
+* `features` - (Optional, Available since v1.289.0) A [`features`](#features) block that changes how certain resources behave. Only one `features` block may be in the configuration.
+
 * `configuration_source` - (Optional, Available since v1.56.0) Use a string to mark a configuration file source, like `terraform-alicloud-modules/terraform-alicloud-ecs-instance` or `terraform-provider-alicloud/examples/vpc`.
 The length should not more than 1024(Before 1.283.0, it should not more than 128. Before 1.207.2, it should not more than 64). Since the version 1.145.0, it supports to be set by environment variable `TF_APPEND_USER_AGENT`. See `Custom User-Agent Information`.
 
-* `protocol` - (Optional, Available since v1.72.0) The Protocol of used by API request. Valid values: `HTTP` and `HTTPS`. Default to `HTTPS`. 
+* `protocol` - (Optional, Available since v1.72.0) The Protocol of used by API request. Valid values: `HTTP` and `HTTPS`. Default to `HTTPS`.
 
 * `client_read_timeout` - (Optional, Available since v1.125.0) The maximum timeout in millisecond second of the client read request. Default to 60000.
 
@@ -363,9 +367,9 @@ The length should not more than 1024(Before 1.283.0, it should not more than 128
 
 * `max_retry_timeout` - (Optional, Available since v1.183.0) The maximum retry timeout in second of the request. Default to `0`.
 
-### `assume_role` Configuration Block
+### `assume_role`
 
-* `role_arn` - (Required) The ARN of the role to assume. If ARN is set to an empty string, it does not perform role switching. 
+* `role_arn` - (Required) The ARN of the role to assume. If ARN is set to an empty string, it does not perform role switching.
   Can also be set with the `ALIBABA_CLOUD_ROLE_ARN` environment variable since v1.228.0.
   Environment variable `ALICLOUD_ASSUME_ROLE_ARN` has been deprecated since v1.228.0.
   Terraform executes configuration on account with provided credentials.
@@ -373,17 +377,17 @@ The length should not more than 1024(Before 1.283.0, it should not more than 128
 * `policy` - (Optional) A more restrictive policy to apply to the temporary credentials. This gives you a way to further restrict the permissions for the resulting temporary
   security credentials. You cannot use the passed policy to grant permissions that are in excess of those allowed by the access policy of the role that is being assumed.
 
-* `session_name` - (Optional) The session name to use when assuming the role. If omitted, 'terraform' is passed to the AssumeRole call as session name. 
+* `session_name` - (Optional) The session name to use when assuming the role. If omitted, 'terraform' is passed to the AssumeRole call as session name.
   Can also be set with the `ALIBABA_CLOUD_ROLE_SESSION_NAME` environment variable since v1.228.0.
   Environment variable `ALICLOUD_ASSUME_ROLE_SESSION_NAME` has been deprecated since v1.228.0.
 
 * `session_expiration` - (Optional) The time after which the established session for assuming role expires. Valid value range: [900-43200] seconds. Default to 3600 (in this case Alicloud use own default value). It supports environment variable `ALICLOUD_ASSUME_ROLE_SESSION_EXPIRATION`.
 
-* `external_id` - (Optional, Available since v1.207.1) The external ID of the RAM role. 
+* `external_id` - (Optional, Available since v1.207.1) The external ID of the RAM role.
   This parameter is provided by an external party and is used to prevent the confused deputy problem. 
   The value must be 2 to 1,224 characters in length and can contain letters, digits, and the following special characters:`= , . @ : / - _`.
 
-### `assume_role_with_oidc` Configuration Block
+### `assume_role_with_oidc`
 
 The `assume_role_with_oidc` configuration block supports the following arguments:
 
@@ -393,20 +397,50 @@ The `assume_role_with_oidc` configuration block supports the following arguments
   Can also be set with the `ALIBABA_CLOUD_OIDC_TOKEN` environment variable.
 * `oidc_token_file` - (Optional) File containing a RRSA security token from an OIDC. One of `oidc_token_file` or `oidc_token` is required.
   Can also be set with the `ALIBABA_CLOUD_OIDC_TOKEN_FILE` environment variable.
-* `role_session_name` - (Optional) The session name to use when assuming the role. If omitted, 'terraform' is passed to the AssumeRoleWithOIDC call as session name. 
+* `role_session_name` - (Optional) The session name to use when assuming the role. If omitted, 'terraform' is passed to the AssumeRoleWithOIDC call as session name.
   Can also be set with the `ALIBABA_CLOUD_ROLE_SESSION_NAME` environment variable.
 * `session_expiration` - (Optional) The validity period of the STS token. Unit: seconds. Default value: 3600. Minimum value: 900. Maximum value: the value of the MaxSessionDuration parameter when creating a ram role.
 * `policy` - (Optional) The policy that specifies the permissions of the returned STS token. You can use this parameter to grant the STS token fewer permissions than the permissions granted to the RAM role.
 
-### `sign_version` Configuration Block
+### `sign_version`
 
 The `sign_version` configuration block overrides the signature version used by the SDK client of specific cloud products. See [Custom Product Sign Version](#custom-product-sign-version) for an example. The following arguments are supported:
 
-* `oss` - (Optional) The signature version used by the OSS SDK client. Valid values: `v1`, `v4`. Starting from v1.278.0, the default value is changed from `v1` to `v4`; in earlier versions the default was `v1`. Set this field to `v1` explicitly if you need to keep using the legacy signature. 
+* `oss` - (Optional) The signature version used by the OSS SDK client. Valid values: `v1`, `v4`. Starting from v1.278.0, the default value is changed from `v1` to `v4`; in earlier versions the default was `v1`. Set this field to `v1` explicitly if you need to keep using the legacy signature.
 
  ->**NOTE:** `v2` is no longer accepted starting from v1.278.0; the value will be treated as the default and the client will fall back to `v4`.
 
 * `sls` - (Optional) The signature version used by the SLS (Log Service) SDK client. Valid values: `v1`, `v4`. Defaults to `v1`. Full v4 signature support across all `alicloud_sls_*` / `alicloud_log_*` resources is available since v1.276.0.
+
+### `features`
+
+The `features` configuration block groups the arguments that change how a resource behaves, as opposed to which account, region or endpoint the provider talks to. Every argument in it is optional, so leaving the block out keeps the provider's default behaviour. The arguments of this block have no environment variable equivalent, and can only be set in the `provider` block.
+
+```terraform
+provider "alicloud" {
+  features {
+    ecs_instance {
+      replace_on_image_update = true
+    }
+  }
+}
+```
+
+The following arguments are supported:
+
+* `ecs_instance` - (Optional) An [`ecs_instance`](#features-ecs_instance) block that changes how the [alicloud_instance](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/instance) resource behaves. Only one `ecs_instance` block may be in the configuration.
+
+### `features-ecs_instance`
+
+The `ecs_instance` configuration block applies to the [alicloud_instance](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/instance) resource only. The following arguments are supported:
+
+* `replace_on_image_update` - (Optional) Whether a change to `image_id` is planned as a replacement of the instance instead of an in-place update. Default value: `false`. Valid values:
+  - `false`: The instance is stopped if it is running, its system disk is replaced with a new one created from the new image, and the instance is started again. It keeps its ID, its private IP address and its data disks, and `terraform plan` reports an in-place update.
+  - `true`: The existing instance is destroyed and a new one is created from the new image, and `terraform plan` reports `forces replacement`.
+
+  -> **NOTE:** The system disk is created anew from the image either way, so its data never survives an `image_id` change. Setting this argument to `true` gives up the instance ID, the private IP address and the data disks as well, and requires the instance to be destroyable: a `prevent_destroy` lifecycle rule turns the planned replacement into an error, the provider refuses to destroy an instance whose `instance_charge_type` is `PrePaid` unless `force_delete` is `true`, and ECS rejects the deletion itself while `deletion_protection` is `true`.
+
+  -> **NOTE:** A new `image_id` that is not known until apply time, because it is read from a resource or a data source that has yet to be created, is applied in place: `terraform plan` cannot report a replacement for a value it does not have. Run `terraform apply` again after the new image exists to get the replacement.
 
 ### `endpoints`
 

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -104,7 +104,12 @@ to create several ECS instances one-click.
 
 The following arguments are supported:
 
-* `image_id` - (Optional) The Image to use for the instance. ECS instance's image can be replaced via changing `image_id`. When it is changed, the instance will reboot to make the change take effect. If you do not use `launch_template_id` or `launch_template_name` to specify a launch template, you must specify `image_id`.
+* `image_id` - (Optional) The Image to use for the instance. ECS instance's image can be replaced via changing `image_id`. If you do not use `launch_template_id` or `launch_template_name` to specify a launch template, you must specify `image_id`. How the change is applied is controlled by the provider argument `features.ecs_instance.replace_on_image_update`:
+  - `false` (default): The instance is stopped if it is running, its system disk is replaced with a new one created from the new image, and the instance is started again. It keeps its ID, its private IP address and its data disks, `system_disk_id` changes, and any key pair is attached again afterwards.
+  - `true`: The change is planned as `forces replacement`, so the existing instance is destroyed and a new one is created from the new image.
+
+  -> **NOTE:** The system disk is created anew from the image either way, so its data never survives an `image_id` change. Setting `replace_on_image_update` to `true` gives up the instance ID, the private IP address and the data disks as well, and requires the instance to be destroyable: a `prevent_destroy` lifecycle rule turns the planned replacement into an error, the provider refuses to destroy an instance whose `instance_charge_type` is `PrePaid` unless `force_delete` is `true`, and ECS rejects the deletion itself while `deletion_protection` is `true`. See the [`features.ecs_instance`](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs#features-ecs_instance) documentation for the cases in which a change cannot be planned as a replacement.
+
 * `instance_type` - (Optional) The type of instance to start. When it is changed, the instance will reboot to make the change take effect. If you do not use `launch_template_id` or `launch_template_name` to specify a launch template, you must specify `instance_type`.
 * `io_optimized` - (Removed) It has been deprecated on instance resource. All the launched alicloud instances will be I/O optimized.
 * `is_outdated` - (Optional) Whether to use outdated instance type.


### PR DESCRIPTION
### Why

A change to `image_id` on `alicloud_instance` is applied in place: the provider calls `ReplaceSystemDisk`, which keeps the instance and its id but wipes the system disk. Users who treat the image as immutable infrastructure expect `terraform plan` to report `forces replacement` instead, so that the instance is recreated from the new image. See #4550.

Flipping the default would change the plan of every configuration that relies on the in-place path, so the behaviour is opt-in.

### What

A provider-level `features` block carries the toggle, so that behaviour switches are grouped in one place instead of each one becoming another top-level provider argument:

```hcl
provider "alicloud" {
  features {
    ecs_instance {
      replace_on_image_update = true
    }
  }
}
```

With the toggle off (the default) nothing changes. With it on, a `CustomizeDiff` on `alicloud_instance` calls `ForceNew("image_id")` when the attribute changes.

* New package `alicloud/features` holds the toggle struct. It imports nothing, so `connectivity` can carry it without an import cycle and a resource can read a toggle without pulling in `connectivity`.
* `AliyunClient.Features` exposes it to resources; `expandFeatures` reads the block starting from the Go-side defaults, because every level of the block is optional.
* Unit test `TestProviderFeatures` covers the six shapes of the block (absent, null, present without `ecs_instance`, empty `ecs_instance`, enabled, explicitly disabled). `TestUnitAliCloudInstanceImageUpdateForcesNew` covers the diff logic itself.

Two limitations are documented in the code and in the provider docs, both inherent to plugin SDK v1:

* `ResourceDiff.ForceNew` sets `ForceNew = true` on the shared `*Schema` and nothing unsets it. From the first forced replacement onwards, every `image_id` change in that provider process is a replacement, including instances of a second `provider` block that left the toggle at `false`. The SDK's own `customdiff.ForceNewIfChange` behaves the same way. The docs ask for the argument to be set consistently across aliases.
* An `image_id` that is unknown until apply time falls back to the in-place path: a plan cannot report a replacement for a value it does not have yet.

An `image_id` the API filled in — an instance created from a launch template, for example — is exempt, since the attribute is `Optional+Computed` and an empty side is not user intent.

### Acceptance tests

Two new cases, verified at the API level and not only by the state assertions: the replace case shows `RunInstances` → `DeleteInstance` → `RunInstances` with no `ReplaceSystemDisk`, the in-place case shows a single instance plus `ReplaceSystemDisk`.

```
--- PASS: TestAccAliCloudECSInstanceImageUpdateReplace (180.78s)
--- PASS: TestAccAliCloudECSInstanceImageUpdateInPlace (101.86s)
```

Full `TestAccAliCloudECSInstance*` regression (37 cases): **PASS 32, FAIL 4, SKIP 1**.

```
--- PASS: TestAccAliCloudECSInstanceDataDisks (111.49s)
--- PASS: TestAccAliCloudECSInstanceDedicatedHostId (99.93s)
--- PASS: TestAccAliCloudECSInstanceImageUpdateInPlace (101.86s)
--- PASS: TestAccAliCloudECSInstanceImageUpdateReplace (180.78s)
--- PASS: TestAccAliCloudECSInstanceIpv6Addresses (132.34s)
--- PASS: TestAccAliCloudECSInstanceIpv6AddressesCount (193.51s)
--- PASS: TestAccAliCloudECSInstanceMaintenance (223.63s)
--- PASS: TestAccAliCloudECSInstanceMetadataOptions (127.83s)
--- PASS: TestAccAliCloudECSInstanceMulti (107.52s)
--- PASS: TestAccAliCloudECSInstanceNetworkInterface0 (181.17s)
--- PASS: TestAccAliCloudECSInstanceNetworkInterface1 (234.04s)
--- PASS: TestAccAliCloudECSInstanceNetworkInterface2 (119.76s)
--- PASS: TestAccAliCloudECSInstanceNetworkInterface3 (120.29s)
--- PASS: TestAccAliCloudECSInstancePrivatePool (333.80s)
--- PASS: TestAccAliCloudECSInstanceSecondaryIpCount (107.51s)
--- PASS: TestAccAliCloudECSInstanceSecondaryIps (93.27s)
--- PASS: TestAccAliCloudECSInstanceSet_basic0 (158.81s)
--- PASS: TestAccAliCloudECSInstanceSet_basic1 (110.54s)
--- PASS: TestAccAliCloudECSInstanceSpotInstanceLimit (100.71s)
--- PASS: TestAccAliCloudECSInstanceSystemDisk (123.78s)
--- PASS: TestAccAliCloudECSInstanceTypesDataSource_basic (91.79s)
--- PASS: TestAccAliCloudECSInstanceTypesDataSource_empty (4.01s)
--- PASS: TestAccAliCloudECSInstanceTypesDataSource_gpu (11.08s)
--- PASS: TestAccAliCloudECSInstanceTypesDataSource_imageId (9.63s)
--- PASS: TestAccAliCloudECSInstanceTypesDataSource_k8sFamily (3.36s)
--- PASS: TestAccAliCloudECSInstanceTypesDataSource_k8sSpec (8.16s)
--- PASS: TestAccAliCloudECSInstanceVpc (889.82s)
--- PASS: TestAccAliCloudECSInstance_AutoSnapshotPolicyId (117.15s)
--- PASS: TestAccAliCloudECSInstance_DeploymentSetID (118.58s)
--- PASS: TestAccAliCloudECSInstance_LaunchTemplate (131.83s)
--- PASS: TestAccAliCloudECSInstance_OperatorType (258.42s)
--- PASS: TestAccAliCloudECSInstance_StatusUpdated (174.28s)
--- SKIP: TestAccAliCloudECSInstanceBasic (0.00s)
--- FAIL: TestAccAliCloudECSInstanceHpcCluster (2.26s)
--- FAIL: TestAccAliCloudECSInstancePrepaid (121.90s)
--- FAIL: TestAccAliCloudECSInstancePrepaidAll (53.29s)
--- FAIL: TestAccAliCloudECSInstancesDataSourceBasic (37.07s)
```

None of the four failures touches the code in this PR — all four fail on `master` in the same environment, and each one fails before any `image_id` change is planned:

* `HpcCluster` — the case's region whitelist includes a region where `alicloud_instance_types` returns nothing for an hpc family, so the fixture fails at plan with `Invalid index`. Pre-existing whitelist/fixture mismatch; passes in another whitelisted region. Left alone to keep this diff to the feature.
* `Prepaid`, `PrepaidAll` — `ModifyInstanceAutoRenewAttribute` returns `ChargeTypeViolation` right after a successful PostPaid to PrePaid conversion, even though `DescribeInstances` already reports `PrePaid`. An eventual-consistency race between the instance attribute view and the renewal service, with no retry at the call site. Flaky rather than deterministic, tracked internally, and out of scope here.
* `InstancesDataSourceBasic` — the test account has disk default encryption enabled, so `RunInstances` is rejected with `InvalidEncrypted.NotMatchDiskDefaultEncryption` for the unencrypted disk in the fixture. Environmental.
* `InstanceBasic` is skipped by the existing classic-network gate (`ENABLE_CLASSIC_NETWORK` unset).

### Note for reviewers

Two pre-existing doc-rendering defects sit next to the lines this PR touches and were deliberately left alone rather than inflating the diff: a `->**NOTE:**` with no space after the arrow in the `sign_version` section of the provider index page, and the `network_interface_id` note in `instance.html.markdown` written at column 0, which detaches it from its bullet and splits the list.
