### PR TITLE
resource/alicloud_amqp_*: create_time as TypeString to fix 32-bit panic

### DIFF
--- a/CHANGELOG-v2.md
+++ b/CHANGELOG-v2.md
@@ -1,4 +1,12 @@
-## 2.0.0-beta3 (August 17, 2026)
+## 2.0.0-beta4 (Unreleased)
+
+BREAKING CHANGES:
+
+- resource/alicloud_amqp_exchange: `create_time` changed from `TypeInt` to `TypeString`, fixing a provider panic on 32-bit builds. No configuration or state migration is needed; expressions that consumed it as a number now need `tonumber`. ([#10254](https://github.com/aliyun/terraform-provider-alicloud/issues/10254))
+- resource/alicloud_amqp_instance: `create_time` changed from `TypeInt` to `TypeString`, fixing a provider panic on 32-bit builds. No configuration or state migration is needed; expressions that consumed it as a number now need `tonumber`. ([#10254](https://github.com/aliyun/terraform-provider-alicloud/issues/10254))
+- resource/alicloud_amqp_static_account: `create_time` changed from `TypeInt` to `TypeString`, fixing a provider panic on 32-bit builds. No configuration or state migration is needed; expressions that consumed it as a number now need `tonumber`. ([#10254](https://github.com/aliyun/terraform-provider-alicloud/issues/10254))
+
+## 2.0.0-beta3 (August 19, 2026)
 
 This beta rolls up every change merged from the 1.x line since v2.0.0-beta2 — see the `1.288.0` and `1.289.0` sections of [CHANGELOG.md](CHANGELOG.md) — plus the v2-only changes below.
 

--- a/alicloud/resource_alicloud_amqp_exchange.go
+++ b/alicloud/resource_alicloud_amqp_exchange.go
@@ -36,7 +36,7 @@ func resourceAliCloudAmqpExchange() *schema.Resource {
 				ForceNew: true,
 			},
 			"create_time": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"exchange_name": {

--- a/alicloud/resource_alicloud_amqp_instance.go
+++ b/alicloud/resource_alicloud_amqp_instance.go
@@ -36,7 +36,7 @@ func resourceAliCloudAmqpInstance() *schema.Resource {
 				Optional: true,
 			},
 			"create_time": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"edition": {
@@ -410,7 +410,7 @@ func resourceAliCloudAmqpInstanceRead(d *schema.ResourceData, meta interface{}) 
 
 	if v, ok := objectRaw["CreateTime"].(string); ok {
 		if t, err := time.Parse(time.RFC3339, v); err == nil {
-			d.Set("create_time", t.UnixMilli())
+			d.Set("create_time", fmt.Sprint(t.UnixMilli()))
 		}
 	}
 	d.Set("payment_type", objectRaw["SubscriptionType"])

--- a/alicloud/resource_alicloud_amqp_instance_test.go
+++ b/alicloud/resource_alicloud_amqp_instance_test.go
@@ -1247,12 +1247,12 @@ func AliCloudAmqpInstanceBasicDependence6128(name string) string {
 
 	data "alicloud_vswitches" "default" {
   		vpc_id     = data.alicloud_vpcs.default.ids.0
-  		name_regex = "^default-NODELETING-ACK-switch"
+  		name_regex = "^default-NODELETING-vsw"
 	}
 
 	data "alicloud_security_groups" "default" {
   		vpc_id     = data.alicloud_vpcs.default.ids.0
-  		name_regex = "^sae"
+  		name_regex = "default-NODELETING"
 	}
 `, name)
 }
@@ -1543,12 +1543,12 @@ func AliCloudAmqpInstanceBasicDependence11166(name string) string {
 
 	data "alicloud_vswitches" "default" {
   		vpc_id     = data.alicloud_vpcs.default.ids.0
-  		name_regex = "^default-NODELETING-ACK-switch"
+  		name_regex = "^default-NODELETING-vsw"
 	}
 
 	data "alicloud_security_groups" "default" {
   		vpc_id     = data.alicloud_vpcs.default.ids.0
-  		name_regex = "^sae"
+  		name_regex = "default-NODELETING"
 	}
 `, name)
 }

--- a/alicloud/resource_alicloud_amqp_static_account.go
+++ b/alicloud/resource_alicloud_amqp_static_account.go
@@ -57,7 +57,7 @@ func resourceAliCloudAmqpStaticAccount() *schema.Resource {
 				Computed: true,
 			},
 			"create_time": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},

--- a/website/docs/r/amqp_exchange.html.markdown
+++ b/website/docs/r/amqp_exchange.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 * `id` - The ID of the resource supplied above.The value is formulated as `<instance_id>:<virtual_host_name>:<exchange_name>`.
-* `create_time` - CreateTime
+* `create_time` - The time when the exchange was created. Unix timestamp, to millisecond level.
 
 ## Timeouts
 

--- a/website/docs/r/amqp_instance.html.markdown
+++ b/website/docs/r/amqp_instance.html.markdown
@@ -245,7 +245,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the resource supplied above.
-* `create_time` - OrderCreateTime.
+* `create_time` - The time when the order was created. Unix timestamp, to millisecond level.
 * `status` - The status of the resource.
 
 ## Timeouts

--- a/website/docs/r/amqp_static_account.html.markdown
+++ b/website/docs/r/amqp_static_account.html.markdown
@@ -70,7 +70,7 @@ The following attributes are exported:
 * `user_name` - The static username.
 * `password` - The static password.
 * `master_uid` - The ID of the user's primary account.
-* `create_time` - The timestamp that indicates when the pair of static username and password was created.
+* `create_time` - The time when the pair of static username and password was created. Unix timestamp, to millisecond level.
 
 ## Timeouts
 


### PR DESCRIPTION
### Problem

`terraform plan` crashes the provider on 32-bit builds:

```
panic: Error reading level state: strconv.ParseInt: value out of range

github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*ResourceData).get(...)
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*ResourceData).GetOk(...)
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(...)
```

The AMQP APIs return `create_time` as a **13-digit millisecond epoch**, but the three
amqp resources declared it as `schema.TypeInt`.

### Root cause

`TypeInt` is modelled as Go's **native `int`** end to end, so its width follows the
target CPU. `helper/schema/field_reader.go` reads flatmap state with:

```go
v, err := strconv.ParseInt(value, 0, 0)   // bitSize 0 == native int width
...
returnVal = int(v)
```

On a 32-bit build the ceiling is `2147483647`; a millisecond epoch is ~800x larger, so
the read panics. `ResourceData.get` calls a **bare `panic(err)`**, which kills the whole
plugin process — so a single affected attribute shows up as several
`Error: Plugin did not respond` blocks for *unrelated* resources in the same plan
(data sources, vswitches, resource groups). Those are collateral damage from one bug,
not separate bugs.

Notes on the shape of the problem:

* **10-digit (second) epochs are fine** until 2038-01-19; only sub-second epochs
  overflow today. Durations measured in milliseconds (`timeout`, `interval`, ...) are
  small numbers and can stay `TypeInt`.
* 64-bit installs are unaffected, which is why CI and the acceptance tests never
  caught it.
* The write path (`reflect.Value.SetInt`) truncates **silently**; only the read path
  panics. State written by a 64-bit run therefore detonates when read by a 32-bit one.
* `windows_386` is still in `.goreleaser.yml`, so this is a shipped target.

### Why change the type instead of widening the parse

Passing `64` as the bitSize does not help: the next line narrows the result back with
`int(v)`, which would convert the panic into **silent data corruption** (a negative
number in state). The width has to come from the API field, not from the CPU — which is
what `TypeString` gives us.

### Compatibility

* **No state upgrader is needed.** An existing numeric value survives the decode path
  losslessly: `json.Unmarshal` -> `float64` (1.7e12 is far below 2^53) ->
  `ctyjson` with `UseNumber()` -> `cty.StringVal`, and the flatmap reader returns
  `TypeString` verbatim with no parse at all.
* `create_time` is `Computed` on all three resources, so it is never written in HCL and
  no configuration has to change.
* `create_time` is **already `TypeString` on the four amqp data sources**, so this also
  closes a pre-existing resource/data-source divergence. It is also the house
  convention: `create_time` is `TypeString` on 252 resources versus `TypeInt` on 37.
* The `int64` write-back in `resourceAliCloudAmqpInstanceRead` needs an explicit
  `fmt.Sprint` (mapstructure only coerces int->string under `WeaklyTypedInput`, which
  `helper/schema` never sets, and `d.Set` errors are ignored — so without it the field
  would silently stop being written). The other two write-backs pass the raw API value,
  which is a `json.Number` (a `string` alias) and needs no change.
* Because changing an attribute type is a breaking change, this targets the
  `release/v2` major-version beta window, and is recorded under `BREAKING CHANGES:` in a
  new `2.0.0-beta4 (Unreleased)` section of `CHANGELOG-v2.md`. `v2.0.0-beta3` is already
  tagged, so no shipped section is edited. Anything that consumed `create_time` as a
  number needs an explicit `tonumber`.
* While in that file, the `2.0.0-beta3` heading date is corrected from August 17 to
  August 19, its actual release date.

The remaining `TypeInt` timestamp attributes elsewhere in the provider are tracked
separately, together with a static check to stop new ones landing.

### Acceptance tests

```
PASS: TestAccAliCloudAmqpInstanceResource_basic6128 (1536.03s)
PASS: TestAccAliCloudAmqpInstanceResource_basic6128_twin (549.57s)
PASS: TestAccAliCloudAmqpInstanceResource_encryptedServerlessDedicatedCreate (558.96s)
FAIL: TestAccAliCloudAmqpInstanceResource_basic11166 (507.31s)
FAIL: TestAccAliCloudAmqpInstanceResource_basic11166_twin (16.78s)
3 passed / 2 failed / 0 skipped

PASS: TestAccAliCloudOnsStaticAccount_basic1775 (19.53s)
PASS: TestAccAliCloudAmqpExchange_DIRECT (469.94s)
2 passed / 0 failed / 0 skipped
```

`TestAccAliCloudAmqpInstanceResource_basic6128` is a 12-step lifecycle case plus destroy,
and it exercises **both** `create_time` write paths in `resourceAliCloudAmqpInstanceRead`:
the raw `OrderCreateTime`, which the API returns as a 13-digit millisecond number, and the
RFC3339 `CreateTime`, which is converted with `fmt.Sprint(t.UnixMilli())`. The debug log
for that run shows 13-digit values being written to state and read back on every refresh —
exactly the value shape that panics on a 32-bit build, now stored and read as a string.

`TestAccAliCloudOnsStaticAccount_basic1775` asserts `create_time` is `CHECKSET`, and the
API response in that run also carried a 13-digit millisecond value. Its `Delete` feeds
`create_time` from state into the request, via an untyped `d.GetOk`, and destroy passed —
that re-read from state is the exact operation that panics on a 32-bit build.

Each of the three changed resources therefore has a passing case that executes its changed
`d.Set("create_time", …)`. `alicloud_amqp_exchange` was covered by one of its 15 cases; the
other 14 vary `exchange_type`, `arguments` and `internal` and reach the same single write,
so they were not run.

The two failures are an **account entitlement limit**, not a defect in this change.
`_basic11166` asks for `instance_type = "vip"` (the Platinum edition) with
`modify_type = "Upgrade"`, and the AMQP order API refuses it:

```
Step 3/12 error: ... UpdateInstance Failed!!!
  Code: innerUserBuyVipInstance
  Message: 内部用户下单铂金版，请联系开发同学申请
```

`_basic11166_twin` creates at that same spec and fails on `CreateInstance` with the same
code after 16.78s. `create_time` is `Computed` and is not an input to `CreateInstance` or
`UpdateInstance`; `_basic11166` had already completed a create and two updates before the
refusal, so `create_time` round-tripped through the changed code repeatedly first. The
test account would have to be allowlisted for that edition for these two to pass at all,
so they are accepted as a known account limitation rather than treated as a regression.

This branch also repairs the shared dependence config for the amqp_instance cases. It was
resolving a vswitch pair and a security group by name regexes that match nothing in the
test account, so every case died in pre-apply refresh with
`data.alicloud_vswitches.default.ids is empty list of string`, before any provider code
ran — which is why `alicloud_amqp_instance`, the resource this bug was reported against,
had never been exercised. The regexes now point at the permanent shared fixtures. The same
stale security-group regex also appears in `data_source_alicloud_amqp_instances_test.go`
and `resource_alicloud_amqp_virtual_host_test.go`; those are untouched here and belong in
a separate test-only change.


## CI status

Two red checks, neither of them a defect in this change.

**1. `BreakingChange`** — it flags exactly the intended change, once per resource:

```
==> Checking resource alicloud_amqp_exchange breaking change...
[Breaking Change]: 'create_time' type should not been changed from TypeInt to TypeString!
--- FAIL
```

`scripts/compatibility/breaking_change_check.go` rejects any attribute type change and
has no exemption mechanism, and the step in `.github/workflows/acctest-terraform-basic.yml`
runs unconditionally for both `master` and `release/v2`. That gate protects the 1.x
compatibility promise on `master`, where it is exactly right. On the 2.0 beta branch a
type change is the intent — as it stands, no breaking change can ever land on
`release/v2`. Suggest branch-scoping that one step to `master`; I can send it as a
separate CI change.

**2. `tflint`** — pre-existing on this branch, and unrelated to this diff:

```
Found issues (could not determine changed files, showing all):
alicloud/service/ims/data_source_default_domain_test.go:11:28: AT001: missing CheckDestroy
```

That file is not touched here. Two stacked causes, neither of them in this change:

- It is a data source test (`TestAccAliCloudImsDefaultDomainDataSource`), and AT001 is meant to
  be suppressed for data sources — `scripts/run-tflint.sh` passes
  `-AT001.ignored-filename-prefixes data_source_alicloud_`. Under the per-service subpackage
  layout the basename is `data_source_default_domain_test.go`, which no longer carries the
  `alicloud_` infix, so the prefix no longer matches. Adding `data_source_` to that flag
  restores the original intent.
- The lint job's checkout sets no `fetch-depth`, so it defaults to `1`. `get_changed_go_files`
  then runs `git diff origin/${GITHUB_BASE_REF}...HEAD`, which cannot resolve a merge base in a
  shallow clone; it returns nothing and the script takes its fallback path, reporting every
  issue in the repository. The changed-files filter therefore never engages in CI, so any
  pre-existing issue anywhere fails every unrelated PR. `fetch-depth: 0` on that step fixes it.

Both are one-liners and belong in a separate CI change rather than in this bugfix; happy to
send them.

**Previously red, now green** — `Consistency`, `Content` and `TestingCoverageRate` were all
failing on this branch before they ever read the diff:

```
go: go.mod requires go >= 1.25.8 (running go 1.25.0; GOTOOLCHAIN=local)
```

`go.mod` had been bumped to `go 1.25.8` while `.go-version` still pinned `1.25.0`, breaking
every workflow that resolves its toolchain with `go-version-file: .go-version` plus
`GOTOOLCHAIN=local`. Fixed separately in #10256; this branch has been rebased onto it and the
three checks now pass.
