### PR TITLE
resource/alicloud_kvstore_instance: add cluster_backup_id, auto_pay, force_trans and minor_version

### DIFF
--- a/alicloud/resource_alicloud_kvstore_instance.go
+++ b/alicloud/resource_alicloud_kvstore_instance.go
@@ -31,6 +31,11 @@ func resourceAliCloudKvstoreInstance() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
+			"auto_pay": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"auto_renew": {
 				Type:             schema.TypeBool,
 				Optional:         true,
@@ -84,6 +89,11 @@ func resourceAliCloudKvstoreInstance() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
+			},
+			"cluster_backup_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 			// lintignore: S006
 			"config": {
@@ -139,6 +149,11 @@ func resourceAliCloudKvstoreInstance() *schema.Resource {
 				ValidateFunc: StringInSlice([]string{"2.8", "4.0", "5.0", "6.0", "7.0"}, false),
 				Computed:     true,
 			},
+			"force_trans": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"force_upgrade": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -178,6 +193,11 @@ func resourceAliCloudKvstoreInstance() *schema.Resource {
 				Computed: true,
 			},
 			"maintain_start_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"minor_version": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -465,6 +485,10 @@ func resourceAliCloudKvstoreInstanceCreate(d *schema.ResourceData, meta interfac
 
 	if v, ok := d.GetOk("backup_id"); ok {
 		request["BackupId"] = v
+	}
+
+	if v, ok := d.GetOk("cluster_backup_id"); ok {
+		request["ClusterBackupId"] = v
 	}
 
 	if v, ok := d.GetOk("business_info"); ok {
@@ -805,6 +829,7 @@ func resourceAliCloudKvstoreInstanceRead(d *schema.ResourceData, meta interface{
 	}
 
 	d.Set("is_auto_upgrade_open", engineVersionObject["IsAutoUpgradeOpen"])
+	d.Set("minor_version", engineVersionObject["MinorVersion"])
 
 	return nil
 }
@@ -882,7 +907,7 @@ func resourceAliCloudKvstoreInstanceUpdate(d *schema.ResourceData, meta interfac
 
 	update := false
 	transformInstanceChargeTypeReq := map[string]interface{}{
-		"AutoPay":    true,
+		"AutoPay":    d.Get("auto_pay").(bool),
 		"InstanceId": d.Id(),
 	}
 
@@ -1361,7 +1386,7 @@ func resourceAliCloudKvstoreInstanceUpdate(d *schema.ResourceData, meta interfac
 	update = false
 	modifyInstanceSpecReq := map[string]interface{}{
 		"RegionId":   client.RegionId,
-		"AutoPay":    true,
+		"AutoPay":    d.Get("auto_pay").(bool),
 		"InstanceId": d.Id(),
 	}
 
@@ -1426,6 +1451,10 @@ func resourceAliCloudKvstoreInstanceUpdate(d *schema.ResourceData, meta interfac
 
 	if v, ok := d.GetOkExists("force_upgrade"); ok {
 		modifyInstanceSpecReq["ForceUpgrade"] = v
+	}
+
+	if v, ok := d.GetOkExists("force_trans"); ok {
+		modifyInstanceSpecReq["ForceTrans"] = v
 	}
 
 	if v, ok := d.GetOk("order_type"); ok {
@@ -1539,6 +1568,51 @@ func resourceAliCloudKvstoreInstanceUpdate(d *schema.ResourceData, meta interfac
 		}
 		d.SetPartial("engine_version")
 	}
+
+	update = false
+	modifyInstanceMinorVersionReq := map[string]interface{}{
+		"InstanceId": d.Id(),
+	}
+
+	if !d.IsNewResource() && d.HasChange("minor_version") {
+		if v, ok := d.GetOk("minor_version"); ok && fmt.Sprint(v) != "" {
+			update = true
+			modifyInstanceMinorVersionReq["Minorversion"] = v
+		}
+	}
+
+	if v, ok := d.GetOk("effective_time"); ok {
+		modifyInstanceMinorVersionReq["EffectiveTime"] = v
+	}
+
+	if update {
+		action := "ModifyInstanceMinorVersion"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
+			response, err = client.RpcPost("R-kvstore", "2015-01-01", action, nil, modifyInstanceMinorVersionReq, false)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, modifyInstanceMinorVersionReq)
+
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		stateConf := BuildStateConf([]string{}, []string{"Normal"}, d.Timeout(schema.TimeoutUpdate), 300*time.Second, r_kvstoreService.KvstoreInstanceStateRefreshFunc(d.Id(), []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+
+		d.SetPartial("minor_version")
+	}
+
 	if d.HasChange("parameters") {
 		request := r_kvstore.CreateModifyInstanceConfigRequest()
 		request.InstanceId = d.Id()

--- a/alicloud/resource_alicloud_kvstore_instance_test.go
+++ b/alicloud/resource_alicloud_kvstore_instance_test.go
@@ -45,10 +45,12 @@ func TestAccAliCloudKVStoreRedisInstance_coverage(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"auto_pay":                    "false",
 					"auto_use_coupon":             "false",
 					"backup_id":                   "backup-id",
 					"business_info":               "business-info",
 					"capacity":                    "1",
+					"cluster_backup_id":           "cb-id",
 					"coupon_no":                   "coupon-no",
 					"dedicated_host_group_id":     "dhg-id",
 					"effective_time":              "Immediately",
@@ -56,6 +58,7 @@ func TestAccAliCloudKVStoreRedisInstance_coverage(t *testing.T) {
 					"encryption_key":              "key",
 					"encryption_name":             "AES-CTR-256",
 					"engine_version":              "6.0",
+					"force_trans":                 "true",
 					"force_upgrade":               "true",
 					"global_instance":             "false",
 					"global_instance_id":          "global-instance-id",
@@ -76,17 +79,127 @@ func TestAccAliCloudKVStoreRedisInstance_coverage(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"auto_pay":               "true",
 					"encryption_key":         "key-update",
 					"encryption_name":        "AES-CTR-256-update",
 					"engine_version":         "7.0",
+					"force_trans":            "false",
 					"kms_encrypted_password": "kms-password-update",
 					"kms_encryption_context": map[string]string{"name": "value-update"},
+					"minor_version":          "redis-minor-version-update",
 					"port":                   "6380",
 					"resource_group_id":      "rg-id-update",
 					"role_arn":               "acs:ram::1234567890123456:role/example-update",
 					"security_group_id":      "sg-id-update",
 				}),
 				ExpectError: regexp.MustCompile(".+"),
+			},
+		},
+	})
+}
+
+// TestAccAliCloudKVStoreRedisInstance_autoPayForceTransMinorVersion covers the
+// auto_pay, force_trans and minor_version attributes.
+//
+// Instances are provisioned with the latest minor version and
+// ModifyInstanceMinorVersion cannot downgrade, so a real upgrade to a higher
+// version cannot be triggered deterministically on a freshly created instance
+// (there is no higher target available). This test instead verifies:
+//   - the current minor version is read back into state after creation;
+//   - minor_version is an in-place updatable attribute (a plan changing it must
+//     not force a replacement); this step is plan-only on purpose because no
+//     higher version is available for a freshly created instance;
+//   - removing the attribute from the configuration keeps the value read back
+//     from the instance (no spurious diff, no upgrade triggered);
+//   - force_trans is carried alongside an instance_class change through
+//     ModifyInstanceSpec; auto_pay controls order payment for subscription
+//     instances and is a no-op for PostPaid spec changes.
+func TestAccAliCloudKVStoreRedisInstance_autoPayForceTransMinorVersion(t *testing.T) {
+	var v r_kvstore.DBInstanceAttribute
+	resourceId := "alicloud_kvstore_instance.default"
+	ra := resourceAttrInit(resourceId, AliCloudKVStoreMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &R_kvstoreService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeKvstoreInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccKvstoreRedisInstanceMinorVersion%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudKVStoreRedisInstanceVpcBasicDependence0)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_class":   "redis.shard.with.proxy.small.ce",
+					"db_instance_name": name,
+					"instance_type":    "Redis",
+					"engine_version":   "6.0",
+					"shard_count":      "2",
+					"payment_type":     "PostPaid",
+					"auto_pay":         "true",
+					"force_trans":      "false",
+					"zone_id":          "${data.alicloud_kvstore_zones.default.zones.0.id}",
+					"vswitch_id":       "${data.alicloud_vswitches.default.ids.0}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_class":   "redis.shard.with.proxy.small.ce",
+						"db_instance_name": name,
+						"instance_type":    "Redis",
+						"engine_version":   "6.0",
+						"shard_count":      "2",
+						"payment_type":     "PostPaid",
+						"auto_pay":         "true",
+						"force_trans":      "false",
+						"minor_version":    CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_class": "redis.shard.with.proxy.mid.ce",
+					"force_trans":    "true",
+					"auto_pay":       "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_class": "redis.shard.with.proxy.mid.ce",
+						"force_trans":    "true",
+						"auto_pay":       "true",
+					}),
+				),
+			},
+			{
+				// Plan-only: verify that changing minor_version is planned as an
+				// in-place update without applying it (see the function comment).
+				Config: testAccConfig(map[string]interface{}{
+					"minor_version": "redis-target-minor-version",
+				}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"minor_version": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"minor_version": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auto_pay", "dry_run", "business_info", "coupon_no", "effective_time", "force_trans", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 		},
 	})
@@ -250,7 +363,7 @@ func SkipTestAccAliCloudKVStoreRedisInstance_vpctest(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"auto_pay", "dry_run", "business_info", "coupon_no", "effective_time", "force_trans", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -599,7 +712,7 @@ func TestAccAliCloudKVStoreRedisInstance_6_0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"auto_pay", "dry_run", "business_info", "coupon_no", "effective_time", "force_trans", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -928,7 +1041,7 @@ func TestAccAliCloudKVStoreRedisInstance_7_0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"auto_pay", "dry_run", "business_info", "coupon_no", "effective_time", "force_trans", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -1230,7 +1343,7 @@ func TestAccAliCloudKVStoreRedisInstance_7_0_with_proxy_class(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"auto_pay", "dry_run", "business_info", "coupon_no", "effective_time", "force_trans", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -1563,7 +1676,7 @@ func SkipTestAccAliCloudKVStoreRedisInstance_prepaid(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"auto_pay", "dry_run", "business_info", "coupon_no", "effective_time", "force_trans", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -1900,7 +2013,7 @@ func TestAccAliCloudKVStoreRedisInstance_7_0_with_proxy_class_replica(t *testing
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"auto_pay", "dry_run", "business_info", "coupon_no", "effective_time", "force_trans", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -2013,7 +2126,7 @@ func TestAccAliCloudKVStoreRedisInstance_5_0_memory_classic_standard(t *testing.
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"auto_pay", "dry_run", "business_info", "coupon_no", "effective_time", "force_trans", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -2371,7 +2484,7 @@ func TestAccAliCloudKVStoreRedisInstance_5_0_memory_classic_cluster(t *testing.T
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"auto_pay", "dry_run", "business_info", "coupon_no", "effective_time", "force_trans", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -2682,7 +2795,7 @@ func TestAccAliCloudKVStoreMemcacheInstance_vpctest(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"auto_pay", "dry_run", "business_info", "coupon_no", "effective_time", "force_trans", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -2879,7 +2992,7 @@ func TestAccAliCloudKVStoreRedisInstance_classic_cluster_instance_class(t *testi
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"dry_run", "business_info", "coupon_no", "effective_time", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
+				ImportStateVerifyIgnore: []string{"auto_pay", "dry_run", "business_info", "coupon_no", "effective_time", "force_trans", "force_upgrade", "global_instance_id", "order_type", "password", "period", "enable_public", "security_ip_group_attribute", "enable_backup_log"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{

--- a/website/docs/r/kvstore_instance.html.markdown
+++ b/website/docs/r/kvstore_instance.html.markdown
@@ -224,6 +224,7 @@ The following arguments are supported:
 * `security_group_id` - (Optional, Available since v1.76.0) The ID of security groups. Separate multiple security group IDs with commas (,), such as `sg-***,sg-***,sg-***`.
 * `private_ip`- (Optional, ForceNew) The internal IP address of the instance.
 * `backup_id`- (Optional, ForceNew) The ID of the backup file of the source instance.
+* `cluster_backup_id` - (Optional, ForceNew, Available since v1.290.0) The ID of the cluster backup set of the source instance. You can call the `DescribeClusterBackupList` operation to query cluster backup set IDs. It is valid when you clone a new instance from a cluster-architecture instance that supports cluster backup sets, and it replaces the need to list per-shard backup IDs in `backup_id`. It must be used together with `srcdb_instance_id`.
 * `srcdb_instance_id`- (Optional, ForceNew, Available since v1.101.0) The ID of the source instance.
 * `restore_time`- (Optional, ForceNew, Available since v1.101.0) The point in time of a backup file.
 * `vpc_auth_mode`- (Optional) Only meaningful if instance_type is `Redis` and network type is VPC. Valid values: `Close`, `Open`. Default value: `Open`. `Close` means the redis instance can be accessed without authentication. `Open` means authentication is required.
@@ -239,6 +240,7 @@ The following arguments are supported:
 * `connection_string_prefix` - (Deprecated since v1.101.0) It has been deprecated from provider version 1.101.0 and resource `alicloud_kvstore_connection` instead.
 * `port` - (Optional, Int, Available since v1.94.0) It has been deprecated from provider version 1.101.0 and resource `alicloud_kvstore_connection` instead.
 * `order_type`- (Optional, Available since v1.101.0) Specifies a change type when you change the configuration of a subscription instance. Valid values: `UPGRADE`, `DOWNGRADE`. Default value: `UPGRADE`. `UPGRADE` means upgrades the configuration of a subscription instance. `DOWNGRADE` means downgrades the configuration of a subscription instance.
+* `auto_pay` - (Optional, Bool, Available since v1.290.0) Specifies whether to automatically pay the order generated when the instance specification is changed or when the billing method is converted. Valid values: `true`: automatically pays the order. `false`: does not automatically pay the order; you must pay it manually in the console. Default value: `true`. **NOTE:** It is valid only for subscription (`payment_type = "PrePaid"`) instances; pay-as-you-go instances do not generate orders.
 * `node_type`- (Deprecated since v1.120.1) Node type, valid values:
   - `MASTER_SLAVE`: High availability (dual copies)
   - `STAND_ALONE`: Single copy
@@ -248,6 +250,7 @@ The following arguments are supported:
 * `ssl_enable`- (Optional, Available since v1.101.0) Modifies the SSL status. Valid values: `Disable`, `Enable` and `Update`.
   **NOTE:** This functionality is supported by Cluster mode (Redis 2.8, 4.0, 5.0) and Standard mode( Redis 2.8 only).
 * `force_upgrade`- (Optional, Bool, Available since v1.101.0) Specifies whether to forcibly change the type. Default value: `true`.
+* `force_trans` - (Optional, Bool, Available since v1.290.0) Specifies whether to skip the minor version check before changing the instance specification. Valid values: `false` (default): the system checks the current minor version of the instance before the specification change and reports an error if the minor version is too low; upgrade the minor version and retry. `true`: skips the check and directly performs the specification change. It is valid when `instance_class` changes.
 * `dedicated_host_group_id`- (Optional, ForceNew, Available since v1.101.0) The ID of the dedicated cluster. This parameter is required when you create a Tair (Redis OSS-Compatible) And Memcache (KVStore) Classic Instance in a dedicated cluster.
 * `coupon_no`- (Optional, Available since v1.101.0) The coupon code. **NOTE:** The default value `youhuiquan_promotion_option_id_for_blank` removed since v1.216.0, this can cause your status file to change even if it has not been modified, so please review your change plan before apply change plan.
 * `business_info`- (Optional, Available since v1.101.0) The ID of the event or the business information.
@@ -279,6 +282,7 @@ The following arguments are supported:
 * `is_auto_upgrade_open` - (Optional, Available since v1.228.0) Specifies whether to enable automatic minor version update. Valid values:
   - `1`: Enables automatic minor version update.
   - `0`: Disables automatic minor version update.
+* `minor_version` - (Optional, Available since v1.290.0) The minor version of the instance. Changing this attribute upgrades the instance to the specified minor version in place. If it is not specified, the latest minor version is used when the upgrade is triggered. **NOTE:** The minor version can only be upgraded, not downgraded; a newly created instance is always provisioned with the latest minor version. The current minor version is read back into this attribute.
 * `bandwidth` - (Optional, Int) The total bandwidth of the instance. **NOTE:** From version 1.232.0, `bandwidth` can be set. If the instance is a cluster instance, `bandwidth` must be divisible by the number of `shard_count` in the instance, and if the instance is a read/write splitting instance, `bandwidth` cannot be set.
 * `connection_string` - (Deprecated since v1.101.0) Indicates whether the address is a private endpoint.
 * `modify_mode`- (Removed since v1.216.0) The method of modifying the whitelist. **NOTE:** Field `modify_mode` has been removed from provider version 1.216.0.
@@ -289,7 +293,7 @@ The following arguments are supported:
 
 -> **NOTE:** The `private_ip` must be in the Classless Inter-Domain Routing (CIDR) block of the VSwitch to which the instance belongs.
 
--> **NOTE:** If you specify the `srcdb_instance_id` parameter, you must specify the `backup_id` or `restore_time` parameter.
+-> **NOTE:** If you specify the `srcdb_instance_id` parameter, you must specify one of the `backup_id`, `cluster_backup_id` or `restore_time` parameters.
 
 ### `parameters`
 


### PR DESCRIPTION
## Summary

- Adds `cluster_backup_id` (create-only) so a new instance can be cloned from a cluster backup set via `CreateInstance.ClusterBackupId`, as an alternative to listing per-shard backup IDs in `backup_id` (must be used together with `srcdb_instance_id`).
- Adds `auto_pay` (default `true`) to control automatic payment of the orders generated by specification changes (`ModifyInstanceSpec`) and billing-method conversions (`TransformInstanceChargeType`); the value was previously hardcoded to `true`.
- Adds `force_trans` (default `false`) to skip the minor version pre-check when changing the instance specification via `ModifyInstanceSpec`.
- Adds `minor_version`, an in-place updatable attribute that upgrades the instance minor version via `ModifyInstanceMinorVersion`; the current minor version is read back from `DescribeEngineVersion`. The minor version can only be upgraded, not downgraded.

## Changes

### `cluster_backup_id` on Create
- New Optional + ForceNew string attribute, sent as `CreateInstance.ClusterBackupId`.
- Mirrors the existing `cluster_backup_id` create parameter of `alicloud_redis_tair_instance`; cloud-native cluster-architecture instances can be cloned from a cluster backup set without enumerating per-shard backup IDs.

### `auto_pay` on Update
- `ModifyInstanceSpec` and `TransformInstanceChargeType` previously hardcoded `AutoPay: true`; both now use the schema value.
- Only subscription instances generate orders; for pay-as-you-go instances the parameter is a no-op.

### `force_trans` on Update
- Sent as `ModifyInstanceSpec.ForceTrans` alongside specification changes.
- `true` skips the kernel minor version pre-check and directly performs the specification change.

### `minor_version` on Read/Update
- Read sets `minor_version` from `DescribeEngineVersion.MinorVersion` (the call already existed for `is_auto_upgrade_open`).
- Update calls `ModifyInstanceMinorVersion` with the exact API parameter name `Minorversion`, passing `effective_time` when set, then waits for the instance to return to `Normal` (same pattern as the major version upgrade block).
- Guarded by `!d.IsNewResource()` so the create path never triggers an upgrade.

### Tests
- New `TestAccAliCloudKVStoreRedisInstance_autoPayForceTransMinorVersion`: create → verify `minor_version` read-back → spec change with `force_trans=true` and `auto_pay=true` → plan-only `minor_version` change (in-place, no replacement) → REMOVEKEY keeps the read-back value → import. Instances are provisioned with the latest minor version and `ModifyInstanceMinorVersion` cannot downgrade, so the real upgrade path cannot be triggered deterministically on a fresh instance; the plan-only step verifies the update semantics instead (same approach as `TestAccAliCloudGPDBDBInstance_minorVersion`).
- `TestAccAliCloudKVStoreRedisInstance_coverage` extended with the four new attributes.
- `auto_pay`/`force_trans` added to every `ImportStateVerifyIgnore` list: both carry defaults and are ordering parameters that the Read path never writes back (same pattern as `force_upgrade`).

### Docs
- `website/docs/r/kvstore_instance.html.markdown`: documents the four new arguments and updates the `srcdb_instance_id` note.

## Test plan

- [ ] `TestAccAliCloudKVStoreRedisInstance_autoPayForceTransMinorVersion` — remote ACC pending
- [ ] `TestAccAliCloudKVStoreRedisInstance_coverage` — remote ACC pending
