### PR TITLE
resource/alicloud_ecd_ad_connector_directory: add directory_type and refine desktop_access_type

### DIFF
--- a/alicloud/resource_alicloud_ecd_ad_connector_directory.go
+++ b/alicloud/resource_alicloud_ecd_ad_connector_directory.go
@@ -39,6 +39,10 @@ func resourceAlicloudEcdAdConnectorDirectory() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"VPC", "INTERNET", "ANY"}, false),
 			},
+			"directory_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"dns_address": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -112,7 +116,7 @@ func resourceAlicloudEcdAdConnectorDirectoryCreate(d *schema.ResourceData, meta 
 	var err error
 	request["DirectoryName"] = d.Get("directory_name")
 	if v, ok := d.GetOk("desktop_access_type"); ok {
-		request["DesktopAccessType"] = v
+		request["DesktopAccessType"] = v.(string)
 	}
 	request["DnsAddress"] = d.Get("dns_address")
 	request["DomainName"] = d.Get("domain_name")
@@ -170,6 +174,7 @@ func resourceAlicloudEcdAdConnectorDirectoryRead(d *schema.ResourceData, meta in
 	}
 	d.Set("directory_name", object["Name"])
 	d.Set("desktop_access_type", object["DesktopAccessType"])
+	d.Set("directory_type", object["DirectoryType"])
 	d.Set("dns_address", object["DnsAddress"])
 	d.Set("domain_name", object["DomainName"])
 	d.Set("domain_user_name", object["DomainUserName"])

--- a/website/docs/r/ecd_ad_connector_directory.html.markdown
+++ b/website/docs/r/ecd_ad_connector_directory.html.markdown
@@ -91,6 +91,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `directory_type` - The type of the directory. Valid values: `SIMPLE`, `AD_CONNECTOR`.
 * `id` - The resource ID in terraform of Ad Connector Directory.
 * `status` - The status of directory.
 


### PR DESCRIPTION
## What
- Add `directory_type` as a computed attribute for `alicloud_ecd_ad_connector_directory`, read back from the `DescribeDirectories` response (`$.Directories[*].DirectoryType`). For an AD Connector directory this is always `AD_CONNECTOR`.
- Refine the `desktop_access_type` create request to pass a typed `string` value.
- Update the resource documentation Attributes Reference.

## Why
The `DirectoryType` field is returned by `DescribeDirectories` but was not surfaced in the resource schema. Exposing it as a computed attribute lets users read the directory type after creation/import.

## Notes
- `desktop_access_type` already existed in schema/create/read; this change only tightens the create-request value typing.
- Acceptance tests will be run against this PR.
