### PR TITLE
ci: reject new SDK v2 helper/resource retry usage on release/v2

### DIFF
--- a/.aoneci/document-check.yml
+++ b/.aoneci/document-check.yml
@@ -35,6 +35,21 @@ jobs:
           go-version: '1.24.0'
       - run: BASIC_CHECK_AUTO_RANGE=true bash scripts/basic-check.sh
 
+  V2RetryGuard:
+    steps:
+      - uses: checkout
+      - name: Reject new SDK v2 helper/resource retry usage on release/v2
+        run: |
+          targetBranch='${{git.merge_request.targetBranch ?: ""}}'
+          if [[ "$targetBranch" != "release/v2" ]]; then
+            echo "target branch is ${targetBranch:-<empty>}, skipping the v2 retry guard"
+            exit 0
+          fi
+          git fetch --no-tags origin release/v2:refs/remotes/origin/release/v2
+          DIFF_BASE="$(git merge-base origin/release/v2 HEAD)" \
+          DIFF_HEAD="$(git rev-parse HEAD)" \
+            bash scripts/ci/v2-retry-guard.sh
+
   Content:
     steps:
       - uses: checkout

--- a/.github/workflows/acctest-terraform-basic.yml
+++ b/.github/workflows/acctest-terraform-basic.yml
@@ -182,6 +182,34 @@ jobs:
 
             throw new Error("Timed out waiting for a unique Basic Policy result.");
 
+  V2RetryGuard:
+    needs: route
+    # Only release/v2 carries the helper/retry migration; new SDK v2
+    # helper/resource retry usage must not be merged into it.
+    if: ${{ needs.route.outputs.relevant == 'true' && github.event.pull_request.base.ref == 'release/v2' }}
+    permissions:
+      contents: read
+    runs-on: ${{ fromJSON(needs.route.outputs.runner) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Resolve change range
+        id: change-range
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          CI_BASE_REPOSITORY_URL: https://github.com/${{ github.repository }}.git
+        run: scripts/ci/resolve-change-range.sh >> "$GITHUB_OUTPUT"
+      - name: Reject new SDK v2 helper/resource retry usage
+        env:
+          DIFF_BASE: ${{ steps.change-range.outputs.diff_base }}
+          DIFF_HEAD: ${{ steps.change-range.outputs.diff_head }}
+        run: bash scripts/ci/v2-retry-guard.sh
+
   BreakingChange:
     needs: route
     if: ${{ needs.route.outputs.relevant == 'true' }}

--- a/.github/workflows/document-check.yml
+++ b/.github/workflows/document-check.yml
@@ -186,6 +186,9 @@ jobs:
         env:
           DIFF_BASE: ${{ steps.change-range.outputs.diff_base }}
           DIFF_HEAD: ${{ steps.change-range.outputs.diff_head }}
+          # release/v2 retry guard: the PR base ref for pull requests, the
+          # pushed branch otherwise; the guard no-ops on every other branch.
+          V2_RETRY_GUARD_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}
         run: bash scripts/basic-check.sh
 
   Content:

--- a/scripts/basic-check.sh
+++ b/scripts/basic-check.sh
@@ -102,5 +102,17 @@ if [[ "$error" == "true" ]]; then
 	exit 1
 fi
 
+# release/v2 guard: reject new SDK v2 helper/resource retry usage so the
+# helper/retry migration cannot regress (see scripts/ci/v2-retry-guard.sh).
+v2_guard_base_ref="${V2_RETRY_GUARD_BASE_REF:-${GITHUB_BASE_REF:-}}"
+if [[ "$v2_guard_base_ref" == "release/v2" && -n "${diff_base:-}" && -n "${diff_head:-}" ]]; then
+	echo "==> Checking for new SDK v2 helper/resource retry usage (release/v2)..."
+	DIFF_BASE="$diff_base" DIFF_HEAD="$diff_head" \
+		bash "$(dirname "${BASH_SOURCE[0]}")/ci/v2-retry-guard.sh" || {
+		echo -e "\033[31mbasic-check: release/v2 must not introduce terraform-plugin-sdk helper/resource retry helpers; use helper/retry instead.\033[0m" >&2
+		exit 1
+	}
+fi
+
 echo "==> All basic checks passed!"
 exit 0

--- a/scripts/ci/v2-retry-guard.sh
+++ b/scripts/ci/v2-retry-guard.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+# Guard the release/v2 branch against new SDK v2 helper/resource retry usage.
+#
+# Background: helper/resource and terraform-plugin-testing both register a
+# -sweep flag in init(), so a test binary linking both dies at startup with
+# "flag redefined: sweep". The Route 1 migration (see the helper-retry
+# migration design doc) moves the retry helpers of non-test files in package
+# alicloud to terraform-plugin-sdk/v2/helper/retry so framework-hosted tests
+# can coexist. This guard stops new usages from creeping back in.
+#
+# The check inspects only lines ADDED by the change range, so files that have
+# not been migrated yet can still be edited. It covers:
+#   - new imports of terraform-plugin-sdk{,/v2}/helper/resource, including
+#     aliased imports, in non-test files
+#   - new uses of the retry symbols through the imported identifier:
+#     Retry, RetryableError, NonRetryableError, RetryError,
+#     StateRefreshFunc, StateChangeConf
+#
+# Every violation is reported with its real file line number and the exact
+# replacement (e.g. resource.Retry -> retry.Retry). Under GitHub Actions the
+# violations are additionally emitted as ::error workflow commands so they
+# show up as inline annotations in the pull request diff; a plain-text copy
+# is printed as well because workflow commands are hidden from the job log.
+#
+# Usage: DIFF_BASE=<sha> DIFF_HEAD=<sha> v2-retry-guard.sh
+#
+# When DIFF_BASE/DIFF_HEAD are unset and V2_RETRY_GUARD_AUTO_RANGE=true, the
+# range is resolved against origin/${GITHUB_BASE_REF:-master} the same way
+# scripts/basic-check.sh does for the retained Aone workflow.
+
+set -euo pipefail
+
+die() {
+        echo "v2-retry-guard: $*" >&2
+        exit 2
+}
+
+resolve_commit() {
+        local name="$1"
+        local value="$2"
+        local resolved
+
+        [[ "$value" =~ ^[0-9a-f]{40}$ ]] ||
+                die "$name is not a valid commit"
+        if ! resolved="$(git rev-parse --verify "${value}^{commit}" 2>/dev/null)"; then
+                die "$name is not a valid commit"
+        fi
+        printf '%s\n' "$resolved"
+}
+
+if [[ -z "${DIFF_BASE:-}" || -z "${DIFF_HEAD:-}" ]]; then
+        [[ "${V2_RETRY_GUARD_AUTO_RANGE:-false}" == "true" ]] ||
+                die "DIFF_BASE and DIFF_HEAD are required (or set V2_RETRY_GUARD_AUTO_RANGE=true)"
+
+        if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+                git fetch --no-tags --unshallow origin ||
+                        die "failed to fetch complete history"
+        fi
+        base_ref="origin/${GITHUB_BASE_REF:-master}"
+        base_tip="$(git rev-parse --verify "${base_ref}^{commit}" 2>/dev/null)" ||
+                die "base branch is unavailable: $base_ref"
+        head_tip="$(git rev-parse --verify 'HEAD^{commit}' 2>/dev/null)" ||
+                die "HEAD is not a valid commit"
+        DIFF_BASE="$(git merge-base "$base_tip" "$head_tip")" ||
+                die "base branch and HEAD do not have a common ancestor"
+        DIFF_HEAD="$head_tip"
+fi
+
+diff_base="$(resolve_commit DIFF_BASE "$DIFF_BASE")"
+diff_head="$(resolve_commit DIFF_HEAD "$DIFF_HEAD")"
+git merge-base --is-ancestor "$diff_base" "$diff_head" ||
+        die "DIFF_BASE must be an ancestor of DIFF_HEAD"
+
+# Test files keep using SDK v2 helper/resource by design: they only link into
+# their package's test binary, which never links terraform-plugin-testing.
+# scripts/migration is a standalone package main tool, likewise exempt.
+skipped_prefixes=("scripts/migration/")
+
+retry_symbols="Retry|RetryableError|NonRetryableError|RetryError|StateRefreshFunc|StateChangeConf"
+import_pattern='"github\.com/hashicorp/terraform-plugin-sdk(/v2)?/helper/resource"'
+retry_import='"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"'
+
+violations=0
+
+# Report one violation. Under GitHub Actions the same message becomes an
+# inline annotation on the offending line of the pull request diff.
+emit_violation() {
+        local file="$1" lineno="$2" message="$3"
+
+        if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+                echo "::error file=${file},line=${lineno},title=v2-retry-guard::${message}"
+                # Workflow commands are hidden from the job log; repeat the
+                # violation as plain text so it is visible there too.
+                echo "v2-retry-guard: ${file}:${lineno}: ${message}"
+        else
+                echo "v2-retry-guard: ${file}:${lineno}: ${message}"
+        fi
+        violations=$((violations + 1))
+}
+
+check_file() {
+        local file="$1"
+        local prefix added_lines identifiers symbol symbols lineno line_text
+
+        [[ "$file" == *.go && "$file" != *_test.go ]] || return 0
+        for prefix in "${skipped_prefixes[@]}"; do
+                [[ "$file" == "$prefix"* ]] && return 0
+        done
+        [[ -f "$file" ]] || return 0
+
+        # Added lines with their real line numbers in the head version,
+        # derived from the @@ hunk headers of a zero-context diff.
+        added_lines="$(git diff --unified=0 "$diff_base" "$diff_head" -- "$file" |
+                awk '/^\+\+\+/ { next }
+                        /^@@/ { match($0, /\+[0-9]+/); n = substr($0, RSTART + 1, RLENGTH - 1) + 0; next }
+                        /^\+/ { printf "%d %s\n", n, substr($0, 2); n++ }')" || true
+        [[ -n "$added_lines" ]] || return 0
+
+        # Identifiers bound to helper/resource by added import lines: the
+        # default package name plus any explicit aliases.
+        identifiers="resource"
+        while IFS= read -r alias; do
+                [[ -n "$alias" ]] && identifiers="${identifiers}|${alias}"
+        done < <(printf '%s\n' "$added_lines" |
+                { grep -oE "[A-Za-z_][A-Za-z0-9_]*[[:space:]]+${import_pattern}" || true; } |
+                { grep -oE "^[A-Za-z_][A-Za-z0-9_]*" || true; })
+
+        while IFS= read -r added; do
+                [[ -n "$added" ]] || continue
+                lineno="${added%% *}"
+                line_text="${added#* }"
+
+                if grep -Eq "^[[:space:]]*(_[[:space:]]+|[A-Za-z_][A-Za-z0-9_]*[[:space:]]+)?${import_pattern}" <<<"$line_text"; then
+                        deprecated_import="$(grep -oE "${import_pattern}" <<<"$line_text" | head -1)"
+                        emit_violation "$file" "$lineno" \
+                                "deprecated import ${deprecated_import} -> replace with ${retry_import} (same module, already in go.mod; no go get needed, just change the import)"
+                fi
+
+                symbols="$(grep -oE "(${identifiers})\\.(${retry_symbols})" <<<"$line_text")" || true
+                [[ -n "$symbols" ]] || continue
+                while IFS= read -r symbol; do
+                        [[ -n "$symbol" ]] || continue
+                        emit_violation "$file" "$lineno" \
+                                "deprecated symbol: ${symbol} -> retry.${symbol#*.}"
+                done <<<"$symbols"
+        done <<<"$added_lines"
+}
+
+changed_files="$(git diff --name-only --diff-filter=MA "$diff_base" "$diff_head")"
+if [[ -n "$changed_files" ]]; then
+        while IFS= read -r changed_file; do
+                [[ -n "$changed_file" ]] && check_file "$changed_file"
+        done <<<"$changed_files"
+fi
+
+if ((violations > 0)); then
+        echo "v2-retry-guard: ${violations} deprecated helper/resource usage(s) introduced."
+        echo "        release/v2 requires terraform-plugin-sdk/v2/helper/retry; apply the replacements above."
+        echo "        See the helper-retry migration design doc."
+        exit 1
+fi
+
+echo "v2-retry-guard: no new SDK v2 helper/resource retry usage found"

--- a/scripts/ci/v2-retry-guard_test.sh
+++ b/scripts/ci/v2-retry-guard_test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+# Fixture tests for scripts/ci/v2-retry-guard.sh. Each case builds a throwaway
+# git repository with a base commit and one or more head commits, then runs the
+# guard over the resulting range and asserts the exit code and output.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+guard="$script_dir/v2-retry-guard.sh"
+
+die() {
+        echo "FAIL: $*" >&2
+        exit 1
+}
+
+setup_repo() {
+        local repository="$1"
+        mkdir -p "$repository/alicloud"
+        git init -q -b master "$repository"
+        git -C "$repository" config core.hooksPath /dev/null
+        git -C "$repository" config user.name "V2 Retry Guard Test"
+        git -C "$repository" config user.email "v2-retry-guard-test@example.invalid"
+}
+
+commit_file() {
+        local repository="$1"
+        local path="$2"
+        local content="$3"
+        local subject="$4"
+        mkdir -p "$(dirname "$repository/$path")"
+        printf '%s\n' "$content" >"$repository/$path"
+        git -C "$repository" add "$path"
+        git -C "$repository" commit -q -m "$subject"
+}
+
+run_guard() {
+        # run_guard <repository> <base> <head> -> captures output, returns the
+        # guard exit code.
+        local repository="$1"
+        local base="$2"
+        local head="$3"
+        guard_output="$(cd "$repository" &&
+                DIFF_BASE="$base" DIFF_HEAD="$head" bash "$guard" 2>&1)" || return $?
+        return 0
+}
+
+run_guard_github_actions() {
+        # Same as run_guard but with GITHUB_ACTIONS=true so the guard emits
+        # workflow-command annotations instead of plain lines.
+        local repository="$1"
+        local base="$2"
+        local head="$3"
+        guard_output="$(cd "$repository" &&
+                DIFF_BASE="$base" DIFF_HEAD="$head" \
+                        env GITHUB_ACTIONS=true bash "$guard" 2>&1)" || return $?
+        return 0
+}
+
+assert_output_contains() {
+        local needle="$1"
+        [[ "$guard_output" == *"$needle"* ]] ||
+                die "expected output to contain '$needle', got:
+$guard_output"
+}
+
+test_new_retry_call_is_rejected() {
+        local repository="$1/new-retry-call"
+        setup_repo "$repository"
+        commit_file "$repository" alicloud/service_example.go \
+                $'package alicloud\n\nfunc example() {}' "base"
+        local base head
+        base="$(git -C "$repository" rev-parse HEAD)"
+        commit_file "$repository" alicloud/service_example.go \
+                $'package alicloud\n\nimport (\n\t"context"\n\t"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"\n)\n\nfunc example(ctx context.Context) {\n\tresource.Retry(60, func() *resource.RetryError {\n\t\treturn resource.RetryableError("try again")\n\t})\n}' "head"
+        head="$(git -C "$repository" rev-parse HEAD)"
+
+        if run_guard "$repository" "$base" "$head"; then
+                die "new resource.Retry call should be rejected
+$guard_output"
+        fi
+        assert_output_contains "service_example.go:5: deprecated import \"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource\" -> replace with \"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry\""
+        assert_output_contains "service_example.go:9: deprecated symbol: resource.Retry -> retry.Retry"
+        assert_output_contains "service_example.go:9: deprecated symbol: resource.RetryError -> retry.RetryError"
+        assert_output_contains "service_example.go:10: deprecated symbol: resource.RetryableError -> retry.RetryableError"
+}
+
+test_new_import_is_rejected() {
+        local repository="$1/new-import"
+        setup_repo "$repository"
+        commit_file "$repository" alicloud/service_import.go \
+                $'package alicloud\n\nfunc example() {}' "base"
+        local base head
+        base="$(git -C "$repository" rev-parse HEAD)"
+        # Import added but the (existing) retry calls are untouched: the
+        # import itself is the regression signal.
+        commit_file "$repository" alicloud/service_import.go \
+                $'package alicloud\n\nimport (\n\t_ "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"\n)\n\nfunc example() {}' "head"
+        head="$(git -C "$repository" rev-parse HEAD)"
+
+        if run_guard "$repository" "$base" "$head"; then
+                die "new helper/resource import should be rejected
+$guard_output"
+        fi
+        assert_output_contains "service_import.go:4: deprecated import \"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource\" -> replace with"
+        assert_output_contains "no go get needed"
+}
+
+test_helper_retry_is_accepted() {
+        local repository="$1/helper-retry"
+        setup_repo "$repository"
+        commit_file "$repository" alicloud/service_retry.go \
+                $'package alicloud\n\nfunc example() {}' "base"
+        local base head
+        base="$(git -C "$repository" rev-parse HEAD)"
+        commit_file "$repository" alicloud/service_retry.go \
+                $'package alicloud\n\nimport (\n\t"context"\n\t"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"\n)\n\nfunc example(ctx context.Context) {\n\tretry.Retry(ctx, 60, func() *retry.RetryError {\n\t\treturn retry.RetryableError("try again")\n\t})\n}' "head"
+        head="$(git -C "$repository" rev-parse HEAD)"
+
+        run_guard "$repository" "$base" "$head" ||
+                die "helper/retry usage should be accepted
+$guard_output"
+}
+
+test_untouched_legacy_usage_is_accepted() {
+        local repository="$1/legacy-untouched"
+        setup_repo "$repository"
+        commit_file "$repository" alicloud/service_legacy.go \
+                $'package alicloud\n\nimport (\n\t"context"\n\t"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"\n)\n\nfunc example(ctx context.Context) {\n\tresource.Retry(60, func() *resource.RetryError {\n\t\treturn resource.RetryableError("try again")\n\t})\n}\n\nfunc other() {}' "base"
+        local base head
+        base="$(git -C "$repository" rev-parse HEAD)"
+        # Edit the file without touching the retry lines: unmigrated files
+        # must stay editable until the Route 1 migration reaches them.
+        commit_file "$repository" alicloud/service_legacy.go \
+                $'package alicloud\n\nimport (\n\t"context"\n\t"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"\n)\n\nfunc example(ctx context.Context) {\n\tresource.Retry(60, func() *resource.RetryError {\n\t\treturn resource.RetryableError("try again")\n\t})\n}\n\nfunc other() {\n\t// updated\n}' "head"
+        head="$(git -C "$repository" rev-parse HEAD)"
+
+        run_guard "$repository" "$base" "$head" ||
+                die "untouched legacy usage should be accepted
+$guard_output"
+}
+
+test_aliased_import_is_rejected() {
+        local repository="$1/aliased-import"
+        setup_repo "$repository"
+        commit_file "$repository" alicloud/service_alias.go \
+                $'package alicloud\n\nfunc example() {}' "base"
+        local base head
+        base="$(git -C "$repository" rev-parse HEAD)"
+        commit_file "$repository" alicloud/service_alias.go \
+                $'package alicloud\n\nimport (\n\t"context"\n\tsdkresource "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"\n)\n\nfunc example(ctx context.Context) {\n\tsdkresource.Retry(60, func() *sdkresource.RetryError {\n\t\treturn sdkresource.RetryableError("try again")\n\t})\n}' "head"
+        head="$(git -C "$repository" rev-parse HEAD)"
+
+        if run_guard "$repository" "$base" "$head"; then
+                die "aliased helper/resource usage should be rejected
+$guard_output"
+        fi
+        assert_output_contains "service_alias.go:9: deprecated symbol: sdkresource.Retry -> retry.Retry"
+        assert_output_contains "service_alias.go:10: deprecated symbol: sdkresource.RetryableError -> retry.RetryableError"
+}
+
+test_github_actions_annotations() {
+        local repository="$1/annotations"
+        setup_repo "$repository"
+        commit_file "$repository" alicloud/service_annotations.go \
+                $'package alicloud\n\nfunc example() {}' "base"
+        local base head
+        base="$(git -C "$repository" rev-parse HEAD)"
+        commit_file "$repository" alicloud/service_annotations.go \
+                $'package alicloud\n\nimport (\n\t"context"\n\t"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"\n)\n\nfunc example(ctx context.Context) {\n\tresource.Retry(60, func() *resource.RetryError {\n\t\treturn resource.RetryableError("try again")\n\t})\n}' "head"
+        head="$(git -C "$repository" rev-parse HEAD)"
+
+        if run_guard_github_actions "$repository" "$base" "$head"; then
+                die "annotations run should be rejected
+$guard_output"
+        fi
+        assert_output_contains "::error file=alicloud/service_annotations.go,line=9,title=v2-retry-guard::deprecated symbol: resource.Retry -> retry.Retry"
+        # Workflow commands are consumed by the runner; the plain-text copy
+        # keeps the violation with its line number visible in the job log.
+        assert_output_contains "v2-retry-guard: alicloud/service_annotations.go:9: deprecated symbol: resource.Retry -> retry.Retry"
+        assert_output_contains "v2-retry-guard: 4 deprecated helper/resource usage(s) introduced."
+}
+
+test_test_files_are_exempt() {
+        local repository="$1/test-files"
+        setup_repo "$repository"
+        commit_file "$repository" alicloud/resource_alicloud_example_test.go \
+                $'package alicloud\n\nfunc TestExample() {}' "base"
+        local base head
+        base="$(git -C "$repository" rev-parse HEAD)"
+        commit_file "$repository" alicloud/resource_alicloud_example_test.go \
+                $'package alicloud\n\nimport (\n\t"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"\n)\n\nfunc TestExample() {\n\tresource.Retry(60, func() *resource.RetryError {\n\t\treturn resource.RetryableError("try again")\n\t})\n}' "head"
+        head="$(git -C "$repository" rev-parse HEAD)"
+
+        run_guard "$repository" "$base" "$head" ||
+                die "test files should stay exempt
+$guard_output"
+}
+
+main() {
+        temp_dir="$(mktemp -d)"
+        trap 'rm -rf "${temp_dir:-}"' EXIT
+
+        test_new_retry_call_is_rejected "$temp_dir"
+        test_new_import_is_rejected "$temp_dir"
+        test_aliased_import_is_rejected "$temp_dir"
+        test_github_actions_annotations "$temp_dir"
+        test_helper_retry_is_accepted "$temp_dir"
+        test_untouched_legacy_usage_is_accepted "$temp_dir"
+        test_test_files_are_exempt "$temp_dir"
+
+        echo "v2-retry-guard tests: all passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Why

`helper/resource` and `terraform-plugin-testing` each register a `-sweep` flag in `init()`, so a binary linking both dies at startup with `flag redefined: sweep`. The Route 1 migration moves the retry helpers of non-test files to `terraform-plugin-sdk/v2/helper/retry` so framework-hosted tests can coexist with package `alicloud`. This guard stops new usages from creeping back into `release/v2`.

## What

New `scripts/ci/v2-retry-guard.sh` inspects **only lines ADDED** by the change range, so files that have not been migrated yet stay editable. In non-test files it rejects:

- new imports of `terraform-plugin-sdk{,/v2}/helper/resource` (plain, blank, or aliased)
- new uses of `Retry`, `RetryableError`, `NonRetryableError`, `RetryError`, `StateRefreshFunc`, `StateChangeConf` through the imported identifier

Test files and `scripts/migration` stay exempt by design (they never link `terraform-plugin-testing`).

Wiring:

- `.github/workflows/acctest-terraform-basic.yml` — new `V2RetryGuard` job behind the existing policy route, active only for PRs targeting `release/v2`
- `scripts/basic-check.sh` + `document-check.yml` — guard also runs inside basic-check whenever the base ref is `release/v2`
- `.aoneci/document-check.yml` — `V2RetryGuard` job gated on the merge request target branch

## Verification

- `scripts/ci/v2-retry-guard_test.sh`: 6/6 fixture cases pass (new call / new import / aliased import rejected; `helper/retry` accepted; untouched legacy lines accepted; test files exempt)
- Smoke test over `HEAD~3..HEAD` locally correctly flags the `ecs_disk` commit's added `resource.Retry` block
- This PR itself should pass the guard (scripts/yml only)