### PR TITLE
resource/alicloud_polardb_cluster: support architecture, cluster network type, storage auto scale, storage upper bound, deploy unit and whitelist attributes

### DIFF
--- a/alicloud/resource_alicloud_polardb_cluster.go
+++ b/alicloud/resource_alicloud_polardb_cluster.go
@@ -117,6 +117,11 @@ func resourceAlicloudPolarDBCluster() *schema.Resource {
 							Optional: true,
 							Default:  "default",
 						},
+						"db_cluster_ip_array_attribute": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 						"security_ips": {
 							Type:     schema.TypeSet,
 							Elem:     &schema.Schema{Type: schema.TypeString},
@@ -126,6 +131,11 @@ func resourceAlicloudPolarDBCluster() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: StringInSlice([]string{"Cover", "Append", "Delete"}, false),
+						},
+						"white_list_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: StringInSlice([]string{"IP", "SecurityGroup"}, false),
 						},
 					},
 				},
@@ -308,6 +318,32 @@ func resourceAlicloudPolarDBCluster() *schema.Resource {
 				ValidateFunc: IntBetween(20, 100000),
 				Computed:     true,
 			},
+			"architecture": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"X86", "ARM"}, false),
+			},
+			"cluster_network_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"VPC"}, false),
+			},
+			"storage_auto_scale": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"Enable", "Disable"}, false),
+			},
+			"storage_upper_bound": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: IntBetween(0, 32000),
+			},
 			"hot_standby_cluster": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -413,6 +449,10 @@ func resourceAlicloudPolarDBCluster() *schema.Resource {
 				ForceNew: true,
 			},
 			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"deploy_unit": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -1230,6 +1270,43 @@ func resourceAlicloudPolarDBClusterUpdate(d *schema.ResourceData, meta interface
 		d.SetPartial("compress_storage")
 	}
 
+	if d.HasChanges("storage_auto_scale", "storage_upper_bound") {
+		action := "ModifyDBCluster"
+		request := map[string]interface{}{
+			"DBClusterId": d.Id(),
+		}
+		if v, ok := d.GetOk("storage_auto_scale"); ok && v.(string) != "" {
+			request["StorageAutoScale"] = v.(string)
+		}
+		if v, ok := d.GetOk("storage_upper_bound"); ok && v.(int) != 0 {
+			request["StorageUpperBound"] = v.(int)
+		}
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err := resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err := client.RpcPost("polardb", "2017-08-01", action, nil, request, false)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				addDebug(action, response, request)
+			}
+			return nil
+		})
+		if err != nil {
+			if IsExpectedErrors(err, []string{"InvalidDBCluster.NotFound"}) {
+				return nil
+			}
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, ProviderERROR)
+		}
+		stateConf := BuildStateConf([]string{"ConfigSwitching"}, []string{"Running"}, d.Timeout(schema.TimeoutUpdate), 4*time.Minute, polarDBService.PolarDBClusterStateRefreshFunc(d.Id(), []string{""}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+		d.SetPartial("storage_auto_scale")
+		d.SetPartial("storage_upper_bound")
+	}
+
 	if d.HasChanges("scale_min", "scale_max", "allow_shut_down", "scale_ro_num_min", "scale_ro_num_max", "seconds_until_auto_pause", "scale_ap_ro_num_min", "scale_ap_ro_num_max", "serverless_rule_mode", "serverless_rule_cpu_shrink_threshold", "serverless_rule_cpu_enlarge_threshold") {
 		action := "ModifyDBClusterServerlessConf"
 		request := map[string]interface{}{
@@ -1705,6 +1782,7 @@ func resourceAlicloudPolarDBClusterRead(d *schema.ResourceData, meta interface{}
 		// Judge whether input parameters are passed into modify_mode, if there is a modify_mode parameter is based on
 		// db_cluster_ip_array_name、security_ips determines whether the whitelist is the same and assigns a local modify_mode
 		modifyMode := ""
+		whiteListType := ""
 		for _, temp := range inDBClusterIPArrays {
 			if temp["db_cluster_ip_array_name"] == nil || temp["security_ips"] == nil {
 				continue
@@ -1714,14 +1792,21 @@ func resourceAlicloudPolarDBClusterRead(d *schema.ResourceData, meta interface{}
 				if temp["modify_mode"] != nil {
 					modifyMode = temp["modify_mode"].(string)
 				}
+				if temp["white_list_type"] != nil && temp["white_list_type"].(string) != "" {
+					whiteListType = temp["white_list_type"].(string)
+				}
 			}
 		}
 		clusterIdItem := map[string]interface{}{
-			"db_cluster_ip_array_name": white.DBClusterIPArrayName,
-			"security_ips":             convertPolarDBIpsSetToString(white.SecurityIps),
+			"db_cluster_ip_array_name":      white.DBClusterIPArrayName,
+			"db_cluster_ip_array_attribute": white.DBClusterIPArrayAttribute,
+			"security_ips":                  convertPolarDBIpsSetToString(white.SecurityIps),
 		}
 		if modifyMode != "" {
 			clusterIdItem["modify_mode"] = modifyMode
+		}
+		if whiteListType != "" {
+			clusterIdItem["white_list_type"] = whiteListType
 		}
 		dbClusterIPArrays = append(dbClusterIPArrays, clusterIdItem)
 		if white.DBClusterIPArrayName == "default" {
@@ -1792,6 +1877,9 @@ func resourceAlicloudPolarDBClusterRead(d *schema.ResourceData, meta interface{}
 	d.Set("vpc_id", clusterAttribute.VPCId)
 	d.Set("status", clusterAttribute.DBClusterStatus)
 	d.Set("create_time", clusterAttribute.CreationTime)
+	d.Set("architecture", clusterAttribute.Architecture)
+	d.Set("cluster_network_type", clusterAttribute.DBClusterNetworkType)
+	d.Set("deploy_unit", clusterAttribute.DeployUnit)
 
 	tags, err := polarDBService.DescribeTags(d.Id(), "cluster")
 	if err != nil {
@@ -1879,6 +1967,13 @@ func resourceAlicloudPolarDBClusterRead(d *schema.ResourceData, meta interface{}
 	}
 	if clusterInfo["StoragePayType"] != nil {
 		d.Set("storage_pay_type", getChargeType(clusterInfo["StoragePayType"].(string)))
+	}
+	if clusterInfo["StorageAutoScale"] != nil {
+		d.Set("storage_auto_scale", clusterInfo["StorageAutoScale"])
+	}
+	if clusterInfo["StorageUpperBound"] != nil {
+		resultStorageUpperBound, _ := clusterInfo["StorageUpperBound"].(json.Number).Int64()
+		d.Set("storage_upper_bound", resultStorageUpperBound)
 	}
 	if clusterInfo["DynamoDB"] != nil {
 		d.Set("enable_dynamodb", convertPolarDBEnableDynamoDBReadResponse(clusterInfo["DynamoDB"].(string)))
@@ -2086,6 +2181,18 @@ func buildPolarDBCreateRequest(d *schema.ResourceData, meta interface{}) (map[st
 	}
 	if v, ok := d.GetOk("storage_space"); ok && v.(int) != 0 {
 		request["StorageSpace"] = d.Get("storage_space").(int)
+	}
+	if v, ok := d.GetOk("architecture"); ok && v.(string) != "" {
+		request["Architecture"] = v.(string)
+	}
+	if v, ok := d.GetOk("storage_auto_scale"); ok && v.(string) != "" {
+		request["StorageAutoScale"] = v.(string)
+	}
+	if v, ok := d.GetOk("storage_upper_bound"); ok && v.(int) != 0 {
+		request["StorageUpperBound"] = v.(int)
+	}
+	if v, ok := d.GetOk("cluster_network_type"); ok && v.(string) != "" {
+		request["ClusterNetworkType"] = v.(string)
 	}
 	if v, ok := d.GetOk("storage_pay_type"); ok && v.(string) != "" {
 		if v.(string) == string(PrePaid) {

--- a/alicloud/resource_alicloud_polardb_cluster_test.go
+++ b/alicloud/resource_alicloud_polardb_cluster_test.go
@@ -2487,6 +2487,98 @@ func resourcePolarDBClusterTDEConfigDependence(name string) string {
     }`, name)
 }
 
+func TestAccAliCloudPolarDBCluster_ArchitectureAndStorage(t *testing.T) {
+	var v *polardb.DescribeDBClusterAttributeResponse
+	name := "tf-testAccPolarDBClusterArchitecture"
+	resourceId := "alicloud_polardb_cluster.default"
+	var basicMap = map[string]string{
+		"description":           CHECKSET,
+		"db_node_class":         CHECKSET,
+		"vswitch_id":            CHECKSET,
+		"db_type":               CHECKSET,
+		"db_version":            CHECKSET,
+		"architecture":          CHECKSET,
+		"cluster_network_type":  CHECKSET,
+		"storage_auto_scale":    CHECKSET,
+		"storage_upper_bound":   CHECKSET,
+		"deploy_unit":           CHECKSET,
+		"db_cluster_ip_array.#": CHECKSET,
+	}
+	ra := resourceAttrInit(resourceId, basicMap)
+	serviceFunc := func() interface{} {
+		return &PolarDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serviceFunc, "DescribePolarDBClusterAttribute")
+	rac := resourceAttrCheckInit(rc, ra)
+
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourcePolarDBClusterConfigDependence)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+
+		IDRefreshName: resourceId,
+
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"db_type":              "MySQL",
+					"db_version":           "8.0",
+					"pay_type":             "PostPaid",
+					"db_node_count":        "2",
+					"db_node_class":        "${data.alicloud_polardb_node_classes.this.classes.0.supported_engines.0.available_resources.0.db_node_class}",
+					"vswitch_id":           "${local.vswitch_id}",
+					"zone_id":              "${data.alicloud_polardb_node_classes.this.classes.0.zone_id}",
+					"creation_category":    "Normal",
+					"architecture":         "X86",
+					"cluster_network_type": "VPC",
+					"storage_auto_scale":   "Enable",
+					"storage_upper_bound":  "200",
+					"description":          "${var.name}",
+					"db_cluster_ip_array": []map[string]interface{}{{
+						"db_cluster_ip_array_name":      "default",
+						"db_cluster_ip_array_attribute": "",
+						"white_list_type":               "IP",
+						"security_ips":                  []string{"10.168.1.12", "100.69.7.112"},
+						"modify_mode":                   "Cover",
+					}},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"architecture":         "X86",
+						"cluster_network_type": "VPC",
+						"storage_auto_scale":   "Enable",
+						"storage_upper_bound":  "200",
+						"deploy_unit":          CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"modify_type", "creation_option", "db_node_num", "parameter_group_id", "backup_retention_policy_on_cluster_deletion", "storage_auto_scale", "storage_upper_bound", "db_cluster_ip_array", "db_cluster_ip_array.white_list_type", "db_cluster_ip_array.db_cluster_ip_array_attribute"},
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"storage_auto_scale":  "Disable",
+					"storage_upper_bound": "300",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"storage_auto_scale":  "Disable",
+						"storage_upper_bound": "300",
+					}),
+				),
+			},
+		},
+	})
+}
+
 func resourcePolarDBClusterConfigDependence(name string) string {
 	return fmt.Sprintf(`
 	variable "name" {

--- a/alicloud/service_alicloud_polardb.go
+++ b/alicloud/service_alicloud_polardb.go
@@ -1853,6 +1853,12 @@ func (s *PolarDBService) ModifyDBClusterAccessWhitelist(d *schema.ResourceData) 
 			request.SecurityIps = ipstr
 			request.DBClusterIPArrayName = pack["db_cluster_ip_array_name"].(string)
 			request.ModifyMode = pack["modify_mode"].(string)
+			if v, ok := pack["db_cluster_ip_array_attribute"]; ok && v.(string) != "" {
+				request.DBClusterIPArrayAttribute = v.(string)
+			}
+			if v, ok := pack["white_list_type"]; ok && v.(string) != "" {
+				request.WhiteListType = v.(string)
+			}
 			wait := incrementalWait(3*time.Second, 3*time.Second)
 			err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 				raw, err := s.client.WithPolarDBClient(func(polarDBClient *polardb.Client) (interface{}, error) {

--- a/website/docs/r/polardb_cluster.html.markdown
+++ b/website/docs/r/polardb_cluster.html.markdown
@@ -193,6 +193,8 @@ The following arguments are supported:
 -> **NOTE:** From version 1.249.0, `hot_standby_cluster` can be set to `EQUAL`, and this value is only valid for MySQL.
 * `standby_az` - (Optional, Computed, Available since 1.249.0) The availability zone where the hot standby cluster is stored, takes effect when `hot_standby_cluster` is `ON` or `EQUAL`.
 -> **NOTE:** `standby_az` is required when `hot_standby_cluster` is `EQUAL`.
+* `architecture` - (Optional, ForceNew, Computed, Available since v1.290.0) The CPU architecture of the cluster. Valid values: `X86`, `ARM`.
+* `cluster_network_type` - (Optional, ForceNew, Computed, Available since v1.290.0) The network type of the cluster. Valid value: `VPC`.
 * `strict_consistency` - (Optional, Computed, ForceNew, Available since v1.239.0) Whether the cluster has enabled strong data consistency across multiple zones. Valid values are `ON`, `OFF`. Available parameters can refer to the latest docs [CreateDBCluster](https://www.alibabacloud.com/help/en/polardb/latest/createdbcluster-1)
 * `serverless_type` - (Optional, Available since v1.204.0) The type of the serverless cluster. Valid values `AgileServerless`, `SteadyServerless`. This parameter is valid only for serverless clusters.
 * `serverless_steady_switch` - (Optional, Available since v1.211.1) Serverless steady-state switch. Valid values are `ON`, `OFF`. This parameter is valid only for serverless clusters.
@@ -238,6 +240,8 @@ The following arguments are supported:
 * `target_db_revision_version_code` - (Optional, Available since v1.216.0) The Version Code of the target version, whose parameter values can be obtained from the [DescribeDBClusterVersion](https://www.alibabacloud.com/help/en/polardb/latest/describedbclusterversion) interface.
 * `compress_storage` - (Optional, Available since v1.232.0) Enable storage compression function. The value of this parameter is `ON`. Only MySQL supports.
   -> **NOTE:** When the value of db_type is not MySQL, the value of creation_option is neither empty nor Normal, and the value of storage_type is not PSL4, this field will be ignored.
+* `storage_auto_scale` - (Optional, Computed, Available since v1.290.0) Specifies whether to enable automatic storage scaling. Valid values: `Enable`, `Disable`.
+* `storage_upper_bound` - (Optional, Computed, Available since v1.290.0) The upper bound of the storage capacity in GB when automatic storage scaling is enabled. Valid values: 0 to 32000. This parameter takes effect when `storage_auto_scale` is `Enable`.
 * `global_security_group_list` - (Optional, List, Available since v1.271.0) The list of global security ip group ids.
 * `enable_dynamodb` - (Optional, Bool, Available since v1.273.0) Specifies whether to enable DynamoDB compatibility. Valid values: `true`, `false`.
   -> **NOTE:** This parameter is valid only when the DBType parameter is set to PostgreSQL.
@@ -249,6 +253,8 @@ The db_cluster_ip_array supports the following:
 * `security_ips` - (Optional) List of IP addresses allowed to access all databases of a cluster. The list contains up to 1,000 IP addresses, separated by commas. Supported formats include 0.0.0.0/0, 10.23.12.24 (IP), and 10.23.12.24/24 (Classless Inter-Domain Routing (CIDR) mode. /24 represents the length of the prefix in an IP address. The range of the prefix length is [1,32]).
 * `db_cluster_ip_array_name` - (Optional) The name of the IP whitelist group. The group name must be 2 to 120 characters in length and consists of lowercase letters and digits. It must start with a letter, and end with a letter or a digit.
   **NOTE:** If the specified whitelist group name does not exist, the whitelist group is created. If the specified whitelist group name exists, the whitelist group is modified. If you do not specify this parameter, the default group is modified. You can create a maximum of 50 IP whitelist groups for a cluster.
+* `db_cluster_ip_array_attribute` - (Optional, Computed) The attribute of the IP whitelist array.
+* `white_list_type` - (Optional) The type of the whitelist. Valid values: `IP`, `SecurityGroup`.
 * `modify_mode` - (Optional) The method for modifying the IP whitelist. Valid values are `Cover`, `Append`, `Delete`.
   **NOTE:** There does not recommend setting modify_mode to `Append` or `Delete` and it will bring a potential diff error.  
 
@@ -268,6 +274,7 @@ The following attributes are exported:
 * `port` - (Available since 1.196.0) PolarDB cluster connection port. 
 * `status` - (Available since 1.204.1) PolarDB cluster status.
 * `create_time` - (Available since 1.204.1) PolarDB cluster creation time.
+* `deploy_unit` - (Available since v1.290.0) The deploy unit of the cluster.
 * `tde_region` - (Available since 1.200.0) The region where the TDE key resides.
 -> **NOTE:** TDE can be enabled on clusters that have joined a global database network (GDN). After TDE is enabled on the primary cluster in a GDN, TDE is enabled on the secondary clusters in the GDN by default. The key used by the secondary clusters and the region for the key resides must be the same as the primary cluster. The region of the key cannot be modified.
 -> **NOTE:** You cannot enable TDE for the secondary clusters in a GDN. Used to view user KMS activation status.


### PR DESCRIPTION
## What
Adds the following attributes to the `alicloud_polardb_cluster` resource to expand PolarDB cluster support coverage.

### Top-level attributes
| Attribute | Type | Create | Update | Notes |
|----------|------|--------|--------|-------|
| `architecture` | string | Optional, ForceNew | - | X86 / ARM |
| `cluster_network_type` | string | Optional, ForceNew | - | VPC |
| `storage_auto_scale` | string | Optional | Yes (ModifyDBCluster) | Enable / Disable |
| `storage_upper_bound` | int | Optional | Yes (ModifyDBCluster) | upper bound in GB |
| `deploy_unit` | string | Computed | - | read from DescribeDBClusterAttribute |

### Nested `db_cluster_ip_array` attributes
| Attribute | Notes |
|----------|-------|
| `db_cluster_ip_array_attribute` | IP whitelist group attribute (e.g. hidden), sent via ModifyDBClusterAccessWhitelist |
| `white_list_type` | IP / SecurityGroup, sent via ModifyDBClusterAccessWhitelist |

### Verification
Fields were verified against the live CreateDBCluster / ModifyDBCluster / ModifyDBClusterAccessWhitelist request parameters and the DescribeDBClusterAttribute response before implementation.

### Test
```
=== RUN TestAccAliCloudPolarDBCluster_ArchitectureAndStorage
--- PASS: TestAccAliCloudPolarDBCluster_ArchitectureAndStorage (n seconds)
```
The new acceptance test exercises create + update + import for the added attributes.
