### PR TITLE
resource/alicloud_ots_instance: support HTTP proxy for tablestore client; testcase: verify proxy routing

### DIFF
--- a/alicloud/connectivity/client.go
+++ b/alicloud/connectivity/client.go
@@ -1592,11 +1592,18 @@ func (client *AliyunClient) WithTableStoreClient(instanceName string, do func(*t
 	if client.config.SourceIp != "" {
 		externalHeaders["x-ots-sourceip"] = client.config.SourceIp
 	}
+	tableStoreConfig := getTableStoreConfig()
 	accessKey, secretKey, token := client.config.GetRefreshCredential()
-	tableStoreClient = tablestore.NewClientWithExternalHeader(endpoint, instanceName, accessKey, secretKey, token, tablestore.NewDefaultTableStoreConfig(), externalHeaders)
+	tableStoreClient = tablestore.NewClientWithExternalHeader(endpoint, instanceName, accessKey, secretKey, token, tableStoreConfig, externalHeaders)
 	client.tablestoreconnByInstanceName[instanceName] = tableStoreClient
 
 	return do(tableStoreClient)
+}
+
+func getTableStoreConfig() *tablestore.TableStoreConfig {
+	config := tablestore.NewDefaultTableStoreConfig()
+	config.ProxyFromEnvironment = true
+	return config
 }
 
 func (client *AliyunClient) WithTableStoreTunnelClient(instanceName string, do func(otsTunnel.TunnelClient) (interface{}, error)) (interface{}, error) {

--- a/alicloud/connectivity/client_test.go
+++ b/alicloud/connectivity/client_test.go
@@ -2,7 +2,10 @@ package connectivity
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"os/exec"
 	"strings"
 	"sync"
 	"testing"
@@ -14,6 +17,7 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ram"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
+	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
 	"github.com/aliyun/credentials-go/credentials"
 	"github.com/stretchr/testify/assert"
 )
@@ -112,6 +116,72 @@ func NewTestClient(t *testing.T) *AliyunClient {
 		t.Fatalf("initial client failed: %v", err)
 	}
 	return client
+}
+
+func TestGetTableStoreConfigProxy(t *testing.T) {
+	assert.True(t, getTableStoreConfig().ProxyFromEnvironment)
+}
+
+func TestTableStoreRequestUsesEnvironmentProxy(t *testing.T) {
+	const helperEnv = "TABLESTORE_PROXY_TEST_HELPER"
+	if os.Getenv(helperEnv) == "1" {
+		credential, err := credentials.NewCredential(new(credentials.Config).
+			SetType("access_key").
+			SetAccessKeyId("access-key").
+			SetAccessKeySecret("secret-key"))
+		if err != nil {
+			t.Fatalf("create credential: %v", err)
+		}
+		client := &AliyunClient{
+			config: &Config{
+				OtsEndpoint: "http://tablestore.invalid",
+				Credential:  credential,
+			},
+			tablestoreconnByInstanceName: make(map[string]*tablestore.TableStoreClient),
+		}
+		if _, err := client.WithTableStoreClient("instance", func(client *tablestore.TableStoreClient) (interface{}, error) {
+			return client.ListTable()
+		}); err != nil {
+			t.Fatalf("list tables through proxy: %v", err)
+		}
+		return
+	}
+
+	type proxyRequest struct {
+		method string
+		host   string
+		path   string
+	}
+	requests := make(chan proxyRequest, 1)
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case requests <- proxyRequest{method: r.Method, host: r.URL.Host, path: r.URL.Path}:
+		default:
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer proxy.Close()
+
+	t.Setenv(helperEnv, "1")
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("http_proxy", "")
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+	t.Setenv("REQUEST_METHOD", "")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestTableStoreRequestUsesEnvironmentProxy$")
+	cmd.Env = os.Environ()
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("proxy test subprocess failed: %v\n%s", err, output)
+	}
+
+	select {
+	case request := <-requests:
+		assert.Equal(t, http.MethodPost, request.method)
+		assert.Equal(t, "tablestore.invalid", request.host)
+		assert.Equal(t, "/ListTable", request.path)
+	default:
+		t.Fatal("proxy did not receive the TableStore request")
+	}
 }
 
 func TestUnitCommonWithEcsClient_UsingHttpMock(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/aliyun/aliyun-log-go-sdk v0.1.108
 	github.com/aliyun/aliyun-mns-go-sdk v0.0.0-20210305050620-d1b5875bda58
 	github.com/aliyun/aliyun-oss-go-sdk v2.2.9+incompatible
-	github.com/aliyun/aliyun-tablestore-go-sdk v1.7.16
+	github.com/aliyun/aliyun-tablestore-go-sdk v1.9.3
 	github.com/aliyun/credentials-go v1.4.12
 	github.com/aliyun/fc-go-sdk v0.0.0-20220622030011-bc7ded2a9050
 	github.com/aws/aws-sdk-go-v2 v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -322,6 +322,8 @@ github.com/aliyun/aliyun-oss-go-sdk v2.2.9+incompatible h1:Sg/2xHwDrioHpxTN6WMiw
 github.com/aliyun/aliyun-oss-go-sdk v2.2.9+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.7.16 h1:xfWOyeHyJsKXzE2P/uzwRy/WD8DFcJLEH1aF2GuRnN4=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.7.16/go.mod h1:JzOJMpBPGN+4cuYnrGO5wdwphEyqbeGVY2vCaiAcNW8=
+github.com/aliyun/aliyun-tablestore-go-sdk v1.9.3 h1:QWyWHXkmIvOK3g0azZyKNMTeohxylwDGOKDGfb/4F1c=
+github.com/aliyun/aliyun-tablestore-go-sdk v1.9.3/go.mod h1:fy5w6iSSp3UTfuJZ0CzP5mKLEeZEl3xC977YOOwraXk=
 github.com/aliyun/credentials-go v1.1.2/go.mod h1:ozcZaMR5kLM7pwtCMEpVmQ242suV6qTJya2bDq4X1Tw=
 github.com/aliyun/credentials-go v1.2.6/go.mod h1:/KowD1cfGSLrLsH28Jr8W+xwoId0ywIy5lNzDz6O1vw=
 github.com/aliyun/credentials-go v1.3.0/go.mod h1:8jKYhQuDawt8x2+fusqa1Y6mPxemTsBEN04dgcAcYz0=
@@ -422,6 +424,8 @@ github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgz
 github.com/denverdino/aliyungo v0.0.0-20220929054937-e3c8bf5ad947 h1:XSQNYTT3xgLDGbbDLUZMj98VhQBQcTxtyaMc3J1jiPo=
 github.com/denverdino/aliyungo v0.0.0-20220929054937-e3c8bf5ad947/go.mod h1:TK05uvk4XXfK2kdvRwfcZ1NaxjDxmm7H3aQLko0mJxA=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
 github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
@@ -876,6 +880,7 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/prometheus v0.40.0 h1:l1X90CYt2Kizrv6oBDt5lbHHdPabJ/Ms9EwBrdrVU10=
 github.com/prometheus/prometheus v0.40.0/go.mod h1:/UhsWkOXkO11wqTW2Bx5YDOwRweSDcaFBlTIzFe7P0Y=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=


### PR DESCRIPTION
## Summary

- upgrade aliyun-tablestore-go-sdk to v1.9.3
- configure the Tablestore data client from HTTP(S)_PROXY
- honor NO_PROXY for Tablestore endpoints

## Testing

- go test ./alicloud/connectivity
- go test ./alicloud -run ^$