### PR TITLE
resource/alicloud_arms_prometheus_alert_rule: fix labels and annotations being cleared on update

### DIFF
--- a/alicloud/resource_alicloud_arms_prometheus_alert_rule.go
+++ b/alicloud/resource_alicloud_arms_prometheus_alert_rule.go
@@ -272,45 +272,49 @@ func resourceAlicloudArmsPrometheusAlertRuleUpdate(d *schema.ResourceData, meta 
 	request["RegionId"] = client.RegionId
 	if d.HasChange("annotations") {
 		update = true
-		if v, ok := d.GetOk("annotations"); ok {
-			annotationsMaps := make([]map[string]interface{}, 0)
-			for _, annotations := range v.(*schema.Set).List() {
-				annotationsMap := annotations.(map[string]interface{})
-				annotationsMaps = append(annotationsMaps, annotationsMap)
-			}
-			if v, err := convertArrayObjectToJsonString(annotationsMaps); err == nil {
-				request["Annotations"] = v
-			} else {
-				return WrapError(err)
-			}
-		}
 	}
 	if d.HasChange("dispatch_rule_id") {
 		update = true
-		if v, ok := d.GetOk("dispatch_rule_id"); ok {
-			request["DispatchRuleId"] = v
-		}
 	}
 	if d.HasChange("labels") {
 		update = true
-		if v, ok := d.GetOk("labels"); ok {
-			labelsMaps := make([]map[string]interface{}, 0)
-			for _, labels := range v.(*schema.Set).List() {
-				labelsMap := labels.(map[string]interface{})
-				labelsMaps = append(labelsMaps, labelsMap)
-			}
-			if v, err := convertArrayObjectToJsonString(labelsMaps); err == nil {
-				request["Labels"] = v
-			} else {
-				return WrapError(err)
-			}
-		}
 	}
 	if d.HasChange("notify_type") {
 		update = true
-		if v, ok := d.GetOk("notify_type"); ok {
-			request["NotifyType"] = v
+	}
+	// UpdatePrometheusAlertRule works with full replacement semantics, and any
+	// attribute absent from the request is cleared on the server side. Always
+	// send the current values of these attributes in every update request, so
+	// that modifying one of them does not clear the others.
+	if v, ok := d.GetOk("annotations"); ok {
+		annotationsMaps := make([]map[string]interface{}, 0)
+		for _, annotations := range v.(*schema.Set).List() {
+			annotationsMap := annotations.(map[string]interface{})
+			annotationsMaps = append(annotationsMaps, annotationsMap)
 		}
+		if v, err := convertArrayObjectToJsonString(annotationsMaps); err == nil {
+			request["Annotations"] = v
+		} else {
+			return WrapError(err)
+		}
+	}
+	if v, ok := d.GetOk("dispatch_rule_id"); ok {
+		request["DispatchRuleId"] = v
+	}
+	if v, ok := d.GetOk("labels"); ok {
+		labelsMaps := make([]map[string]interface{}, 0)
+		for _, labels := range v.(*schema.Set).List() {
+			labelsMap := labels.(map[string]interface{})
+			labelsMaps = append(labelsMaps, labelsMap)
+		}
+		if v, err := convertArrayObjectToJsonString(labelsMaps); err == nil {
+			request["Labels"] = v
+		} else {
+			return WrapError(err)
+		}
+	}
+	if v, ok := d.GetOk("notify_type"); ok {
+		request["NotifyType"] = v
 	}
 
 	if update {

--- a/alicloud/resource_alicloud_arms_prometheus_alert_rule_test.go
+++ b/alicloud/resource_alicloud_arms_prometheus_alert_rule_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAccAlicloudARMSPrometheusAlertRule_basic0(t *testing.T) {
+func TestAccAliCloudARMSPrometheusAlertRule_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_arms_prometheus_alert_rule.default"
 	ra := resourceAttrInit(resourceId, AlicloudARMSPrometheusAlertRuleMap0)
@@ -33,7 +33,8 @@ func TestAccAlicloudARMSPrometheusAlertRule_basic0(t *testing.T) {
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudARMSPrometheusAlertRuleBasicDependence0)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckPrePaidResources(t)
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.ARMSSupportRegions)
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
@@ -42,7 +43,7 @@ func TestAccAlicloudARMSPrometheusAlertRule_basic0(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"prometheus_alert_rule_name": name,
-					"cluster_id":                 "${data.alicloud_cs_managed_kubernetes_clusters.default.clusters.0.id}",
+					"cluster_id":                 "${data.alicloud_cs_clusters.default.ids.0}",
 					"expression":                 "node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10",
 					"message":                    "node available memory is less than 10%",
 					"duration":                   "1",
@@ -108,6 +109,34 @@ func TestAccAlicloudARMSPrometheusAlertRule_basic0(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"annotations.#": "1",
+						"labels.#":      "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"labels": []map[string]interface{}{
+						{
+							"name":  "TF2",
+							"value": "test2",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"labels.#":      "1",
+						"annotations.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"annotations": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"annotations.#": "0",
+						"labels.#":      "1",
 					}),
 				),
 			},
@@ -168,7 +197,7 @@ func TestAccAlicloudARMSPrometheusAlertRule_basic0(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudARMSPrometheusAlertRule_basic1(t *testing.T) {
+func TestAccAliCloudARMSPrometheusAlertRule_basic1(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_arms_prometheus_alert_rule.default"
 	ra := resourceAttrInit(resourceId, AlicloudARMSPrometheusAlertRuleMap0)
@@ -182,7 +211,8 @@ func TestAccAlicloudARMSPrometheusAlertRule_basic1(t *testing.T) {
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudARMSPrometheusAlertRuleBasicDependence1)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckPrePaidResources(t)
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.ARMSSupportRegions)
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
@@ -191,7 +221,7 @@ func TestAccAlicloudARMSPrometheusAlertRule_basic1(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"prometheus_alert_rule_name": name,
-					"cluster_id":                 "${data.alicloud_cs_managed_kubernetes_clusters.default.clusters.0.id}",
+					"cluster_id":                 "${data.alicloud_cs_clusters.default.ids.0}",
 					"expression":                 "node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10",
 					"message":                    "node available memory is less than 10%",
 					"duration":                   "1",
@@ -213,6 +243,47 @@ func TestAccAlicloudARMSPrometheusAlertRule_basic1(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"labels": []map[string]interface{}{
+						{
+							"name":  "TF",
+							"value": "test1",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"labels.#":         "1",
+						"notify_type":      "DISPATCH_RULE",
+						"dispatch_rule_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"dispatch_rule_id": "${alicloud_arms_dispatch_rule.default2.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"notify_type":      "DISPATCH_RULE",
+						"dispatch_rule_id": CHECKSET,
+						"labels.#":         "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"notify_type":      "ALERT_MANAGER",
+					"dispatch_rule_id": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"notify_type":      "ALERT_MANAGER",
+						"dispatch_rule_id": REMOVEKEY,
+					}),
+				),
+			},
+			{
 				ResourceName:      resourceId,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -228,8 +299,7 @@ func AlicloudARMSPrometheusAlertRuleBasicDependence0(name string) string {
 variable "name" {
   default = "%s"
 }
-data "alicloud_cs_managed_kubernetes_clusters" "default" {
-  name_regex = "Default"
+data "alicloud_cs_clusters" "default" {
 }
 `, name)
 }
@@ -239,8 +309,7 @@ func AlicloudARMSPrometheusAlertRuleBasicDependence1(name string) string {
 variable "name" {
  default = "%v"
 }
-data "alicloud_cs_managed_kubernetes_clusters" "default" {
-  name_regex = "Default"
+data "alicloud_cs_clusters" "default" {
 }
 resource "alicloud_arms_alert_contact" "default" {
   alert_contact_name = var.name
@@ -282,7 +351,46 @@ resource "alicloud_arms_dispatch_rule" "default" {
       notify_type      = "ARMS_CONTACT_GROUP"
       name             = var.name
     }
-    notify_channels = ["dingTalk", "wechat"]
+    notify_channels   = ["dingTalk", "wechat"]
+    notify_start_time = "00:00"
+    notify_end_time   = "23:59"
+  }
+}
+
+resource "alicloud_arms_dispatch_rule" "default2" {
+  dispatch_rule_name = "${var.name}-2"
+  dispatch_type      = "CREATE_ALERT"
+  group_rules {
+    group_wait_time = 5
+    group_interval  = 15
+    repeat_interval = 100
+    grouping_fields = [
+      "alertname"]
+  }
+  label_match_expression_grid {
+   label_match_expression_groups {
+     label_match_expressions {
+       key      = "_aliyun_arms_involvedObject_kind"
+       value    = "app"
+       operator = "eq"
+     }
+   }
+  }
+
+  notify_rules {
+    notify_objects {
+      notify_object_id = alicloud_arms_alert_contact.default.id
+      notify_type      = "ARMS_CONTACT"
+      name             = var.name
+    }
+    notify_objects {
+      notify_object_id = alicloud_arms_alert_contact_group.default.id
+      notify_type      = "ARMS_CONTACT_GROUP"
+      name             = var.name
+    }
+    notify_channels   = ["dingTalk", "wechat"]
+    notify_start_time = "00:00"
+    notify_end_time   = "23:59"
   }
 }
 `, name)


### PR DESCRIPTION
## What this PR does

Fixes `alicloud_arms_prometheus_alert_rule` so that updating one of `labels`, `annotations`, `notify_type` or `dispatch_rule_id` no longer clears the others on the server side.

## Changes

- `alicloud/resource_alicloud_arms_prometheus_alert_rule.go`: the update function previously sent `labels`, `annotations`, `notify_type` and `dispatch_rule_id` only when the corresponding attribute changed. `UpdatePrometheusAlertRule` works with full replacement semantics, and any attribute absent from the request is cleared on the server side, so modifying one attribute wiped out the others and every following plan showed a diff again. The update request now always carries the current values of these attributes.
- `alicloud/resource_alicloud_arms_prometheus_alert_rule_test.go`:
  - Extend `basic0` with alternating update steps: change `labels` while `annotations` are set, then remove `annotations` while keeping `labels`, asserting the untouched attribute survives each update.
  - Extend `basic1` (`DISPATCH_RULE`) with in-place update steps: add `labels`, switch `dispatch_rule_id` to a different dispatch rule, then switch `notify_type` back to `ALERT_MANAGER`, asserting the notify settings survive each update.
  - Rename the acceptance test functions to the standard `TestAccAliCloud` prefix.

## Why

Because `UpdatePrometheusAlertRule` replaces the whole rule definition, a partial update request silently resets every attribute that is not included. Users who only changed `labels` lost their `annotations` (and vice versa), which made consecutive plans never converge. Sending the current values of all mutable attributes in every update request makes the update idempotent and keeps unrelated attributes intact.

## Testing

- `gofmt -l` clean, `go build ./alicloud/` and `go vet ./alicloud` pass (the only vet findings are pre-existing on master in `alicloud/common.go`).
- Local testing coverage check passes: 100% attribute coverage and 100% modified coverage for `alicloud_arms_prometheus_alert_rule`.
- Acceptance test cases (remote run in progress, results will be added here):

```
TestAccAliCloudARMSPrometheusAlertRule_basic0
TestAccAliCloudARMSPrometheusAlertRule_basic1
TestUnitAlicloudARMSPrometheusAlertRule
```
