### PR TITLE
function/arn_build: support provider-defined function arn_build

### DIFF
--- a/CHANGELOG-v2.md
+++ b/CHANGELOG-v2.md
@@ -4,6 +4,7 @@ FEATURES:
 
 - **Terraform Plugin Framework:** the provider binary now serves a `terraform-plugin-framework` provider alongside the existing `terraform-plugin-sdk/v2` one, muxed behind `tf5muxserver`. Protocol version, provider address and provider schema are unchanged; new resources and data sources can be authored framework-native, and the framework-only concept types (ephemeral resources, provider functions, list resources, actions) become available for the first time.
 - **New Data Source:** `alicloud_ims_default_domain` — the default domain of the Alibaba Cloud account, backed by the Ims `GetDefaultDomain` API. Served by the framework provider.
+- **New Function:** `arn_build` — builds an Alibaba Cloud Resource Name (ARN) of the form `acs:<ram_code>:<region>:<account_id>:<relative_id>` from its constituent parts, invoked as `provider::alicloud::arn_build(ram_code, region, account_id, relative_id)`. Mirrors the AWS provider's `arn_build` function. Requires Terraform 1.8+ with the provider declared in `required_providers`.
 
 ## 2.0.0-beta2 (August 4, 2026)
 

--- a/alicloud/function/arn_build.go
+++ b/alicloud/function/arn_build.go
@@ -1,0 +1,61 @@
+package function
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+)
+
+var _ function.Function = &arnBuildFunction{}
+
+// NewARNBuildFunction returns the provider-defined function implementation of
+// provider::alicloud::arn_build.
+func NewARNBuildFunction() function.Function {
+	return &arnBuildFunction{}
+}
+
+type arnBuildFunction struct{}
+
+func (f *arnBuildFunction) Metadata(ctx context.Context, req function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "arn_build"
+}
+
+func (f *arnBuildFunction) Definition(ctx context.Context, req function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary:             "Build an Alibaba Cloud Resource Name (ARN) from its constituent parts.",
+		MarkdownDescription: "Builds an ARN of the form `acs:<ram_code>:<region>:<account_id>:<relative_id>`. The relative ID may itself contain colons.",
+		Parameters: []function.Parameter{
+			function.StringParameter{
+				Name:                "ram_code",
+				MarkdownDescription: "RAM code of the Alibaba Cloud service, such as `ecs`, `oss`, `ram`, `fc`, `mns`, `fnf`, or `kms`.",
+			},
+			function.StringParameter{
+				Name:                "region",
+				MarkdownDescription: "Region of the resource, such as `cn-hangzhou`. Use `*` to match every region, or an empty string for services that carry no region component, such as `ram`.",
+			},
+			function.StringParameter{
+				Name:                "account_id",
+				MarkdownDescription: "ID of the Alibaba Cloud account.",
+			},
+			function.StringParameter{
+				Name:                "relative_id",
+				MarkdownDescription: "Service-specific resource path, typically composed of a resource type and identifier, such as `instance/i-bp1234567890abcdef`.",
+			},
+		},
+		Return: function.StringReturn{},
+	}
+}
+
+func (f *arnBuildFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var ramCode, region, accountID, relativeID string
+
+	resp.Error = function.ConcatFuncErrors(req.Arguments.Get(ctx, &ramCode, &region, &accountID, &relativeID))
+	if resp.Error != nil {
+		return
+	}
+
+	result := fmt.Sprintf("acs:%s:%s:%s:%s", ramCode, region, accountID, relativeID)
+
+	resp.Error = function.ConcatFuncErrors(resp.Result.Set(ctx, result))
+}

--- a/alicloud/function/arn_build_test.go
+++ b/alicloud/function/arn_build_test.go
@@ -1,0 +1,238 @@
+package function
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	fwdatasource "github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	fwprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	sdkresource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	sdkschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestARNBuildFunction_Metadata(t *testing.T) {
+	resp := &function.MetadataResponse{}
+
+	NewARNBuildFunction().Metadata(context.Background(), function.MetadataRequest{}, resp)
+
+	if resp.Name != "arn_build" {
+		t.Errorf("unexpected name: got %q, want %q", resp.Name, "arn_build")
+	}
+}
+
+func TestARNBuildFunction_Definition(t *testing.T) {
+	resp := &function.DefinitionResponse{}
+
+	NewARNBuildFunction().Definition(context.Background(), function.DefinitionRequest{}, resp)
+
+	if len(resp.Definition.Parameters) != 4 {
+		t.Fatalf("expected 4 parameters, got %d", len(resp.Definition.Parameters))
+	}
+
+	expected := []string{"ram_code", "region", "account_id", "relative_id"}
+	for i, param := range resp.Definition.Parameters {
+		if got := param.GetName(); got != expected[i] {
+			t.Errorf("parameter %d: got %q, want %q", i, got, expected[i])
+		}
+		// The Registry and the language server render MarkdownDescription, not
+		// Description, so every parameter must carry the former.
+		if got := param.GetMarkdownDescription(); got == "" {
+			t.Errorf("parameter %d (%s): empty MarkdownDescription", i, expected[i])
+		}
+		// Every component is a plain string; anything else changes the documented
+		// signature and silently breaks existing calls.
+		if _, ok := param.(function.StringParameter); !ok {
+			t.Errorf("parameter %d (%s): unexpected type %T", i, expected[i], param)
+		}
+	}
+
+	if resp.Definition.Summary == "" {
+		t.Error("empty Summary on the function definition")
+	}
+
+	if resp.Definition.MarkdownDescription == "" {
+		t.Error("empty MarkdownDescription on the function definition")
+	}
+
+	if resp.Definition.VariadicParameter != nil {
+		t.Errorf("unexpected variadic parameter: %v", resp.Definition.VariadicParameter)
+	}
+
+	if _, ok := resp.Definition.Return.(function.StringReturn); !ok {
+		t.Errorf("unexpected return type: %T", resp.Definition.Return)
+	}
+}
+
+func TestARNBuildFunction_Run(t *testing.T) {
+	cases := []struct {
+		ramCode, region, accountID, relativeID, expected string
+	}{
+		{"ram", "", "123456789012****", "role/MyRole",
+			"acs:ram::123456789012****:role/MyRole"},
+		{"ecs", "cn-hangzhou", "*", "instance/i-123456",
+			"acs:ecs:cn-hangzhou:*:instance/i-123456"},
+		{"oss", "*", "*", "my-bucket/*",
+			"acs:oss:*:*:my-bucket/*"},
+		{"fc", "cn-hangzhou", "123456789012****", "services/foo.LATEST/functions/bar",
+			"acs:fc:cn-hangzhou:123456789012****:services/foo.LATEST/functions/bar"},
+		{"kms", "*", "*", "*",
+			"acs:kms:*:*:*"},
+		{"mns", "cn-hangzhou", "123456789012****", "/queues/my-queue/messages",
+			"acs:mns:cn-hangzhou:123456789012****:/queues/my-queue/messages"},
+		// The relative ID is the last component, so colons inside it are part of
+		// the resource path and must survive verbatim.
+		{"log", "cn-hangzhou", "123456789012****", "project/my-project:logstore/my-logstore",
+			"acs:log:cn-hangzhou:123456789012****:project/my-project:logstore/my-logstore"},
+		// The two cases below pin down deliberate behaviour, not desirable output.
+		// Like the AWS provider's arn_build, this function is a formatter and not a
+		// validator: it never rejects an argument, so a caller that passes an empty
+		// or colon-bearing component gets a malformed ARN back rather than an error.
+		// Changing that is a breaking change and must break these cases first.
+		{"", "", "", "", "acs::::"},
+		{"ecs:extra", "cn-hangzhou", "123456789012****", "instance/i-123456",
+			"acs:ecs:extra:cn-hangzhou:123456789012****:instance/i-123456"},
+	}
+
+	f := NewARNBuildFunction()
+
+	for _, c := range cases {
+		req := function.RunRequest{
+			Arguments: function.NewArgumentsData([]attr.Value{
+				types.StringValue(c.ramCode),
+				types.StringValue(c.region),
+				types.StringValue(c.accountID),
+				types.StringValue(c.relativeID),
+			}),
+		}
+		resp := &function.RunResponse{
+			Result: function.NewResultData(types.StringNull()),
+		}
+
+		f.Run(context.Background(), req, resp)
+
+		if resp.Error != nil {
+			t.Errorf("arn_build(%q, %q, %q, %q) unexpected error: %v",
+				c.ramCode, c.region, c.accountID, c.relativeID, resp.Error)
+			continue
+		}
+
+		if got := resp.Result.Value(); !got.Equal(types.StringValue(c.expected)) {
+			t.Errorf("arn_build(%q, %q, %q, %q) = %v, want %q",
+				c.ramCode, c.region, c.accountID, c.relativeID, got, c.expected)
+		}
+	}
+}
+
+// harnessProvider is a minimal framework provider whose only purpose is to serve
+// arn_build to a real terraform binary. It declares no schema and no credentials,
+// so the HCL test below reaches no Alibaba Cloud API.
+type harnessProvider struct{}
+
+var _ fwprovider.ProviderWithFunctions = &harnessProvider{}
+
+func (p *harnessProvider) Metadata(ctx context.Context, req fwprovider.MetadataRequest, resp *fwprovider.MetadataResponse) {
+	resp.TypeName = "alicloud"
+}
+
+func (p *harnessProvider) Schema(ctx context.Context, req fwprovider.SchemaRequest, resp *fwprovider.SchemaResponse) {
+}
+
+func (p *harnessProvider) Configure(ctx context.Context, req fwprovider.ConfigureRequest, resp *fwprovider.ConfigureResponse) {
+}
+
+func (p *harnessProvider) Resources(ctx context.Context) []func() fwresource.Resource {
+	return nil
+}
+
+func (p *harnessProvider) DataSources(ctx context.Context) []func() fwdatasource.DataSource {
+	return nil
+}
+
+func (p *harnessProvider) Functions(ctx context.Context) []func() function.Function {
+	return []func() function.Function{NewARNBuildFunction}
+}
+
+// The required_providers block is mandatory: Terraform resolves provider-defined
+// functions only for providers explicitly declared in the module. The source must
+// match the reattach registration the test harness performs, which defaults to
+// registry.terraform.io/hashicorp/alicloud and is overridable through
+// TF_ACC_PROVIDER_HOST / TF_ACC_PROVIDER_NAMESPACE. User-facing documentation
+// shows the real aliyun/alicloud source instead.
+const arnBuildHCLConfig = `
+terraform {
+  required_providers {
+    alicloud = {
+      source = "hashicorp/alicloud"
+    }
+  }
+}
+
+output "role_arn" {
+  value = provider::alicloud::arn_build("ram", "", "123456789012****", "role/example")
+}
+
+output "instance_arn" {
+  value = provider::alicloud::arn_build("ecs", "cn-hangzhou", "123456789012****", "instance/i-bp1234567890abcdef")
+}
+
+output "bucket_arn" {
+  value = provider::alicloud::arn_build("oss", "*", "*", "my-bucket/*")
+}
+
+output "function_arn" {
+  value = provider::alicloud::arn_build("fc", "cn-hangzhou", "123456789012****", "services/foo.LATEST/functions/bar")
+}
+
+output "queue_arn" {
+  value = provider::alicloud::arn_build("mns", "cn-hangzhou", "123456789012****", "/queues/my-queue/messages")
+}
+`
+
+// TestARNBuildFunction_HCL drives arn_build from real HCL through a real terraform
+// binary, with the SDK v2 provider muxed behind tf5muxserver exactly as the released
+// binary serves it. This is the only test that proves the function is reachable as
+// provider::alicloud::arn_build rather than merely correct in Go.
+//
+// It needs a terraform binary (1.8+) and TF_ACC=1, but no Alibaba Cloud credentials:
+//
+//	TF_ACC=1 go test ./alicloud/function/ -run TestARNBuildFunction_HCL -v
+//
+// AT001: the config creates no resources, so CheckDestroy has nothing to verify.
+// AT005: this is a function, not a resource, and a TestAcc prefix would make the
+// remote acceptance-test runner pick it up. Do not put a space after the comma.
+// lintignore: AT001,AT005
+func TestARNBuildFunction_HCL(t *testing.T) {
+	sdkresource.Test(t, sdkresource.TestCase{
+		ProtoV5ProviderFactories: map[string]func() (tfprotov5.ProviderServer, error){
+			"alicloud": func() (tfprotov5.ProviderServer, error) {
+				muxServer, err := tf5muxserver.NewMuxServer(context.Background(),
+					(&sdkschema.Provider{}).GRPCProvider,
+					providerserver.NewProtocol5(&harnessProvider{}),
+				)
+				if err != nil {
+					return nil, err
+				}
+				return muxServer.ProviderServer(), nil
+			},
+		},
+		Steps: []sdkresource.TestStep{
+			{
+				Config: arnBuildHCLConfig,
+				Check: sdkresource.ComposeTestCheckFunc(
+					sdkresource.TestCheckOutput("role_arn", "acs:ram::123456789012****:role/example"),
+					sdkresource.TestCheckOutput("instance_arn", "acs:ecs:cn-hangzhou:123456789012****:instance/i-bp1234567890abcdef"),
+					sdkresource.TestCheckOutput("bucket_arn", "acs:oss:*:*:my-bucket/*"),
+					sdkresource.TestCheckOutput("function_arn", "acs:fc:cn-hangzhou:123456789012****:services/foo.LATEST/functions/bar"),
+					sdkresource.TestCheckOutput("queue_arn", "acs:mns:cn-hangzhou:123456789012****:/queues/my-queue/messages"),
+				),
+			},
+		},
+	})
+}

--- a/alicloud/provider/framework/provider.go
+++ b/alicloud/provider/framework/provider.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 
+	tffunction "github.com/aliyun/terraform-provider-alicloud/alicloud/function"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/service/ims"
 	"github.com/hashicorp/terraform-plugin-framework/action"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -73,7 +74,9 @@ func (p *alicloudProvider) EphemeralResources(ctx context.Context) []func() ephe
 }
 
 func (p *alicloudProvider) Functions(ctx context.Context) []func() function.Function {
-	return []func() function.Function{}
+	return []func() function.Function{
+		tffunction.NewARNBuildFunction,
+	}
 }
 
 func (p *alicloudProvider) ListResources(ctx context.Context) []func() list.ListResource {

--- a/alicloud/provider/framework/provider_test.go
+++ b/alicloud/provider/framework/provider_test.go
@@ -1,0 +1,74 @@
+package framework_test
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/framework"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TestUnitFrameworkProviderFunctions asserts that the provider advertises its
+// provider-defined functions over the wire, through the same muxed server main.go
+// builds. Each function's own tests exercise its implementation directly, or through a
+// stand-in provider, so none of them notices if the registration in
+// alicloudProvider.Functions is dropped — this test is the one that does.
+func TestUnitFrameworkProviderFunctions(t *testing.T) {
+	ctx := context.Background()
+
+	serverFactory, err := framework.ProtoV5ProviderServerFactory(ctx, alicloud.Provider())
+	if err != nil {
+		t.Fatalf("muxing the SDK v2 and framework providers: %s", err)
+	}
+
+	resp, err := serverFactory().GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema on the muxed provider: %s", err)
+	}
+
+	expected := []struct {
+		name   string
+		params []string
+	}{
+		{"arn_build", []string{"ram_code", "region", "account_id", "relative_id"}},
+	}
+
+	for _, want := range expected {
+		name, params := want.name, want.params
+
+		fn, ok := resp.Functions[name]
+		if !ok {
+			t.Errorf("the muxed provider does not serve function %q; it serves %v",
+				name, slices.Sorted(maps.Keys(resp.Functions)))
+			continue
+		}
+
+		if fn.Summary == "" {
+			t.Errorf("function %q: empty Summary", name)
+		}
+
+		if fn.Return == nil || !fn.Return.Type.Is(tftypes.String) {
+			t.Errorf("function %q: unexpected return: %+v", name, fn.Return)
+		}
+
+		if len(fn.Parameters) != len(params) {
+			t.Errorf("function %q: got %d parameters, want %d", name, len(fn.Parameters), len(params))
+			continue
+		}
+
+		// Parameters are positional, so a reordering is a breaking change to every
+		// existing call even though each individual name still resolves.
+		for i, param := range fn.Parameters {
+			if param.Name != params[i] {
+				t.Errorf("function %q parameter %d: got %q, want %q", name, i, param.Name, params[i])
+			}
+			if !param.Type.Is(tftypes.String) {
+				t.Errorf("function %q parameter %d (%s): got type %s, want string", name, i, param.Name, param.Type)
+			}
+		}
+	}
+}

--- a/website/docs/functions/arn_build.html.markdown
+++ b/website/docs/functions/arn_build.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: ""
+layout: "alicloud"
+page_title: "Alibaba Cloud: arn_build"
+description: |-
+  Builds an ARN from its constituent parts.
+---
+
+# Function: arn_build
+
+Builds an ARN from its constituent parts.
+
+See the [Alibaba Cloud documentation](https://www.alibabacloud.com/help/en/ram/policy-elements) for additional information on Alibaba Cloud Resource Names (ARNs).
+
+## Example Usage
+
+```terraform
+terraform {
+  required_providers {
+    alicloud = {
+      source = "aliyun/alicloud"
+    }
+  }
+}
+
+# result: acs:ram::123456789012****:role/example
+output "role_arn" {
+  value = provider::alicloud::arn_build("ram", "", "123456789012****", "role/example")
+}
+
+# result: acs:ecs:cn-hangzhou:123456789012****:instance/i-bp1234567890abcdef
+output "instance_arn" {
+  value = provider::alicloud::arn_build("ecs", "cn-hangzhou", "123456789012****", "instance/i-bp1234567890abcdef")
+}
+
+# result: acs:oss:*:*:my-bucket/*
+output "bucket_arn" {
+  value = provider::alicloud::arn_build("oss", "*", "*", "my-bucket/*")
+}
+```
+
+## Signature
+
+```text
+arn_build(ram_code string, region string, account_id string, relative_id string) string
+```
+
+## Arguments
+
+1. `ram_code` (String) RAM code of the Alibaba Cloud service, such as `ecs`, `oss`, `ram`, `fc`, `mns`, `fnf`, or `kms`.
+1. `region` (String) Region of the resource, such as `cn-hangzhou`. Use `*` to match every region, or an empty string for services that carry no region component, such as `ram`.
+1. `account_id` (String) ID of the Alibaba Cloud account.
+1. `relative_id` (String) Service-specific resource path, typically composed of a resource type and identifier, such as `instance/i-bp1234567890abcdef`.


### PR DESCRIPTION
Adds the provider-defined function `arn_build`, which assembles an Alibaba Cloud Resource Name from its constituent parts:

```terraform
provider::alicloud::arn_build("ecs", "cn-hangzhou", var.account_id, "instance/${alicloud_instance.example.id}")
# => acs:ecs:cn-hangzhou:<account-id>:instance/<instance-id>
```

Today users hand-roll ARNs with string interpolation in every policy document, and the provider itself does the same in a number of places. This gives them one documented way to do it.

### Design

Modelled on the AWS provider's `arn_build`. Four parameters rather than five, because `acs` is a fixed prefix where AWS has a variable partition.

Like its AWS counterpart, this is a **formatter, not a validator**: no argument is ever rejected, so a caller who passes an empty or colon-bearing component gets a malformed ARN back rather than an error. That is deliberate — the relative ID legitimately contains colons for some services, and Alibaba Cloud has no single grammar the function could validate every service's ARN against. Two test cases pin the behaviour down so it cannot be changed silently.

The function is served by the framework provider, so it requires **Terraform 1.8+** and the provider declared in a `required_providers` block.

Layout follows the AWS provider: a flat `alicloud/function` package (one file per function), imported into the framework provider under the `tffunction` alias to avoid colliding with `terraform-plugin-framework/function`.

### Tests

No acceptance test: the function reaches no API, so there is nothing to create or destroy. The tests are deliberately not `TestAcc`-prefixed to keep the acceptance-test runner from picking them up, which is what the `AT001,AT005` lintignore covers.

Run locally against a real Terraform 1.14 binary:

```
--- PASS: TestARNBuildFunction_Metadata (0.00s)
--- PASS: TestARNBuildFunction_Definition (0.00s)
--- PASS: TestARNBuildFunction_Run (0.00s)
--- PASS: TestARNBuildFunction_HCL (0.67s)
ok  	github.com/aliyun/terraform-provider-alicloud/alicloud/function	1.058s

--- PASS: TestUnitProviderSchema (0.00s)
--- PASS: TestUnitProviderSchemaUnsupported (0.00s)
--- PASS: TestUnitFrameworkProviderSchemaMatchesSDK (0.04s)
--- PASS: TestUnitFrameworkProviderFunctions (0.03s)
ok  	github.com/aliyun/terraform-provider-alicloud/alicloud/provider/framework	2.012s
```

**8 passed, 0 failed, 0 skipped.** The four `provider/framework` cases include the two pre-existing ones, to check the registration edit caused no regression.

Two of these are worth calling out:

- `TestARNBuildFunction_HCL` drives the function from real HCL through a real `terraform` binary, with the SDK v2 provider muxed behind `tf5muxserver` exactly as the released binary serves it. This is the only test that proves the function is reachable as `provider::alicloud::arn_build` rather than merely correct in Go. It needs `TF_ACC=1` but no credentials.
- `TestUnitFrameworkProviderFunctions` asserts the **muxed** provider advertises the function over `GetProviderSchema`, with the right parameter names, order and types. Without it, deleting the registration line would leave every other test green — the function's own tests use a stand-in provider. Verified by mutation: removing the registration makes it fail with `the muxed provider does not serve function "arn_build"; it serves []`.

### Follow-up

`arn_parse` is the natural other half and is not included here.
