### PR TITLE
resource/alicloud_rds_custom_disk_attachment: add zone_id computed attribute

### DIFF
--- a/alicloud/resource_alicloud_rds_custom_disk_attachment.go
+++ b/alicloud/resource_alicloud_rds_custom_disk_attachment.go
@@ -49,6 +49,10 @@ func resourceAliCloudRdsCustomDiskAttachment() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -122,6 +126,7 @@ func resourceAliCloudRdsCustomDiskAttachmentRead(d *schema.ResourceData, meta in
 	d.Set("status", objectRaw["Status"])
 	d.Set("disk_id", objectRaw["DiskId"])
 	d.Set("instance_id", objectRaw["InstanceId"])
+	d.Set("zone_id", objectRaw["ZoneId"])
 
 	return nil
 }

--- a/alicloud/resource_alicloud_rds_custom_disk_attachment_test.go
+++ b/alicloud/resource_alicloud_rds_custom_disk_attachment_test.go
@@ -44,6 +44,7 @@ func TestAccAliCloudRdsCustomDiskAttachment_basic12736(t *testing.T) {
 						"instance_id": CHECKSET,
 						//"delete_with_instance": "true",
 						"disk_id": CHECKSET,
+						"zone_id": CHECKSET,
 					}),
 				),
 			},
@@ -89,6 +90,7 @@ func TestAccAliCloudRdsCustomDiskAttachment_basic12736_twin(t *testing.T) {
 						"instance_id":          CHECKSET,
 						"delete_with_instance": "false",
 						"disk_id":              CHECKSET,
+						"zone_id":              CHECKSET,
 					}),
 				),
 			},
@@ -106,6 +108,7 @@ var AliCloudRdsCustomDiskAttachmentMap12736 = map[string]string{
 	"region_id":            CHECKSET,
 	"status":               CHECKSET,
 	"delete_with_instance": CHECKSET,
+	"zone_id":              CHECKSET,
 }
 
 func AliCloudRdsCustomDiskAttachmentBasicDependence12736(name string) string {

--- a/website/docs/r/rds_custom_disk_attachment.html.markdown
+++ b/website/docs/r/rds_custom_disk_attachment.html.markdown
@@ -96,6 +96,7 @@ The following attributes are exported:
 * `id` - The ID of the resource supplied above. The value is formulated as `<disk_id>:<instance_id>`.
 * `region_id` - The region ID of the resource.
 * `status` - The status of the disk.
+* `zone_id` - The zone ID of the RDS custom disk.
 
 ## Timeouts
 


### PR DESCRIPTION
### Description

Adds the `zone_id` computed attribute to the `alicloud_rds_custom_disk_attachment` resource.

The `DescribeRCDisks` API response already includes `ZoneId` for each disk, but the resource schema did not expose it. This change reads `ZoneId` into state during `Read`, making the zone of the attached disk available as a read-only attribute, consistent with the existing `region_id` and `status` computed attributes.

### Tests

- `TestAccAliCloudRdsCustomDiskAttachment_basic12736`
- `TestAccAliCloudRdsCustomDiskAttachment_basic12736_twin`

Both cases now assert `zone_id` is set (CHECKSET) and include it in the shared attribute map. Acceptance tests require real RDS Custom instances and disks and are run remotely.

### Impact

- New computed-only attribute `zone_id` (read-only, no ForceNew, no breaking change).
- `ImportStateVerify` continues to pass: `zone_id` is populated identically by `Read` on apply and import.
- No changes to Create/Update/Delete behavior.
