### PR TITLE
resource/alicloud_polardb_global_database_network: support resource_group_id; data-source/alicloud_polardb_global_database_networks: support resource_group_id

### DIFF
--- a/alicloud/data_source_alicloud_polardb_global_database_networks.go
+++ b/alicloud/data_source_alicloud_polardb_global_database_networks.go
@@ -68,6 +68,10 @@ func dataSourceAlicloudPolarDBGlobalDatabaseNetworks() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"resource_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"db_type": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -183,13 +187,14 @@ func dataSourceAlicloudPolarDBGlobalDatabaseNetworksRead(d *schema.ResourceData,
 	s := make([]map[string]interface{}, 0)
 	for _, object := range objects {
 		mapping := map[string]interface{}{
-			"id":          fmt.Sprint(object["GDNId"]),
-			"gdn_id":      fmt.Sprint(object["GDNId"]),
-			"description": object["GDNDescription"],
-			"db_type":     object["DBType"],
-			"db_version":  object["DBVersion"],
-			"create_time": object["CreateTime"],
-			"status":      object["GDNStatus"],
+			"id":                fmt.Sprint(object["GDNId"]),
+			"gdn_id":            fmt.Sprint(object["GDNId"]),
+			"description":       object["GDNDescription"],
+			"resource_group_id": object["ResourceGroupId"],
+			"db_type":           object["DBType"],
+			"db_version":        object["DBVersion"],
+			"create_time":       object["CreateTime"],
+			"status":            object["GDNStatus"],
 		}
 		if v, ok := object["DBClusters"]; ok {
 			dbClustersMaps := make([]map[string]interface{}, 0)

--- a/alicloud/data_source_alicloud_polardb_global_database_networks_test.go
+++ b/alicloud/data_source_alicloud_polardb_global_database_networks_test.go
@@ -75,6 +75,7 @@ func TestAccAlicloudPolarDBGlobalDatabaseNetworkDataSource(t *testing.T) {
 			"networks.0.id":                          CHECKSET,
 			"networks.0.gdn_id":                      CHECKSET,
 			"networks.0.description":                 CHECKSET,
+			"networks.0.resource_group_id":           CHECKSET,
 			"networks.0.db_type":                     CHECKSET,
 			"networks.0.db_version":                  CHECKSET,
 			"networks.0.create_time":                 CHECKSET,
@@ -108,14 +109,16 @@ func testAccCheckAlicloudPolarDBGlobalDatabaseNetworkDataSourceName(rand int, at
 	variable "name" {
 		default = "tf-testAcc-%d"
 	}
+	data "alicloud_resource_manager_resource_groups" "default" {}
+
 	data "alicloud_vpcs" "default" {
 		name_regex = "^default-NODELETING$"
 	}
-	
+
 	data "alicloud_vswitches" "default" {
 		vpc_id = data.alicloud_vpcs.default.ids.0
 	}
-	
+
 	data "alicloud_polardb_node_classes" "default" {
 		zone_id    = data.alicloud_vswitches.default.vswitches.0.zone_id
 		pay_type   = "PostPaid"
@@ -132,8 +135,9 @@ func testAccCheckAlicloudPolarDBGlobalDatabaseNetworkDataSourceName(rand int, at
 		description   = "${var.name}"
 	}
 	resource "alicloud_polardb_global_database_network" "default" {
-		db_cluster_id = "${alicloud_polardb_cluster.default.id}"
-		description   = var.name
+		db_cluster_id     = "${alicloud_polardb_cluster.default.id}"
+		description       = var.name
+		resource_group_id = data.alicloud_resource_manager_resource_groups.default.ids.0
 	}
 	data "alicloud_polardb_global_database_networks" "default" {
 		%s

--- a/alicloud/resource_alicloud_polardb_global_database_network.go
+++ b/alicloud/resource_alicloud_polardb_global_database_network.go
@@ -34,6 +34,11 @@ func resourceAlicloudPolarDBGlobalDatabaseNetwork() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -54,6 +59,10 @@ func resourceAlicloudPolarDBGlobalDatabaseNetworkCreate(d *schema.ResourceData, 
 
 	if v, ok := d.GetOk("description"); ok {
 		request["GDNDescription"] = v
+	}
+
+	if v, ok := d.GetOk("resource_group_id"); ok && v.(string) != "" {
+		request["ResourceGroupId"] = v.(string)
 	}
 
 	wait := incrementalWait(3*time.Second, 3*time.Second)
@@ -96,6 +105,7 @@ func resourceAlicloudPolarDBGlobalDatabaseNetworkRead(d *schema.ResourceData, me
 	dBClusterId := object["DBClusters"].([]interface{})[0].(map[string]interface{})["DBClusterId"]
 	d.Set("db_cluster_id", dBClusterId)
 	d.Set("description", object["GDNDescription"])
+	d.Set("resource_group_id", object["ResourceGroupId"])
 	d.Set("status", object["GDNStatus"])
 
 	return nil
@@ -115,6 +125,13 @@ func resourceAlicloudPolarDBGlobalDatabaseNetworkUpdate(d *schema.ResourceData, 
 	}
 	if v, ok := d.GetOk("description"); ok {
 		request["GDNDescription"] = v
+	}
+
+	if d.HasChange("resource_group_id") {
+		update = true
+		if v, ok := d.GetOk("resource_group_id"); ok && v.(string) != "" {
+			request["ResourceGroupId"] = v.(string)
+		}
 	}
 
 	if update {

--- a/alicloud/resource_alicloud_polardb_global_database_network_test.go
+++ b/alicloud/resource_alicloud_polardb_global_database_network_test.go
@@ -137,21 +137,25 @@ func TestAccAliCloudPolarDBGlobalDatabaseNetwork_basic00(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"db_cluster_id": "${alicloud_polardb_cluster.default.id}",
+					"db_cluster_id":     "${alicloud_polardb_cluster.default.id}",
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"db_cluster_id": CHECKSET,
+						"db_cluster_id":     CHECKSET,
+						"resource_group_id": CHECKSET,
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"description": "tf-testAcc",
+					"description":       "tf-testAcc",
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"description": "tf-testAcc",
+						"description":       "tf-testAcc",
+						"resource_group_id": CHECKSET,
 					}),
 				),
 			},
@@ -161,7 +165,8 @@ func TestAccAliCloudPolarDBGlobalDatabaseNetwork_basic00(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"description": "update-tf-testAcc",
+						"description":       "update-tf-testAcc",
+						"resource_group_id": CHECKSET,
 					}),
 				),
 			},
@@ -175,7 +180,8 @@ func TestAccAliCloudPolarDBGlobalDatabaseNetwork_basic00(t *testing.T) {
 }
 
 var resourceAlicloudPolarDBGlobalDatabaseNetworkMap = map[string]string{
-	"status": CHECKSET,
+	"status":            CHECKSET,
+	"resource_group_id": CHECKSET,
 }
 
 func resourceAlicloudPolarDBGlobalDatabaseNetworkBasicDependence(name string) string {
@@ -183,6 +189,8 @@ func resourceAlicloudPolarDBGlobalDatabaseNetworkBasicDependence(name string) st
 variable "name" {
 	default = "%s"
 }
+
+data "alicloud_resource_manager_resource_groups" "default" {}
 
 data "alicloud_vpcs" "default" {
 	name_regex = "^default-NODELETING$"
@@ -224,8 +232,9 @@ func TestUnitAlicloudPolarDBGlobalDatabaseNetwork(t *testing.T) {
 	dExisted, _ := schema.InternalMap(p["alicloud_polardb_global_database_network"].Schema).Data(nil, nil)
 	dInit.MarkNewResource()
 	attributes := map[string]interface{}{
-		"db_cluster_id": "CreatePolarDBGDNValue",
-		"description":   "CreatePolarDBGDNValue",
+		"db_cluster_id":     "CreatePolarDBGDNValue",
+		"description":       "CreatePolarDBGDNValue",
+		"resource_group_id": "CreatePolarDBGDNValue",
 	}
 	for key, value := range attributes {
 		err := dInit.Set(key, value)
@@ -246,8 +255,9 @@ func TestUnitAlicloudPolarDBGlobalDatabaseNetwork(t *testing.T) {
 	rawClient = rawClient.(*connectivity.AliyunClient)
 	ReadMockResponse := map[string]interface{}{
 		// DescribeGlobalDatabaseNetwork
-		"GDNStatus":      "active",
-		"GDNDescription": "CreatePolarDBGDNValue",
+		"GDNStatus":       "active",
+		"GDNDescription":  "CreatePolarDBGDNValue",
+		"ResourceGroupId": "CreatePolarDBGDNValue",
 		"DBClusters": []interface{}{
 			map[string]interface{}{
 				"DBClusterId": "CreatePolarDBGDNValue",
@@ -344,7 +354,8 @@ func TestUnitAlicloudPolarDBGlobalDatabaseNetwork(t *testing.T) {
 	dExisted, _ = schema.InternalMap(p["alicloud_polardb_global_database_network"].Schema).Data(dInit.State(), diff)
 	ReadMockResponseDiff = map[string]interface{}{
 		// DescribeGlobalDatabaseNetwork Response
-		"GDNDescription": "PutPolarDBGDNValue",
+		"GDNDescription":  "PutPolarDBGDNValue",
+		"ResourceGroupId": "CreatePolarDBGDNValue",
 		"DBClusters": []interface{}{
 			map[string]interface{}{
 				"DBClusterId": "CreatePolarDBGDNValue",

--- a/website/docs/d/polardb_global_database_networks.html.markdown
+++ b/website/docs/d/polardb_global_database_networks.html.markdown
@@ -48,8 +48,9 @@ resource "alicloud_polardb_cluster" "cluster" {
 }
 
 resource "alicloud_polardb_global_database_network" "default" {
-  db_cluster_id = alicloud_polardb_cluster.cluster.id
-  description   = alicloud_polardb_cluster.cluster.id
+  db_cluster_id     = alicloud_polardb_cluster.cluster.id
+  description       = alicloud_polardb_cluster.cluster.id
+  resource_group_id = "rg-xxxxxxxxxx"
 }
 data "alicloud_polardb_global_database_networks" "ids" {
   ids = [alicloud_polardb_global_database_network.default.id]
@@ -75,11 +76,11 @@ The following arguments are supported:
 * `db_cluster_id` - (Optional, ForceNew) The ID of the cluster.
 * `description` - (Optional, ForceNew, Computed) The description of the Global Database Network.
 * `status` - (Optional, ForceNew) The status of the Global Database Network. Valid values:
-	- `creating`: The Global Database Network is being created.
-	- `active`: The Global Database Network is running.
-	- `deleting`: The Global Database Network is being deleted.
-	- `locked`: The Global Database Network is locked. If the Global Database Network is locked, you cannot perform operations on clusters in the Global Database Network.
-	- `removing_member`: The secondary cluster is being removed from the Global Database Network.
+  - `creating`: The Global Database Network is being created.
+  - `active`: The Global Database Network is running.
+  - `deleting`: The Global Database Network is being deleted.
+  - `locked`: The Global Database Network is locked. If the Global Database Network is locked, you cannot perform operations on clusters in the Global Database Network.
+  - `removing_member`: The secondary cluster is being removed from the Global Database Network.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 
 ## Attributes Reference
@@ -87,14 +88,15 @@ The following arguments are supported:
 The following attributes are exported in addition to the arguments listed above:
 
 * `networks` - A list of PolarDB Global Database Networks. Each element contains the following attributes:
-	* `id` - The ID of the Global Database Network.
-	* `gdn_id` - The ID of the Global Database Network.
-	* `description` - The description of the Global Database Network.
-	* `db_type` - The type of the database engine. Only MySQL is supported.
-	* `db_version` - The version number of the database engine. Only the 8.0 version is supported.
-	* `create_time` - The time when the Global Database Network was created. The time is in the YYYY-MM-DDThh:mm:ssZ format. The time is displayed in UTC.
-	* `status` - The status of the Global Database Network.
-	* `db_clusters` - The details of each cluster in the Global Database Network.
-		* `db_cluster_id` - The ID of the PolarDB cluster.
-		* `role` - The role of the cluster.
-		* `region_id` - The region ID of the cluster.
+  * `id` - The ID of the Global Database Network.
+  * `gdn_id` - The ID of the Global Database Network.
+  * `description` - The description of the Global Database Network.
+  * `resource_group_id` - The ID of the resource group.
+  * `db_type` - The type of the database engine. Only MySQL is supported.
+  * `db_version` - The version number of the database engine. Only the 8.0 version is supported.
+  * `create_time` - The time when the Global Database Network was created. The time is in the YYYY-MM-DDThh:mm:ssZ format. The time is displayed in UTC.
+  * `status` - The status of the Global Database Network.
+  * `db_clusters` - The details of each cluster in the Global Database Network.
+    * `db_cluster_id` - The ID of the PolarDB cluster.
+    * `role` - The role of the cluster.
+    * `region_id` - The region ID of the cluster.

--- a/website/docs/r/polardb_global_database_network.html.markdown
+++ b/website/docs/r/polardb_global_database_network.html.markdown
@@ -55,8 +55,9 @@ resource "alicloud_polardb_cluster" "default" {
 }
 
 resource "alicloud_polardb_global_database_network" "default" {
-  db_cluster_id = alicloud_polardb_cluster.default.id
-  description   = "terraform-example"
+  db_cluster_id     = alicloud_polardb_cluster.default.id
+  description       = "terraform-example"
+  resource_group_id = "rg-xxxxxxxxxx"
 }
 ```
 
@@ -69,6 +70,7 @@ The following arguments are supported:
 * `db_cluster_id` - (Required, ForceNew) The ID of the primary cluster.
 * `status` - (Computed) The status of the Global Database Network.
 * `description` - (Optional, Computed) The description of the Global Database Network.
+* `resource_group_id` - (Optional, Computed) The ID of the resource group.
 
 ## Attributes Reference
 
@@ -76,6 +78,7 @@ The following attributes are exported:
 
 * `id` - The resource ID in terraform of Global Database Network.
 * `status` - The status of the Global Database Network.
+* `resource_group_id` - The ID of the resource group.
 
 ## Timeouts
 


### PR DESCRIPTION
### What this PR does

Adds `resource_group_id` support to `alicloud_polardb_global_database_network` resource and `alicloud_polardb_global_database_networks` data source.

### Why

The `ResourceGroupId` parameter is available on the PolarDB GlobalDatabaseNetwork Create/Describe/Modify APIs but was not exposed in the Terraform provider. This wires it through so users can place a GDN in a specific resource group and move it between groups at runtime.

### Changes

- `resource_alicloud_polardb_global_database_network`:
  - schema: add `resource_group_id` (Optional, Computed)
  - Create: send `ResourceGroupId` in `CreateGlobalDatabaseNetwork` when set
  - Read: read `ResourceGroupId` back from `DescribeGlobalDatabaseNetwork`
  - Update: send `ResourceGroupId` in `ModifyGlobalDatabaseNetwork` on change (Modify supports runtime resource group migration, so no `ForceNew`)
- `data_source_alicloud_polardb_global_database_networks`:
  - expose `resource_group_id` as a computed output field
- docs: document the new field in resource and data source pages

### Tests

Acceptance and unit tests updated:
- `TestAccAliCloudPolarDBGlobalDatabaseNetwork_basic00`
- `TestUnitAlicloudPolarDBGlobalDatabaseNetwork`
- `TestAccAlicloudPolarDBGlobalDatabaseNetworkDataSource`

CI will verify the acceptance and unit tests.
