### PR TITLE
resource/alicloud_ecd_ad_connector_office_site: support sso_enabled and enable_cross_desktop_access

### DIFF
--- a/alicloud/resource_alicloud_ecd_ad_connector_office_site.go
+++ b/alicloud/resource_alicloud_ecd_ad_connector_office_site.go
@@ -23,6 +23,7 @@ func resourceAlicloudEcdAdConnectorOfficeSite() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
@@ -85,6 +86,11 @@ func resourceAlicloudEcdAdConnectorOfficeSite() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"enable_cross_desktop_access": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"enable_internet_access": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -104,6 +110,11 @@ func resourceAlicloudEcdAdConnectorOfficeSite() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntInSlice([]int{1, 2}),
+			},
+			"sso_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
 			},
 			"status": {
 				Type:     schema.TypeString,
@@ -229,15 +240,82 @@ func resourceAlicloudEcdAdConnectorOfficeSiteRead(d *schema.ResourceData, meta i
 	d.Set("domain_name", object["DomainName"])
 	d.Set("domain_user_name", object["DomainUserName"])
 	d.Set("enable_admin_access", object["EnableAdminAccess"])
+	d.Set("enable_cross_desktop_access", object["EnableCrossDesktopAccess"])
 	d.Set("enable_internet_access", object["EnableInternetAccess"])
 	d.Set("mfa_enabled", object["MfaEnabled"])
+	d.Set("sso_enabled", object["SsoEnabled"])
 	d.Set("status", object["Status"])
 	d.Set("sub_domain_dns_address", object["SubDnsAddress"])
 	d.Set("sub_domain_name", object["SubDomainName"])
 	return nil
 }
 func resourceAlicloudEcdAdConnectorOfficeSiteUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Println(fmt.Sprintf("[WARNING] The resouce has not update operation."))
+	client := meta.(*connectivity.AliyunClient)
+	var err error
+	var response map[string]interface{}
+
+	update := false
+	request := map[string]interface{}{
+		"OfficeSiteId": d.Id(),
+	}
+	if d.HasChange("enable_cross_desktop_access") {
+		update = true
+		if v, ok := d.GetOkExists("enable_cross_desktop_access"); ok {
+			request["EnableCrossDesktopAccess"] = v
+		}
+	}
+	if update {
+		request["RegionId"] = client.RegionId
+		action := "ModifyOfficeSiteCrossDesktopAccess"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("ecd", "2020-09-30", action, nil, request, false)
+			if err != nil {
+				if NeedRetry(err) || IsExpectedErrors(err, []string{"DirectoryNotReady"}) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	update = false
+	request = map[string]interface{}{
+		"OfficeSiteId": d.Id(),
+	}
+	if d.HasChange("sso_enabled") {
+		update = true
+		request["RegionId"] = client.RegionId
+		if v, ok := d.GetOkExists("sso_enabled"); ok {
+			request["EnableSso"] = v
+		}
+	}
+	if update {
+		action := "SetOfficeSiteSsoStatus"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("ecd", "2020-09-30", action, nil, request, false)
+			if err != nil {
+				if NeedRetry(err) || IsExpectedErrors(err, []string{"DirectoryNotReady"}) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
 	return resourceAlicloudEcdAdConnectorOfficeSiteRead(d, meta)
 }
 func resourceAlicloudEcdAdConnectorOfficeSiteDelete(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_ecd_ad_connector_office_site_test.go
+++ b/alicloud/resource_alicloud_ecd_ad_connector_office_site_test.go
@@ -125,6 +125,7 @@ func TestAccAliCloudECDAdConnectorOfficeSite_basic0(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.CenTRSupportRegions)
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
@@ -143,7 +144,7 @@ func TestAccAliCloudECDAdConnectorOfficeSite_basic0(t *testing.T) {
 					"enable_admin_access":           "true",
 					"mfa_enabled":                   "true",
 					"domain_password":               "YourPassword1234",
-					"cen_id":                        "${data.alicloud_cen_instances.default.instances.0.id}",
+					"cen_id":                        "${alicloud_cen_instance.default.id}",
 					"desktop_access_type":           "INTERNET",
 					"domain_user_name":              "Administrator",
 				}),
@@ -192,6 +193,7 @@ func TestAccAliCloudECDAdConnectorOfficeSite_basic1(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.CenTRSupportRegions)
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
@@ -202,7 +204,7 @@ func TestAccAliCloudECDAdConnectorOfficeSite_basic1(t *testing.T) {
 					"ad_connector_office_site_name": name,
 					"cidr_block":                    "10.0.0.0/12",
 					"domain_name":                   "example1234.com",
-					"cen_id":                        "${data.alicloud_cen_instances.default.instances.0.id}",
+					"cen_id":                        "${alicloud_cen_instance.default.id}",
 					"dns_address":                   []string{"127.0.0.2"},
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -220,6 +222,80 @@ func TestAccAliCloudECDAdConnectorOfficeSite_basic1(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"protocol_type", "verify_code", "specification", "ad_hostname", "cen_owner_id"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudECDAdConnectorOfficeSite_basic2(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ecd_ad_connector_office_site.default"
+	checkoutSupportedRegions(t, true, connectivity.EcdSupportRegions)
+	ra := resourceAttrInit(resourceId, AliCloudECDAdConnectorOfficeSiteMap2)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EcdService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEcdAdConnectorOfficeSite")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%secdadconnectorofficesite%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudECDAdConnectorOfficeSiteBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.CenTRSupportRegions)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ad_connector_office_site_name": name,
+					"cidr_block":                    "10.0.0.0/12",
+					"domain_name":                   "example1234.com",
+					"cen_id":                        "${alicloud_cen_instance.default.id}",
+					"dns_address":                   []string{"127.0.0.2"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ad_connector_office_site_name": name,
+						"cidr_block":                    "10.0.0.0/12",
+						"domain_name":                   "example1234.com",
+						"cen_id":                        CHECKSET,
+						"dns_address.#":                 "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"sso_enabled":                 "true",
+					"enable_cross_desktop_access": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"sso_enabled":                 "true",
+						"enable_cross_desktop_access": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"sso_enabled":                 "false",
+					"enable_cross_desktop_access": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"sso_enabled":                 "false",
+						"enable_cross_desktop_access": "false",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"domain_password", "protocol_type", "verify_code", "specification", "ad_hostname", "cen_owner_id", "ad_connector_office_site_name", "desktop_access_type", "dns_address", "domain_name", "domain_user_name", "mfa_enabled", "sub_domain_dns_address", "sub_domain_name"},
 			},
 		},
 	})
@@ -245,14 +321,32 @@ var AliCloudECDAdConnectorOfficeSiteMap1 = map[string]string{
 	"ad_hostname":         NOSET,
 }
 
+var AliCloudECDAdConnectorOfficeSiteMap2 = map[string]string{
+	"dns_address.#":               CHECKSET,
+	"desktop_access_type":         CHECKSET,
+	"protocol_type":               NOSET,
+	"verify_code":                 NOSET,
+	"status":                      CHECKSET,
+	"ad_hostname":                 NOSET,
+	"cen_owner_id":                NOSET,
+	"sso_enabled":                 CHECKSET,
+	"enable_cross_desktop_access": CHECKSET,
+}
+
 func AliCloudECDAdConnectorOfficeSiteBasicDependence0(name string) string {
 	return fmt.Sprintf(` 
 	variable "name" {
   		default = "%s"
 	}
 
-	data "alicloud_cen_instances" "default" {
-  		name_regex = "no-deleting-cen"
+	resource "alicloud_cen_instance" "default" {
+  		cen_instance_name = var.name
+  		description       = var.name
+	}
+
+	resource "alicloud_cen_transit_router" "default" {
+  		cen_id              = alicloud_cen_instance.default.id
+  		transit_router_name = var.name
 	}
 `, name)
 }
@@ -273,6 +367,7 @@ func TestUnitAliCloudECDAdConnectorOfficeSite(t *testing.T) {
 		"enable_internet_access":        true,
 		"domain_name":                   "CreateEcdAdConnectorOfficeSiteValue",
 		"enable_admin_access":           true,
+		"enable_cross_desktop_access":   true,
 		"mfa_enabled":                   false,
 		"domain_password":               "CreateEcdAdConnectorOfficeSiteValue",
 		"cen_id":                        "CreateEcdAdConnectorOfficeSiteValue",
@@ -282,6 +377,7 @@ func TestUnitAliCloudECDAdConnectorOfficeSite(t *testing.T) {
 		"cen_owner_id":                  "CreateEcdAdConnectorOfficeSiteValue",
 		"protocol_type":                 "CreateEcdAdConnectorOfficeSiteValue",
 		"specification":                 1,
+		"sso_enabled":                   true,
 		"verify_code":                   "CreateEcdAdConnectorOfficeSiteValue",
 	}
 	for key, value := range attributes {

--- a/website/docs/r/ecd_ad_connector_office_site.html.markdown
+++ b/website/docs/r/ecd_ad_connector_office_site.html.markdown
@@ -74,10 +74,12 @@ The following arguments are supported:
 * `domain_password` - (Optional) The password of the domain administrator. The password can be up to 64 characters in length.
 * `domain_user_name` - (Optional) The username of the domain administrator. The username can be up to 64 characters in length.
 * `enable_admin_access` - (Optional, ForceNew, Computed) Specifies whether to grant the permissions of the local administrator to the desktop users. Default value: true.
+* `enable_cross_desktop_access` - (Optional, Computed) Specifies whether to enable cross-desktop access.
 * `enable_internet_access` - (Optional, ForceNew, Computed) Specifies whether to enable Internet access.
 * `mfa_enabled` - (Optional) Specifies whether to enable multi-factor authentication (MFA).
 * `protocol_type` - (Optional) The protocol type. Valid values: `ASP`, `HDX`.
 * `specification` - (Optional) The AD Connector specifications. Valid values: `1`, `2`.
+* `sso_enabled` - (Optional, Computed) Specifies whether to enable single sign-on (SSO) for user-based SSO.
 * `sub_domain_dns_address` - (Optional) The DNS address N of the enterprise AD subdomain. If you specify a value for the `sub_domain_name` parameter but you do not specify a value for this parameter, the DNS address of the subdomain is the same as the DNS address of the parent domain.
 * `sub_domain_name` - (Optional) The domain name of the enterprise AD subdomain.
 * `verify_code` - (Optional) The verification code. If the CEN instance that you specify for the CenId parameter belongs to another Alibaba Cloud account, you must call the SendVerifyCode operation to obtain the verification code.


### PR DESCRIPTION
### What this PR does

Adds two new Optional, Computed boolean attributes to the `alicloud_ecd_ad_connector_office_site` resource:

- `sso_enabled` — enables single sign-on (SSO) for user-based SSO.
- `enable_cross_desktop_access` — enables cross-desktop access.

These attributes are not accepted by the `CreateADConnectorOfficeSite` API and must be configured after the workspace is created, so they are applied during update via:

- `SetOfficeSiteSsoStatus` (for `sso_enabled`)
- `ModifyOfficeSiteCrossDesktopAccess` (for `enable_cross_desktop_access`)

Both are read back from `DescribeOfficeSites`. The implementation mirrors the existing behavior of `alicloud_ecd_simple_office_site`, which already supports these two fields. The corresponding data source already exposes them.

### Why

AD Connector office sites were missing SSO and cross-desktop access support, while the sibling simple office site resource and the data source already surface these fields.

### Tests

- `TestAccAliCloudECDAdConnectorOfficeSite_basic2`: create, then toggle both attributes on and off, then import.
- Extended `TestUnitAliCloudECDAdConnectorOfficeSite` to cover the two new schema fields.
- Updated the resource documentation.

### Example

```terraform
resource "alicloud_ecd_ad_connector_office_site" "default" {
  ad_connector_office_site_name = "example"
  cidr_block                    = "10.0.0.0/12"
  domain_name                   = "corp.example.com"
  dns_address                   = ["127.0.0.2"]
  cen_id                        = alicloud_cen_instance.default.id
  sso_enabled                   = true
  enable_cross_desktop_access   = true
}
```
