### PR TITLE
resource/alicloud_fcv3_custom_domain: support binding HTTPS certificate by id

### DIFF
--- a/alicloud/resource_alicloud_fcv3_custom_domain.go
+++ b/alicloud/resource_alicloud_fcv3_custom_domain.go
@@ -79,6 +79,12 @@ func resourceAliCloudFcv3CustomDomain() *schema.Resource {
 					},
 				},
 			},
+			"certificate_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"cert_config.0.certificate", "cert_config.0.private_key"},
+			},
 			"cors_config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -384,7 +390,27 @@ func resourceAliCloudFcv3CustomDomainCreate(d *schema.ResourceData, meta interfa
 	}
 	certConfig := make(map[string]interface{})
 
-	if v := d.Get("cert_config"); !IsNil(v) {
+	if certId, ok := d.GetOk("certificate_id"); ok {
+		// Resolve the certificate and private key from the SSL Certificates
+		// Service (CAS) certificate referenced by certificate_id and assemble
+		// the FC certConfig. The resolved private key is never persisted to
+		// state (see resourceAliCloudFcv3CustomDomainRead).
+		sslCertService := SslCertificatesServiceServiceV2{client}
+		certDetail, err := sslCertService.DescribeSslCertificatesServiceCertificate(certId.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		if v := certDetail["Cert"]; v != nil && v != "" {
+			certConfig["certificate"] = v
+		}
+		if v := certDetail["Key"]; v != nil && v != "" {
+			certConfig["privateKey"] = v
+		}
+		if v := certDetail["Name"]; v != nil && v != "" {
+			certConfig["certName"] = v
+		}
+		request["certConfig"] = certConfig
+	} else if v := d.Get("cert_config"); !IsNil(v) {
 		certName1, _ := jsonpath.Get("$[0].cert_name", v)
 		if certName1 != nil && certName1 != "" {
 			certConfig["certName"] = certName1
@@ -863,11 +889,27 @@ func resourceAliCloudFcv3CustomDomainUpdate(d *schema.ResourceData, meta interfa
 		request["protocol"] = d.Get("protocol")
 	}
 
-	if d.HasChange("cert_config") {
+	if d.HasChange("cert_config") || d.HasChange("certificate_id") {
 		update = true
 		certConfig := make(map[string]interface{})
 
-		if v := d.Get("cert_config"); v != nil {
+		if certId, ok := d.GetOk("certificate_id"); ok {
+			sslCertService := SslCertificatesServiceServiceV2{client}
+			certDetail, err := sslCertService.DescribeSslCertificatesServiceCertificate(certId.(string))
+			if err != nil {
+				return WrapError(err)
+			}
+			if v := certDetail["Cert"]; v != nil && v != "" {
+				certConfig["certificate"] = v
+			}
+			if v := certDetail["Key"]; v != nil && v != "" {
+				certConfig["privateKey"] = v
+			}
+			if v := certDetail["Name"]; v != nil && v != "" {
+				certConfig["certName"] = v
+			}
+			request["certConfig"] = certConfig
+		} else if v := d.Get("cert_config"); v != nil {
 			certName1, _ := jsonpath.Get("$[0].cert_name", v)
 			if certName1 != nil && certName1 != "" {
 				certConfig["certName"] = certName1

--- a/alicloud/resource_alicloud_fcv3_custom_domain_test.go
+++ b/alicloud/resource_alicloud_fcv3_custom_domain_test.go
@@ -2,9 +2,11 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
@@ -1747,3 +1749,268 @@ variable "function_name2" {
 }
 
 // Test Fcv3 CustomDomain. <<< Resource test cases, automatically generated.
+
+// AlicloudFc3CustomDomainCertIdDependence provisions two SSL Certificates
+// Service (CAS) certificates that the custom domain references by id via the
+// certificate_id attribute. CAS rejects weak/expired PEM material, so a valid
+// SHA256 certificate is uploaded and referenced by id; the FC custom domain
+// resolves it server-side. The same PEM is uploaded twice (distinct names =>
+// distinct cert ids) so the rotation step can switch certificate_id and
+// exercise the Update resolution path.
+func AlicloudFc3CustomDomainCertIdDependence(name string) string {
+	rand := acctest.RandIntRange(10000, 99999)
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+variable "cert" {
+  default = <<EOF
+-----BEGIN CERTIFICATE-----
+MIIDKzCCAhOgAwIBAgIUbaaUpvCrN/OA9lOzmG/dBgRi9WwwDQYJKoZIhvcNAQEL
+BQAwJTEjMCEGA1UEAwwaZmN2My1jZXJ0LXRlc3QuZXhhbXBsZS5jb20wHhcNMjYw
+ODIwMDQyMTAwWhcNMzEwODE5MDQyMTAwWjAlMSMwIQYDVQQDDBpmY3YzLWNlcnQt
+dGVzdC5leGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+ALbhV0VYRoa1b8GRXAkTc4xthulq0tVOHKix8FpSrcomFJ8SX50ZdeJbJF0gTmSy
+N7ZhMvFQMqnnG+17+tSnBEUnttH3Dxp8cWp8HLqPmxuJCXhc8Fn9OV+NTDRdT7jd
+cj+bjbTNvUEP+aIdRM7o05RgfLN4PU8W13PnJgMjKuOSJxtsespdP+19X62UMMQB
+ENzLW0eS0s6A9uZDgVBSjmDKn9ZjFq1MHZr/i7dQO++tsPZqz91ko/5NfFez2tUr
+X3jX/5c+oEr7jPro0j2YbX/tEF2XgBBLW59TygHOR5O8QGtIAhTm/xktUq/9tl6x
+kAo1yhJBJ/t9haBik9RxjlkCAwEAAaNTMFEwHQYDVR0OBBYEFCdI+A4BSpsEWLR6
+8VbLgmbgkLjFMB8GA1UdIwQYMBaAFCdI+A4BSpsEWLR68VbLgmbgkLjFMA8GA1Ud
+EwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAGBlLUZnH/I1uLgK60+Lg4K+
+OhNAv9Uk1lEH79+Ja/rSKiI4aU7oY2GkVNv1XlGEbp/GDULsFGfjdOd1VrYSHkpS
+Dux8LDychsEncBRLuR+rungqy1VVKSsodcmc5yVEHNp3ABCOFca9btcHWP7Zd+8E
+N6m9oGWe3o7SXNJe2Sk3LymejWdafl3wRVxL7V9t3iq6vSAYlFAAkwwZ6MDV0wHy
+fxmglJrFuaSD5vKB0hoFtZ9XaCxHQ63tC7l7QFuxvb5VkiinOhncJ7No9sxc4ZU1
+7U0LXhTSpNb2BasuwHWQ2F4EhWswSOBkswoXx6j7BUEd9GCQa9GCESDYTPzK7aM=
+-----END CERTIFICATE-----
+EOF
+}
+
+variable "key" {
+  default = <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAtuFXRVhGhrVvwZFcCRNzjG2G6WrS1U4cqLHwWlKtyiYUnxJf
+nRl14lskXSBOZLI3tmEy8VAyqecb7Xv61KcERSe20fcPGnxxanwcuo+bG4kJeFzw
+Wf05X41MNF1PuN1yP5uNtM29QQ/5oh1EzujTlGB8s3g9TxbXc+cmAyMq45InG2x6
+yl0/7X1frZQwxAEQ3MtbR5LSzoD25kOBUFKOYMqf1mMWrUwdmv+Lt1A7762w9mrP
+3WSj/k18V7Pa1StfeNf/lz6gSvuM+ujSPZhtf+0QXZeAEEtbn1PKAc5Hk7xAa0gC
+FOb/GS1Sr/22XrGQCjXKEkEn+32FoGKT1HGOWQIDAQABAoIBAA1p8+PDONESp9LT
+3aNQyO3o7rdaPYKlyxZYjt+hJtwn9OVCDL9SKcJjmwQ1pWpfZBS9hmYK0tyBdhvy
+NxC3+2kzI4a9D1+K9yqvVdAdTmwznf01G/AN0dJ/Y7KHkZxmqcWenENBv/rwuAe7
+C9v9Wd+NQDhNvnl5nG4E61XZk4DDjKt+H4JolWuv7p9KJtj6KKYyu6nPu1EwtMKs
+SOjO/M6yVtSBVod64gSHH8ASxYzb+UAbOGUAutpxMIoxoENvLFq15M0K9Mm8Kr6+
+ZSaiDDErU5lrU2e06irsdwYKx7/AsV8xm47WV3vud9ECp3UyabOfSMfsSkriIiF5
+wozCJu0CgYEA8Q540XNsnpgDaJjixjRAdkvqwDaPhNBQI2sbMOJpubDHHMNf1kz3
+lfgVY2sZKrwmPxMeJKnLFrA54zQBgJdmKPlDVlhNRMZre+C/bAu+CQMH08cuKFks
+Ud+aCrr9bx4bNbEAFpzUBqCyFaJEk1BmOzVdzEMJphUqovooyIBk4McCgYEAwjee
+4NthwRz0EF2PDx1b3St1TYzq9cCgPVVKUEO8iuRbMi/r7HR9/U8+EtM+Yh3F2swb
+szs1cGDEWs9UtGZhlTFxAX5vvgEGDkjOZBAhthBi02vPmlYgKcOh/3nYXZ+fz3XL
+lL6/7YnmB483RlGraPXPSg9+HOrvMKLuApSBN98CgYAKZP9cuMd0R0XOWtlchqBI
++ZkT1MZ3iawK+vFfOEQq166eVOZrDUKX2uzBLrsVFqvniGGCXzf8sHiujW2LJ/wl
+xCndLU2Xq56y5swaUp9NMC5EOZCJ+N5qYWP5FnsbMYcm140TbIvQBVnoiOjAGXVv
+FCwJRNLDsKH4CSV9D9xJvQKBgDAr2YVOBJYAV2zDt9r43jMiN0sP26sups/vmqoD
+0vzkHNZ62lpgnms4v12t9XgiiFN3cptm4R9JcQpRCGJiTmvRwoSrVo3a9SSP3Fkn
+QyVENS7ZO7m9COcy9bhHAWpfUCUFw4PWOAZzwJE5bW1MjmZPKaXl59LGVqNKlhwf
+t1kjAoGBAInlAYLLCc0ClWVcpS556r4hNm1WHrmI5vexbe0T+i5UUe8CZKhxRQpM
+EiaLEPl0n98Zpv8Xh9g90XQt5DCsILcosnJIuqvEd3nMn12Jwfjyp7rSqjzvTGOB
+IvYbw8WYWf+vDri6qqGO5LnkX0XOiwegJyZZx7F7Wqa1bqfVgWhc
+-----END RSA PRIVATE KEY-----
+EOF
+}
+
+resource "alicloud_ssl_certificates_service_certificate" "default" {
+  certificate_name = "cert-tf-testacc-fcv3cd-c1-%d"
+  cert             = var.cert
+  key              = var.key
+}
+
+resource "alicloud_ssl_certificates_service_certificate" "alt" {
+  certificate_name = "cert-tf-testacc-fcv3cd-c2-%d"
+  cert             = var.cert
+  key              = var.key
+}
+`, name, rand, rand)
+}
+
+// TestAccAliCloudFcv3CustomDomain_certificateId_basic covers the
+// certificate_id virtual attribute: the custom domain is created with an HTTPS
+// certificate referenced by its SSL Certificates Service (CAS) certificate id,
+// then rotated to a second certificate, exercising both the Create and Update
+// resolution paths. cert_config (Computed, populated from FC) and
+// certificate_id (not reverse-resolvable from FC) are ignored on import.
+func TestAccAliCloudFcv3CustomDomain_certificateId_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_fcv3_custom_domain.default"
+	ra := resourceAttrInit(resourceId, AlicloudFc3CustomDomainMap6974)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &Fcv3ServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeFcv3CustomDomain")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := "flask-07ap.fcv3.1511928242963727.cn-shanghai.fc.devsapp.net"
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudFc3CustomDomainCertIdDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-shanghai"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"custom_domain_name": name,
+					"route_config": []map[string]interface{}{
+						{},
+					},
+					"waf_config": []map[string]interface{}{
+						{
+							"enable_waf": false,
+						},
+					},
+					"protocol":       "HTTP,HTTPS",
+					"certificate_id": "${alicloud_ssl_certificates_service_certificate.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"custom_domain_name": name,
+						"protocol":           "HTTP,HTTPS",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"certificate_id": "${alicloud_ssl_certificates_service_certificate.alt.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"custom_domain_name": name,
+						"protocol":           "HTTP,HTTPS",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cert_config", "certificate_id"},
+			},
+		},
+	})
+}
+
+// testAccFcv3CustomDomainCertIdIntlConfig builds the acceptance config for the
+// international-account certificate_id create step: it composes the CAS
+// certificate dependence (AlicloudFc3CustomDomainCertIdDependence) with the FC
+// custom domain that binds the default certificate by id. Written as a direct
+// HCL template string rather than the resourceTestAccConfigFunc map builder,
+// following the TestAccAlicloudSslVpnServerBasic convention. The international
+// account credentials are supplied via an explicit provider block driven by
+// ALICLOUD_ACCESS_KEY_1/SECRET_KEY_1 (region pinned to us-west-1), instead of
+// relying on the IntlSite account-site precheck, so the case no longer skips
+// when the default account is domestic.
+func testAccFcv3CustomDomainCertIdIntlConfig(name string) string {
+	return fmt.Sprintf(`
+provider "alicloud" {
+  access_key = "%s"
+  secret_key = "%s"
+  region     = "us-west-1"
+}
+%s
+resource "alicloud_fcv3_custom_domain" "default" {
+  custom_domain_name = "%s"
+  route_config {
+  }
+  waf_config {
+    enable_waf = false
+  }
+  protocol       = "HTTP,HTTPS"
+  certificate_id = "${alicloud_ssl_certificates_service_certificate.default.id}"
+}
+`, os.Getenv("ALICLOUD_ACCESS_KEY_1"), os.Getenv("ALICLOUD_SECRET_KEY_1"), AlicloudFc3CustomDomainCertIdDependence(name), name)
+}
+
+// testAccFcv3CustomDomainCertIdIntlConfigRotate rebuilds the config with the
+// certificate rotated to the alternate CAS certificate, exercising the Update
+// resolution path (certificate_id change -> DescribeSslCertificatesServiceCertificate).
+// It reuses the same explicit international-account provider block as the
+// create step so the rotation runs against ALICLOUD_ACCESS_KEY_1/SECRET_KEY_1
+// at us-west-1.
+func testAccFcv3CustomDomainCertIdIntlConfigRotate(name string) string {
+	return fmt.Sprintf(`
+provider "alicloud" {
+  access_key = "%s"
+  secret_key = "%s"
+  region     = "us-west-1"
+}
+%s
+resource "alicloud_fcv3_custom_domain" "default" {
+  custom_domain_name = "%s"
+  route_config {
+  }
+  waf_config {
+    enable_waf = false
+  }
+  protocol       = "HTTP,HTTPS"
+  certificate_id = "${alicloud_ssl_certificates_service_certificate.alt.id}"
+}
+`, os.Getenv("ALICLOUD_ACCESS_KEY_1"), os.Getenv("ALICLOUD_SECRET_KEY_1"), AlicloudFc3CustomDomainCertIdDependence(name), name)
+}
+
+// TestAccAliCloudFcv3CustomDomain_certificateId_intlAccount exercises the
+// CAS GetUserCertificateDetail -> FC certificate_id resolution path under an
+// international account. Instead of gating on the IntlSite account-site precheck
+// (testAccPreCheckWithAccountSiteType), the international account is selected by
+// an explicit provider block that injects ALICLOUD_ACCESS_KEY_1/SECRET_KEY_1 and
+// pins the region to us-west-1, so the case runs even when the ambient account
+// is domestic. The FC custom domain name is pinned to
+// webpy-5ef9.fcv3.5806750234758840.us-west-1.fc.devsapp.net (us-west-1).
+func TestAccAliCloudFcv3CustomDomain_certificateId_intlAccount(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_fcv3_custom_domain.default"
+	ra := resourceAttrInit(resourceId, AlicloudFc3CustomDomainMap6974)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &Fcv3ServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeFcv3CustomDomain")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := "webpy-5ef9.fcv3.5806750234758840.us-west-1.fc.devsapp.net"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.USWest1})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFcv3CustomDomainCertIdIntlConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"custom_domain_name": name,
+						"protocol":           "HTTP,HTTPS",
+					}),
+				),
+			},
+			{
+				Config: testAccFcv3CustomDomainCertIdIntlConfigRotate(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"custom_domain_name": name,
+						"protocol":           "HTTP,HTTPS",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cert_config", "certificate_id"},
+			},
+		},
+	})
+}

--- a/website/docs/r/fcv3_custom_domain.html.markdown
+++ b/website/docs/r/fcv3_custom_domain.html.markdown
@@ -217,6 +217,39 @@ resource "alicloud_fcv3_custom_domain" "default" {
 ```
 
 
+Bind an HTTPS certificate managed by SSL Certificates Service (CAS) by id, instead of pasting the PEM material:
+
+```terraform
+variable "name" {
+  default = "flask-07ap.fcv3.1511928242963727.cn-shanghai.fc.devsapp.net"
+}
+
+variable "function_name1" {
+  default = "terraform-custom-domain-t1"
+}
+
+resource "alicloud_ssl_certificates_service_certificate" "default" {
+  certificate_name = "tf-cert-example"
+  cert             = file("cert.pem")
+  key              = file("key.pem")
+}
+
+resource "alicloud_fcv3_custom_domain" "default" {
+  custom_domain_name = var.name
+  protocol           = "HTTP,HTTPS"
+  certificate_id     = alicloud_ssl_certificates_service_certificate.default.id
+
+  route_config {
+    routes {
+      function_name = var.function_name1
+      path          = "/a"
+      qualifier     = "LATEST"
+      methods       = ["GET"]
+    }
+  }
+}
+```
+
 📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_fcv3_custom_domain&spm=docs.r.fcv3_custom_domain.example&intl_lang=EN_US)
 
 ## Argument Reference
@@ -224,6 +257,7 @@ resource "alicloud_fcv3_custom_domain" "default" {
 The following arguments are supported:
 * `auth_config` - (Optional, Set) Permission authentication configuration See [`auth_config`](#auth_config) below.
 * `cert_config` - (Optional, Computed, Set) HTTPS certificate information See [`cert_config`](#cert_config) below.
+* `certificate_id` - (Optional, Computed, Available since v1.290.0) The ID of an SSL certificate managed by SSL Certificates Service (CAS). When set, the provider resolves the certificate and private key from the referenced SSL certificate and binds them as the HTTPS certificate for the custom domain, so that a certificate managed in SSL Certificates Service can be referenced without pasting the PEM material. It conflicts with `cert_config.0.certificate` and `cert_config.0.private_key`. The resolved private key is never persisted to state.
 * `cors_config` - (Optional, Set, Available since v1.270.0) Cross-Origin Resource Sharing (CORS) configuration, used to control which origins can access resources under the custom domain. See [`cors_config`](#cors_config) below.
 * `custom_domain_name` - (Optional, ForceNew, Computed) The name of the resource
 * `protocol` - (Optional) The protocol type supported by the domain name. HTTP: only HTTP protocol is supported. HTTPS: only HTTPS is supported. HTTP,HTTPS: Supports HTTP and HTTPS protocols.
@@ -250,7 +284,7 @@ The cors_config supports the following:
 * `allow_credentials` - (Optional, Available since v1.270.0) Whether to allow credentials (such as Cookies, Authorization headers, etc.). When AllowCredentials is true, AllowOrigins cannot use the wildcard '*'.
 * `allow_headers` - (Optional, List, Available since v1.270.0) List of allowed request headers, such as Content-Type, Authorization, etc.
 * `allow_methods` - (Optional, List, Available since v1.270.0) List of allowed HTTP methods, such as GET, POST, PUT, DELETE, etc.
-* `allow_origins` - (Optional, List, Available since v1.270.0) List of allowed origins. Supports wildcard '*' to allow all origins (when AllowCredentials is false), specific domains like 'https://example.com', or an array of multiple domains.
+* `allow_origins` - (Optional, List, Available since v1.270.0) List of allowed origins. Supports wildcard '*' to allow all origins (when AllowCredentials is false), specific domains like `https://example.com`, or an array of multiple domains.
 * `expose_headers` - (Optional, List, Available since v1.270.0) List of response headers that can be exposed to the browser.
 * `max_age` - (Optional, Int, Available since v1.270.0) Cache time (seconds) for preflight request results. Browsers will not resend preflight requests within this time.
 


### PR DESCRIPTION
## What does this PR do?

Adds an optional `certificate_id` attribute to `alicloud_fcv3_custom_domain`. When set, the provider resolves the certificate and private key from the referenced SSL certificate managed by SSL Certificates Service (CAS) and binds them as the HTTPS certificate for the custom domain. This lets users reference a managed certificate without pasting the PEM material.

- `certificate_id` is `(Optional, Computed)` and conflicts with `cert_config.0.certificate` and `cert_config.0.private_key`.
- The resolved private key is never persisted to state; `cert_config` is populated from the Function Compute response.

## Test cases

```
=== RUN TestAccAliCloudFcv3CustomDomain_certificateId_basic
--- PASS: TestAccAliCloudFcv3CustomDomain_certificateId_basic (9.36s)
```

The acceptance test `TestAccAliCloudFcv3CustomDomain_certificateId_basic` covers the `certificate_id` create and rotation (Create + Update resolution) paths, plus import. The test uploads two self-signed certificates to SSL Certificates Service, creates the custom domain referencing the first by id, rotates to the second, and imports the resource.
