### PR TITLE
ci: extend the remaining pull_request workflows to release/v2

### DIFF
--- a/.github/workflows/acctest-terraform-basic-policy.yml
+++ b/.github/workflows/acctest-terraform-basic-policy.yml
@@ -118,7 +118,7 @@ jobs:
               relevant =
                 protectedPathChanged ||
                 changedFiles.some(({ filename }) =>
-                  /^alicloud\/[^/]+\.go$/.test(filename)
+                  /^alicloud\/.+\.go$/.test(filename)
                 );
 
               const allowlistedAutomation =

--- a/.github/workflows/acctest-terraform-lint.yml
+++ b/.github/workflows/acctest-terraform-lint.yml
@@ -8,6 +8,7 @@ on:
       - ready_for_review
     branches:
       - master
+      - release/v2
     paths:
       - .github/workflows/acctest-terraform-lint.yml
       - alicloud/*.go
@@ -32,7 +33,7 @@ jobs:
     steps:
       - name: Select runner
         id: select
-        uses: aliyun/terraform-provider-alicloud/.github/actions/terraform-ci-select-policy@eaf310539de91ddbb455d3f5bcfd5de39037b432
+        uses: aliyun/terraform-provider-alicloud/.github/actions/terraform-ci-select-policy@a5ba492fefd8a566da45892dd8abba28c631270c
 
   errcheck:
     name: runner / errcheck

--- a/.github/workflows/consistency-check.yml
+++ b/.github/workflows/consistency-check.yml
@@ -12,6 +12,7 @@ on:
       - ready_for_review
     branches:
       - master
+      - release/v2
 
 permissions: {}
 
@@ -32,7 +33,7 @@ jobs:
     steps:
       - name: Select runner
         id: select
-        uses: aliyun/terraform-provider-alicloud/.github/actions/terraform-ci-select-policy@eaf310539de91ddbb455d3f5bcfd5de39037b432
+        uses: aliyun/terraform-provider-alicloud/.github/actions/terraform-ci-select-policy@a5ba492fefd8a566da45892dd8abba28c631270c
 
   consistency:
     name: Consistency

--- a/.github/workflows/document-check.yml
+++ b/.github/workflows/document-check.yml
@@ -11,6 +11,7 @@ on:
       - ready_for_review
     branches:
       - master
+      - release/v2
     paths:
       - .github/markdownlint/website-docs.json
       - .github/workflows/document-check.yml
@@ -35,7 +36,7 @@ jobs:
     steps:
       - name: Select runner
         id: select
-        uses: aliyun/terraform-provider-alicloud/.github/actions/terraform-ci-select-policy@1c4bb6762031f53732611700cad5d71d1ec84dfe
+        uses: aliyun/terraform-provider-alicloud/.github/actions/terraform-ci-select-policy@a5ba492fefd8a566da45892dd8abba28c631270c
 
   markdown-link:
     needs: route

--- a/.github/workflows/testing-coverage-rate.yml
+++ b/.github/workflows/testing-coverage-rate.yml
@@ -11,6 +11,7 @@ on:
       - ready_for_review
     branches:
       - master
+      - release/v2
     paths:
       - .github/workflows/testing-coverage-rate.yml
       - .go-version
@@ -35,7 +36,7 @@ jobs:
     steps:
       - name: Select runner
         id: select
-        uses: aliyun/terraform-provider-alicloud/.github/actions/terraform-ci-select-policy@eaf310539de91ddbb455d3f5bcfd5de39037b432
+        uses: aliyun/terraform-provider-alicloud/.github/actions/terraform-ci-select-policy@a5ba492fefd8a566da45892dd8abba28c631270c
 
   TestingCoverageRate:
     needs: route


### PR DESCRIPTION
### Why

The base-branch allowlist merged in the previous PR only reached the two workflows that carry the policy script inline (`acctest-terraform-basic-policy.yml`, `acctest-terraform-basic.yml`). The four workflows that consume the pinned `terraform-ci-select-policy` composite action were left behind on two counts:

1. Their `pull_request.branches` filter is still `[master]`, and their workflow files are **byte-identical** on `master` and `release/v2`. So syncing `master` into `release/v2` propagates the master-only filter — a pull request targeting `release/v2` simply never triggers them.
2. Their pinned router still hard-codes the base ref: `baseRef !== "master"` and `const ref = "refs/heads/master"`. Adding the branch without bumping the pin would trade "no check" for "a red X on every v2 pull request".

Both have to change together, which is exactly what could not be done in one commit last time — the pin has to name the SHA of the commit that contains the new router, and a single commit naming its own hash is impossible.

### What

- Bump the pin in `acctest-terraform-lint.yml`, `consistency-check.yml`, `document-check.yml`, and `testing-coverage-rate.yml` to the commit carrying the allowlist. `document-check.yml` was one revision further behind than the others; the action's interface only gained an output between the two pins, so the bump is interface-safe.
- Add `release/v2` to those four `pull_request.branches` filters.
- Widen the relevance probe in the policy gate from `/^alicloud\/[^/]+\.go$/` to `/^alicloud\/.+\.go$/`, so a change confined to a nested package under `alicloud/` is no longer classified `relevant=false` and silently skipped.

### Deliberately left alone

- **`push.branches` stays `[master]`** everywhere. The cache-save step is additionally gated on `github.ref == 'refs/heads/master'`, and widening the push trigger would put a second branch's worth of load on the heavy runners for no review benefit. The push allowlist in the router therefore stays inert for now.
- **`paths: alicloud/*.go`** in `acctest-terraform-lint.yml` and `testing-coverage-rate.yml` is the same top-level-only pattern as the relevance probe above, but those two drive tflint / errcheck / coverage — tooling that has never looked at the nested packages. Widening it will most likely surface pre-existing lint debt, which deserves to fail in isolation rather than inside a plumbing change. Left for a separate pull request.

### Verification

The router's unit tests are unchanged by this pull request and still pass against the pinned revision:

```
$ node --test .github/actions/terraform-ci-select-policy/route.test.js
# pass 37
# fail 0
```

End-to-end confirmation of the four workflows requires a pull request whose base is `release/v2`, which is only possible after `master` is synced into that branch — the same ordering constraint as the previous change.

No provider code is touched, so no acceptance tests apply.
