### PR TITLE
resource/alicloud_api_gateway_vpc_access: support vpc_target_host_name

### DIFF
--- a/alicloud/resource_alicloud_api_gateway_vpc_access.go
+++ b/alicloud/resource_alicloud_api_gateway_vpc_access.go
@@ -40,6 +40,11 @@ func resourceAliCloudApiGatewayVpcAccess() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"vpc_target_host_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"vpc_access_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -56,6 +61,7 @@ func resourceAliCloudApiGatewayVpcAccessCreate(d *schema.ResourceData, meta inte
 	request.VpcId = d.Get("vpc_id").(string)
 	request.InstanceId = d.Get("instance_id").(string)
 	request.Port = requests.NewInteger(d.Get("port").(int))
+	request.VpcTargetHostName = d.Get("vpc_target_host_name").(string)
 
 	var raw interface{}
 	var err error
@@ -101,6 +107,7 @@ func resourceAliCloudApiGatewayVpcAccessRead(d *schema.ResourceData, meta interf
 	d.Set("vpc_id", object["VpcId"])
 	d.Set("instance_id", object["InstanceId"])
 	d.Set("port", object["Port"])
+	d.Set("vpc_target_host_name", object["VpcTargetHostName"])
 	if v, ok := object["VpcAccessId"]; ok {
 		d.Set("vpc_access_id", v)
 	}

--- a/alicloud/resource_alicloud_api_gateway_vpc_access_test.go
+++ b/alicloud/resource_alicloud_api_gateway_vpc_access_test.go
@@ -104,17 +104,19 @@ func TestAccAliCloudApiGatewayVpcAccess_basic0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"name":        name,
-					"vpc_id":      "${alicloud_vpc.default.id}",
-					"instance_id": "${alicloud_instance.default.id}",
-					"port":        "8080",
+					"name":                 name,
+					"vpc_id":               "${alicloud_vpc.default.id}",
+					"instance_id":          "${alicloud_instance.default.id}",
+					"port":                 "8080",
+					"vpc_target_host_name": "www.example.com",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"name":        name,
-						"vpc_id":      CHECKSET,
-						"instance_id": CHECKSET,
-						"port":        "8080",
+						"name":                 name,
+						"vpc_id":               CHECKSET,
+						"instance_id":          CHECKSET,
+						"port":                 "8080",
+						"vpc_target_host_name": "www.example.com",
 					}),
 				),
 			},

--- a/website/docs/r/api_gateway_vpc_access.html.markdown
+++ b/website/docs/r/api_gateway_vpc_access.html.markdown
@@ -84,10 +84,11 @@ resource "alicloud_instance" "default" {
 }
 
 resource "alicloud_api_gateway_vpc_access" "default" {
-  name        = var.name
-  vpc_id      = alicloud_vpc.default.id
-  instance_id = alicloud_instance.default.id
-  port        = 8080
+  name                 = var.name
+  vpc_id               = alicloud_vpc.default.id
+  instance_id          = alicloud_instance.default.id
+  port                 = 8080
+  vpc_target_host_name = "www.example.com"
 }
 ```
 
@@ -101,6 +102,7 @@ The following arguments are supported:
 * `vpc_id` - (Required, ForceNew) The ID of the VPC. The VPC must be an available one that belongs to the same account as the API.
 * `instance_id` - (Required, ForceNew) The ID of an ECS or SLB instance in the VPC.
 * `port` - (Required, ForceNew) The port number that corresponds to the instance.
+* `vpc_target_host_name` - (Optional, ForceNew) The host of the backend service.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Add the `vpc_target_host_name` argument to the `alicloud_api_gateway_vpc_access` resource. This argument maps to the `VpcTargetHostName` parameter of the SetVpcAccess API, which specifies the host of the backend service for the VPC access configuration.

## Changes

- **schema**: add `vpc_target_host_name` (Optional, ForceNew), consistent with the existing `name`, `vpc_id`, `instance_id`, and `port` arguments which are all ForceNew (the resource has no Update path; SetVpcAccess is create/overwrite semantics).
- **Create**: pass `VpcTargetHostName` through to the SetVpcAccess request.
- **Read**: populate `vpc_target_host_name` from the DescribeVpcAccesses response.
- **docs**: update the example and argument reference.
- **tests**: cover `vpc_target_host_name` in the existing basic acceptance test (config + state check + import state verify).

## Test

The new attribute is covered in `TestAccAliCloudApiGatewayVpcAccess_basic0` (config + state check + import state verify).
