### PR TITLE
New Resource: alicloud_ecd_desktop_group; New Data Source: alicloud_ecd_desktop_groups

### DIFF
--- a/alicloud/data_source_alicloud_ecd_desktop_groups.go
+++ b/alicloud/data_source_alicloud_ecd_desktop_groups.go
@@ -1,0 +1,420 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudEcdDesktopGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudEcdDesktopGroupRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"desktop_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"desktop_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"office_site_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"period_unit": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allow_auto_setup": {
+							Type:      schema.TypeInt,
+							Computed:  true,
+							Sensitive: true,
+						},
+						"allow_buffer_count": {
+							Type:      schema.TypeInt,
+							Computed:  true,
+							Sensitive: true,
+						},
+						"bundle_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"comments": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cpu": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"creator": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"data_disk_category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"data_disk_size": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"desktop_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"desktop_group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"directory_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"directory_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"end_user_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"end_user_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"expired_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gpu_count": {
+							Type:     schema.TypeFloat,
+							Computed: true,
+						},
+						"gpu_spec": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"keep_duration": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"max_desktops_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"memory": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"min_desktops_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"office_site_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"office_site_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"office_site_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"own_bundle_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"pay_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"policy_group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"res_type": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"system_disk_category": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"system_disk_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudEcdDesktopGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeDesktopGroups"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("desktop_group_id"); ok {
+		request["DesktopGroupId"] = v
+	}
+	if v, ok := d.GetOk("desktop_group_name"); ok {
+		request["DesktopGroupName"] = v
+	}
+	if v, ok := d.GetOk("office_site_id"); ok {
+		request["OfficeSiteId"] = v
+	}
+	if v, ok := d.GetOk("period_unit"); ok {
+		request["PeriodUnit"] = v
+	}
+	request["MaxResults"] = PageSizeLarge
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("ecd", "2020-09-30", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.DesktopGroups[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["DesktopGroupName"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["DesktopGroupId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if nextToken, ok := response["NextToken"].(string); ok && nextToken != "" {
+			request["NextToken"] = nextToken
+		} else {
+			break
+		}
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["DesktopGroupId"]
+
+		mapping["bundle_id"] = objectRaw["OwnBundleId"]
+		mapping["comments"] = objectRaw["Comments"]
+		mapping["cpu"] = objectRaw["Cpu"]
+		mapping["create_time"] = objectRaw["CreateTime"]
+		mapping["creator"] = objectRaw["Creator"]
+		mapping["data_disk_category"] = objectRaw["DataDiskCategory"]
+		mapping["data_disk_size"] = objectRaw["DataDiskSize"]
+		mapping["desktop_group_name"] = objectRaw["DesktopGroupName"]
+		mapping["directory_id"] = objectRaw["DirectoryId"]
+		mapping["directory_type"] = objectRaw["DirectoryType"]
+		mapping["expired_time"] = objectRaw["ExpiredTime"]
+		mapping["gpu_count"] = objectRaw["GpuCount"]
+		mapping["gpu_spec"] = objectRaw["GpuSpec"]
+		mapping["keep_duration"] = objectRaw["KeepDuration"]
+		mapping["max_desktops_count"] = objectRaw["MaxDesktopsCount"]
+		mapping["memory"] = objectRaw["Memory"]
+		mapping["min_desktops_count"] = objectRaw["MinDesktopsCount"]
+		mapping["office_site_id"] = objectRaw["OfficeSiteId"]
+		mapping["office_site_name"] = objectRaw["OfficeSiteName"]
+		mapping["office_site_type"] = objectRaw["OfficeSiteType"]
+		mapping["own_bundle_name"] = objectRaw["OwnBundleName"]
+		mapping["pay_type"] = objectRaw["PayType"]
+		mapping["policy_group_id"] = objectRaw["PolicyGroupId"]
+		mapping["policy_group_name"] = objectRaw["PolicyGroupName"]
+		mapping["system_disk_category"] = objectRaw["SystemDiskCategory"]
+		mapping["system_disk_size"] = objectRaw["SystemDiskSize"]
+		mapping["desktop_group_id"] = objectRaw["DesktopGroupId"]
+		mapping["end_user_count"] = objectRaw["EndUserCount"]
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			names = append(names, objectRaw["DesktopGroupName"])
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["DesktopGroupId"])
+		mapping, err = dataSourceAliCloudEcdDesktopGroupReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["DesktopGroupName"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("groups", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudEcdDesktopGroupReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	ecdServiceV2 := EcdServiceV2{client}
+	getResp, err := ecdServiceV2.DescribeEcdDesktopGroup(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["allow_auto_setup"] = objectRaw["AllowAutoSetup"]
+	mapping["allow_buffer_count"] = objectRaw["AllowBufferCount"]
+	mapping["bundle_id"] = objectRaw["OwnBundleId"]
+	mapping["comments"] = objectRaw["Comments"]
+	mapping["cpu"] = objectRaw["Cpu"]
+	mapping["create_time"] = objectRaw["CreationTime"]
+	mapping["creator"] = objectRaw["Creator"]
+	mapping["data_disk_category"] = objectRaw["DataDiskCategory"]
+	mapping["data_disk_size"] = objectRaw["DataDiskSize"]
+	mapping["desktop_group_name"] = objectRaw["DesktopGroupName"]
+	mapping["directory_id"] = objectRaw["DirectoryId"]
+	mapping["directory_type"] = objectRaw["DirectoryType"]
+	mapping["expired_time"] = objectRaw["ExpiredTime"]
+	mapping["gpu_count"] = objectRaw["GpuCount"]
+	mapping["gpu_spec"] = objectRaw["GpuSpec"]
+	mapping["keep_duration"] = objectRaw["KeepDuration"]
+	mapping["max_desktops_count"] = objectRaw["MaxDesktopsCount"]
+	mapping["memory"] = objectRaw["Memory"]
+	mapping["min_desktops_count"] = objectRaw["MinDesktopsCount"]
+	mapping["office_site_id"] = objectRaw["OfficeSiteId"]
+	mapping["office_site_name"] = objectRaw["OfficeSiteName"]
+	mapping["office_site_type"] = objectRaw["OfficeSiteType"]
+	mapping["own_bundle_name"] = objectRaw["OwnBundleName"]
+	mapping["pay_type"] = objectRaw["PayType"]
+	mapping["policy_group_id"] = objectRaw["PolicyGroupId"]
+	mapping["policy_group_name"] = objectRaw["PolicyGroupName"]
+	mapping["res_type"] = objectRaw["ResType"]
+	mapping["system_disk_category"] = objectRaw["SystemDiskCategory"]
+	mapping["system_disk_size"] = objectRaw["SystemDiskSize"]
+	mapping["desktop_group_id"] = objectRaw["DesktopGroupId"]
+
+	usersObject, err := ecdServiceV2.DescribeDesktopGroupDescribeUsersInGroup(id)
+	if err != nil {
+		if !NotFoundError(err) {
+			return nil, WrapError(err)
+		}
+	} else {
+		mapping["end_user_ids"] = usersObject["EndUserIds"]
+	}
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_ecd_desktop_groups_test.go
+++ b/alicloud/data_source_alicloud_ecd_desktop_groups_test.go
@@ -1,0 +1,174 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudEcdDesktopGroupsDataSource_basic0(t *testing.T) {
+	rand := 10000 + acctest.RandIntRange(0, 89999)
+	resourceId := "data.alicloud_ecd_desktop_groups.default"
+	name := fmt.Sprintf("tf-testaccdesktopgroupds%d", rand)
+	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceEcdDesktopGroupsConfig)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"ids":            []string{"${alicloud_ecd_desktop_group.default.id}"},
+			"enable_details": "true",
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"ids": []string{"${alicloud_ecd_desktop_group.default.id}_fake"},
+		}),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"name_regex":     "${alicloud_ecd_desktop_group.default.desktop_group_name}",
+			"enable_details": "true",
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"name_regex": "tf-fake-nonexist",
+		}),
+	}
+
+	officeSiteIdConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"office_site_id": "${alicloud_ecd_simple_office_site.default.id}",
+			"enable_details": "true",
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"office_site_id": "cn-shanghai+dir-0000000000",
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"ids":                []string{"${alicloud_ecd_desktop_group.default.id}"},
+			"name_regex":         "${alicloud_ecd_desktop_group.default.desktop_group_name}",
+			"desktop_group_id":   "${alicloud_ecd_desktop_group.default.id}",
+			"desktop_group_name": "${alicloud_ecd_desktop_group.default.desktop_group_name}",
+			"office_site_id":     "${alicloud_ecd_simple_office_site.default.id}",
+			"period_unit":        "Month",
+			"enable_details":     "true",
+			"output_file":        "desktop_groups_output.json",
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"ids":              []string{"${alicloud_ecd_desktop_group.default.id}_fake"},
+			"name_regex":       "tf-fake-nonexist",
+			"desktop_group_id": "dg-0000000000fake",
+			"enable_details":   "true",
+		}),
+	}
+
+	var existAliCloudEcdDesktopGroupsMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":                         "1",
+			"names.#":                       "1",
+			"groups.#":                      "1",
+			"groups.0.id":                   CHECKSET,
+			"groups.0.desktop_group_id":     CHECKSET,
+			"groups.0.desktop_group_name":   CHECKSET,
+			"groups.0.bundle_id":            CHECKSET,
+			"groups.0.comments":             CHECKSET,
+			"groups.0.office_site_id":       CHECKSET,
+			"groups.0.office_site_name":     CHECKSET,
+			"groups.0.office_site_type":     CHECKSET,
+			"groups.0.policy_group_id":      CHECKSET,
+			"groups.0.policy_group_name":    CHECKSET,
+			"groups.0.pay_type":             CHECKSET,
+			"groups.0.create_time":          CHECKSET,
+			"groups.0.cpu":                  CHECKSET,
+			"groups.0.memory":               CHECKSET,
+			"groups.0.system_disk_category": CHECKSET,
+			"groups.0.system_disk_size":     CHECKSET,
+			"groups.0.min_desktops_count":   CHECKSET,
+			"groups.0.max_desktops_count":   CHECKSET,
+			"groups.0.allow_auto_setup":     CHECKSET,
+			"groups.0.allow_buffer_count":   CHECKSET,
+			"groups.0.keep_duration":        CHECKSET,
+			"groups.0.end_user_count":       CHECKSET,
+			"groups.0.end_user_ids.#":       "1",
+			"groups.0.end_user_ids.0":       CHECKSET,
+			"groups.0.res_type":             CHECKSET,
+			"groups.0.creator":              CHECKSET,
+		}
+	}
+
+	var fakeAliCloudEcdDesktopGroupsMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":    "0",
+			"names.#":  "0",
+			"groups.#": "0",
+		}
+	}
+
+	var aliCloudEcdDesktopGroupsInfo = dataSourceAttr{
+		resourceId:   "data.alicloud_ecd_desktop_groups.default",
+		existMapFunc: existAliCloudEcdDesktopGroupsMapFunc,
+		fakeMapFunc:  fakeAliCloudEcdDesktopGroupsMapFunc,
+	}
+
+	preCheck := func() {
+		testAccPreCheckWithRegions(t, true, connectivity.EcdUserSupportRegions)
+	}
+
+	aliCloudEcdDesktopGroupsInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, idsConf, nameRegexConf, officeSiteIdConf, allConf)
+}
+
+func dataSourceEcdDesktopGroupsConfig(name string) string {
+	rand := 10000 + acctest.RandIntRange(0, 89999)
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_ecd_bundles" "default" {
+  bundle_type = "SYSTEM"
+}
+
+resource "alicloud_ecd_simple_office_site" "default" {
+  cidr_block          = "172.16.0.0/12"
+  desktop_access_type = "Internet"
+  office_site_name    = var.name
+}
+
+resource "alicloud_ecd_policy_group" "default" {
+  policy_group_name = var.name
+  clipboard         = "readwrite"
+  local_drive       = "read"
+  authorize_access_policy_rules {
+    description = var.name
+    cidr_ip     = "1.2.3.4/24"
+  }
+  authorize_security_policy_rules {
+    type        = "inflow"
+    policy      = "accept"
+    description = var.name
+    port_range  = "80/80"
+    ip_protocol = "TCP"
+    priority    = "1"
+    cidr_ip     = "0.0.0.0/0"
+  }
+}
+
+resource "alicloud_ecd_user" "default" {
+  end_user_id = "tf_testacc-dgds-u1-%d"
+  email       = "hello.dgds.%d@aaa.com"
+  phone       = "158016%d"
+  password    = "%d"
+}
+
+resource "alicloud_ecd_desktop_group" "default" {
+  office_site_id     = alicloud_ecd_simple_office_site.default.id
+  policy_group_id    = alicloud_ecd_policy_group.default.id
+  bundle_id          = data.alicloud_ecd_bundles.default.bundles.0.id
+  end_user_ids       = [alicloud_ecd_user.default.id]
+  desktop_group_name = var.name
+  comments           = var.name
+  allow_buffer_count = 0
+}
+`, name, rand, rand, rand, rand)
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -173,6 +173,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"alicloud_express_connect_router_express_connect_routers": dataSourceAliCloudExpressConnectRouterExpressConnectRouters(),
+			"alicloud_ecd_desktop_groups":                             dataSourceAliCloudEcdDesktopGroups(),
 			"alicloud_redis_global_security_ip_groups":                dataSourceAliCloudRedisGlobalSecurityIpGroups(),
 			"alicloud_cr_artifact_subscription_rules":                 dataSourceAliCloudCrArtifactSubscriptionRules(),
 			"alicloud_cms_event_notify_policies":                      dataSourceAliCloudCmsEventNotifyPolicies(),
@@ -960,6 +961,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_gpdb_db_extension":                                    resourceAliCloudGpdbDbExtension(),
+			"alicloud_ecd_desktop_group":                                    resourceAliCloudEcdDesktopGroup(),
 			"alicloud_redis_global_security_ip_group":                       resourceAliCloudRedisGlobalSecurityIpGroup(),
 			"alicloud_cr_artifact_subscription_rule":                        resourceAliCloudCrArtifactSubscriptionRule(),
 			"alicloud_cms_event_notify_policy":                              resourceAliCloudCmsEventNotifyPolicy(),

--- a/alicloud/resource_alicloud_ecd_desktop_group.go
+++ b/alicloud/resource_alicloud_ecd_desktop_group.go
@@ -1,0 +1,594 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudEcdDesktopGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudEcdDesktopGroupCreate,
+		Read:   resourceAliCloudEcdDesktopGroupRead,
+		Update: resourceAliCloudEcdDesktopGroupUpdate,
+		Delete: resourceAliCloudEcdDesktopGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"allow_auto_setup": {
+				Type:      schema.TypeInt,
+				Optional:  true,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"allow_buffer_count": {
+				Type:      schema.TypeInt,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"bundle_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"comments": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cpu": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"creator": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_disk_category": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_disk_size": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"desktop_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"directory_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"directory_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"end_user_ids": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"expired_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"gpu_count": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"gpu_spec": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"keep_duration": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"max_desktops_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"memory": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"min_desktops_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"office_site_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"office_site_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"office_site_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"own_bundle_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"pay_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"policy_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"policy_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"res_type": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"scale_strategy_id": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"system_disk_category": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"system_disk_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudEcdDesktopGroupCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateDesktopGroup"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	request["ClientToken"] = buildClientToken(action)
+	request["ChargeType"] = "PostPaid"
+
+	if v, ok := d.GetOkExists("allow_auto_setup"); ok {
+		request["AllowAutoSetup"] = v
+	}
+	request["OfficeSiteId"] = d.Get("office_site_id")
+	if v, ok := d.GetOk("end_user_ids"); ok {
+		endUserIdsMapsArray := convertToInterfaceArray(v)
+
+		request["EndUserIds"] = endUserIdsMapsArray
+	}
+
+	if v, ok := d.GetOkExists("max_desktops_count"); ok {
+		request["MaxDesktopsCount"] = v
+	}
+	request["BundleId"] = d.Get("bundle_id")
+	if v, ok := d.GetOkExists("keep_duration"); ok {
+		request["KeepDuration"] = v
+	}
+	if v, ok := d.GetOk("directory_id"); ok {
+		request["DirectoryId"] = v
+	}
+	if v, ok := d.GetOk("desktop_group_name"); ok {
+		request["DesktopGroupName"] = v
+	}
+	if v, ok := d.GetOk("comments"); ok {
+		request["Comments"] = v
+	}
+	if v, ok := d.GetOkExists("allow_buffer_count"); ok {
+		request["AllowBufferCount"] = v
+	}
+	if v, ok := d.GetOkExists("min_desktops_count"); ok {
+		request["MinDesktopsCount"] = v
+	}
+	if v, ok := d.GetOk("scale_strategy_id"); ok {
+		request["ScaleStrategyId"] = v
+	}
+	request["PolicyGroupId"] = d.Get("policy_group_id")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("ecd", "2020-09-30", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ecd_desktop_group", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["DesktopGroupId"]))
+
+	return resourceAliCloudEcdDesktopGroupUpdate(d, meta)
+}
+
+func resourceAliCloudEcdDesktopGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ecdServiceV2 := EcdServiceV2{client}
+
+	objectRaw, err := ecdServiceV2.DescribeEcdDesktopGroup(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ecd_desktop_group DescribeEcdDesktopGroup Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("allow_auto_setup", objectRaw["AllowAutoSetup"])
+	d.Set("allow_buffer_count", objectRaw["AllowBufferCount"])
+	d.Set("bundle_id", objectRaw["OwnBundleId"])
+	d.Set("comments", objectRaw["Comments"])
+	d.Set("cpu", objectRaw["Cpu"])
+	d.Set("create_time", objectRaw["CreationTime"])
+	d.Set("creator", objectRaw["Creator"])
+	d.Set("data_disk_category", objectRaw["DataDiskCategory"])
+	d.Set("data_disk_size", objectRaw["DataDiskSize"])
+	d.Set("desktop_group_name", objectRaw["DesktopGroupName"])
+	d.Set("directory_id", objectRaw["DirectoryId"])
+	d.Set("directory_type", objectRaw["DirectoryType"])
+	d.Set("expired_time", objectRaw["ExpiredTime"])
+	d.Set("gpu_count", objectRaw["GpuCount"])
+	d.Set("gpu_spec", objectRaw["GpuSpec"])
+	d.Set("keep_duration", objectRaw["KeepDuration"])
+	d.Set("max_desktops_count", objectRaw["MaxDesktopsCount"])
+	d.Set("memory", objectRaw["Memory"])
+	d.Set("min_desktops_count", objectRaw["MinDesktopsCount"])
+	d.Set("office_site_id", objectRaw["OfficeSiteId"])
+	d.Set("office_site_name", objectRaw["OfficeSiteName"])
+	d.Set("office_site_type", objectRaw["OfficeSiteType"])
+	d.Set("own_bundle_name", objectRaw["OwnBundleName"])
+	d.Set("pay_type", objectRaw["PayType"])
+	d.Set("policy_group_id", objectRaw["PolicyGroupId"])
+	d.Set("policy_group_name", objectRaw["PolicyGroupName"])
+	d.Set("res_type", objectRaw["ResType"])
+	d.Set("system_disk_category", objectRaw["SystemDiskCategory"])
+	d.Set("system_disk_size", objectRaw["SystemDiskSize"])
+
+	usersObject, err := ecdServiceV2.DescribeDesktopGroupDescribeUsersInGroup(d.Id())
+	if err != nil {
+		if !NotFoundError(err) {
+			return WrapError(err)
+		}
+	} else {
+		d.Set("end_user_ids", usersObject["EndUserIds"])
+	}
+
+	return nil
+}
+
+func resourceAliCloudEcdDesktopGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "ModifyDesktopGroup"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["DesktopGroupId"] = d.Id()
+	request["RegionId"] = client.RegionId
+	if !d.IsNewResource() && d.HasChange("allow_auto_setup") {
+		update = true
+		request["AllowAutoSetup"] = d.Get("allow_auto_setup")
+	}
+
+	if !d.IsNewResource() && d.HasChange("min_desktops_count") {
+		update = true
+		request["MinDesktopsCount"] = d.Get("min_desktops_count")
+	}
+
+	if !d.IsNewResource() && d.HasChange("scale_strategy_id") {
+		update = true
+		request["ScaleStrategyId"] = d.Get("scale_strategy_id")
+	}
+
+	if !d.IsNewResource() && d.HasChange("max_desktops_count") {
+		update = true
+		request["MaxDesktopsCount"] = d.Get("max_desktops_count")
+	}
+
+	if !d.IsNewResource() && d.HasChange("bundle_id") {
+		update = true
+	}
+	request["OwnBundleId"] = d.Get("bundle_id")
+	if !d.IsNewResource() && d.HasChange("keep_duration") {
+		update = true
+		request["KeepDuration"] = d.Get("keep_duration")
+	}
+
+	if !d.IsNewResource() && d.HasChange("desktop_group_name") {
+		update = true
+		request["DesktopGroupName"] = d.Get("desktop_group_name")
+	}
+
+	if !d.IsNewResource() && d.HasChange("comments") {
+		update = true
+		request["Comments"] = d.Get("comments")
+	}
+
+	if !d.IsNewResource() && d.HasChange("allow_buffer_count") {
+		update = true
+		request["AllowBufferCount"] = d.Get("allow_buffer_count")
+	}
+
+	if !d.IsNewResource() && d.HasChange("policy_group_id") {
+		update = true
+	}
+	request["PolicyGroupId"] = d.Get("policy_group_id")
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("ecd", "2020-09-30", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	if !d.IsNewResource() && d.HasChange("end_user_ids") {
+		var err error
+		oldEntry, newEntry := d.GetChange("end_user_ids")
+		oldUsers := make(map[string]interface{})
+		for _, v := range oldEntry.([]interface{}) {
+			oldUsers[fmt.Sprint(v)] = v
+		}
+		newUsers := make(map[string]interface{})
+		for _, v := range newEntry.([]interface{}) {
+			newUsers[fmt.Sprint(v)] = v
+		}
+		removed := make([]interface{}, 0)
+		for _, v := range oldEntry.([]interface{}) {
+			if _, ok := newUsers[fmt.Sprint(v)]; !ok {
+				removed = append(removed, v)
+			}
+		}
+		added := make([]interface{}, 0)
+		for _, v := range newEntry.([]interface{}) {
+			if _, ok := oldUsers[fmt.Sprint(v)]; !ok {
+				added = append(added, v)
+			}
+		}
+
+		if len(removed) > 0 {
+			action := "RemoveUserFromDesktopGroup"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["DesktopGroupId"] = d.Id()
+			request["RegionId"] = client.RegionId
+			endUserIdsMapsArray := removed
+			request["EndUserIds"] = endUserIdsMapsArray
+
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("ecd", "2020-09-30", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+
+		}
+
+		if len(added) > 0 {
+			action := "AddUserToDesktopGroup"
+			request = make(map[string]interface{})
+			query = make(map[string]interface{})
+			request["DesktopGroupId"] = d.Id()
+			request["RegionId"] = client.RegionId
+			request["ClientToken"] = buildClientToken(action)
+			endUserIdsMapsArray := added
+			request["EndUserIds"] = endUserIdsMapsArray
+
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("ecd", "2020-09-30", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+
+		}
+	}
+	return resourceAliCloudEcdDesktopGroupRead(d, meta)
+}
+
+func resourceAliCloudEcdDesktopGroupDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	ecdServiceV2 := EcdServiceV2{client}
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	var err error
+
+	// DeleteDesktopGroup requires that no end user is authorized to the
+	// desktop group, so remove all authorized end users before deletion.
+	usersObject, err := ecdServiceV2.DescribeDesktopGroupDescribeUsersInGroup(d.Id())
+	if err != nil {
+		if !NotFoundError(err) {
+			return WrapError(err)
+		}
+	} else if endUserIds, ok := usersObject["EndUserIds"].([]interface{}); ok && len(endUserIds) > 0 {
+		action := "RemoveUserFromDesktopGroup"
+		request = make(map[string]interface{})
+		query = make(map[string]interface{})
+		request["DesktopGroupId"] = d.Id()
+		request["RegionId"] = client.RegionId
+		request["EndUserIds"] = endUserIds
+
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+			response, err = client.RpcPost("ecd", "2020-09-30", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) || strings.Contains(err.Error(), "NotAllowOperation") {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	action := "DeleteDesktopGroup"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["DesktopGroupId"] = d.Id()
+	request["RegionId"] = client.RegionId
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("ecd", "2020-09-30", action, query, request, true)
+		if err != nil {
+			// The desktop group cannot be deleted while it is in a transient
+			// state (e.g. desktops are being created or released in the group).
+			if NeedRetry(err) || strings.Contains(err.Error(), "NotAllowOperation") {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	// The desktops in the desktop group are released asynchronously after the
+	// desktop group is deleted, and they keep referencing resources such as the
+	// policy group until the release completes. Deleting those resources in the
+	// meantime fails with DependencyViolation, so wait until DescribeDesktopsInGroup
+	// no longer lists any desktop (releasing desktops are listed with status
+	// Deleted until they are purged).
+	groupId := d.Id()
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		listAction := "DescribeDesktopsInGroup"
+		nextToken := ""
+		remaining := 0
+		for {
+			listRequest := make(map[string]interface{})
+			listQuery := make(map[string]interface{})
+			listRequest["RegionId"] = client.RegionId
+			listRequest["DesktopGroupId"] = groupId
+			listRequest["MaxResults"] = PageSizeLarge
+			if nextToken != "" {
+				listRequest["NextToken"] = nextToken
+			}
+			listResponse, listErr := client.RpcPost("ecd", "2020-09-30", listAction, listQuery, listRequest, true)
+			if listErr != nil {
+				if NotFoundError(listErr) {
+					return nil
+				}
+				if NeedRetry(listErr) {
+					return resource.RetryableError(listErr)
+				}
+				return resource.NonRetryableError(listErr)
+			}
+			// Desktops that are being released stay listed with status Deleted
+			// for a long time, but they no longer block the deletion of the
+			// resources they reference; only the desktops that are not in the
+			// Deleted status are counted here.
+			for _, key := range []string{"$.PostPaidDesktops[*]", "$.PaidDesktops[*]"} {
+				if v, err := jsonpath.Get(key, listResponse); err == nil {
+					if desktops, ok := v.([]interface{}); ok {
+						for _, desktop := range desktops {
+							if desktopMap, ok := desktop.(map[string]interface{}); ok && fmt.Sprint(desktopMap["DesktopStatus"]) != "Deleted" {
+								remaining++
+							}
+						}
+					}
+				}
+			}
+			if token, ok := listResponse["NextToken"].(string); ok && token != "" {
+				nextToken = token
+			} else {
+				break
+			}
+		}
+		if remaining > 0 {
+			return resource.RetryableError(fmt.Errorf("there are still %d desktops being released in the desktop group %s", remaining, groupId))
+		}
+		return nil
+	})
+	if err != nil {
+		return WrapError(err)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ecd_desktop_group_test.go
+++ b/alicloud/resource_alicloud_ecd_desktop_group_test.go
@@ -1,0 +1,301 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers(
+		"alicloud_ecd_desktop_group",
+		&resource.Sweeper{
+			Name: "alicloud_ecd_desktop_group",
+			F:    testSweepEcdDesktopGroup,
+		})
+}
+
+func testSweepEcdDesktopGroup(region string) error {
+	rawClient, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting Alicloud client: %s", err)
+	}
+	client := rawClient.(*connectivity.AliyunClient)
+	prefixes := []string{
+		"tf-testAcc",
+		"tf_testAcc",
+	}
+
+	action := "DescribeDesktopGroups"
+	request := map[string]interface{}{
+		"RegionId":   region,
+		"MaxResults": PageSizeLarge,
+	}
+
+	var response map[string]interface{}
+	for {
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPost("ecd", "2020-09-30", action, nil, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			log.Printf("[ERROR] %s get an error: %#v", action, err)
+			return nil
+		}
+		resp, err := jsonpath.Get("$.DesktopGroups", response)
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+
+			skip := true
+			if !sweepAll() {
+				for _, prefix := range prefixes {
+					if strings.HasPrefix(strings.ToLower(fmt.Sprint(item["DesktopGroupName"])), strings.ToLower(prefix)) {
+						skip = false
+					}
+				}
+				if skip {
+					log.Printf("[INFO] Skipping EcdDesktopGroup: %s", fmt.Sprint(item["DesktopGroupName"]))
+					continue
+				}
+			}
+			action := "DeleteDesktopGroup"
+			request := map[string]interface{}{
+				"RegionId":       region,
+				"DesktopGroupId": fmt.Sprint(item["DesktopGroupId"]),
+			}
+
+			_, err = client.RpcPost("ecd", "2020-09-30", action, nil, request, false)
+			if err != nil {
+				log.Printf("[ERROR] Failed to delete EcdDesktopGroup (%s): %s", fmt.Sprint(item["DesktopGroupId"]), err)
+			}
+			log.Printf("[INFO] Delete EcdDesktopGroup success: %s ", fmt.Sprint(item["DesktopGroupId"]))
+		}
+		if nextToken, ok := response["NextToken"].(string); ok && nextToken != "" {
+			request["NextToken"] = nextToken
+		} else {
+			break
+		}
+	}
+	return nil
+}
+
+func TestAccAliCloudEcdDesktopGroup_basic0(t *testing.T) {
+	var v map[string]interface{}
+	checkoutSupportedRegions(t, true, connectivity.EcdUserSupportRegions)
+	resourceId := "alicloud_ecd_desktop_group.default"
+	ra := resourceAttrInit(resourceId, AlicloudECDDesktopGroupMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EcdServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEcdDesktopGroup")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := 10000 + acctest.RandIntRange(0, 89999)
+	name := fmt.Sprintf("tf-testaccdesktopgroup%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudECDDesktopGroupBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"office_site_id":     "${alicloud_ecd_simple_office_site.default.id}",
+					"policy_group_id":    "${alicloud_ecd_policy_group.default.id}",
+					"bundle_id":          "${data.alicloud_ecd_bundles.default.bundles.0.id}",
+					"end_user_ids":       []string{"${alicloud_ecd_user.default.id}"},
+					"desktop_group_name": name,
+					"comments":           "test-comments",
+					"keep_duration":      "180000",
+					"min_desktops_count": "0",
+					"max_desktops_count": "1",
+					"allow_auto_setup":   "0",
+					"allow_buffer_count": "0",
+					"directory_id":       "",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"office_site_id":     CHECKSET,
+						"policy_group_id":    CHECKSET,
+						"bundle_id":          CHECKSET,
+						"end_user_ids.#":     "1",
+						"desktop_group_name": name,
+						"comments":           "test-comments",
+						"keep_duration":      "180000",
+						"min_desktops_count": "0",
+						"max_desktops_count": "1",
+						"allow_auto_setup":   "0",
+						"allow_buffer_count": "0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"desktop_group_name": fmt.Sprintf("tf-testaccdesktopgroupnew%d", rand),
+					"comments":           "test-comments-update",
+					"keep_duration":      "360000",
+					"max_desktops_count": "2",
+					"allow_buffer_count": "1",
+					"scale_strategy_id":  "",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"desktop_group_name": fmt.Sprintf("tf-testaccdesktopgroupnew%d", rand),
+						"comments":           "test-comments-update",
+						"keep_duration":      "360000",
+						"max_desktops_count": "2",
+						"allow_buffer_count": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"policy_group_id":    "${alicloud_ecd_policy_group.default0.id}",
+					"bundle_id":          "${data.alicloud_ecd_bundles.default.bundles.1.id}",
+					"allow_auto_setup":   "1",
+					"min_desktops_count": "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"policy_group_id":    CHECKSET,
+						"bundle_id":          CHECKSET,
+						"allow_auto_setup":   "1",
+						"min_desktops_count": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"end_user_ids": []string{"${alicloud_ecd_user.default.id}", "${alicloud_ecd_user.default1.id}"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"end_user_ids.#": "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"end_user_ids": []string{"${alicloud_ecd_user.default1.id}"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"end_user_ids.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"scale_strategy_id"},
+			},
+		},
+	})
+}
+
+var AlicloudECDDesktopGroupMap0 = map[string]string{
+	"office_site_id":     CHECKSET,
+	"policy_group_id":    CHECKSET,
+	"bundle_id":          CHECKSET,
+	"end_user_ids.#":     CHECKSET,
+	"desktop_group_name": CHECKSET,
+	"cpu":                CHECKSET,
+	"create_time":        CHECKSET,
+	"creator":            CHECKSET,
+	"memory":             CHECKSET,
+	"office_site_name":   CHECKSET,
+	"office_site_type":   CHECKSET,
+	"pay_type":           CHECKSET,
+	"policy_group_name":  CHECKSET,
+}
+
+func AlicloudECDDesktopGroupBasicDependence0(name string) string {
+	rand := 10000 + acctest.RandIntRange(0, 89999)
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_ecd_bundles" "default" {
+  bundle_type = "SYSTEM"
+}
+
+resource "alicloud_ecd_simple_office_site" "default" {
+  cidr_block          = "172.16.0.0/12"
+  desktop_access_type = "Internet"
+  office_site_name    = var.name
+}
+
+resource "alicloud_ecd_policy_group" "default" {
+  policy_group_name = var.name
+  clipboard         = "readwrite"
+  local_drive       = "read"
+  authorize_access_policy_rules {
+    description = var.name
+    cidr_ip     = "1.2.3.4/24"
+  }
+  authorize_security_policy_rules {
+    type        = "inflow"
+    policy      = "accept"
+    description = var.name
+    port_range  = "80/80"
+    ip_protocol = "TCP"
+    priority    = "1"
+    cidr_ip     = "0.0.0.0/0"
+  }
+}
+
+resource "alicloud_ecd_policy_group" "default0" {
+  policy_group_name = var.name
+  clipboard         = "readwrite"
+  local_drive       = "read"
+  authorize_access_policy_rules {
+    description = var.name
+    cidr_ip     = "1.2.3.4/24"
+  }
+  authorize_security_policy_rules {
+    type        = "inflow"
+    policy      = "accept"
+    description = var.name
+    port_range  = "80/80"
+    ip_protocol = "TCP"
+    priority    = "1"
+    cidr_ip     = "0.0.0.0/0"
+  }
+}
+
+resource "alicloud_ecd_user" "default" {
+  end_user_id = "tf_testacc-dg-u1-%d"
+  email       = "hello.dg1.%d@aaa.com"
+  phone       = "158016%d"
+  password    = "%d"
+}
+
+resource "alicloud_ecd_user" "default1" {
+  end_user_id = "tf_testacc-dg-u2-%d"
+  email       = "hello.dg2.%d@aaa.com"
+  phone       = "139017%d"
+  password    = "%d"
+}
+`, name, rand, rand, rand, rand, rand, rand, rand, rand)
+}

--- a/alicloud/service_alicloud_ecd_v2.go
+++ b/alicloud/service_alicloud_ecd_v2.go
@@ -1,0 +1,161 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+type EcdServiceV2 struct {
+	client *connectivity.AliyunClient
+}
+
+// DescribeEcdDesktopGroup <<< Encapsulated get interface for Ecd DesktopGroup.
+
+func (s *EcdServiceV2) DescribeEcdDesktopGroup(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["DesktopGroupId"] = id
+	request["RegionId"] = client.RegionId
+	action := "GetDesktopGroupDetail"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("ecd", "2020-09-30", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Desktops", response)
+	if err != nil || v == nil {
+		// GetDesktopGroupDetail returns a response without the Desktops key
+		// when the desktop group does not exist.
+		return object, WrapErrorf(NotFoundErr("DesktopGroup", id), NotFoundMsg, response)
+	}
+
+	desktops, ok := v.(map[string]interface{})
+	if !ok || len(desktops) == 0 {
+		return object, WrapErrorf(NotFoundErr("DesktopGroup", id), NotFoundMsg, response)
+	}
+
+	return desktops, nil
+}
+func (s *EcdServiceV2) DescribeDesktopGroupDescribeUsersInGroup(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeUsersInGroup"
+	endUserIds := make([]interface{}, 0)
+	nextToken := ""
+
+	for {
+		request = make(map[string]interface{})
+		query = make(map[string]interface{})
+		request["DesktopGroupId"] = id
+		request["RegionId"] = client.RegionId
+		request["MaxResults"] = PageSizeLarge
+		if nextToken != "" {
+			request["NextToken"] = nextToken
+		}
+
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPost("ecd", "2020-09-30", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+		}
+
+		v, _ := jsonpath.Get("$.EndUsers[*]", response)
+		if users, ok := v.([]interface{}); ok {
+			for _, user := range users {
+				if userMap, ok := user.(map[string]interface{}); ok {
+					if userId, ok := userMap["EndUserId"]; ok && userId != nil {
+						endUserIds = append(endUserIds, userId)
+					}
+				}
+			}
+		}
+
+		if token, ok := response["NextToken"].(string); ok && token != "" {
+			nextToken = token
+		} else {
+			break
+		}
+	}
+
+	sort.Slice(endUserIds, func(i, j int) bool {
+		return fmt.Sprint(endUserIds[i]) < fmt.Sprint(endUserIds[j])
+	})
+	object = map[string]interface{}{
+		"EndUserIds": endUserIds,
+	}
+	return object, nil
+}
+
+func (s *EcdServiceV2) EcdDesktopGroupStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.EcdDesktopGroupStateRefreshFuncWithApi(id, field, failStates, s.DescribeEcdDesktopGroup)
+}
+
+func (s *EcdServiceV2) EcdDesktopGroupStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeEcdDesktopGroup >>> Encapsulated.

--- a/website/docs/d/ecd_desktop_groups.html.markdown
+++ b/website/docs/d/ecd_desktop_groups.html.markdown
@@ -1,0 +1,131 @@
+---
+subcategory: "Elastic Desktop Service (ECD)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ecd_desktop_groups"
+sidebar_current: "docs-alicloud-datasource-ecd-desktop-groups"
+description: |-
+  Provides a list of Elastic Desktop Service (ECD) Desktop Groups owned by an Alibaba Cloud account.
+---
+
+# alicloud_ecd_desktop_groups
+
+This data source provides Elastic Desktop Service (ECD) Desktop Groups available to the user. For information about Elastic Desktop Service (ECD) Desktop Group, see [What is Desktop Group](https://next.api.alibabacloud.com/document/ecd/2020-09-30/CreateDesktopGroup).
+
+-> **NOTE:** Available since v1.289.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-shanghai"
+}
+
+data "alicloud_ecd_bundles" "default" {
+  bundle_type = "SYSTEM"
+}
+
+resource "alicloud_ecd_simple_office_site" "default" {
+  cidr_block          = "172.16.0.0/12"
+  desktop_access_type = "Internet"
+  office_site_name    = var.name
+}
+
+resource "alicloud_ecd_policy_group" "default" {
+  policy_group_name = var.name
+  clipboard         = "readwrite"
+  local_drive       = "read"
+  authorize_access_policy_rules {
+    description = var.name
+    cidr_ip     = "1.2.3.4/24"
+  }
+  authorize_security_policy_rules {
+    type        = "inflow"
+    policy      = "accept"
+    description = var.name
+    port_range  = "80/80"
+    ip_protocol = "TCP"
+    priority    = "1"
+    cidr_ip     = "0.0.0.0/0"
+  }
+}
+
+resource "alicloud_ecd_user" "default" {
+  end_user_id = "terraform-example-user"
+  email       = "terraform-example@example.com"
+  password    = "Example12345"
+}
+
+resource "alicloud_ecd_desktop_group" "default" {
+  desktop_group_name = var.name
+  office_site_id     = alicloud_ecd_simple_office_site.default.id
+  policy_group_id    = alicloud_ecd_policy_group.default.id
+  bundle_id          = data.alicloud_ecd_bundles.default.bundles.0.id
+  end_user_ids       = [alicloud_ecd_user.default.id]
+  allow_buffer_count = 1
+}
+
+data "alicloud_ecd_desktop_groups" "default" {
+  ids        = [alicloud_ecd_desktop_group.default.id]
+  name_regex = alicloud_ecd_desktop_group.default.desktop_group_name
+}
+
+output "alicloud_ecd_desktop_group_example_id" {
+  value = data.alicloud_ecd_desktop_groups.default.groups.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `desktop_group_id` - (Optional) The ID of the desktop group.
+* `desktop_group_name` - (Optional) The name of the desktop group. Fuzzy search is supported.
+* `office_site_id` - (Optional) The ID of the office network to which the desktop groups belong.
+* `period_unit` - (Optional) The subscription duration unit of the desktop groups. Valid values: `Month` and `Year`.
+* `ids` - (Optional, Computed) A list of Desktop Group IDs.
+* `name_regex` - (Optional) A regex string to filter results by Desktop Group name.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Desktop Group IDs.
+* `names` - A list of name of Desktop Groups.
+* `groups` - A list of Desktop Group Entries. Each element contains the following attributes:
+  * `allow_auto_setup` - **NOTE:** This field is only available when `enable_details` is `true`. Whether cloud desktops can be automatically created for the subscription desktop group.
+  * `allow_buffer_count` - **NOTE:** This field is only available when `enable_details` is `true`. The number of cloud desktops that are reserved in the desktop group.
+  * `bundle_id` - The ID of the desktop template.
+  * `comments` - The remarks of the desktop group.
+  * `cpu` - The number of vCPUs.
+  * `create_time` - The time when the desktop group was created. The time follows the ISO 8601 standard in UTC.
+  * `creator` - The ID of the Alibaba Cloud account that created the desktop group.
+  * `data_disk_category` - The category of the data disk.
+  * `data_disk_size` - The size of the data disk. Unit: GiB.
+  * `desktop_group_id` - The ID of the desktop group.
+  * `desktop_group_name` - The name of the desktop group.
+  * `directory_id` - The ID of the directory.
+  * `directory_type` - The type of the directory.
+  * `end_user_count` - The number of end users authorized to use the desktop group.
+  * `end_user_ids` - **NOTE:** This field is only available when `enable_details` is `true`. The list of IDs of the end users authorized to use the desktop group.
+  * `expired_time` - The time when the subscription desktop group expires. The time follows the ISO 8601 standard in UTC.
+  * `gpu_count` - The number of GPUs.
+  * `gpu_spec` - The GPU specifications.
+  * `keep_duration` - The retention duration of a session after it is disconnected. Unit: milliseconds.
+  * `max_desktops_count` - The maximum number of cloud desktops that the desktop group can contain.
+  * `memory` - The memory size. Unit: MiB.
+  * `min_desktops_count` - The minimum number of cloud desktops that the desktop group automatically creates.
+  * `office_site_id` - The ID of the office network.
+  * `office_site_name` - The name of the office network.
+  * `office_site_type` - The type of the account system of the office network.
+  * `own_bundle_name` - The name of the desktop template.
+  * `pay_type` - The billing method.
+  * `policy_group_id` - The ID of the policy group.
+  * `policy_group_name` - The name of the policy group.
+  * `res_type` - **NOTE:** This field is only available when `enable_details` is `true`. The type of the resource.
+  * `system_disk_category` - The category of the system disk.
+  * `system_disk_size` - The size of the system disk. Unit: GiB.
+  * `id` - The ID of the resource supplied above.

--- a/website/docs/r/ecd_desktop_group.html.markdown
+++ b/website/docs/r/ecd_desktop_group.html.markdown
@@ -1,0 +1,133 @@
+---
+subcategory: "Elastic Desktop Service (ECD)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ecd_desktop_group"
+description: |-
+  Provides a Alicloud Elastic Desktop Service (ECD) Desktop Group resource.
+---
+
+# alicloud_ecd_desktop_group
+
+Provides a Elastic Desktop Service (ECD) Desktop Group resource.
+
+A desktop group is a pool of shared cloud desktops. End users authorized to the
+desktop group are assigned an available cloud desktop from the pool when they
+connect.
+
+For information about Elastic Desktop Service (ECD) Desktop Group and how to use it, see [What is Desktop Group](https://next.api.alibabacloud.com/document/ecd/2020-09-30/CreateDesktopGroup).
+
+-> **NOTE:** Available since v1.289.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-shanghai"
+}
+
+data "alicloud_ecd_bundles" "default" {
+  bundle_type = "SYSTEM"
+}
+
+resource "alicloud_ecd_simple_office_site" "default" {
+  cidr_block          = "172.16.0.0/12"
+  desktop_access_type = "Internet"
+  office_site_name    = var.name
+}
+
+resource "alicloud_ecd_policy_group" "default" {
+  policy_group_name = var.name
+  clipboard         = "readwrite"
+  local_drive       = "read"
+  authorize_access_policy_rules {
+    description = var.name
+    cidr_ip     = "1.2.3.4/24"
+  }
+  authorize_security_policy_rules {
+    type        = "inflow"
+    policy      = "accept"
+    description = var.name
+    port_range  = "80/80"
+    ip_protocol = "TCP"
+    priority    = "1"
+    cidr_ip     = "0.0.0.0/0"
+  }
+}
+
+resource "alicloud_ecd_user" "default" {
+  end_user_id = "terraform-example-user"
+  email       = "terraform-example@example.com"
+  password    = "Example12345"
+}
+
+resource "alicloud_ecd_desktop_group" "default" {
+  desktop_group_name = var.name
+  office_site_id     = alicloud_ecd_simple_office_site.default.id
+  policy_group_id    = alicloud_ecd_policy_group.default.id
+  bundle_id          = data.alicloud_ecd_bundles.default.bundles.0.id
+  end_user_ids       = [alicloud_ecd_user.default.id]
+  allow_buffer_count = 1
+  comments           = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `bundle_id` - (Required) The ID of the desktop template.
+* `end_user_ids` - (Required, List) The list of IDs of the end users authorized to use the desktop group.
+* `office_site_id` - (Required, ForceNew) The ID of the office network to which the desktop group belongs.
+* `policy_group_id` - (Required) The ID of the policy group associated with the desktop group.
+* `allow_auto_setup` - (Optional, Int) Specifies whether to allow cloud desktops to be automatically created for a subscription desktop group. This parameter takes effect only when the desktop group uses the subscription billing method. Valid values: `0` and `1`.
+* `allow_buffer_count` - (Optional, Int) The number of cloud desktops that are reserved in the desktop group. Reserved desktops are kept started and idle, waiting for connections. Valid values: `0` to `100`. `0` indicates that no desktop is reserved.
+* `comments` - (Optional) The remarks of the desktop group.
+* `desktop_group_name` - (Optional) The name of the desktop group. The name must be 1 to 30 characters in length, and can contain letters, digits, colons (:), underscores (_), periods (.), and hyphens (-). It must start with a letter but cannot start with `http://` or `https://`.
+* `directory_id` - (Optional, ForceNew) The ID of the directory.
+* `keep_duration` - (Optional, Int) The retention duration of a session after it is disconnected. Unit: milliseconds. Valid values: `180000` to `345600000`. `0` indicates that the session is always retained. If the user does not reconnect within the retention duration, the session is logged off and unsaved data is destroyed.
+* `max_desktops_count` - (Optional, Int) The maximum number of cloud desktops that the pay-as-you-go desktop group can contain. Valid values: `0` to `500`.
+* `min_desktops_count` - (Optional, Int) The minimum number of cloud desktops that the pay-as-you-go desktop group automatically creates. Valid values: `0` to the value of `max_desktops_count`.
+* `scale_strategy_id` - (Optional) The ID of the scaling policy.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+* `cpu` - The number of vCPUs.
+* `create_time` - The time when the desktop group was created. The time follows the ISO 8601 standard in UTC.
+* `creator` - The ID of the Alibaba Cloud account that created the desktop group.
+* `data_disk_category` - The category of the data disk.
+* `data_disk_size` - The size of the data disk. Unit: GiB.
+* `directory_type` - The type of the directory.
+* `expired_time` - The time when the subscription desktop group expires. The time follows the ISO 8601 standard in UTC.
+* `gpu_count` - The number of GPUs.
+* `gpu_spec` - The GPU specifications.
+* `memory` - The memory size. Unit: MiB.
+* `office_site_name` - The name of the office network.
+* `office_site_type` - The type of the account system of the office network.
+* `own_bundle_name` - The name of the desktop template.
+* `pay_type` - The billing method.
+* `policy_group_name` - The name of the policy group.
+* `res_type` - The type of the resource.
+* `system_disk_category` - The category of the system disk.
+* `system_disk_size` - The size of the system disk. Unit: GiB.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Desktop Group.
+* `delete` - (Defaults to 10 mins) Used when delete the Desktop Group.
+* `update` - (Defaults to 5 mins) Used when update the Desktop Group.
+
+## Import
+
+Elastic Desktop Service (ECD) Desktop Group can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ecd_desktop_group.example <desktop_group_id>
+```


### PR DESCRIPTION
### New Resource: alicloud_ecd_desktop_group

Add the `alicloud_ecd_desktop_group` resource and the `alicloud_ecd_desktop_groups` data source.

A desktop group is a pool of shared cloud desktops in Elastic Desktop Service (ECD). End users authorized to the desktop group are assigned an available cloud desktop from the pool when they connect. This resource manages the desktop group's template, office network, policy group, desktop count limits, reserved desktops, session retention duration and authorized end users (users can be added or removed without recreating the group).

### Example Usage

```hcl
variable "name" {
  default = "terraform-example"
}

provider "alicloud" {
  region = "cn-shanghai"
}

data "alicloud_ecd_bundles" "default" {
  bundle_type = "SYSTEM"
}

resource "alicloud_ecd_simple_office_site" "default" {
  cidr_block          = "172.16.0.0/12"
  desktop_access_type = "Internet"
  office_site_name    = var.name
}

resource "alicloud_ecd_policy_group" "default" {
  policy_group_name = var.name
  clipboard         = "readwrite"
  local_drive       = "read"
  authorize_access_policy_rules {
    description = var.name
    cidr_ip     = "1.2.3.4/24"
  }
  authorize_security_policy_rules {
    type        = "inflow"
    policy      = "accept"
    description = var.name
    port_range  = "80/80"
    ip_protocol = "TCP"
    priority    = "1"
    cidr_ip     = "0.0.0.0/0"
  }
}

resource "alicloud_ecd_user" "default" {
  end_user_id = "terraform-example-user"
  email       = "terraform-example@example.com"
  password    = "Example12345"
}

resource "alicloud_ecd_desktop_group" "default" {
  desktop_group_name = var.name
  office_site_id     = alicloud_ecd_simple_office_site.default.id
  policy_group_id    = alicloud_ecd_policy_group.default.id
  bundle_id          = data.alicloud_ecd_bundles.default.bundles.0.id
  end_user_ids       = [alicloud_ecd_user.default.id]
  allow_buffer_count = 1
}

data "alicloud_ecd_desktop_groups" "default" {
  ids            = [alicloud_ecd_desktop_group.default.id]
  enable_details = true
}
```

### Test Result

```
=== RUN   TestAccAliCloudEcdDesktopGroup_basic0
--- PASS: TestAccAliCloudEcdDesktopGroup_basic0 (149.08s)

=== RUN   TestAccAliCloudEcdDesktopGroupsDataSource_basic0
--- PASS: TestAccAliCloudEcdDesktopGroupsDataSource_basic0 (111.07s)
```
