### PR TITLE
New Resource: alicloud_data_works_certificate and New Data Source: alicloud_data_works_certificates

### DIFF
--- a/alicloud/data_source_alicloud_data_works_certificates.go
+++ b/alicloud/data_source_alicloud_data_works_certificates.go
@@ -1,0 +1,221 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudDataWorksCertificates() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudDataWorksCertificateRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"certificates": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_user": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"file_size_in_bytes": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"project_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudDataWorksCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListCertificates"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	query["RegionId"] = client.RegionId
+	if v, ok := d.GetOkExists("project_id"); ok {
+		query["ProjectId"] = strconv.Itoa(v.(int))
+	}
+
+	request["PageSize"] = PageSizeLarge
+	request["PageNumber"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcGet("dataworks-public", "2024-05-18", action, query, request)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.PagingInfo.Certificates[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				// The resource id is composite "<project_id>:<certificate_id>"; accept both
+				// the composite form and the raw certificate id for filtering.
+				rawId := fmt.Sprint(item["Id"])
+				compositeId := fmt.Sprintf("%v:%v", d.Get("project_id"), item["Id"])
+				if _, ok := idsMap[rawId]; !ok {
+					if _, ok := idsMap[compositeId]; !ok {
+						continue
+					}
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["Id"]
+
+		mapping["create_time"] = dataWorksCertificateCreateTimeFormat(objectRaw["CreateTime"])
+		mapping["create_user"] = objectRaw["CreateUser"]
+		mapping["description"] = objectRaw["Description"]
+		mapping["file_size_in_bytes"] = objectRaw["FileSizeInBytes"]
+		mapping["name"] = objectRaw["Name"]
+		mapping["id"] = objectRaw["Id"]
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["Id"])
+		mapping, err = dataSourceAliCloudDataWorksCertificateReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("certificates", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudDataWorksCertificateReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	dataWorksServiceV2 := DataWorksServiceV2{client}
+	// DescribeDataWorksCertificate expects a composite id "<project_id>:<certificate_id>".
+	compositeId := fmt.Sprintf("%v:%v", d.Get("project_id"), id)
+	getResp, err := dataWorksServiceV2.DescribeDataWorksCertificate(compositeId)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["create_time"] = dataWorksCertificateCreateTimeFormat(objectRaw["CreateTime"])
+	mapping["create_user"] = objectRaw["CreateUser"]
+	mapping["description"] = objectRaw["Description"]
+	mapping["file_size_in_bytes"] = objectRaw["FileSizeInBytes"]
+	mapping["name"] = objectRaw["Name"]
+	mapping["project_id"] = objectRaw["ProjectId"]
+	mapping["id"] = objectRaw["Id"]
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_data_works_certificates_test.go
+++ b/alicloud/data_source_alicloud_data_works_certificates_test.go
@@ -1,0 +1,134 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudDataWorksCertificateDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudDataWorksCertificateSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_data_works_certificate.default.id}"]`,
+			"project_id": `"${alicloud_data_works_project.defaultxWQGsP.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudDataWorksCertificateSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_data_works_certificate.default.id}_fake"]`,
+			"project_id": `"${alicloud_data_works_project.defaultxWQGsP.id}"`,
+		}),
+	}
+
+	ProjectIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudDataWorksCertificateSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_data_works_certificate.default.id}"]`,
+			"project_id": `"${alicloud_data_works_project.defaultxWQGsP.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudDataWorksCertificateSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_data_works_certificate.default.id}_fake"]`,
+			"project_id": `"${alicloud_data_works_project.defaultxWQGsP.id}"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudDataWorksCertificateSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_data_works_certificate.default.id}"]`,
+			"project_id": `"${alicloud_data_works_project.defaultxWQGsP.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudDataWorksCertificateSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_data_works_certificate.default.id}_fake"]`,
+			"project_id": `"${alicloud_data_works_project.defaultxWQGsP.id}"`,
+		}),
+	}
+
+	DataWorksCertificateCheckInfo.dataSourceTestCheck(t, rand, idsConf, ProjectIdConf, allConf)
+}
+
+var existDataWorksCertificateMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"certificates.#":                    "1",
+		"certificates.0.description":        CHECKSET,
+		"certificates.0.create_time":        CHECKSET,
+		"certificates.0.create_user":        CHECKSET,
+		"certificates.0.file_size_in_bytes": CHECKSET,
+		"certificates.0.id":                 CHECKSET,
+		"certificates.0.name":               CHECKSET,
+	}
+}
+
+var fakeDataWorksCertificateMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"certificates.#": "0",
+	}
+}
+
+var DataWorksCertificateCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_data_works_certificates.default",
+	existMapFunc: existDataWorksCertificateMapFunc,
+	fakeMapFunc:  fakeDataWorksCertificateMapFunc,
+}
+
+func testAccCheckAlicloudDataWorksCertificateSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tfaccdwcert%d"
+}
+resource "alicloud_data_works_project" "defaultxWQGsP" {
+  description      = "tf-acc-test"
+  project_name     = var.name
+  pai_task_enabled = false
+  display_name     = var.name
+}
+
+resource "alicloud_oss_bucket" "cert" {
+  bucket = "tfaccdwcert%d"
+  acl    = "public-read"
+}
+
+resource "alicloud_oss_bucket_object" "cert" {
+  bucket  = alicloud_oss_bucket.cert.id
+  key     = "tf-acc-cert.pem"
+  acl     = "public-read"
+  content = <<-EOT
+-----BEGIN CERTIFICATE-----
+MIICqDCCAZACCQCbNs38rCeB6TANBgkqhkiG9w0BAQsFADAWMRQwEgYDVQQDDAt0
+Zi1hY2MtdGVzdDAeFw0yNjA5MDMwMDE4MDFaFw0zNjA4MzEwMDE4MDFaMBYxFDAS
+BgNVBAMMC3RmLWFjYy10ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAwyKgyXSNG+NfmE6Ukz7oX4AgDbTaHAyJ3BWHfTK/DJNY0+0tgYE5Zle8bNui
+rksdOpydcGAJeaoFNpCGwvd5FO9HklcYwLGdzASRXEHEN0XtG2oeHNnyH82yE2SH
+hINbhYcM98WCEuIU5cIsohaQUXhdgBzQcUdc7q5mG/U87LQk4ZGq+JuqUhOAB2xG
+8phoguTZ3ODk4+x9MEycpXfpTVkzz9y4JmL6jh3dEZvpyMmC94NYjrGRbioI9CDe
+mpY1BsHRtSgxJ7Pvl5yYy7Tj2KC3jRv4FEP7C8vg9tqqV37yLtZsXw/UeVhn9nOm
+tOQcqaS3o4BTp//Db7/ReoE2fwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBn+Hi1
+Lq6pHiV0PPLN+4cQK8sLFSk1nHvJ1ONk9FsBmsnkrbky6I5fNQiBnzOm/rNl72Ao
+JvsyROYVyyxX/M5LnZQwahUwDTaz4cNasUiPt33lNtueiLLhzC7UpB8NzH/v29MT
+YnEmgc7msKrSnj8SfvZu6y9vbmLhJ0CbrpBTmcG6cXr/Em+l781p4hFdJmpOA7o8
+oX+vfX/riPSP8bGgYlmsr2Iv4Uo/b8q6ZpF5p76M/MJirligYjc5fZG8UmsBu6eX
+d5LC+4/r6W5uyIS/7fF7FLdzHfRhZknuu8Wzx+HXI+oKv0r/z8MGa1DsvJ6DHQIE
+qWre020mtWvGRU1t
+-----END CERTIFICATE-----
+EOT
+}
+
+resource "alicloud_data_works_certificate" "default" {
+  project_id       = alicloud_data_works_project.defaultxWQGsP.id
+  name             = var.name
+  certificate_file = "http://${alicloud_oss_bucket.cert.id}.${alicloud_oss_bucket.cert.extranet_endpoint}/${alicloud_oss_bucket_object.cert.key}"
+}
+
+data "alicloud_data_works_certificates" "default" {
+%s
+}
+`, rand, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_data_works_certificates":                        dataSourceAliCloudDataWorksCertificates(),
 			"alicloud_redis_global_security_ip_groups":                dataSourceAliCloudRedisGlobalSecurityIpGroups(),
 			"alicloud_cr_artifact_subscription_rules":                 dataSourceAliCloudCrArtifactSubscriptionRules(),
 			"alicloud_cms_event_notify_policies":                      dataSourceAliCloudCmsEventNotifyPolicies(),
@@ -956,6 +957,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_data_works_certificate":                               resourceAliCloudDataWorksCertificate(),
 			"alicloud_redis_global_security_ip_group":                       resourceAliCloudRedisGlobalSecurityIpGroup(),
 			"alicloud_cr_artifact_subscription_rule":                        resourceAliCloudCrArtifactSubscriptionRule(),
 			"alicloud_cms_event_notify_policy":                              resourceAliCloudCmsEventNotifyPolicy(),

--- a/alicloud/resource_alicloud_data_works_certificate.go
+++ b/alicloud/resource_alicloud_data_works_certificate.go
@@ -1,0 +1,169 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudDataWorksCertificate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudDataWorksCertificateCreate,
+		Read:   resourceAliCloudDataWorksCertificateRead,
+		Delete: resourceAliCloudDataWorksCertificateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"certificate_file": {
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				Sensitive: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_user": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"file_size_in_bytes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"project_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudDataWorksCertificateCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "ImportCertificate"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+
+	if v, ok := d.GetOk("description"); ok {
+		request["Description"] = v
+	}
+	request["CertificateFile"] = d.Get("certificate_file")
+	request["ProjectId"] = d.Get("project_id")
+	request["Name"] = d.Get("name")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("dataworks-public", "2024-05-18", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_data_works_certificate", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", d.Get("project_id"), response["Id"]))
+
+	return resourceAliCloudDataWorksCertificateRead(d, meta)
+}
+
+func resourceAliCloudDataWorksCertificateRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	dataWorksServiceV2 := DataWorksServiceV2{client}
+
+	objectRaw, err := dataWorksServiceV2.DescribeDataWorksCertificate(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_data_works_certificate DescribeDataWorksCertificate Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("create_time", dataWorksCertificateCreateTimeFormat(objectRaw["CreateTime"]))
+	d.Set("create_user", objectRaw["CreateUser"])
+	d.Set("description", objectRaw["Description"])
+	d.Set("file_size_in_bytes", objectRaw["FileSizeInBytes"])
+	d.Set("name", objectRaw["Name"])
+	d.Set("project_id", objectRaw["ProjectId"])
+
+	return nil
+}
+
+func resourceAliCloudDataWorksCertificateDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteCertificate"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	if len(parts) != 2 {
+		return WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length 2, got %d", d.Id(), len(parts)))
+	}
+	request = make(map[string]interface{})
+	request["Id"] = parts[1]
+	request["RegionId"] = client.RegionId
+
+	request["ProjectId"] = parts[0]
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("dataworks-public", "2024-05-18", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_data_works_certificate_test.go
+++ b/alicloud/resource_alicloud_data_works_certificate_test.go
@@ -1,0 +1,212 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test DataWorks Certificate. >>> Resource test cases, automatically generated.
+// Case 测试Certificate1（有前置步骤，上海预发执行） 9054
+func TestAccAliCloudDataWorksCertificate_basic9054(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_data_works_certificate.default"
+	ra := resourceAttrInit(resourceId, AlicloudDataWorksCertificateMap9054)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &DataWorksServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeDataWorksCertificate")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccdataworks%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudDataWorksCertificateBasicDependence9054)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-shenzhen"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"project_id":       "${alicloud_data_works_project.defaultxWQGsP.id}",
+					"name":             name,
+					"certificate_file": "http://${alicloud_oss_bucket.cert.id}.${alicloud_oss_bucket.cert.extranet_endpoint}/${alicloud_oss_bucket_object.cert.key}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"project_id":       CHECKSET,
+						"name":             CHECKSET,
+						"certificate_file": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"certificate_file"},
+			},
+		},
+	})
+}
+
+var AlicloudDataWorksCertificateMap9054 = map[string]string{
+	"create_time":        CHECKSET,
+	"create_user":        CHECKSET,
+	"file_size_in_bytes": CHECKSET,
+}
+
+func AlicloudDataWorksCertificateBasicDependence9054(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_data_works_project" "defaultxWQGsP" {
+  description      = "tf-acc-test"
+  project_name     = var.name
+  pai_task_enabled = false
+  display_name     = var.name
+}
+
+resource "alicloud_oss_bucket" "cert" {
+  bucket = "${var.name}-cert"
+  acl    = "public-read"
+}
+
+resource "alicloud_oss_bucket_object" "cert" {
+  bucket  = alicloud_oss_bucket.cert.id
+  key     = "tf-acc-cert.pem"
+  acl     = "public-read"
+  content = <<-EOT
+-----BEGIN CERTIFICATE-----
+MIICqDCCAZACCQCbNs38rCeB6TANBgkqhkiG9w0BAQsFADAWMRQwEgYDVQQDDAt0
+Zi1hY2MtdGVzdDAeFw0yNjA5MDMwMDE4MDFaFw0zNjA4MzEwMDE4MDFaMBYxFDAS
+BgNVBAMMC3RmLWFjYy10ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAwyKgyXSNG+NfmE6Ukz7oX4AgDbTaHAyJ3BWHfTK/DJNY0+0tgYE5Zle8bNui
+rksdOpydcGAJeaoFNpCGwvd5FO9HklcYwLGdzASRXEHEN0XtG2oeHNnyH82yE2SH
+hINbhYcM98WCEuIU5cIsohaQUXhdgBzQcUdc7q5mG/U87LQk4ZGq+JuqUhOAB2xG
+8phoguTZ3ODk4+x9MEycpXfpTVkzz9y4JmL6jh3dEZvpyMmC94NYjrGRbioI9CDe
+mpY1BsHRtSgxJ7Pvl5yYy7Tj2KC3jRv4FEP7C8vg9tqqV37yLtZsXw/UeVhn9nOm
+tOQcqaS3o4BTp//Db7/ReoE2fwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBn+Hi1
+Lq6pHiV0PPLN+4cQK8sLFSk1nHvJ1ONk9FsBmsnkrbky6I5fNQiBnzOm/rNl72Ao
+JvsyROYVyyxX/M5LnZQwahUwDTaz4cNasUiPt33lNtueiLLhzC7UpB8NzH/v29MT
+YnEmgc7msKrSnj8SfvZu6y9vbmLhJ0CbrpBTmcG6cXr/Em+l781p4hFdJmpOA7o8
+oX+vfX/riPSP8bGgYlmsr2Iv4Uo/b8q6ZpF5p76M/MJirligYjc5fZG8UmsBu6eX
+d5LC+4/r6W5uyIS/7fF7FLdzHfRhZknuu8Wzx+HXI+oKv0r/z8MGa1DsvJ6DHQIE
+qWre020mtWvGRU1t
+-----END CERTIFICATE-----
+EOT
+}
+
+`, name)
+}
+
+// Case 测试Certificate2（没有前置步骤，能够运行就行） 9055
+func TestAccAliCloudDataWorksCertificate_basic9055(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_data_works_certificate.default"
+	ra := resourceAttrInit(resourceId, AlicloudDataWorksCertificateMap9055)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &DataWorksServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeDataWorksCertificate")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccdataworks%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudDataWorksCertificateBasicDependence9055)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-shenzhen"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":      "tf-acc-cert",
+					"project_id":       "${alicloud_data_works_project.defaultxWQGsP.id}",
+					"name":             name,
+					"certificate_file": "http://${alicloud_oss_bucket.cert.id}.${alicloud_oss_bucket.cert.extranet_endpoint}/${alicloud_oss_bucket_object.cert.key}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":      "tf-acc-cert",
+						"project_id":       CHECKSET,
+						"name":             CHECKSET,
+						"certificate_file": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"certificate_file"},
+			},
+		},
+	})
+}
+
+var AlicloudDataWorksCertificateMap9055 = map[string]string{
+	"create_time":        CHECKSET,
+	"create_user":        CHECKSET,
+	"file_size_in_bytes": CHECKSET,
+}
+
+func AlicloudDataWorksCertificateBasicDependence9055(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_data_works_project" "defaultxWQGsP" {
+  description      = "tf-acc-test"
+  project_name     = var.name
+  pai_task_enabled = false
+  display_name     = var.name
+}
+
+resource "alicloud_oss_bucket" "cert" {
+  bucket = "${var.name}-cert"
+  acl    = "public-read"
+}
+
+resource "alicloud_oss_bucket_object" "cert" {
+  bucket  = alicloud_oss_bucket.cert.id
+  key     = "tf-acc-cert.pem"
+  acl     = "public-read"
+  content = <<-EOT
+-----BEGIN CERTIFICATE-----
+MIICqDCCAZACCQCbNs38rCeB6TANBgkqhkiG9w0BAQsFADAWMRQwEgYDVQQDDAt0
+Zi1hY2MtdGVzdDAeFw0yNjA5MDMwMDE4MDFaFw0zNjA4MzEwMDE4MDFaMBYxFDAS
+BgNVBAMMC3RmLWFjYy10ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAwyKgyXSNG+NfmE6Ukz7oX4AgDbTaHAyJ3BWHfTK/DJNY0+0tgYE5Zle8bNui
+rksdOpydcGAJeaoFNpCGwvd5FO9HklcYwLGdzASRXEHEN0XtG2oeHNnyH82yE2SH
+hINbhYcM98WCEuIU5cIsohaQUXhdgBzQcUdc7q5mG/U87LQk4ZGq+JuqUhOAB2xG
+8phoguTZ3ODk4+x9MEycpXfpTVkzz9y4JmL6jh3dEZvpyMmC94NYjrGRbioI9CDe
+mpY1BsHRtSgxJ7Pvl5yYy7Tj2KC3jRv4FEP7C8vg9tqqV37yLtZsXw/UeVhn9nOm
+tOQcqaS3o4BTp//Db7/ReoE2fwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBn+Hi1
+Lq6pHiV0PPLN+4cQK8sLFSk1nHvJ1ONk9FsBmsnkrbky6I5fNQiBnzOm/rNl72Ao
+JvsyROYVyyxX/M5LnZQwahUwDTaz4cNasUiPt33lNtueiLLhzC7UpB8NzH/v29MT
+YnEmgc7msKrSnj8SfvZu6y9vbmLhJ0CbrpBTmcG6cXr/Em+l781p4hFdJmpOA7o8
+oX+vfX/riPSP8bGgYlmsr2Iv4Uo/b8q6ZpF5p76M/MJirligYjc5fZG8UmsBu6eX
+d5LC+4/r6W5uyIS/7fF7FLdzHfRhZknuu8Wzx+HXI+oKv0r/z8MGa1DsvJ6DHQIE
+qWre020mtWvGRU1t
+-----END CERTIFICATE-----
+EOT
+}
+
+`, name)
+}
+
+// Test DataWorks Certificate. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_data_works_v2.go
+++ b/alicloud/service_alicloud_data_works_v2.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -725,3 +726,115 @@ func (s *DataWorksServiceV2) DataWorksDwResourceGroupStateRefreshFunc(id string,
 }
 
 // DescribeDataWorksDwResourceGroup >>> Encapsulated.
+// DescribeDataWorksCertificate <<< Encapsulated get interface for DataWorks Certificate.
+
+func (s *DataWorksServiceV2) DescribeDataWorksCertificate(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length 2, got %d", id, len(parts)))
+		return
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	query["Id"] = parts[1]
+	query["ProjectId"] = parts[0]
+	query["RegionId"] = client.RegionId
+	action := "GetCertificate"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcGet("dataworks-public", "2024-05-18", action, query, request)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Certificate", response)
+	if err != nil {
+		return object, WrapErrorf(NotFoundErr("Certificate", id), NotFoundMsg, response)
+	}
+
+	currentStatus := v.(map[string]interface{})["Id"]
+	if currentStatus == nil {
+		return object, WrapErrorf(NotFoundErr("Certificate", id), NotFoundMsg, response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *DataWorksServiceV2) DataWorksCertificateStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.DataWorksCertificateStateRefreshFuncWithApi(id, field, failStates, s.DescribeDataWorksCertificate)
+}
+
+func (s *DataWorksServiceV2) DataWorksCertificateStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeDataWorksCertificate >>> Encapsulated.
+
+// dataWorksCertificateCreateTimeFormat converts the millisecond timestamp returned by the
+// DataWorks API into an RFC3339 (ISO8601) string. Hand-fix: generator v4 does not honour the
+// @format("iso8601") annotation on CreateTime, so a raw int64 ms value would otherwise be
+// stored verbatim in state and cause perpetual plan drift.
+func dataWorksCertificateCreateTimeFormat(raw interface{}) string {
+	if raw == nil {
+		return ""
+	}
+	var ms int64
+	switch v := raw.(type) {
+	case float64:
+		ms = int64(v)
+	case int64:
+		ms = v
+	case int:
+		ms = int64(v)
+	default:
+		if s, err := strconv.ParseInt(fmt.Sprint(raw), 10, 64); err == nil {
+			ms = s
+		} else {
+			return fmt.Sprint(raw)
+		}
+	}
+	if ms <= 0 {
+		return ""
+	}
+	return time.UnixMilli(ms).UTC().Format(time.RFC3339)
+}

--- a/website/docs/d/data_works_certificates.html.markdown
+++ b/website/docs/d/data_works_certificates.html.markdown
@@ -1,0 +1,70 @@
+---
+subcategory: "Data Works"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_data_works_certificates"
+description: |-
+  Provides a list of Data Works Certificate owned by an Alibaba Cloud account.
+---
+
+# alicloud_data_works_certificates
+
+This data source provides Data Works Certificate available to the user.[What is Certificate](https://next.api.alibabacloud.com/document/dataworks-public/2024-05-18/ImportCertificate)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-shenzhen"
+}
+
+resource "alicloud_data_works_project" "default" {
+  description      = "Terraform example project"
+  project_name     = "terraform-example"
+  pai_task_enabled = false
+  display_name     = "terraform-example"
+}
+
+
+resource "alicloud_data_works_certificate" "default" {
+  project_id       = alicloud_data_works_project.default.id
+  name             = "terraform-example"
+  certificate_file = "https://example.com/certificate.pem"
+}
+
+data "alicloud_data_works_certificates" "default" {
+  ids        = ["${alicloud_data_works_certificate.default.id}"]
+  project_id = alicloud_data_works_project.default.id
+}
+
+output "alicloud_data_works_certificate_example_id" {
+  value = data.alicloud_data_works_certificates.default.certificates.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `project_id` - (Required) The ID of the DataWorks workspace to which the certificate file belongs.
+* `ids` - (Optional, Computed) A list of Certificate IDs.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Certificate IDs.
+* `certificates` - A list of Certificate Entries. Each element contains the following attributes:
+  * `create_time` - Creation time in RFC3339 format (converted from the millisecond timestamp returned by the API).
+  * `create_user` - The creator ID of the certificate file.
+  * `description` - The description of the certificate file.
+  * `file_size_in_bytes` - File size in bytes.
+  * `id` - The unique identifier of the certificate file.
+  * `name` - The name of the certificate file, unique within the workspace.
+  * `project_id` - **NOTE:** This field is only available when `enable_details` is `true`. The ID of the DataWorks workspace to which the certificate file belongs.

--- a/website/docs/r/data_works_certificate.html.markdown
+++ b/website/docs/r/data_works_certificate.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "Data Works"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_data_works_certificate"
+description: |-
+  Provides a Alicloud Data Works Certificate resource.
+---
+
+# alicloud_data_works_certificate
+
+Provides a Data Works Certificate resource.
+
+
+
+For information about Data Works Certificate and how to use it, see [What is Certificate](https://next.api.alibabacloud.com/document/dataworks-public/2024-05-18/ImportCertificate).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-shenzhen"
+}
+
+resource "alicloud_data_works_project" "default" {
+  description      = "Terraform example project"
+  project_name     = "terraform-example"
+  pai_task_enabled = false
+  display_name     = "terraform-example"
+}
+
+
+resource "alicloud_data_works_certificate" "default" {
+  project_id       = alicloud_data_works_project.default.id
+  name             = "terraform-example"
+  certificate_file = "https://example.com/certificate.pem"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `certificate_file` - (Required, ForceNew, Sensitive) The certificate file content. Changes require re-import.
+* `description` - (Optional, ForceNew) The description of the certificate file.
+* `name` - (Required, ForceNew) The name of the certificate file, unique within the workspace.
+* `project_id` - (Required, ForceNew, Int) The ID of the DataWorks workspace to which the certificate file belongs.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+* `create_time` - Creation time in RFC3339 format (converted from the millisecond timestamp returned by the API).
+* `create_user` - The creator ID of the certificate file.
+* `file_size_in_bytes` - File size in bytes.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Certificate.
+* `delete` - (Defaults to 5 mins) Used when delete the Certificate.
+
+## Import
+
+Data Works Certificate can be imported using the composite id `<project_id>:<certificate_id>`, e.g.
+
+```shell
+$ terraform import alicloud_data_works_certificate.example <project_id>:<certificate_id>
+```


### PR DESCRIPTION
## What

Adds a new resource `alicloud_data_works_certificate` and the companion data source `alicloud_data_works_certificates` for managing DataWorks certificate files used by data sources / DI jobs.

Backed by the DataWorks `ImportCertificate` / `GetCertificate` / `DeleteCertificate` / `ListCertificates` APIs (product `dataworks-public`, version `2024-05-18`). There is no Update API, so all writable arguments are `ForceNew`.

## Schema

| field | type | required | notes |
|---|---|---|---|
| `project_id` | int | yes, ForceNew | DataWorks workspace the certificate belongs to; required on the resource and the data source |
| `name` | string | yes, ForceNew | certificate name, unique within the workspace |
| `certificate_file` | string | yes, ForceNew, Sensitive | certificate file content (write-only) |
| `description` | string | no, ForceNew | description of the certificate file |
| `create_time` | string | Computed | creation time in RFC3339, converted from the millisecond timestamp returned by the API |
| `create_user` | string | Computed | creator id |
| `file_size_in_bytes` | int | Computed | file size in bytes |
| `id` | int | Computed | certificate id (unique within the workspace) |

## CRUD mapping

- **Create** — `ImportCertificate`.
- **Read** — `GetCertificate`.
- **Delete** — `DeleteCertificate`.
- **List** (data source) — `ListCertificates`.
- **Import** — `terraform import alicloud_data_works_certificate.example <project_id>:<certificate_id>`.

`project_id` is a required query parameter on `GetCertificate` / `DeleteCertificate` / `ListCertificates`, so the resource id is composite `<project_id>:<certificate_id>` and the data source takes `project_id` as a required argument.

`create_time` is returned by the API as a millisecond int64 timestamp but modelled as an RFC3339 string; the provider converts it in Read so it does not produce perpetual plan drift.

## Tests

- `TestAccAliCloudDataWorksCertificate_basic9054` — create with project + certificate file, import.
- `TestAccAliCloudDataWorksCertificate_basic9055` — create with description, import.
- `TestAccAlicloudDataWorksCertificateDataSource` — data source read backed by the resource (ids / project_id filtering).

Acceptance cases (`TestAcc*`) target remote execution.
