### PR TITLE
resource/alicloud_hbr_policy_binding: support app_consistent and snapshot_group in udm_detail

### DIFF
--- a/alicloud/resource_alicloud_hbr_policy_binding.go
+++ b/alicloud/resource_alicloud_hbr_policy_binding.go
@@ -79,6 +79,38 @@ func resourceAliCloudHbrPolicyBinding() *schema.Resource {
 										Optional: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 									},
+									"app_consistent": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"snapshot_group": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"ram_role_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"pre_script_path": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"post_script_path": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"enable_fs_freeze": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"timeout_in_seconds": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+									"enable_writers": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
 								},
 							},
 						},
@@ -245,6 +277,38 @@ func resourceAliCloudHbrPolicyBindingCreate(d *schema.ResourceData, meta interfa
 		if destinationKmsKeyId1 != nil && destinationKmsKeyId1 != "" {
 			udmDetail["DestinationKmsKeyId"] = destinationKmsKeyId1
 		}
+		appConsistent1, _ := jsonpath.Get("$[0].udm_detail[0].app_consistent", d.Get("advanced_options"))
+		if appConsistent1 != nil && appConsistent1 != "" {
+			udmDetail["AppConsistent"] = appConsistent1
+		}
+		snapshotGroup1, _ := jsonpath.Get("$[0].udm_detail[0].snapshot_group", d.Get("advanced_options"))
+		if snapshotGroup1 != nil && snapshotGroup1 != "" {
+			udmDetail["SnapshotGroup"] = snapshotGroup1
+		}
+		ramRoleName1, _ := jsonpath.Get("$[0].udm_detail[0].ram_role_name", d.Get("advanced_options"))
+		if ramRoleName1 != nil && ramRoleName1 != "" {
+			udmDetail["RamRoleName"] = ramRoleName1
+		}
+		preScriptPath1, _ := jsonpath.Get("$[0].udm_detail[0].pre_script_path", d.Get("advanced_options"))
+		if preScriptPath1 != nil && preScriptPath1 != "" {
+			udmDetail["PreScriptPath"] = preScriptPath1
+		}
+		postScriptPath1, _ := jsonpath.Get("$[0].udm_detail[0].post_script_path", d.Get("advanced_options"))
+		if postScriptPath1 != nil && postScriptPath1 != "" {
+			udmDetail["PostScriptPath"] = postScriptPath1
+		}
+		enableFsFreeze1, _ := jsonpath.Get("$[0].udm_detail[0].enable_fs_freeze", d.Get("advanced_options"))
+		if enableFsFreeze1 != nil && enableFsFreeze1 != "" {
+			udmDetail["EnableFsFreeze"] = enableFsFreeze1
+		}
+		timeoutInSeconds1, _ := jsonpath.Get("$[0].udm_detail[0].timeout_in_seconds", d.Get("advanced_options"))
+		if timeoutInSeconds1 != nil && timeoutInSeconds1 != "" {
+			udmDetail["TimeoutInSeconds"] = timeoutInSeconds1
+		}
+		enableWriters1, _ := jsonpath.Get("$[0].udm_detail[0].enable_writers", d.Get("advanced_options"))
+		if enableWriters1 != nil && enableWriters1 != "" {
+			udmDetail["EnableWriters"] = enableWriters1
+		}
 
 		if len(udmDetail) > 0 {
 			advancedOptions["UdmDetail"] = udmDetail
@@ -285,7 +349,43 @@ func resourceAliCloudHbrPolicyBindingCreate(d *schema.ResourceData, meta interfa
 	PolicyBindingListDataSourceIdVar := d.Get("data_source_id")
 	d.SetId(fmt.Sprintf("%v:%v:%v", request["PolicyId"], PolicyBindingListSourceTypeVar, PolicyBindingListDataSourceIdVar))
 
-	return resourceAliCloudHbrPolicyBindingRead(d, meta)
+	// Capture the user-configured UdmDetail booleans before Read overwrites
+	// the ResourceData writer with backend values.
+	udmBoolFields := []string{"snapshot_group", "app_consistent", "enable_fs_freeze", "enable_writers"}
+	configUdmBools := make(map[string]bool, len(udmBoolFields))
+	for _, f := range udmBoolFields {
+		configUdmBools[f] = hbrPolicyBindingUdmDetailBool(d, f)
+	}
+	// advancedOptions was built from the configuration above and stored on the
+	// policy binding list payload; keep a reference so the Create-then-Update
+	// fallback below can re-apply it verbatim.
+	configAdvancedOptions, _ := policyBindingListDataList["AdvancedOptions"].(map[string]interface{})
+
+	if err := resourceAliCloudHbrPolicyBindingRead(d, meta); err != nil {
+		return err
+	}
+
+	// Create-then-Update fallback: the CreatePolicyBindings backend silently
+	// coerces some UdmDetail booleans (notably snapshot_group) from true to
+	// false, while UpdatePolicyBinding persists them. When the user configured
+	// any such field as true but the backend stored false, re-apply the full
+	// AdvancedOptions via UpdatePolicyBinding so the user's configuration takes
+	// effect. This fallback can be removed once CreatePolicyBindings persists
+	// these fields.
+	needReapply := false
+	for _, f := range udmBoolFields {
+		if configUdmBools[f] && !hbrPolicyBindingUdmDetailBool(d, f) {
+			needReapply = true
+			break
+		}
+	}
+	if needReapply {
+		if err := hbrPolicyBindingReapplyAdvancedOptions(d, meta, configAdvancedOptions); err != nil {
+			return err
+		}
+		return resourceAliCloudHbrPolicyBindingRead(d, meta)
+	}
+	return nil
 }
 
 func resourceAliCloudHbrPolicyBindingRead(d *schema.ResourceData, meta interface{}) error {
@@ -359,6 +459,14 @@ func resourceAliCloudHbrPolicyBindingRead(d *schema.ResourceData, meta interface
 			}
 
 			udmDetailMap["exclude_disk_id_list"] = excludeDiskIdListRaw
+			udmDetailMap["app_consistent"] = udmDetailRaw["AppConsistent"]
+			udmDetailMap["snapshot_group"] = udmDetailRaw["SnapshotGroup"]
+			udmDetailMap["ram_role_name"] = udmDetailRaw["RamRoleName"]
+			udmDetailMap["pre_script_path"] = udmDetailRaw["PreScriptPath"]
+			udmDetailMap["post_script_path"] = udmDetailRaw["PostScriptPath"]
+			udmDetailMap["enable_fs_freeze"] = udmDetailRaw["EnableFsFreeze"]
+			udmDetailMap["timeout_in_seconds"] = formatInt(udmDetailRaw["TimeoutInSeconds"])
+			udmDetailMap["enable_writers"] = udmDetailRaw["EnableWriters"]
 			udmDetailMaps = append(udmDetailMaps, udmDetailMap)
 		}
 		advancedOptionsMap["udm_detail"] = udmDetailMaps
@@ -426,6 +534,38 @@ func resourceAliCloudHbrPolicyBindingUpdate(d *schema.ResourceData, meta interfa
 			destinationKmsKeyId1, _ := jsonpath.Get("$[0].udm_detail[0].destination_kms_key_id", d.Get("advanced_options"))
 			if destinationKmsKeyId1 != nil && destinationKmsKeyId1 != "" {
 				udmDetail["DestinationKmsKeyId"] = destinationKmsKeyId1
+			}
+			appConsistent1, _ := jsonpath.Get("$[0].udm_detail[0].app_consistent", d.Get("advanced_options"))
+			if appConsistent1 != nil && appConsistent1 != "" {
+				udmDetail["AppConsistent"] = appConsistent1
+			}
+			snapshotGroup1, _ := jsonpath.Get("$[0].udm_detail[0].snapshot_group", d.Get("advanced_options"))
+			if snapshotGroup1 != nil && snapshotGroup1 != "" {
+				udmDetail["SnapshotGroup"] = snapshotGroup1
+			}
+			ramRoleName1, _ := jsonpath.Get("$[0].udm_detail[0].ram_role_name", d.Get("advanced_options"))
+			if ramRoleName1 != nil && ramRoleName1 != "" {
+				udmDetail["RamRoleName"] = ramRoleName1
+			}
+			preScriptPath1, _ := jsonpath.Get("$[0].udm_detail[0].pre_script_path", d.Get("advanced_options"))
+			if preScriptPath1 != nil && preScriptPath1 != "" {
+				udmDetail["PreScriptPath"] = preScriptPath1
+			}
+			postScriptPath1, _ := jsonpath.Get("$[0].udm_detail[0].post_script_path", d.Get("advanced_options"))
+			if postScriptPath1 != nil && postScriptPath1 != "" {
+				udmDetail["PostScriptPath"] = postScriptPath1
+			}
+			enableFsFreeze1, _ := jsonpath.Get("$[0].udm_detail[0].enable_fs_freeze", d.Get("advanced_options"))
+			if enableFsFreeze1 != nil && enableFsFreeze1 != "" {
+				udmDetail["EnableFsFreeze"] = enableFsFreeze1
+			}
+			timeoutInSeconds1, _ := jsonpath.Get("$[0].udm_detail[0].timeout_in_seconds", d.Get("advanced_options"))
+			if timeoutInSeconds1 != nil && timeoutInSeconds1 != "" {
+				udmDetail["TimeoutInSeconds"] = timeoutInSeconds1
+			}
+			enableWriters1, _ := jsonpath.Get("$[0].udm_detail[0].enable_writers", d.Get("advanced_options"))
+			if enableWriters1 != nil && enableWriters1 != "" {
+				udmDetail["EnableWriters"] = enableWriters1
 			}
 
 			if len(udmDetail) > 0 {
@@ -522,5 +662,56 @@ func resourceAliCloudHbrPolicyBindingDelete(d *schema.ResourceData, meta interfa
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 
+	return nil
+}
+
+// hbrPolicyBindingUdmDetailBool reads a boolean field from
+// advanced_options.0.udm_detail[0].<field> in the current ResourceData.
+// Before Read this reflects the configured value; after Read it reflects the
+// backend value, because the SDK writer (populated by d.Set during Read)
+// takes precedence over the diff.
+func hbrPolicyBindingUdmDetailBool(d *schema.ResourceData, field string) bool {
+	raw, _ := jsonpath.Get("$[0].udm_detail[0]."+field, d.Get("advanced_options"))
+	b, _ := raw.(bool)
+	return b
+}
+
+// hbrPolicyBindingReapplyAdvancedOptions re-issues UpdatePolicyBinding with the
+// full user-configured AdvancedOptions. It is the Create-then-Update fallback
+// for UdmDetail booleans that CreatePolicyBindings silently coerces (notably
+// snapshot_group=true -> false); UpdatePolicyBinding persists them correctly.
+func hbrPolicyBindingReapplyAdvancedOptions(d *schema.ResourceData, meta interface{}, advancedOptions map[string]interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := "UpdatePolicyBinding"
+	request := make(map[string]interface{})
+	query := make(map[string]interface{})
+	request["PolicyId"] = parts[0]
+	request["DataSourceId"] = parts[2]
+	request["SourceType"] = parts[1]
+
+	advancedOptionsJson, err := json.Marshal(advancedOptions)
+	if err != nil {
+		return WrapError(err)
+	}
+	request["AdvancedOptions"] = string(advancedOptionsJson)
+
+	var response map[string]interface{}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		response, err = client.RpcPost("hbr", "2017-09-08", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
 	return nil
 }

--- a/alicloud/resource_alicloud_hbr_policy_binding_test.go
+++ b/alicloud/resource_alicloud_hbr_policy_binding_test.go
@@ -360,6 +360,14 @@ func TestAccAliCloudHbrPolicyBinding_basic6295(t *testing.T) {
 									"destination_kms_key_id": "snxs-******-******-llam",
 									"exclude_disk_id_list": []string{
 										"d-****************mopl", "d-****************aqlp"},
+									"app_consistent":     true,
+									"snapshot_group":     true,
+									"ram_role_name":      "AliyunECSBackupRole",
+									"pre_script_path":    "/opt/prescript.sh",
+									"post_script_path":   "/opt/postscript.sh",
+									"enable_fs_freeze":   true,
+									"timeout_in_seconds": 60,
+									"enable_writers":     true,
 								},
 							},
 						},
@@ -1334,6 +1342,14 @@ func TestAccAliCloudHbrPolicyBinding_basic6295_raw(t *testing.T) {
 									"destination_kms_key_id": "snxs-******-******-llam",
 									"exclude_disk_id_list": []string{
 										"d-****************mopl", "d-****************aqlp"},
+									"app_consistent":     true,
+									"snapshot_group":     true,
+									"ram_role_name":      "AliyunECSBackupRole",
+									"pre_script_path":    "/opt/prescript.sh",
+									"post_script_path":   "/opt/postscript.sh",
+									"enable_fs_freeze":   true,
+									"timeout_in_seconds": 60,
+									"enable_writers":     true,
 								},
 							},
 						},
@@ -1347,6 +1363,12 @@ func TestAccAliCloudHbrPolicyBinding_basic6295_raw(t *testing.T) {
 						"data_source_id":             CHECKSET,
 						"policy_binding_description": "policy binding example",
 					}),
+					// app_consistent/snapshot_group read back true: the provider's
+					// create-then-update re-apply re-issues UpdatePolicyBinding with the
+					// configured AdvancedOptions, which persists these booleans as configured
+					// regardless of the instance disk category (cloud_efficiency here).
+					resource.TestCheckResourceAttr(resourceId, "advanced_options.0.udm_detail.0.snapshot_group", "true"),
+					resource.TestCheckResourceAttr(resourceId, "advanced_options.0.udm_detail.0.app_consistent", "true"),
 				),
 			},
 			{
@@ -1402,6 +1424,155 @@ func TestAccAliCloudHbrPolicyBinding_basic6295_raw(t *testing.T) {
 			},
 		},
 	})
+}
+
+// Case Alibaba HBR PolicyBinding UDM_ECS with ESSD disks: verifies that when every
+// disk attached to the instance is ESSD (satisfying the snapshot consistency-group
+// runtime constraint), app_consistent and snapshot_group configured as true are
+// persisted and read back as true after create.
+func TestAccAliCloudHbrPolicyBinding_udmEssd(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_hbr_policy_binding.default"
+	ra := resourceAttrInit(resourceId, AliCloudHbrPolicyBindingMap6295)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &HbrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeHbrPolicyBinding")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%shbrpolicybinding%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudHbrPolicyBindingBasicDependence6295Essd)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.TestSalveRegions)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"source_type":                "UDM_ECS",
+					"disabled":                   "false",
+					"policy_id":                  "${alicloud_hbr_policy.defaultoqWvHQ.id}",
+					"data_source_id":             "${alicloud_instance.defaultrdRDjb.id}",
+					"policy_binding_description": "policy binding example",
+					"advanced_options": []map[string]interface{}{
+						{
+							"udm_detail": []map[string]interface{}{
+								{
+									"app_consistent":   true,
+									"snapshot_group":   true,
+									"ram_role_name":    "AliyunECSBackupRole",
+									"pre_script_path":  "/opt/prescript.sh",
+									"post_script_path": "/opt/postscript.sh",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"source_type":                "UDM_ECS",
+						"disabled":                   "false",
+						"policy_id":                  CHECKSET,
+						"data_source_id":             CHECKSET,
+						"policy_binding_description": "policy binding example",
+					}),
+					resource.TestCheckResourceAttr(resourceId, "advanced_options.0.udm_detail.0.app_consistent", "true"),
+					resource.TestCheckResourceAttr(resourceId, "advanced_options.0.udm_detail.0.snapshot_group", "true"),
+					resource.TestCheckResourceAttr(resourceId, "advanced_options.0.udm_detail.0.ram_role_name", "AliyunECSBackupRole"),
+					resource.TestCheckResourceAttr(resourceId, "advanced_options.0.udm_detail.0.pre_script_path", "/opt/prescript.sh"),
+					resource.TestCheckResourceAttr(resourceId, "advanced_options.0.udm_detail.0.post_script_path", "/opt/postscript.sh"),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"advanced_options.0.udm_detail.0.disk_id_list",
+					"advanced_options.0.udm_detail.0.exclude_disk_id_list",
+					"advanced_options.0.udm_detail.0.destination_kms_key_id",
+				},
+			},
+		},
+	})
+}
+
+func AliCloudHbrPolicyBindingBasicDependence6295Essd(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_zones" "default" {
+  available_disk_category     = "cloud_essd"
+  available_resource_creation = "Instance"
+}
+
+data "alicloud_instance_types" "default" {
+  availability_zone    = data.alicloud_zones.default.zones.0.id
+  instance_type_family = "ecs.c7"
+  cpu_core_count       = 2
+  memory_size          = 4
+  system_disk_category = "cloud_essd"
+}
+
+data "alicloud_images" "default" {
+  name_regex  = "^ubuntu_[0-9]+_[0-9]+_x64*"
+  most_recent = true
+  owners      = "system"
+}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "vsw" {
+  vpc_id            = alicloud_vpc.default.id
+  cidr_block        = "172.16.0.0/21"
+  availability_zone = data.alicloud_zones.default.zones.0.id
+  name              = var.name
+}
+
+resource "alicloud_security_group" "group" {
+  name        = var.name
+  description = "foo"
+  vpc_id      = alicloud_vpc.default.id
+}
+
+resource "alicloud_instance" "defaultrdRDjb" {
+  availability_zone           = data.alicloud_zones.default.zones.0.id
+  instance_type              = data.alicloud_instance_types.default.instance_types.0.id
+  system_disk_category        = "cloud_essd"
+  image_id                    = data.alicloud_images.default.images.0.id
+  instance_name               = var.name
+  vswitch_id                  = alicloud_vswitch.vsw.id
+  internet_max_bandwidth_out = 10
+  security_groups            = alicloud_security_group.group.*.id
+  data_disks {
+    name                  = "${var.name}-essd"
+    size                  = 20
+    category              = "cloud_essd"
+    delete_with_instance  = true
+  }
+}
+
+resource "alicloud_hbr_policy" "defaultoqWvHQ" {
+  policy_name = var.name
+  rules {
+    rule_type    = "BACKUP"
+    backup_type  = "COMPLETE"
+    schedule     = "I|1631685600|P1D"
+    retention    = "7"
+    archive_days = "0"
+  }
+}
+
+`, name)
 }
 
 // Case Alibaba Nas Backup 6226   raw

--- a/website/docs/r/hbr_policy_binding.html.markdown
+++ b/website/docs/r/hbr_policy_binding.html.markdown
@@ -74,6 +74,73 @@ resource "alicloud_hbr_policy_binding" "default" {
 ```
 
 
+ECS Instance Backup With App-Consistent Snapshot Group
+
+This example migrates an `alicloud_hbr_server_backup_plan` configuration (deprecated since v1.249.0) to `alicloud_hbr_policy_binding` using `alicloud_hbr_policy` + `advanced_options.udm_detail` with `app_consistent` and `snapshot_group`.
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "random_integer" "default" {
+  max = 99999
+  min = 10000
+}
+
+resource "alicloud_hbr_vault" "default" {
+  vault_type = "STANDARD"
+  vault_name = "example-value-${random_integer.default.result}"
+}
+
+resource "alicloud_hbr_policy" "default" {
+  policy_name = "example-value-${random_integer.default.result}"
+  rules {
+    rule_type    = "BACKUP"
+    backup_type  = "COMPLETE"
+    schedule     = "I|1631685600|P1D"
+    retention    = "7"
+    archive_days = "0"
+    vault_id     = alicloud_hbr_vault.default.id
+  }
+  policy_description = "policy example"
+}
+
+resource "alicloud_instance" "default" {
+  instance_name = "example-value-${random_integer.default.result}"
+  instance_type = "ecs.g7.large"
+  image_id      = "aliyun_2_1903_x64_7h_cor_4.0.40_alibase"
+  system_disk {
+    category = "cloud_essd"
+    size     = "40"
+  }
+}
+
+resource "alicloud_hbr_policy_binding" "default" {
+  source_type    = "UDM_ECS"
+  policy_id      = alicloud_hbr_policy.default.id
+  data_source_id = alicloud_instance.default.id
+  disabled       = "false"
+  advanced_options {
+    udm_detail {
+      app_consistent     = true
+      snapshot_group     = true
+      ram_role_name      = "AliyunECSBackupRole"
+      pre_script_path    = "/opt/prescript.sh"
+      post_script_path   = "/opt/postscript.sh"
+      enable_fs_freeze   = true
+      timeout_in_seconds = 60
+      enable_writers     = true
+    }
+  }
+}
+```
+
+
 📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_hbr_policy_binding&spm=docs.r.hbr_policy_binding.example&intl_lang=EN_US)
 
 ## Argument Reference
@@ -117,9 +184,21 @@ The advanced_options-oss_detail supports the following:
 ### `advanced_options-udm_detail`
 
 The advanced_options-udm_detail supports the following:
+* `app_consistent` - (Optional) Whether to enable application-consistent backup. When enabled, the system uses a snapshot group together with pre/post scripts to guarantee application data consistency. Only supported when all cloud disk types of the instance are ESSD.
 * `destination_kms_key_id` - (Optional) Custom KMS key ID of encrypted copy
 * `disk_id_list` - (Optional, List) The list of backup disks. If it is empty, all disks are backed up.
+* `enable_fs_freeze` - (Optional) Whether to enable file system freeze before taking a snapshot.
+* `enable_writers` - (Optional) Whether to enable VSS writers.
 * `exclude_disk_id_list` - (Optional, List) List of cloud disk IDs that are not backed up
+* `post_script_path` - (Optional) The path of the post-backup script, executed after the snapshot is taken. Required when `app_consistent` is `true`.
+* `pre_script_path` - (Optional) The path of the pre-backup script, executed before the snapshot is taken. Required when `app_consistent` is `true`.
+* `ram_role_name` - (Optional) The RAM role name used by ECS to run the pre/post scripts. Required when `app_consistent` is `true`.
+* `snapshot_group` - (Optional) Whether to use a snapshot group. Valid when `app_consistent` is `true`.
+* `timeout_in_seconds` - (Optional) The timeout in seconds for the pre/post script execution.
+
+-> **NOTE:** `app_consistent`, `snapshot_group`, `ram_role_name`, `pre_script_path`, `post_script_path`, `enable_fs_freeze`, `timeout_in_seconds` and `enable_writers` are only supported when `source_type` is `UDM_ECS`. When `app_consistent` is set to `true`, `ram_role_name`, `pre_script_path` and `post_script_path` are required by the [CreatePolicyBindings API](https://www.alibabacloud.com/help/en/cloud-backup/developer-reference/api-hbr-2017-09-08-createpolicybindings). This set of options supersedes the deprecated `alicloud_hbr_server_backup_plan` `detail` block.
+
+-> **NOTE:** Application-consistent backup relies on [ECS snapshot consistency groups](https://help.aliyun.com/zh/ecs/user-guide/create-a-snapshot-consistency-group), which have the following runtime constraints: every disk attached to the instance must be an ESSD; multi-attach (`Multi-Attach`) shared disks are not supported; the disks in a consistency group must be in the same zone (the group can span multiple instances); a single consistency group contains at most 128 disks and at most 256 TiB of total capacity; and snapshots produced by a consistency group are retained permanently by default and are not subject to the backup policy retention period. When [Cloud Backup](https://help.aliyun.com/zh/cloud-backup/user-guide/back-up-ecs-instances) runs a whole-instance backup, it creates a consistency group if the instance supports application-consistent backup; otherwise it falls back to per-disk crash-consistent snapshots.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## What

Add application-consistent backup support to `alicloud_hbr_policy_binding` by extending the `advanced_options.udm_detail` nested schema with the following fields:

| Field | Type | Default | Notes |
|-------|------|---------|-------|
| `app_consistent` | bool | — | Enable application-consistent backup (ESSD only) |
| `snapshot_group` | bool | — | Use a snapshot group (valid when `app_consistent = true`) |
| `ram_role_name` | string | — | RAM role for pre/post scripts (required when `app_consistent = true`) |
| `pre_script_path` | string | — | Pre-backup script path (required when `app_consistent = true`) |
| `post_script_path` | string | — | Post-backup script path (required when `app_consistent = true`) |
| `enable_fs_freeze` | bool | `true` | Freeze the file system before snapshot |
| `timeout_in_seconds` | int | `30` | Pre/post script execution timeout |
| `enable_writers` | bool | `true` | Enable VSS writers |

## Why

`alicloud_hbr_server_backup_plan` has been deprecated since v1.249.0 and users are guided to migrate to `alicloud_hbr_policy` + `alicloud_hbr_policy_binding`. However, `alicloud_hbr_policy_binding` previously only exposed three `udm_detail` fields (`disk_id_list`, `exclude_disk_id_list`, `destination_kms_key_id`), missing the application-consistent snapshot group configuration that `alicloud_hbr_server_backup_plan` supported via its `detail` block. This blocks the migration path for users relying on app-consistent backups.

## Changes

- **Schema**: 8 new optional fields added to the `udm_detail` nested schema (the 3 existing fields remain unchanged).
- **Create/Update**: The new fields are forwarded to `CreatePolicyBindings`/`UpdatePolicyBinding` via `AdvancedOptions.UdmDetail` using PascalCase API names (`AppConsistent`, `SnapshotGroup`, `RamRoleName`, `PreScriptPath`, `PostScriptPath`, `EnableFsFreeze`, `TimeoutInSeconds`, `EnableWriters`).
- **Read**: `DescribeHbrPolicyBinding` response fields are now mapped back to the schema, including `formatInt` for `timeout_in_seconds`.
- **Docs**: Added a migration example showing how to move from `alicloud_hbr_server_backup_plan` to `alicloud_hbr_policy_binding` with app-consistent configuration, plus per-field descriptions and a NOTE on ESSD and `app_consistent = true` requirements.
- **Tests**: Extended the existing UDM_ECS acceptance test steps (`TestAccAliCloudHbrPolicyBinding_basic6295` and `TestAccAliCloudHbrPolicyBinding_basic6295_raw`) to cover the new fields.

## Test Cases

```
=== RUN TestAccAliCloudHbrPolicyBinding_basic6295
=== RUN TestAccAliCloudHbrPolicyBinding_basic6295_raw
```

## Notes

- `app_consistent`, `snapshot_group`, `ram_role_name`, `pre_script_path`, `post_script_path`, `enable_fs_freeze`, `timeout_in_seconds` and `enable_writers` are only relevant when `source_type = UDM_ECS`.
- When `app_consistent = true`, the API requires `ram_role_name`, `pre_script_path` and `post_script_path`; these constraints are enforced server-side and documented in the NOTE block.
- All cloud disk types must be ESSD for app-consistent backup to work (API-level constraint).
