### PR TITLE
ci: gate CI on a base-branch allowlist so release/v2 is covered

### DIFF
--- a/.github/actions/terraform-ci-select-policy/route.js
+++ b/.github/actions/terraform-ci-select-policy/route.js
@@ -16,6 +16,10 @@ const PULL_REQUEST_ACTIONS = new Set([
   "synchronize",
   "ready_for_review",
 ]);
+const SUPPORTED_BASE_REFS = new Set(["master", "release/v2"]);
+const SUPPORTED_PUSH_REFS = new Set(
+  Array.from(SUPPORTED_BASE_REFS, (branch) => `refs/heads/${branch}`)
+);
 const ACTIONS_APP = Object.freeze({
   id: 15368,
   slug: "github-actions",
@@ -91,7 +95,8 @@ function pullRequestMetadata(context, repository) {
     !REPOSITORY_PATTERN.test(headRepository) ||
     !isCommitSha(headSha) ||
     baseRepository !== repository.fullName ||
-    baseRef !== "master"
+    typeof baseRef !== "string" ||
+    !SUPPORTED_BASE_REFS.has(baseRef)
   ) {
     throw new Error("Pull request metadata is invalid.");
   }
@@ -102,13 +107,14 @@ function pullRequestMetadata(context, repository) {
 function eventMetadata(context, repository) {
   if (context?.eventName === "push") {
     const payload = context.payload;
-    const ref = "refs/heads/master";
+    const ref = context.ref;
     if (
       !isRecord(payload) ||
+      typeof ref !== "string" ||
+      !SUPPORTED_PUSH_REFS.has(ref) ||
       payload.action !== undefined ||
       payload.repository?.full_name !== repository.fullName ||
       payload.ref !== ref ||
-      context.ref !== ref ||
       payload.deleted !== false ||
       !isCommitSha(context.sha) ||
       payload.after !== context.sha

--- a/.github/actions/terraform-ci-select-policy/route.test.js
+++ b/.github/actions/terraform-ci-select-policy/route.test.js
@@ -14,7 +14,7 @@ const CHECK_ID = 123456789;
 const CHECK_URL =
   `https://github.com/${OWNER}/${REPO}/runs/${CHECK_ID}`;
 
-function pullRequest() {
+function pullRequest(overrides = {}) {
   return {
     number: 100,
     head: {
@@ -23,7 +23,7 @@ function pullRequest() {
     },
     base: {
       repo: { full_name: `${OWNER}/${REPO}` },
-      ref: "master",
+      ref: overrides.baseRef ?? "master",
     },
   };
 }
@@ -32,7 +32,7 @@ function pullRequestContext(overrides = {}) {
   const eventName = overrides.eventName ?? "pull_request";
   const payload = {
     action: overrides.action ?? "synchronize",
-    pull_request: pullRequest(),
+    pull_request: pullRequest(overrides),
   };
   if (eventName === "pull_request_review") {
     payload.action = overrides.action ?? "submitted";
@@ -239,6 +239,20 @@ test("push to the repository master branch is trusted and relevant", async () =>
   assert.equal(result.calls.length, 0);
 });
 
+test("push to a supported release branch is trusted and relevant", async () => {
+  const result = await execute(
+    pushContext({ ref: "refs/heads/release/v2" }),
+    []
+  );
+  assert.deepEqual(result.outputs, {
+    classification: "trusted",
+    relevant: "true",
+    runner: JSON.stringify("terraform-ci-trusted"),
+    heavy_runner: JSON.stringify("terraform-ci-heavy"),
+  });
+  assert.equal(result.calls.length, 0);
+});
+
 test("push rejects another repository", async () => {
   await assert.rejects(
     execute(pushContext({ repository: "someone/else" }), []),
@@ -400,6 +414,33 @@ test("a completed non-success Check Run fails closed", async () => {
       [[checkRun({ conclusion: "failure" })]]
     ),
     /rejected/i
+  );
+});
+
+test("pull_request targeting a supported release branch is routed", async () => {
+  const result = await execute(
+    pullRequestContext({ baseRef: "release/v2" }),
+    [[checkRun()]]
+  );
+
+  assert.deepEqual(result.outputs, {
+    classification: "trusted",
+    relevant: "true",
+    runner: JSON.stringify("terraform-ci-trusted"),
+    heavy_runner: JSON.stringify("terraform-ci-heavy"),
+  });
+});
+
+test("pull_request targeting an unsupported base branch fails closed", async () => {
+  await assert.rejects(
+    execute(pullRequestContext({ baseRef: "feature" }), [[checkRun()]]),
+    /pull request metadata/i
+  );
+  await assert.rejects(
+    execute(pullRequestContext({ baseRef: "refs/heads/master" }), [
+      [checkRun()],
+    ]),
+    /pull request metadata/i
   );
 });
 

--- a/.github/workflows/acctest-terraform-basic-policy.yml
+++ b/.github/workflows/acctest-terraform-basic-policy.yml
@@ -8,6 +8,7 @@ on:
       - ready_for_review
     branches:
       - master
+      - release/v2
 
 permissions: {}
 
@@ -35,6 +36,7 @@ jobs:
               "synchronize",
               "ready_for_review",
             ]);
+            const supportedBaseRefs = new Set(["master", "release/v2"]);
             const actionsApp = {
               id: 15368,
               slug: "github-actions",
@@ -68,7 +70,8 @@ jobs:
                 !repositoryPattern.test(headRepository) ||
                 !/^[0-9a-f]{40}$/.test(headSha ?? "") ||
                 baseRepository !== expectedBaseRepository ||
-                baseRef !== "master" ||
+                typeof baseRef !== "string" ||
+                !supportedBaseRefs.has(baseRef) ||
                 !Number.isSafeInteger(pullNumber) ||
                 pullNumber <= 0 ||
                 !Number.isSafeInteger(changedFileCount) ||

--- a/.github/workflows/acctest-terraform-basic.yml
+++ b/.github/workflows/acctest-terraform-basic.yml
@@ -10,6 +10,7 @@ on:
       - ready_for_review
     branches:
       - master
+      - release/v2
 
 permissions: {}
 
@@ -41,6 +42,7 @@ jobs:
               "synchronize",
               "ready_for_review",
             ]);
+            const supportedBaseRefs = new Set(["master", "release/v2"]);
             const actionsApp = {
               id: 15368,
               slug: "github-actions",
@@ -65,7 +67,8 @@ jobs:
               !repositoryPattern.test(headRepository) ||
               !/^[0-9a-f]{40}$/.test(headSha ?? "") ||
               baseRepository !== expectedBaseRepository ||
-              baseRef !== "master" ||
+              typeof baseRef !== "string" ||
+              !supportedBaseRefs.has(baseRef) ||
               !Number.isSafeInteger(pullNumber) ||
               pullNumber <= 0
             ) {


### PR DESCRIPTION
### Why

`release/v2` currently has **no CI at all**. Every workflow is gated with `branches: [master]`, so a PR against `release/v2` gets zero checks — no Compile, no Formatter, no BreakingChange, no lint, and no PR-title/single-commit gate. The only v2-aware workflow is `release.yml`, and only on `release/v2`'s own copy, which filters `v2.*` tags — nothing on `master` reacts to a v2 base branch.

Widening the `branches:` filters alone is not enough, and is actively worse than the status quo: the base-branch guard is hardcoded to `master` in three separate places, so a v2 pull request would reach the guard, throw `Pull request metadata is invalid.`, and show a red X on every PR.

### What

1. **Generalize the guard into an allowlist** — the real fix, applied at all three sites:
   - `.github/actions/terraform-ci-select-policy/route.js` — `SUPPORTED_BASE_REFS = new Set(["master", "release/v2"])`, replacing `baseRef !== "master"`.
   - `.github/workflows/acctest-terraform-basic.yml` — same, in the inline `route` script.
   - `.github/workflows/acctest-terraform-basic-policy.yml` — same, in the inline policy-gate script.

2. **Un-pin the push ref.** `eventMetadata()` compared the push ref against a hardcoded `"refs/heads/master"` constant. It now reads `context.ref` and validates it against `SUPPORTED_PUSH_REFS`, derived from the same allowlist. `payload.ref !== ref` still cross-checks the payload against the context, so an unknown branch keeps failing closed — only the set of accepted branches changed, not the strictness. The now-tautological `context.ref !== ref` comparison is dropped. This part is forward-looking: the three push-triggered workflows are all still `branches: [master]` and still pinned to the previous action SHA, so nothing exercises the new push allowlist until the follow-up below.

3. **Enable `release/v2`** on the two workflows whose policy script is inline, and which therefore take effect immediately: `acctest-terraform-basic.yml` and `acctest-terraform-basic-policy.yml`. That is Basic Policy Gate + BreakingChange / Formatter / Compile.

### Deliberately not in this PR

`acctest-terraform-lint.yml`, `consistency-check.yml`, `document-check.yml` and `testing-coverage-rate.yml` consume `terraform-ci-select-policy` pinned by full commit SHA. The pinned commit has to exist in this repository before it can be referenced, so adding `release/v2` to their `branches:` now would run them against the *old* `route.js` and hard-fail every v2 PR — exactly the failure mode this PR exists to avoid. They need a follow-up PR that re-pins the SHA and adds the branch in the same change. (`document-check.yml` is additionally a version behind the other three.)

Also left alone, on purpose:

- `pull_requests.yml` (title / single-commit gates) — worth enabling for v2, but its title rules key off `alicloud/resource_alicloud*` and `alicloud/data_source_alicloud*` top-level paths, which do not describe v2's per-service layout. It deserves its own discussion rather than a silent widening.
- `consistency-check.yml`'s `github.ref == 'refs/heads/master'` cache-save condition — that one *should* stay master-only, so v2 does not overwrite master's cache entry.
- The `relevant` path filter `/^alicloud\/[^/]+\.go$/` only matches **top-level** files under `alicloud/`. v2's framework-native code lives in nested packages (`alicloud/service/…`, `alicloud/function/…`, `alicloud/arn/…`), so a PR touching only those computes `relevant=false` and skips Compile. This is a pre-existing gap on master too (it already misses `alicloud/connectivity/`), and broadening it changes how many master PRs get gated, so it belongs in its own PR.

### Test

`route.test.js` is plain `node:test` and is not currently wired into any workflow, but it does run:

```
$ node --test .github/actions/terraform-ci-select-policy/route.test.js
ℹ tests 37
ℹ pass 37
ℹ fail 0
```

Three cases added, plus a `baseRef` override plumbed through the PR-context fixture:

- `pull_request targeting a supported release branch is routed` — v2 base ref accepted, trusted runner selected.
- `pull_request targeting an unsupported base branch fails closed` — `feature` rejected, and `refs/heads/master` rejected too, pinning down that `base.ref` is a short name.
- `push to a supported release branch is trusted and relevant`.

The pre-existing `push rejects another ref` case still passes, which is the fail-closed proof for the un-pinned push ref.

Both inline `github-script` bodies were extracted and syntax-checked with `node --check`, and both workflow files re-parsed as YAML to confirm the branch filters read `[master, release/v2]`.

### Note on when this takes effect

`acctest-terraform-basic-policy.yml` is a `pull_request_target` workflow, so GitHub evaluates the **base branch's** copy of the file. It starts gating v2 PRs only after this lands on `master` and reaches `release/v2` through the routine `Merge upstream/master into release/v2`. Basing the PR on `master` is deliberate: it is the branch that has CI today, so the change gets self-tested, and it keeps `.github/` from diverging between the two branches.

