### PR TITLE
resource/alicloud_ecd_desktop: expose additional create-only attributes

### DIFF
--- a/alicloud/resource_alicloud_ecd_desktop.go
+++ b/alicloud/resource_alicloud_ecd_desktop.go
@@ -155,6 +155,76 @@ func resourceAlicloudEcdDesktop() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"app_rule_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"desktop_member_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"desktop_name_suffix": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"ou_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"promotion_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"qos_rule_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"reseller_owner_uid": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"snapshot_policy_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"timer_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"volume_encryption_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"volume_encryption_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -213,6 +283,48 @@ func resourceAlicloudEcdDesktopCreate(d *schema.ResourceData, meta interface{}) 
 	}
 	if v, ok := d.GetOk("host_name"); ok {
 		request["HostName"] = v
+	}
+	if v, ok := d.GetOk("app_rule_id"); ok {
+		request["AppRuleId"] = v
+	}
+	if v, ok := d.GetOk("desktop_member_ip"); ok {
+		request["DesktopMemberIp"] = v
+	}
+	if v, ok := d.GetOkExists("desktop_name_suffix"); ok {
+		request["DesktopNameSuffix"] = v
+	}
+	if v, ok := d.GetOk("group_id"); ok {
+		request["GroupId"] = v
+	}
+	if v, ok := d.GetOk("ou_path"); ok {
+		request["OUPath"] = v
+	}
+	if v, ok := d.GetOk("promotion_id"); ok {
+		request["PromotionId"] = v
+	}
+	if v, ok := d.GetOk("qos_rule_id"); ok {
+		request["QosRuleId"] = v
+	}
+	if v, ok := d.GetOk("reseller_owner_uid"); ok {
+		request["ResellerOwnerUid"] = v
+	}
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
+	}
+	if v, ok := d.GetOk("snapshot_policy_id"); ok {
+		request["SnapshotPolicyId"] = v
+	}
+	if v, ok := d.GetOk("subnet_id"); ok {
+		request["SubnetId"] = v
+	}
+	if v, ok := d.GetOk("timer_group_id"); ok {
+		request["TimerGroupId"] = v
+	}
+	if v, ok := d.GetOkExists("volume_encryption_enabled"); ok {
+		request["VolumeEncryptionEnabled"] = v
+	}
+	if v, ok := d.GetOk("volume_encryption_key"); ok {
+		request["VolumeEncryptionKey"] = v
 	}
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {

--- a/alicloud/resource_alicloud_ecd_desktop_test.go
+++ b/alicloud/resource_alicloud_ecd_desktop_test.go
@@ -93,7 +93,7 @@ func testSweepEcdDesktop(region string) error {
 	return nil
 }
 
-func TestAccAlicloudECDDesktop_basic0(t *testing.T) {
+func TestAccAliCloudECDDesktop_basic0(t *testing.T) {
 	var v map[string]interface{}
 	checkoutSupportedRegions(t, true, connectivity.EcdUserSupportRegions)
 	resourceId := "alicloud_ecd_desktop.default"
@@ -116,11 +116,26 @@ func TestAccAlicloudECDDesktop_basic0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"office_site_id":  "${alicloud_ecd_simple_office_site.default.id}",
-					"policy_group_id": "${alicloud_ecd_policy_group.default.id}",
-					"bundle_id":       "${data.alicloud_ecd_bundles.default.bundles.1.id}",
-					"desktop_name":    name,
-					"amount":          "1",
+					"office_site_id":            "${alicloud_ecd_simple_office_site.default.id}",
+					"policy_group_id":           "${alicloud_ecd_policy_group.default.id}",
+					"bundle_id":                 "${data.alicloud_ecd_bundles.default.bundles.1.id}",
+					"desktop_name":              name,
+					"amount":                    "1",
+					"app_rule_id":               "",
+					"desktop_member_ip":         "",
+					"desktop_name_suffix":       false,
+					"group_id":                  "",
+					"host_name":                 "",
+					"ou_path":                   "",
+					"promotion_id":              "",
+					"qos_rule_id":               "",
+					"reseller_owner_uid":        0,
+					"resource_group_id":         "",
+					"snapshot_policy_id":        "",
+					"subnet_id":                 "",
+					"timer_group_id":            "",
+					"volume_encryption_enabled": false,
+					"volume_encryption_key":     "",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -216,13 +231,13 @@ func TestAccAlicloudECDDesktop_basic0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_disk_size_gib", "auto_renew", "period", "bundle_id", "user_assign_mode", "user_disk_size_gib", "host_name", "period_unit", "stopped_mode", "amount", "auto_pay", "desktop_id"},
+				ImportStateVerifyIgnore: []string{"root_disk_size_gib", "auto_renew", "period", "bundle_id", "user_assign_mode", "user_disk_size_gib", "host_name", "period_unit", "stopped_mode", "amount", "auto_pay", "app_rule_id", "desktop_member_ip", "desktop_name_suffix", "group_id", "ou_path", "promotion_id", "qos_rule_id", "reseller_owner_uid", "resource_group_id", "snapshot_policy_id", "subnet_id", "timer_group_id", "volume_encryption_enabled", "volume_encryption_key"},
 			},
 		},
 	})
 }
 
-func TestAccAlicloudECDDesktop_basic1(t *testing.T) {
+func TestAccAliCloudECDDesktop_basic1(t *testing.T) {
 	var v map[string]interface{}
 	checkoutSupportedRegions(t, true, connectivity.EcdUserSupportRegions)
 	resourceId := "alicloud_ecd_desktop.default"
@@ -280,13 +295,13 @@ func TestAccAlicloudECDDesktop_basic1(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_disk_size_gib", "auto_renew", "period", "bundle_id", "user_assign_mode", "user_disk_size_gib", "host_name", "period_unit", "stopped_mode", "amount", "auto_pay", "desktop_id"},
+				ImportStateVerifyIgnore: []string{"root_disk_size_gib", "auto_renew", "period", "bundle_id", "user_assign_mode", "user_disk_size_gib", "host_name", "period_unit", "stopped_mode", "amount", "auto_pay"},
 			},
 		},
 	})
 }
 
-func TestAccAlicloudECDDesktop_basic2(t *testing.T) {
+func TestAccAliCloudECDDesktop_basic2(t *testing.T) {
 	var v map[string]interface{}
 	checkoutSupportedRegions(t, true, connectivity.EcdUserSupportRegions)
 	resourceId := "alicloud_ecd_desktop.default"
@@ -340,7 +355,7 @@ func TestAccAlicloudECDDesktop_basic2(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"root_disk_size_gib", "auto_renew", "period", "bundle_id", "user_assign_mode", "user_disk_size_gib", "host_name", "period_unit", "stopped_mode", "amount", "auto_pay", "desktop_id"},
+				ImportStateVerifyIgnore: []string{"root_disk_size_gib", "auto_renew", "period", "bundle_id", "user_assign_mode", "user_disk_size_gib", "host_name", "period_unit", "stopped_mode", "amount", "auto_pay"},
 			},
 		},
 	})
@@ -348,7 +363,6 @@ func TestAccAlicloudECDDesktop_basic2(t *testing.T) {
 
 var AlicloudECDDesktopMap0 = map[string]string{
 	"user_disk_size_gib": NOSET,
-	"host_name":          NOSET,
 	"period_unit":        NOSET,
 	"desktop_id":         NOSET,
 	"desktop_name":       CHECKSET,

--- a/website/docs/r/ecd_desktop.html.markdown
+++ b/website/docs/r/ecd_desktop.html.markdown
@@ -102,6 +102,20 @@ The following arguments are supported:
 * `user_assign_mode` - (Optional) The user assign mode of the Desktop. Valid values: `ALL`, `PER_USER`. Default to `ALL`.
 * `user_disk_size_gib` - (Optional) The user disk size gib of the Desktop.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+* `app_rule_id` - (Optional, ForceNew) The application control policy ID.
+* `desktop_member_ip` - (Optional, ForceNew) The private IP address of the cloud desktop.
+* `desktop_name_suffix` - (Optional, ForceNew) Specifies whether to automatically append a suffix to the cloud desktop name when you create multiple cloud desktops in a batch. values: `true`, `false`.
+* `group_id` - (Optional, ForceNew) The cloud desktop pool ID.
+* `ou_path` - (Optional, ForceNew) The OU path. If specified, the cloud desktop is added to the corresponding organizational unit (OU) in Active Directory (AD).
+* `promotion_id` - (Optional, ForceNew) The promotion ID.
+* `qos_rule_id` - (Optional, ForceNew) The public network rate limiting rule ID.
+* `reseller_owner_uid` - (Optional, ForceNew) The user ID for resource ownership in reseller pattern. It is not required in non-reseller pattern.
+* `resource_group_id` - (Optional, ForceNew) The WUYING resource group ID.
+* `snapshot_policy_id` - (Optional, ForceNew) The WUYING automatic snapshot policy ID.
+* `subnet_id` - (Optional, ForceNew) The subnet ID.
+* `timer_group_id` - (Optional, ForceNew) The scheduled task group ID.
+* `volume_encryption_enabled` - (Optional, ForceNew) Specifies whether to enable cloud disk encryption. values: `true`, `false`.
+* `volume_encryption_key` - (Optional, ForceNew) The ID of the Key Management Service (KMS) key used for cloud disk encryption.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description

Expose additional create-only arguments on the `alicloud_ecd_desktop` resource. Each new argument maps to a corresponding parameter of the `CreateDesktops` API (`ecd`, version `2020-09-30`).

### New arguments

| Argument | API parameter | Type |
|---|---|---|
| `app_rule_id` | `AppRuleId` | string |
| `desktop_member_ip` | `DesktopMemberIp` | string |
| `desktop_name_suffix` | `DesktopNameSuffix` | bool |
| `group_id` | `GroupId` | string |
| `ou_path` | `OUPath` | string |
| `promotion_id` | `PromotionId` | string |
| `qos_rule_id` | `QosRuleId` | string |
| `reseller_owner_uid` | `ResellerOwnerUid` | int |
| `resource_group_id` | `ResourceGroupId` | string |
| `snapshot_policy_id` | `SnapshotPolicyId` | string |
| `subnet_id` | `SubnetId` | string |
| `timer_group_id` | `TimerGroupId` | string |
| `volume_encryption_enabled` | `VolumeEncryptionEnabled` | bool |
| `volume_encryption_key` | `VolumeEncryptionKey` | string |

All new arguments are `Optional` and `ForceNew`: no backing `Modify*` API has been verified for them, so changing any of these values triggers resource replacement rather than a silent in-place no-op. Boolean arguments use `GetOkExists` so an explicit `false` is forwarded to the API, matching the existing `auto_pay` handling.

### Tests

`TestAccAlicloudECDDesktop_basic0` is extended to set the new arguments with zero/empty values so every new schema field is covered by the acceptance config. `GetOk` skips empty/zero values, so these additions do not change the existing create behavior.

### Notes

- `desktop-timers` (deprecated in favor of `TimerGroupId`) is intentionally not exposed; `timer_group_id` covers the replacement.
- API parameters marked "not available for use" (`directory-id`, `channel-cookie`, `saving-plan-id`, `user-name`, `vpc-id`) and the internal-only `extend-info` are not exposed.
- Complex nested parameters (`bundle-models`, `desktop-attachment`, `desktop-name-model`, `month-desktop-setting`, `purchase-options`, `user-commands`) require dedicated schema design and are deferred to follow-up changes.
