### PR TITLE
resource/alicloud_alikafka_topic: fallback region_id when API omits it

### DIFF
--- a/alicloud/resource_alicloud_alikafka_topic.go
+++ b/alicloud/resource_alicloud_alikafka_topic.go
@@ -166,7 +166,13 @@ func resourceAliCloudAlikafkaTopicRead(d *schema.ResourceData, meta interface{})
 	d.Set("create_time", objectRaw["CreateTime"])
 	d.Set("local_topic", objectRaw["LocalTopic"])
 	d.Set("partition_num", objectRaw["PartitionNum"])
-	d.Set("region_id", objectRaw["RegionId"])
+	// Fallback to client.RegionId when the topic response omits RegionId (e.g. serverless topics),
+	// so that the computed region_id stays consistent with the documented readable attribute.
+	if objectRaw["RegionId"] == nil || objectRaw["RegionId"] == "" {
+		d.Set("region_id", client.RegionId)
+	} else {
+		d.Set("region_id", objectRaw["RegionId"])
+	}
 	d.Set("remark", objectRaw["Remark"])
 	d.Set("status", objectRaw["Status"])
 	d.Set("instance_id", objectRaw["InstanceId"])


### PR DESCRIPTION
## Summary

The `alicloud_alikafka_topic` resource computed `region_id` directly from the GetTopicList response. For serverless topics the response may omit `RegionId`, leaving `region_id` empty and breaking the documented readable attribute (`region_id` - The ID of the region where the instance resides).

This change falls back to `client.RegionId` when the API response omits or empties `RegionId`, so the computed `region_id` stays populated.

## Testing

Remote acceptance tests for `alicloud_alikafka_topic` continue to pass with this change. Coverage of the serverless path is tracked separately because it requires a serverless alikafka instance.