### PR TITLE
resource/alicloud_ecd_simple_office_site: support governance attributes

### DIFF
--- a/alicloud/resource_alicloud_ecd_simple_office_site.go
+++ b/alicloud/resource_alicloud_ecd_simple_office_site.go
@@ -37,6 +37,12 @@ func resourceAlicloudEcdSimpleOfficeSite() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"cloud_box_office_site": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"cidr_block": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -70,6 +76,16 @@ func resourceAlicloudEcdSimpleOfficeSite() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
+			"need_verify_login_risk": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"need_verify_zero_device": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"office_site_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -78,6 +94,17 @@ func resourceAlicloudEcdSimpleOfficeSite() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 				Optional: true,
+			},
+			"verify_code": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"vpc_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
 			},
 			"status": {
 				Type:     schema.TypeString,
@@ -118,6 +145,18 @@ func resourceAlicloudEcdSimpleOfficeSiteCreate(d *schema.ResourceData, meta inte
 
 	if v, ok := d.GetOk("desktop_access_type"); ok {
 		request["DesktopAccessType"] = v
+	}
+	if v, ok := d.GetOkExists("cloud_box_office_site"); ok {
+		request["CloudBoxOfficeSite"] = v
+	}
+	if v, ok := d.GetOk("verify_code"); ok {
+		request["VerifyCode"] = v
+	}
+	if v, ok := d.GetOkExists("need_verify_zero_device"); ok {
+		request["NeedVerifyZeroDevice"] = v
+	}
+	if v, ok := d.GetOk("vpc_type"); ok {
+		request["VpcType"] = v
 	}
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
@@ -170,6 +209,10 @@ func resourceAlicloudEcdSimpleOfficeSiteRead(d *schema.ResourceData, meta interf
 	d.Set("mfa_enabled", object["MfaEnabled"])
 	d.Set("enable_internet_access", object["EnableInternetAccess"])
 	d.Set("sso_enabled", object["SsoEnabled"])
+	d.Set("need_verify_login_risk", object["NeedVerifyLoginRisk"])
+	d.Set("cloud_box_office_site", object["CloudBoxOfficeSite"])
+	d.Set("need_verify_zero_device", object["NeedVerifyZeroDevice"])
+	d.Set("vpc_type", object["VpcType"])
 	d.Set("status", object["Status"])
 	return nil
 }
@@ -290,6 +333,18 @@ func resourceAlicloudEcdSimpleOfficeSiteUpdate(d *schema.ResourceData, meta inte
 	if v, ok := d.GetOk("office_site_name"); ok {
 		request["OfficeSiteName"] = v
 	}
+	if !d.IsNewResource() && d.HasChange("need_verify_login_risk") {
+		update = true
+		if v, ok := d.GetOkExists("need_verify_login_risk"); ok {
+			request["NeedVerifyLoginRisk"] = v
+		}
+	}
+	if !d.IsNewResource() && d.HasChange("need_verify_zero_device") {
+		update = true
+		if v, ok := d.GetOkExists("need_verify_zero_device"); ok {
+			request["NeedVerifyZeroDevice"] = v
+		}
+	}
 	if update {
 		request["RegionId"] = client.RegionId
 		action := "ModifyOfficeSiteAttribute"
@@ -311,6 +366,8 @@ func resourceAlicloudEcdSimpleOfficeSiteUpdate(d *schema.ResourceData, meta inte
 		}
 		d.SetPartial("desktop_access_type")
 		d.SetPartial("office_site_name")
+		d.SetPartial("need_verify_login_risk")
+		d.SetPartial("need_verify_zero_device")
 	}
 	d.Partial(false)
 	return resourceAlicloudEcdSimpleOfficeSiteRead(d, meta)

--- a/alicloud/resource_alicloud_ecd_simple_office_site_test.go
+++ b/alicloud/resource_alicloud_ecd_simple_office_site_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAccAlicloudECDSimpleOfficeSite_basic0(t *testing.T) {
+func TestAccAliCloudECDSimpleOfficeSite_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ecd_simple_office_site.default"
 	ra := resourceAttrInit(resourceId, AlicloudECDSimpleOfficeSiteMap0)
@@ -47,6 +47,7 @@ func TestAccAlicloudECDSimpleOfficeSite_basic0(t *testing.T) {
 					"enable_internet_access": "false",
 					"enable_admin_access":    "true",
 					"office_site_name":       name,
+					"cloud_box_office_site":  "false",
 					// TODO: there is an api bug that the api does not return cen_id. It will be reopen after the bug is gone.
 					//"cen_id": "${alicloud_cen_instance.default.id}",
 				}),
@@ -56,6 +57,7 @@ func TestAccAlicloudECDSimpleOfficeSite_basic0(t *testing.T) {
 						"enable_admin_access":    "true",
 						"enable_internet_access": "false",
 						"office_site_name":       name,
+						"cloud_box_office_site":  "false",
 					}),
 				),
 			},
@@ -99,6 +101,18 @@ func TestAccAlicloudECDSimpleOfficeSite_basic0(t *testing.T) {
 					}),
 				),
 			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"need_verify_login_risk":  "true",
+					"need_verify_zero_device": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"need_verify_login_risk":  "true",
+						"need_verify_zero_device": "true",
+					}),
+				),
+			},
 			// TODO: Any or Vpc access type need a cen id and this needs fixing above api bug at first.
 			//{
 			//	Config: testAccConfig(map[string]interface{}{
@@ -127,6 +141,8 @@ func TestAccAlicloudECDSimpleOfficeSite_basic0(t *testing.T) {
 					"enable_cross_desktop_access": "true",
 					"desktop_access_type":         "Internet",
 					"office_site_name":            name,
+					"need_verify_login_risk":      "false",
+					"need_verify_zero_device":     "false",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -135,13 +151,65 @@ func TestAccAlicloudECDSimpleOfficeSite_basic0(t *testing.T) {
 						"enable_cross_desktop_access": "true",
 						"desktop_access_type":         "Internet",
 						"office_site_name":            name,
+						"need_verify_login_risk":      "false",
+						"need_verify_zero_device":     "false",
 					}),
 				),
 			},
 			{
-				ResourceName:      resourceId,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cen_owner_id"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudECDSimpleOfficeSite_attrs(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ecd_simple_office_site.default"
+	ra := resourceAttrInit(resourceId, AlicloudECDSimpleOfficeSiteMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EcdService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEcdSimpleOfficeSite")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%secdattrs%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudECDSimpleOfficeSiteBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.EcdSupportRegions)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"cidr_block":             "172.16.0.0/12",
+					"enable_internet_access": "false",
+					"enable_admin_access":    "true",
+					"office_site_name":       name,
+					"cloud_box_office_site":  "false",
+					"vpc_type":               "standard",
+					"verify_code":            "tf-acc-verify-code",
+					"cen_id":                 "${alicloud_cen_instance.default.id}",
+					"cen_owner_id":           "${data.alicloud_account.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cidr_block":             "172.16.0.0/12",
+						"enable_admin_access":    "true",
+						"enable_internet_access": "false",
+						"office_site_name":       name,
+						"cloud_box_office_site":  "false",
+						"vpc_type":               "standard",
+						"verify_code":            "tf-acc-verify-code",
+						"cen_id":                 CHECKSET,
+					}),
+				),
 			},
 		},
 	})
@@ -152,10 +220,11 @@ var AlicloudECDSimpleOfficeSiteMap0 = map[string]string{
 }
 
 func AlicloudECDSimpleOfficeSiteBasicDependence0(name string) string {
-	return fmt.Sprintf(` 
+	return fmt.Sprintf(`
 variable "name" {
   default = "%s"
 }
+data "alicloud_account" "default" {}
 resource "alicloud_cen_instance" "default" {
   cen_instance_name = var.name
   description       = var.name
@@ -170,13 +239,17 @@ func TestUnitAlicloudECDSimpleOfficeSite(t *testing.T) {
 	dCreate, _ := schema.InternalMap(p["alicloud_ecd_simple_office_site"].Schema).Data(nil, nil)
 	dCreate.MarkNewResource()
 	for key, value := range map[string]interface{}{
-		"enable_admin_access":    true,
-		"cen_owner_id":           "cen_owner_id",
-		"cen_id":                 "cen_id",
-		"office_site_name":       "office_site_name",
-		"enable_internet_access": true,
-		"bandwidth":              10,
-		"desktop_access_type":    "Internet",
+		"enable_admin_access":     true,
+		"cen_owner_id":            "cen_owner_id",
+		"cen_id":                  "cen_id",
+		"office_site_name":        "office_site_name",
+		"enable_internet_access":  true,
+		"bandwidth":               10,
+		"desktop_access_type":     "Internet",
+		"cloud_box_office_site":   false,
+		"need_verify_zero_device": true,
+		"vpc_type":                "standard",
+		"verify_code":             "verify_code",
 	} {
 		err := dCreate.Set(key, value)
 		assert.Nil(t, err)
@@ -204,6 +277,10 @@ func TestUnitAlicloudECDSimpleOfficeSite(t *testing.T) {
 				"MfaEnabled":               true,
 				"EnableInternetAccess":     true,
 				"SsoEnabled":               true,
+				"NeedVerifyLoginRisk":      true,
+				"CloudBoxOfficeSite":       false,
+				"NeedVerifyZeroDevice":     true,
+				"VpcType":                  "standard",
 				"Status":                   "REGISTERED",
 			},
 		},
@@ -526,7 +603,7 @@ func TestUnitAlicloudECDSimpleOfficeSite(t *testing.T) {
 
 	t.Run("UpdateModifyOfficeSiteAttributeAbnormal", func(t *testing.T) {
 		diff := terraform.NewInstanceDiff()
-		for _, key := range []string{"desktop_access_type", "office_site_name"} {
+		for _, key := range []string{"desktop_access_type", "office_site_name", "need_verify_login_risk", "need_verify_zero_device"} {
 			switch p["alicloud_ecd_simple_office_site"].Schema[key].Type {
 			case schema.TypeString:
 				diff.SetAttribute(key, &terraform.ResourceAttrDiff{Old: d.Get(key).(string), New: d.Get(key).(string) + "_update"})
@@ -561,7 +638,7 @@ func TestUnitAlicloudECDSimpleOfficeSite(t *testing.T) {
 
 	t.Run("UpdateModifyOfficeSiteAttributeNormal", func(t *testing.T) {
 		diff := terraform.NewInstanceDiff()
-		for _, key := range []string{"desktop_access_type", "office_site_name"} {
+		for _, key := range []string{"desktop_access_type", "office_site_name", "need_verify_login_risk", "need_verify_zero_device"} {
 			switch p["alicloud_ecd_simple_office_site"].Schema[key].Type {
 			case schema.TypeString:
 				diff.SetAttribute(key, &terraform.ResourceAttrDiff{Old: d.Get(key).(string), New: d.Get(key).(string) + "_update"})

--- a/website/docs/r/ecd_simple_office_site.html.markdown
+++ b/website/docs/r/ecd_simple_office_site.html.markdown
@@ -49,13 +49,18 @@ The following arguments are supported:
 * `cen_id` - (Optional, ForceNew) Cloud Enterprise Network Instance ID.
 * `cen_owner_id` - (Optional) The cen owner id.
 * `cidr_block` - (Required, ForceNew) Workspace Corresponds to the Security Office Network of IPv4 Segment.
+* `cloud_box_office_site` - (Optional, ForceNew) Specifies whether to create a Cloud Box office site. Valid values: `true`, `false`.
 * `desktop_access_type` - (Optional, Computed) Connect to the Cloud Desktop Allows the Use of the Access Mode of. Valid values: `Any`, `Internet`, `VPC`.
 * `enable_admin_access` - (Optional, ForceNew) Whether to Use Cloud Desktop User Empowerment of Local Administrator Permissions.
 * `enable_cross_desktop_access` - (Optional) Enable Cross-Desktop Access.
 * `enable_internet_access` - (Deprecated from 1.142.0) Whether the Open Internet Access Function.
 * `mfa_enabled` - (Optional) Whether to Enable Multi-Factor Authentication MFA.
+* `need_verify_login_risk` - (Optional, Computed) Specifies whether to enable two-factor authentication. Applicable to only office sites that use convenience accounts.
+* `need_verify_zero_device` - (Optional, Computed) Specifies whether to enable trusted device verification.
 * `office_site_name` - (Optional) The office site name.
 * `sso_enabled` - (Optional) Whether to Enable Single Sign-on (SSO) for User-Based SSO.
+* `verify_code` - (Optional, ForceNew) The verification code. If the CEN instance is owned by another Alibaba Cloud account, you must first call SendVerifyCode to obtain a verification code.
+* `vpc_type` - (Optional, ForceNew) The type of the office site. Valid values: `standard`, `basic`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds the following governance attributes to the `alicloud_ecd_simple_office_site` resource:

- `need_verify_login_risk` (bool, Optional + Computed) — updatable via `ModifyOfficeSiteAttribute`
- `need_verify_zero_device` (bool, Optional + Computed) — updatable via `ModifyOfficeSiteAttribute`
- `verify_code` (string, Optional, ForceNew) — create-only, not returned by Describe
- `cloud_box_office_site` (bool, Optional, ForceNew, Computed) — create-only
- `vpc_type` (string, Optional, ForceNew, Computed) — create-only

### CRUD mapping (ecd 2020-09-30 RPC)
- **Create** (`CreateSimpleOfficeSite`): sends `VerifyCode`, `CloudBoxOfficeSite`, `NeedVerifyZeroDevice`, `VpcType`
- **Read** (`DescribeOfficeSites`): populates `NeedVerifyLoginRisk`, `CloudBoxOfficeSite`, `NeedVerifyZeroDevice`, `VpcType`
- **Update** (`ModifyOfficeSiteAttribute`): sends `NeedVerifyLoginRisk`, `NeedVerifyZeroDevice` on change
- `need_verify_login_risk` is not a Create parameter (server default on create, updatable afterwards)

### Tests
- `TestAccAlicloudECDSimpleOfficeSite_basic0` — create/update/import lifecycle, covers `cloud_box_office_site` and `need_verify_login_risk`/`need_verify_zero_device` modify steps
- `TestAccAlicloudECDSimpleOfficeSite_attrs` — create-only coverage for `verify_code` and `vpc_type` (ForceNew, no import step to avoid create-only attribute diff)
- `TestUnitAlicloudECDSimpleOfficeSite` — unit mock updated with the new attributes
