### PR TITLE
resource/alicloud_alikafka_topic: fix the perpetual diff on configs

### DIFF
--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"encoding/json"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -720,6 +721,93 @@ func alikafkaInstanceConfigDiffSuppressFunc(k, old, new string, d *schema.Resour
 	}
 
 	return true
+}
+
+// alikafkaTopicConfigsDiffSuppressFunc suppresses the diff on the configs attribute of
+// alicloud_alikafka_topic as long as every key declared in the configuration already matches
+// the value reported by the server.
+//
+// Subset semantics are required because the server answers with the full effective topic
+// config, which contains keys the user never declared: a serverless instance always reports
+// cloud.native.topic.type and replication-factor, so state is a strict superset of the
+// configuration and a whole-document equality check can never converge.
+//
+// The instance-level comparator is deliberately not reused here: it unmarshals both sides into
+// map[string]string, so a single non-string JSON value makes the unmarshal fail and the diff is
+// then silently not suppressed. Topic configs hit that case routinely, from both directions --
+// the server may report a number (for example {"replication-factor":3}) and jsonencode of a
+// numeric attribute value is a valid configuration too. Decoding with UseNumber keeps every
+// scalar comparable through its literal text, so 3 and "3" are treated as the same value and
+// large integers are never reformatted into scientific notation.
+//
+// Known limitation: removing a key that was previously declared is not reported as a diff,
+// because the update API merges the submitted keys and offers no way to delete or reset a
+// single key. A key that state does not contain yet is still reported as a diff so that it gets
+// applied.
+func alikafkaTopicConfigsDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	if new == "" {
+		return true
+	}
+	if old == "" {
+		return false
+	}
+
+	oldMap, err := decodeJsonObjectKeepingNumbers(old)
+	if err != nil {
+		log.Printf("[DEBUG] %s: the reported configuration is not a JSON object, keeping the diff: %s", k, err)
+		return false
+	}
+	newMap, err := decodeJsonObjectKeepingNumbers(new)
+	if err != nil {
+		log.Printf("[DEBUG] %s: the declared configuration is not a JSON object, keeping the diff: %s", k, err)
+		return false
+	}
+
+	for key, newValue := range newMap {
+		oldValue, ok := oldMap[key]
+		if !ok {
+			log.Printf("[DEBUG] %s: the reported configuration does not contain the declared key %q, keeping the diff", k, key)
+			return false
+		}
+		if formatJsonConfigValue(oldValue) != formatJsonConfigValue(newValue) {
+			log.Printf("[DEBUG] %s: the declared key %q is %q while the service reports %q, keeping the diff",
+				k, key, formatJsonConfigValue(newValue), formatJsonConfigValue(oldValue))
+			return false
+		}
+	}
+
+	return true
+}
+
+// decodeJsonObjectKeepingNumbers decodes a JSON object without converting numbers to float64,
+// which keeps their literal text available for comparison.
+func decodeJsonObjectKeepingNumbers(s string) (map[string]interface{}, error) {
+	decoder := json.NewDecoder(strings.NewReader(s))
+	decoder.UseNumber()
+
+	object := make(map[string]interface{})
+	if err := decoder.Decode(&object); err != nil {
+		return nil, err
+	}
+	return object, nil
+}
+
+// formatJsonConfigValue renders a decoded JSON value as the text an API would carry it in, so
+// that values only differing in their JSON type compare equal.
+func formatJsonConfigValue(value interface{}) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case json.Number:
+		return v.String()
+	case bool:
+		return strconv.FormatBool(v)
+	default:
+		encoded, _ := json.Marshal(v)
+		return string(encoded)
+	}
 }
 
 func payTypePostPaidDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {

--- a/alicloud/diff_suppress_funcs_test.go
+++ b/alicloud/diff_suppress_funcs_test.go
@@ -4641,3 +4641,110 @@ func TestUnitCommonEsDataNodeDiskPerformanceLevelDiffSuppressFunc(t *testing.T) 
 		})
 	}
 }
+
+func TestUnitAlikafkaTopicConfigsDiffSuppressFunc(t *testing.T) {
+	// The server always reports the full effective topic config, so `old` (state) is a
+	// superset of `new` (the keys declared in HCL) whenever the instance injects defaults.
+	serverInjectedConfig := `{"cloud.native.topic.type":"true","replication-factor":"3","max.message.bytes":"1048576","retention.hours":"72"}`
+
+	testCases := []struct {
+		name        string
+		old         string
+		new         string
+		expected    bool
+		description string
+	}{
+		{
+			name:        "ServerInjectedKeysIgnored",
+			old:         serverInjectedConfig,
+			new:         `{"max.message.bytes":"1048576","retention.hours":"72"}`,
+			expected:    true,
+			description: "keys injected by the server must not produce a diff",
+		},
+		{
+			name:        "DeclaredKeyChanged",
+			old:         serverInjectedConfig,
+			new:         `{"max.message.bytes":"10485760","retention.hours":"72"}`,
+			expected:    false,
+			description: "a real change on a declared key must still produce a diff",
+		},
+		{
+			name:        "NumberOnStateSide",
+			old:         `{"cloud.native.topic.type":"true","replication-factor":3,"retention.hours":72}`,
+			new:         `{"retention.hours":"72"}`,
+			expected:    true,
+			description: "numeric values reported by the server compare equal to their string form",
+		},
+		{
+			name:        "NumberOnConfigSide",
+			old:         serverInjectedConfig,
+			new:         `{"max.message.bytes":1048576}`,
+			expected:    true,
+			description: "jsonencode with a numeric value compares equal to the string form",
+		},
+		{
+			name:        "BoolAndStringBoolAreEqual",
+			old:         `{"cloud.native.topic.type":"true","preallocate":true}`,
+			new:         `{"preallocate":"true"}`,
+			expected:    true,
+			description: "boolean values compare equal to their string form",
+		},
+		{
+			name:        "RemovedKeyIsNotADiff",
+			old:         serverInjectedConfig,
+			new:         `{"retention.hours":"72"}`,
+			expected:    true,
+			description: "known limitation: dropping a previously declared key is suppressed because the update API only merges keys and cannot reset one",
+		},
+		{
+			name:        "NewlyDeclaredKeyIsADiff",
+			old:         `{"cloud.native.topic.type":"true","replication-factor":"3"}`,
+			new:         `{"retention.hours":"72"}`,
+			expected:    false,
+			description: "a key that the server does not report yet must produce a diff so it gets applied",
+		},
+		{
+			name:        "EmptyConfigDeclared",
+			old:         serverInjectedConfig,
+			new:         `{}`,
+			expected:    true,
+			description: "declaring an empty object enforces nothing",
+		},
+		{
+			name:        "EmptyNew",
+			old:         serverInjectedConfig,
+			new:         "",
+			expected:    true,
+			description: "an unset attribute keeps the value read back from the server",
+		},
+		{
+			name:        "EmptyOld",
+			old:         "",
+			new:         `{"retention.hours":"72"}`,
+			expected:    false,
+			description: "nothing in state yet, so the declared config must be applied",
+		},
+		{
+			name:        "InvalidNewJson",
+			old:         serverInjectedConfig,
+			new:         `{"retention.hours":`,
+			expected:    false,
+			description: "malformed config must not be suppressed",
+		},
+		{
+			name:        "InvalidOldJson",
+			old:         `not-json`,
+			new:         `{"retention.hours":"72"}`,
+			expected:    false,
+			description: "malformed state must not be suppressed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := initTestData(t, nil)
+			result := alikafkaTopicConfigsDiffSuppressFunc("configs", tc.old, tc.new, d)
+			assert.Equal(t, tc.expected, result, tc.description)
+		})
+	}
+}

--- a/alicloud/resource_alicloud_alikafka_topic.go
+++ b/alicloud/resource_alicloud_alikafka_topic.go
@@ -25,7 +25,7 @@ func resourceAliCloudAlikafkaTopic() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(5 * time.Minute),
+			Create: schema.DefaultTimeout(15 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(16 * time.Minute),
 		},
@@ -36,14 +36,11 @@ func resourceAliCloudAlikafkaTopic() *schema.Resource {
 				ForceNew: true,
 			},
 			"configs": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringIsJSON,
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					equal, _ := compareJsonTemplateAreEquivalent(old, new)
-					return equal
-				},
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateFunc:     validation.StringIsJSON,
+				DiffSuppressFunc: alikafkaTopicConfigsDiffSuppressFunc,
 			},
 			"create_time": {
 				Type:     schema.TypeInt,
@@ -122,7 +119,7 @@ func resourceAliCloudAlikafkaTopicCreate(d *schema.ResourceData, meta interface{
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("alikafka", "2019-09-16", action, query, request, true)
 		if err != nil {
-			if IsExpectedErrors(err, []string{"ONS_SYSTEM_FLOW_CONTROL"}) || NeedRetry(err) {
+			if IsExpectedErrors(err, []string{"ONS_SYSTEM_FLOW_CONTROL", "BIZ_INSTANCE_STATUS_ERROR", "BIZ.INSTANCE.STATUS.ERROR"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}
@@ -203,7 +200,7 @@ func resourceAliCloudAlikafkaTopicUpdate(d *schema.ResourceData, meta interface{
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			response, err = client.RpcPost("alikafka", "2019-09-16", action, query, request, true)
 			if err != nil {
-				if NeedRetry(err) {
+				if IsExpectedErrors(err, []string{"ONS_SYSTEM_FLOW_CONTROL", "BIZ_INSTANCE_STATUS_ERROR", "BIZ.INSTANCE.STATUS.ERROR"}) || NeedRetry(err) {
 					wait()
 					return resource.RetryableError(err)
 				}
@@ -240,7 +237,7 @@ func resourceAliCloudAlikafkaTopicUpdate(d *schema.ResourceData, meta interface{
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			response, err = client.RpcPost("alikafka", "2019-09-16", action, query, request, true)
 			if err != nil {
-				if NeedRetry(err) {
+				if IsExpectedErrors(err, []string{"ONS_SYSTEM_FLOW_CONTROL", "BIZ_INSTANCE_STATUS_ERROR", "BIZ.INSTANCE.STATUS.ERROR"}) || NeedRetry(err) {
 					wait()
 					return resource.RetryableError(err)
 				}
@@ -274,7 +271,7 @@ func resourceAliCloudAlikafkaTopicUpdate(d *schema.ResourceData, meta interface{
 			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 				response, err = client.RpcPost("alikafka", "2019-09-16", action, query, request, true)
 				if err != nil {
-					if IsExpectedErrors(err, []string{"ONS_SYSTEM_FLOW_CONTROL"}) || NeedRetry(err) {
+					if IsExpectedErrors(err, []string{"ONS_SYSTEM_FLOW_CONTROL", "BIZ_INSTANCE_STATUS_ERROR", "BIZ.INSTANCE.STATUS.ERROR"}) || NeedRetry(err) {
 						wait()
 						return resource.RetryableError(err)
 					}
@@ -318,7 +315,7 @@ func resourceAliCloudAlikafkaTopicDelete(d *schema.ResourceData, meta interface{
 		response, err = client.RpcPost("alikafka", "2019-09-16", action, query, request, true)
 
 		if err != nil {
-			if IsExpectedErrors(err, []string{"ONS_SYSTEM_FLOW_CONTROL"}) || NeedRetry(err) {
+			if IsExpectedErrors(err, []string{"ONS_SYSTEM_FLOW_CONTROL", "BIZ_INSTANCE_STATUS_ERROR", "BIZ.INSTANCE.STATUS.ERROR"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}

--- a/alicloud/resource_alicloud_alikafka_topic_test.go
+++ b/alicloud/resource_alicloud_alikafka_topic_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func init() {
@@ -565,3 +566,186 @@ func AliCloudAlikafkaTopicBasicDependence10065(name string) string {
 }
 
 // Test Alikafka Topic. <<< Resource test cases, automatically generated.
+
+// TestUnitAlikafkaTopicConfigsSchemaDiffSuppress drives the diff through the resource schema so
+// that the configs attribute stays wired to the subset comparator. Reproduces the case where a
+// plan never converges because the instance injects config keys the configuration never set.
+func TestUnitAlikafkaTopicConfigsSchemaDiffSuppress(t *testing.T) {
+	suppress := resourceAliCloudAlikafkaTopic().Schema["configs"].DiffSuppressFunc
+	if suppress == nil {
+		t.Fatal("configs has no DiffSuppressFunc")
+	}
+
+	stateConfigs := `{"cloud.native.topic.type":"true","replication-factor":"3","max.message.bytes":"1048576","retention.hours":"72"}`
+
+	testCases := []struct {
+		name        string
+		old         string
+		new         string
+		expected    bool
+		description string
+	}{
+		{
+			name:        "ConvergesOnServerInjectedKeys",
+			old:         stateConfigs,
+			new:         `{"max.message.bytes":"1048576","retention.hours":"72"}`,
+			expected:    true,
+			description: "apply then plan must converge when the server reports extra keys",
+		},
+		{
+			name:        "StillPlansRealChange",
+			old:         stateConfigs,
+			new:         `{"max.message.bytes":"10485760","retention.hours":"72"}`,
+			expected:    false,
+			description: "changing a declared key must still be planned",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, resourceAliCloudAlikafkaTopic().Schema, map[string]interface{}{
+				"configs": tc.old,
+			})
+			if result := suppress("configs", tc.old, tc.new, d); result != tc.expected {
+				t.Errorf("%s: expected %v got %v", tc.description, tc.expected, result)
+			}
+		})
+	}
+}
+
+var AliCloudAlikafkaTopicServerlessConfigsMap = map[string]string{
+	"instance_id": CHECKSET,
+	"create_time": CHECKSET,
+	"status":      CHECKSET,
+}
+
+func AliCloudAlikafkaTopicServerlessConfigsDependence(name string) string {
+	return fmt.Sprintf(`
+	variable "name" {
+  		default = "%s"
+	}
+
+	data "alicloud_zones" "default" {
+  		available_resource_creation = "VSwitch"
+	}
+
+	data "alicloud_vswitches" "default" {
+  		zone_id = data.alicloud_zones.default.zones.0.id
+	}
+
+	resource "alicloud_security_group" "default" {
+  		vpc_id = data.alicloud_vswitches.default.vswitches.0.vpc_id
+	}
+
+	resource "alicloud_alikafka_instance" "default" {
+  		name            = "tf-testAcc-${var.name}"
+  		deploy_type     = "4"
+  		instance_type   = "alikafka_serverless"
+  		vswitch_id      = data.alicloud_vswitches.default.vswitches.0.id
+  		spec_type       = "normal"
+  		service_version = "3.3.1"
+  		security_group  = alicloud_security_group.default.id
+  		serverless_config {
+    		reserved_publish_capacity   = 60
+    		reserved_subscribe_capacity = 60
+  		}
+	}
+`, name)
+}
+
+// TestAccAliCloudAlikafkaTopic_serverlessConfigs covers the configs attribute on a serverless
+// instance, where the service reports configuration keys that were never declared
+// (cloud.native.topic.type and replication-factor). The defect this case guards against is a plan
+// that never converges rather than an apply that fails, so every applied configuration is followed
+// by a plan-only step: those steps refresh from the service first and then require an empty plan.
+func TestAccAliCloudAlikafkaTopic_serverlessConfigs(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alikafka_topic.default"
+	ra := resourceAttrInit(resourceId, AliCloudAlikafkaTopicServerlessConfigsMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlikafkaServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlikafkaTopic")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalikafka%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudAlikafkaTopicServerlessConfigsDependence)
+
+	// Keys accepted by the topic configuration update on a serverless instance. retention.ms is
+	// deliberately absent: it is only accepted on a reserved instance with the Local storage engine.
+	declaredConfigs := `{\"retention.hours\":\"72\",\"max.message.bytes\":\"1048576\",\"message.timestamp.type\":\"LogAppendTime\"}`
+	updatedConfigs := `{\"retention.hours\":\"72\",\"max.message.bytes\":\"10485760\",\"message.timestamp.type\":\"LogAppendTime\"}`
+	// The same configuration with a numeric value, which is what jsonencode produces for a number
+	// while the service keeps reporting the value as a string.
+	updatedConfigsAsNumber := `{\"retention.hours\":\"72\",\"max.message.bytes\":10485760,\"message.timestamp.type\":\"LogAppendTime\"}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_id": "${alicloud_alikafka_instance.default.id}",
+					"topic":       name,
+					"remark":      name,
+					"configs":     declaredConfigs,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_id": CHECKSET,
+						"topic":       name,
+						"remark":      name,
+						"configs":     REGEXMATCH + `"max\.message\.bytes":\s*"?1048576"?[,}]`,
+					}),
+				),
+			},
+			{
+				// The reported configuration is a superset of the declared one, so re-planning the
+				// configuration that was just applied must still produce an empty plan.
+				Config: testAccConfig(map[string]interface{}{
+					"configs": declaredConfigs,
+				}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				// A real change on a declared key must still be planned and applied.
+				Config: testAccConfig(map[string]interface{}{
+					"configs": updatedConfigs,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"configs": REGEXMATCH + `"max\.message\.bytes":\s*"?10485760"?[,}]`,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"configs": updatedConfigs,
+				}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				// Values are compared through their literal text, so declaring the same value as a
+				// number must not produce a diff either.
+				Config: testAccConfig(map[string]interface{}{
+					"configs": updatedConfigsAsNumber,
+				}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}

--- a/website/docs/r/alikafka_topic.html.markdown
+++ b/website/docs/r/alikafka_topic.html.markdown
@@ -78,11 +78,9 @@ resource "alicloud_alikafka_topic" "default" {
   partition_num = "18"
   configs = jsonencode(
     {
-      "message.format.version" : "2.2.0",
+      "retention.ms" : "3600000",
       "max.message.bytes" : "10485760",
-      "min.insync.replicas" : "1",
-      "replication-factor" : "2",
-      "retention.ms" : "3600000"
+      "message.timestamp.type" : "LogAppendTime"
     }
   )
   tags = {
@@ -100,7 +98,13 @@ The following arguments are supported:
 * `compact_topic` - (Optional, ForceNew, Bool) The cleanup policy for the topic. This parameter is available only if you set the storage engine of the topic to Local storage. Valid values:
   - false: The delete cleanup policy is used.
   - true: The compact cleanup policy is used.
-* `configs` - (Optional, Available since v1.262.1) The advanced configurations.
+* `configs` - (Optional, Available since v1.262.1) The advanced configurations of the topic, as a JSON encoded object. The service carries every value as a string; a value declared as a number or a boolean is compared through its literal text, so it matches the string the service reports for it. The keys the service accepts and their value ranges are defined by [UpdateTopicConfig](https://www.alibabacloud.com/help/en/apsaramq-for-kafka/cloud-message-queue-for-kafka/developer-reference/api-alikafka-2019-09-16-updatetopicconfig) and depend on the instance:
+  - Serverless instance: `retention.hours` (the retention period in hours, from `24` to `8760`), `max.message.bytes` (the maximum message size in bytes, from `1048576` to `10485760`), `message.timestamp.type` (`CreateTime` or `LogAppendTime`) and `message.timestamp.difference.max.ms` (the maximum difference allowed between the timestamp carried by a message and the time the server receives it - a message that exceeds it is rejected, and the key has no effect when `message.timestamp.type` is `LogAppendTime`).
+  - Reserved instance: only a topic that uses the Local storage engine can be configured, and the supported keys are `retention.ms` (the retention period in milliseconds, from `3600000` to `31536000000`), `max.message.bytes`, `message.timestamp.type` and `message.timestamp.difference.max.ms`.
+-> **NOTE:** The service reports the whole effective configuration of the topic, which can contain keys that were never declared in `configs` - a topic on a serverless instance reports `cloud.native.topic.type` and `replication-factor`, for example. Only the keys declared in `configs` are compared against the reported configuration, so those extra keys do not produce a diff.
+-> **NOTE:** Removing a key from `configs` neither resets it on the topic nor produces a diff, because the update merges the submitted keys and offers no way to delete or reset a single key. Set the key to the value you want instead of removing it, or recreate the topic.
+-> **NOTE:** A key that the service does not accept for the instance makes the update fail with `InvalidParameter.NotSupport`, so a configuration written for one instance type cannot be reused for the other as is - `retention.ms` and `retention.hours` in particular are not interchangeable.
+-> **NOTE:** `replication-factor` is part of the configuration reported by the service, but it is not one of the keys accepted when the topic configuration is updated - the number of replicas is only taken when the topic is created. Declaring it in `configs` therefore cannot be used to make the reported configuration match the configuration.
 * `instance_id` - (Required, ForceNew) The ID of the instance.
 * `local_topic` - (Optional, ForceNew, Bool) The storage engine of the topic. Valid values:
   - false: Cloud storage.
@@ -123,7 +127,7 @@ The following attributes are exported:
 -> **NOTE:** Available since v1.119.0.
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
-* `create` - (Defaults to 5 mins) Used when create the Topic.
+* `create` - (Defaults to 15 mins) Used when create the Topic.
 * `delete` - (Defaults to 16 mins) Used when delete the Topic.
 * `update` - (Defaults to 5 mins) Used when update the Topic.
 


### PR DESCRIPTION
## Summary
- `resource/alicloud_alikafka_topic`: the `configs` diff no longer reappears after a successful apply. The service reports the whole effective topic configuration, so the keys it injects itself - a topic on a serverless instance always reports `cloud.native.topic.type` and `replication-factor` - made the previous whole-document equality check fail on every plan.
- Only the keys declared in the configuration are compared now, and both sides are decoded with `json.Decoder.UseNumber` so a numeric value stays comparable with its string form. That happens in both directions: the service may report `{"replication-factor":3}` and `jsonencode` of a numeric value is a valid configuration as well, so decoding into `map[string]string` or formatting through `float64` is not enough.
- Added an acceptance case on a serverless instance. The existing cases all run against a reserved instance, so this code path had no coverage at all.
- Documented the `configs` keys the update accepts per instance type, the fact that the reported configuration is a superset of the declared one, that removing a key cannot reset it because the update only merges the submitted keys, and that `replication-factor` is only taken when the topic is created. The example now uses keys that the update actually accepts.

## Test plan
- [x] `TestUnitAlikafkaTopicConfigsDiffSuppressFunc` - 12 cases: server-injected keys ignored, real change on a declared key still planned, number on either side, bool vs string bool, key removal (documented limitation), newly declared key still planned, empty object, empty old/new, malformed JSON on either side.
- [x] `TestUnitAlikafkaTopicConfigsSchemaDiffSuppress` - drives the diff through the resource schema, so the attribute stays wired to the comparator; it fails on the unpatched code with `expected true got false`.

```
=== RUN   TestUnitAlikafkaTopicConfigsDiffSuppressFunc
--- PASS: TestUnitAlikafkaTopicConfigsDiffSuppressFunc (0.00s)

=== RUN   TestUnitAlikafkaTopicConfigsSchemaDiffSuppress
--- PASS: TestUnitAlikafkaTopicConfigsSchemaDiffSuppress (0.00s)

PASS
ok  	github.com/aliyun/terraform-provider-alicloud/alicloud	5.684s
```

`TestAccAliCloudAlikafkaTopic_serverlessConfigs` is the new acceptance case for this path: it applies a topic configuration on a serverless instance, then requires an empty plan (plan-only steps, which refresh from the service first), changes `max.message.bytes` to prove a real change is still planned, declares the same value as a number, and finishes with an import check. The existing topic cases pass; this new case is still being run and its result will be reported here once the whole set is green.


## Also in this PR: retry the topic calls while the instance is not operable yet

This is a second, independent fix for a pre-existing flake in the same resource, found while running the acceptance cases above.

On an unmodified checkout of `master`, 3 of the 4 existing topic acceptance cases fail on the very first `CreateTopic`, immediately after the instance resource reports that the instance is running:

```
SDKError:
   StatusCode: 400
   Code: BIZ.INSTANCE.STATUS.ERROR
   Message: code: 400, instance is in PREPARED. Please check and try again later.
```

The topic control plane keeps rejecting topic operations for a while after the instance itself reaches its running state, so every topic call has to tolerate that error. It was not tolerated: the code is an HTTP 400, and `NeedRetry` only covers transport errors, `Client.Timeout`, throttling codes and `code: 5xx` messages, so the call was classified non-retryable and failed on the first attempt instead of waiting for the instance. The debug log confirms it - one request, no retry, immediate failure.

- `BIZ.INSTANCE.STATUS.ERROR` is now in the retryable set of all five topic calls (`CreateTopic`, `ModifyTopicRemark`, `UpdateTopicConfig`, `ModifyPartitionNum`, `DeleteTopic`). All five are writes against the same instance and are gated on the same server-side instance state. `CreateTopic` and `DeleteTopic` were both observed hitting it - the `DeleteTopic` one during destroy, which is worse than a failed apply because it leaves the topic behind.
- `ModifyTopicRemark` and `UpdateTopicConfig` had no `IsExpectedErrors` list at all, only `NeedRetry`, so they also gain `ONS_SYSTEM_FLOW_CONTROL` - also an HTTP 400, also transient - which the other three already had. All five predicates are identical now.
- The create timeout goes from 5 to 15 minutes so that the retry window actually covers the time the instance needs to become operable; for comparison, `alicloud_alikafka_instance` itself allows 60 minutes to create and 120 to update. The update and delete timeouts are unchanged.

The update timeout is deliberately left at 5 minutes. The window this fix needs is a create-time one - by the time a topic is updated its instance has already been operable once - and the update path runs up to three of these calls in sequence (`ModifyTopicRemark`, `UpdateTopicConfig`, `ModifyPartitionNum`), each taking the update timeout on its own, so raising it multiplies the worst case by three for no established benefit.

### Worst-case behaviour of the delete path

Retrying on an instance-state error means a topic whose instance is *permanently* not operable now waits instead of failing fast, and this is worth stating precisely rather than calling the exposure small:

- The delete path can take roughly twice the delete timeout, not once: the retry loop takes it, and the status wait that follows takes it again. The SDK does not enforce these as a hard deadline that cuts the operation off.
- The `NotFoundError` short circuit in the delete path does **not** catch this error, so the window is not cut short by it. That helper only matches HTTP 404 or a `NotFound` code, and this is an HTTP 400 with a `BIZ.INSTANCE.STATUS.ERROR` code.
- Elsewhere in the provider this same code is mapped to *not found* on the read paths of neighbouring alikafka resources, which suggests it is not exclusively a transient pre-provisioning signal.

This is accepted rather than hidden: Terraform destroys a topic before its instance, and an instance removed out of band makes the read return not-found so delete is never reached. Making delete treat this code as success instead would change destroy semantics and could drop a topic that still exists, so it is deliberately out of scope here.

A longer timeout does not slow down genuine failures: any error outside the retryable set is still returned immediately.

