### PR TITLE
resource/alicloud_adb_backup_policy: support enable_backup_log and log_backup_retention_period

### DIFF
--- a/alicloud/resource_alicloud_adb_backup_policy.go
+++ b/alicloud/resource_alicloud_adb_backup_policy.go
@@ -46,6 +46,17 @@ func resourceAlicloudAdbBackupPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"enable_backup_log": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Enable", "Disable"}, false),
+			},
+			"log_backup_retention_period": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -73,6 +84,15 @@ func resourceAlicloudAdbBackupPolicyRead(d *schema.ResourceData, meta interface{
 	d.Set("backup_retention_period", object.BackupRetentionPeriod)
 	d.Set("preferred_backup_period", strings.Split(object.PreferredBackupPeriod, ","))
 	d.Set("preferred_backup_time", object.PreferredBackupTime)
+	v := object.EnableBackupLog
+	switch strings.ToLower(v) {
+	case "true", "1", "enable":
+		v = "Enable"
+	case "false", "0", "disable", "":
+		v = "Disable"
+	}
+	d.Set("enable_backup_log", v)
+	d.Set("log_backup_retention_period", object.LogBackupRetentionPeriod)
 
 	return nil
 }
@@ -82,17 +102,19 @@ func resourceAlicloudAdbBackupPolicyUpdate(d *schema.ResourceData, meta interfac
 	client := meta.(*connectivity.AliyunClient)
 	adbService := AdbService{client}
 
-	if d.HasChange("preferred_backup_period") || d.HasChange("preferred_backup_time") {
+	if d.HasChange("preferred_backup_period") || d.HasChange("preferred_backup_time") || d.HasChange("enable_backup_log") || d.HasChange("log_backup_retention_period") {
 		periodList := expandStringList(d.Get("preferred_backup_period").(*schema.Set).List())
 		preferredBackupPeriod := fmt.Sprintf("%s", strings.Join(periodList[:], COMMA_SEPARATED))
 		preferredBackupTime := d.Get("preferred_backup_time").(string)
+		enableBackupLog := d.Get("enable_backup_log").(string)
+		logBackupRetentionPeriod := d.Get("log_backup_retention_period").(int)
 
 		// wait instance running before modifying
 		if err := adbService.WaitForCluster(d.Id(), Running, DefaultTimeoutMedium); err != nil {
 			return WrapError(err)
 		}
 		if err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-			if err := adbService.ModifyAdbBackupPolicy(d.Id(), preferredBackupTime, preferredBackupPeriod); err != nil {
+			if err := adbService.ModifyAdbBackupPolicy(d.Id(), preferredBackupTime, preferredBackupPeriod, enableBackupLog, logBackupRetentionPeriod); err != nil {
 				if IsExpectedErrors(err, OperationDeniedDBStatus) {
 					return resource.RetryableError(err)
 				}

--- a/alicloud/resource_alicloud_adb_backup_policy_test.go
+++ b/alicloud/resource_alicloud_adb_backup_policy_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAlicloudADBBackupPolicy(t *testing.T) {
+func TestAccAliCloudADBBackupPolicy(t *testing.T) {
 	var v *adb.DescribeBackupPolicyResponse
 	resourceId := "alicloud_adb_backup_policy.default"
 	serverFunc := func() interface{} {
@@ -30,15 +30,20 @@ func TestAccAlicloudADBBackupPolicy(t *testing.T) {
 		CheckDestroy:  rac.checkResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
+				// Create the backup policy with log backup enabled and a retention period.
 				Config: testAccConfig(map[string]interface{}{
-					"db_cluster_id":           "${alicloud_adb_db_cluster.default.id}",
-					"preferred_backup_period": []string{"Tuesday", "Wednesday"},
-					"preferred_backup_time":   "10:00Z-11:00Z",
+					"db_cluster_id":               "${alicloud_adb_db_cluster.default.id}",
+					"preferred_backup_period":     []string{"Tuesday", "Wednesday"},
+					"preferred_backup_time":       "10:00Z-11:00Z",
+					"enable_backup_log":           "Enable",
+					"log_backup_retention_period": 7,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"preferred_backup_period.#": "2",
-						"preferred_backup_time":     "10:00Z-11:00Z",
+						"preferred_backup_period.#":   "2",
+						"preferred_backup_time":       "10:00Z-11:00Z",
+						"enable_backup_log":           "Enable",
+						"log_backup_retention_period": "7",
 					}),
 				),
 			},
@@ -46,6 +51,46 @@ func TestAccAlicloudADBBackupPolicy(t *testing.T) {
 				ResourceName:      resourceId,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			{
+				// Update the log backup retention period.
+				Config: testAccConfig(map[string]interface{}{
+					"log_backup_retention_period": 30,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"log_backup_retention_period": "30",
+						"enable_backup_log":           "Enable",
+					}),
+				),
+			},
+			{
+				// Disable log backup. The retention period is only meaningful when
+				// log backup is enabled, so it is removed from the config to let
+				// the server value settle without a perpetual diff.
+				Config: testAccConfig(map[string]interface{}{
+					"enable_backup_log":           "Disable",
+					"log_backup_retention_period": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable_backup_log": "Disable",
+					}),
+				),
+			},
+			{
+				// Re-enable log backup with a retention period to verify the
+				// set/read roundtrip works after a disable.
+				Config: testAccConfig(map[string]interface{}{
+					"enable_backup_log":           "Enable",
+					"log_backup_retention_period": 7,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable_backup_log":           "Enable",
+						"log_backup_retention_period": "7",
+					}),
+				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{

--- a/alicloud/service_alicloud_adb.go
+++ b/alicloud/service_alicloud_adb.go
@@ -487,13 +487,22 @@ func (s *AdbService) DescribeAdbBackupPolicy(id string) (policy *adb.DescribeBac
 	return raw.(*adb.DescribeBackupPolicyResponse), nil
 }
 
-func (s *AdbService) ModifyAdbBackupPolicy(clusterId, backupTime, backupPeriod string) error {
+func (s *AdbService) ModifyAdbBackupPolicy(clusterId, backupTime, backupPeriod, enableBackupLog string, logBackupRetentionPeriod int) error {
 
 	request := adb.CreateModifyBackupPolicyRequest()
 	request.RegionId = s.client.RegionId
 	request.DBClusterId = clusterId
 	request.PreferredBackupPeriod = backupPeriod
 	request.PreferredBackupTime = backupTime
+	// EnableBackupLog and LogBackupRetentionPeriod are only sent when the user
+	// explicitly configures them, so that an unset Optional field does not
+	// overwrite the cluster's existing log backup settings.
+	if enableBackupLog != "" {
+		request.EnableBackupLog = enableBackupLog
+	}
+	if logBackupRetentionPeriod > 0 {
+		request.LogBackupRetentionPeriod = requests.NewInteger(logBackupRetentionPeriod)
+	}
 
 	raw, err := s.client.WithAdbClient(func(adbClient *adb.Client) (interface{}, error) {
 		return adbClient.ModifyBackupPolicy(request)

--- a/website/docs/r/adb_backup_policy.html.markdown
+++ b/website/docs/r/adb_backup_policy.html.markdown
@@ -54,11 +54,14 @@ resource "alicloud_adb_db_cluster" "cluster" {
 }
 
 resource "alicloud_adb_backup_policy" "default" {
-  db_cluster_id           = alicloud_adb_db_cluster.cluster.id
-  preferred_backup_period = ["Tuesday", "Wednesday"]
-  preferred_backup_time   = "10:00Z-11:00Z"
+  db_cluster_id               = alicloud_adb_db_cluster.cluster.id
+  preferred_backup_period     = ["Tuesday", "Wednesday"]
+  preferred_backup_time       = "10:00Z-11:00Z"
+  enable_backup_log           = "Enable"
+  log_backup_retention_period = 7
 }
 ```
+
 ### Removing alicloud_adb_cluster from your configuration
  
 The alicloud_adb_backup_policy resource allows you to manage your adb cluster policy, but Terraform cannot destroy it. Removing this resource from your configuration will remove it from your statefile and management, but will not destroy the cluster policy. You can resume managing the cluster via the adb Console.
@@ -72,6 +75,8 @@ The following arguments are supported:
 * `db_cluster_id` - (Required, ForceNew) The Id of cluster that can run database.
 * `preferred_backup_period` - (Required) ADB Cluster backup period. Valid values: [Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday].
 * `preferred_backup_time` - (Required) ADB Cluster backup time, in the format of HH:mmZ- HH:mmZ. Time setting interval is one hour. China time is 8 hours behind it.
+* `enable_backup_log` - (Optional) Whether to enable log backup for the cluster. Valid values: `Enable`, `Disable`.
+* `log_backup_retention_period` - (Optional) The number of days for which log backup files are retained. It is only valid when `enable_backup_log` is `Enable`.
 
 ## Attributes Reference
 
@@ -79,6 +84,8 @@ The following attributes are exported:
 
 * `id` - The current backup policy resource ID. It is same as 'db_cluster_id'.
 * `backup_retention_period` - Cluster backup retention days, Fixed for 7 days, not modified.
+* `enable_backup_log` - Whether log backup is enabled for the cluster.
+* `log_backup_retention_period` - The number of days for which log backup files are retained.
 
 ## Import
 


### PR DESCRIPTION
### What this PR does

Adds `enable_backup_log` and `log_backup_retention_period` to the `alicloud_adb_backup_policy` resource, so the cluster log backup can be enabled/disabled and its retention period configured.

### Changes

- `resource_alicloud_adb_backup_policy.go`: new `enable_backup_log` (string, valid values `Enable`/`Disable`) and `log_backup_retention_period` (int) schema fields; Read maps them from `DescribeBackupPolicy`; Update includes them in the `HasChange` condition and sends them via `ModifyAdbBackupPolicy`.
- `service_alicloud_adb.go`: extend `ModifyAdbBackupPolicy` to send `EnableBackupLog`/`LogBackupRetentionPeriod`. The fields are sent only when explicitly configured, so an unset optional field does not overwrite the cluster's existing log backup settings.
- `resource_alicloud_adb_backup_policy_test.go`: extended to cover create/update/disable/re-enable round-trip for both fields.
- `website/docs/r/adb_backup_policy.html.markdown`: documented the new arguments and attributes.

### Test plan

Acceptance test `TestAccAlicloudADBBackupPolicy` covers create with log backup enabled, retention period update, disable, and re-enable, verifying the set/Update/Read round-trip for both fields.
