### PR TITLE
docs: annotate composite import ID composition for 332 resource docs

### DIFF
--- a/website/docs/r/adb_account.html.markdown
+++ b/website/docs/r/adb_account.html.markdown
@@ -96,7 +96,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-AnalyticDB for MySQL (ADB) Account can be imported using the id, e.g.
+AnalyticDB for MySQL (ADB) Account can be imported using the id, which consists of db_cluster_id and account_name, e.g.
 
 ```shell
 $ terraform import alicloud_adb_account.example <db_cluster_id>:<account_name>

--- a/website/docs/r/adb_lake_account.html.markdown
+++ b/website/docs/r/adb_lake_account.html.markdown
@@ -152,7 +152,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ADB Lake Account can be imported using the id, e.g.
+ADB Lake Account can be imported using the id, which consists of db_cluster_id and account_name, e.g.
 
 ```shell
 $ terraform import alicloud_adb_lake_account.example <db_cluster_id>:<account_name>

--- a/website/docs/r/adb_resource_group.html.markdown
+++ b/website/docs/r/adb_resource_group.html.markdown
@@ -116,7 +116,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Adb Resource Group can be imported using the id, e.g.
+Adb Resource Group can be imported using the id, which consists of db_cluster_id and group_name, e.g.
 
 ```shell
 $ terraform import alicloud_adb_resource_group.example <db_cluster_id>:<group_name>

--- a/website/docs/r/alb_acl_entry_attachment.html.markdown
+++ b/website/docs/r/alb_acl_entry_attachment.html.markdown
@@ -65,7 +65,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Acl entry attachment can be imported using the id, e.g.
+Acl entry attachment can be imported using the id, which consists of acl_id and entry, e.g.
 
 ```shell
 $ terraform import alicloud_alb_acl_entry_attachment.example <acl_id>:<entry>

--- a/website/docs/r/alb_listener_acl_attachment.html.markdown
+++ b/website/docs/r/alb_listener_acl_attachment.html.markdown
@@ -149,7 +149,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ALB Listener Acl Attachment can be imported using the id, e.g.
+ALB Listener Acl Attachment can be imported using the id, which consists of listener_id and acl_id, e.g.
 
 ```shell
 $ terraform import alicloud_alb_listener_acl_attachment.example <listener_id>:<acl_id>

--- a/website/docs/r/alb_listener_additional_certificate_attachment.html.markdown
+++ b/website/docs/r/alb_listener_additional_certificate_attachment.html.markdown
@@ -201,7 +201,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Application Load Balancer (ALB) Listener Additional Certificate Attachment can be imported using the id, e.g.
+Application Load Balancer (ALB) Listener Additional Certificate Attachment can be imported using the id, which consists of listener_id and certificate_id, e.g.
 
 ```shell
 $ terraform import alicloud_alb_listener_additional_certificate_attachment.example <listener_id>:<certificate_id>

--- a/website/docs/r/alb_load_balancer_common_bandwidth_package_attachment.html.markdown
+++ b/website/docs/r/alb_load_balancer_common_bandwidth_package_attachment.html.markdown
@@ -106,7 +106,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Alb Load Balancer Common Bandwidth Package Attachment can be imported using the id, e.g.
+Alb Load Balancer Common Bandwidth Package Attachment can be imported using the id, which consists of load_balancer_id and bandwidth_package_id, e.g.
 
 ```shell
 $ terraform import alicloud_alb_load_balancer_common_bandwidth_package_attachment.example <load_balancer_id>:<bandwidth_package_id>

--- a/website/docs/r/alb_load_balancer_security_group_attachment.html.markdown
+++ b/website/docs/r/alb_load_balancer_security_group_attachment.html.markdown
@@ -112,7 +112,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Application Load Balancer (ALB) Load Balancer Security Group Attachment can be imported using the id, e.g.
+Application Load Balancer (ALB) Load Balancer Security Group Attachment can be imported using the id, which consists of load_balancer_id and security_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_alb_load_balancer_security_group_attachment.example <load_balancer_id>:<security_group_id>

--- a/website/docs/r/alb_load_balancer_zone_shifted_attachment.html.markdown
+++ b/website/docs/r/alb_load_balancer_zone_shifted_attachment.html.markdown
@@ -114,7 +114,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Application Load Balancer (ALB) Load Balancer Zone Shifted Attachment can be imported using the id, e.g.
+Application Load Balancer (ALB) Load Balancer Zone Shifted Attachment can be imported using the id, which consists of load_balancer_id, vswitch_id and zone_id, e.g.
 
 ```shell
 $ terraform import alicloud_alb_load_balancer_zone_shifted_attachment.example <load_balancer_id>:<vswitch_id>:<zone_id>

--- a/website/docs/r/alidns_cloud_gtm_instance_config.html.markdown
+++ b/website/docs/r/alidns_cloud_gtm_instance_config.html.markdown
@@ -98,7 +98,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Alidns Cloud Gtm Instance Config can be imported using the id, e.g.
+Alidns Cloud Gtm Instance Config can be imported using the id, which consists of config_id and instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_alidns_cloud_gtm_instance_config.example <config_id>:<instance_id>

--- a/website/docs/r/alikafka_consumer_group.html.markdown
+++ b/website/docs/r/alikafka_consumer_group.html.markdown
@@ -70,7 +70,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-AliKafka Consumer Group can be imported using the id, e.g.
+AliKafka Consumer Group can be imported using the id, which consists of instance_id and consumer_id, e.g.
 
 ```shell
 $ terraform import alicloud_alikafka_consumer_group.example <instance_id>:<consumer_id>

--- a/website/docs/r/alikafka_instance_allowed_ip_attachment.html.markdown
+++ b/website/docs/r/alikafka_instance_allowed_ip_attachment.html.markdown
@@ -107,7 +107,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-AliKafka Instance Allowed Ip Attachment can be imported using the id, e.g.
+AliKafka Instance Allowed Ip Attachment can be imported using the id, which consists of instance_id, allowed_type, port_range and allowed_ip, e.g.
 
 ```shell
 $ terraform import alicloud_alikafka_instance_allowed_ip_attachment.example <instance_id>:<allowed_type>:<port_range>:<allowed_ip>

--- a/website/docs/r/alikafka_sasl_acl.html.markdown
+++ b/website/docs/r/alikafka_sasl_acl.html.markdown
@@ -147,7 +147,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Alikafka Sasl Acl can be imported using the id, e.g.
+Alikafka Sasl Acl can be imported using the id, which consists of instance_id, username, acl_resource_type, acl_resource_name, acl_resource_pattern_type and acl_operation_type, e.g.
 
 ```shell
 $ terraform import alicloud_alikafka_sasl_acl.example <instance_id>:<username>:<acl_resource_type>:<acl_resource_name>:<acl_resource_pattern_type>:<acl_operation_type>

--- a/website/docs/r/alikafka_sasl_user.html.markdown
+++ b/website/docs/r/alikafka_sasl_user.html.markdown
@@ -107,7 +107,7 @@ The following attributes are exported:
 
 ## Import
 
-AliKafka Sasl User can be imported using the id, e.g.
+AliKafka Sasl User can be imported using the id, which consists of instance_id and username, e.g.
 
 ```shell
 terraform import alicloud_alikafka_sasl_user.example <instance_id>:<username>

--- a/website/docs/r/alikafka_scheduled_scaling_rule.html.markdown
+++ b/website/docs/r/alikafka_scheduled_scaling_rule.html.markdown
@@ -125,7 +125,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Alikafka Scheduled Scaling Rule can be imported using the id, e.g.
+Alikafka Scheduled Scaling Rule can be imported using the id, which consists of instance_id and rule_name, e.g.
 
 ```shell
 $ terraform import alicloud_alikafka_scheduled_scaling_rule.example <instance_id>:<rule_name>

--- a/website/docs/r/alikafka_topic.html.markdown
+++ b/website/docs/r/alikafka_topic.html.markdown
@@ -129,7 +129,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Alikafka Topic can be imported using the id, e.g.
+Alikafka Topic can be imported using the id, which consists of instance_id and topic, e.g.
 
 ```shell
 $ terraform import alicloud_alikafka_topic.example <instance_id>:<topic>

--- a/website/docs/r/amqp_binding.html.markdown
+++ b/website/docs/r/amqp_binding.html.markdown
@@ -101,7 +101,7 @@ The following attributes are exported:
 
 ## Import
 
-RabbitMQ (AMQP) Binding can be imported using the id, e.g.
+RabbitMQ (AMQP) Binding can be imported using the id, which consists of instance_id, virtual_host_name, source_exchange and destination_name, e.g.
 
 ```shell
 $ terraform import alicloud_amqp_binding.example <instance_id>:<virtual_host_name>:<source_exchange>:<destination_name>

--- a/website/docs/r/amqp_exchange.html.markdown
+++ b/website/docs/r/amqp_exchange.html.markdown
@@ -113,7 +113,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RabbitMQ (AMQP) Exchange can be imported using the id, e.g.
+RabbitMQ (AMQP) Exchange can be imported using the id, which consists of instance_id, virtual_host_name and exchange_name, e.g.
 
 ```shell
 $ terraform import alicloud_amqp_exchange.example <instance_id>:<virtual_host_name>:<exchange_name>

--- a/website/docs/r/amqp_open_source_account.html.markdown
+++ b/website/docs/r/amqp_open_source_account.html.markdown
@@ -126,7 +126,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RabbitMQ (AMQP) Open Source Account can be imported using the id, e.g.
+RabbitMQ (AMQP) Open Source Account can be imported using the id, which consists of user_name and instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_amqp_open_source_account.example <user_name>:<instance_id>

--- a/website/docs/r/amqp_open_source_permission.html.markdown
+++ b/website/docs/r/amqp_open_source_permission.html.markdown
@@ -131,7 +131,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RabbitMQ (AMQP) Open Source Permission can be imported using the id, e.g.
+RabbitMQ (AMQP) Open Source Permission can be imported using the id, which consists of user_name, vhost and instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_amqp_open_source_permission.example <user_name>:<vhost>:<instance_id>

--- a/website/docs/r/amqp_queue.html.markdown
+++ b/website/docs/r/amqp_queue.html.markdown
@@ -88,7 +88,7 @@ The following attributes are exported:
 
 ## Import
 
-RabbitMQ (AMQP) Queue can be imported using the id, e.g.
+RabbitMQ (AMQP) Queue can be imported using the id, which consists of instance_id, virtual_host_name and queue_name, e.g.
 
 ```shell
 $ terraform import alicloud_amqp_queue.example <instance_id>:<virtual_host_name>:<queue_name>

--- a/website/docs/r/amqp_static_account.html.markdown
+++ b/website/docs/r/amqp_static_account.html.markdown
@@ -81,7 +81,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Amqp Static Account can be imported using the id, e.g.
+Amqp Static Account can be imported using the id, which consists of instance_id and access_key, e.g.
 
 ```shell
 $terraform import alicloud_amqp_static_account.example <instance_id>:<access_key>

--- a/website/docs/r/amqp_virtual_host.html.markdown
+++ b/website/docs/r/amqp_virtual_host.html.markdown
@@ -78,7 +78,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RabbitMQ (AMQP) Virtual Host can be imported using the id, e.g.
+RabbitMQ (AMQP) Virtual Host can be imported using the id, which consists of instance_id and virtual_host_name, e.g.
 
 ```shell
 $ terraform import alicloud_amqp_virtual_host.example <instance_id>:<virtual_host_name>

--- a/website/docs/r/api_gateway_acl_entry_attachment.html.markdown
+++ b/website/docs/r/api_gateway_acl_entry_attachment.html.markdown
@@ -67,7 +67,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Api Gateway Acl Entry Attachment can be imported using the id, e.g.
+Api Gateway Acl Entry Attachment can be imported using the id, which consists of acl_id and entry, e.g.
 
 ```shell
 $ terraform import alicloud_api_gateway_acl_entry_attachment.example <acl_id>:<entry>

--- a/website/docs/r/api_gateway_backend_model.html.markdown
+++ b/website/docs/r/api_gateway_backend_model.html.markdown
@@ -78,7 +78,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Api Gateway Backend Model can be imported using the id, e.g.
+Api Gateway Backend Model can be imported using the id, which consists of backend_id and stage_name, e.g.
 
 ```shell
 $ terraform import alicloud_api_gateway_backend_model.example <backend_id>:<stage_name>

--- a/website/docs/r/api_gateway_instance_acl_attachment.html.markdown
+++ b/website/docs/r/api_gateway_instance_acl_attachment.html.markdown
@@ -84,7 +84,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Api Gateway Instance Acl Attachment can be imported using the id, e.g.
+Api Gateway Instance Acl Attachment can be imported using the id, which consists of instance_id, acl_id and acl_type, e.g.
 
 ```shell
 $ terraform import alicloud_api_gateway_instance_acl_attachment.example <instance_id>:<acl_id>:<acl_type>

--- a/website/docs/r/api_gateway_model.html.markdown
+++ b/website/docs/r/api_gateway_model.html.markdown
@@ -66,7 +66,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Api Gateway Model can be imported using the id, e.g.
+Api Gateway Model can be imported using the id, which consists of group_id and model_name, e.g.
 
 ```shell
 $ terraform import alicloud_api_gateway_model.example <group_id>:<model_name>

--- a/website/docs/r/api_gateway_vpc_access.html.markdown
+++ b/website/docs/r/api_gateway_vpc_access.html.markdown
@@ -113,7 +113,7 @@ The following attributes are exported:
 
 ## Import
 
-Api Gateway Vpc Access can be imported using the id, e.g.
+Api Gateway Vpc Access can be imported using the id, which consists of name, vpc_id, instance_id and port, e.g.
 
 ```shell
 $ terraform import alicloud_api_gateway_vpc_access.example <name>:<vpc_id>:<instance_id>:<port>

--- a/website/docs/r/arms_addon_release.html.markdown
+++ b/website/docs/r/arms_addon_release.html.markdown
@@ -147,7 +147,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ARMS Addon Release can be imported using the id, e.g.
+ARMS Addon Release can be imported using the id, which consists of environment_id and addon_release_name, e.g.
 
 ```shell
 $ terraform import alicloud_arms_addon_release.example <environment_id>:<addon_release_name>

--- a/website/docs/r/arms_env_custom_job.html.markdown
+++ b/website/docs/r/arms_env_custom_job.html.markdown
@@ -96,7 +96,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ARMS Env Custom Job can be imported using the id, e.g.
+ARMS Env Custom Job can be imported using the id, which consists of environment_id and env_custom_job_name, e.g.
 
 ```shell
 $ terraform import alicloud_arms_env_custom_job.example <environment_id>:<env_custom_job_name>

--- a/website/docs/r/arms_env_feature.html.markdown
+++ b/website/docs/r/arms_env_feature.html.markdown
@@ -137,7 +137,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ARMS Env Feature can be imported using the id, e.g.
+ARMS Env Feature can be imported using the id, which consists of environment_id and env_feature_name, e.g.
 
 ```shell
 $ terraform import alicloud_arms_env_feature.example <environment_id>:<env_feature_name>

--- a/website/docs/r/arms_env_pod_monitor.html.markdown
+++ b/website/docs/r/arms_env_pod_monitor.html.markdown
@@ -163,7 +163,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ARMS Env Pod Monitor can be imported using the id, e.g.
+ARMS Env Pod Monitor can be imported using the id, which consists of environment_id, namespace and env_pod_monitor_name, e.g.
 
 ```shell
 $ terraform import alicloud_arms_env_pod_monitor.example <environment_id>:<namespace>:<env_pod_monitor_name>

--- a/website/docs/r/arms_env_service_monitor.html.markdown
+++ b/website/docs/r/arms_env_service_monitor.html.markdown
@@ -161,7 +161,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ARMS Env Service Monitor can be imported using the id, e.g.
+ARMS Env Service Monitor can be imported using the id, which consists of environment_id, namespace and env_service_monitor_name, e.g.
 
 ```shell
 $ terraform import alicloud_arms_env_service_monitor.example <environment_id>:<namespace>:<env_service_monitor_name>

--- a/website/docs/r/arms_integration_exporter.html.markdown
+++ b/website/docs/r/arms_integration_exporter.html.markdown
@@ -100,7 +100,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Application Real-Time Monitoring Service (ARMS) Integration Exporter can be imported using the id, e.g.
+Application Real-Time Monitoring Service (ARMS) Integration Exporter can be imported using the id, which consists of cluster_id, integration_type and instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_arms_integration_exporter.example <cluster_id>:<integration_type>:<instance_id>

--- a/website/docs/r/arms_prometheus_alert_rule.html.markdown
+++ b/website/docs/r/arms_prometheus_alert_rule.html.markdown
@@ -93,7 +93,7 @@ The following attributes are exported:
 
 ## Import
 
-Application Real-Time Monitoring Service (ARMS) Prometheus Alert Rule can be imported using the id, e.g.
+Application Real-Time Monitoring Service (ARMS) Prometheus Alert Rule can be imported using the id, which consists of cluster_id and prometheus_alert_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_arms_prometheus_alert_rule.example <cluster_id>:<prometheus_alert_rule_id>

--- a/website/docs/r/arms_prometheus_monitoring.html.markdown
+++ b/website/docs/r/arms_prometheus_monitoring.html.markdown
@@ -151,7 +151,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ARMS Prometheus Monitoring can be imported using the id, e.g.
+ARMS Prometheus Monitoring can be imported using the id, which consists of cluster_id, monitoring_name and type, e.g.
 
 ```shell
 $ terraform import alicloud_arms_prometheus_monitoring.example <cluster_id>:<monitoring_name>:<type>

--- a/website/docs/r/arms_remote_write.html.markdown
+++ b/website/docs/r/arms_remote_write.html.markdown
@@ -92,7 +92,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Application Real-Time Monitoring Service (ARMS) Remote Write can be imported using the id, e.g.
+Application Real-Time Monitoring Service (ARMS) Remote Write can be imported using the id, which consists of cluster_id and remote_write_name, e.g.
 
 ```shell
 $ terraform import alicloud_arms_remote_write.example <cluster_id>:<remote_write_name>

--- a/website/docs/r/bastionhost_host.html.markdown
+++ b/website/docs/r/bastionhost_host.html.markdown
@@ -98,7 +98,7 @@ The following attributes are exported:
 
 ## Import
 
-Bastion Host Host can be imported using the id, e.g.
+Bastion Host Host can be imported using the id, which consists of instance_id and host_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_host.example <instance_id>:<host_id>

--- a/website/docs/r/bastionhost_host_account.html.markdown
+++ b/website/docs/r/bastionhost_host_account.html.markdown
@@ -99,7 +99,7 @@ The following attributes are exported:
 
 ## Import
 
-Bastion Host Host Account can be imported using the id, e.g.
+Bastion Host Host Account can be imported using the id, which consists of instance_id and host_account_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_host_account.example <instance_id>:<host_account_id>

--- a/website/docs/r/bastionhost_host_account_share_key_attachment.html.markdown
+++ b/website/docs/r/bastionhost_host_account_share_key_attachment.html.markdown
@@ -117,7 +117,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Bastion Host Account Share Key Attachment can be imported using the id, e.g.
+Bastion Host Account Share Key Attachment can be imported using the id, which consists of instance_id, host_share_key_id and host_account_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_host_account_share_key_attachment.example <instance_id>:<host_share_key_id>:<host_account_id>

--- a/website/docs/r/bastionhost_host_account_user_attachment.html.markdown
+++ b/website/docs/r/bastionhost_host_account_user_attachment.html.markdown
@@ -109,7 +109,7 @@ The following attributes are exported:
 
 ## Import
 
-Bastion Host Host Account can be imported using the id, e.g.
+Bastion Host Host Account can be imported using the id, which consists of instance_id, user_id and host_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_host_account.example <instance_id>:<user_id>:<host_id>

--- a/website/docs/r/bastionhost_host_account_user_group_attachment.html.markdown
+++ b/website/docs/r/bastionhost_host_account_user_group_attachment.html.markdown
@@ -105,7 +105,7 @@ The following attributes are exported:
 
 ## Import
 
-Bastion Host Host Account can be imported using the id, e.g.
+Bastion Host Host Account can be imported using the id, which consists of instance_id, user_group_id and host_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_host_account.example <instance_id>:<user_group_id>:<host_id>

--- a/website/docs/r/bastionhost_host_attachment.html.markdown
+++ b/website/docs/r/bastionhost_host_attachment.html.markdown
@@ -95,7 +95,7 @@ The following attributes are exported:
 
 ## Import
 
-Bastion Host Host Attachment can be imported using the id, e.g.
+Bastion Host Host Attachment can be imported using the id, which consists of instance_id, host_group_id and host_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_host_attachment.example <instance_id>:<host_group_id>:<host_id>

--- a/website/docs/r/bastionhost_host_group.html.markdown
+++ b/website/docs/r/bastionhost_host_group.html.markdown
@@ -84,7 +84,7 @@ The following attributes are exported:
 
 ## Import
 
-Bastion Host Host Group can be imported using the id, e.g.
+Bastion Host Host Group can be imported using the id, which consists of instance_id and host_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_host_group.example <instance_id>:<host_group_id>

--- a/website/docs/r/bastionhost_host_group_account_user_attachment.html.markdown
+++ b/website/docs/r/bastionhost_host_group_account_user_attachment.html.markdown
@@ -115,7 +115,7 @@ The following attributes are exported:
 
 ## Import
 
-Bastion Host Host Account can be imported using the id, e.g.
+Bastion Host Host Account can be imported using the id, which consists of instance_id, user_id and host_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_host_account.example <instance_id>:<user_id>:<host_group_id>

--- a/website/docs/r/bastionhost_host_group_account_user_group_attachment.html.markdown
+++ b/website/docs/r/bastionhost_host_group_account_user_group_attachment.html.markdown
@@ -109,7 +109,7 @@ The following attributes are exported:
 
 ## Import
 
-Bastion Host Host Account can be imported using the id, e.g.
+Bastion Host Host Account can be imported using the id, which consists of instance_id, user_group_id and host_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_host_account.example <instance_id>:<user_group_id>:<host_group_id>

--- a/website/docs/r/bastionhost_host_share_key.html.markdown
+++ b/website/docs/r/bastionhost_host_share_key.html.markdown
@@ -109,7 +109,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Bastion Host Share Key can be imported using the id, e.g.
+Bastion Host Share Key can be imported using the id, which consists of instance_id and host_share_key_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_host_share_key.example <instance_id>:<host_share_key_id>

--- a/website/docs/r/bastionhost_user.html.markdown
+++ b/website/docs/r/bastionhost_user.html.markdown
@@ -148,7 +148,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Bastion Host User can be imported using the id, e.g.
+Bastion Host User can be imported using the id, which consists of instance_id and user_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_user.example <instance_id>:<user_id>

--- a/website/docs/r/bastionhost_user_attachment.html.markdown
+++ b/website/docs/r/bastionhost_user_attachment.html.markdown
@@ -95,7 +95,7 @@ The following attributes are exported:
 
 ## Import
 
-Bastion Host User Attachment can be imported using the id, e.g.
+Bastion Host User Attachment can be imported using the id, which consists of instance_id, user_group_id and user_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_user_attachment.example <instance_id>:<user_group_id>:<user_id>

--- a/website/docs/r/bastionhost_user_group.html.markdown
+++ b/website/docs/r/bastionhost_user_group.html.markdown
@@ -84,7 +84,7 @@ The following attributes are exported:
 
 ## Import
 
-Bastion Host User Group can be imported using the id, e.g.
+Bastion Host User Group can be imported using the id, which consists of instance_id and user_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_bastionhost_user_group.example <instance_id>:<user_group_id>

--- a/website/docs/r/cddc_dedicated_host.html.markdown
+++ b/website/docs/r/cddc_dedicated_host.html.markdown
@@ -115,7 +115,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ApsaraDB for MyBase Dedicated Host can be imported using the id, e.g.
+ApsaraDB for MyBase Dedicated Host can be imported using the id, which consists of dedicated_host_group_id and dedicated_host_id, e.g.
 
 ```shell
 $ terraform import alicloud_cddc_dedicated_host.example <dedicated_host_group_id>:<dedicated_host_id>

--- a/website/docs/r/cddc_dedicated_host_account.html.markdown
+++ b/website/docs/r/cddc_dedicated_host_account.html.markdown
@@ -97,7 +97,7 @@ The following attributes are exported:
 
 ## Import
 
-ApsaraDB for MyBase Dedicated Host Account can be imported using the id, e.g.
+ApsaraDB for MyBase Dedicated Host Account can be imported using the id, which consists of dedicated_host_id and account_name, e.g.
 
 ```shell
 $ terraform import alicloud_cddc_dedicated_host_account.example <dedicated_host_id>:<account_name>

--- a/website/docs/r/cddc_dedicated_propre_host.html.markdown
+++ b/website/docs/r/cddc_dedicated_propre_host.html.markdown
@@ -229,7 +229,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-CDDC Dedicated Propre Host can be imported using the id, e.g.
+CDDC Dedicated Propre Host can be imported using the id, which consists of dedicated_host_group_id and ecs_instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_cddc_dedicated_propre_host.example <dedicated_host_group_id>:<ecs_instance_id>

--- a/website/docs/r/cdn_domain_config.html.markdown
+++ b/website/docs/r/cdn_domain_config.html.markdown
@@ -84,7 +84,7 @@ The following attributes are exported:
 
 ## Import
 
-CDN domain config can be imported using the id, e.g.
+CDN domain config can be imported using the id, which consists of domain_name, function_name and config_id, e.g.
 
 ```shell
 terraform import alicloud_cdn_domain_config.example <domain_name>:<function_name>:<config_id>

--- a/website/docs/r/cen_child_instance_route_entry_to_attachment.html.markdown
+++ b/website/docs/r/cen_child_instance_route_entry_to_attachment.html.markdown
@@ -117,7 +117,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cen Child Instance Route Entry To Attachment can be imported using the id, e.g.
+Cen Child Instance Route Entry To Attachment can be imported using the id, which consists of cen_id, child_instance_route_table_id, transit_router_attachment_id and destination_cidr_block, e.g.
 
 ```shell
 $terraform import alicloud_cen_child_instance_route_entry_to_attachment.example <cen_id>:<child_instance_route_table_id>:<transit_router_attachment_id>:<destination_cidr_block>

--- a/website/docs/r/cen_private_zone.html.markdown
+++ b/website/docs/r/cen_private_zone.html.markdown
@@ -94,7 +94,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Enterprise Network (CEN) Private Zone can be imported using the id, e.g.
+Cloud Enterprise Network (CEN) Private Zone can be imported using the id, which consists of cen_id and access_region_id, e.g.
 
 ```shell
 $ terraform import alicloud_cen_private_zone.example <cen_id>:<access_region_id>

--- a/website/docs/r/cen_route_map.html.markdown
+++ b/website/docs/r/cen_route_map.html.markdown
@@ -149,7 +149,7 @@ The RouteMapId attributes are exported:
 
 ## Import
 
-CEN RouteMap can be imported using the id, e.g.
+CEN RouteMap can be imported using the id, which consists of cen_id and route_map_id, e.g.
 
 ```shell
 $ terraform import alicloud_cen_route_map.default <cen_id>:<route_map_id>.

--- a/website/docs/r/cen_transit_router.html.markdown
+++ b/website/docs/r/cen_transit_router.html.markdown
@@ -78,7 +78,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Enterprise Network (CEN) Transit Router can be imported using the id, e.g.
+Cloud Enterprise Network (CEN) Transit Router can be imported using the id, which consists of cen_id and transit_router_id, e.g.
 
 ```shell
 $ terraform import alicloud_cen_transit_router.example <cen_id>:<transit_router_id>

--- a/website/docs/r/cen_transit_router_cidr.html.markdown
+++ b/website/docs/r/cen_transit_router_cidr.html.markdown
@@ -82,7 +82,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Enterprise Network (CEN) Transit Router Cidr can be imported using the id, e.g.
+Cloud Enterprise Network (CEN) Transit Router Cidr can be imported using the id, which consists of transit_router_id and transit_router_cidr_id, e.g.
 
 ```shell
 $ terraform import alicloud_cen_transit_router_cidr.example <transit_router_id>:<transit_router_cidr_id>

--- a/website/docs/r/cen_transit_router_grant_attachment.html.markdown
+++ b/website/docs/r/cen_transit_router_grant_attachment.html.markdown
@@ -79,7 +79,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Enterprise Network (CEN) Transit Router Grant Attachment can be imported using the id, e.g.
+Cloud Enterprise Network (CEN) Transit Router Grant Attachment can be imported using the id, which consists of instance_type, instance_id, cen_owner_id and cen_id, e.g.
 
 ```shell
 $ terraform import alicloud_cen_transit_router_grant_attachment.example <instance_type>:<instance_id>:<cen_owner_id>:<cen_id>

--- a/website/docs/r/cen_transit_router_multicast_domain_association.html.markdown
+++ b/website/docs/r/cen_transit_router_multicast_domain_association.html.markdown
@@ -107,7 +107,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Enterprise Network (CEN) Transit Router Multicast Domain Association can be imported using the id, e.g.
+Cloud Enterprise Network (CEN) Transit Router Multicast Domain Association can be imported using the id, which consists of transit_router_multicast_domain_id, transit_router_attachment_id and vswitch_id, e.g.
 
 ```shell
 $ terraform import alicloud_cen_transit_router_multicast_domain_association.example <transit_router_multicast_domain_id>:<transit_router_attachment_id>:<vswitch_id>

--- a/website/docs/r/cen_transit_router_multicast_domain_member.html.markdown
+++ b/website/docs/r/cen_transit_router_multicast_domain_member.html.markdown
@@ -128,7 +128,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cen Transit Router Multicast Domain Member can be imported using the id, e.g.
+Cen Transit Router Multicast Domain Member can be imported using the id, which consists of transit_router_multicast_domain_id, group_ip_address and network_interface_id, e.g.
 
 ```shell
 $terraform import alicloud_cen_transit_router_multicast_domain_member.example <transit_router_multicast_domain_id>:<group_ip_address>:<network_interface_id>

--- a/website/docs/r/cen_transit_router_multicast_domain_peer_member.html.markdown
+++ b/website/docs/r/cen_transit_router_multicast_domain_peer_member.html.markdown
@@ -128,7 +128,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cen Transit Router Multicast Domain Peer Member can be imported using the id, e.g.
+Cen Transit Router Multicast Domain Peer Member can be imported using the id, which consists of transit_router_multicast_domain_id, group_ip_address and peer_transit_router_multicast_domain_id, e.g.
 
 ```shell
 $terraform import alicloud_cen_transit_router_multicast_domain_peer_member.example <transit_router_multicast_domain_id>:<group_ip_address>:<peer_transit_router_multicast_domain_id>

--- a/website/docs/r/cen_transit_router_multicast_domain_source.html.markdown
+++ b/website/docs/r/cen_transit_router_multicast_domain_source.html.markdown
@@ -149,7 +149,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cen Transit Router Multicast Domain Source can be imported using the id, e.g.
+Cen Transit Router Multicast Domain Source can be imported using the id, which consists of transit_router_multicast_domain_id, group_ip_address and network_interface_id, e.g.
 
 ```shell
 $terraform import alicloud_cen_transit_router_multicast_domain_source.example <transit_router_multicast_domain_id>:<group_ip_address>:<network_interface_id>

--- a/website/docs/r/cen_transit_router_peer_attachment.html.markdown
+++ b/website/docs/r/cen_transit_router_peer_attachment.html.markdown
@@ -149,7 +149,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Enterprise Network (CEN) Transit Router Peer Attachment can be imported using the id, e.g.
+Cloud Enterprise Network (CEN) Transit Router Peer Attachment can be imported using the id, which consists of cen_id and transit_router_attachment_id, e.g.
 
 ```shell
 $ terraform import alicloud_cen_transit_router_peer_attachment.example <cen_id>:<transit_router_attachment_id>

--- a/website/docs/r/cen_transit_router_prefix_list_association.html.markdown
+++ b/website/docs/r/cen_transit_router_prefix_list_association.html.markdown
@@ -90,7 +90,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Enterprise Network (CEN) Transit Router Prefix List Association can be imported using the id, e.g.
+Cloud Enterprise Network (CEN) Transit Router Prefix List Association can be imported using the id, which consists of prefix_list_id, transit_router_id, transit_router_table_id and next_hop, e.g.
 
 ```shell
 $ terraform import alicloud_cen_transit_router_prefix_list_association.default <prefix_list_id>:<transit_router_id>:<transit_router_table_id>:<next_hop>.

--- a/website/docs/r/cen_transit_router_route_table_association.html.markdown
+++ b/website/docs/r/cen_transit_router_route_table_association.html.markdown
@@ -120,7 +120,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Enterprise Network (CEN) Transit Router Route Table Association can be imported using the id, e.g.
+Cloud Enterprise Network (CEN) Transit Router Route Table Association can be imported using the id, which consists of transit_router_attachment_id and transit_router_route_table_id, e.g.
 
 ```shell
 $ terraform import alicloud_cen_transit_router_route_table_association.example <transit_router_attachment_id>:<transit_router_route_table_id>

--- a/website/docs/r/cen_transit_router_vbr_attachment.html.markdown
+++ b/website/docs/r/cen_transit_router_vbr_attachment.html.markdown
@@ -111,7 +111,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Enterprise Network (CEN) Transit Router Vbr Attachment can be imported using the id, e.g.
+Cloud Enterprise Network (CEN) Transit Router Vbr Attachment can be imported using the id, which consists of cen_id and transit_router_attachment_id, e.g.
 
 ```shell
 $ terraform import alicloud_cen_transit_router_vbr_attachment.example <cen_id>:<transit_router_attachment_id>

--- a/website/docs/r/click_house_account.html.markdown
+++ b/website/docs/r/click_house_account.html.markdown
@@ -110,7 +110,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Click House Account can be imported using the id, e.g.
+Click House Account can be imported using the id, which consists of db_cluster_id and account_name, e.g.
 
 ```shell
 $ terraform import alicloud_click_house_account.example <db_cluster_id>:<account_name>

--- a/website/docs/r/click_house_enterprise_db_cluster_account.html.markdown
+++ b/website/docs/r/click_house_enterprise_db_cluster_account.html.markdown
@@ -129,7 +129,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Click House Enterprise Db Cluster Account can be imported using the id, e.g.
+Click House Enterprise Db Cluster Account can be imported using the id, which consists of db_instance_id and account, e.g.
 
 ```shell
 $ terraform import alicloud_click_house_enterprise_db_cluster_account.example <db_instance_id>:<account>

--- a/website/docs/r/click_house_enterprise_db_cluster_computing_group.html.markdown
+++ b/website/docs/r/click_house_enterprise_db_cluster_computing_group.html.markdown
@@ -129,7 +129,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Click House Enterprise Db Cluster Computing Group can be imported using the id, e.g.
+Click House Enterprise Db Cluster Computing Group can be imported using the id, which consists of db_instance_id and computing_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_click_house_enterprise_db_cluster_computing_group.example <db_instance_id>:<computing_group_id>

--- a/website/docs/r/click_house_enterprise_db_cluster_public_endpoint.html.markdown
+++ b/website/docs/r/click_house_enterprise_db_cluster_public_endpoint.html.markdown
@@ -101,7 +101,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Click House Enterprise Db Cluster Public Endpoint can be imported using the id, e.g.
+Click House Enterprise Db Cluster Public Endpoint can be imported using the id, which consists of db_instance_id and net_type, e.g.
 
 ```shell
 $ terraform import alicloud_click_house_enterprise_db_cluster_public_endpoint.example <db_instance_id>:<net_type>

--- a/website/docs/r/click_house_enterprise_db_cluster_security_ip.html.markdown
+++ b/website/docs/r/click_house_enterprise_db_cluster_security_ip.html.markdown
@@ -100,7 +100,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Click House Enterprise Db Cluster Security I P can be imported using the id, e.g.
+Click House Enterprise Db Cluster Security I P can be imported using the id, which consists of db_instance_id and group_name, e.g.
 
 ```shell
 $ terraform import alicloud_click_house_enterprise_db_cluster_security_ip.example <db_instance_id>:<group_name>

--- a/website/docs/r/cloud_control_resource.html.markdown
+++ b/website/docs/r/cloud_control_resource.html.markdown
@@ -74,7 +74,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Control Resource can be imported using the id, e.g.
+Cloud Control Resource can be imported using the id, which consists of provider, product, resource_code and resource_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_control_resource.example <provider>:<product>:<resource_code>:<resource_id>

--- a/website/docs/r/cloud_firewall_control_policy_order.html.markdown
+++ b/website/docs/r/cloud_firewall_control_policy_order.html.markdown
@@ -68,7 +68,7 @@ The following attributes are exported:
 
 ## Import
 
-Cloud Firewall Control Policy Order can be imported using the id, e.g.
+Cloud Firewall Control Policy Order can be imported using the id, which consists of acl_uuid and direction, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_firewall_control_policy_order.example <acl_uuid>:<direction>

--- a/website/docs/r/cloud_firewall_nat_firewall_control_policy.html.markdown
+++ b/website/docs/r/cloud_firewall_nat_firewall_control_policy.html.markdown
@@ -230,7 +230,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Firewall Nat Firewall Control Policy can be imported using the id, e.g.
+Cloud Firewall Nat Firewall Control Policy can be imported using the id, which consists of acl_uuid, nat_gateway_id and direction, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_firewall_nat_firewall_control_policy.example <acl_uuid>:<nat_gateway_id>:<direction>

--- a/website/docs/r/cloud_firewall_nat_firewall_control_policy_order.html.markdown
+++ b/website/docs/r/cloud_firewall_nat_firewall_control_policy_order.html.markdown
@@ -81,7 +81,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Firewall Nat Firewall Control Policy Order can be imported using the id, e.g.
+Cloud Firewall Nat Firewall Control Policy Order can be imported using the id, which consists of acl_uuid, nat_gateway_id and direction, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_firewall_nat_firewall_control_policy_order.example <acl_uuid>:<nat_gateway_id>:<direction>

--- a/website/docs/r/cloud_firewall_private_dns.html.markdown
+++ b/website/docs/r/cloud_firewall_private_dns.html.markdown
@@ -112,7 +112,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Firewall Private Dns can be imported using the id, e.g.
+Cloud Firewall Private Dns can be imported using the id, which consists of access_instance_id and region_no, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_firewall_private_dns.example <access_instance_id>:<region_no>

--- a/website/docs/r/cloud_firewall_vpc_firewall_control_policy.html.markdown
+++ b/website/docs/r/cloud_firewall_vpc_firewall_control_policy.html.markdown
@@ -139,7 +139,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Firewall Vpc Firewall Control Policy can be imported using the id, e.g.
+Cloud Firewall Vpc Firewall Control Policy can be imported using the id, which consists of vpc_firewall_id and acl_uuid, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_firewall_vpc_firewall_control_policy.example <vpc_firewall_id>:<acl_uuid>

--- a/website/docs/r/cloud_firewall_vpc_firewall_control_policy_order.html.markdown
+++ b/website/docs/r/cloud_firewall_vpc_firewall_control_policy_order.html.markdown
@@ -92,7 +92,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Firewall Vpc Firewall Control Policy Order can be imported using the id, e.g.
+Cloud Firewall Vpc Firewall Control Policy Order can be imported using the id, which consists of vpc_firewall_id and acl_uuid, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_firewall_vpc_firewall_control_policy_order.example <vpc_firewall_id>:<acl_uuid>

--- a/website/docs/r/cloud_monitor_service_group_monitoring_agent_process.html.markdown
+++ b/website/docs/r/cloud_monitor_service_group_monitoring_agent_process.html.markdown
@@ -127,7 +127,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Monitor Service Group Monitoring Agent Process can be imported using the id, e.g.
+Cloud Monitor Service Group Monitoring Agent Process can be imported using the id, which consists of group_id and group_monitoring_agent_process_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_monitor_service_group_monitoring_agent_process.example <group_id>:<group_monitoring_agent_process_id>

--- a/website/docs/r/cloud_monitor_service_hybrid_double_write.html.markdown
+++ b/website/docs/r/cloud_monitor_service_hybrid_double_write.html.markdown
@@ -74,7 +74,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Monitor Service Hybrid Double Write can be imported using the id, e.g.
+Cloud Monitor Service Hybrid Double Write can be imported using the id, which consists of source_namespace and source_user_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_monitor_service_hybrid_double_write.example <source_namespace>:<source_user_id>

--- a/website/docs/r/cloud_monitor_service_monitoring_agent_process.html.markdown
+++ b/website/docs/r/cloud_monitor_service_monitoring_agent_process.html.markdown
@@ -108,7 +108,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Monitor Service Monitoring Agent Process can be imported using the id, e.g.
+Cloud Monitor Service Monitoring Agent Process can be imported using the id, which consists of instance_id and process_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_monitor_service_monitoring_agent_process.example <instance_id>:<process_id>

--- a/website/docs/r/cloud_sso_access_assignment.html.markdown
+++ b/website/docs/r/cloud_sso_access_assignment.html.markdown
@@ -107,7 +107,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud SSO Access Assignment can be imported using the id, e.g.
+Cloud SSO Access Assignment can be imported using the id, which consists of directory_id, access_configuration_id, target_type, target_id, principal_type and principal_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_sso_access_assignment.example <directory_id>:<access_configuration_id>:<target_type>:<target_id>:<principal_type>:<principal_id>

--- a/website/docs/r/cloud_sso_access_configuration.html.markdown
+++ b/website/docs/r/cloud_sso_access_configuration.html.markdown
@@ -103,7 +103,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud SSO Access Configuration can be imported using the id, e.g.
+Cloud SSO Access Configuration can be imported using the id, which consists of directory_id and access_configuration_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_sso_access_configuration.example <directory_id>:<access_configuration_id>

--- a/website/docs/r/cloud_sso_access_configuration_provisioning.html.markdown
+++ b/website/docs/r/cloud_sso_access_configuration_provisioning.html.markdown
@@ -89,7 +89,7 @@ The following attributes are exported:
 
 ## Import
 
-Cloud SSO Access Configuration Provisioning can be imported using the id, e.g.
+Cloud SSO Access Configuration Provisioning can be imported using the id, which consists of directory_id, access_configuration_id, target_type and target_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_sso_access_assignment.example <directory_id>:<access_configuration_id>:<target_type>:<target_id>

--- a/website/docs/r/cloud_sso_group.html.markdown
+++ b/website/docs/r/cloud_sso_group.html.markdown
@@ -69,7 +69,7 @@ The following attributes are exported:
 
 ## Import
 
-Cloud SSO Group can be imported using the id, e.g.
+Cloud SSO Group can be imported using the id, which consists of directory_id and group_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_sso_group.example <directory_id>:<group_id>

--- a/website/docs/r/cloud_sso_scim_server_credential.html.markdown
+++ b/website/docs/r/cloud_sso_scim_server_credential.html.markdown
@@ -68,7 +68,7 @@ The following attributes are exported:
 
 ## Import
 
-Cloud SSO SCIM Server Credential can be imported using the id, e.g.
+Cloud SSO SCIM Server Credential can be imported using the id, which consists of directory_id and credential_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_sso_scim_server_credential.example <directory_id>:<credential_id>

--- a/website/docs/r/cloud_sso_user.html.markdown
+++ b/website/docs/r/cloud_sso_user.html.markdown
@@ -93,7 +93,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Sso User can be imported using the id, e.g.
+Cloud Sso User can be imported using the id, which consists of directory_id and user_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_sso_user.example <directory_id>:<user_id>

--- a/website/docs/r/cloud_sso_user_attachment.html.markdown
+++ b/website/docs/r/cloud_sso_user_attachment.html.markdown
@@ -87,7 +87,7 @@ The following attributes are exported:
 
 ## Import
 
-Cloud SSO User Attachment can be imported using the id, e.g.
+Cloud SSO User Attachment can be imported using the id, which consists of directory_id, group_id and user_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_sso_user_attachment.example <directory_id>:<group_id>:<user_id>

--- a/website/docs/r/cloud_sso_user_provisioning.html.markdown
+++ b/website/docs/r/cloud_sso_user_provisioning.html.markdown
@@ -112,7 +112,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud SSO User Provisioning can be imported using the id, e.g.
+Cloud SSO User Provisioning can be imported using the id, which consists of directory_id and user_provisioning_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_sso_user_provisioning.example <directory_id>:<user_provisioning_id>

--- a/website/docs/r/cloud_storage_gateway_express_sync_share_attachment.html.markdown
+++ b/website/docs/r/cloud_storage_gateway_express_sync_share_attachment.html.markdown
@@ -141,7 +141,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Storage Gateway Express Sync Share Attachment can be imported using the id, e.g.
+Cloud Storage Gateway Express Sync Share Attachment can be imported using the id, which consists of express_sync_id, gateway_id and share_name, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_storage_gateway_express_sync_share_attachment.example <express_sync_id>:<gateway_id>:<share_name>

--- a/website/docs/r/cloud_storage_gateway_gateway_block_volume.html.markdown
+++ b/website/docs/r/cloud_storage_gateway_gateway_block_volume.html.markdown
@@ -134,7 +134,7 @@ The following attributes are exported:
 
 ## Import
 
-Cloud Storage Gateway Gateway Block Volume can be imported using the id, e.g.
+Cloud Storage Gateway Gateway Block Volume can be imported using the id, which consists of gateway_id and index_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_storage_gateway_gateway_block_volume.example <gateway_id>:<index_id>

--- a/website/docs/r/cloud_storage_gateway_gateway_cache_disk.html.markdown
+++ b/website/docs/r/cloud_storage_gateway_gateway_cache_disk.html.markdown
@@ -92,7 +92,7 @@ The following attributes are exported:
 
 ## Import
 
-Cloud Storage Gateway Gateway Cache Disk can be imported using the id, e.g.
+Cloud Storage Gateway Gateway Cache Disk can be imported using the id, which consists of gateway_id, cache_id and local_file_path, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_storage_gateway_gateway_cache_disk.example <gateway_id>:<cache_id>:<local_file_path>

--- a/website/docs/r/cloud_storage_gateway_gateway_file_share.html.markdown
+++ b/website/docs/r/cloud_storage_gateway_gateway_file_share.html.markdown
@@ -147,7 +147,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Storage Gateway Gateway File Share can be imported using the id, e.g.
+Cloud Storage Gateway Gateway File Share can be imported using the id, which consists of gateway_id and index_id, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_storage_gateway_gateway_file_share.example <gateway_id>:<index_id>

--- a/website/docs/r/cloud_storage_gateway_gateway_smb_user.html.markdown
+++ b/website/docs/r/cloud_storage_gateway_gateway_smb_user.html.markdown
@@ -95,7 +95,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Storage Gateway Gateway SMB User can be imported using the id, e.g.
+Cloud Storage Gateway Gateway SMB User can be imported using the id, which consists of gateway_id and username, e.g.
 
 ```shell
 $ terraform import alicloud_cloud_storage_gateway_gateway_smb_user.example <gateway_id>:<username>

--- a/website/docs/r/cms_addon_release.html.markdown
+++ b/website/docs/r/cms_addon_release.html.markdown
@@ -95,7 +95,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cms Addon Release can be imported using the id, e.g.
+Cms Addon Release can be imported using the id, which consists of integration_policy_id and addon_release_name, e.g.
 
 ```shell
 $ terraform import alicloud_cms_addon_release.example <integration_policy_id>:<addon_release_name>

--- a/website/docs/r/cms_agg_task_group.html.markdown
+++ b/website/docs/r/cms_agg_task_group.html.markdown
@@ -110,7 +110,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cms Agg Task Group can be imported using the id, e.g.
+Cms Agg Task Group can be imported using the id, which consists of source_prometheus_id and agg_task_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_cms_agg_task_group.example <source_prometheus_id>:<agg_task_group_id>

--- a/website/docs/r/cms_event_notify_policy.html.markdown
+++ b/website/docs/r/cms_event_notify_policy.html.markdown
@@ -239,7 +239,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cms Event Notify Policy can be imported using the id, e.g.
+Cms Event Notify Policy can be imported using the id, which consists of uuid and workspace, e.g.
 
 ```shell
 $ terraform import alicloud_cms_event_notify_policy.example <uuid>:<workspace>

--- a/website/docs/r/cms_hybrid_monitor_fc_task.html.markdown
+++ b/website/docs/r/cms_hybrid_monitor_fc_task.html.markdown
@@ -92,7 +92,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Monitor Service Hybrid Monitor Fc Task can be imported using the id, e.g.
+Cloud Monitor Service Hybrid Monitor Fc Task can be imported using the id, which consists of hybrid_monitor_fc_task_id and namespace, e.g.
 
 ```shell
 $ terraform import alicloud_cms_hybrid_monitor_fc_task.example <hybrid_monitor_fc_task_id>:<namespace>

--- a/website/docs/r/common_bandwidth_package_attachment.html.markdown
+++ b/website/docs/r/common_bandwidth_package_attachment.html.markdown
@@ -85,7 +85,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-EIP Bandwidth Plan (CBWP) Common Bandwidth Package Attachment can be imported using the id, e.g.
+EIP Bandwidth Plan (CBWP) Common Bandwidth Package Attachment can be imported using the id, which consists of bandwidth_package_id and instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_common_bandwidth_package_attachment.example <bandwidth_package_id>:<instance_id>

--- a/website/docs/r/config_aggregate_compliance_pack.html.markdown
+++ b/website/docs/r/config_aggregate_compliance_pack.html.markdown
@@ -130,7 +130,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Config Aggregate Compliance Pack can be imported using the id, e.g.
+Cloud Config Aggregate Compliance Pack can be imported using the id, which consists of aggregator_id and aggregator_compliance_pack_id, e.g.
 
 ```shell
 $ terraform import alicloud_config_aggregate_compliance_pack.example <aggregator_id>:<aggregator_compliance_pack_id>

--- a/website/docs/r/config_aggregate_config_rule.html.markdown
+++ b/website/docs/r/config_aggregate_config_rule.html.markdown
@@ -112,7 +112,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Config Aggregate Config Rule can be imported using the id, e.g.
+Cloud Config Aggregate Config Rule can be imported using the id, which consists of aggregator_id and config_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_config_aggregate_config_rule.example "<aggregator_id>:<config_rule_id>"

--- a/website/docs/r/config_aggregate_delivery.html.markdown
+++ b/website/docs/r/config_aggregate_delivery.html.markdown
@@ -127,7 +127,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Config Aggregate Delivery can be imported using the id, e.g.
+Config Aggregate Delivery can be imported using the id, which consists of aggregator_id and delivery_channel_id, e.g.
 
 ```shell
 $ terraform import alicloud_config_aggregate_delivery.example <aggregator_id>:<delivery_channel_id>

--- a/website/docs/r/config_aggregate_remediation.html.markdown
+++ b/website/docs/r/config_aggregate_remediation.html.markdown
@@ -139,7 +139,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Cloud Config (Config) Aggregate Remediation can be imported using the id, e.g.
+Cloud Config (Config) Aggregate Remediation can be imported using the id, which consists of aggregator_id and remediation_id, e.g.
 
 ```shell
 $ terraform import alicloud_config_aggregate_remediation.example <aggregator_id>:<remediation_id>

--- a/website/docs/r/cr_artifact_lifecycle_rule.html.markdown
+++ b/website/docs/r/cr_artifact_lifecycle_rule.html.markdown
@@ -105,7 +105,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-CR Artifact Lifecycle Rule can be imported using the id, e.g.
+CR Artifact Lifecycle Rule can be imported using the id, which consists of instance_id and artifact_lifecycle_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_cr_artifact_lifecycle_rule.example <instance_id>:<artifact_lifecycle_rule_id>

--- a/website/docs/r/cr_artifact_subscription_rule.html.markdown
+++ b/website/docs/r/cr_artifact_subscription_rule.html.markdown
@@ -104,7 +104,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-cr Artifact Subscription Rule can be imported using the id, e.g.
+cr Artifact Subscription Rule can be imported using the id, which consists of instance_id and artifact_subscription_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_cr_artifact_subscription_rule.example <instance_id>:<artifact_subscription_rule_id>

--- a/website/docs/r/cr_chain.html.markdown
+++ b/website/docs/r/cr_chain.html.markdown
@@ -241,7 +241,7 @@ The following attributes are exported:
 
 ## Import
 
-CR Chain can be imported using the id, e.g.
+CR Chain can be imported using the id, which consists of instance_id and chain_id, e.g.
 
 ```shell
 $ terraform import alicloud_cr_chain.example <instance_id>:<chain_id>

--- a/website/docs/r/cr_chart_namespace.html.markdown
+++ b/website/docs/r/cr_chart_namespace.html.markdown
@@ -71,7 +71,7 @@ The following attributes are exported:
 
 ## Import
 
-CR Chart Namespace can be imported using the id, e.g.
+CR Chart Namespace can be imported using the id, which consists of instance_id and namespace_name, e.g.
 
 ```shell
 $ terraform import alicloud_cr_chart_namespace.example <instance_id>:<namespace_name>

--- a/website/docs/r/cr_chart_repository.html.markdown
+++ b/website/docs/r/cr_chart_repository.html.markdown
@@ -76,7 +76,7 @@ The following attributes are exported:
 
 ## Import
 
-CR Chart Repository can be imported using the id, e.g.
+CR Chart Repository can be imported using the id, which consists of instance_id, repo_namespace_name and repo_name, e.g.
 
 ```shell
 $ terraform import alicloud_cr_chart_repository.example <instance_id>:<repo_namespace_name>:<repo_name>

--- a/website/docs/r/cr_ee_namespace.html.markdown
+++ b/website/docs/r/cr_ee_namespace.html.markdown
@@ -75,7 +75,7 @@ The following attributes are exported:
 
 ## Import
 
-Container Registry Enterprise Edition Namespace can be imported using the id, e.g.
+Container Registry Enterprise Edition Namespace can be imported using the id, which consists of instance_id and name, e.g.
 
 ```shell
 $ terraform import alicloud_cr_ee_namespace.example <instance_id>:<name>

--- a/website/docs/r/cr_ee_repo.html.markdown
+++ b/website/docs/r/cr_ee_repo.html.markdown
@@ -90,7 +90,7 @@ The following attributes are exported:
 
 ## Import
 
-Container Registry Enterprise Edition Repository can be imported using the id, e.g.
+Container Registry Enterprise Edition Repository can be imported using the id, which consists of instance_id, namespace and name, e.g.
 
 ```shell
 $ terraform import alicloud_cr_ee_repo.example <instance_id>:<namespace>:<name>

--- a/website/docs/r/cr_ee_sync_rule.html.markdown
+++ b/website/docs/r/cr_ee_sync_rule.html.markdown
@@ -146,7 +146,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Container Registry Sync Rule can be imported using the id, e.g.
+Container Registry Sync Rule can be imported using the id, which consists of instance_id, namespace_name and repo_sync_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_cr_ee_sync_rule.example <instance_id>:<namespace_name>:<repo_sync_rule_id>

--- a/website/docs/r/cr_endpoint_acl_policy.html.markdown
+++ b/website/docs/r/cr_endpoint_acl_policy.html.markdown
@@ -86,7 +86,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-CR Endpoint Acl Policy can be imported using the id, e.g.
+CR Endpoint Acl Policy can be imported using the id, which consists of instance_id, endpoint_type and entry, e.g.
 
 ```shell
 $ terraform import alicloud_cr_endpoint_acl_policy.example <instance_id>:<endpoint_type>:<entry>

--- a/website/docs/r/cr_scan_rule.html.markdown
+++ b/website/docs/r/cr_scan_rule.html.markdown
@@ -95,7 +95,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-CR Scan Rule can be imported using the id, e.g.
+CR Scan Rule can be imported using the id, which consists of instance_id and scan_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_cr_scan_rule.example <instance_id>:<scan_rule_id>

--- a/website/docs/r/cr_storage_domain_routing_rule.html.markdown
+++ b/website/docs/r/cr_storage_domain_routing_rule.html.markdown
@@ -85,7 +85,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-CR Storage Domain Routing Rule can be imported using the id, e.g.
+CR Storage Domain Routing Rule can be imported using the id, which consists of instance_id and rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_cr_storage_domain_routing_rule.example <instance_id>:<rule_id>

--- a/website/docs/r/cr_vpc_endpoint_linked_vpc.html.markdown
+++ b/website/docs/r/cr_vpc_endpoint_linked_vpc.html.markdown
@@ -100,7 +100,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-CR Vpc Endpoint Linked Vpc can be imported using the id, e.g.
+CR Vpc Endpoint Linked Vpc can be imported using the id, which consists of instance_id, vpc_id, vswitch_id and module_name, e.g.
 
 ```shell
 $ terraform import alicloud_cr_vpc_endpoint_linked_vpc.example <instance_id>:<vpc_id>:<vswitch_id>:<module_name>

--- a/website/docs/r/cs_kubernetes_node_pool.html.markdown
+++ b/website/docs/r/cs_kubernetes_node_pool.html.markdown
@@ -1114,7 +1114,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Container Service for Kubernetes (ACK) Nodepool can be imported using the id, e.g.
+Container Service for Kubernetes (ACK) Nodepool can be imported using the id, which consists of cluster_id and node_pool_id, e.g.
 
 ```shell
 $ terraform import alicloud_cs_kubernetes_node_pool.example <cluster_id>:<node_pool_id>

--- a/website/docs/r/cs_kubernetes_policy_instance.html.markdown
+++ b/website/docs/r/cs_kubernetes_policy_instance.html.markdown
@@ -182,7 +182,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Container Service for Kubernetes (ACK) Policy Instance can be imported using the id, e.g.
+Container Service for Kubernetes (ACK) Policy Instance can be imported using the id, which consists of cluster_id, policy_name and instance_name, e.g.
 
 ```shell
 $ terraform import alicloud_cs_kubernetes_policy_instance.example <cluster_id>:<policy_name>:<instance_name>

--- a/website/docs/r/data_works_data_source.html.markdown
+++ b/website/docs/r/data_works_data_source.html.markdown
@@ -95,7 +95,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Data Works Data Source can be imported using the id, e.g.
+Data Works Data Source can be imported using the id, which consists of project_id and data_source_id, e.g.
 
 ```shell
 $ terraform import alicloud_data_works_data_source.example <project_id>:<data_source_id>

--- a/website/docs/r/data_works_data_source_shared_rule.html.markdown
+++ b/website/docs/r/data_works_data_source_shared_rule.html.markdown
@@ -96,7 +96,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Data Works Data Source Shared Rule can be imported using the id, e.g.
+Data Works Data Source Shared Rule can be imported using the id, which consists of data_source_id and data_source_shared_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_data_works_data_source_shared_rule.example <data_source_id>:<data_source_shared_rule_id>

--- a/website/docs/r/data_works_di_alarm_rule.html.markdown
+++ b/website/docs/r/data_works_di_alarm_rule.html.markdown
@@ -217,7 +217,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Data Works Di Alarm Rule can be imported using the id, e.g.
+Data Works Di Alarm Rule can be imported using the id, which consists of di_job_id and di_alarm_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_data_works_di_alarm_rule.example <di_job_id>:<di_alarm_rule_id>

--- a/website/docs/r/data_works_di_job.html.markdown
+++ b/website/docs/r/data_works_di_job.html.markdown
@@ -353,7 +353,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Data Works Di Job can be imported using the id, e.g.
+Data Works Di Job can be imported using the id, which consists of project_id and di_job_id, e.g.
 
 ```shell
 $ terraform import alicloud_data_works_di_job.example <project_id>:<di_job_id>

--- a/website/docs/r/data_works_project_member.html.markdown
+++ b/website/docs/r/data_works_project_member.html.markdown
@@ -103,7 +103,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Data Works Project Member can be imported using the id, e.g.
+Data Works Project Member can be imported using the id, which consists of project_id and user_id, e.g.
 
 ```shell
 $ terraform import alicloud_data_works_project_member.example <project_id>:<user_id>

--- a/website/docs/r/dcdn_domain_config.html.markdown
+++ b/website/docs/r/dcdn_domain_config.html.markdown
@@ -107,7 +107,7 @@ The following attributes are exported:
 
 ## Import
 
-DCDN domain config can be imported using the id, e.g.
+DCDN domain config can be imported using the id, which consists of domain_name, function_name and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_dcdn_domain_config.example <domain_name>:<function_name>:<config_id>

--- a/website/docs/r/dcdn_kv.html.markdown
+++ b/website/docs/r/dcdn_kv.html.markdown
@@ -72,7 +72,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Dcdn Kv can be imported using the id, e.g.
+Dcdn Kv can be imported using the id, which consists of namespace and key, e.g.
 
 ```shell
 $ terraform import alicloud_dcdn_kv.example <namespace>:<key>

--- a/website/docs/r/ddos_basic_defense_threshold.html.markdown
+++ b/website/docs/r/ddos_basic_defense_threshold.html.markdown
@@ -73,7 +73,7 @@ The following attributes are exported:
 
 ## Import
 
-Ddos Basic Antiddos can be imported using the id, e.g.
+Ddos Basic Antiddos can be imported using the id, which consists of instance_id, instance_type and ddos_type, e.g.
 
 ```shell
 $ terraform import alicloud_ddos_basic_antiddos.example <instance_id>:<instance_type>:<ddos_type>

--- a/website/docs/r/ddos_basic_threshold.html.markdown
+++ b/website/docs/r/ddos_basic_threshold.html.markdown
@@ -114,7 +114,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Ddos Basic Threshold can be imported using the id, e.g.
+Ddos Basic Threshold can be imported using the id, which consists of instance_type, instance_id and internet_ip, e.g.
 
 ```shell
 $ terraform import alicloud_ddos_basic_threshold.example <instance_type>:<instance_id>:<internet_ip>

--- a/website/docs/r/ddosbgp_ip.html.markdown
+++ b/website/docs/r/ddosbgp_ip.html.markdown
@@ -83,7 +83,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Anti-DDoS Pro (DdosBgp) Ip can be imported using the id, e.g.
+Anti-DDoS Pro (DdosBgp) Ip can be imported using the id, which consists of instance_id and ip, e.g.
 
 ```shell
 $ terraform import alicloud_ddosbgp_ip.example <instance_id>:<ip>

--- a/website/docs/r/ddoscoo_domain_precise_access_rule.html.markdown
+++ b/website/docs/r/ddoscoo_domain_precise_access_rule.html.markdown
@@ -108,7 +108,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-DdosCoo Domain Precise Access Rule can be imported using the id, e.g.
+DdosCoo Domain Precise Access Rule can be imported using the id, which consists of domain and name, e.g.
 
 ```shell
 $ terraform import alicloud_ddoscoo_domain_precise_access_rule.example <domain>:<name>

--- a/website/docs/r/ddoscoo_port.html.markdown
+++ b/website/docs/r/ddoscoo_port.html.markdown
@@ -93,7 +93,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Ddos Coo Port can be imported using the id, e.g.
+Ddos Coo Port can be imported using the id, which consists of instance_id, frontend_port and frontend_protocol, e.g.
 
 ```shell
 $ terraform import alicloud_ddoscoo_port.example <instance_id>:<frontend_port>:<frontend_protocol>

--- a/website/docs/r/ddoscoo_web_cc_rule.html.markdown
+++ b/website/docs/r/ddoscoo_web_cc_rule.html.markdown
@@ -184,7 +184,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-DdosCoo Web Cc Rule can be imported using the id, e.g.
+DdosCoo Web Cc Rule can be imported using the id, which consists of domain and name, e.g.
 
 ```shell
 $ terraform import alicloud_ddoscoo_web_cc_rule.example <domain>:<name>

--- a/website/docs/r/dfs_access_rule.html.markdown
+++ b/website/docs/r/dfs_access_rule.html.markdown
@@ -71,7 +71,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-DFS Access Rule can be imported using the id, e.g.
+DFS Access Rule can be imported using the id, which consists of access_group_id and access_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_dfs_access_rule.example <access_group_id>:<access_rule_id>

--- a/website/docs/r/dfs_mount_point.html.markdown
+++ b/website/docs/r/dfs_mount_point.html.markdown
@@ -103,7 +103,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Apsara File Storage for HDFS (DFS) Mount Point can be imported using the id, e.g.
+Apsara File Storage for HDFS (DFS) Mount Point can be imported using the id, which consists of file_system_id and mount_point_id, e.g.
 
 ```shell
 $ terraform import alicloud_dfs_mount_point.example <file_system_id>:<mount_point_id>

--- a/website/docs/r/dfs_vsc_mount_point.html.markdown
+++ b/website/docs/r/dfs_vsc_mount_point.html.markdown
@@ -86,7 +86,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Apsara File Storage for HDFS (DFS) Vsc Mount Point can be imported using the id, e.g.
+Apsara File Storage for HDFS (DFS) Vsc Mount Point can be imported using the id, which consists of file_system_id and mount_point_id, e.g.
 
 ```shell
 $ terraform import alicloud_dfs_vsc_mount_point.example <file_system_id>:<mount_point_id>

--- a/website/docs/r/dms_airflow.html.markdown
+++ b/website/docs/r/dms_airflow.html.markdown
@@ -115,7 +115,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Dms Airflow can be imported using the id, e.g.
+Dms Airflow can be imported using the id, which consists of workspace_id and airflow_id, e.g.
 
 ```shell
 $ terraform import alicloud_dms_airflow.example <workspace_id>:<airflow_id>

--- a/website/docs/r/dms_enterprise_authority_template.html.markdown
+++ b/website/docs/r/dms_enterprise_authority_template.html.markdown
@@ -69,7 +69,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-DMS Enterprise Authority Template can be imported using the id, e.g.
+DMS Enterprise Authority Template can be imported using the id, which consists of tid and authority_template_id, e.g.
 
 ```shell
 $ terraform import alicloud_dms_enterprise_authority_template.example <tid>:<authority_template_id>

--- a/website/docs/r/dts_consumer_channel.html.markdown
+++ b/website/docs/r/dts_consumer_channel.html.markdown
@@ -142,7 +142,7 @@ The following attributes are exported:
 
 ## Import
 
-DTS Consumer Channel can be imported using the id, e.g.
+DTS Consumer Channel can be imported using the id, which consists of dts_instance_id and consumer_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_dts_consumer_channel.example <dts_instance_id>:<consumer_group_id>

--- a/website/docs/r/eais_client_instance_attachment.html.markdown
+++ b/website/docs/r/eais_client_instance_attachment.html.markdown
@@ -148,7 +148,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-EAIS Client Instance Attachment can be imported using the id, e.g.
+EAIS Client Instance Attachment can be imported using the id, which consists of instance_id and client_instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_eais_client_instance_attachment.example <instance_id>:<client_instance_id>

--- a/website/docs/r/ebs_enterprise_snapshot_policy_attachment.html.markdown
+++ b/website/docs/r/ebs_enterprise_snapshot_policy_attachment.html.markdown
@@ -85,7 +85,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-EBS Enterprise Snapshot Policy Attachment can be imported using the id, e.g.
+EBS Enterprise Snapshot Policy Attachment can be imported using the id, which consists of policy_id and disk_id, e.g.
 
 ```shell
 $ terraform import alicloud_ebs_enterprise_snapshot_policy_attachment.example <policy_id>:<disk_id>

--- a/website/docs/r/ebs_replica_group_drill.html.markdown
+++ b/website/docs/r/ebs_replica_group_drill.html.markdown
@@ -60,7 +60,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-EBS Replica Group Drill can be imported using the id, e.g.
+EBS Replica Group Drill can be imported using the id, which consists of group_id and replica_group_drill_id, e.g.
 
 ```shell
 $ terraform import alicloud_ebs_replica_group_drill.example <group_id>:<replica_group_drill_id>

--- a/website/docs/r/ebs_replica_pair_drill.html.markdown
+++ b/website/docs/r/ebs_replica_pair_drill.html.markdown
@@ -60,7 +60,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-EBS Replica Pair Drill can be imported using the id, e.g.
+EBS Replica Pair Drill can be imported using the id, which consists of pair_id and replica_pair_drill_id, e.g.
 
 ```shell
 $ terraform import alicloud_ebs_replica_pair_drill.example <pair_id>:<replica_pair_drill_id>

--- a/website/docs/r/ecs_auto_snapshot_policy_attachment.html.markdown
+++ b/website/docs/r/ecs_auto_snapshot_policy_attachment.html.markdown
@@ -77,7 +77,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ECS Auto Snapshot Policy Attachment can be imported using the id, e.g.
+ECS Auto Snapshot Policy Attachment can be imported using the id, which consists of auto_snapshot_policy_id and disk_id, e.g.
 
 ```shell
 $ terraform import alicloud_ecs_auto_snapshot_policy_attachment.example <auto_snapshot_policy_id>:<disk_id>

--- a/website/docs/r/ecs_key_pair_attachment.html.markdown
+++ b/website/docs/r/ecs_key_pair_attachment.html.markdown
@@ -122,7 +122,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ECS Key Pair Attachment can be imported using the id, e.g.
+ECS Key Pair Attachment can be imported using the id, which consists of key_pair_name and instance_ids, e.g.
 
 ```shell
 $ terraform import alicloud_ecs_key_pair_attachment.example <key_pair_name>:<instance_ids>

--- a/website/docs/r/ecs_network_interface_attachment.html.markdown
+++ b/website/docs/r/ecs_network_interface_attachment.html.markdown
@@ -125,7 +125,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ECS Network Interface Attachment can be imported using the id, e.g.
+ECS Network Interface Attachment can be imported using the id, which consists of network_interface_id and instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_ecs_network_interface_attachment.example <network_interface_id>:<instance_id>

--- a/website/docs/r/eflo_node_group.html.markdown
+++ b/website/docs/r/eflo_node_group.html.markdown
@@ -283,7 +283,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Eflo Node Group can be imported using the id, e.g.
+Eflo Node Group can be imported using the id, which consists of cluster_id and node_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_eflo_node_group.example <cluster_id>:<node_group_id>

--- a/website/docs/r/eflo_node_group_attachment.html.markdown
+++ b/website/docs/r/eflo_node_group_attachment.html.markdown
@@ -83,7 +83,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Eflo Node Group Attachment can be imported using the id, e.g.
+Eflo Node Group Attachment can be imported using the id, which consists of cluster_id, node_group_id and node_id, e.g.
 
 ```shell
 $ terraform import alicloud_eflo_node_group_attachment.example <cluster_id>:<node_group_id>:<node_id>

--- a/website/docs/r/eflo_subnet.html.markdown
+++ b/website/docs/r/eflo_subnet.html.markdown
@@ -85,7 +85,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Eflo Subnet can be imported using the id, e.g.
+Eflo Subnet can be imported using the id, which consists of vpd_id and subnet_id, e.g.
 
 ```shell
 $ terraform import alicloud_eflo_subnet.example <vpd_id>:<subnet_id>

--- a/website/docs/r/eip_association.html.markdown
+++ b/website/docs/r/eip_association.html.markdown
@@ -146,7 +146,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-EIP Association can be imported using the id, e.g.
+EIP Association can be imported using the id, which consists of allocation_id and instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_eip_association.example <allocation_id>:<instance_id>

--- a/website/docs/r/ens_disk_instance_attachment.html.markdown
+++ b/website/docs/r/ens_disk_instance_attachment.html.markdown
@@ -91,7 +91,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ENS Disk Instance Attachment can be imported using the id, e.g.
+ENS Disk Instance Attachment can be imported using the id, which consists of disk_id and instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_ens_disk_instance_attachment.example <disk_id>:<instance_id>

--- a/website/docs/r/ens_eip_instance_attachment.html.markdown
+++ b/website/docs/r/ens_eip_instance_attachment.html.markdown
@@ -107,7 +107,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Ens Eip Instance Attachment can be imported using the id, e.g.
+Ens Eip Instance Attachment can be imported using the id, which consists of allocation_id, instance_id and instance_type, e.g.
 
 ```shell
 $ terraform import alicloud_ens_eip_instance_attachment.example <allocation_id>:<instance_id>:<instance_type>

--- a/website/docs/r/ens_instance_security_group_attachment.html.markdown
+++ b/website/docs/r/ens_instance_security_group_attachment.html.markdown
@@ -86,7 +86,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ENS Instance Security Group Attachment can be imported using the id, e.g.
+ENS Instance Security Group Attachment can be imported using the id, which consists of instance_id and security_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_ens_instance_security_group_attachment.example <instance_id>:<security_group_id>

--- a/website/docs/r/ens_key_pair.html.markdown
+++ b/website/docs/r/ens_key_pair.html.markdown
@@ -52,7 +52,7 @@ The following attributes are exported:
 
 ## Import
 
-ENS Key Pair can be imported using the id, e.g.
+ENS Key Pair can be imported using the id, which consists of key_pair_name and version, e.g.
 
 ```shell
 $ terraform import alicloud_ens_key_pair.example <key_pair_name>:<version>

--- a/website/docs/r/esa_certificate.html.markdown
+++ b/website/docs/r/esa_certificate.html.markdown
@@ -84,7 +84,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Certificate can be imported using the id, e.g.
+ESA Certificate can be imported using the id, which consists of site_id and cert_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_certificate.example <site_id>:<cert_id>

--- a/website/docs/r/esa_client_certificate.html.markdown
+++ b/website/docs/r/esa_client_certificate.html.markdown
@@ -75,7 +75,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Client Certificate can be imported using the id, e.g.
+ESA Client Certificate can be imported using the id, which consists of site_id and client_cert_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_client_certificate.example <site_id>:<client_cert_id>

--- a/website/docs/r/esa_compression_rule.html.markdown
+++ b/website/docs/r/esa_compression_rule.html.markdown
@@ -90,7 +90,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Compression Rule can be imported using the id, e.g.
+ESA Compression Rule can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_compression_rule.example <site_id>:<config_id>

--- a/website/docs/r/esa_custom_response_code_rule.html.markdown
+++ b/website/docs/r/esa_custom_response_code_rule.html.markdown
@@ -98,7 +98,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Custom Response Code Rule can be imported using the id, e.g.
+ESA Custom Response Code Rule can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_custom_response_code_rule.example <site_id>:<config_id>

--- a/website/docs/r/esa_edge_container_app_record.html.markdown
+++ b/website/docs/r/esa_edge_container_app_record.html.markdown
@@ -94,7 +94,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Edge Container App Record can be imported using the id, e.g.
+ESA Edge Container App Record can be imported using the id, which consists of site_id, app_id and record_name, e.g.
 
 ```shell
 $ terraform import alicloud_esa_edge_container_app_record.example <site_id>:<app_id>:<record_name>

--- a/website/docs/r/esa_http_incoming_request_header_modification_rule.html.markdown
+++ b/website/docs/r/esa_http_incoming_request_header_modification_rule.html.markdown
@@ -130,7 +130,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Http Incoming Request Header Modification Rule can be imported using the id, e.g.
+ESA Http Incoming Request Header Modification Rule can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_http_incoming_request_header_modification_rule.example <site_id>:<config_id>

--- a/website/docs/r/esa_http_incoming_response_header_modification_rule.html.markdown
+++ b/website/docs/r/esa_http_incoming_response_header_modification_rule.html.markdown
@@ -130,7 +130,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Http Incoming Response Header Modification Rule can be imported using the id, e.g.
+ESA Http Incoming Response Header Modification Rule can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_http_incoming_response_header_modification_rule.example <site_id>:<config_id>

--- a/website/docs/r/esa_http_request_header_modification_rule.html.markdown
+++ b/website/docs/r/esa_http_request_header_modification_rule.html.markdown
@@ -118,7 +118,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Http Request Header Modification Rule can be imported using the id, e.g.
+ESA Http Request Header Modification Rule can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_http_request_header_modification_rule.example <site_id>:<config_id>

--- a/website/docs/r/esa_http_response_header_modification_rule.html.markdown
+++ b/website/docs/r/esa_http_response_header_modification_rule.html.markdown
@@ -126,7 +126,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Http Response Header Modification Rule can be imported using the id, e.g.
+ESA Http Response Header Modification Rule can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_http_response_header_modification_rule.example <site_id>:<config_id>

--- a/website/docs/r/esa_https_application_configuration.html.markdown
+++ b/website/docs/r/esa_https_application_configuration.html.markdown
@@ -123,7 +123,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Https Application Configuration can be imported using the id, e.g.
+ESA Https Application Configuration can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_https_application_configuration.example <site_id>:<config_id>

--- a/website/docs/r/esa_https_basic_configuration.html.markdown
+++ b/website/docs/r/esa_https_basic_configuration.html.markdown
@@ -121,7 +121,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Https Basic Configuration can be imported using the id, e.g.
+ESA Https Basic Configuration can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_https_basic_configuration.example <site_id>:<config_id>

--- a/website/docs/r/esa_image_transform.html.markdown
+++ b/website/docs/r/esa_image_transform.html.markdown
@@ -82,7 +82,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Image Transform can be imported using the id, e.g.
+ESA Image Transform can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_image_transform.example <site_id>:<config_id>

--- a/website/docs/r/esa_kv.html.markdown
+++ b/website/docs/r/esa_kv.html.markdown
@@ -69,7 +69,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Kv can be imported using the id, e.g.
+ESA Kv can be imported using the id, which consists of namespace and key, e.g.
 
 ```shell
 $ terraform import alicloud_esa_kv.example <namespace>:<key>

--- a/website/docs/r/esa_load_balancer.html.markdown
+++ b/website/docs/r/esa_load_balancer.html.markdown
@@ -184,7 +184,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Load Balancer can be imported using the id, e.g.
+ESA Load Balancer can be imported using the id, which consists of site_id and load_balancer_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_load_balancer.example <site_id>:<load_balancer_id>

--- a/website/docs/r/esa_network_optimization.html.markdown
+++ b/website/docs/r/esa_network_optimization.html.markdown
@@ -101,7 +101,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Network Optimization can be imported using the id, e.g.
+ESA Network Optimization can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_network_optimization.example <site_id>:<config_id>

--- a/website/docs/r/esa_origin_ca_certificate.html.markdown
+++ b/website/docs/r/esa_origin_ca_certificate.html.markdown
@@ -76,7 +76,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Origin Ca Certificate can be imported using the id, e.g.
+ESA Origin Ca Certificate can be imported using the id, which consists of site_id and origin_ca_certificate_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_origin_ca_certificate.example <site_id>:<origin_ca_certificate_id>

--- a/website/docs/r/esa_origin_client_certificate.html.markdown
+++ b/website/docs/r/esa_origin_client_certificate.html.markdown
@@ -79,7 +79,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Origin Client Certificate can be imported using the id, e.g.
+ESA Origin Client Certificate can be imported using the id, which consists of site_id and origin_client_certificate_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_origin_client_certificate.example <site_id>:<origin_client_certificate_id>

--- a/website/docs/r/esa_origin_pool.html.markdown
+++ b/website/docs/r/esa_origin_pool.html.markdown
@@ -161,7 +161,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Origin Pool can be imported using the id, e.g.
+ESA Origin Pool can be imported using the id, which consists of site_id and origin_pool_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_origin_pool.example <site_id>:<origin_pool_id>

--- a/website/docs/r/esa_origin_rule.html.markdown
+++ b/website/docs/r/esa_origin_rule.html.markdown
@@ -110,7 +110,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Origin Rule can be imported using the id, e.g.
+ESA Origin Rule can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_origin_rule.example <site_id>:<config_id>

--- a/website/docs/r/esa_redirect_rule.html.markdown
+++ b/website/docs/r/esa_redirect_rule.html.markdown
@@ -117,7 +117,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Redirect Rule can be imported using the id, e.g.
+ESA Redirect Rule can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_redirect_rule.example <site_id>:<config_id>

--- a/website/docs/r/esa_rewrite_url_rule.html.markdown
+++ b/website/docs/r/esa_rewrite_url_rule.html.markdown
@@ -108,7 +108,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Rewrite Url Rule can be imported using the id, e.g.
+ESA Rewrite Url Rule can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_rewrite_url_rule.example <site_id>:<config_id>

--- a/website/docs/r/esa_routine_code_deployment.html.markdown
+++ b/website/docs/r/esa_routine_code_deployment.html.markdown
@@ -84,7 +84,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Routine Code Deployment can be imported using the id, e.g.
+ESA Routine Code Deployment can be imported using the id, which consists of routine_name and env, e.g.
 
 ```shell
 $ terraform import alicloud_esa_routine_code_deployment.example <routine_name>:<env>

--- a/website/docs/r/esa_routine_related_record.html.markdown
+++ b/website/docs/r/esa_routine_related_record.html.markdown
@@ -76,7 +76,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Routine Related Record can be imported using the id, e.g.
+ESA Routine Related Record can be imported using the id, which consists of name and record_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_routine_related_record.example <name>:<record_id>

--- a/website/docs/r/esa_routine_route.html.markdown
+++ b/website/docs/r/esa_routine_route.html.markdown
@@ -95,7 +95,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Routine Route can be imported using the id, e.g.
+ESA Routine Route can be imported using the id, which consists of site_id, routine_name and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_routine_route.example <site_id>:<routine_name>:<config_id>

--- a/website/docs/r/esa_scheduled_preload_execution.html.markdown
+++ b/website/docs/r/esa_scheduled_preload_execution.html.markdown
@@ -81,7 +81,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Scheduled Preload Execution can be imported using the id, e.g.
+ESA Scheduled Preload Execution can be imported using the id, which consists of scheduled_preload_job_id and scheduled_preload_execution_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_scheduled_preload_execution.example <scheduled_preload_job_id>:<scheduled_preload_execution_id>

--- a/website/docs/r/esa_scheduled_preload_job.html.markdown
+++ b/website/docs/r/esa_scheduled_preload_job.html.markdown
@@ -78,7 +78,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Scheduled Preload Job can be imported using the id, e.g.
+ESA Scheduled Preload Job can be imported using the id, which consists of site_id and scheduled_preload_job_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_scheduled_preload_job.example <site_id>:<scheduled_preload_job_id>

--- a/website/docs/r/esa_site_delivery_task.html.markdown
+++ b/website/docs/r/esa_site_delivery_task.html.markdown
@@ -200,7 +200,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Site Delivery Task can be imported using the id, e.g.
+ESA Site Delivery Task can be imported using the id, which consists of site_id and task_name, e.g.
 
 ```shell
 $ terraform import alicloud_esa_site_delivery_task.example <site_id>:<task_name>

--- a/website/docs/r/esa_site_origin_client_certificate.html.markdown
+++ b/website/docs/r/esa_site_origin_client_certificate.html.markdown
@@ -77,7 +77,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Site Origin Client Certificate can be imported using the id, e.g.
+ESA Site Origin Client Certificate can be imported using the id, which consists of site_id and site_origin_client_certificate_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_site_origin_client_certificate.example <site_id>:<site_origin_client_certificate_id>

--- a/website/docs/r/esa_transport_layer_application.html.markdown
+++ b/website/docs/r/esa_transport_layer_application.html.markdown
@@ -121,7 +121,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Transport Layer Application can be imported using the id, e.g.
+ESA Transport Layer Application can be imported using the id, which consists of site_id and application_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_transport_layer_application.example <site_id>:<application_id>

--- a/website/docs/r/esa_url_observation.html.markdown
+++ b/website/docs/r/esa_url_observation.html.markdown
@@ -75,7 +75,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Url Observation can be imported using the id, e.g.
+ESA Url Observation can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_url_observation.example <site_id>:<config_id>

--- a/website/docs/r/esa_version.html.markdown
+++ b/website/docs/r/esa_version.html.markdown
@@ -76,7 +76,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Site Version can be imported using the id, e.g.
+ESA Site Version can be imported using the id, which consists of site_id and site_version, e.g.
 
 ```shell
 $ terraform import alicloud_esa_version.example <site_id>:<site_version>

--- a/website/docs/r/esa_video_processing.html.markdown
+++ b/website/docs/r/esa_video_processing.html.markdown
@@ -103,7 +103,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Video Processing can be imported using the id, e.g.
+ESA Video Processing can be imported using the id, which consists of site_id and config_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_video_processing.example <site_id>:<config_id>

--- a/website/docs/r/esa_waf_rule.html.markdown
+++ b/website/docs/r/esa_waf_rule.html.markdown
@@ -328,7 +328,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Waf Rule can be imported using the id, e.g.
+ESA Waf Rule can be imported using the id, which consists of site_id and waf_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_waf_rule.example <site_id>:<waf_rule_id>

--- a/website/docs/r/esa_waf_ruleset.html.markdown
+++ b/website/docs/r/esa_waf_ruleset.html.markdown
@@ -72,7 +72,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Waf Ruleset can be imported using the id, e.g.
+ESA Waf Ruleset can be imported using the id, which consists of ruleset_id and site_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_waf_ruleset.example <ruleset_id>:<site_id>

--- a/website/docs/r/esa_waiting_room.html.markdown
+++ b/website/docs/r/esa_waiting_room.html.markdown
@@ -139,7 +139,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Waiting Room can be imported using the id, e.g.
+ESA Waiting Room can be imported using the id, which consists of site_id and waiting_room_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_waiting_room.example <site_id>:<waiting_room_id>

--- a/website/docs/r/esa_waiting_room_event.html.markdown
+++ b/website/docs/r/esa_waiting_room_event.html.markdown
@@ -149,7 +149,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Waiting Room Event can be imported using the id, e.g.
+ESA Waiting Room Event can be imported using the id, which consists of site_id, waiting_room_id and waiting_room_event_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_waiting_room_event.example <site_id>:<waiting_room_id>:<waiting_room_event_id>

--- a/website/docs/r/esa_waiting_room_rule.html.markdown
+++ b/website/docs/r/esa_waiting_room_rule.html.markdown
@@ -99,7 +99,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-ESA Waiting Room Rule can be imported using the id, e.g.
+ESA Waiting Room Rule can be imported using the id, which consists of site_id, waiting_room_id and waiting_room_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_esa_waiting_room_rule.example <site_id>:<waiting_room_id>:<waiting_room_rule_id>

--- a/website/docs/r/express_connect_grant_rule_to_cen.html.markdown
+++ b/website/docs/r/express_connect_grant_rule_to_cen.html.markdown
@@ -91,7 +91,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Express Connect Grant Rule To Cen can be imported using the id, e.g.
+Express Connect Grant Rule To Cen can be imported using the id, which consists of cen_id, cen_owner_id and instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_express_connect_grant_rule_to_cen.example <cen_id>:<cen_owner_id>:<instance_id>

--- a/website/docs/r/express_connect_router_grant_association.html.markdown
+++ b/website/docs/r/express_connect_router_grant_association.html.markdown
@@ -91,7 +91,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Express Connect Router Grant Association can be imported using the id, e.g.
+Express Connect Router Grant Association can be imported using the id, which consists of ecr_id, instance_id, instance_region_id, ecr_owner_ali_uid and instance_type, e.g.
 
 ```shell
 $ terraform import alicloud_express_connect_router_grant_association.example <ecr_id>:<instance_id>:<instance_region_id>:<ecr_owner_ali_uid>:<instance_type>

--- a/website/docs/r/express_connect_router_tr_association.html.markdown
+++ b/website/docs/r/express_connect_router_tr_association.html.markdown
@@ -111,7 +111,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Express Connect Router Express Connect Router Tr Association can be imported using the id, e.g.
+Express Connect Router Express Connect Router Tr Association can be imported using the id, which consists of ecr_id, association_id and transit_router_id, e.g.
 
 ```shell
 $ terraform import alicloud_express_connect_router_tr_association.example <ecr_id>:<association_id>:<transit_router_id>

--- a/website/docs/r/express_connect_router_vbr_child_instance.html.markdown
+++ b/website/docs/r/express_connect_router_vbr_child_instance.html.markdown
@@ -92,7 +92,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Express Connect Router Express Connect Router Vbr Child Instance can be imported using the id, e.g.
+Express Connect Router Express Connect Router Vbr Child Instance can be imported using the id, which consists of ecr_id, child_instance_id and child_instance_type, e.g.
 
 ```shell
 $ terraform import alicloud_express_connect_router_vbr_child_instance.example <ecr_id>:<child_instance_id>:<child_instance_type>

--- a/website/docs/r/express_connect_router_vpc_association.html.markdown
+++ b/website/docs/r/express_connect_router_vpc_association.html.markdown
@@ -87,7 +87,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Express Connect Router Express Connect Router Vpc Association can be imported using the id, e.g.
+Express Connect Router Express Connect Router Vpc Association can be imported using the id, which consists of ecr_id, association_id and vpc_id, e.g.
 
 ```shell
 $ terraform import alicloud_express_connect_router_vpc_association.example <ecr_id>:<association_id>:<vpc_id>

--- a/website/docs/r/express_connect_traffic_qos_association.html.markdown
+++ b/website/docs/r/express_connect_traffic_qos_association.html.markdown
@@ -72,7 +72,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Express Connect Traffic Qos Association can be imported using the id, e.g.
+Express Connect Traffic Qos Association can be imported using the id, which consists of qos_id, instance_id and instance_type, e.g.
 
 ```shell
 $ terraform import alicloud_express_connect_traffic_qos_association.example <qos_id>:<instance_id>:<instance_type>

--- a/website/docs/r/express_connect_traffic_qos_queue.html.markdown
+++ b/website/docs/r/express_connect_traffic_qos_queue.html.markdown
@@ -97,7 +97,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Express Connect Traffic Qos Queue can be imported using the id, e.g.
+Express Connect Traffic Qos Queue can be imported using the id, which consists of qos_id and queue_id, e.g.
 
 ```shell
 $ terraform import alicloud_express_connect_traffic_qos_queue.example <qos_id>:<queue_id>

--- a/website/docs/r/express_connect_vbr_pconn_association.html.markdown
+++ b/website/docs/r/express_connect_vbr_pconn_association.html.markdown
@@ -109,7 +109,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Express Connect Vbr Pconn Association can be imported using the id, e.g.
+Express Connect Vbr Pconn Association can be imported using the id, which consists of vbr_id and physical_connection_id, e.g.
 
 ```shell
 $ terraform import alicloud_express_connect_vbr_pconn_association.example <vbr_id>:<physical_connection_id>

--- a/website/docs/r/fcv2_function.html.markdown
+++ b/website/docs/r/fcv2_function.html.markdown
@@ -422,7 +422,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-FCV2 Function can be imported using the id, e.g.
+FCV2 Function can be imported using the id, which consists of service_name and function_name, e.g.
 
 ```shell
 $ terraform import alicloud_fcv2_function.example <service_name>:<function_name>

--- a/website/docs/r/fcv3_alias.html.markdown
+++ b/website/docs/r/fcv3_alias.html.markdown
@@ -78,7 +78,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-FCV3 Alias can be imported using the id, e.g.
+FCV3 Alias can be imported using the id, which consists of function_name and alias_name, e.g.
 
 ```shell
 $ terraform import alicloud_fcv3_alias.example <function_name>:<alias_name>

--- a/website/docs/r/fcv3_function_version.html.markdown
+++ b/website/docs/r/fcv3_function_version.html.markdown
@@ -83,7 +83,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-FCV3 Function Version can be imported using the id, e.g.
+FCV3 Function Version can be imported using the id, which consists of function_name and version_id, e.g.
 
 ```shell
 $ terraform import alicloud_fcv3_function_version.example <function_name>:<version_id>

--- a/website/docs/r/fcv3_layer_version.html.markdown
+++ b/website/docs/r/fcv3_layer_version.html.markdown
@@ -86,7 +86,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-FCV3 Layer Version can be imported using the id, e.g.
+FCV3 Layer Version can be imported using the id, which consists of layer_name and version, e.g.
 
 ```shell
 $ terraform import alicloud_fcv3_layer_version.example <layer_name>:<version>

--- a/website/docs/r/fcv3_trigger.html.markdown
+++ b/website/docs/r/fcv3_trigger.html.markdown
@@ -171,7 +171,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-FCV3 Trigger can be imported using the id, e.g.
+FCV3 Trigger can be imported using the id, which consists of function_name and trigger_name, e.g.
 
 ```shell
 $ terraform import alicloud_fcv3_trigger.example <function_name>:<trigger_name>

--- a/website/docs/r/fcv3_vpc_binding.html.markdown
+++ b/website/docs/r/fcv3_vpc_binding.html.markdown
@@ -82,7 +82,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-FCV3 Vpc Binding can be imported using the id, e.g.
+FCV3 Vpc Binding can be imported using the id, which consists of function_name and vpc_id, e.g.
 
 ```shell
 $ terraform import alicloud_fcv3_vpc_binding.example <function_name>:<vpc_id>

--- a/website/docs/r/fnf_execution.html.markdown
+++ b/website/docs/r/fnf_execution.html.markdown
@@ -102,7 +102,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Serverless Workflow Execution can be imported using the id, e.g.
+Serverless Workflow Execution can be imported using the id, which consists of flow_name and execution_name, e.g.
 
 ```shell
 $ terraform import alicloud_fnf_execution.example <flow_name>:<execution_name>

--- a/website/docs/r/fnf_schedule.html.markdown
+++ b/website/docs/r/fnf_schedule.html.markdown
@@ -84,7 +84,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Serverless Workflow Schedule can be imported using the id, e.g.
+Serverless Workflow Schedule can be imported using the id, which consists of schedule_name and flow_name, e.g.
 
 ```shell
 $ terraform import alicloud_fnf_schedule.example <schedule_name>:<flow_name>

--- a/website/docs/r/forward_entry.html.markdown
+++ b/website/docs/r/forward_entry.html.markdown
@@ -118,7 +118,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Nat Gateway Forward Entry can be imported using the id, e.g.
+Nat Gateway Forward Entry can be imported using the id, which consists of forward_table_id and forward_entry_id, e.g.
 
 ```shell
 $ terraform import alicloud_forward_entry.example <forward_table_id>:<forward_entry_id>

--- a/website/docs/r/ga_accelerator_spare_ip_attachment.html.markdown
+++ b/website/docs/r/ga_accelerator_spare_ip_attachment.html.markdown
@@ -83,7 +83,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Global Accelerator (GA) Accelerator Spare Ip Attachment can be imported using the id, e.g.
+Global Accelerator (GA) Accelerator Spare Ip Attachment can be imported using the id, which consists of accelerator_id and spare_ip, e.g.
 
 ```shell
 $ terraform import alicloud_ga_accelerator_spare_ip_attachment.example <accelerator_id>:<spare_ip>

--- a/website/docs/r/ga_access_log.html.markdown
+++ b/website/docs/r/ga_access_log.html.markdown
@@ -137,7 +137,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Global Accelerator (GA) Access Log can be imported using the id, e.g.
+Global Accelerator (GA) Access Log can be imported using the id, which consists of accelerator_id, listener_id and endpoint_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_ga_access_log.example <accelerator_id>:<listener_id>:<endpoint_group_id>

--- a/website/docs/r/ga_acl_attachment.html.markdown
+++ b/website/docs/r/ga_acl_attachment.html.markdown
@@ -101,7 +101,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Global Accelerator (GA) Acl Attachment can be imported using the id, e.g.
+Global Accelerator (GA) Acl Attachment can be imported using the id, which consists of listener_id and acl_id, e.g.
 
 ```shell
 $ terraform import alicloud_ga_acl_attachment.example <listener_id>:<acl_id>

--- a/website/docs/r/ga_acl_entry_attachment.html.markdown
+++ b/website/docs/r/ga_acl_entry_attachment.html.markdown
@@ -68,7 +68,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Global Accelerator (GA) Acl Entry Attachment can be imported using the id, e.g.
+Global Accelerator (GA) Acl Entry Attachment can be imported using the id, which consists of acl_id and entry, e.g.
 
 ```shell
 $ terraform import alicloud_ga_acl_entry_attachment.example <acl_id>:<entry>

--- a/website/docs/r/ga_additional_certificate.html.markdown
+++ b/website/docs/r/ga_additional_certificate.html.markdown
@@ -172,7 +172,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Global Accelerator (GA) Additional Certificate can be imported using the id, e.g.
+Global Accelerator (GA) Additional Certificate can be imported using the id, which consists of accelerator_id, listener_id and domain, e.g.
 
 ```shell
 $ terraform import alicloud_ga_additional_certificate.example <accelerator_id>:<listener_id>:<domain>

--- a/website/docs/r/ga_bandwidth_package_attachment.html.markdown
+++ b/website/docs/r/ga_bandwidth_package_attachment.html.markdown
@@ -75,7 +75,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Ga Bandwidth Package Attachment can be imported using the id, e.g.
+Ga Bandwidth Package Attachment can be imported using the id, which consists of accelerator_id and bandwidth_package_id, e.g.
 
 ```shell
 $ terraform import alicloud_ga_bandwidth_package_attachment.example <accelerator_id>:<bandwidth_package_id>

--- a/website/docs/r/ga_basic_accelerate_ip_endpoint_relation.html.markdown
+++ b/website/docs/r/ga_basic_accelerate_ip_endpoint_relation.html.markdown
@@ -147,7 +147,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Global Accelerator (GA) Basic Accelerate Ip Endpoint Relation can be imported using the id, e.g.
+Global Accelerator (GA) Basic Accelerate Ip Endpoint Relation can be imported using the id, which consists of accelerator_id, accelerate_ip_id and endpoint_id, e.g.
 
 ```shell
 $ terraform import alicloud_ga_basic_accelerate_ip_endpoint_relation.example <accelerator_id>:<accelerate_ip_id>:<endpoint_id>

--- a/website/docs/r/ga_basic_endpoint.html.markdown
+++ b/website/docs/r/ga_basic_endpoint.html.markdown
@@ -136,7 +136,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Global Accelerator (GA) Basic Endpoint can be imported using the id, e.g.
+Global Accelerator (GA) Basic Endpoint can be imported using the id, which consists of endpoint_group_id and endpoint_id, e.g.
 
 ```shell
 $ terraform import alicloud_ga_basic_endpoint.example <endpoint_group_id>:<endpoint_id>

--- a/website/docs/r/ga_custom_routing_endpoint.html.markdown
+++ b/website/docs/r/ga_custom_routing_endpoint.html.markdown
@@ -129,7 +129,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Global Accelerator (GA) Custom Routing Endpoint can be imported using the id, e.g.
+Global Accelerator (GA) Custom Routing Endpoint can be imported using the id, which consists of endpoint_group_id and custom_routing_endpoint_id, e.g.
 
 ```shell
 $ terraform import alicloud_ga_custom_routing_endpoint.example <endpoint_group_id>:<custom_routing_endpoint_id>

--- a/website/docs/r/ga_custom_routing_endpoint_group_destination.html.markdown
+++ b/website/docs/r/ga_custom_routing_endpoint_group_destination.html.markdown
@@ -110,7 +110,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Global Accelerator (GA) Custom Routing Endpoint Group Destination can be imported using the id, e.g.
+Global Accelerator (GA) Custom Routing Endpoint Group Destination can be imported using the id, which consists of endpoint_group_id and custom_routing_endpoint_group_destination_id, e.g.
 
 ```shell
 $ terraform import alicloud_ga_custom_routing_endpoint_group_destination.example <endpoint_group_id>:<custom_routing_endpoint_group_destination_id>

--- a/website/docs/r/ga_custom_routing_endpoint_traffic_policy.html.markdown
+++ b/website/docs/r/ga_custom_routing_endpoint_traffic_policy.html.markdown
@@ -155,7 +155,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Global Accelerator (GA) Custom Routing Endpoint Traffic Policy can be imported using the id, e.g.
+Global Accelerator (GA) Custom Routing Endpoint Traffic Policy can be imported using the id, which consists of endpoint_id and custom_routing_endpoint_traffic_policy_id, e.g.
 
 ```shell
 $ terraform import alicloud_ga_custom_routing_endpoint_traffic_policy.example <endpoint_id>:<custom_routing_endpoint_traffic_policy_id>

--- a/website/docs/r/ga_domain.html.markdown
+++ b/website/docs/r/ga_domain.html.markdown
@@ -60,7 +60,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Ga Domain can be imported using the id, e.g.
+Ga Domain can be imported using the id, which consists of accelerator_id and domain, e.g.
 
 ```shell
 $ terraform import alicloud_ga_domain.example <accelerator_id>:<domain>

--- a/website/docs/r/ga_forwarding_rule.html.markdown
+++ b/website/docs/r/ga_forwarding_rule.html.markdown
@@ -215,7 +215,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Ga Forwarding Rule can be imported using the id, e.g.
+Ga Forwarding Rule can be imported using the id, which consists of accelerator_id, listener_id and forwarding_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_ga_forwarding_rule.example <accelerator_id>:<listener_id>:<forwarding_rule_id>

--- a/website/docs/r/gpdb_account.html.markdown
+++ b/website/docs/r/gpdb_account.html.markdown
@@ -106,7 +106,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-GPDB Account can be imported using the id, e.g.
+GPDB Account can be imported using the id, which consists of db_instance_id and account_name, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_account.example <db_instance_id>:<account_name>

--- a/website/docs/r/gpdb_api_key.html.markdown
+++ b/website/docs/r/gpdb_api_key.html.markdown
@@ -72,7 +72,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-AnalyticDB for PostgreSQL (GPDB) Api Key can be imported using the id, e.g.
+AnalyticDB for PostgreSQL (GPDB) Api Key can be imported using the id, which consists of workspace_id and key_id, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_api_key.example <workspace_id>:<key_id>

--- a/website/docs/r/gpdb_database.html.markdown
+++ b/website/docs/r/gpdb_database.html.markdown
@@ -101,7 +101,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-GPDB Database can be imported using the id, e.g.
+GPDB Database can be imported using the id, which consists of db_instance_id and database_name, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_database.example <db_instance_id>:<database_name>

--- a/website/docs/r/gpdb_db_instance_ip_array.html.markdown
+++ b/website/docs/r/gpdb_db_instance_ip_array.html.markdown
@@ -114,7 +114,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-GPDB DB Instance IP Array can be imported using the id, e.g.
+GPDB DB Instance IP Array can be imported using the id, which consists of db_instance_id and db_instance_ip_array_name, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_db_instance_ip_array.example <db_instance_id>:<db_instance_ip_array_name>

--- a/website/docs/r/gpdb_db_instance_plan.html.markdown
+++ b/website/docs/r/gpdb_db_instance_plan.html.markdown
@@ -193,7 +193,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-GPDB DB Instance Plan can be imported using the id, e.g.
+GPDB DB Instance Plan can be imported using the id, which consists of db_instance_id and plan_id, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_db_instance_plan.example <db_instance_id>:<plan_id>

--- a/website/docs/r/gpdb_db_resource_group.html.markdown
+++ b/website/docs/r/gpdb_db_resource_group.html.markdown
@@ -100,7 +100,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-AnalyticDB for PostgreSQL (GPDB) Db Resource Group can be imported using the id, e.g.
+AnalyticDB for PostgreSQL (GPDB) Db Resource Group can be imported using the id, which consists of db_instance_id and resource_group_name, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_db_resource_group.example <db_instance_id>:<resource_group_name>

--- a/website/docs/r/gpdb_external_data_service.html.markdown
+++ b/website/docs/r/gpdb_external_data_service.html.markdown
@@ -104,7 +104,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-AnalyticDB for PostgreSQL (GPDB) External Data Service can be imported using the id, e.g.
+AnalyticDB for PostgreSQL (GPDB) External Data Service can be imported using the id, which consists of db_instance_id and service_id, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_external_data_service.example <db_instance_id>:<service_id>

--- a/website/docs/r/gpdb_hadoop_data_source.html.markdown
+++ b/website/docs/r/gpdb_hadoop_data_source.html.markdown
@@ -269,7 +269,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-GPDB Hadoop Data Source can be imported using the id, e.g.
+GPDB Hadoop Data Source can be imported using the id, which consists of db_instance_id and data_source_id, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_hadoop_data_source.example <db_instance_id>:<data_source_id>

--- a/website/docs/r/gpdb_jdbc_data_source.html.markdown
+++ b/website/docs/r/gpdb_jdbc_data_source.html.markdown
@@ -123,7 +123,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-AnalyticDB for PostgreSQL (GPDB) Jdbc Data Source can be imported using the id, e.g.
+AnalyticDB for PostgreSQL (GPDB) Jdbc Data Source can be imported using the id, which consists of db_instance_id and data_source_id, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_jdbc_data_source.example <db_instance_id>:<data_source_id>

--- a/website/docs/r/gpdb_remote_adb_data_source.html.markdown
+++ b/website/docs/r/gpdb_remote_adb_data_source.html.markdown
@@ -146,7 +146,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-GPDB Remote ADB Data Source can be imported using the id, e.g.
+GPDB Remote ADB Data Source can be imported using the id, which consists of local_db_instance_id and remote_adb_data_source_id, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_remote_adb_data_source.example <local_db_instance_id>:<remote_adb_data_source_id>

--- a/website/docs/r/gpdb_streaming_data_service.html.markdown
+++ b/website/docs/r/gpdb_streaming_data_service.html.markdown
@@ -105,7 +105,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-AnalyticDB for PostgreSQL (GPDB) Streaming Data Service can be imported using the id, e.g.
+AnalyticDB for PostgreSQL (GPDB) Streaming Data Service can be imported using the id, which consists of db_instance_id and service_id, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_streaming_data_service.example <db_instance_id>:<service_id>

--- a/website/docs/r/gpdb_streaming_data_source.html.markdown
+++ b/website/docs/r/gpdb_streaming_data_source.html.markdown
@@ -140,7 +140,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-GPDB Streaming Data Source can be imported using the id, e.g.
+GPDB Streaming Data Source can be imported using the id, which consists of db_instance_id and data_source_id, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_streaming_data_source.example <db_instance_id>:<data_source_id>

--- a/website/docs/r/gpdb_streaming_job.html.markdown
+++ b/website/docs/r/gpdb_streaming_job.html.markdown
@@ -209,7 +209,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-GPDB Streaming Job can be imported using the id, e.g.
+GPDB Streaming Job can be imported using the id, which consists of db_instance_id and job_id, e.g.
 
 ```shell
 $ terraform import alicloud_gpdb_streaming_job.example <db_instance_id>:<job_id>

--- a/website/docs/r/hbr_cross_account.html.markdown
+++ b/website/docs/r/hbr_cross_account.html.markdown
@@ -66,7 +66,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Hybrid Backup Recovery (HBR) Cross Account can be imported using the id, e.g.
+Hybrid Backup Recovery (HBR) Cross Account can be imported using the id, which consists of cross_account_user_id and cross_account_role_name, e.g.
 
 ```shell
 $ terraform import alicloud_hbr_cross_account.example <cross_account_user_id>:<cross_account_role_name>

--- a/website/docs/r/hbr_hana_backup_client.html.markdown
+++ b/website/docs/r/hbr_hana_backup_client.html.markdown
@@ -131,7 +131,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Hybrid Backup Recovery (HBR) Hana Backup Client can be imported using the id, e.g.
+Hybrid Backup Recovery (HBR) Hana Backup Client can be imported using the id, which consists of vault_id and client_id, e.g.
 
 ```shell
 $ terraform import alicloud_hbr_hana_backup_client.example <vault_id>:<client_id>

--- a/website/docs/r/hbr_hana_backup_plan.html.markdown
+++ b/website/docs/r/hbr_hana_backup_plan.html.markdown
@@ -102,7 +102,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Hybrid Backup Recovery (HBR) Hana Backup Plan can be imported using the id, e.g.
+Hybrid Backup Recovery (HBR) Hana Backup Plan can be imported using the id, which consists of plan_id, vault_id and cluster_id, e.g.
 
 ```shell
 $ terraform import alicloud_hbr_hana_backup_plan.example <plan_id>:<vault_id>:<cluster_id>

--- a/website/docs/r/hbr_hana_instance.html.markdown
+++ b/website/docs/r/hbr_hana_instance.html.markdown
@@ -93,7 +93,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Hybrid Backup Recovery (HBR) Hana Instance can be imported using the id, e.g.
+Hybrid Backup Recovery (HBR) Hana Instance can be imported using the id, which consists of vault_id and hana_instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_hbr_hana_instance.example <vault_id>:<hana_instance_id>

--- a/website/docs/r/hbr_policy_binding.html.markdown
+++ b/website/docs/r/hbr_policy_binding.html.markdown
@@ -136,7 +136,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Hybrid Backup Recovery (HBR) Policy Binding can be imported using the id, e.g.
+Hybrid Backup Recovery (HBR) Policy Binding can be imported using the id, which consists of policy_id, source_type and data_source_id, e.g.
 
 ```shell
 $ terraform import alicloud_hbr_policy_binding.example <policy_id>:<source_type>:<data_source_id>

--- a/website/docs/r/log_dashboard.html.markdown
+++ b/website/docs/r/log_dashboard.html.markdown
@@ -106,7 +106,7 @@ The following attributes are exported:
 
 ## Import
 
-Log Dashboard can be imported using the id, e.g.
+Log Dashboard can be imported using the id, which consists of project_name and dashboard_name, e.g.
 
 ```shell
 $ terraform import alicloud_log_dashboard.example <project_name>:<dashboard_name>

--- a/website/docs/r/log_resource_record.html.markdown
+++ b/website/docs/r/log_resource_record.html.markdown
@@ -98,7 +98,7 @@ The following attributes are exported:
 
 ## Import
 
-Log resource record can be imported using the id, e.g.
+Log resource record can be imported using the id, which consists of resource_name and record_id, e.g.
 
 ```shell
 $ terraform import alicloud_log_resource_record.example <resource_name>:<record_id>

--- a/website/docs/r/log_store.html.markdown
+++ b/website/docs/r/log_store.html.markdown
@@ -193,7 +193,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-SLS Log Store can be imported using the id, e.g.
+SLS Log Store can be imported using the id, which consists of project_name and logstore_name, e.g.
 
 ```shell
 $ terraform import alicloud_log_store.example <project_name>:<logstore_name>

--- a/website/docs/r/max_compute_quota_plan.html.markdown
+++ b/website/docs/r/max_compute_quota_plan.html.markdown
@@ -137,7 +137,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Max Compute Quota Plan can be imported using the id, e.g.
+Max Compute Quota Plan can be imported using the id, which consists of nickname and plan_name, e.g.
 
 ```shell
 $ terraform import alicloud_max_compute_quota_plan.example <nickname>:<plan_name>

--- a/website/docs/r/max_compute_quota_schedule.html.markdown
+++ b/website/docs/r/max_compute_quota_schedule.html.markdown
@@ -211,7 +211,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Max Compute Quota Schedule can be imported using the id, e.g.
+Max Compute Quota Schedule can be imported using the id, which consists of nickname and timezone, e.g.
 
 ```shell
 $ terraform import alicloud_max_compute_quota_schedule.example <nickname>:<timezone>

--- a/website/docs/r/max_compute_role.html.markdown
+++ b/website/docs/r/max_compute_role.html.markdown
@@ -81,7 +81,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Max Compute Role can be imported using the id, e.g.
+Max Compute Role can be imported using the id, which consists of project_name and role_name, e.g.
 
 ```shell
 $ terraform import alicloud_max_compute_role.example <project_name>:<role_name>

--- a/website/docs/r/max_compute_tenant_role_user_attachment.html.markdown
+++ b/website/docs/r/max_compute_tenant_role_user_attachment.html.markdown
@@ -75,7 +75,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Max Compute Tenant Role User Attachment can be imported using the id, e.g.
+Max Compute Tenant Role User Attachment can be imported using the id, which consists of account_id and tenant_role, e.g.
 
 ```shell
 $ terraform import alicloud_max_compute_tenant_role_user_attachment.example <account_id>:<tenant_role>

--- a/website/docs/r/message_service_endpoint_acl.html.markdown
+++ b/website/docs/r/message_service_endpoint_acl.html.markdown
@@ -68,7 +68,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Message Service Endpoint Acl can be imported using the id, e.g.
+Message Service Endpoint Acl can be imported using the id, which consists of endpoint_type, acl_strategy and cidr, e.g.
 
 ```shell
 $ terraform import alicloud_message_service_endpoint_acl.example <endpoint_type>:<acl_strategy>:<cidr>

--- a/website/docs/r/message_service_subscription.html.markdown
+++ b/website/docs/r/message_service_subscription.html.markdown
@@ -91,7 +91,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Message Service Subscription can be imported using the id, e.g.
+Message Service Subscription can be imported using the id, which consists of topic_name and subscription_name, e.g.
 
 ```shell
 $ terraform import alicloud_message_service_subscription.example <topic_name>:<subscription_name>

--- a/website/docs/r/mongodb_account.html.markdown
+++ b/website/docs/r/mongodb_account.html.markdown
@@ -105,7 +105,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Mongodb Account can be imported using the id, e.g.
+Mongodb Account can be imported using the id, which consists of instance_id and account_name, e.g.
 
 ```shell
 $ terraform import alicloud_mongodb_account.example <instance_id>:<account_name>

--- a/website/docs/r/mongodb_sharding_network_private_address.html.markdown
+++ b/website/docs/r/mongodb_sharding_network_private_address.html.markdown
@@ -112,7 +112,7 @@ The following attributes are exported:
 
 ## Import
 
-MongoDB Sharding Network Private Address can be imported using the id, e.g.
+MongoDB Sharding Network Private Address can be imported using the id, which consists of db_instance_id and node_id, e.g.
 
 ```shell
 $ terraform import alicloud_mongodb_sharding_network_private_address.example <db_instance_id>:<node_id>

--- a/website/docs/r/mongodb_sharding_network_public_address.html.markdown
+++ b/website/docs/r/mongodb_sharding_network_public_address.html.markdown
@@ -111,7 +111,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-MongoDB Sharding Network Public Address can be imported using the id, e.g.
+MongoDB Sharding Network Public Address can be imported using the id, which consists of db_instance_id and node_id, e.g.
 
 ```shell
 $ terraform import alicloud_mongodb_sharding_network_public_address.example <db_instance_id>:<node_id>

--- a/website/docs/r/mse_engine_namespace.html.markdown
+++ b/website/docs/r/mse_engine_namespace.html.markdown
@@ -95,7 +95,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Microservice Engine (MSE) Engine Namespace can be imported using the id, e.g.
+Microservice Engine (MSE) Engine Namespace can be imported using the id, which consists of instance_id and namespace_id, e.g.
 
 ```shell
 $ terraform import alicloud_mse_engine_namespace.example <instance_id>:<namespace_id>

--- a/website/docs/r/nas_access_point.html.markdown
+++ b/website/docs/r/nas_access_point.html.markdown
@@ -142,7 +142,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-File Storage (NAS) Access Point can be imported using the id, e.g.
+File Storage (NAS) Access Point can be imported using the id, which consists of file_system_id and access_point_id, e.g.
 
 ```shell
 $ terraform import alicloud_nas_access_point.example <file_system_id>:<access_point_id>

--- a/website/docs/r/nas_access_rule.html.markdown
+++ b/website/docs/r/nas_access_rule.html.markdown
@@ -84,7 +84,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-NAS Access Rule can be imported using the id, e.g.
+NAS Access Rule can be imported using the id, which consists of access_group_name, file_system_type and access_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_nas_access_rule.example <access_group_name>:<file_system_type>:<access_rule_id>

--- a/website/docs/r/nas_data_flow.html.markdown
+++ b/website/docs/r/nas_data_flow.html.markdown
@@ -128,7 +128,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-File Storage (NAS) Data Flow can be imported using the id, e.g.
+File Storage (NAS) Data Flow can be imported using the id, which consists of file_system_id and data_flow_id, e.g.
 
 ```shell
 $ terraform import alicloud_nas_data_flow.example <file_system_id>:<data_flow_id>

--- a/website/docs/r/nas_fileset.html.markdown
+++ b/website/docs/r/nas_fileset.html.markdown
@@ -95,7 +95,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-File Storage (NAS) Fileset can be imported using the id, e.g.
+File Storage (NAS) Fileset can be imported using the id, which consists of file_system_id and fileset_id, e.g.
 
 ```shell
 $ terraform import alicloud_nas_fileset.example <file_system_id>:<fileset_id>

--- a/website/docs/r/nlb_listener_additional_certificate_attachment.html.markdown
+++ b/website/docs/r/nlb_listener_additional_certificate_attachment.html.markdown
@@ -223,7 +223,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-NLB Listener Additional Certificate Attachment can be imported using the id, e.g.
+NLB Listener Additional Certificate Attachment can be imported using the id, which consists of listener_id and certificate_id, e.g.
 
 ```shell
 $ terraform import alicloud_nlb_listener_additional_certificate_attachment.example <listener_id>:<certificate_id>

--- a/website/docs/r/nlb_load_balancer_security_group_attachment.html.markdown
+++ b/website/docs/r/nlb_load_balancer_security_group_attachment.html.markdown
@@ -106,7 +106,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-NLB Load Balancer Security Group Attachment can be imported using the id, e.g.
+NLB Load Balancer Security Group Attachment can be imported using the id, which consists of load_balancer_id and security_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_nlb_load_balancer_security_group_attachment.example <load_balancer_id>:<security_group_id>

--- a/website/docs/r/nlb_load_balancer_zone_shifted_attachment.html.markdown
+++ b/website/docs/r/nlb_load_balancer_zone_shifted_attachment.html.markdown
@@ -101,7 +101,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Network Load Balancer (NLB) Load Balancer Zone Shifted Attachment can be imported using the id, e.g.
+Network Load Balancer (NLB) Load Balancer Zone Shifted Attachment can be imported using the id, which consists of load_balancer_id, zone_id and vswitch_id, e.g.
 
 ```shell
 $ terraform import alicloud_nlb_load_balancer_zone_shifted_attachment.example <load_balancer_id>:<zone_id>:<vswitch_id>

--- a/website/docs/r/nlb_loadbalancer_common_bandwidth_package_attachment.html.markdown
+++ b/website/docs/r/nlb_loadbalancer_common_bandwidth_package_attachment.html.markdown
@@ -112,7 +112,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-NLB Loadbalancer Common Bandwidth Package Attachment can be imported using the id, e.g.
+NLB Loadbalancer Common Bandwidth Package Attachment can be imported using the id, which consists of load_balancer_id and bandwidth_package_id, e.g.
 
 ```shell
 $ terraform import alicloud_nlb_loadbalancer_common_bandwidth_package_attachment.example <load_balancer_id>:<bandwidth_package_id>

--- a/website/docs/r/oos_application_group.html.markdown
+++ b/website/docs/r/oos_application_group.html.markdown
@@ -84,7 +84,7 @@ The following attributes are exported:
 
 ## Import
 
-OOS Application Group can be imported using the id, e.g.
+OOS Application Group can be imported using the id, which consists of application_name and application_group_name, e.g.
 
 ```shell
 $ terraform import alicloud_oos_application_group.example <application_name>:<application_group_name>

--- a/website/docs/r/oss_access_point.html.markdown
+++ b/website/docs/r/oss_access_point.html.markdown
@@ -91,7 +91,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-OSS Access Point can be imported using the id, e.g.
+OSS Access Point can be imported using the id, which consists of bucket and access_point_name, e.g.
 
 ```shell
 $ terraform import alicloud_oss_access_point.example <bucket>:<access_point_name>

--- a/website/docs/r/oss_bucket_cname_token.html.markdown
+++ b/website/docs/r/oss_bucket_cname_token.html.markdown
@@ -71,7 +71,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-OSS Bucket Cname Token can be imported using the id, e.g.
+OSS Bucket Cname Token can be imported using the id, which consists of bucket and domain, e.g.
 
 ```shell
 $ terraform import alicloud_oss_bucket_cname_token.example <bucket>:<domain>

--- a/website/docs/r/oss_bucket_data_redundancy_transition.html.markdown
+++ b/website/docs/r/oss_bucket_data_redundancy_transition.html.markdown
@@ -72,7 +72,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-OSS Bucket Data Redundancy Transition can be imported using the id, e.g.
+OSS Bucket Data Redundancy Transition can be imported using the id, which consists of bucket and task_id, e.g.
 
 ```shell
 $ terraform import alicloud_oss_bucket_data_redundancy_transition.example <bucket>:<task_id>

--- a/website/docs/r/oss_bucket_inventory.html.markdown
+++ b/website/docs/r/oss_bucket_inventory.html.markdown
@@ -156,7 +156,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-OSS Bucket Inventory can be imported using the id, e.g.
+OSS Bucket Inventory can be imported using the id, which consists of bucket and inventory_id, e.g.
 
 ```shell
 $ terraform import alicloud_oss_bucket_inventory.example <bucket>:<inventory_id>

--- a/website/docs/r/oss_bucket_style.html.markdown
+++ b/website/docs/r/oss_bucket_style.html.markdown
@@ -78,7 +78,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-OSS Bucket Style can be imported using the id, e.g.
+OSS Bucket Style can be imported using the id, which consists of bucket and style_name, e.g.
 
 ```shell
 $ terraform import alicloud_oss_bucket_style.example <bucket>:<style_name>

--- a/website/docs/r/oss_bucket_worm.html.markdown
+++ b/website/docs/r/oss_bucket_worm.html.markdown
@@ -80,7 +80,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-OSS Bucket Worm can be imported using the id, e.g.
+OSS Bucket Worm can be imported using the id, which consists of bucket and worm_id, e.g.
 
 ```shell
 $ terraform import alicloud_oss_bucket_worm.example <bucket>:<worm_id>

--- a/website/docs/r/pai_workspace_datasetversion.html.markdown
+++ b/website/docs/r/pai_workspace_datasetversion.html.markdown
@@ -130,7 +130,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-PAI Workspace Datasetversion can be imported using the id, e.g.
+PAI Workspace Datasetversion can be imported using the id, which consists of dataset_id and version_name, e.g.
 
 ```shell
 $ terraform import alicloud_pai_workspace_datasetversion.example <dataset_id>:<version_name>

--- a/website/docs/r/pai_workspace_member.html.markdown
+++ b/website/docs/r/pai_workspace_member.html.markdown
@@ -83,7 +83,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-PAI Workspace Member can be imported using the id, e.g.
+PAI Workspace Member can be imported using the id, which consists of workspace_id and member_id, e.g.
 
 ```shell
 $ terraform import alicloud_pai_workspace_member.example <workspace_id>:<member_id>

--- a/website/docs/r/pai_workspace_model_version.html.markdown
+++ b/website/docs/r/pai_workspace_model_version.html.markdown
@@ -159,7 +159,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 
 ## Import
 
-PAI Workspace Model Version can be imported using the id, e.g.
+PAI Workspace Model Version can be imported using the id, which consists of model_id and version_name, e.g.
 
 ```shell
 $ terraform import alicloud_pai_workspace_model_version.example <model_id>:<version_name>

--- a/website/docs/r/pai_workspace_user_config.html.markdown
+++ b/website/docs/r/pai_workspace_user_config.html.markdown
@@ -66,7 +66,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-PAI Workspace User Config can be imported using the id, e.g.
+PAI Workspace User Config can be imported using the id, which consists of category_name and config_key, e.g.
 
 ```shell
 $ terraform import alicloud_pai_workspace_user_config.example <category_name>:<config_key>

--- a/website/docs/r/polar_db_extension.html.markdown
+++ b/website/docs/r/polar_db_extension.html.markdown
@@ -115,7 +115,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Polar Db Extension can be imported using the id, e.g.
+Polar Db Extension can be imported using the id, which consists of db_cluster_id, account_name, db_name and extension_name, e.g.
 
 ```shell
 $ terraform import alicloud_polar_db_extension.example <db_cluster_id>:<account_name>:<db_name>:<extension_name>

--- a/website/docs/r/polardb_account.html.markdown
+++ b/website/docs/r/polardb_account.html.markdown
@@ -105,7 +105,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Polar Db Account can be imported using the id, e.g.
+Polar Db Account can be imported using the id, which consists of db_cluster_id and account_name, e.g.
 
 ```shell
 $ terraform import alicloud_polardb_account.example <db_cluster_id>:<account_name>

--- a/website/docs/r/polardb_database.html.markdown
+++ b/website/docs/r/polardb_database.html.markdown
@@ -95,7 +95,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Polar Db Database can be imported using the id, e.g.
+Polar Db Database can be imported using the id, which consists of db_cluster_id and db_name, e.g.
 
 ```shell
 $ terraform import alicloud_polardb_database.example <db_cluster_id>:<db_name>

--- a/website/docs/r/privatelink_vpc_endpoint_connection.html.markdown
+++ b/website/docs/r/privatelink_vpc_endpoint_connection.html.markdown
@@ -113,7 +113,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Private Link Vpc Endpoint Connection can be imported using the id, e.g.
+Private Link Vpc Endpoint Connection can be imported using the id, which consists of service_id and endpoint_id, e.g.
 
 ```shell
 $ terraform import alicloud_privatelink_vpc_endpoint_connection.example <service_id>:<endpoint_id>

--- a/website/docs/r/privatelink_vpc_endpoint_service_resource.html.markdown
+++ b/website/docs/r/privatelink_vpc_endpoint_service_resource.html.markdown
@@ -108,7 +108,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Private Link Vpc Endpoint Service Resource can be imported using the id, e.g.
+Private Link Vpc Endpoint Service Resource can be imported using the id, which consists of service_id, resource_id and zone_id, e.g.
 
 ```shell
 $ terraform import alicloud_privatelink_vpc_endpoint_service_resource.example <service_id>:<resource_id>:<zone_id>

--- a/website/docs/r/privatelink_vpc_endpoint_service_user.html.markdown
+++ b/website/docs/r/privatelink_vpc_endpoint_service_user.html.markdown
@@ -76,7 +76,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Private Link Vpc Endpoint Service User can be imported using the id, e.g.
+Private Link Vpc Endpoint Service User can be imported using the id, which consists of service_id and user_id, e.g.
 
 ```shell
 $ terraform import alicloud_privatelink_vpc_endpoint_service_user.example <service_id>:<user_id>

--- a/website/docs/r/privatelink_vpc_endpoint_zone.html.markdown
+++ b/website/docs/r/privatelink_vpc_endpoint_zone.html.markdown
@@ -112,7 +112,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Private Link Vpc Endpoint Zone can be imported using the id, e.g.
+Private Link Vpc Endpoint Zone can be imported using the id, which consists of endpoint_id and zone_id, e.g.
 
 ```shell
 $ terraform import alicloud_privatelink_vpc_endpoint_zone.example <endpoint_id>:<zone_id>

--- a/website/docs/r/pvtz_user_vpc_authorization.html.markdown
+++ b/website/docs/r/pvtz_user_vpc_authorization.html.markdown
@@ -58,7 +58,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Private Zone User Vpc Authorization can be imported using the id, e.g.
+Private Zone User Vpc Authorization can be imported using the id, which consists of authorized_user_id and auth_type, e.g.
 
 ```shell
 $ terraform import alicloud_pvtz_user_vpc_authorization.example <authorized_user_id>:<auth_type>

--- a/website/docs/r/ram_user_group_attachment.html.markdown
+++ b/website/docs/r/ram_user_group_attachment.html.markdown
@@ -76,7 +76,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RAM User Group Attachment can be imported using the id, e.g.
+RAM User Group Attachment can be imported using the id, which consists of group_name and user_name, e.g.
 
 ```shell
 $ terraform import alicloud_ram_user_group_attachment.example <group_name>:<user_name>

--- a/website/docs/r/rds_custom_disk_attachment.html.markdown
+++ b/website/docs/r/rds_custom_disk_attachment.html.markdown
@@ -105,7 +105,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RDS Custom Disk Attachment can be imported using the id, e.g.
+RDS Custom Disk Attachment can be imported using the id, which consists of disk_id and instance_id, e.g.
 
 ```shell
 $ terraform import alicloud_rds_custom_disk_attachment.example <disk_id>:<instance_id>

--- a/website/docs/r/rds_db_instance_endpoint.html.markdown
+++ b/website/docs/r/rds_db_instance_endpoint.html.markdown
@@ -139,7 +139,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RDS database endpoint feature can be imported using the id, e.g.
+RDS database endpoint feature can be imported using the id, which consists of db_instance_id and db_instance_endpoint_id, e.g.
 
 ```shell
 $ terraform import alicloud_rds_db_instance_endpoint.example <db_instance_id>:<db_instance_endpoint_id>

--- a/website/docs/r/rds_db_instance_endpoint_address.html.markdown
+++ b/website/docs/r/rds_db_instance_endpoint_address.html.markdown
@@ -136,7 +136,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RDS database endpoint public address feature can be imported using the id, e.g.
+RDS database endpoint public address feature can be imported using the id, which consists of db_instance_id and db_instance_endpoint_id, e.g.
 
 ```shell
 $ terraform import alicloud_rds_db_instance_endpoint_address.example <db_instance_id>:<db_instance_endpoint_id>

--- a/website/docs/r/realtime_compute_deployment.html.markdown
+++ b/website/docs/r/realtime_compute_deployment.html.markdown
@@ -250,7 +250,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Realtime Compute Deployment can be imported using the id, e.g.
+Realtime Compute Deployment can be imported using the id, which consists of resource_id, namespace and deployment_id, e.g.
 
 ```shell
 $ terraform import alicloud_realtime_compute_deployment.example <resource_id>:<namespace>:<deployment_id>

--- a/website/docs/r/realtime_compute_job.html.markdown
+++ b/website/docs/r/realtime_compute_job.html.markdown
@@ -174,7 +174,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Realtime Compute Job can be imported using the id, e.g.
+Realtime Compute Job can be imported using the id, which consists of resource_id, namespace and job_id, e.g.
 
 ```shell
 $ terraform import alicloud_realtime_compute_job.example <resource_id>:<namespace>:<job_id>

--- a/website/docs/r/redis_backup.html.markdown
+++ b/website/docs/r/redis_backup.html.markdown
@@ -105,7 +105,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Tair (Redis OSS-Compatible) And Memcache (KVStore) Backup can be imported using the id, e.g.
+Tair (Redis OSS-Compatible) And Memcache (KVStore) Backup can be imported using the id, which consists of instance_id and backup_id, e.g.
 
 ```shell
 $ terraform import alicloud_redis_backup.example <instance_id>:<backup_id>

--- a/website/docs/r/resource_manager_control_policy_attachment.html.markdown
+++ b/website/docs/r/resource_manager_control_policy_attachment.html.markdown
@@ -94,7 +94,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Resource Manager Control Policy Attachment can be imported using the id, e.g.
+Resource Manager Control Policy Attachment can be imported using the id, which consists of policy_id and target_id, e.g.
 
 ```shell
 $ terraform import alicloud_resource_manager_control_policy_attachment.example <policy_id>:<target_id>

--- a/website/docs/r/resource_manager_delegated_administrator.html.markdown
+++ b/website/docs/r/resource_manager_delegated_administrator.html.markdown
@@ -59,7 +59,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Resource Manager Delegated Administrator can be imported using the id, e.g.
+Resource Manager Delegated Administrator can be imported using the id, which consists of account_id and service_principal, e.g.
 
 ```shell
 $ terraform import alicloud_resource_manager_delegated_administrator.example <account_id>:<service_principal>

--- a/website/docs/r/resource_manager_service_linked_role.html.markdown
+++ b/website/docs/r/resource_manager_service_linked_role.html.markdown
@@ -52,7 +52,7 @@ The following attributes are exported:
 
 ## Import
 
-Resource Manager Service Linked Role can be imported using the id, e.g.
+Resource Manager Service Linked Role can be imported using the id, which consists of service_name and role_name, e.g.
 
 ```shell
 $ terraform import alicloud_resource_manager_service_linked_role.default <service_name>:<role_name>

--- a/website/docs/r/resource_manager_shared_resource.html.markdown
+++ b/website/docs/r/resource_manager_shared_resource.html.markdown
@@ -99,7 +99,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Resource Manager Shared Resource can be imported using the id, e.g.
+Resource Manager Shared Resource can be imported using the id, which consists of resource_share_id, resource_id and resource_type, e.g.
 
 ```shell
 $ terraform import alicloud_resource_manager_shared_resource.example <resource_share_id>:<resource_id>:<resource_type>

--- a/website/docs/r/resource_manager_shared_target.html.markdown
+++ b/website/docs/r/resource_manager_shared_target.html.markdown
@@ -72,7 +72,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Resource Manager Shared Target can be imported using the id, e.g.
+Resource Manager Shared Target can be imported using the id, which consists of resource_share_id and target_id, e.g.
 
 ```shell
 $ terraform import alicloud_resource_manager_shared_target.example <resource_share_id>:<target_id>

--- a/website/docs/r/rocketmq_account.html.markdown
+++ b/website/docs/r/rocketmq_account.html.markdown
@@ -118,7 +118,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RocketMQ Account can be imported using the id, e.g.
+RocketMQ Account can be imported using the id, which consists of instance_id and username, e.g.
 
 ```shell
 $ terraform import alicloud_rocketmq_account.example <instance_id>:<username>

--- a/website/docs/r/rocketmq_acl.html.markdown
+++ b/website/docs/r/rocketmq_acl.html.markdown
@@ -132,7 +132,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RocketMQ Acl can be imported using the id, e.g.
+RocketMQ Acl can be imported using the id, which consists of instance_id, username, resource_type and resource_name, e.g.
 
 ```shell
 $ terraform import alicloud_rocketmq_acl.example <instance_id>:<username>:<resource_type>:<resource_name>

--- a/website/docs/r/rocketmq_consumer_group.html.markdown
+++ b/website/docs/r/rocketmq_consumer_group.html.markdown
@@ -135,7 +135,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RocketMQ Consumer Group can be imported using the id, e.g.
+RocketMQ Consumer Group can be imported using the id, which consists of instance_id and consumer_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_rocketmq_consumer_group.example <instance_id>:<consumer_group_id>

--- a/website/docs/r/rocketmq_topic.html.markdown
+++ b/website/docs/r/rocketmq_topic.html.markdown
@@ -122,7 +122,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-RocketMQ Topic can be imported using the id, e.g.
+RocketMQ Topic can be imported using the id, which consists of instance_id and topic_name, e.g.
 
 ```shell
 $ terraform import alicloud_rocketmq_topic.example <instance_id>:<topic_name>

--- a/website/docs/r/route_entry.html.markdown
+++ b/website/docs/r/route_entry.html.markdown
@@ -132,7 +132,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Route Entry can be imported using the id, e.g.
+Route Entry can be imported using the id, which consists of route_table_id, router_id, destination_cidrblock, nexthop_type and nexthop_id, e.g.
 
 ```shell
 $ terraform import alicloud_route_entry.example <route_table_id>:<router_id>:<destination_cidrblock>:<nexthop_type>:<nexthop_id>

--- a/website/docs/r/route_table_attachment.html.markdown
+++ b/website/docs/r/route_table_attachment.html.markdown
@@ -79,7 +79,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPC Route Table Attachment can be imported using the id, e.g.
+VPC Route Table Attachment can be imported using the id, which consists of route_table_id and vswitch_id, e.g.
 
 ```shell
 $ terraform import alicloud_route_table_attachment.example <route_table_id>:<vswitch_id>

--- a/website/docs/r/sae_application_scaling_rule.html.markdown
+++ b/website/docs/r/sae_application_scaling_rule.html.markdown
@@ -217,7 +217,7 @@ The following attributes are exported:
 
 ## Import
 
-Serverless App Engine (SAE) Application Scaling Rule can be imported using the id, e.g.
+Serverless App Engine (SAE) Application Scaling Rule can be imported using the id, which consists of app_id and scaling_rule_name, e.g.
 
 ```shell
 $ terraform import alicloud_sae_application_scaling_rule.example <app_id>:<scaling_rule_name>

--- a/website/docs/r/sag_qos_car.html.markdown
+++ b/website/docs/r/sag_qos_car.html.markdown
@@ -78,7 +78,7 @@ The following attributes are exported:
 
 ## Import
 
-The Sag Qos Car can be imported using the id, e.g.
+The Sag Qos Car can be imported using the id, which consists of qos_id and qos_car_id, e.g.
 
 ```shell
 $ terraform import alicloud_sag_qos_car.example <qos_id>:<qos_car_id>

--- a/website/docs/r/schedulerx_app_group.html.markdown
+++ b/website/docs/r/schedulerx_app_group.html.markdown
@@ -99,7 +99,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Schedulerx App Group can be imported using the id, e.g.
+Schedulerx App Group can be imported using the id, which consists of namespace and group_id, e.g.
 
 ```shell
 $ terraform import alicloud_schedulerx_app_group.example <namespace>:<group_id>

--- a/website/docs/r/schedulerx_job.html.markdown
+++ b/website/docs/r/schedulerx_job.html.markdown
@@ -224,7 +224,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Schedulerx Job can be imported using the id, e.g.
+Schedulerx Job can be imported using the id, which consists of namespace, group_id and job_id, e.g.
 
 ```shell
 $ terraform import alicloud_schedulerx_job.example <namespace>:<group_id>:<job_id>

--- a/website/docs/r/selectdb_db_cluster.html.markdown
+++ b/website/docs/r/selectdb_db_cluster.html.markdown
@@ -120,7 +120,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-SelectDB DBCluster can be imported using the id, e.g.
+SelectDB DBCluster can be imported using the id, which consists of db_instance_id and db_cluster_id, e.g.
 
 ```shell
 $ terraform import alicloud_selectdb_db_cluster.example <db_instance_id>:<db_cluster_id>

--- a/website/docs/r/service_catalog_principal_portfolio_association.html.markdown
+++ b/website/docs/r/service_catalog_principal_portfolio_association.html.markdown
@@ -94,7 +94,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Service Catalog Principal Portfolio Association can be imported using the id, e.g.
+Service Catalog Principal Portfolio Association can be imported using the id, which consists of principal_id, principal_type and portfolio_id, e.g.
 
 ```shell
 $ terraform import alicloud_service_catalog_principal_portfolio_association.example <principal_id>:<principal_type>:<portfolio_id>

--- a/website/docs/r/service_catalog_product_portfolio_association.html.markdown
+++ b/website/docs/r/service_catalog_product_portfolio_association.html.markdown
@@ -75,7 +75,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Service Catalog Product Portfolio Association can be imported using the id, e.g.
+Service Catalog Product Portfolio Association can be imported using the id, which consists of product_id and portfolio_id, e.g.
 
 ```shell
 $ terraform import alicloud_service_catalog_product_portfolio_association.example <product_id>:<portfolio_id>

--- a/website/docs/r/simple_application_server_firewall_rule.html.markdown
+++ b/website/docs/r/simple_application_server_firewall_rule.html.markdown
@@ -75,7 +75,7 @@ The following attributes are exported:
 
 ## Import
 
-Simple Application Server Firewall Rule can be imported using the id, e.g.
+Simple Application Server Firewall Rule can be imported using the id, which consists of instance_id and firewall_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_simple_application_server_firewall_rule.example <instance_id>:<firewall_rule_id>

--- a/website/docs/r/slb_acl_entry_attachment.html.markdown
+++ b/website/docs/r/slb_acl_entry_attachment.html.markdown
@@ -63,7 +63,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Acl entry attachment can be imported using the id, e.g.
+Acl entry attachment can be imported using the id, which consists of acl_id and entry, e.g.
 
 ```shell
 $ terraform import alicloud_slb_acl_entry_attachment.example <acl_id>:<entry>

--- a/website/docs/r/slb_server_group_server_attachment.html.markdown
+++ b/website/docs/r/slb_server_group_server_attachment.html.markdown
@@ -125,7 +125,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Load Balancer Virtual Backend Server Group Server Attachment can be imported using the id, e.g.
+Load Balancer Virtual Backend Server Group Server Attachment can be imported using the id, which consists of server_group_id, server_id and port, e.g.
 
 ```shell
 $ terraform import alicloud_slb_server_group_server_attachment.example <server_group_id>:<server_id>:<port>

--- a/website/docs/r/sls_etl.html.markdown
+++ b/website/docs/r/sls_etl.html.markdown
@@ -126,7 +126,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Log Service (SLS) Etl can be imported using the id, e.g.
+Log Service (SLS) Etl can be imported using the id, which consists of project and job_name, e.g.
 
 ```shell
 $ terraform import alicloud_sls_etl.example <project>:<job_name>

--- a/website/docs/r/sls_index.html.markdown
+++ b/website/docs/r/sls_index.html.markdown
@@ -142,7 +142,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Log Service (SLS) Index can be imported using the id, e.g.
+Log Service (SLS) Index can be imported using the id, which consists of project_name and logstore_name, e.g.
 
 ```shell
 $ terraform import alicloud_sls_index.example <project_name>:<logstore_name>

--- a/website/docs/r/sls_logtail_config.html.markdown
+++ b/website/docs/r/sls_logtail_config.html.markdown
@@ -126,7 +126,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Log Service (SLS) Logtail Config can be imported using the id, e.g.
+Log Service (SLS) Logtail Config can be imported using the id, which consists of project_name and logtail_config_name, e.g.
 
 ```shell
 $ terraform import alicloud_sls_logtail_config.example <project_name>:<logtail_config_name>

--- a/website/docs/r/sls_logtail_pipeline_config.html.markdown
+++ b/website/docs/r/sls_logtail_pipeline_config.html.markdown
@@ -134,7 +134,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Log Service (SLS) Logtail Pipeline Config can be imported using the id, e.g.
+Log Service (SLS) Logtail Pipeline Config can be imported using the id, which consists of project and config_name, e.g.
 
 ```shell
 $ terraform import alicloud_sls_logtail_pipeline_config.example <project>:<config_name>

--- a/website/docs/r/sls_machine_group.html.markdown
+++ b/website/docs/r/sls_machine_group.html.markdown
@@ -99,7 +99,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Log Service (SLS) Machine Group can be imported using the id, e.g.
+Log Service (SLS) Machine Group can be imported using the id, which consists of project_name and group_name, e.g.
 
 ```shell
 $ terraform import alicloud_sls_machine_group.example <project_name>:<group_name>

--- a/website/docs/r/snat_entry.html.markdown
+++ b/website/docs/r/snat_entry.html.markdown
@@ -104,7 +104,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-NAT Gateway Snat Entry can be imported using the id, e.g.
+NAT Gateway Snat Entry can be imported using the id, which consists of snat_table_id and snat_entry_id, e.g.
 
 ```shell
 $ terraform import alicloud_snat_entry.example <snat_table_id>:<snat_entry_id>

--- a/website/docs/r/star_rocks_node_group.html.markdown
+++ b/website/docs/r/star_rocks_node_group.html.markdown
@@ -175,7 +175,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Star Rocks Node Group can be imported using the id, e.g.
+Star Rocks Node Group can be imported using the id, which consists of instance_id and node_group_id, e.g.
 
 ```shell
 $ terraform import alicloud_star_rocks_node_group.example <instance_id>:<node_group_id>

--- a/website/docs/r/vpc_bgp_network.html.markdown
+++ b/website/docs/r/vpc_bgp_network.html.markdown
@@ -81,7 +81,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Express Connect Bgp Network can be imported using the id, e.g.
+Express Connect Bgp Network can be imported using the id, which consists of router_id and dst_cidr_block, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_bgp_network.example <router_id>:<dst_cidr_block>

--- a/website/docs/r/vpc_gateway_endpoint_route_table_attachment.html.markdown
+++ b/website/docs/r/vpc_gateway_endpoint_route_table_attachment.html.markdown
@@ -89,7 +89,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPC Gateway Endpoint Route Table Attachment can be imported using the id, e.g.
+VPC Gateway Endpoint Route Table Attachment can be imported using the id, which consists of gateway_endpoint_id and route_table_id, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_gateway_endpoint_route_table_attachment.example <gateway_endpoint_id>:<route_table_id>

--- a/website/docs/r/vpc_gateway_route_table_attachment.html.markdown
+++ b/website/docs/r/vpc_gateway_route_table_attachment.html.markdown
@@ -85,7 +85,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPC Gateway Route Table Attachment can be imported using the id, e.g.
+VPC Gateway Route Table Attachment can be imported using the id, which consists of route_table_id and ipv4_gateway_id, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_gateway_route_table_attachment.example <route_table_id>:<ipv4_gateway_id>

--- a/website/docs/r/vpc_ipv4_cidr_block.html.markdown
+++ b/website/docs/r/vpc_ipv4_cidr_block.html.markdown
@@ -72,7 +72,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPC Ipv4 Cidr Block can be imported using the id, e.g.
+VPC Ipv4 Cidr Block can be imported using the id, which consists of vpc_id and secondary_cidr_block, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_ipv4_cidr_block.example <vpc_id>:<secondary_cidr_block>

--- a/website/docs/r/vpc_ipv6_egress_rule.html.markdown
+++ b/website/docs/r/vpc_ipv6_egress_rule.html.markdown
@@ -128,7 +128,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPC Ipv6 Egress Rule can be imported using the id, e.g.
+VPC Ipv6 Egress Rule can be imported using the id, which consists of ipv6_gateway_id and ipv6_egress_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_ipv6_egress_rule.example <ipv6_gateway_id>:<ipv6_egress_rule_id>

--- a/website/docs/r/vpc_nat_ip.html.markdown
+++ b/website/docs/r/vpc_nat_ip.html.markdown
@@ -103,7 +103,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Nat Gateway Nat Ip can be imported using the id, e.g.
+Nat Gateway Nat Ip can be imported using the id, which consists of nat_gateway_id and nat_ip_id, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_nat_ip.example <nat_gateway_id>:<nat_ip_id>

--- a/website/docs/r/vpc_nat_ip_cidr.html.markdown
+++ b/website/docs/r/vpc_nat_ip_cidr.html.markdown
@@ -103,7 +103,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Nat Gateway Nat Ip Cidr can be imported using the id, e.g.
+Nat Gateway Nat Ip Cidr can be imported using the id, which consists of nat_gateway_id and nat_ip_cidr, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_nat_ip_cidr.example <nat_gateway_id>:<nat_ip_cidr>

--- a/website/docs/r/vpc_network_acl_attachment.html.markdown
+++ b/website/docs/r/vpc_network_acl_attachment.html.markdown
@@ -77,7 +77,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPC Network Acl Attachment can be imported using the id, e.g.
+VPC Network Acl Attachment can be imported using the id, which consists of network_acl_id and resource_id, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_network_acl_attachment.example <network_acl_id>:<resource_id>

--- a/website/docs/r/vpc_public_ip_address_pool_cidr_block.html.markdown
+++ b/website/docs/r/vpc_public_ip_address_pool_cidr_block.html.markdown
@@ -74,7 +74,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPC Public Ip Address Pool Cidr Block can be imported using the id, e.g.
+VPC Public Ip Address Pool Cidr Block can be imported using the id, which consists of public_ip_address_pool_id and cidr_block, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_public_ip_address_pool_cidr_block.example <public_ip_address_pool_id>:<cidr_block>

--- a/website/docs/r/vpc_route_entry.html.markdown
+++ b/website/docs/r/vpc_route_entry.html.markdown
@@ -114,7 +114,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPC Route Entry can be imported using the id, e.g.
+VPC Route Entry can be imported using the id, which consists of route_table_id and destination_cidr_block, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_route_entry.example <route_table_id>:<destination_cidr_block>

--- a/website/docs/r/vpc_traffic_mirror_filter_egress_rule.html.markdown
+++ b/website/docs/r/vpc_traffic_mirror_filter_egress_rule.html.markdown
@@ -75,7 +75,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPC Traffic Mirror Filter Egress Rule can be imported using the id, e.g.
+VPC Traffic Mirror Filter Egress Rule can be imported using the id, which consists of traffic_mirror_filter_id and traffic_mirror_filter_egress_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_traffic_mirror_filter_egress_rule.example <traffic_mirror_filter_id>:<traffic_mirror_filter_egress_rule_id>

--- a/website/docs/r/vpc_traffic_mirror_filter_ingress_rule.html.markdown
+++ b/website/docs/r/vpc_traffic_mirror_filter_ingress_rule.html.markdown
@@ -77,7 +77,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPC Traffic Mirror Filter Ingress Rule can be imported using the id, e.g.
+VPC Traffic Mirror Filter Ingress Rule can be imported using the id, which consists of traffic_mirror_filter_id and traffic_mirror_filter_ingress_rule_id, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_traffic_mirror_filter_ingress_rule.example <traffic_mirror_filter_id>:<traffic_mirror_filter_ingress_rule_id>

--- a/website/docs/r/vpc_vswitch_cidr_reservation.html.markdown
+++ b/website/docs/r/vpc_vswitch_cidr_reservation.html.markdown
@@ -92,7 +92,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-Vpc Vswitch Cidr Reservation can be imported using the id, e.g.
+Vpc Vswitch Cidr Reservation can be imported using the id, which consists of vswitch_id and vswitch_cidr_reservation_id, e.g.
 
 ```shell
 $ terraform import alicloud_vpc_vswitch_cidr_reservation.example <vswitch_id>:<vswitch_cidr_reservation_id>

--- a/website/docs/r/vpn_gateway_vco_route.html.markdown
+++ b/website/docs/r/vpn_gateway_vco_route.html.markdown
@@ -148,7 +148,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPN Gateway Vco Route can be imported using the id, e.g.
+VPN Gateway Vco Route can be imported using the id, which consists of vpn_connection_id, route_dest, next_hop and weight, e.g.
 
 ```shell
 $ terraform import alicloud_vpn_gateway_vco_route.example <vpn_connection_id>:<route_dest>:<next_hop>:<weight>

--- a/website/docs/r/vpn_pbr_route_entry.html.markdown
+++ b/website/docs/r/vpn_pbr_route_entry.html.markdown
@@ -164,7 +164,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-VPN Pbr route entry can be imported using the id, e.g.
+VPN Pbr route entry can be imported using the id, which consists of vpn_gateway_id, next_hop, route_source and route_dest, e.g.
 
 ```shell
 $ terraform import alicloud_vpn_pbr_route_entry.example <vpn_gateway_id>:<next_hop>:<route_source>:<route_dest>

--- a/website/docs/r/wafv3_address_book.html.markdown
+++ b/website/docs/r/wafv3_address_book.html.markdown
@@ -78,7 +78,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-WAFV3 Address Book can be imported using the id, e.g.
+WAFV3 Address Book can be imported using the id, which consists of instance_id and address_book_id, e.g.
 
 ```shell
 $ terraform import alicloud_wafv3_address_book.example <instance_id>:<address_book_id>

--- a/website/docs/r/wafv3_defense_resource_group.html.markdown
+++ b/website/docs/r/wafv3_defense_resource_group.html.markdown
@@ -114,7 +114,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-WAFV3 Defense Resource Group can be imported using the id, e.g.
+WAFV3 Defense Resource Group can be imported using the id, which consists of instance_id and group_name, e.g.
 
 ```shell
 $ terraform import alicloud_wafv3_defense_resource_group.example <instance_id>:<group_name>

--- a/website/docs/r/wafv3_defense_template.html.markdown
+++ b/website/docs/r/wafv3_defense_template.html.markdown
@@ -95,7 +95,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-WAFV3 Defense Template can be imported using the id, e.g.
+WAFV3 Defense Template can be imported using the id, which consists of instance_id and defense_template_id, e.g.
 
 ```shell
 $ terraform import alicloud_wafv3_defense_template.example <instance_id>:<defense_template_id>

--- a/website/docs/r/wafv3_domain.html.markdown
+++ b/website/docs/r/wafv3_domain.html.markdown
@@ -232,7 +232,7 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 
 ## Import
 
-WAFV3 Domain can be imported using the id, e.g.
+WAFV3 Domain can be imported using the id, which consists of instance_id and domain, e.g.
 
 ```shell
 $ terraform import alicloud_wafv3_domain.example <instance_id>:<domain>


### PR DESCRIPTION
## What

For each resource whose import id is composite (e.g. `<a>:<b>:<c>`), the Import section of its doc now states which attributes make up the id, in the order they appear in the shell example:

```
<name> can be imported using the id, which consists of a, b and c, e.g.

$ terraform import alicloud_xxx.example <a>:<b>:<c>
```

The shell example itself is unchanged. Single-id resources are not affected.

## Why

Composite import IDs were previously only shown as a colon-joined example string, with no explicit list of the attributes that form the id. This makes it hard to know which attributes combine into the import id without reading the provider source. Annotating the composition inline in the doc resolves that.

## Scope

- 332 resource docs updated — composite id with a placeholder example (e.g. `<a>:<b>:<c>`), token names taken from the example placeholders in order.
- 1 resource doc already annotated (`ack_one_membership_attachment`) — skipped.
- ~692 single-id resources — not affected.
- ~86 resources whose import example uses literal values or non-standard formatting (no `<placeholder>` form to extract token names from) — left for a follow-up to avoid guessing attribute names.

## Deferred: 39 docs with pre-existing lint/Content debt

39 additional composite-id resources are intentionally **excluded** from this PR. Their docs already carry pre-existing markdown-lint or Content violations in lines outside the Import section, present on `master` (the per-PR lint only runs on changed files, so annotating them here would surface that debt and block CI). They are deferred to a separate follow-up PR that fixes the lint debt first, then adds the same import-id annotation.

The debt breaks down as:
- markdown-lint violations (MD007 ul-indent, MD010 hard-tabs, MD022, MD037, MD040, etc.), including `wafv3_defense_rule`.
- Content (`scripts/document/document_check.go`) violations: `help.aliyun.com` links that should be `www.alibabacloud.com/help`, `Available in v` version-notes that should be `Available since`, `depends_on`/`test` usage in examples, and frontmatter/heading format nits — including `dbfs_instance_attachment`, `ehpc_queue`, `mhub_app`, `mse_znode`, `nas_lifecycle_policy`, `oss_bucket_cname`, `service_mesh_extension_provider`, `slb_listener`, `waf_certificate`, `waf_protection_module`.

The Content check runs per-file and the CI step stops at the first failing file, so the full set was identified by running the check locally on every candidate. The annotation pattern itself is unchanged for all resources.

## Relationship to #9942

Supersedes #9942 (pilot batch of 10). This PR is based on the latest `master`, covers the same 10 resources plus 322 more, and does not touch `CHANGELOG.md` (left to the release engineer).

## Verification

- Only `website/docs/r/*.markdown` files changed; no Go source changes.
- Each file changed by exactly one line (the Import paragraph); shell examples are byte-for-byte unchanged.
- Token order matches the shell example placeholder order.
- Single commit, author `api-tool-agent`.
- The included 332 files were verified locally against the repo's `document_check.go` to have no Content violations; `markdown-lint`/`Content`/`misspell`/`markdown-link`/`terrafmt`/`Consistency`/`basic-check` and format gates (`Pull Request Title`, `Pull Request Max Commits`, `license/cla`, `Basic Policy`) are all green.
