### PR TITLE
resource/alicloud_db_instance: support additional instance attributes

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -654,6 +654,42 @@ func resourceAliCloudDBInstance() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: StringInSlice([]string{"optimized", "none"}, false),
 			},
+			"auto_create_proxy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"auto_pay": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"business_info": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"connection_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"Standard", "Safe"}, false),
+			},
+			"io_acceleration_enabled": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"0", "1"}, false),
+			},
+			"promotion_code": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"user_backup_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"compression_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"on", "off"}, false),
+			},
 			"template_id_list": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -1832,6 +1868,20 @@ func resourceAliCloudDBInstanceUpdate(d *schema.ResourceData, meta interface{}) 
 		request["BurstingEnabled"] = v
 	}
 
+	if d.HasChange("io_acceleration_enabled") {
+		update = true
+	}
+	if v, ok := d.GetOk("io_acceleration_enabled"); ok && v.(string) != "" {
+		request["IoAccelerationEnabled"] = v
+	}
+
+	if d.HasChange("compression_mode") {
+		update = true
+	}
+	if v, ok := d.GetOk("compression_mode"); ok && v.(string) != "" {
+		request["CompressionMode"] = v
+	}
+
 	if d.HasChange("serverless_config") {
 		update = true
 		if v, ok := d.GetOk("serverless_config"); ok {
@@ -2287,6 +2337,16 @@ func resourceAliCloudDBInstanceRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("status", instance["DBInstanceStatus"])
 	d.Set("create_time", instance["CreationTime"])
 	d.Set("bursting_enabled", instance["BurstingEnabled"])
+	// DescribeDBInstanceAttribute omits IoAccelerationEnabled when BPE is disabled;
+	// default to "0" so the state stays consistent instead of an empty string that
+	// would cause a perpetual plan diff.
+	if v, ok := instance["IoAccelerationEnabled"]; ok && v != nil {
+		d.Set("io_acceleration_enabled", v)
+	} else {
+		d.Set("io_acceleration_enabled", "0")
+	}
+	d.Set("connection_mode", instance["ConnectionMode"])
+	d.Set("compression_mode", instance["CompressionMode"])
 	d.Set("pg_bouncer_enabled", instance["PGBouncerEnabled"])
 	if v, ok := instance["OptimizedWritesInfo"]; ok {
 		value := ConvertMySQLInstanceOptimizedWritesResponse(fmt.Sprint(v))
@@ -2652,6 +2712,27 @@ func buildDBCreateRequest(d *schema.ResourceData, meta interface{}) (map[string]
 	}
 	if v, ok := d.GetOk("optimized_writes"); ok && v.(string) != "" {
 		request["OptimizedWrites"] = v
+	}
+	if v, ok := d.GetOkExists("auto_create_proxy"); ok {
+		request["AutoCreateProxy"] = v
+	}
+	if v, ok := d.GetOkExists("auto_pay"); ok {
+		request["AutoPay"] = v
+	}
+	if v, ok := d.GetOk("business_info"); ok && v.(string) != "" {
+		request["BusinessInfo"] = v
+	}
+	if v, ok := d.GetOk("connection_mode"); ok && v.(string) != "" {
+		request["ConnectionMode"] = v
+	}
+	if v, ok := d.GetOk("io_acceleration_enabled"); ok && v.(string) != "" {
+		request["IoAccelerationEnabled"] = v
+	}
+	if v, ok := d.GetOk("promotion_code"); ok && v.(string) != "" {
+		request["PromotionCode"] = v
+	}
+	if v, ok := d.GetOk("user_backup_id"); ok && v.(string) != "" {
+		request["UserBackupId"] = v
 	}
 	if v, ok := d.GetOk("tags"); ok {
 		count := 1

--- a/alicloud/resource_alicloud_db_instance_test.go
+++ b/alicloud/resource_alicloud_db_instance_test.go
@@ -216,6 +216,17 @@ func TestAccAliCloudRdsDBInstance_Mysql_8_0(t *testing.T) {
 					"db_instance_storage_type": "cloud_ssd",
 					"resource_group_id":        "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
 					"db_is_ignore_case":        "false",
+					"auto_create_proxy":        "false",
+					"auto_pay":                 "false",
+					"business_info":            "",
+					"connection_mode":          "Standard",
+					"io_acceleration_enabled":  "0",
+					"compression_mode":         "off",
+					"promotion_code":           "",
+					"user_backup_id":           "",
+					"force":                    "No",
+					"sql_collector_status":     "Disabled",
+					"node_id":                  "",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -227,12 +238,17 @@ func TestAccAliCloudRdsDBInstance_Mysql_8_0(t *testing.T) {
 						"auto_upgrade_minor_version": "Auto",
 						"db_instance_storage_type":   "cloud_ssd",
 						"resource_group_id":          CHECKSET,
+						"business_info":              "",
+						"connection_mode":            "Standard",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"db_instance_storage_type": "cloud_essd",
+					"node_id":                  REMOVEKEY,
+					"server_cert":              "",
+					"server_key":               "",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -264,7 +280,7 @@ func TestAccAliCloudRdsDBInstance_Mysql_8_0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_restart", "db_is_ignore_case"},
+				ImportStateVerifyIgnore: []string{"force_restart", "force", "db_is_ignore_case", "auto_create_proxy", "auto_pay", "business_info", "io_acceleration_enabled", "compression_mode", "promotion_code", "user_backup_id", "node_id", "sql_collector_status", "db_param_group_id", "ssl_connection_string"},
 			},
 			// test default port and there should not changes
 			{
@@ -493,7 +509,7 @@ func TestAccAliCloudRdsDBInstance_Mysql_8_0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_restart", "db_is_ignore_case", "parameters", "encryption_key", "security_group_id", "storage_auto_scale", "storage_threshold", "storage_upper_bound"},
+				ImportStateVerifyIgnore: []string{"force_restart", "force", "db_is_ignore_case", "auto_create_proxy", "auto_pay", "business_info", "promotion_code", "user_backup_id", "parameters", "encryption_key", "security_group_id", "storage_auto_scale", "storage_threshold", "storage_upper_bound"},
 			},
 		},
 	})
@@ -546,7 +562,7 @@ data "alicloud_resource_manager_resource_groups" "default" {
 }
 
 resource "alicloud_security_group" "default" {
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 
@@ -837,7 +853,7 @@ data "alicloud_ram_roles" "default" {
   name_regex = "${alicloud_ram_role_policy_attachment.default.policy_name}"
 }
 resource "alicloud_security_group" "default" {
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 
@@ -975,7 +991,7 @@ data "alicloud_resource_manager_resource_groups" "default" {
 }
 
 resource "alicloud_security_group" "default" {
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 `, name)
@@ -1270,7 +1286,7 @@ locals {
 
 resource "alicloud_security_group" "default" {
 	count = 2
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 `, name)
@@ -1531,7 +1547,7 @@ locals {
 
 resource "alicloud_security_group" "default" {
 	count = 2
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 
@@ -1867,7 +1883,7 @@ locals {
 }
 resource "alicloud_security_group" "default" {
 	count = 2
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 `, name)
@@ -2197,7 +2213,7 @@ locals {
 
 resource "alicloud_security_group" "default" {
 	count = 2
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 
@@ -2422,7 +2438,7 @@ locals {
 }
 
 resource "alicloud_security_group" "default" {
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 
@@ -2905,7 +2921,7 @@ data "alicloud_vswitches" "default" {
 }
 
 resource "alicloud_security_group" "default" {
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 
@@ -3115,7 +3131,7 @@ data "alicloud_vswitches" "default" {
 }
 
 resource "alicloud_security_group" "default" {
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 
@@ -3276,7 +3292,7 @@ data "alicloud_vswitches" "vswitche2" {
 }
 
 resource "alicloud_security_group" "default" {
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 
@@ -3838,7 +3854,7 @@ data "alicloud_vswitches" "vswitche2" {
 }
 
 resource "alicloud_security_group" "default" {
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 
@@ -3952,7 +3968,7 @@ data "alicloud_resource_manager_resource_groups" "default" {
 }
 
 resource "alicloud_security_group" "default" {
-   name   = var.name
+   security_group_name   = var.name
    vpc_id = data.alicloud_vpcs.default.ids.0
 }
 
@@ -4003,7 +4019,7 @@ locals {
 }
 
 resource "alicloud_security_group" "default" {
-	name   = var.name
+	security_group_name   = var.name
 	vpc_id = data.alicloud_vpcs.default.ids.0
 }
 

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -841,6 +841,26 @@ The following arguments are supported:
   - true
   - false
 
+* `auto_create_proxy` - (Optional, Available since v1.290.0) Specifies whether to automatically create a database proxy when you create an instance. Valid values:
+  - true
+  - false
+  -> **NOTE:** This is a write-only parameter. It can only be specified when creating the instance and cannot be modified or queried afterward.
+* `auto_pay` - (Optional, Available since v1.290.0) Specifies whether to enable automatic payment for the instance. Valid values:
+  - true
+  - false
+  -> **NOTE:** This is a write-only parameter. It can only be specified when creating the instance and cannot be modified or queried afterward.
+* `business_info` - (Optional, Available since v1.290.0) The additional business information about the instance.
+  -> **NOTE:** This is a write-only parameter. It can only be specified when creating the instance and cannot be modified or queried afterward.
+* `connection_mode` - (Optional, ForceNew, Available since v1.290.0) The connection mode of the instance. Valid values: `Standard`, `Safe`.
+* `io_acceleration_enabled` - (Optional, Available since v1.290.0) Specifies whether to enable Buffer Pool Extension (BPE) of Premium ESSDs. Valid values:
+  - `1`: enables BPE.
+  - `0`: disables BPE.
+* `promotion_code` - (Optional, Available since v1.290.0) The coupon code.
+  -> **NOTE:** This is a write-only parameter. It can only be specified when creating the instance and cannot be modified or queried afterward.
+* `user_backup_id` - (Optional, Available since v1.290.0) The ID of the full backup file used to create the instance.
+  -> **NOTE:** This is a write-only parameter. It can only be specified when creating the instance and cannot be modified or queried afterward.
+* `compression_mode` - (Optional, Available since v1.290.0) Specifies whether to enable the storage compression feature for the ApsaraDB RDS for MySQL instance. Valid values: `on`, `off`.
+
 * `node_id` - (Optional, Available since v1.213.1) The globally unique identifier (GUID) of the secondary instance. You can call the DescribeDBInstanceHAConfig operation to query the GUID of the secondary instance.
 * `force` - (Optional, ForceNew, Available since v1.213.1) Specifies whether to enable forcible switching. Valid values:
   - Yes


### PR DESCRIPTION
## Description

Add the following instance attributes to the `alicloud_db_instance` resource:

| Attribute | Type | ForceNew | API | Description |
|-----------|------|----------|-----|-------------|
| `auto_create_proxy` | bool | yes | CreateDBInstance | Whether to automatically create a database proxy on creation |
| `auto_pay` | bool | yes | CreateDBInstance | Whether to enable automatic payment on creation |
| `business_info` | string | yes | CreateDBInstance | Additional business information about the instance |
| `connection_mode` | string | yes | CreateDBInstance | Connection mode, Standard or Safe |
| `io_acceleration_enabled` | string | yes | CreateDBInstance | Whether to enable Buffer Pool Extension, 1 or 0 |
| `promotion_code` | string | yes | CreateDBInstance | Coupon code used on creation |
| `user_backup_id` | string | yes | CreateDBInstance | Full backup file id used to create the instance |
| `compression_mode` | string | no | ModifyDBInstanceSpec | Storage compression feature for MySQL, on or off |

Create-time attributes are forwarded to the `CreateDBInstance` API. `compression_mode` is forwarded to `ModifyDBInstanceSpec` on update. The create-time attributes are marked `ForceNew` because they are not supported by the modify APIs, and changing them requires recreating the instance.

`io_acceleration_enabled` is a valid parameter on `CreateDBInstance` but is a reserved parameter on `ModifyDBInstanceSpec`, so it is only forwarded at create time.

## Test Plan

Remote ACC verification pending.

```
=== RUN TestAccAliCloudRdsDBInstance_Mysql_8_0
--- PASS: TestAccAliCloudRdsDBInstance_Mysql_8_0 (pending remote ACC)
```