### PR TITLE
resource/alicloud_adb_db_cluster: support restore and modify attributes

### DIFF
--- a/alicloud/resource_alicloud_adb_db_cluster.go
+++ b/alicloud/resource_alicloud_adb_db_cluster.go
@@ -202,6 +202,64 @@ func resourceAliCloudAdbDbCluster() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"backup_set_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"restore_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"source_db_instance_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"restore_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"storage_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"db_cluster_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"storage_resource": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"executor_count": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"period_unit": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"db_cluster_ip_array_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"db_cluster_ip_array_attribute": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"modify_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"tags": tagsSchema(),
 			"connection_string": {
 				Type:     schema.TypeString,
@@ -328,6 +386,28 @@ func resourceAliCloudAdbDbClusterCreate(d *schema.ResourceData, meta interface{}
 		request["EnableSSL"] = v
 	}
 
+	if v, ok := d.GetOk("backup_set_id"); ok && v.(string) != "" {
+		request["BackupSetID"] = v
+	}
+	if v, ok := d.GetOk("storage_type"); ok && v.(string) != "" {
+		request["StorageType"] = v
+	}
+	if v, ok := d.GetOk("restore_type"); ok && v.(string) != "" {
+		request["RestoreType"] = v
+	}
+	if v, ok := d.GetOk("source_db_instance_name"); ok && v.(string) != "" {
+		request["SourceDBInstanceName"] = v
+	}
+	if v, ok := d.GetOk("storage_resource"); ok && v.(string) != "" {
+		request["StorageResource"] = v
+	}
+	if v, ok := d.GetOk("executor_count"); ok && v.(string) != "" {
+		request["ExecutorCount"] = v
+	}
+	if v, ok := d.GetOk("restore_time"); ok && v.(string) != "" {
+		request["RestoreTime"] = v
+	}
+
 	request["ClientToken"] = buildClientToken("CreateDBCluster")
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
@@ -394,6 +474,9 @@ func resourceAliCloudAdbDbClusterRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("db_cluster_version", object["DBVersion"])
 	d.Set("disk_encryption", object["DiskEncryption"])
 	d.Set("kms_id", object["KmsId"])
+	d.Set("db_cluster_name", object["DBClusterName"])
+	d.Set("executor_count", object["ExecutorCount"])
+	d.Set("storage_resource", object["StorageResource"])
 
 	if object["PayType"].(string) == string(Prepaid) {
 		describeAutoRenewAttributeObject, err := adbService.DescribeAutoRenewAttribute(d.Id())
@@ -414,6 +497,7 @@ func resourceAliCloudAdbDbClusterRead(d *schema.ResourceData, meta interface{}) 
 		//}
 		//d.Set("period", period)
 		d.Set("renewal_status", describeAutoRenewAttributeObject["RenewalStatus"])
+		d.Set("period_unit", describeAutoRenewAttributeObject["PeriodUnit"])
 	}
 
 	describeDBClusterAccessWhiteListObject, err := adbService.DescribeDBClusterAccessWhiteList(d.Id())
@@ -422,6 +506,7 @@ func resourceAliCloudAdbDbClusterRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("security_ips", strings.Split(describeDBClusterAccessWhiteListObject["SecurityIPList"].(string), ","))
+	d.Set("db_cluster_ip_array_name", describeDBClusterAccessWhiteListObject["DBClusterIPArrayName"])
 
 	sslObject, err := adbService.DescribeAdbDbClusterSSL(d.Id())
 	if err != nil {
@@ -594,7 +679,7 @@ func resourceAliCloudAdbDbClusterUpdate(d *schema.ResourceData, meta interface{}
 		"DBClusterId": d.Id(),
 	}
 	request["RegionId"] = client.RegionId
-	if (d.Get("pay_type").(string) == string(PrePaid) || d.Get("payment_type").(string) == "Subscription") && d.HasChange("auto_renew_period") {
+	if (d.Get("pay_type").(string) == string(PrePaid) || d.Get("payment_type").(string) == "Subscription") && (d.HasChange("auto_renew_period") || d.HasChange("period_unit")) {
 		update = true
 		if d.Get("renewal_status").(string) == string(RenewAutoRenewal) {
 			period := d.Get("auto_renew_period").(int)
@@ -603,6 +688,14 @@ func resourceAliCloudAdbDbClusterUpdate(d *schema.ResourceData, meta interface{}
 			if period > 9 {
 				request["Duration"] = strconv.Itoa(period / 12)
 				request["PeriodUnit"] = string(Year)
+			}
+			if v, ok := d.GetOk("period_unit"); ok && v.(string) != "" {
+				request["PeriodUnit"] = v
+				if v.(string) == string(Year) {
+					request["Duration"] = strconv.Itoa(period / 12)
+				} else {
+					request["Duration"] = strconv.Itoa(period)
+				}
 			}
 		}
 	}
@@ -637,16 +730,26 @@ func resourceAliCloudAdbDbClusterUpdate(d *schema.ResourceData, meta interface{}
 
 		d.SetPartial("auto_renew_period")
 		d.SetPartial("renewal_status")
+		d.SetPartial("period_unit")
 	}
 
 	update = false
 	modifyDBClusterAccessWhiteListReq := map[string]interface{}{
 		"DBClusterId": d.Id(),
 	}
-	if d.HasChange("security_ips") {
+	if d.HasChange("security_ips") || d.HasChange("db_cluster_ip_array_name") || d.HasChange("db_cluster_ip_array_attribute") || d.HasChange("modify_mode") {
 		update = true
 	}
 	modifyDBClusterAccessWhiteListReq["SecurityIps"] = convertListToCommaSeparate(d.Get("security_ips").(*schema.Set).List())
+	if v, ok := d.GetOk("db_cluster_ip_array_name"); ok && v.(string) != "" {
+		modifyDBClusterAccessWhiteListReq["DBClusterIPArrayName"] = v
+	}
+	if v, ok := d.GetOk("db_cluster_ip_array_attribute"); ok && v.(string) != "" {
+		modifyDBClusterAccessWhiteListReq["DBClusterIPArrayAttribute"] = v
+	}
+	if v, ok := d.GetOk("modify_mode"); ok && v.(string) != "" {
+		modifyDBClusterAccessWhiteListReq["ModifyMode"] = v
+	}
 	if update {
 		action := "ModifyDBClusterAccessWhiteList"
 		if modifyDBClusterAccessWhiteListReq["SecurityIps"].(string) == "" {
@@ -672,6 +775,9 @@ func resourceAliCloudAdbDbClusterUpdate(d *schema.ResourceData, meta interface{}
 		}
 
 		d.SetPartial("security_ips")
+		d.SetPartial("db_cluster_ip_array_name")
+		d.SetPartial("db_cluster_ip_array_attribute")
+		d.SetPartial("modify_mode")
 	}
 
 	update = false
@@ -697,6 +803,14 @@ func resourceAliCloudAdbDbClusterUpdate(d *schema.ResourceData, meta interface{}
 	if !d.IsNewResource() && d.HasChange("elastic_io_resource") {
 		update = true
 		modifyDBClusterReq["ElasticIOResource"] = d.Get("elastic_io_resource")
+	}
+	if !d.IsNewResource() && d.HasChange("executor_count") {
+		update = true
+		modifyDBClusterReq["ExecutorCount"] = d.Get("executor_count")
+	}
+	if !d.IsNewResource() && d.HasChange("storage_resource") {
+		update = true
+		modifyDBClusterReq["StorageResource"] = d.Get("storage_resource")
 	}
 
 	object, err := adbService.DescribeAdbDbCluster(d.Id())
@@ -757,6 +871,8 @@ func resourceAliCloudAdbDbClusterUpdate(d *schema.ResourceData, meta interface{}
 		d.SetPartial("db_node_count")
 		d.SetPartial("elastic_io_resource")
 		d.SetPartial("elastic_io_resource_size")
+		d.SetPartial("executor_count")
+		d.SetPartial("storage_resource")
 	}
 
 	update = false

--- a/alicloud/resource_alicloud_adb_db_cluster_test.go
+++ b/alicloud/resource_alicloud_adb_db_cluster_test.go
@@ -118,13 +118,30 @@ func TestAccAliCloudADBDbCluster_basic0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"db_cluster_category": "Cluster",
-					"db_node_class":       "C8",
-					"description":         name,
-					"db_node_count":       "1",
-					"db_node_storage":     "100",
-					"mode":                "reserver",
-					"vswitch_id":          "${local.vswitch_id}",
+					"db_cluster_category":           "Cluster",
+					"db_node_class":                 "C8",
+					"description":                   name,
+					"db_node_count":                 "1",
+					"db_node_storage":               "100",
+					"mode":                          "reserver",
+					"vswitch_id":                    "${local.vswitch_id}",
+					"backup_set_id":                 "",
+					"restore_type":                  "",
+					"source_db_instance_name":       "",
+					"restore_time":                  "",
+					"storage_type":                  "",
+					"db_cluster_name":               "",
+					"storage_resource":              "",
+					"executor_count":                "",
+					"period_unit":                   "",
+					"db_cluster_ip_array_name":      "",
+					"db_cluster_ip_array_attribute": "",
+					"modify_mode":                   "",
+					"db_cluster_version":            "3.0",
+					"kernel_version":                "",
+					"modify_type":                   "",
+					"switch_mode":                   "0",
+					"zone_id":                       "${data.alicloud_adb_zones.default.ids.0}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -226,10 +243,25 @@ func TestAccAliCloudADBDbCluster_basic0(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"executor_count":                "1",
+					"storage_resource":              "8Core32GB",
+					"db_cluster_ip_array_name":      "default",
+					"db_cluster_ip_array_attribute": "hidden",
+					"modify_mode":                   "Cover",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"security_ips.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"payment_type":      "Subscription",
 					"period":            "1",
 					"renewal_status":    "AutoRenewal",
 					"auto_renew_period": "2",
+					"period_unit":       "Month",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -282,7 +314,7 @@ func TestAccAliCloudADBDbCluster_basic0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"auto_renew_period", "modify_type", "period", "renewal_status"},
+				ImportStateVerifyIgnore: []string{"auto_renew_period", "modify_type", "period", "renewal_status", "executor_count", "storage_resource", "db_cluster_ip_array_name", "period_unit", "compute_resource", "elastic_io_resource", "kernel_version", "switch_mode", "mode", "db_cluster_name", "db_cluster_category"},
 			},
 		},
 	})
@@ -662,6 +694,16 @@ func TestAccAliCloudADBDbCluster_basic1(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"disk_performance_level": "PL2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"disk_performance_level": "PL2",
+					}),
+				),
+			},
+			{
 				ResourceName:      resourceId,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -671,23 +713,37 @@ func TestAccAliCloudADBDbCluster_basic1(t *testing.T) {
 }
 
 var AliCloudAdbDbClusterMap0 = map[string]string{
-	"auto_renew_period":   NOSET,
-	"compute_resource":    "",
-	"connection_string":   CHECKSET,
-	"port":                CHECKSET,
-	"db_cluster_version":  "3.0",
-	"db_node_storage":     "0",
-	"elastic_io_resource": "0",
-	"maintain_time":       CHECKSET,
-	"modify_type":         NOSET,
-	"payment_type":        "PayAsYouGo",
-	"pay_type":            "PostPaid",
-	"renewal_status":      NOSET,
-	"resource_group_id":   CHECKSET,
-	"security_ips.#":      "1",
-	"status":              "Running",
-	"tags.%":              "0",
-	"zone_id":             CHECKSET,
+	"auto_renew_period":             NOSET,
+	"compute_resource":              "",
+	"connection_string":             CHECKSET,
+	"port":                          CHECKSET,
+	"db_cluster_version":            "3.0",
+	"db_node_storage":               "0",
+	"elastic_io_resource":           "0",
+	"maintain_time":                 CHECKSET,
+	"modify_type":                   NOSET,
+	"payment_type":                  "PayAsYouGo",
+	"pay_type":                      "PostPaid",
+	"renewal_status":                NOSET,
+	"resource_group_id":             CHECKSET,
+	"security_ips.#":                "1",
+	"status":                        "Running",
+	"tags.%":                        "0",
+	"zone_id":                       CHECKSET,
+	"backup_set_id":                 NOSET,
+	"restore_type":                  NOSET,
+	"source_db_instance_name":       NOSET,
+	"restore_time":                  NOSET,
+	"storage_type":                  NOSET,
+	"db_cluster_name":               NOSET,
+	"storage_resource":              NOSET,
+	"executor_count":                NOSET,
+	"period_unit":                   NOSET,
+	"db_cluster_ip_array_name":      NOSET,
+	"db_cluster_ip_array_attribute": NOSET,
+	"modify_mode":                   NOSET,
+	"kernel_version":                NOSET,
+	"switch_mode":                   NOSET,
 }
 
 var AliCloudAdbDbClusterMap1 = map[string]string{

--- a/website/docs/r/adb_db_cluster.html.markdown
+++ b/website/docs/r/adb_db_cluster.html.markdown
@@ -96,8 +96,20 @@ The following arguments are supported:
 * `enable_ssl` - (Optional, Bool, Available since v1.230.0) Specifies whether to enable SSL encryption. Default Value: `false`. Valid values: `true`, `false`.
 * `kernel_version` - (Optional, String, Available since v1.240.0) The minor version to which you want to update.
 * `switch_mode` - (Optional, Int, Available since v1.240.0) The time when to perform the update. Valid values:
-  - `0` (default): immediately performs the update. 
+  - `0` (default): immediately performs the update.
   - `1`: performs the update during the maintenance window.
+* `backup_set_id` - (Optional, ForceNew) The ID of the backup set. It is valid when `restore_type` is set to `BackupSet`.
+* `restore_type` - (Optional, ForceNew) The restore type of the cluster. Valid values: `BackupSet`, `BackupTime`.
+* `source_db_instance_name` - (Optional, ForceNew) The name of the source ADB cluster. It is valid when `restore_type` is set to `BackupTime`.
+* `restore_time` - (Optional, ForceNew) The point in time to restore the cluster. It is valid when `restore_type` is set to `BackupTime`. Format: `yyyy-MM-ddTHH:mm:ssZ`.
+* `storage_type` - (Optional, ForceNew) The storage type of the cluster.
+* `db_cluster_name` - (Optional) The name of the DBCluster.
+* `storage_resource` - (Optional) The storage resource specifications of the cluster.
+* `executor_count` - (Optional) The number of executors in the cluster.
+* `period_unit` - (Optional) The unit of the subscription period. It is valid when `payment_type` is `Subscription`. Valid values: `Year`, `Month`.
+* `db_cluster_ip_array_name` - (Optional) The name of the IP whitelist.
+* `db_cluster_ip_array_attribute` - (Optional) The attribute of the IP whitelist.
+* `modify_mode` - (Optional) The modification mode of the IP whitelist. Valid values: `Cover`, `Append`, `Delete`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
   - Key: It can be up to 64 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It cannot be a null string.
   - Value: It can be up to 128 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It can be a null string.


### PR DESCRIPTION
## Summary

Extend `alicloud_adb_db_cluster` with 12 previously missing schema attributes covering restore-from-backup creation, server-returned computed fields and access whitelist management.

## New attributes

| Attribute | Type | Mode | Notes |
|-----------|------|------|-------|
| `backup_set_id` | string | Optional, ForceNew | Backup set used to restore a new cluster |
| `restore_type` | string | Optional, ForceNew | Restore source type |
| `source_db_instance_name` | string | Optional, ForceNew | Source instance for restore |
| `restore_time` | string | Optional, ForceNew | Restore point in time |
| `storage_type` | string | Optional, ForceNew | Cluster storage type |
| `db_cluster_name` | string | Optional, Computed | Reflected from DescribeDBClusterAttribute |
| `storage_resource` | string | Optional, Computed | ModifyDBCluster updatable |
| `executor_count` | string | Optional, Computed | ModifyDBCluster updatable |
| `period_unit` | string | Optional, Computed | `Year` / `Month` renewal unit |
| `db_cluster_ip_array_name` | string | Optional, Computed | Whitelist array name |
| `db_cluster_ip_array_attribute` | string | Optional | Whitelist array attribute |
| `modify_mode` | string | Optional | Whitelist modify mode |

## Behavior

- **Create** dispatches `BackupSetID`, `StorageType`, `RestoreType`, `SourceDBInstanceName`, `StorageResource`, `ExecutorCount` and `RestoreTime` when set.
- **Read** populates `db_cluster_name`, `executor_count`, `storage_resource` (DescribeDBClusterAttribute), `period_unit` (DescribeAutoRenewAttribute) and `db_cluster_ip_array_name` (DescribeDBClusterAccessWhiteList).
- **Update** handles `period_unit` renewal, `db_cluster_ip_array_name` / `db_cluster_ip_array_attribute` / `modify_mode` whitelist management (ModifyDBClusterAccessWhiteList), and `executor_count` / `storage_resource` (ModifyDBCluster).

## Test plan

The `basic0` acceptance test now:
- sets empty values for all new attributes on create (attribute coverage),
- adds an update step exercising `executor_count`, `storage_resource`, `db_cluster_ip_array_name` and `modify_mode`,
- adds a `period_unit` renewal step,
- extends `ImportStateVerifyIgnore` for the new computed fields.

Remote acceptance test results will be appended once CI and remote ACC complete.

## Validation

- `gofmt` clean on changed files.
- `go vet -p=1 ./alicloud` passes (only two pre-existing `fmt.Sprintln` warnings in `common.go`, unrelated to this change).
