### PR TITLE
resource/alicloud_kvstore_instance: skip no-op private connection string/port modifications

### DIFF
--- a/alicloud/resource_alicloud_kvstore_instance.go
+++ b/alicloud/resource_alicloud_kvstore_instance.go
@@ -16,6 +16,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+// DBInstanceNetType values returned by DescribeDBInstanceNetInfo (R-kvstore
+// 2015-01-01): "0" = public network (IPType=Public), "1" = classic network
+// (IPType=Inner), "2" = VPC (IPType=Private). See the DescribeDBInstanceNetInfo
+// API document.
+const (
+	kvstoreDBInstanceNetTypePublic = "0"
+	kvstoreDBInstanceNetTypeVPC    = "2"
+)
+
 func resourceAliCloudKvstoreInstance() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAliCloudKvstoreInstanceCreate,
@@ -654,12 +663,12 @@ func resourceAliCloudKvstoreInstanceRead(d *schema.ResourceData, meta interface{
 	for _, netInfo := range netInfoList {
 		netInfoArg := netInfo.(map[string]interface{})
 
-		if fmt.Sprint(netInfoArg["DBInstanceNetType"]) == "0" {
+		if fmt.Sprint(netInfoArg["DBInstanceNetType"]) == kvstoreDBInstanceNetTypePublic {
 			d.Set("enable_public", true)
 			d.Set("connection_string", netInfoArg["ConnectionString"])
 		}
 
-		if fmt.Sprint(netInfoArg["DBInstanceNetType"]) == "2" {
+		if fmt.Sprint(netInfoArg["DBInstanceNetType"]) == kvstoreDBInstanceNetTypeVPC {
 			if _, ok := netInfoArg["IsSlaveProxy"]; !ok {
 				d.Set("private_connection_port", netInfoArg["Port"])
 			}
@@ -1288,31 +1297,81 @@ func resourceAliCloudKvstoreInstanceUpdate(d *schema.ResourceData, meta interfac
 	update = false
 	modifyDBInstanceConnectionStringReq := r_kvstore.CreateModifyDBInstanceConnectionStringRequest()
 	modifyDBInstanceConnectionStringReq.DBInstanceId = d.Id()
+	modifyDBInstanceConnectionStringReq.IPType = "Private"
+	// Create chains into Update (resourceAliCloudKvstoreInstanceCreate ends with
+	// "return resourceAliCloudKvstoreInstanceUpdate(d, meta)"), so HasChange is
+	// true for every explicitly configured attribute even on a brand new
+	// resource. ModifyDBInstanceConnectionString rejects a prefix or port that
+	// equals the current private endpoint value with
+	// InvalidConnectionStringOrPort.Duplicate, which taints the resource on create
+	// (e.g. private_connection_port = "6379") and forces an unrecoverable replace
+	// on every subsequent apply. Diff against the live private endpoint first and
+	// only send the fields that actually differ.
+	var targetPrefix, targetPort string
 	if d.HasChange("private_connection_prefix") {
-		update = true
-		modifyDBInstanceConnectionStringReq.NewConnectionString = d.Get("private_connection_prefix").(string)
+		targetPrefix = d.Get("private_connection_prefix").(string)
 	}
 	if d.HasChange("private_connection_port") {
-		update = true
-		modifyDBInstanceConnectionStringReq.Port = d.Get("private_connection_port").(string)
+		targetPort = d.Get("private_connection_port").(string)
 	}
-	modifyDBInstanceConnectionStringReq.IPType = "Private"
-	if update {
-		object, err := r_kvstoreService.DescribeKvstoreInstance(d.Id())
-		modifyDBInstanceConnectionStringReq.CurrentConnectionString = fmt.Sprint(object["ConnectionDomain"])
-		raw, err := client.WithRKvstoreClient(func(r_kvstoreClient *r_kvstore.Client) (interface{}, error) {
-			return r_kvstoreClient.ModifyDBInstanceConnectionString(modifyDBInstanceConnectionStringReq)
-		})
-		addDebug(modifyDBInstanceConnectionStringReq.GetActionName(), raw)
+	if targetPrefix != "" || targetPort != "" {
+		netInfoList, err := r_kvstoreService.DescribeKvStoreInstanceNetInfo(d.Id())
 		if err != nil {
-			return WrapErrorf(err, DefaultErrorMsg, d.Id(), modifyDBInstanceConnectionStringReq.GetActionName(), AlibabaCloudSdkGoERROR)
+			return WrapError(err)
 		}
-		stateConf := BuildStateConf([]string{}, []string{"Normal"}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, r_kvstoreService.KvstoreInstanceStateRefreshFunc(d.Id(), []string{}))
-		if _, err := stateConf.WaitForState(); err != nil {
-			return WrapErrorf(err, IdMsg, d.Id())
+		// Locate the primary private (VPC, DBInstanceNetType="2") endpoint and
+		// skip standby proxies: IsSlaveProxy is only present on multi-AZ
+		// read/write-splitting instances and marks the standby-zone address.
+		var currentConnectionString, currentPort string
+		for _, netInfo := range netInfoList {
+			arg := netInfo.(map[string]interface{})
+			if fmt.Sprint(arg["DBInstanceNetType"]) != kvstoreDBInstanceNetTypeVPC {
+				continue
+			}
+			if _, ok := arg["IsSlaveProxy"]; ok {
+				continue
+			}
+			currentConnectionString = fmt.Sprint(arg["ConnectionString"])
+			currentPort = fmt.Sprint(arg["Port"])
+			break
 		}
-		d.SetPartial("private_connection_prefix")
-		d.SetPartial("private_connection_port")
+		// currentConnectionString is the full private endpoint (e.g.
+		// "myprefix.redis.rds.aliyuncs.com"); NewConnectionString is only the
+		// leading prefix segment, so compare with the dot suffix.
+		if targetPrefix != "" && currentConnectionString != "" && strings.HasPrefix(currentConnectionString, targetPrefix+".") {
+			targetPrefix = ""
+		}
+		if targetPort != "" && targetPort == currentPort {
+			targetPort = ""
+		}
+		if targetPrefix != "" || targetPort != "" {
+			if currentConnectionString == "" {
+				return WrapError(Error("no private connection endpoint found for instance %s; cannot modify private connection string/port", d.Id()))
+			}
+			modifyDBInstanceConnectionStringReq.CurrentConnectionString = currentConnectionString
+			if targetPrefix != "" {
+				modifyDBInstanceConnectionStringReq.NewConnectionString = targetPrefix
+			}
+			if targetPort != "" {
+				modifyDBInstanceConnectionStringReq.Port = targetPort
+			}
+			raw, err := client.WithRKvstoreClient(func(r_kvstoreClient *r_kvstore.Client) (interface{}, error) {
+				return r_kvstoreClient.ModifyDBInstanceConnectionString(modifyDBInstanceConnectionStringReq)
+			})
+			addDebug(modifyDBInstanceConnectionStringReq.GetActionName(), raw)
+			// Tolerate InvalidConnectionStringOrPort.Duplicate as a fallback for
+			// concurrent external modification between the Describe above and this
+			// Modify; the diff filter is the primary defense.
+			if err != nil && !IsExpectedErrors(err, []string{"InvalidConnectionStringOrPort.Duplicate"}) {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), modifyDBInstanceConnectionStringReq.GetActionName(), AlibabaCloudSdkGoERROR)
+			}
+			stateConf := BuildStateConf([]string{}, []string{"Normal"}, d.Timeout(schema.TimeoutUpdate), 60*time.Second, r_kvstoreService.KvstoreInstanceStateRefreshFunc(d.Id(), []string{}))
+			if _, err := stateConf.WaitForState(); err != nil {
+				return WrapErrorf(err, IdMsg, d.Id())
+			}
+			d.SetPartial("private_connection_prefix")
+			d.SetPartial("private_connection_port")
+		}
 	}
 	update = false
 	modifySecurityIpsReq := r_kvstore.CreateModifySecurityIpsRequest()

--- a/alicloud/resource_alicloud_kvstore_instance_test.go
+++ b/alicloud/resource_alicloud_kvstore_instance_test.go
@@ -3005,6 +3005,97 @@ func TestUnitKvstoreResolveMajorVersionForSpecChange(t *testing.T) {
 	}
 }
 
+// TestAccAliCloudKVStoreRedisInstance_privateConnectionCreate is a regression
+// test for a create-time config that pins the connection string fields to the
+// instance's default private endpoint values (e.g. private_connection_port =
+// "6379"). Create chains into Update, so HasChange is true for every
+// explicitly configured attribute on a brand new resource, and
+// ModifyDBInstanceConnectionString used to reject same-value modifications with
+// InvalidConnectionStringOrPort.Duplicate, tainting the resource and forcing
+// an unrecoverable replace on the next apply.
+func TestAccAliCloudKVStoreRedisInstance_privateConnectionCreate(t *testing.T) {
+	var v r_kvstore.DBInstanceAttribute
+	resourceId := "alicloud_kvstore_instance.default"
+	ra := resourceAttrInit(resourceId, AliCloudKVStoreMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &R_kvstoreService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeKvstoreInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccKvstoreRedisPrivConnCreate%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudKVStoreRedisInstanceVpcBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Create step carries both connection string fields, with port
+				// pinned to the instance default (6379). Historical bug: create
+				// failed here with InvalidConnectionStringOrPort.Duplicate.
+				Config: testAccConfig(map[string]interface{}{
+					"instance_class":            "redis.master.small.default",
+					"db_instance_name":          name,
+					"instance_type":             "Redis",
+					"engine_version":            "5.0",
+					"payment_type":              "PostPaid",
+					"resource_group_id":         "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+					"zone_id":                   "${data.alicloud_kvstore_zones.default.zones.0.id}",
+					"vswitch_id":                "${data.alicloud_vswitches.default.ids.0}",
+					"password":                  "YourPassword_123",
+					"private_connection_prefix": fmt.Sprintf("privateprefixcreate%d", rand),
+					"private_connection_port":   "6379",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_class":            "redis.master.small.default",
+						"db_instance_name":          name,
+						"instance_type":             "Redis",
+						"engine_version":            "5.0",
+						"payment_type":              "PostPaid",
+						"resource_group_id":         CHECKSET,
+						"zone_id":                   CHECKSET,
+						"vswitch_id":                CHECKSET,
+						"private_connection_port":   "6379",
+						"private_connection_prefix": CHECKSET,
+					}),
+				),
+			},
+			{
+				// In-place prefix change: verifies the diff filter still forwards
+				// a real change.
+				Config: testAccConfig(map[string]interface{}{
+					"private_connection_prefix": fmt.Sprintf("privateprefixmodify%d", rand),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"private_connection_prefix": CHECKSET,
+						"private_connection_port":   "6379",
+					}),
+				),
+			},
+			{
+				// Unrelated update while connection fields stay put: the diff
+				// filter must collapse to a no-op instead of re-sending the
+				// current prefix/port.
+				Config: testAccConfig(map[string]interface{}{
+					"db_instance_name": name + "_upd",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"db_instance_name":        name + "_upd",
+						"private_connection_port": "6379",
+					}),
+				),
+			},
+		},
+	})
+}
+
 var AliCloudKVStoreMap0 = map[string]string{
 	"connection_domain": CHECKSET,
 	"bandwidth":         CHECKSET,


### PR DESCRIPTION
## What

`alicloud_kvstore_instance` failed to create — and then forced an unrecoverable
replace on every subsequent apply — whenever `private_connection_prefix` or
`private_connection_port` was explicitly configured to a value that already
matched the instance's default private endpoint (e.g.
`private_connection_port = "6379"`). Once the private link existed, any
unrelated attribute update re-triggered the same failure.

## Root cause

`resourceAliCloudKvstoreInstanceCreate` ends with
`return resourceAliCloudKvstoreInstanceUpdate(d, meta)`, so the Create path
chains into Update. On a brand new resource `d.HasChange(...)` is true for every
explicitly configured attribute even when the value already equals the instance
default. The old Update sent `ModifyDBInstanceConnectionString` with that value
unchanged, and the API rejected it with `InvalidConnectionStringOrPort.Duplicate`.
Because the failure happened after the instance was already created, the
resource became tainted; the next apply rebuilt it and hit the same error,
making the instance unmanageable.

## Changes (line by line)

This is a focused replacement for the broader PR #9937 (now closed). It also
addresses the feedback that the bare `DBInstanceNetType` string literals were
unexplained and that the previous change bundled in too much.

### 1. Named constants for `DBInstanceNetType` (top of resource file)

```go
// DBInstanceNetType values returned by DescribeDBInstanceNetInfo (R-kvstore
// 2015-01-01): "0" = public network (IPType=Public), "1" = classic network
// (IPType=Inner), "2" = VPC (IPType=Private). See the DescribeDBInstanceNetInfo
// API document.
const (
    kvstoreDBInstanceNetTypePublic = "0"
    kvstoreDBInstanceNetTypeVPC    = "2"
)
```

`DescribeDBInstanceNetInfo` documents `DBInstanceNetType` as an enum:

| Value | Meaning        | Paired `IPType` |
|-------|----------------|-----------------|
| `0`   | Public network | `Public`        |
| `1`   | Classic network| `Inner`         |
| `2`   | VPC            | `Private`       |

So `"0"` and `"2"` are not magic values — they are the documented enum members.
The constants name them and cite the source API. The classic-network value
(`1`) is not compared anywhere in this resource today, so it is intentionally
omitted to keep the set to what the code actually uses.

### 2. `Read` uses the constants

The two `fmt.Sprint(netInfoArg["DBInstanceNetType"]) == "0"` / `== "2"`
comparisons in `resourceAliCloudKvstoreInstanceRead` now use
`kvstoreDBInstanceNetTypePublic` / `kvstoreDBInstanceNetTypeVPC`. Behaviour is
unchanged; this only removes the bare literals.

### 3. `Update` diffs against the live private endpoint before sending

Before sending `ModifyDBInstanceConnectionString`, Update now calls
`DescribeDBInstanceNetInfo`, locates the primary private endpoint
(`DBInstanceNetType == "2"` / VPC), skips standby proxies (`IsSlaveProxy`, only
present on multi-AZ read/write-splitting instances), and compares the
configured prefix/port against the live values:

- `private_connection_prefix` is the leading segment of the full private
  endpoint (e.g. `myprefix.redis.rds.aliyuncs.com`), so a match is detected with
  `strings.HasPrefix(currentConnectionString, targetPrefix+".")`.
- `private_connection_port` is compared directly to the live `Port`.

Only fields that actually differ are set on the request. If both collapse to a
no-op, no `ModifyDBInstanceConnectionString` call is made at all — this is what
unblocks create-with-default-port and unrelated updates. If a real change
remains, `CurrentConnectionString` is taken from the same
`DescribeDBInstanceNetInfo` response (the full private `ConnectionString`), and
the call proceeds.

`InvalidConnectionStringOrPort.Duplicate` is still tolerated as a fallback for
concurrent external modification between the Describe and the Modify; the diff
filter is the primary defence.

### 4. Regression test

`TestAccAliCloudKVStoreRedisInstance_privateConnectionCreate` covers three
steps:

1. Create with `private_connection_port = "6379"` and a custom prefix — the
   create-time scenario that used to fail.
2. In-place prefix change — verifies a real change is still forwarded.
3. Unrelated update (`db_instance_name`) with the connection fields unchanged —
   verifies the diff filter collapses to a no-op instead of re-sending.

## Out of scope (deliberately split out)

PR #9937 also bundled `ImportStateVerifyIgnore` additions (adding `port` across
several existing tests) and a large attribute-coverage test. Those are
unrelated to this bug and are intentionally **not** included here to keep this
PR focused; they can land in a separate PR.

## Test results

Local: `go vet -p=1 ./alicloud` compiles clean for the changed files (two
pre-existing `fmt.Sprintln` warnings in `common.go` are unrelated to this
change). Remote ACC for the new regression case will be run separately.
