### PR TITLE
resource/alicloud_das_sql_log_config: support enable_audit argument

### DIFF
--- a/alicloud/resource_alicloud_das_sql_log_config.go
+++ b/alicloud/resource_alicloud_das_sql_log_config.go
@@ -35,6 +35,10 @@ func resourceAliCloudDasSqlLogConfig() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"enable_audit": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"hot_retention": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -95,6 +99,9 @@ func resourceAliCloudDasSqlLogConfigCreate(d *schema.ResourceData, meta interfac
 	}
 	if v, ok := d.GetOkExists("hot_retention"); ok {
 		request["HotRetention"] = v
+	}
+	if v, ok := d.GetOkExists("enable_audit"); ok {
+		request["EnableAudit"] = v
 	}
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
@@ -176,6 +183,9 @@ func resourceAliCloudDasSqlLogConfigUpdate(d *schema.ResourceData, meta interfac
 	if d.HasChange("hot_retention") {
 		update = true
 	}
+	if d.HasChange("enable_audit") {
+		update = true
+	}
 
 	if update {
 		if v, ok := d.GetOkExists("enable"); ok {
@@ -189,6 +199,9 @@ func resourceAliCloudDasSqlLogConfigUpdate(d *schema.ResourceData, meta interfac
 		}
 		if v, ok := d.GetOkExists("hot_retention"); ok {
 			request["HotRetention"] = v
+		}
+		if v, ok := d.GetOkExists("enable_audit"); ok {
+			request["EnableAudit"] = v
 		}
 
 		wait := incrementalWait(3*time.Second, 5*time.Second)

--- a/alicloud/resource_alicloud_das_sql_log_config_test.go
+++ b/alicloud/resource_alicloud_das_sql_log_config_test.go
@@ -34,6 +34,7 @@ func TestAccAliCloudDasSqlLogConfig_basic0(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"instance_id":    "${alicloud_polardb_cluster.default.id}",
 					"enable":         "true",
+					"enable_audit":   "true",
 					"request_enable": "true",
 					"retention":      "30",
 					"hot_retention":  "7",
@@ -42,6 +43,7 @@ func TestAccAliCloudDasSqlLogConfig_basic0(t *testing.T) {
 					testAccCheck(map[string]string{
 						"instance_id":    CHECKSET,
 						"enable":         "true",
+						"enable_audit":   "true",
 						"request_enable": "true",
 						"retention":      "30",
 						"hot_retention":  "7",
@@ -76,7 +78,7 @@ func TestAccAliCloudDasSqlLogConfig_basic0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enable", "request_enable"},
+				ImportStateVerifyIgnore: []string{"enable", "enable_audit", "request_enable"},
 			},
 		},
 	})

--- a/website/docs/r/das_sql_log_config.html.markdown
+++ b/website/docs/r/das_sql_log_config.html.markdown
@@ -38,6 +38,7 @@ data "alicloud_db_instances" "default" {
 resource "alicloud_das_sql_log_config" "default" {
   instance_id    = data.alicloud_db_instances.default.instances.0.id
   enable         = true
+  enable_audit   = true
   request_enable = true
   retention      = 30
   hot_retention  = 7
@@ -57,9 +58,12 @@ Terraform cannot destroy resource `alicloud_das_sql_log_config`. Terraform will 
 The following arguments are supported:
 * `instance_id` - (Required, ForceNew) The ID of the database instance.
 * `enable` - (Optional, Computed) Specifies whether SQL Explorer is enabled.
+* `enable_audit` - (Optional) Specifies whether to enable security audit.
 * `request_enable` - (Optional, Computed) The requested state of SQL Explorer.
 * `retention` - (Optional, Computed, Int) The retention period of SQL audit logs. Unit: days.
 * `hot_retention` - (Optional, Computed, Int) The retention period of hot SQL audit logs. Unit: days.
+
+-> **NOTE:** `enable_audit` is a write-only parameter. The `DescribeSqlLogConfig` API does not return this field, so Terraform cannot read it back during refresh; the value set in the configuration is preserved in state, and the field is ignored during import verification.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## What this PR does

Adds the `enable_audit` argument to the `alicloud_das_sql_log_config` resource, mapping to the `EnableAudit` request parameter of the DAS `ModifySqlLogConfig` API.

## Why

`EnableAudit` controls whether security audit is enabled for a DAS-managed database instance. It was previously not surfaced in the Terraform provider, so users could not manage it declaratively.

## How

- `EnableAudit` is a write-only parameter: `ModifySqlLogConfig` accepts it, but `DescribeSqlLogConfig` does not return it.
- The schema field is therefore `Optional` (not `Computed`): the configured value is preserved in state and is not overwritten during refresh.
- The field is ignored during import verification (`ImportStateVerifyIgnore`) because the read API cannot populate it.

## Files changed

- `alicloud/resource_alicloud_das_sql_log_config.go`: schema field + Create/Update request parameter passthrough.
- `alicloud/resource_alicloud_das_sql_log_config_test.go`: cover `enable_audit` in the basic acc test and ignore it for import verify.
- `website/docs/r/das_sql_log_config.html.markdown`: document the new argument and its write-only behavior.

## Test

`TestAccAliCloudDasSqlLogConfig_basic0` covers the new `enable_audit` argument in both the create and check steps.
