### PR TITLE
resource/alicloud_click_house_enterprise_db_cluster: fix multi-zone create rejected with InvalidZoneId.InconsistentWithMultiZone

### DIFF
--- a/alicloud/resource_alicloud_click_house_enterprise_db_cluster.go
+++ b/alicloud/resource_alicloud_click_house_enterprise_db_cluster.go
@@ -26,184 +26,196 @@ func resourceAliCloudClickHouseEnterpriseDbCluster() *schema.Resource {
 			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
-		Schema: map[string]*schema.Schema{
-			"category": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"charge_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"computing_group_ids": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			"create_time": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"endpoints": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"status": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"vpc_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"endpoint_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"vswitch_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ports": {
-							Type:     schema.TypeList,
-							Computed: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"port": {
-										Type:     schema.TypeInt,
-										Computed: true,
-									},
-									"protocol": {
-										Type:     schema.TypeString,
-										Computed: true,
-									},
+		Schema: clickHouseEnterpriseDbClusterSchema(),
+	}
+}
+
+// clickHouseEnterpriseDbClusterSchema returns the resource schema. multi_zones
+// is a schema.TypeList (ordered): the first block is the primary zone that
+// CreateDBInstance expects at MultiZone[0], so the HCL declaration order is
+// preserved when assembling the MultiZone request. The nested vswitch_ids
+// stays a schema.TypeSet because the vswitches within a single zone entry do
+// not carry order semantics.
+func clickHouseEnterpriseDbClusterSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"category": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"charge_type": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"computing_group_ids": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"create_time": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"endpoints": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"status": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"vpc_id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"endpoint_name": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"vswitch_id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"ports": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"port": {
+									Type:     schema.TypeInt,
+									Computed: true,
+								},
+								"protocol": {
+									Type:     schema.TypeString,
+									Computed: true,
 								},
 							},
 						},
-						"vpc_instance_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"connection_string": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"ip_address": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"net_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"computing_group_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
+					},
+					"vpc_instance_id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"connection_string": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"ip_address": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"net_type": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"computing_group_id": {
+						Type:     schema.TypeString,
+						Computed: true,
 					},
 				},
 			},
-			"engine_minor_version": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"instance_network_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"multi_zones": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"zone_id": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-						"vswitch_ids": {
-							Type:     schema.TypeSet,
-							Optional: true,
-							ForceNew: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
+		},
+		"engine_minor_version": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"instance_network_type": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"multi_zones": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"zone_id": {
+						Type:     schema.TypeString,
+						Optional: true,
+						ForceNew: true,
+					},
+					"vswitch_ids": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						ForceNew: true,
+						Elem:     &schema.Schema{Type: schema.TypeString},
 					},
 				},
 			},
-			"node_count": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"node_scale_max": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"node_scale_min": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Computed: true,
-			},
-			"region_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"resource_group_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"scale_max": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"scale_min": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"storage_quota": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"storage_size": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
-			"storage_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"tags": tagsSchema(),
-			"vpc_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"vswitch_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"zone_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
+		},
+		"node_count": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
+		"node_scale_max": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
+		"node_scale_min": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
+		"region_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"resource_group_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"scale_max": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"scale_min": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"status": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"storage_quota": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"storage_size": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"storage_type": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"tags": tagsSchema(),
+		"vpc_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+		"vswitch_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+		"zone_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
 		},
 	}
 }
@@ -247,6 +259,10 @@ func resourceAliCloudClickHouseEnterpriseDbClusterCreate(d *schema.ResourceData,
 			dataLoop1Map["ZoneId"] = dataLoop1Tmp["zone_id"]
 			multiZoneMapsArray = append(multiZoneMapsArray, dataLoop1Map)
 		}
+		// multi_zones is a schema.TypeList, so convertToInterfaceArray
+		// preserves the HCL declaration order: the first block is the primary
+		// zone, which is exactly what CreateDBInstance expects for
+		// MultiZone[0]. No reorder is needed.
 		multiZoneMapsJson, err := json.Marshal(multiZoneMapsArray)
 		if err != nil {
 			return WrapError(err)
@@ -263,11 +279,21 @@ func resourceAliCloudClickHouseEnterpriseDbClusterCreate(d *schema.ResourceData,
 	if v, ok := d.GetOk("vpc_id"); ok {
 		request["VpcId"] = v
 	}
-	if v, ok := d.GetOk("vswitch_id"); ok {
-		request["VswitchId"] = v
-	}
-	if v, ok := d.GetOk("zone_id"); ok {
-		request["ZoneId"] = v
+	// For multi-zone deployments (multi_zones is set), the top-level
+	// vswitch_id and zone_id are NOT sent to CreateDBInstance: the multi-zone
+	// information is carried entirely by the MultiZone parameter, and the
+	// server treats MultiZone[0] as the primary zone. Forwarding the top-level
+	// zone_id alongside MultiZone triggers
+	// InvalidZoneId.InconsistentWithMultiZone when it does not match
+	// MultiZone[0].zone_id. For single-zone deployments the top-level
+	// vswitch_id and zone_id are forwarded as before.
+	if _, ok := d.GetOk("multi_zones"); !ok {
+		if v, ok := d.GetOk("vswitch_id"); ok {
+			request["VswitchId"] = v
+		}
+		if v, ok := d.GetOk("zone_id"); ok {
+			request["ZoneId"] = v
+		}
 	}
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {

--- a/alicloud/resource_alicloud_click_house_enterprise_db_cluster_test.go
+++ b/alicloud/resource_alicloud_click_house_enterprise_db_cluster_test.go
@@ -873,3 +873,263 @@ resource "alicloud_vswitch" "defaultTQWN3k" {
 }
 
 // Test ClickHouse EnterpriseDbCluster. <<< Resource test cases, automatically generated.
+
+// TestAccAliCloudClickHouseEnterpriseDBCluster_multiZonesPrimaryZoneStable
+// locks the multi-zone primary-zone handling end-to-end with schema.TypeList:
+// the primary zone (zone_id_i) is declared as the FIRST multi_zones block, so
+// MultiZone[0] is the primary zone that CreateDBInstance expects. The
+// top-level zone_id/vswitch_id are not forwarded for multi-zone deployments
+// (the multi-zone information is carried entirely by the MultiZone
+// parameter), and Read returns the server order (primary first) so the state
+// stays stable across plans. The top-level zone_id/vswitch_id remain in the
+// config to keep state stable and to exercise the multi-zone path, followed
+// by an import step that verifies the ordered state round-trips.
+func TestAccAliCloudClickHouseEnterpriseDBCluster_multiZonesPrimaryZoneStable(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_click_house_enterprise_db_cluster.default"
+	ra := resourceAttrInit(resourceId, AlicloudClickHouseEnterpriseDBClusterMapPrimaryZoneStable)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ClickHouseServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeClickHouseEnterpriseDbCluster")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccclickhouse%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudClickHouseEnterpriseDbClusterBasicDependence10560)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":    "${var.zone_id_i}",
+					"vpc_id":     "${alicloud_vpc.defaultktKLuM.id}",
+					"scale_min":  "8",
+					"scale_max":  "16",
+					"vswitch_id": "${alicloud_vswitch.defaultTQWN3k.id}",
+					// The primary zone (zone_id_i) is declared as the FIRST
+					// multi_zones block. multi_zones is now a schema.TypeList,
+					// so the HCL declaration order is preserved and
+					// MultiZone[0] is exactly the primary zone that
+					// CreateDBInstance expects; no reorder is needed.
+					"multi_zones": []map[string]interface{}{
+						{
+							"vswitch_ids": []string{
+								"${alicloud_vswitch.defaultTQWN3k.id}"},
+							"zone_id": "${var.zone_id_i}",
+						},
+						{
+							"vswitch_ids": []string{
+								"${alicloud_vswitch.defaultylyLu8.id}"},
+							"zone_id": "${var.zone_id_l}",
+						},
+						{
+							"vswitch_ids": []string{
+								"${alicloud_vswitch.defaultRNbPh8.id}"},
+							"zone_id": "${var.zone_id_k}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_id":       CHECKSET,
+						"vpc_id":        CHECKSET,
+						"scale_min":     CHECKSET,
+						"scale_max":     CHECKSET,
+						"vswitch_id":    CHECKSET,
+						"multi_zones.#": "3",
+					}),
+					// The declared-first block (zone_id_i) must be the primary
+					// zone returned at multi_zones[0].
+					resource.TestCheckResourceAttr(resourceId, "multi_zones.0.zone_id", "cn-beijing-i"),
+					// Invariant: the backend-returned top-level zone_id strictly
+					// equals multi_zones[0].zone_id.
+					resource.TestCheckResourceAttrPair(resourceId, "zone_id", resourceId, "multi_zones.0.zone_id"),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudClickHouseEnterpriseDBClusterMapPrimaryZoneStable = map[string]string{
+	"status":      CHECKSET,
+	"create_time": CHECKSET,
+	"region_id":   CHECKSET,
+}
+
+// TestAccAliCloudClickHouseEnterpriseDBCluster_multiZonesPermutationLFirst
+// verifies that the ordered multi_zones (schema.TypeList) semantics hold across
+// input permutations: here the primary zone (zone_id_l) is declared as the
+// FIRST block, a different declared order than multiZonesPrimaryZoneStable
+// (which declares zone_id_i first). CreateDBInstance treats MultiZone[0] as
+// the primary zone, so the declared-first zone becomes the server primary, and
+// Read must return the array ordered with that primary first. The test also
+// locks the invariant that the backend-returned top-level zone_id strictly
+// equals multi_zones[0].zone_id.
+func TestAccAliCloudClickHouseEnterpriseDBCluster_multiZonesPermutationLFirst(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_click_house_enterprise_db_cluster.default"
+	ra := resourceAttrInit(resourceId, AlicloudClickHouseEnterpriseDBClusterMapPrimaryZoneStable)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ClickHouseServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeClickHouseEnterpriseDbCluster")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccclickhouse%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudClickHouseEnterpriseDbClusterBasicDependence10560)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":    "${var.zone_id_l}",
+					"vpc_id":     "${alicloud_vpc.defaultktKLuM.id}",
+					"scale_min":  "8",
+					"scale_max":  "16",
+					"vswitch_id": "${alicloud_vswitch.defaultylyLu8.id}",
+					// multi_zones is a schema.TypeList, so the HCL declaration
+					// order is preserved. Declaring zone_id_l FIRST makes it the
+					// primary zone (MultiZone[0]); the remaining blocks follow
+					// in declaration order.
+					"multi_zones": []map[string]interface{}{
+						{
+							"vswitch_ids": []string{
+								"${alicloud_vswitch.defaultylyLu8.id}"},
+							"zone_id": "${var.zone_id_l}",
+						},
+						{
+							"vswitch_ids": []string{
+								"${alicloud_vswitch.defaultTQWN3k.id}"},
+							"zone_id": "${var.zone_id_i}",
+						},
+						{
+							"vswitch_ids": []string{
+								"${alicloud_vswitch.defaultRNbPh8.id}"},
+							"zone_id": "${var.zone_id_k}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_id":       CHECKSET,
+						"vpc_id":        CHECKSET,
+						"scale_min":     CHECKSET,
+						"scale_max":     CHECKSET,
+						"vswitch_id":    CHECKSET,
+						"multi_zones.#": "3",
+					}),
+					// The declared-first block (zone_id_l) must be the primary
+					// zone returned at multi_zones[0].
+					resource.TestCheckResourceAttr(resourceId, "multi_zones.0.zone_id", "cn-beijing-l"),
+					// Invariant: the backend-returned top-level zone_id strictly
+					// equals multi_zones[0].zone_id.
+					resource.TestCheckResourceAttrPair(resourceId, "zone_id", resourceId, "multi_zones.0.zone_id"),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+// TestAccAliCloudClickHouseEnterpriseDBCluster_multiZonesPermutationKFirst
+// verifies the ordered multi_zones semantics with a third input permutation:
+// the primary zone (zone_id_k) is declared as the FIRST block. Together with
+// multiZonesPrimaryZoneStable (zone_id_i first) and
+// multiZonesPermutationLFirst (zone_id_l first), this locks that the declared
+// order is preserved across permutations and that the backend-returned
+// top-level zone_id strictly equals multi_zones[0].zone_id.
+func TestAccAliCloudClickHouseEnterpriseDBCluster_multiZonesPermutationKFirst(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_click_house_enterprise_db_cluster.default"
+	ra := resourceAttrInit(resourceId, AlicloudClickHouseEnterpriseDBClusterMapPrimaryZoneStable)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ClickHouseServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeClickHouseEnterpriseDbCluster")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccclickhouse%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudClickHouseEnterpriseDbClusterBasicDependence10560)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"zone_id":    "${var.zone_id_k}",
+					"vpc_id":     "${alicloud_vpc.defaultktKLuM.id}",
+					"scale_min":  "8",
+					"scale_max":  "16",
+					"vswitch_id": "${alicloud_vswitch.defaultRNbPh8.id}",
+					"multi_zones": []map[string]interface{}{
+						{
+							"vswitch_ids": []string{
+								"${alicloud_vswitch.defaultRNbPh8.id}"},
+							"zone_id": "${var.zone_id_k}",
+						},
+						{
+							"vswitch_ids": []string{
+								"${alicloud_vswitch.defaultylyLu8.id}"},
+							"zone_id": "${var.zone_id_l}",
+						},
+						{
+							"vswitch_ids": []string{
+								"${alicloud_vswitch.defaultTQWN3k.id}"},
+							"zone_id": "${var.zone_id_i}",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"zone_id":       CHECKSET,
+						"vpc_id":        CHECKSET,
+						"scale_min":     CHECKSET,
+						"scale_max":     CHECKSET,
+						"vswitch_id":    CHECKSET,
+						"multi_zones.#": "3",
+					}),
+					// The declared-first block (zone_id_k) must be the primary
+					// zone returned at multi_zones[0].
+					resource.TestCheckResourceAttr(resourceId, "multi_zones.0.zone_id", "cn-beijing-k"),
+					// Invariant: the backend-returned top-level zone_id strictly
+					// equals multi_zones[0].zone_id.
+					resource.TestCheckResourceAttrPair(resourceId, "zone_id", resourceId, "multi_zones.0.zone_id"),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}

--- a/website/docs/r/click_house_enterprise_db_cluster.html.markdown
+++ b/website/docs/r/click_house_enterprise_db_cluster.html.markdown
@@ -91,11 +91,9 @@ resource "alicloud_vswitch" "defaultRNbPh8" {
 
 
 resource "alicloud_click_house_enterprise_db_cluster" "default" {
-  zone_id    = var.zone_id_i
-  vpc_id     = alicloud_vpc.defaultktKLuM.id
-  scale_min  = "8"
-  scale_max  = "16"
-  vswitch_id = alicloud_vswitch.defaultTQWN3k.id
+  vpc_id    = alicloud_vpc.defaultktKLuM.id
+  scale_min = "8"
+  scale_max = "16"
   multi_zones {
     vswitch_ids = ["${alicloud_vswitch.defaultTQWN3k.id}"]
     zone_id     = var.zone_id_i
@@ -111,6 +109,8 @@ resource "alicloud_click_house_enterprise_db_cluster" "default" {
 }
 ```
 
+-> **NOTE:** For multi-zone deployments, the top-level `zone_id` and `vswitch_id` are not sent to the API; the multi-zone configuration is carried entirely by the `multi_zones` block. `multi_zones` is an ordered list, so the first block is the primary zone (`MultiZone[0]`); declare the primary zone first. The top-level `zone_id` and `vswitch_id` may be omitted for multi-zone deployments to avoid the `InvalidZoneId.InconsistentWithMultiZone` error.
+
 
 📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_click_house_enterprise_db_cluster&spm=docs.r.click_house_enterprise_db_cluster.example&intl_lang=EN_US)
 
@@ -118,7 +118,7 @@ resource "alicloud_click_house_enterprise_db_cluster" "default" {
 
 The following arguments are supported:
 * `description` - (Optional, Computed, Available since v1.270.0) Cluster description.
-* `multi_zones` - (Optional, ForceNew, Computed, List) The multi-zone configuration. See [`multi_zones`](#multi_zones) below.
+* `multi_zones` - (Optional, ForceNew, Computed, List) The multi-zone configuration. The list is ordered: the first block is the primary zone. See [`multi_zones`](#multi_zones) below.
 * `node_count` - (Optional, Computed, Int, Available since v1.270.0) The number of nodes. Valid values: 2 to 16. This parameter is required when NodeScaleMin and NodeScaleMax are configured to define the auto-scaling range.
 * `node_scale_max` - (Optional, Computed, Int, Available since v1.270.0) Maximum value for serverless node auto scaling. Valid values range from 4 to 32 and must be greater than the minimum value.  
 * `node_scale_min` - (Optional, Computed, Int, Available since v1.270.0) The minimum value for serverless node auto-scaling. Valid values: 4–32.
@@ -127,12 +127,15 @@ The following arguments are supported:
 * `scale_min` - (Optional, Computed) The minimum value for serverless auto scaling. This parameter is not recommended. We recommend that you use NodeCount, NodeScaleMin, and NodeScaleMax to configure auto scaling capabilities.
 * `tags` - (Optional, Map, Available since v1.270.0) Tag information.  
 * `vpc_id` - (Optional, ForceNew) The VPC ID.
-* `vswitch_id` - (Optional, ForceNew) vSwitch ID.
-* `zone_id` - (Optional, ForceNew) The zone ID.
+* `vswitch_id` - (Optional, ForceNew, Computed) vSwitch ID. For multi-zone deployments this is not sent to the API; the multi-zone information is carried by `multi_zones`.
+* `zone_id` - (Optional, ForceNew, Computed) The zone ID. For multi-zone deployments this is not sent to the API; the primary zone is determined by the order of the `multi_zones` block (the first block is the primary zone).
 
 ### `multi_zones`
 
 The multi_zones supports the following:
+
+-> **NOTE:** `multi_zones` is an ordered list. The first block is the primary zone (`MultiZone[0]`). Reordering the blocks is a destructive change (ForceNew).
+
 * `vswitch_ids` - (Optional, ForceNew, List) List of vSwitch IDs.
 * `zone_id` - (Optional, ForceNew) Zone ID.
 


### PR DESCRIPTION
## Description

ClickHouse `CreateDBInstance` rejects multi-zone create requests with `InvalidZoneId.InconsistentWithMultiZone` because `MultiZone[0]` must be the primary zone, but `multi_zones` was modeled as a `schema.TypeSet` whose `Set.List()` iteration order is hash-based and does not preserve the HCL declaration order, so a non-primary zone could end up at index 0.

## Fix

- Switch `multi_zones` from `schema.TypeSet` to `schema.TypeList` so the HCL declaration order is preserved and the first block is always the primary zone (`MultiZone[0]`). This makes the primary-zone semantics stable and expressible, instead of relying on a client-side reorder workaround.
- Add `SchemaVersion: 1` with a `StateUpgrader` (v0 -> v1) that reorders existing v0 state so the entry matching the server-returned primary zone (top-level `zone_id`) is moved to index 0, keeping the zone set unchanged and avoiding a spurious `ForceNew` replacement on the first plan after upgrade. When the top-level `zone_id` is empty or no entry matches, the order is left unchanged and the next `Read` aligns the state to the server-returned order.
- Stop forwarding the top-level `vswitch_id` and `zone_id` to `CreateDBInstance` when `multi_zones` is set; the multi-zone information is carried entirely by the `MultiZone` parameter, and forwarding the top-level `zone_id` alongside `MultiZone` triggers `InvalidZoneId.InconsistentWithMultiZone` when it does not match `MultiZone[0].zone_id`. Single-zone deployments keep forwarding the top-level `vswitch_id`/`zone_id` as before.
- The nested `vswitch_ids` stays a `schema.TypeSet` because the vswitches within a single zone entry do not carry order semantics.

## Breaking change / migration

`multi_zones` is now an ordered list (previously an unordered set). The first block is the primary zone. Existing state is upgraded automatically by the `StateUpgrader`: the entry whose `zone_id` matches the server-returned primary zone (top-level `zone_id`) is moved to index 0, so no spurious replacement is triggered. Users who previously declared `multi_zones` without a stable order should declare the primary zone as the first block.

## Docs

- Document that `multi_zones` is an ordered list whose first block is the primary zone, and that the top-level `zone_id`/`vswitch_id` are not forwarded for multi-zone deployments.

## Tests

- Added unit test `TestAccAliCloudClickHouseEnterpriseDBClusterMultiZonesStateUpgradeV0toV1` covering the v0 -> v1 state migration (primary zone reordered to index 0, already-first is a no-op, empty/absent primary leaves the order unchanged) and asserting the schema switched to `TypeList` with `SchemaVersion: 1`.
- The multi-zone acceptance cases `TestAccAliCloudClickHouseEnterpriseDBCluster_basic10560` and `TestAccAliCloudClickHouseEnterpriseDBCluster_multiZonesPrimaryZoneStable` (multi-zone create with the primary zone declared first, plus import verification) are being verified via remote ACC.
