### PR TITLE
resource/alicloud_realtime_compute_vvp_instance: support auto_renew for subscription instance

### DIFF
--- a/alicloud/resource_alicloud_realtime_compute_vvp_instance.go
+++ b/alicloud/resource_alicloud_realtime_compute_vvp_instance.go
@@ -12,6 +12,25 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+// bss (BssOpenApi 2017-12-14) renewal ProductCode/ProductType for the VVP
+// (Realtime Compute for Apache Flink) subscription instance.
+//
+// Domestic values empirically confirmed via bss GetOrderDetail on two ACC VVP
+// orders (ProductCode=sc, ProductType=sc_flinkserverless_public_cn,
+// CommodityCode=sc_flinkserverless_public_cn, SubscriptionType=Subscription,
+// PaymentStatus=Paid) and bss QueryAvailableInstances on a live instance
+// (returned RenewStatus=ManualRenewal, RenewalDurationUnit=M).
+//
+// The intl ProductType follows the domestic _cn → _intl naming convention used
+// by other alicloud subscription resources (e.g. elasticsearchpre →
+// elasticsearchpre_intl). Confirmed by the Flink product owner 2026-09-03;
+// international-site ACC verification is still pending (see PR test plan).
+const (
+	realtimeComputeVvpBssProductCode     = "sc"
+	realtimeComputeVvpBssProductType     = "sc_flinkserverless_public_cn"
+	realtimeComputeVvpBssProductTypeIntl = "sc_flinkserverless_public_intl" // confirmed by the Flink product owner 2026-09-03
+)
+
 func resourceAliCloudRealtimeComputeVvpInstance() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAliCloudRealtimeComputeVvpInstanceCreate,
@@ -27,6 +46,11 @@ func resourceAliCloudRealtimeComputeVvpInstance() *schema.Resource {
 			Delete: schema.DefaultTimeout(35 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
+			"auto_renew_duration": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntInSlice([]int{1, 2, 3, 6, 12}),
+			},
 			"create_time": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -45,6 +69,16 @@ func resourceAliCloudRealtimeComputeVvpInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: StringInSlice([]string{"Month"}, false),
+			},
+			"renew_status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"renewal_duration_unit": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 			"resource_group_id": {
 				Type:     schema.TypeString,
@@ -234,6 +268,10 @@ func resourceAliCloudRealtimeComputeVvpInstanceCreate(d *schema.ResourceData, me
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
 
+	if err := setRealtimeComputeVvpInstanceRenewal(d, meta); err != nil {
+		return WrapError(err)
+	}
+
 	return resourceAliCloudRealtimeComputeVvpInstanceRead(d, meta)
 }
 
@@ -300,6 +338,21 @@ func resourceAliCloudRealtimeComputeVvpInstanceRead(d *schema.ResourceData, meta
 	}
 
 	d.Set("vswitch_ids", vSwitchIds1Raw)
+
+	if checkValue := d.Get("payment_type"); checkValue == "Subscription" {
+		// The foasconsole DescribeInstances API does not return renewal state, so
+		// renewal is read back from bss QueryAvailableInstances. bss uses a
+		// different naming from SetRenewal: RenewStatus / RenewalDuration /
+		// RenewalDurationUnit (vs. RenewalStatus / RenewalPeriod / RenewalPeriodUnit).
+		bssOpenApiService := BssOpenApiService{client}
+		renewRaw, err := bssOpenApiService.QueryAvailableInstances(d.Id(), client.RegionId, realtimeComputeVvpBssProductCode, realtimeComputeVvpBssProductType, realtimeComputeVvpBssProductCode, realtimeComputeVvpBssProductTypeIntl)
+		if err != nil && !NotFoundError(err) {
+			return WrapError(err)
+		}
+		d.Set("renew_status", renewRaw["RenewStatus"])
+		d.Set("auto_renew_duration", renewRaw["RenewalDuration"])
+		d.Set("renewal_duration_unit", renewRaw["RenewalDurationUnit"])
+	}
 
 	return nil
 }
@@ -405,6 +458,9 @@ func resourceAliCloudRealtimeComputeVvpInstanceUpdate(d *schema.ResourceData, me
 		}
 		d.SetPartial("tags")
 	}
+	if err := setRealtimeComputeVvpInstanceRenewal(d, meta); err != nil {
+		return WrapError(err)
+	}
 	d.Partial(false)
 	return resourceAliCloudRealtimeComputeVvpInstanceRead(d, meta)
 }
@@ -450,6 +506,75 @@ func resourceAliCloudRealtimeComputeVvpInstanceDelete(d *schema.ResourceData, me
 	stateConf := BuildStateConf([]string{}, []string{}, d.Timeout(schema.TimeoutDelete), 9*time.Minute, realtimeComputeServiceV2.RealtimeComputeVvpInstanceStateRefreshFunc(d.Id(), "InstanceId", []string{}))
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
+	}
+	return nil
+}
+
+// setRealtimeComputeVvpInstanceRenewal applies bss SetRenewal for a VVP
+// subscription instance. It is a no-op when payment_type is not Subscription
+// and when no renewal argument is configured (create) or changed (update).
+func setRealtimeComputeVvpInstanceRenewal(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	if v, ok := d.GetOk("payment_type"); !ok || v.(string) != "Subscription" {
+		return nil
+	}
+	needUpdate := false
+	if d.IsNewResource() {
+		if _, ok := d.GetOk("renew_status"); ok {
+			needUpdate = true
+		}
+		if v, ok := d.GetOk("auto_renew_duration"); ok && v.(int) > 0 {
+			needUpdate = true
+		}
+		if _, ok := d.GetOk("renewal_duration_unit"); ok {
+			needUpdate = true
+		}
+	} else if d.HasChange("renew_status") || d.HasChange("auto_renew_duration") || d.HasChange("renewal_duration_unit") {
+		needUpdate = true
+	}
+	if !needUpdate {
+		return nil
+	}
+	action := "SetRenewal"
+	request := make(map[string]interface{})
+	request["InstanceIDs"] = d.Id()
+	request["ProductCode"] = realtimeComputeVvpBssProductCode
+	request["ProductType"] = realtimeComputeVvpBssProductType
+	if client.IsInternationalAccount() {
+		request["ProductType"] = realtimeComputeVvpBssProductTypeIntl
+	}
+	if v, ok := d.GetOk("auto_renew_duration"); ok && v.(int) > 0 {
+		request["RenewalPeriod"] = v
+	}
+	if v, ok := d.GetOk("renewal_duration_unit"); ok {
+		request["RenewalPeriodUnit"] = v
+	}
+	if v, ok := d.GetOk("renew_status"); ok {
+		request["RenewalStatus"] = v
+	}
+	var response map[string]interface{}
+	var endpoint string
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err := resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		var err error
+		response, err = client.RpcPostWithEndpoint("BssOpenApi", "2017-12-14", action, nil, request, true, endpoint)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			if !client.IsInternationalAccount() && IsExpectedErrors(err, []string{"NotApplicable"}) {
+				request["ProductType"] = realtimeComputeVvpBssProductTypeIntl
+				endpoint = connectivity.BssOpenAPIEndpointInternational
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 	return nil
 }

--- a/alicloud/resource_alicloud_realtime_compute_vvp_instance_test.go
+++ b/alicloud/resource_alicloud_realtime_compute_vvp_instance_test.go
@@ -125,7 +125,7 @@ func TestAccAliCloudRealtimeComputeVvpInstance_basic4636(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"duration", "pricing_cycle", "zone_id"},
+				ImportStateVerifyIgnore: []string{"auto_renew_duration", "duration", "pricing_cycle", "renew_status", "renewal_duration_unit", "zone_id"},
 			},
 		},
 	})
@@ -210,10 +210,13 @@ func TestAccAliCloudRealtimeComputeVvpInstance_basic4594(t *testing.T) {
 					"vpc_id":            "${data.alicloud_vpcs.default.ids.0}",
 					"vswitch_ids": []string{
 						"${data.alicloud_vswitches.default.ids.0}"},
-					"zone_id":       "cn-hangzhou-i",
-					"payment_type":  "Subscription",
-					"pricing_cycle": "Month",
-					"duration":      "1",
+					"zone_id":               "cn-hangzhou-i",
+					"payment_type":          "Subscription",
+					"pricing_cycle":         "Month",
+					"duration":              "1",
+					"renew_status":          "AutoRenewal",
+					"auto_renew_duration":   1,
+					"renewal_duration_unit": "M",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -234,6 +237,7 @@ func TestAccAliCloudRealtimeComputeVvpInstance_basic4594(t *testing.T) {
 							"memory_gb": "16",
 						},
 					},
+					"auto_renew_duration": 2,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{}),
@@ -243,7 +247,7 @@ func TestAccAliCloudRealtimeComputeVvpInstance_basic4594(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"duration", "pricing_cycle", "zone_id"},
+				ImportStateVerifyIgnore: []string{"auto_renew_duration", "duration", "pricing_cycle", "renew_status", "renewal_duration_unit", "zone_id"},
 			},
 		},
 	})
@@ -334,7 +338,7 @@ func TestAccAliCloudRealtimeComputeVvpInstance_basic4636_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"duration", "pricing_cycle", "zone_id"},
+				ImportStateVerifyIgnore: []string{"auto_renew_duration", "duration", "pricing_cycle", "renew_status", "renewal_duration_unit", "zone_id"},
 			},
 		},
 	})
@@ -405,7 +409,119 @@ func TestAccAliCloudRealtimeComputeVvpInstance_basic4594_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"duration", "pricing_cycle", "zone_id"},
+				ImportStateVerifyIgnore: []string{"auto_renew_duration", "duration", "pricing_cycle", "renew_status", "renewal_duration_unit", "zone_id"},
+			},
+		},
+	})
+}
+
+func AlicloudRealtimeComputeVvpInstanceBasicDependence4594_intl(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id     = alicloud_vpc.default.id
+  cidr_block = "172.16.1.0/24"
+  zone_id    = "ap-southeast-1a"
+}
+
+resource "alicloud_oss_bucket" "defaultOSS" {
+  bucket = var.name
+}
+
+`, name)
+}
+
+// TestAccAliCloudRealtimeComputeVvpInstance_basic4594_intl tests the renewal
+// trio (renew_status / auto_renew_duration / renewal_duration_unit) on an
+// international-site subscription instance. Skipped on domestic accounts.
+// lintignore: AT001
+func TestAccAliCloudRealtimeComputeVvpInstance_basic4594_intl(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_realtime_compute_vvp_instance.default"
+	ra := resourceAttrInit(resourceId, AlicloudRealtimeComputeVvpInstanceMap4594)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &RealtimeComputeServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeRealtimeComputeVvpInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%srealtimecomputevvpinstance%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudRealtimeComputeVvpInstanceBasicDependence4594_intl)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithAccountSiteType(t, IntlSite)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		// CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"storage": []map[string]interface{}{
+						{
+							"oss": []map[string]interface{}{
+								{
+									"bucket": "${alicloud_oss_bucket.defaultOSS.bucket}",
+								},
+							},
+						},
+					},
+					"resource_spec": []map[string]interface{}{
+						{
+							"cpu":       "2",
+							"memory_gb": "8",
+						},
+					},
+					"vvp_instance_name":     name,
+					"vpc_id":                "${alicloud_vpc.default.id}",
+					"vswitch_ids":           []string{"${alicloud_vswitch.default.id}"},
+					"zone_id":               "ap-southeast-1a",
+					"payment_type":          "Subscription",
+					"pricing_cycle":         "Month",
+					"duration":              "1",
+					"renew_status":          "AutoRenewal",
+					"auto_renew_duration":   1,
+					"renewal_duration_unit": "M",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"vvp_instance_name": name,
+						"vpc_id":            CHECKSET,
+						"vswitch_ids.#":     "1",
+						"payment_type":      "Subscription",
+						"pricing_cycle":     "Month",
+						"duration":          "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"resource_spec": []map[string]interface{}{
+						{
+							"cpu":       "4",
+							"memory_gb": "16",
+						},
+					},
+					"auto_renew_duration": 2,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auto_renew_duration", "duration", "pricing_cycle", "renew_status", "renewal_duration_unit", "zone_id"},
 			},
 		},
 	})

--- a/website/docs/r/realtime_compute_vvp_instance.html.markdown
+++ b/website/docs/r/realtime_compute_vvp_instance.html.markdown
@@ -91,9 +91,12 @@ You can resume managing the subscription instance via the AlibabaCloud Console.
 ## Argument Reference
 
 The following arguments are supported:
+* `auto_renew_duration` - (Optional) The auto-renewal period of the subscription instance. It only takes effect when `payment_type = "Subscription"` and `renew_status = "AutoRenewal"`. Valid values: `1`, `2`, `3`, `6`, `12`. The unit is specified by `renewal_duration_unit`.
 * `duration` - (Optional) The number of subscription periods. If the payment type is PRE, this parameter is required.
 * `payment_type` - (Required, ForceNew) The payment type of the resource.
 * `pricing_cycle` - (Optional) The subscription period. If the payment type is PRE, this parameter is required.
+* `renew_status` - (Optional, Computed) The renewal status of the subscription instance. It only takes effect when `payment_type = "Subscription"`. Valid values: `AutoRenewal`, `ManualRenewal`, `NotRenewal`.
+* `renewal_duration_unit` - (Optional, Computed) The unit of the auto-renewal period. It only takes effect when `payment_type = "Subscription"` and `renew_status = "AutoRenewal"`. Valid values: `M` (month), `Y` (year).
 * `resource_group_id` - (Optional, Computed) The resource group to which the newly purchased instance belongs.
 * `resource_spec` - (Optional) Resource specifications. See [`resource_spec`](#resource_spec) below.
 * `storage` - (Required, ForceNew) Store information. See [`storage`](#storage) below.


### PR DESCRIPTION
## Summary
- Add `renew_status`, `auto_renew_duration`, and `renewal_duration_unit` arguments to `alicloud_realtime_compute_vvp_instance` to manage subscription instance renewal through the BssOpenApi `SetRenewal` action.
- `renew_status` accepts `AutoRenewal`, `ManualRenewal`, `NotRenewal`; `auto_renew_duration` accepts `1`, `2`, `3`, `6`, `12` (validated via `IntInSlice`); `renewal_duration_unit` accepts `M` (month) and `Y` (year). These arguments only take effect when `payment_type = "Subscription"`.
- Renewal state is read back from BssOpenApi `QueryAvailableInstances` (`RenewStatus`, `RenewalDuration`, `RenewalDurationUnit`) because the foasconsole `DescribeInstances` API does not return renewal fields.
- Domestic and international accounts are dispatched via `IsInternationalAccount` with the appropriate bss `ProductType`.
- Replaced deprecated `GetOkExists` with `GetOk` + `> 0` guard for `auto_renew_duration` to avoid sending `RenewalPeriod = 0` when the field is unset.

## Test plan
- [x] `TestAccAliCloudRealtimeComputeVvpInstance_basic4594` — Subscription with renewal trio (create + `auto_renew_duration` update); PASS (remote ACC, 833.02s).
- [ ] `TestAccAliCloudRealtimeComputeVvpInstance_basic4594_intl` — International-site subscription with renewal trio; guarded by `testAccPreCheckWithAccountSiteType(t, IntlSite)`. Skipped at the IntlSite gate during remote ACC because the acceptance account is domestic (cn-hangzhou) and lacks international-site subscription capability — not a code defect; pending international-site account access enablement (does not block domestic merge).
- [ ] `TestAccAliCloudRealtimeComputeVvpInstance_basic4636` — PayAsYouGo regression check.
