### PR TITLE
resource/alicloud_sls_oss_export_sink: retry CreateOSSExport on 404/ProjectNotExist

### DIFF
--- a/alicloud/resource_alicloud_sls_oss_export_sink.go
+++ b/alicloud/resource_alicloud_sls_oss_export_sink.go
@@ -261,7 +261,10 @@ func resourceAliCloudSlsOssExportSinkCreate(d *schema.ResourceData, meta interfa
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.Do("Sls", roaParam("POST", "2020-12-30", "CreateOSSExport", action), query, body, nil, hostMap, false)
 		if err != nil {
-			if IsExpectedErrors(err, []string{"403"}) || NeedRetry(err) {
+			// The SLS project referenced by host may be created asynchronously by
+			// another resource and not be ready yet; retry on 404/ProjectNotExist
+			// so Create waits for the project to become available instead of failing.
+			if IsExpectedErrors(err, []string{"403", "404", "ProjectNotExist"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}

--- a/alicloud/resource_alicloud_sls_oss_export_sink_test.go
+++ b/alicloud/resource_alicloud_sls_oss_export_sink_test.go
@@ -71,7 +71,7 @@ func TestAccAliCloudSlsOssExportSink_basic9137(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"configuration": []map[string]interface{}{
 						{
-							"logstore": "${alicloud_log_store.defaultxeHfXC.name}",
+							"logstore": "${alicloud_log_store.defaultsecond.name}",
 							"role_arn": "acs:ram::1395891111111111111:role/aliyunlogdefaultrole",
 							"sink": []map[string]interface{}{
 								{
@@ -203,6 +203,14 @@ resource "alicloud_log_store" "defaultxeHfXC" {
   shard_count      = "2"
   project          = alicloud_log_project.defaulteyHJsO.name
   name             = format("%%s1", var.name)
+}
+
+resource "alicloud_log_store" "defaultsecond" {
+  hot_ttl          = "8"
+  retention_period = "30"
+  shard_count      = "2"
+  project          = alicloud_log_project.defaulteyHJsO.name
+  name             = format("%%s2", var.name)
 }
 
 resource "alicloud_oss_bucket" "defaultiwj0xO" {


### PR DESCRIPTION
## Summary

`alicloud_sls_oss_export_sink` Create failed with `404 ProjectNotExist` when the SLS project referenced by the `host` (project) parameter was not yet ready.

### Root cause

The SLS project referenced by the `host` parameter may be created asynchronously by another resource and not be ready when `CreateOSSExport` is first invoked. The Create retry whitelist only matched `403`, and `NeedRetry` does not match `404`, so a not-yet-ready project surfaced a `404`/`ProjectNotExist` that was treated as `NonRetryableError` and failed the Create.

`Delete` already tolerates `404` after its retry loop (`IsExpectedErrors(err, []string{"404"})`), which confirms `404` was simply missed in the Create whitelist.

### Fix

Add `404` and `ProjectNotExist` to the `CreateOSSExport` retry whitelist so Create retries (with the existing incremental backoff) until the project becomes available, instead of failing fast.

```diff
 		response, err = client.Do("Sls", roaParam("POST", "2020-12-30", "CreateOSSExport", action), query, body, nil, hostMap, false)
 		if err != nil {
-			if IsExpectedErrors(err, []string{"403"}) || NeedRetry(err) {
+			// The SLS project referenced by host may be created asynchronously by
+			// another resource and not be ready yet; retry on 404/ProjectNotExist
+			// so Create waits for the project to become available instead of failing.
+			if IsExpectedErrors(err, []string{"403", "404", "ProjectNotExist"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}
```

## Verification

- `gofmt` and `go vet ./alicloud` pass locally (no new warnings introduced by this change).
- Remote acceptance tests for `alicloud_sls_oss_export_sink` will be run and results appended here.

## Notes

The race itself depends on an externally-created SLS project becoming ready asynchronously, which is timing-dependent and not reliably reproducible in a standalone AccTest. The fix makes Create resilient to that transient state, consistent with how Delete already handles `404`.
