### PR TITLE
New Resource: alicloud_bss_open_api_budget; New Data Source: alicloud_bss_open_api_budgets

### DIFF
--- a/alicloud/data_source_alicloud_bss_open_api_budgets.go
+++ b/alicloud/data_source_alicloud_bss_open_api_budgets.go
@@ -1,0 +1,362 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAlicloudBssOpenApiBudgets() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudBssOpenApiBudgetsRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsValidRegExp,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"budgets": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"budget_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"budget_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"comment": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cycle_end_period": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cycle_start_period": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cycle_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"metric": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"quota": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"quota_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cycle_quota": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cycle_period": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"quota": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"query_filter": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"select_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"code": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"warn_confs": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"msc_channels": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"comment": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"threshold_value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"msc_contacts": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"event_bridge": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"warn_target": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"threshold_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudBssOpenApiBudgetsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	budgetsMaps := make([]map[string]interface{}, 0)
+	ids := make([]string, 0)
+	names := make([]string, 0)
+
+	pageNo := 1
+	pageSize := PageSizeLarge
+	for {
+		action := "DescribeBudgets"
+		request := make(map[string]interface{})
+		query := make(map[string]interface{})
+		request["PageNo"] = pageNo
+		request["PageSize"] = pageSize
+		request["ProductCode"] = ""
+		request["ProductType"] = ""
+		if client.IsInternationalAccount() {
+			request["ProductType"] = ""
+		}
+		var endpoint string
+		var response map[string]interface{}
+		var err error
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPostWithEndpoint("BssOpenApi", "2023-09-30", action, query, request, true, endpoint)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				if !client.IsInternationalAccount() && IsExpectedErrors(err, []string{""}) {
+					request["ProductCode"] = ""
+					request["ProductType"] = ""
+					endpoint = connectivity.BssOpenAPIEndpointInternational
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, "alicloud_bss_open_api_budgets", action, AlibabaCloudSdkGoERROR)
+		}
+
+		dataRaw, _ := jsonpath.Get("$.data", response)
+		items := convertToInterfaceArray(dataRaw)
+		for _, itemRaw := range items {
+			item, ok := itemRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			budgetName := fmt.Sprint(item["budgetName"])
+			if nameRegex != nil && !nameRegex.MatchString(budgetName) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, exist := idsMap[budgetName]; !exist {
+					continue
+				}
+			}
+			budgetMap := make(map[string]interface{})
+			budgetMap["budget_name"] = budgetName
+			budgetMap["budget_type"] = item["budgetType"]
+			budgetMap["comment"] = item["comment"]
+			budgetMap["cycle_end_period"] = item["cycleEndPeriod"]
+			budgetMap["cycle_start_period"] = item["cycleStartPeriod"]
+			budgetMap["cycle_type"] = item["cycleType"]
+			budgetMap["metric"] = item["metric"]
+			budgetMap["quota"] = item["quota"]
+			budgetMap["quota_type"] = item["quotaType"]
+
+			cycleQuotaRaw := item["cycleQuota"]
+			cycleQuotaMaps := make([]map[string]interface{}, 0)
+			if cycleQuotaRaw != nil {
+				for _, childRaw := range convertToInterfaceArray(cycleQuotaRaw) {
+					child, ok := childRaw.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					m := make(map[string]interface{})
+					m["cycle_period"] = child["cyclePeriod"]
+					m["quota"] = child["quota"]
+					cycleQuotaMaps = append(cycleQuotaMaps, m)
+				}
+			}
+			budgetMap["cycle_quota"] = cycleQuotaMaps
+
+			queryFilterRaw := item["queryFilter"]
+			queryFilterMaps := make([]map[string]interface{}, 0)
+			if queryFilterRaw != nil {
+				for _, childRaw := range convertToInterfaceArray(queryFilterRaw) {
+					child, ok := childRaw.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					m := make(map[string]interface{})
+					m["code"] = child["code"]
+					m["select_type"] = child["selectType"]
+					valuesRaw := make([]interface{}, 0)
+					if child["values"] != nil {
+						valuesRaw = convertToInterfaceArray(child["values"])
+					}
+					m["values"] = valuesRaw
+					queryFilterMaps = append(queryFilterMaps, m)
+				}
+			}
+			budgetMap["query_filter"] = queryFilterMaps
+
+			warnConfRaw := item["warnConf"]
+			warnConfsMaps := make([]map[string]interface{}, 0)
+			if warnConfRaw != nil {
+				for _, childRaw := range convertToInterfaceArray(warnConfRaw) {
+					child, ok := childRaw.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					m := make(map[string]interface{})
+					m["comment"] = child["comment"]
+					m["event_bridge"] = child["eventBridge"]
+					m["name"] = child["name"]
+					m["threshold_type"] = child["thresholdType"]
+					m["threshold_value"] = child["thresholdValue"]
+					m["warn_target"] = child["warnTarget"]
+					mscChannelsRaw := make([]interface{}, 0)
+					if child["mscChannels"] != nil {
+						mscChannelsRaw = convertToInterfaceArray(child["mscChannels"])
+					}
+					m["msc_channels"] = mscChannelsRaw
+					mscContactsRaw := make([]interface{}, 0)
+					if child["mscContacts"] != nil {
+						mscContactsRaw = convertToInterfaceArray(child["mscContacts"])
+					}
+					m["msc_contacts"] = mscContactsRaw
+					warnConfsMaps = append(warnConfsMaps, m)
+				}
+			}
+			budgetMap["warn_confs"] = warnConfsMaps
+
+			budgetsMaps = append(budgetsMaps, budgetMap)
+			ids = append(ids, budgetName)
+			names = append(names, budgetName)
+		}
+
+		totalCount := 0
+		if tc, _ := jsonpath.Get("$.totalCount", response); tc != nil {
+			totalCount = int(tc.(float64))
+		}
+		if pageNo*pageSize >= totalCount || len(items) == 0 {
+			break
+		}
+		pageNo++
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("budgets", budgetsMaps); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+
+	if v, ok := d.GetOk("output_file"); ok && v.(string) != "" {
+		if err := writeToFile(v.(string), budgetsMaps); err != nil {
+			return WrapError(err)
+		}
+	}
+
+	return nil
+}

--- a/alicloud/data_source_alicloud_bss_open_api_budgets_test.go
+++ b/alicloud/data_source_alicloud_bss_open_api_budgets_test.go
@@ -1,0 +1,95 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAlicloudBssOpenApiBudgetsDataSource_basic0(t *testing.T) {
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("tf-testacc-budget-ds-%d", rand)
+	resourceId := "alicloud_bss_open_api_budget.default"
+	dataSourceId := "data.alicloud_bss_open_api_budgets.default"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBssOpenApiBudgetDestroyWith(name),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlicloudBssOpenApiBudgetsDataSourceConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceId, "budgets.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceId, "ids.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceId, "budget_name", dataSourceId, "budgets.0.budget_name"),
+					resource.TestCheckResourceAttrPair(resourceId, "budget_type", dataSourceId, "budgets.0.budget_type"),
+					resource.TestCheckResourceAttrPair(resourceId, "metric", dataSourceId, "budgets.0.metric"),
+					resource.TestCheckResourceAttrPair(resourceId, "quota", dataSourceId, "budgets.0.quota"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBssOpenApiBudgetDestroyWith(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*connectivity.AliyunClient)
+		svc := BssOpenApiServiceV2{client}
+		_, err := svc.DescribeBssOpenApiBudget(name)
+		if err != nil {
+			if NotFoundError(err) {
+				return nil
+			}
+			return err
+		}
+		return fmt.Errorf("budget %s still exists", name)
+	}
+}
+
+func testAccAlicloudBssOpenApiBudgetsDataSourceConfig(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+resource "alicloud_bss_open_api_budget" "default" {
+  budget_name        = var.name
+  budget_type        = "cost"
+  metric             = "Cost"
+  cycle_type         = "Month"
+  cycle_start_period = "2026-09"
+  cycle_end_period   = "2026-12"
+  quota_type         = "quota"
+  quota              = "80"
+  comment            = "tf datasource test"
+  cycle_quota {
+    cycle_period = "2026-09"
+    quota        = "80"
+  }
+  query_filter {
+    code        = "productCode"
+    select_type = "equal"
+    values      = ["ECS"]
+  }
+  warn_confs {
+    name             = "tf-warn"
+    warn_target      = "Msc"
+    threshold_type   = "percent"
+    threshold_value  = "80"
+    event_bridge     = false
+    comment          = "tf warn conf"
+  }
+}
+
+data "alicloud_bss_open_api_budgets" "default" {
+  ids = [alicloud_bss_open_api_budget.default.budget_name]
+}
+`, name)
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -914,6 +914,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cen_transit_router_multicast_domain_sources":      dataSourceAlicloudCenTransitRouterMulticastDomainSources(),
 			"alicloud_bss_open_api_products":                            dataSourceAlicloudBssOpenApiProducts(),
 			"alicloud_bss_open_api_pricing_modules":                     dataSourceAlicloudBssOpenApiPricingModules(),
+			"alicloud_bss_open_api_budgets":                             dataSourceAlicloudBssOpenApiBudgets(),
 			"alicloud_service_catalog_provisioned_products":             dataSourceAlicloudServiceCatalogProvisionedProducts(),
 			"alicloud_service_catalog_product_as_end_users":             dataSourceAlicloudServiceCatalogProductAsEndUsers(),
 			"alicloud_service_catalog_product_versions":                 dataSourceAlicloudServiceCatalogProductVersions(),
@@ -967,6 +968,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_ehpc_user":                                            resourceAliCloudEhpcUser(),
+			"alicloud_bss_open_api_budget":                                  resourceAliCloudBssOpenApiBudget(),
 			"alicloud_ens_load_balancer_udp_listener":                       resourceAliCloudEnsLoadBalancerUdpListener(),
 			"alicloud_gpdb_db_extension":                                    resourceAliCloudGpdbDbExtension(),
 			"alicloud_ecd_desktop_group":                                    resourceAliCloudEcdDesktopGroup(),

--- a/alicloud/resource_alicloud_bss_open_api_budget.go
+++ b/alicloud/resource_alicloud_bss_open_api_budget.go
@@ -1,0 +1,578 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudBssOpenApiBudget() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudBssOpenApiBudgetCreate,
+		Read:   resourceAliCloudBssOpenApiBudgetRead,
+		Update: resourceAliCloudBssOpenApiBudgetUpdate,
+		Delete: resourceAliCloudBssOpenApiBudgetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"budget_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"budget_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"comment": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cycle_end_period": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cycle_quota": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cycle_period": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"quota": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"cycle_start_period": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cycle_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"metric": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"nbid": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"query_filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"select_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"code": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"quota": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"quota_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"warn_confs": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"msc_channels": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"comment": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"threshold_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"msc_contacts": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"event_bridge": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"warn_target": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"threshold_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAliCloudBssOpenApiBudgetCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateBudget"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("budget_name"); ok {
+		request["BudgetName"] = v
+	}
+
+	if v, ok := d.GetOk("comment"); ok {
+		request["Comment"] = v
+	}
+	request["WarnConfs"] = buildBudgetWarnConfs(d.Get("warn_confs"))
+	request["Quota"] = d.Get("quota")
+	request["CycleQuota"] = buildBudgetCycleQuota(d.Get("cycle_quota"))
+	request["QueryFilter"] = buildBudgetQueryFilter(d.Get("query_filter"))
+	request["BudgetType"] = d.Get("budget_type")
+	request["QuotaType"] = d.Get("quota_type")
+	request["CycleEndPeriod"] = d.Get("cycle_end_period")
+	if v, ok := d.GetOk("nbid"); ok {
+		request["Nbid"] = v
+	}
+	request["CycleType"] = d.Get("cycle_type")
+	request["Metric"] = d.Get("metric")
+	request["CycleStartPeriod"] = d.Get("cycle_start_period")
+	var endpoint string
+	request["ProductCode"] = ""
+	request["ProductType"] = ""
+	if client.IsInternationalAccount() {
+		request["ProductType"] = ""
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPostWithEndpoint("BssOpenApi", "2023-09-30", action, query, request, true, endpoint)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			if !client.IsInternationalAccount() && IsExpectedErrors(err, []string{""}) {
+				request["ProductCode"] = ""
+				request["ProductType"] = ""
+				endpoint = connectivity.BssOpenAPIEndpointInternational
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_bss_open_api_budget", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.data.budgetName", response)
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudBssOpenApiBudgetRead(d, meta)
+}
+
+func resourceAliCloudBssOpenApiBudgetRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	bssOpenApiServiceV2 := BssOpenApiServiceV2{client}
+
+	objectRaw, err := bssOpenApiServiceV2.DescribeBssOpenApiBudget(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_bss_open_api_budget DescribeBssOpenApiBudget Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("budget_type", objectRaw["budgetType"])
+	d.Set("comment", objectRaw["comment"])
+	d.Set("cycle_end_period", objectRaw["cycleEndPeriod"])
+	d.Set("cycle_start_period", objectRaw["cycleStartPeriod"])
+	d.Set("cycle_type", objectRaw["cycleType"])
+	d.Set("metric", objectRaw["metric"])
+	d.Set("quota", objectRaw["quota"])
+	d.Set("quota_type", objectRaw["quotaType"])
+	d.Set("budget_name", objectRaw["budgetName"])
+
+	cycleQuotaRaw := objectRaw["cycleQuota"]
+	cycleQuotaMaps := make([]map[string]interface{}, 0)
+	if cycleQuotaRaw != nil {
+		for _, cycleQuotaChildRaw := range convertToInterfaceArray(cycleQuotaRaw) {
+			cycleQuotaMap := make(map[string]interface{})
+			cycleQuotaChildRaw := cycleQuotaChildRaw.(map[string]interface{})
+			cycleQuotaMap["cycle_period"] = cycleQuotaChildRaw["cyclePeriod"]
+			cycleQuotaMap["quota"] = cycleQuotaChildRaw["quota"]
+
+			cycleQuotaMaps = append(cycleQuotaMaps, cycleQuotaMap)
+		}
+	}
+	if err := d.Set("cycle_quota", cycleQuotaMaps); err != nil {
+		return err
+	}
+	queryFilterRaw := objectRaw["queryFilter"]
+	queryFilterMaps := make([]map[string]interface{}, 0)
+	if queryFilterRaw != nil {
+		for _, queryFilterChildRaw := range convertToInterfaceArray(queryFilterRaw) {
+			queryFilterMap := make(map[string]interface{})
+			queryFilterChildRaw := queryFilterChildRaw.(map[string]interface{})
+			queryFilterMap["code"] = queryFilterChildRaw["code"]
+			queryFilterMap["select_type"] = queryFilterChildRaw["selectType"]
+
+			valuesRaw := make([]interface{}, 0)
+			if queryFilterChildRaw["values"] != nil {
+				valuesRaw = convertToInterfaceArray(queryFilterChildRaw["values"])
+			}
+
+			queryFilterMap["values"] = valuesRaw
+			queryFilterMaps = append(queryFilterMaps, queryFilterMap)
+		}
+	}
+	if err := d.Set("query_filter", queryFilterMaps); err != nil {
+		return err
+	}
+	warnConfRaw := objectRaw["warnConf"]
+	warnConfsMaps := make([]map[string]interface{}, 0)
+	if warnConfRaw != nil {
+		for _, warnConfChildRaw := range convertToInterfaceArray(warnConfRaw) {
+			warnConfsMap := make(map[string]interface{})
+			warnConfChildRaw := warnConfChildRaw.(map[string]interface{})
+			warnConfsMap["comment"] = warnConfChildRaw["comment"]
+			warnConfsMap["event_bridge"] = warnConfChildRaw["eventBridge"]
+			warnConfsMap["name"] = warnConfChildRaw["name"]
+			warnConfsMap["threshold_type"] = warnConfChildRaw["thresholdType"]
+			warnConfsMap["threshold_value"] = warnConfChildRaw["thresholdValue"]
+			warnConfsMap["warn_target"] = warnConfChildRaw["warnTarget"]
+
+			mscChannelsRaw := make([]interface{}, 0)
+			if warnConfChildRaw["mscChannels"] != nil {
+				mscChannelsRaw = convertToInterfaceArray(warnConfChildRaw["mscChannels"])
+			}
+
+			warnConfsMap["msc_channels"] = mscChannelsRaw
+			mscContactsRaw := make([]interface{}, 0)
+			if warnConfChildRaw["mscContacts"] != nil {
+				mscContactsRaw = convertToInterfaceArray(warnConfChildRaw["mscContacts"])
+			}
+
+			warnConfsMap["msc_contacts"] = mscContactsRaw
+			warnConfsMaps = append(warnConfsMaps, warnConfsMap)
+		}
+	}
+	if err := d.Set("warn_confs", warnConfsMaps); err != nil {
+		return err
+	}
+
+	d.Set("budget_name", d.Id())
+
+	return nil
+}
+
+func resourceAliCloudBssOpenApiBudgetUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "UpdateBudget"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	// UpdateBudget maps BudgetName to both originalBudgetName (old) and budgetName (new).
+	request["OriginalBudgetName"] = d.Id()
+	if d.HasChange("budget_name") {
+		request["BudgetName"] = d.Get("budget_name")
+	} else {
+		request["BudgetName"] = d.Id()
+	}
+
+	if d.HasChange("comment") {
+		update = true
+		request["Comment"] = d.Get("comment")
+	}
+
+	if d.HasChange("warn_confs") {
+		update = true
+		request["WarnConfs"] = buildBudgetWarnConfs(d.Get("warn_confs"))
+	}
+
+	if d.HasChange("quota") {
+		update = true
+		request["Quota"] = d.Get("quota")
+	}
+
+	if d.HasChange("cycle_quota") {
+		update = true
+		request["CycleQuota"] = buildBudgetCycleQuota(d.Get("cycle_quota"))
+	}
+
+	if d.HasChange("query_filter") {
+		update = true
+		request["QueryFilter"] = buildBudgetQueryFilter(d.Get("query_filter"))
+	}
+
+	if d.HasChange("budget_type") {
+		update = true
+	}
+	request["BudgetType"] = d.Get("budget_type")
+	if d.HasChange("quota_type") {
+		update = true
+	}
+	request["QuotaType"] = d.Get("quota_type")
+	if d.HasChange("cycle_end_period") {
+		update = true
+	}
+	request["CycleEndPeriod"] = d.Get("cycle_end_period")
+	if v, ok := d.GetOk("nbid"); ok {
+		request["Nbid"] = v
+	}
+	if d.HasChange("cycle_type") {
+		update = true
+	}
+	request["CycleType"] = d.Get("cycle_type")
+	if d.HasChange("metric") {
+		update = true
+	}
+	request["Metric"] = d.Get("metric")
+	if d.HasChange("cycle_start_period") {
+		update = true
+	}
+	request["CycleStartPeriod"] = d.Get("cycle_start_period")
+	var endpoint string
+	request["ProductCode"] = ""
+	request["ProductType"] = ""
+	if client.IsInternationalAccount() {
+		request["ProductType"] = ""
+	}
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPostWithEndpoint("BssOpenApi", "2023-09-30", action, query, request, true, endpoint)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				if !client.IsInternationalAccount() && IsExpectedErrors(err, []string{""}) {
+					request["ProductCode"] = ""
+					request["ProductType"] = ""
+					endpoint = connectivity.BssOpenAPIEndpointInternational
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudBssOpenApiBudgetRead(d, meta)
+}
+
+func resourceAliCloudBssOpenApiBudgetDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteBudget"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["BudgetName"] = d.Id()
+
+	if v, ok := d.GetOk("nbid"); ok {
+		request["Nbid"] = v
+	}
+	var endpoint string
+	request["ProductCode"] = ""
+	request["ProductType"] = ""
+	if client.IsInternationalAccount() {
+		request["ProductType"] = ""
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPostWithEndpoint("BssOpenApi", "2023-09-30", action, query, request, true, endpoint)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			if !client.IsInternationalAccount() && IsExpectedErrors(err, []string{""}) {
+				request["ProductCode"] = ""
+				request["ProductType"] = ""
+				endpoint = connectivity.BssOpenAPIEndpointInternational
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}
+
+// buildBudgetWarnConfs converts the warn_confs schema list into the API request array.
+func buildBudgetWarnConfs(raw interface{}) []interface{} {
+	result := make([]interface{}, 0)
+	if raw == nil {
+		return result
+	}
+	list, ok := raw.([]interface{})
+	if !ok {
+		return result
+	}
+	for _, itemRaw := range list {
+		item, ok := itemRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		m := make(map[string]interface{})
+		if v, ok := item["name"].(string); ok && v != "" {
+			m["name"] = v
+		}
+		if v, ok := item["warn_target"].(string); ok && v != "" {
+			m["warnTarget"] = v
+		}
+		if v, ok := item["threshold_type"].(string); ok && v != "" {
+			m["thresholdType"] = v
+		}
+		if v, ok := item["threshold_value"].(string); ok && v != "" {
+			m["thresholdValue"] = v
+		}
+		if v := item["msc_contacts"]; v != nil {
+			if contacts, ok := v.([]interface{}); ok && len(contacts) > 0 {
+				m["mscContacts"] = contacts
+			}
+		}
+		if v := item["msc_channels"]; v != nil {
+			if channels, ok := v.([]interface{}); ok && len(channels) > 0 {
+				m["mscChannels"] = channels
+			}
+		}
+		if v, ok := item["event_bridge"]; ok && v != nil {
+			m["eventBridge"] = v
+		}
+		if v, ok := item["comment"].(string); ok && v != "" {
+			m["comment"] = v
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+// buildBudgetCycleQuota converts the cycle_quota schema list into the API request array.
+func buildBudgetCycleQuota(raw interface{}) []interface{} {
+	result := make([]interface{}, 0)
+	if raw == nil {
+		return result
+	}
+	list, ok := raw.([]interface{})
+	if !ok {
+		return result
+	}
+	for _, itemRaw := range list {
+		item, ok := itemRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		m := make(map[string]interface{})
+		if v, ok := item["cycle_period"].(string); ok && v != "" {
+			m["cyclePeriod"] = v
+		}
+		if v, ok := item["quota"].(string); ok && v != "" {
+			m["quota"] = v
+		}
+		result = append(result, m)
+	}
+	return result
+}
+
+// buildBudgetQueryFilter converts the query_filter schema list into the API request array.
+func buildBudgetQueryFilter(raw interface{}) []interface{} {
+	result := make([]interface{}, 0)
+	if raw == nil {
+		return result
+	}
+	list, ok := raw.([]interface{})
+	if !ok {
+		return result
+	}
+	for _, itemRaw := range list {
+		item, ok := itemRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		m := make(map[string]interface{})
+		if v, ok := item["code"].(string); ok && v != "" {
+			m["code"] = v
+		}
+		if v, ok := item["select_type"].(string); ok && v != "" {
+			m["selectType"] = v
+		}
+		if v := item["values"]; v != nil {
+			if values, ok := v.([]interface{}); ok && len(values) > 0 {
+				m["values"] = values
+			}
+		}
+		result = append(result, m)
+	}
+	return result
+}

--- a/alicloud/resource_alicloud_bss_open_api_budget_test.go
+++ b/alicloud/resource_alicloud_bss_open_api_budget_test.go
@@ -1,0 +1,139 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudBssOpenApiBudget_basic0(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_bss_open_api_budget.default"
+	ra := resourceAttrInit(resourceId, AliCloudBssOpenApiBudgetMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &BssOpenApiServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeBssOpenApiBudget")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("tf-testacc-budget-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudBssOpenApiBudgetBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"budget_name":        name,
+					"budget_type":        "cost",
+					"metric":             "Cost",
+					"cycle_type":         "Month",
+					"cycle_start_period": "2026-09",
+					"cycle_end_period":   "2026-12",
+					"quota_type":         "quota",
+					"quota":              "80",
+					"comment":            "tf test budget",
+					"nbid":               "",
+					"cycle_quota": []map[string]interface{}{
+						{"cycle_period": "2026-09", "quota": "80"},
+						{"cycle_period": "2026-10", "quota": "90"},
+					},
+					"query_filter": []map[string]interface{}{
+						{"code": "productCode", "select_type": "equal", "values": []string{"ECS"}},
+					},
+					"warn_confs": []map[string]interface{}{
+						{"name": "tf-warn", "warn_target": "Msc", "threshold_type": "percent", "threshold_value": "80", "msc_contacts": []string{}, "msc_channels": []string{}, "event_bridge": false, "comment": "tf warn conf"},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"budget_name":        name,
+						"budget_type":        "cost",
+						"metric":             "Cost",
+						"cycle_type":         "Month",
+						"cycle_start_period": "2026-09",
+						"cycle_end_period":   "2026-12",
+						"quota_type":         "quota",
+						"quota":              "80",
+						"comment":            "tf test budget",
+						"cycle_quota.#":      "2",
+						"query_filter.#":     "1",
+						"warn_confs.#":       "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"budget_name":        name,
+					"budget_type":        "usage",
+					"metric":             "Usage",
+					"cycle_type":         "Year",
+					"cycle_start_period": "2026",
+					"cycle_end_period":   "2027",
+					"quota_type":         "percent",
+					"quota":              "60",
+					"comment":            "tf test budget updated",
+					"nbid":               "",
+					"cycle_quota": []map[string]interface{}{
+						{"cycle_period": "2026", "quota": "60"},
+					},
+					"query_filter": []map[string]interface{}{
+						{"code": "region", "select_type": "contains", "values": []string{"cn-hangzhou", "cn-beijing"}},
+					},
+					"warn_confs": []map[string]interface{}{
+						{"name": "tf-warn-updated", "warn_target": "Dingtalk", "threshold_type": "absolute", "threshold_value": "60", "msc_contacts": []string{"contact1"}, "msc_channels": []string{"channel1"}, "event_bridge": true, "comment": "tf warn conf updated"},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"budget_type":        "usage",
+						"metric":             "Usage",
+						"cycle_type":         "Year",
+						"cycle_start_period": "2026",
+						"cycle_end_period":   "2027",
+						"quota_type":         "percent",
+						"quota":              "60",
+						"comment":            "tf test budget updated",
+						"cycle_quota.#":      "1",
+						"query_filter.#":     "1",
+						"warn_confs.#":       "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"nbid"},
+			},
+		},
+	})
+}
+
+// AliCloudBssOpenApiBudgetMap0 asserts the persisted attributes after apply.
+var AliCloudBssOpenApiBudgetMap0 = map[string]string{
+	"budget_name":        CHECKSET,
+	"budget_type":        CHECKSET,
+	"comment":            CHECKSET,
+	"cycle_end_period":   CHECKSET,
+	"cycle_start_period": CHECKSET,
+	"cycle_type":         CHECKSET,
+	"metric":             CHECKSET,
+	"quota":              CHECKSET,
+	"quota_type":         CHECKSET,
+	"cycle_quota.#":      CHECKSET,
+	"query_filter.#":     CHECKSET,
+	"warn_confs.#":       CHECKSET,
+}
+
+// AliCloudBssOpenApiBudgetBasicDependence0 returns the dependency HCL (none for a global BSS resource).
+var AliCloudBssOpenApiBudgetBasicDependence0 = func(name string) string {
+	return ""
+}

--- a/alicloud/service_alicloud_bss_open_api_v2.go
+++ b/alicloud/service_alicloud_bss_open_api_v2.go
@@ -1,0 +1,101 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+type BssOpenApiServiceV2 struct {
+	client *connectivity.AliyunClient
+}
+
+// DescribeBssOpenApiBudget <<< Encapsulated get interface for BssOpenApi Budget.
+
+func (s *BssOpenApiServiceV2) DescribeBssOpenApiBudget(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["budgetName"] = id
+
+	var endpoint string
+	request["ProductCode"] = ""
+	request["ProductType"] = ""
+	if client.IsInternationalAccount() {
+		request["ProductType"] = ""
+	}
+	action := "DescribeBudget"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPostWithEndpoint("BssOpenApi", "2023-09-30", action, query, request, true, endpoint)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			if !client.IsInternationalAccount() && IsExpectedErrors(err, []string{""}) {
+				request["ProductCode"] = ""
+				request["ProductType"] = ""
+				endpoint = connectivity.BssOpenAPIEndpointInternational
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.data", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.data", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *BssOpenApiServiceV2) BssOpenApiBudgetStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.BssOpenApiBudgetStateRefreshFuncWithApi(id, field, failStates, s.DescribeBssOpenApiBudget)
+}
+
+func (s *BssOpenApiServiceV2) BssOpenApiBudgetStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeBssOpenApiBudget >>> Encapsulated.

--- a/website/docs/d/bss_open_api_budgets.html.markdown
+++ b/website/docs/d/bss_open_api_budgets.html.markdown
@@ -1,0 +1,66 @@
+---
+subcategory: "Bss Open Api"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_bss_open_api_budgets"
+sidebar_current: "docs-alicloud-datasource-bss-open-api-budgets"
+description: |-
+  Provides a list of Bss Open Api Budgets owned by an Alibaba Cloud account.
+---
+
+# alicloud\_bss_open_api_budgets
+
+This data source provides Bss Open Api Budgets available to the user. [What is Budget](https://next.api.alibabacloud.com/document/BssOpenApi/2023-09-30/DescribeBudgets)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+data "alicloud_bss_open_api_budgets" "default" {
+  ids        = ["my-budget"]
+  name_regex = "terraform-.*"
+}
+
+output "first_budget_name" {
+  value = data.alicloud_bss_open_api_budgets.default.budgets.0.budget_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `ids` - (Optional) A list of Budget IDs (budget names).
+* `name_regex` - (Optional) A regex string to filter results by budget name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Budget IDs (budget names).
+* `names` - A list of budget names.
+* `budgets` - A list of Budget Entries. Each element contains the following attributes:
+  * `budget_name` - The name of the budget.
+  * `budget_type` - The type of the budget.
+  * `cycle_end_period` - The end period of the budget cycle.
+  * `cycle_start_period` - The start period of the budget cycle.
+  * `cycle_type` - The cycle type of the budget.
+  * `metric` - The metric of the budget.
+  * `quota` - The fixed quota value. When the quota type is a quota, the unit is a percentage.
+  * `quota_type` - The quota type of the budget.
+  * `comment` - The comment of the budget.
+  * `cycle_quota` - The specified quota for each cycle.
+    * `cycle_period` - The cycle period.
+    * `quota` - The quota.
+  * `query_filter` - The filter conditions.
+    * `code` - The parameter code.
+    * `select_type` - The select mode.
+    * `values` - The list of filter values.
+  * `warn_confs` - The alert configurations.
+    * `comment` - The comment.
+    * `event_bridge` - Whether to enable EventBridge.
+    * `msc_channels` - The list of message center channels.
+    * `msc_contacts` - The list of message center contacts.
+    * `name` - The alert name.
+    * `threshold_type` - The threshold type.
+    * `threshold_value` - The threshold value.
+    * `warn_target` - The alert target.

--- a/website/docs/r/bss_open_api_budget.html.markdown
+++ b/website/docs/r/bss_open_api_budget.html.markdown
@@ -1,0 +1,114 @@
+---
+subcategory: "Bss Open Api"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_bss_open_api_budget"
+description: |-
+  Provides a Alicloud Bss Open Api Budget resource.
+---
+
+# alicloud_bss_open_api_budget
+
+Provides a Bss Open Api Budget resource.
+
+For information about Bss Open Api Budget and how to use it, see [What is Budget](https://next.api.alibabacloud.com/document/BssOpenApi/2023-09-30/CreateBudget).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+resource "alicloud_bss_open_api_budget" "default" {
+  budget_name        = var.name
+  budget_type        = "cost"
+  metric             = "Cost"
+  cycle_type         = "Month"
+  cycle_start_period = "2026-09"
+  cycle_end_period   = "2026-12"
+  quota_type         = "quota"
+  quota              = "80"
+  comment            = "terraform example budget"
+  cycle_quota {
+    cycle_period = "2026-09"
+    quota        = "80"
+  }
+  query_filter {
+    code        = "productCode"
+    select_type = "equal"
+    values      = ["ECS"]
+  }
+  warn_confs {
+    name            = "terraform-warn"
+    warn_target     = "Msc"
+    threshold_type  = "percent"
+    threshold_value = "80"
+    event_bridge    = false
+    comment         = "terraform warn conf"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `budget_name` - (Required, ForceNew) The name of the budget.
+* `budget_type` - (Required) The type of the budget.
+* `cycle_end_period` - (Required) The end period of the budget cycle.
+* `cycle_start_period` - (Required) The start period of the budget cycle.
+* `cycle_type` - (Required) The cycle type of the budget.
+* `metric` - (Required) The metric of the budget.
+* `quota_type` - (Required) The quota type of the budget.
+* `comment` - (Optional) The comment of the budget.
+* `nbid` - (Optional) The first-level marketplace ID. If empty, the current user marketplace ID is used.
+* `quota` - (Optional) The fixed quota value. When the quota type is a quota, the unit is a percentage.
+* `cycle_quota` - (Optional) The specified quota for each cycle. See [`cycle_quota`](#cycle_quota) below.
+* `query_filter` - (Optional) The filter conditions. See [`query_filter`](#query_filter) below.
+* `warn_confs` - (Optional) The alert configurations. See [`warn_confs`](#warn_confs) below.
+
+### `cycle_quota`
+
+The cycle_quota supports the following:
+* `cycle_period` - (Optional) The cycle period.
+* `quota` - (Optional) The quota.
+
+### `query_filter`
+
+The query_filter supports the following:
+* `code` - (Optional) The parameter code.
+* `select_type` - (Optional) The select mode.
+* `values` - (Optional) The list of filter values.
+
+### `warn_confs`
+
+The warn_confs supports the following:
+* `comment` - (Optional) The comment.
+* `event_bridge` - (Optional) Whether to enable EventBridge.
+* `msc_channels` - (Optional) The list of message center channels.
+* `msc_contacts` - (Optional) The list of message center contacts.
+* `name` - (Optional) The alert name.
+* `threshold_type` - (Optional) The threshold type.
+* `threshold_value` - (Optional) The threshold value.
+* `warn_target` - (Optional) The alert target.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. It is the same as `budget_name`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Budget.
+* `delete` - (Defaults to 5 mins) Used when delete the Budget.
+* `update` - (Defaults to 5 mins) Used when update the Budget.
+
+## Import
+
+Bss Open Api Budget can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_bss_open_api_budget.example <budget_name>
+```


### PR DESCRIPTION
### New Resource and Data Source

- `alicloud_bss_open_api_budget` resource
- `alicloud_bss_open_api_budgets` data source

Adds Terraform support for BssOpenApi Budget management, covering the
`CreateBudget`, `DescribeBudget`, `UpdateBudget`, `DeleteBudget` and
`DescribeBudgets` APIs (BssOpenApi 2023-09-30).

### Argument Reference (resource)

| argument | type | attributes |
|---|---|---|
| budget_name | string | Required, ForceNew |
| budget_type | string | Required |
| cycle_end_period | string | Required |
| cycle_start_period | string | Required |
| cycle_type | string | Required |
| metric | string | Required |
| quota_type | string | Required |
| comment | string | Optional |
| nbid | string | Optional |
| quota | string | Optional |
| cycle_quota | list | Optional |
| query_filter | list | Optional |
| warn_confs | list | Optional |

The resource supports import by `budget_name`.

### Acceptance tests

```
TestAccAliCloudBssOpenApiBudget_basic0
TestAccAlicloudBssOpenApiBudgetsDataSource_basic0
```

Remote acceptance test verification is pending. The resource test exercises
create -> update -> import -> destroy with full attribute coverage, and the
data source test queries budgets by id.

### Check list

- [x] resource + data source code
- [x] resource + data source documentation
- [x] test cases (100% attribute coverage)
- [ ] remote ACC verification
