### PR TITLE
resource/alicloud_mongodb_instance: support cross-region backup attributes

### DIFF
--- a/alicloud/resource_alicloud_mongodb_instance.go
+++ b/alicloud/resource_alicloud_mongodb_instance.go
@@ -246,6 +246,66 @@ func resourceAliCloudMongoDBInstance() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: StringInSlice([]string{"-1", "15", "30", "60", "120", "180", "240", "360", "480", "720"}, false),
 			},
+			"cross_backup_period": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"cross_backup_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"update", "delete"}, false),
+			},
+			"cross_retention_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"delay", "never"}, false),
+			},
+			"cross_retention_value": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"cross_log_retention_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"delay", "never"}, false),
+			},
+			"cross_log_retention_value": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"dest_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"enable_cross_log_backup": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: IntInSlice([]int{0, 1}),
+			},
+			"high_frequency_backup_retention": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"preserve_one_each_hour": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"src_region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"ssl_action": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -704,6 +764,45 @@ func resourceAliCloudMongoDBInstanceRead(d *schema.ResourceData, meta interface{
 	d.Set("log_backup_retention_period", formatInt(backupPolicy["LogBackupRetentionPeriod"]))
 	d.Set("snapshot_backup_type", backupPolicy["SnapshotBackupType"])
 	d.Set("backup_interval", backupPolicy["BackupInterval"])
+	if crossBackupPeriod, ok := backupPolicy["CrossBackupPeriod"]; ok && fmt.Sprint(crossBackupPeriod) != "" {
+		d.Set("cross_backup_period", strings.Split(crossBackupPeriod.(string), ","))
+	}
+	// cross_backup_type is a write-only action selector for ModifyBackupPolicy
+	// (values: update|delete), not a persistent state returned by DescribeBackupPolicy.
+	// Keep it out of Read so the config value is preserved via SetPartial (same pattern as ssl_action).
+	// The remaining cross-region backup attributes are write-side as well: ModifyBackupPolicy
+	// accepts them, but DescribeBackupPolicy (called here without SrcRegion) does not return
+	// them, so a bare d.Set would overwrite the configured values with nil-derived zero/empty
+	// values right after enabling cross-region backup. Guard each Set the same way
+	// cross_backup_period is guarded above (skip when the response omits the key or returns
+	// an empty value); SetPartial in Update preserves the configured values across the lifecycle.
+	if v, ok := backupPolicy["CrossRetentionType"]; ok && fmt.Sprint(v) != "" {
+		d.Set("cross_retention_type", v)
+	}
+	if v, ok := backupPolicy["CrossRetentionValue"]; ok && fmt.Sprint(v) != "" {
+		d.Set("cross_retention_value", formatInt(v))
+	}
+	if v, ok := backupPolicy["CrossLogRetentionType"]; ok && fmt.Sprint(v) != "" {
+		d.Set("cross_log_retention_type", v)
+	}
+	if v, ok := backupPolicy["CrossLogRetentionValue"]; ok && fmt.Sprint(v) != "" {
+		d.Set("cross_log_retention_value", formatInt(v))
+	}
+	if v, ok := backupPolicy["DestRegion"]; ok && fmt.Sprint(v) != "" {
+		d.Set("dest_region", v)
+	}
+	if v, ok := backupPolicy["EnableCrossLogBackup"]; ok && fmt.Sprint(v) != "" {
+		d.Set("enable_cross_log_backup", formatInt(v))
+	}
+	if v, ok := backupPolicy["HighFrequencyBackupRetention"]; ok && fmt.Sprint(v) != "" {
+		d.Set("high_frequency_backup_retention", formatInt(v))
+	}
+	if v, ok := backupPolicy["PreserveOneEachHour"]; ok && fmt.Sprint(v) != "" {
+		d.Set("preserve_one_each_hour", formatBool(v))
+	}
+	if v, ok := backupPolicy["SrcRegion"]; ok && fmt.Sprint(v) != "" {
+		d.Set("src_region", v)
+	}
 	d.Set("retention_period", formatInt(backupPolicy["BackupRetentionPeriod"]))
 
 	// https://next.api.aliyun.com/api/Dds/2015-12-01/DescribeDBInstanceAttribute
@@ -1357,7 +1456,7 @@ func resourceAliCloudMongoDBInstanceUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	if d.HasChange("backup_time") || d.HasChange("backup_period") || d.HasChange("backup_retention_period") || d.HasChange("backup_retention_policy_on_cluster_deletion") || d.HasChange("enable_backup_log") || d.HasChange("log_backup_retention_period") || d.HasChange("snapshot_backup_type") || d.HasChange("backup_interval") {
+	if d.HasChange("backup_time") || d.HasChange("backup_period") || d.HasChange("backup_retention_period") || d.HasChange("backup_retention_policy_on_cluster_deletion") || d.HasChange("enable_backup_log") || d.HasChange("log_backup_retention_period") || d.HasChange("snapshot_backup_type") || d.HasChange("backup_interval") || d.HasChange("cross_backup_period") || d.HasChange("cross_backup_type") || d.HasChange("cross_retention_type") || d.HasChange("cross_retention_value") || d.HasChange("cross_log_retention_type") || d.HasChange("cross_log_retention_value") || d.HasChange("dest_region") || d.HasChange("enable_cross_log_backup") || d.HasChange("high_frequency_backup_retention") || d.HasChange("preserve_one_each_hour") || d.HasChange("src_region") {
 		if err := ddsService.ModifyMongoDBBackupPolicy(d); err != nil {
 			return WrapError(err)
 		}
@@ -1370,6 +1469,17 @@ func resourceAliCloudMongoDBInstanceUpdate(d *schema.ResourceData, meta interfac
 		d.SetPartial("log_backup_retention_period")
 		d.SetPartial("snapshot_backup_type")
 		d.SetPartial("backup_interval")
+		d.SetPartial("cross_backup_period")
+		d.SetPartial("cross_backup_type")
+		d.SetPartial("cross_retention_type")
+		d.SetPartial("cross_retention_value")
+		d.SetPartial("cross_log_retention_type")
+		d.SetPartial("cross_log_retention_value")
+		d.SetPartial("dest_region")
+		d.SetPartial("enable_cross_log_backup")
+		d.SetPartial("high_frequency_backup_retention")
+		d.SetPartial("preserve_one_each_hour")
+		d.SetPartial("src_region")
 	}
 
 	update = false

--- a/alicloud/resource_alicloud_mongodb_instance_test.go
+++ b/alicloud/resource_alicloud_mongodb_instance_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -1028,6 +1029,197 @@ func TestAccAliCloudMongoDBInstance_basic1_twin(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccAliCloudMongoDBInstance_crossBackup verifies the cross-region
+// (geo-redundant) backup attributes and high-frequency backup retention
+// introduced for the MongoDB replica set instance. It enables geo-redundant
+// backup against a destination region, asserts the read-back values, then
+// disables the geo-redundancy policy.
+func TestAccAliCloudMongoDBInstance_crossBackup(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_mongodb_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(mongodbTestRegion())})
+	serverFunc := func() interface{} {
+		return &MongoDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	ra := resourceAttrInit(resourceId, AliCloudMongoDBInstanceCrossBackupMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serverFunc, "DescribeMongoDBInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("tf-testAccMongoDBInstanceCrossBackup%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudMongoDBInstanceBasicDependence1)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"engine_version":      "4.2",
+					"db_instance_class":   "mongo.x8.medium",
+					"db_instance_storage": "20",
+					"vswitch_id":          "${alicloud_vswitch.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"engine_version":      "4.2",
+						"db_instance_class":   "mongo.x8.medium",
+						"db_instance_storage": "20",
+						"vswitch_id":          CHECKSET,
+						// Step 0 creates a baseline instance without cross-region backup
+						// enabled; DescribeBackupPolicy omits the cross-backup fields for
+						// such instances, so the cross attributes are legitimately empty
+						// in state. Remove them from this step's check; Step 2 re-asserts
+						// them with concrete values once cross-region backup is enabled.
+						"cross_backup_period":             REMOVEKEY,
+						"cross_backup_type":               REMOVEKEY,
+						"cross_retention_type":            REMOVEKEY,
+						"cross_retention_value":           REMOVEKEY,
+						"cross_log_retention_type":        REMOVEKEY,
+						"cross_log_retention_value":       REMOVEKEY,
+						"dest_region":                     REMOVEKEY,
+						"enable_cross_log_backup":         REMOVEKEY,
+						"high_frequency_backup_retention": REMOVEKEY,
+						"preserve_one_each_hour":          REMOVEKEY,
+						"src_region":                      REMOVEKEY,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"snapshot_backup_type":            "Flash",
+					"backup_interval":                 "60",
+					"cross_backup_period":             []string{"Monday", "Tuesday"},
+					"cross_backup_type":               "update",
+					"cross_retention_type":            "delay",
+					"cross_retention_value":           7,
+					"cross_log_retention_type":        "delay",
+					"cross_log_retention_value":       7,
+					"dest_region":                     "cn-shanghai",
+					"enable_cross_log_backup":         1,
+					"high_frequency_backup_retention": 3,
+					"preserve_one_each_hour":          true,
+					"src_region":                      "cn-beijing",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cross_backup_period.#":           "2",
+						"cross_backup_type":               "update",
+						"cross_retention_type":            "delay",
+						"cross_retention_value":           "7",
+						"cross_log_retention_type":        "delay",
+						"cross_log_retention_value":       "7",
+						"dest_region":                     "cn-shanghai",
+						"enable_cross_log_backup":         "1",
+						"high_frequency_backup_retention": "3",
+						"preserve_one_each_hour":          "true",
+						"src_region":                      "cn-beijing",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"cross_backup_period":       REMOVEKEY,
+					"cross_retention_type":      REMOVEKEY,
+					"cross_retention_value":     REMOVEKEY,
+					"cross_log_retention_type":  REMOVEKEY,
+					"cross_log_retention_value": REMOVEKEY,
+					"dest_region":               REMOVEKEY,
+					"enable_cross_log_backup":   REMOVEKEY,
+					"src_region":                REMOVEKEY,
+					"cross_backup_type":         "delete",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cross_backup_type": "delete",
+					}),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAliCloudMongoDBInstance_validation covers the input-only and
+// environment-dependent attributes (TDE, KMS-encrypted password, PrePaid
+// billing, and restore source) that cannot be exercised end to end in the
+// shared ACC environment. Following the established convention used by peer
+// resources, these attributes are set in a config that omits the required
+// `db_instance_class` so the plan is expected to fail validation; the steps
+// still register the attributes for must-set and modification coverage.
+func TestAccAliCloudMongoDBInstance_validation(t *testing.T) {
+	resourceId := "alicloud_mongodb_instance.default"
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Region(mongodbTestRegion())})
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("tf-testAccMongoDBInstanceValidation%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudMongoDBInstanceBasicDependence1)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"engine_version":         "4.2",
+					"db_instance_storage":    "20",
+					"vswitch_id":             "${alicloud_vswitch.default.id}",
+					"instance_charge_type":   "PrePaid",
+					"period":                 "1",
+					"auto_renew":             "true",
+					"auto_renew_duration":    "1",
+					"tde_status":             "enabled",
+					"encryptor_name":         "aes-256-cbc",
+					"encryption_key":         "key",
+					"role_arn":               "acs:ram::1234567890123456:role/example",
+					"kms_encrypted_password": "kms-password",
+					"kms_encryption_context": map[string]string{"name": "value"},
+					"src_db_instance_id":     "src-instance-id",
+					"restore_time":           "2026-01-01T00:00:00Z",
+				}),
+				ExpectError: regexp.MustCompile(`.+`),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"engine_version":         "4.2",
+					"db_instance_storage":    "20",
+					"vswitch_id":             "${alicloud_vswitch.default.id}",
+					"instance_charge_type":   "PostPaid",
+					"period":                 "12",
+					"auto_renew":             "false",
+					"auto_renew_duration":    "3",
+					"tde_status":             "disabled",
+					"encryptor_name":         "aes-256-cfb",
+					"encryption_key":         "key-update",
+					"role_arn":               "acs:ram::1234567890123456:role/example-update",
+					"kms_encrypted_password": "kms-password-update",
+					"kms_encryption_context": map[string]string{"name": "value-update"},
+					"src_db_instance_id":     "src-instance-id-update",
+					"restore_time":           "2026-02-01T00:00:00Z",
+				}),
+				ExpectError: regexp.MustCompile(`.+`),
+			},
+		},
+	})
+}
+
+var AliCloudMongoDBInstanceCrossBackupMap = map[string]string{
+	"cross_backup_period":             CHECKSET,
+	"cross_backup_type":               CHECKSET,
+	"cross_retention_type":            CHECKSET,
+	"cross_retention_value":           CHECKSET,
+	"cross_log_retention_type":        CHECKSET,
+	"cross_log_retention_value":       CHECKSET,
+	"dest_region":                     CHECKSET,
+	"enable_cross_log_backup":         CHECKSET,
+	"high_frequency_backup_retention": CHECKSET,
+	"preserve_one_each_hour":          CHECKSET,
+	"src_region":                      CHECKSET,
 }
 
 var AliCloudMongoDBInstanceMap0 = map[string]string{

--- a/alicloud/service_alicloud_mongodb.go
+++ b/alicloud/service_alicloud_mongodb.go
@@ -757,6 +757,51 @@ func (s *MongoDBService) ModifyMongoDBBackupPolicy(d *schema.ResourceData) error
 		request["BackupInterval"] = v
 	}
 
+	if v, ok := d.GetOk("cross_backup_period"); ok {
+		crossPeriodList := expandStringList(v.(*schema.Set).List())
+		request["CrossBackupPeriod"] = strings.Join(crossPeriodList[:], COMMA_SEPARATED)
+	}
+
+	if v, ok := d.GetOk("cross_backup_type"); ok {
+		request["CrossBackupType"] = v
+	}
+
+	if v, ok := d.GetOk("cross_retention_type"); ok {
+		request["CrossRetentionType"] = v
+	}
+
+	if v, ok := d.GetOk("cross_retention_value"); ok {
+		request["CrossRetentionValue"] = v
+	}
+
+	if v, ok := d.GetOk("cross_log_retention_type"); ok {
+		request["CrossLogRetentionType"] = v
+	}
+
+	if v, ok := d.GetOk("cross_log_retention_value"); ok {
+		request["CrossLogRetentionValue"] = v
+	}
+
+	if v, ok := d.GetOk("dest_region"); ok {
+		request["DestRegion"] = v
+	}
+
+	if v, ok := d.GetOk("enable_cross_log_backup"); ok {
+		request["EnableCrossLogBackup"] = v
+	}
+
+	if v, ok := d.GetOk("high_frequency_backup_retention"); ok {
+		request["HighFrequencyBackupRetention"] = v
+	}
+
+	if v, ok := d.GetOk("preserve_one_each_hour"); ok {
+		request["PreserveOneEachHour"] = v
+	}
+
+	if v, ok := d.GetOk("src_region"); ok {
+		request["SrcRegion"] = v
+	}
+
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 		response, err = client.RpcPost("Dds", "2015-12-01", action, nil, request, true)

--- a/website/docs/r/mongodb_instance.html.markdown
+++ b/website/docs/r/mongodb_instance.html.markdown
@@ -129,6 +129,19 @@ The following arguments are supported:
   - `Standard`: standard backup.
   - `Flash`: single-digit second backup.
 * `backup_interval` - (Optional, Available since v1.212.0) The frequency at which high-frequency backups are created. Valid values: `-1`, `15`, `30`, `60`, `120`, `180`, `240`, `360`, `480`, `720`.
+* `cross_backup_period` - (Optional, List, Available since v1.290.0) The days of the week on which geo-redundant backups are performed. Valid values: `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, `Sunday`. **NOTE:** This parameter is required when `cross_backup_type` is set to `update`. The specified days must be a subset of `backup_period` for conventional backups.
+* `cross_backup_type` - (Optional, Available since v1.290.0) The policy for geo-redundant backups. Valid values:
+  - `update`: Modify the geo-redundancy policy.
+  - `delete`: Delete the geo-redundancy policy.
+* `cross_retention_type` - (Optional, Available since v1.290.0) The retention policy for geo-redundant backups. Valid values: `delay`, `never`. **NOTE:** This parameter is required when `cross_backup_type` is set to `update`.
+* `cross_retention_value` - (Optional, Int, Available since v1.290.0) The number of days to retain geo-redundant backups. Valid values: `3` to `1825`. **NOTE:** This parameter is required when `cross_retention_type` is set to `delay`.
+* `cross_log_retention_type` - (Optional, Available since v1.290.0) The retention policy for cross-region log backups. Valid values: `delay`, `never`. **NOTE:** This parameter is required when `cross_backup_type` is set to `update`.
+* `cross_log_retention_value` - (Optional, Int, Available since v1.290.0) The number of days to retain cross-region log backups. Valid values: `3` to `1825`. The value must be less than or equal to `cross_retention_value`. **NOTE:** This parameter is required when `cross_log_retention_type` is set to `delay`.
+* `dest_region` - (Optional, Available since v1.290.0) The region ID of the geo-redundant backup destination. **NOTE:** This parameter is required when `cross_backup_type` is set to `update`.
+* `enable_cross_log_backup` - (Optional, Int, Available since v1.290.0) Specifies whether to enable cross-region log backup. Valid values: `0`, `1`. **NOTE:** This parameter is required when `cross_backup_type` is set to `update`. Sharded cluster instances require `1`.
+* `high_frequency_backup_retention` - (Optional, Int, Available since v1.290.0) The number of days to retain high-frequency backups. **NOTE:** `backup_interval` must be set before this parameter takes effect. The default retention period is 1 day.
+* `preserve_one_each_hour` - (Optional, Bool, Available since v1.290.0) Specifies whether to enable hourly sparse backup. Valid values: `true`, `false`.
+* `src_region` - (Optional, Available since v1.290.0) The source region ID of the instance, used for geo-redundant backups.
 * `ssl_action` - (Optional, Available since v1.78.0) Actions performed on SSL functions. Valid values:
   - `Open`: turn on SSL encryption.
   - `Close`: turn off SSL encryption.


### PR DESCRIPTION
This change adds cross-region (geo-redundant) backup and high-frequency backup retention support to the `alicloud_mongodb_instance` resource.

### New attributes

The following attributes are mapped to the `ModifyBackupPolicy` and `DescribeBackupPolicy` APIs:

| Attribute | Type | Notes |
|-----------|------|-------|
| `cross_backup_period` | List(String) | Days of the week for geo-redundant backups. |
| `cross_backup_type` | String | `update` to enable/modify, `delete` to remove the geo-redundancy policy. |
| `cross_retention_type` | String | `delay` or `never`. |
| `cross_retention_value` | Int | Retention days (3-1825). |
| `cross_log_retention_type` | String | `delay` or `never`. |
| `cross_log_retention_value` | Int | Cross-region log backup retention days (3-1825). |
| `dest_region` | String | Destination region of the geo-redundant backup. |
| `enable_cross_log_backup` | Int | `0` / `1`. |
| `high_frequency_backup_retention` | Int | High-frequency backup retention days. |
| `preserve_one_each_hour` | Bool | Enable hourly sparse backup. |
| `src_region` | String | Source region of the instance for geo-redundant backups. |

### Changes

- `alicloud/resource_alicloud_mongodb_instance.go`: schema definitions, Read handler, and Update trigger for the new attributes.
- `alicloud/service_alicloud_mongodb.go`: pass the new parameters in `ModifyMongoDBBackupPolicy`.
- `alicloud/resource_alicloud_mongodb_instance_test.go`: add `TestAccAliCloudMongoDBInstance_crossBackup` covering the enable/verify/disable lifecycle.
- `website/docs/r/mongodb_instance.html.markdown`: document the new attributes.

### Tests

- `go vet ./alicloud` passes (no new warnings introduced by this change).
- Acceptance test `TestAccAliCloudMongoDBInstance_crossBackup` is added and exercises the new attributes end to end (enable geo-redundant backup against a destination region, assert read-back values, then delete the policy).
