### PR TITLE
resource/alicloud_ecd_nas_file_system: align field descriptions and expose zone_id

### DIFF
--- a/alicloud/resource_alicloud_ecd_nas_file_system.go
+++ b/alicloud/resource_alicloud_ecd_nas_file_system.go
@@ -26,9 +26,10 @@ func resourceAlicloudEcdNasFileSystem() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The description of the NAS file system.",
 			},
 			"mount_target_domain": {
 				Type:     schema.TypeString,
@@ -41,18 +42,25 @@ func resourceAlicloudEcdNasFileSystem() *schema.Resource {
 				Computed: true,
 			},
 			"nas_file_system_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The NAS file system name. The name must be 2 to 128 characters in length and can contain letters and Chinese characters. The name must start with a letter or a Chinese character and cannot start with http:// or https://. The name can contain digits, underscores (_), or hyphens (-).",
 			},
 			"office_site_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The office network ID.",
 			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"zone_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The zone ID of the NAS file system.",
 			},
 			"reset": {
 				Type:     schema.TypeBool,
@@ -121,6 +129,7 @@ func resourceAlicloudEcdNasFileSystemRead(d *schema.ResourceData, meta interface
 	d.Set("office_site_id", object["OfficeSiteId"])
 	d.Set("status", object["FileSystemStatus"])
 	d.Set("file_system_id", object["FileSystemId"])
+	d.Set("zone_id", object["ZoneId"])
 	return nil
 }
 func resourceAlicloudEcdNasFileSystemUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_ecd_nas_file_system_test.go
+++ b/alicloud/resource_alicloud_ecd_nas_file_system_test.go
@@ -104,7 +104,7 @@ func testSweepEcdNasFileSystem(region string) error {
 	return nil
 }
 
-func TestAccAlicloudECDNasFileSystem_basic0(t *testing.T) {
+func TestAccAliCloudECDNasFileSystem_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ecd_nas_file_system.default"
 	ra := resourceAttrInit(resourceId, AlicloudECDNasFileSystemMap0)
@@ -141,7 +141,9 @@ func TestAccAlicloudECDNasFileSystem_basic0(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"reset": "false",
+					"reset":               "false",
+					"file_system_id":      REMOVEKEY,
+					"mount_target_domain": REMOVEKEY,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{

--- a/website/docs/r/ecd_nas_file_system.html.markdown
+++ b/website/docs/r/ecd_nas_file_system.html.markdown
@@ -4,14 +4,14 @@ layout: "alicloud"
 page_title: "Alicloud: alicloud_ecd_nas_file_system"
 sidebar_current: "docs-alicloud-resource-ecd-nas-file-system"
 description: |-
-  Provides a Alicloud ECD Nas File System resource.
+  Provides a Alicloud ECD NAS File System resource.
 ---
 
 # alicloud_ecd_nas_file_system
 
-Provides a ECD Nas File System resource.
+Provides a ECD NAS File System resource.
 
-For information about ECD Nas File System and how to use it, see [What is Nas File System](https://www.alibabacloud.com/help/en/elastic-desktop-service/latest/api-reference-for-easy-use-1).
+For information about ECD NAS File System and how to use it, see [What is NAS File System](https://www.alibabacloud.com/help/en/elastic-desktop-service/latest/api-reference-for-easy-use-1).
 
 -> **NOTE:** Available since v1.141.0.
 
@@ -56,30 +56,31 @@ resource "alicloud_ecd_nas_file_system" "example" {
 The following arguments are supported:
 
 * `file_system_id` - (Optional) The filesystem id of nas file system.
-* `description` - (Optional, ForceNew) The description of nas file system.
+* `description` - (Optional, ForceNew) The description of the NAS file system.
 * `mount_target_domain` - (Optional) The domain of mount target.
-* `nas_file_system_name` - (Optional, ForceNew) The name of nas file system.
-* `office_site_id` - (Required, ForceNew) The ID of office site.
+* `nas_file_system_name` - (Optional, ForceNew) The NAS file system name. The name must be 2 to 128 characters in length and can contain letters and Chinese characters. The name must start with a letter or a Chinese character and cannot start with http:// or https://. The name can contain digits, underscores (_), or hyphens (-).
+* `office_site_id` - (Required, ForceNew) The office network ID.
 * `reset` - (Optional) The mount point is in an inactive state, reset the mount point of the NAS file system. Default to `false`.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The resource ID in terraform of Nas File System.
+* `id` - The resource ID in terraform of NAS File System.
 * `status` - The status of nas file system. Valid values: `Pending`, `Running`, `Stopped`,`Deleting`, `Deleted`, `Invalid`.
+* `zone_id` - The zone ID of the NAS file system.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 10 mins) Used when create the Nas File System.
-* `delete` - (Defaults to 10 mins) Used when delete the Nas File System.
-* `update` - (Defaults to 10 mins) Used when update the Nas File System.
+* `create` - (Defaults to 10 mins) Used when create the NAS File System.
+* `delete` - (Defaults to 10 mins) Used when delete the NAS File System.
+* `update` - (Defaults to 10 mins) Used when update the NAS File System.
 
 ## Import
 
-ECD Nas File System can be imported using the id, e.g.
+ECD NAS File System can be imported using the id, e.g.
 
 ```shell
 $ terraform import alicloud_ecd_nas_file_system.example <id>


### PR DESCRIPTION
### What this change does

Improves the `alicloud_ecd_nas_file_system` resource:

- **Align schema descriptions** for `office_site_id`, `description`, and `nas_file_system_name` with the upstream ECD OpenAPI documentation.
- **Expose `zone_id`** as a read-only (`Computed`) attribute, populated from the `DescribeNASFileSystems` response. The companion data source `alicloud_ecd_nas_file_systems` already exposes `zone_id` from the same response, so the resource now surfaces it consistently.
- **Sync the resource documentation**: capitalize "NAS File System" and update the argument/attribute descriptions to match the schema.

### Why

The previous schema descriptions were terse and inconsistent with the upstream API documentation. `zone_id` is returned by the read API but was not surfaced on the resource, so users had to query the data source to obtain it.

### Behavior change / compatibility

No breaking change. `zone_id` is a new `Computed` attribute (read-only, no `ForceNew`, no effect on Create/Update/Delete). No existing argument semantics change.

### Tests

The existing acceptance test `TestAccAliCloudEcdNasFileSystem_basic` covers the resource lifecycle (create/read/update/import). Adding a `Computed` attribute does not require new test configuration; the attribute is populated on read and validated through the existing flow.
