### PR TITLE
resource/alicloud_nlb_server_group: replace TCPSSL with TCP_UDP for the protocol argument

### DIFF
--- a/alicloud/resource_alicloud_nlb_server_group.go
+++ b/alicloud/resource_alicloud_nlb_server_group.go
@@ -148,7 +148,7 @@ func resourceAliCloudNlbServerGroup() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
-				ValidateFunc: StringInSlice([]string{"TCP", "UDP", "TCPSSL"}, false),
+				ValidateFunc: StringInSlice([]string{"TCP", "UDP", "TCP_UDP"}, false),
 			},
 			"region_id": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_nlb_server_group_test.go
+++ b/alicloud/resource_alicloud_nlb_server_group_test.go
@@ -1971,7 +1971,7 @@ func TestAccAliCloudNlbServerGroup_basic4662(t *testing.T) {
 					"preserve_client_ip_enabled": "true",
 					"connection_drain_enabled":   "true",
 					"any_port_enabled":           "true",
-					"protocol":                   "TCPSSL",
+					"protocol":                   "TCP_UDP",
 					"server_group_type":          "Instance",
 					"server_group_name":          name + "_update",
 					"vpc_id":                     "${alicloud_vpc.defaultEyoN1M.id}",
@@ -2001,7 +2001,7 @@ func TestAccAliCloudNlbServerGroup_basic4662(t *testing.T) {
 						"preserve_client_ip_enabled": "true",
 						"connection_drain_enabled":   "true",
 						"any_port_enabled":           "true",
-						"protocol":                   "TCPSSL",
+						"protocol":                   "TCP_UDP",
 						"server_group_type":          "Instance",
 						"server_group_name":          name + "_update",
 						"vpc_id":                     CHECKSET,
@@ -2530,7 +2530,7 @@ func TestAccAliCloudNlbServerGroup_basic4662_twin(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"any_port_enabled":  "false",
-					"protocol":          "TCPSSL",
+					"protocol":          "TCP_UDP",
 					"server_group_type": "Instance",
 					"server_group_name": name,
 					"vpc_id":            "${alicloud_vpc.defaultEyoN1M.id}",
@@ -2564,7 +2564,7 @@ func TestAccAliCloudNlbServerGroup_basic4662_twin(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"any_port_enabled":         "false",
-						"protocol":                 "TCPSSL",
+						"protocol":                 "TCP_UDP",
 						"server_group_type":        "Instance",
 						"server_group_name":        name,
 						"vpc_id":                   CHECKSET,

--- a/website/docs/r/nlb_server_group.html.markdown
+++ b/website/docs/r/nlb_server_group.html.markdown
@@ -90,7 +90,7 @@ The following arguments are supported:
 
   - `TCP` (default)
   - `UDP`
-  - `TCPSSL`
+  - `TCP_UDP`
 * `resource_group_id` - (Optional, Computed) The ID of the new resource group.
 You can log on to the [Resource Management console](https://resourcemanager.console.aliyun.com/resource-groups) to view resource group IDs.
 * `scheduler` - (Optional, Computed) The scheduling algorithm. Valid values:


### PR DESCRIPTION
### What this PR does

The `protocol` argument of `alicloud_nlb_server_group` previously accepted `TCPSSL`, which is a listener-level protocol and is not a valid value for an NLB server group. This replaces `TCPSSL` with `TCP_UDP`, a valid server group protocol supported by the NLB `CreateServerGroup` API.

### Changes

- `alicloud/resource_alicloud_nlb_server_group.go`: update the `protocol` `ValidateFunc` from `["TCP", "UDP", "TCPSSL"]` to `["TCP", "UDP", "TCP_UDP"]`. The Create/Read pass-through is unchanged because the API already accepts `TCP_UDP`.
- `alicloud/resource_alicloud_nlb_server_group_test.go`: update the acceptance cases that used `TCPSSL` to use `TCP_UDP` (create / refresh / import coverage preserved).
- `website/docs/r/nlb_server_group.html.markdown`: update the documented valid values for `protocol`.

### Tests

- Local: `go vet -p=1 ./alicloud` passes for the changed package.
- Remote acceptance tests for `TestAccAliCloudNlbServerGroup_basic4662` and `_twin` are being submitted and will be reported here once they finish.
