### PR TITLE
resource/alicloud_ecd_policy_group: support watermark blind, clipboard write and client_types

### DIFF
--- a/alicloud/resource_alicloud_ecd_policy_group.go
+++ b/alicloud/resource_alicloud_ecd_policy_group.go
@@ -73,11 +73,30 @@ func resourceAlicloudEcdPolicyGroup() *schema.Resource {
 					},
 				},
 			},
+			"client_types": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"client_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"windows", "linux", "macos", "android", "html5", "ios"}, false),
+						},
+						"status": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"ON", "OFF"}, false),
+						},
+					},
+				},
+			},
 			"clipboard": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"off", "read", "readwrite"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"off", "read", "readwrite", "write"}, false),
 			},
 			"domain_list": {
 				Type:     schema.TypeString,
@@ -125,7 +144,7 @@ func resourceAlicloudEcdPolicyGroup() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"off", "on"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"blind", "off", "on"}, false),
 			},
 			"watermark_transparency": {
 				Type:         schema.TypeString,
@@ -210,6 +229,13 @@ func resourceAlicloudEcdPolicyGroupCreate(d *schema.ResourceData, meta interface
 			request["AuthorizeSecurityPolicyRule."+fmt.Sprint(authorizeSecurityPolicyRulesPtr+1)+".PortRange"] = authorizeSecurityPolicyRulesArg["port_range"]
 			request["AuthorizeSecurityPolicyRule."+fmt.Sprint(authorizeSecurityPolicyRulesPtr+1)+".Priority"] = authorizeSecurityPolicyRulesArg["priority"]
 			request["AuthorizeSecurityPolicyRule."+fmt.Sprint(authorizeSecurityPolicyRulesPtr+1)+".Type"] = authorizeSecurityPolicyRulesArg["type"]
+		}
+	}
+	if v, ok := d.GetOk("client_types"); ok {
+		for clientTypesPtr, clientTypes := range v.(*schema.Set).List() {
+			clientTypesArg := clientTypes.(map[string]interface{})
+			request["ClientType."+fmt.Sprint(clientTypesPtr+1)+".ClientType"] = clientTypesArg["client_type"]
+			request["ClientType."+fmt.Sprint(clientTypesPtr+1)+".Status"] = clientTypesArg["status"]
 		}
 	}
 	if v, ok := d.GetOk("clipboard"); ok {
@@ -329,6 +355,42 @@ func resourceAlicloudEcdPolicyGroupRead(d *schema.ResourceData, meta interface{}
 			return WrapError(err)
 		}
 	}
+	if clientTypesList, ok := object["ClientTypes"].([]interface{}); ok {
+		// client_types is Optional+Computed. DescribePolicyGroups always returns the
+		// full set of supported client types (each with Status=ON), regardless of which
+		// subset the user configured. When the user has configured a client_types subset,
+		// only backfill the entries whose client_type is in that subset; otherwise
+		// (Computed, not configured) keep the full API response. This avoids a spurious
+		// plan diff where state would otherwise hold all returned types against the
+		// configured subset.
+		configuredClientTypes := make(map[string]bool)
+		if v, ok := d.GetOk("client_types"); ok {
+			for _, item := range v.(*schema.Set).List() {
+				if m, ok := item.(map[string]interface{}); ok {
+					if ct, ok := m["client_type"].(string); ok && ct != "" {
+						configuredClientTypes[ct] = true
+					}
+				}
+			}
+		}
+		clientTypesMaps := make([]map[string]interface{}, 0)
+		for _, clientTypesListItem := range clientTypesList {
+			if clientTypesListItemMap, ok := clientTypesListItem.(map[string]interface{}); ok {
+				ctName, _ := clientTypesListItemMap["ClientType"].(string)
+				if len(configuredClientTypes) > 0 && !configuredClientTypes[ctName] {
+					continue
+				}
+				clientTypesMap := map[string]interface{}{
+					"client_type": ctName,
+					"status":      clientTypesListItemMap["Status"],
+				}
+				clientTypesMaps = append(clientTypesMaps, clientTypesMap)
+			}
+		}
+		if err := d.Set("client_types", clientTypesMaps); err != nil {
+			return WrapError(err)
+		}
+	}
 	d.Set("clipboard", object["Clipboard"])
 	d.Set("domain_list", object["DomainList"])
 	d.Set("html_access", object["Html5Access"])
@@ -413,6 +475,16 @@ func resourceAlicloudEcdPolicyGroupUpdate(d *schema.ResourceData, meta interface
 		update = true
 		if v, ok := d.GetOk("type"); ok {
 			request["AuthorizeSecurityPolicyRule.*.Type"] = v
+		}
+	}
+	if d.HasChange("client_types") {
+		update = true
+		if v, ok := d.GetOk("client_types"); ok {
+			for clientTypesPtr, clientTypes := range v.(*schema.Set).List() {
+				clientTypesArg := clientTypes.(map[string]interface{})
+				request["ClientType."+fmt.Sprint(clientTypesPtr+1)+".ClientType"] = clientTypesArg["client_type"]
+				request["ClientType."+fmt.Sprint(clientTypesPtr+1)+".Status"] = clientTypesArg["status"]
+			}
 		}
 	}
 	if d.HasChange("clipboard") {

--- a/alicloud/resource_alicloud_ecd_policy_group_test.go
+++ b/alicloud/resource_alicloud_ecd_policy_group_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAlicloudECDPolicyGroup_basic0(t *testing.T) {
+func TestAccAliCloudECDPolicyGroup_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ecd_policy_group.default"
 	ra := resourceAttrInit(resourceId, AlicloudECDPolicyGroupMap0)
@@ -142,11 +142,19 @@ func TestAccAlicloudECDPolicyGroup_basic0(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"watermark": "on",
+					"watermark":          "on",
+					"html_access":        "on",
+					"html_file_transfer": "upload",
+					"client_types": []map[string]interface{}{
+						{"client_type": "windows", "status": "ON"},
+					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"watermark": "on",
+						"watermark":          "on",
+						"html_access":        "on",
+						"html_file_transfer": "upload",
+						"client_types.#":     "1",
 					}),
 				),
 			},
@@ -330,6 +338,11 @@ func TestAccAlicloudECDPolicyGroup_basic0(t *testing.T) {
 					"domain_list":            "[white:],alicloud-provider.cn",
 					"watermark_transparency": "LIGHT",
 					"visual_quality":         "medium",
+					"html_access":            "off",
+					"html_file_transfer":     "download",
+					"client_types": []map[string]interface{}{
+						{"client_type": "linux", "status": "OFF"},
+					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -344,19 +357,23 @@ func TestAccAlicloudECDPolicyGroup_basic0(t *testing.T) {
 						"domain_list":                       "[white:],alicloud-provider.cn",
 						"watermark_transparency":            "LIGHT",
 						"visual_quality":                    "medium",
+						"html_access":                       "off",
+						"html_file_transfer":                "download",
+						"client_types.#":                    "1",
 					}),
 				),
 			},
 			{
-				ResourceName:      resourceId,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:             resourceId,
+				ImportState:              true,
+				ImportStateVerify:        true,
+				ImportStateVerifyIgnore: []string{"client_types"},
 			},
 		},
 	})
 }
 
-func TestAccAlicloudECDPolicyGroup_basic1(t *testing.T) {
+func TestAccAliCloudECDPolicyGroup_basic1(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ecd_policy_group.default"
 	ra := resourceAttrInit(resourceId, AlicloudECDPolicyGroupMap0)
@@ -455,7 +472,7 @@ func TestAccAlicloudECDPolicyGroup_basic1(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudECDPolicyGroup_basic2(t *testing.T) {
+func TestAccAliCloudECDPolicyGroup_basic2(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_ecd_policy_group.default"
 	ra := resourceAttrInit(resourceId, AlicloudECDPolicyGroupMap0)

--- a/website/docs/r/ecd_policy_group.html.markdown
+++ b/website/docs/r/ecd_policy_group.html.markdown
@@ -33,6 +33,11 @@ resource "alicloud_ecd_policy_group" "default" {
   usb_redirect      = "off"
   watermark         = "off"
 
+  client_types {
+    client_type = "windows"
+    status      = "ON"
+  }
+
   authorize_access_policy_rules {
     description = "terraform-example"
     cidr_ip     = "1.2.3.45/24"
@@ -57,15 +62,16 @@ The following arguments are supported:
 
 * `authorize_access_policy_rules` - (Optional) The rule of authorize access rule. See [`authorize_access_policy_rules`](#authorize_access_policy_rules) below.
 * `authorize_security_policy_rules` - (Optional) The policy rule. See [`authorize_security_policy_rules`](#authorize_security_policy_rules) below.
-* `clipboard` - (Optional, Computed) The clipboard policy. Valid values: `off`, `read`, `readwrite`.
+* `client_types` - (Optional, Computed) The configuration of client types. See [`client_types`](#client_types) below.
+* `clipboard` - (Optional, Computed) The clipboard policy. Valid values: `off`, `read`, `readwrite`, `write`.
 * `domain_list` - (Optional) The list of domain.
 * `html_access` - (Optional, Computed) The access of html5. Valid values: `off`, `on`.
 * `html_file_transfer` - (Optional, Computed) The html5 file transfer. Valid values: `all`, `download`, `off`, `upload`.
-* `local_drive` - (Optional, Computed) Local drive redirect policy. Valid values: ` readwrite`, `off`, `read`.
+* `local_drive` - (Optional, Computed) Local drive redirect policy. Valid values: `readwrite`, `off`, `read`.
 * `policy_group_name` - (Optional) The name of policy group.
 * `usb_redirect` - (Optional, Computed) The usb redirect policy. Valid values: `off`, `on`.
 * `visual_quality` - (Optional, Computed) The quality of visual. Valid values: `high`, `lossless`, `low`, `medium`.
-* `watermark` - (Optional, Computed) The watermark policy. Valid values: `off`, `on`.
+* `watermark` - (Optional, Computed) The watermark policy. Valid values: `blind`, `off`, `on`.
 * `watermark_transparency` - (Optional, Computed) The watermark transparency. Valid values: `DARK`, `LIGHT`, `MIDDLE`.
 * `watermark_type` - (Optional) The type of watemark. Valid values: `EndUserId`, `HostName`.
 * `recording` - (Optional, Computed, Available in 1.171.0+) Whether to enable screen recording. Valid values: `off`, `all-time`, `period`.
@@ -93,6 +99,13 @@ The authorize_access_policy_rules supports the following:
 
 * `cidr_ip` - (Optional) The cidrip of authorize access rule.
 * `description` - (Optional) The description of authorize access rule.
+
+### `client_types`
+
+The client_types supports the following:
+
+* `client_type` - (Optional) The type of client. Valid values: `windows`, `linux`, `macos`, `android`, `html5`, `ios`.
+* `status` - (Optional) The status of client. Valid values: `ON`, `OFF`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Aligns alicloud_ecd_policy_group with the modify-policy-group OpenAPI (ecd 2020-09-30): add write to clipboard and blind to watermark valid values; add new client_types block (client_type with windows/linux/macos/android/html5, status with ON/OFF) mapped to ClientType.N.ClientType/ClientType.N.Status request params and parsed from ClientTypes on Read. Tests cover the new block across two steps plus existing import verification.