### PR TITLE
resource/alicloud_kms_instance: pair vswitch_ids with zone_ids by position

### DIFF
--- a/alicloud/resource_alicloud_kms_instance.go
+++ b/alicloud/resource_alicloud_kms_instance.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/PaesslerAG/jsonpath"
@@ -198,16 +199,18 @@ func resourceAliCloudKmsInstance() *schema.Resource {
 				},
 			},
 			"vswitch_ids": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:             schema.TypeList,
+				Required:         true,
+				ForceNew:         true,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: kmsInstanceIdsOrderDiffSuppressFunc,
 			},
 			"zone_ids": {
-				Type:     schema.TypeSet,
-				Required: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:             schema.TypeList,
+				Required:         true,
+				ForceNew:         true,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: kmsInstanceIdsOrderDiffSuppressFunc,
 			},
 		},
 	}
@@ -923,6 +926,35 @@ func resourceAliCloudKmsInstanceDelete(d *schema.ResourceData, meta interface{})
 
 	}
 	return nil
+}
+
+// kmsInstanceIdsOrderDiffSuppressFunc suppresses order-only changes to vswitch_ids and
+// zone_ids. The API does not report their order back, and both fields are ForceNew, so
+// without this an order-only difference would destroy and recreate a live instance.
+func kmsInstanceIdsOrderDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	oldValue, newValue := d.GetChange(strings.SplitN(k, ".", 2)[0])
+	return kmsInstanceEqualIgnoringOrder(oldValue, newValue)
+}
+
+func kmsInstanceEqualIgnoringOrder(old, new interface{}) bool {
+	oldList := convertToInterfaceArray(old)
+	newList := convertToInterfaceArray(new)
+	if len(oldList) != len(newList) {
+		return false
+	}
+
+	counter := make(map[string]int, len(oldList))
+	for _, item := range oldList {
+		counter[fmt.Sprint(item)]++
+	}
+	for _, item := range newList {
+		key := fmt.Sprint(item)
+		counter[key]--
+		if counter[key] < 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func convertKmsInstanceKmsInstanceChargeTypeResponse(source interface{}) interface{} {

--- a/alicloud/resource_alicloud_kms_instance_test.go
+++ b/alicloud/resource_alicloud_kms_instance_test.go
@@ -59,6 +59,13 @@ func TestAccAliCloudKmsInstance_basic4048(t *testing.T) {
 				),
 			},
 			{
+				// Reordering zone_ids must not plan a replacement.
+				Config: testAccConfig(map[string]interface{}{
+					"zone_ids": []string{"cn-hangzhou-j", "cn-hangzhou-k"},
+				}),
+				PlanOnly: true,
+			},
+			{
 				Config: testAccConfig(map[string]interface{}{
 					"vpc_num": "7",
 				}),

--- a/website/docs/r/kms_instance.html.markdown
+++ b/website/docs/r/kms_instance.html.markdown
@@ -121,6 +121,7 @@ resource "alicloud_kms_instance" "default" {
   payment_type = "Subscription"
 }
 ```
+
 Create a pay-as-you-go kms instance
 
 <div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
@@ -268,8 +269,14 @@ The following arguments are supported:
 * `tags` - (Optional, Map, Available since v1.259.0) The tag of the resource
 * `vpc_id` - (Required, ForceNew) The ID of the virtual private cloud (VPC) that is associated with the KMS instance.
 * `vpc_num` - (Optional, Int) The number of managed accesses. The maximum number of VPCs that can access this KMS instance. The attribute is valid when the attribute `payment_type` is `Subscription`.
-* `vswitch_ids` - (Required, ForceNew, Set) Instance bind vswitches
-* `zone_ids` - (Required, ForceNew, Set) zone id
+* `vswitch_ids` - (Required, ForceNew, List) The IDs of the vSwitches that the KMS instance is bound to. Every vSwitch must reside in a zone declared in `zone_ids`, and that zone must be available for KMS.
+* `zone_ids` - (Required, ForceNew, List) The IDs of the zones in which the KMS instance is deployed. Each zone must be available for KMS.
+
+  -> **NOTE:** A KMS instance is always deployed across two zones, so `zone_ids` must list both of them. Two combinations are supported, written here as the number of `vswitch_ids` to the number of `zone_ids`: `1:2` and `2:2`. With `2:2` the two lists are paired by position - the first zone hosts the first vSwitch, the second zone hosts the second vSwitch - so order them consistently. With a single vSwitch the order carries no meaning, because the API derives that vSwitch's own zone.
+
+  ~> **NOTE:** Do not declare a single zone. The API accepts it and picks the second zone itself, so the created instance spans two zones while the configuration lists one. Since `zone_ids` is `ForceNew`, every subsequent plan then proposes to destroy and recreate the instance, and each new instance is completed the same way. A difference in the number of zones is a real difference, not an ordering one, so it is not suppressed.
+
+  ~> **NOTE:** Since v1.290.0 `vswitch_ids` and `zone_ids` are ordered lists instead of sets. Previously the provider reordered each list independently before submitting it, which could pair a vSwitch with a zone it does not belong to. The change applies to instances created from v1.290.0 on. Existing instances are not replaced by the upgrade and keep the pairing they were created with: the API does not report the order back, so a difference in order alone never produces a diff, and reordering either list in the configuration of an existing instance has no effect. Re-pairing an existing instance means recreating it, with `terraform apply -replace`.
 
 ### `bind_vpcs`
 


### PR DESCRIPTION
Fixes #10273

### Problem

`vswitch_ids` and `zone_ids` were both `schema.TypeSet`. A set enumerates its elements in hash order, and the two sets are ordered independently of each other, so the two comma-separated strings the provider submits to `CreateKmsInstance` no longer line up by index. Once both hold more than one element the API pairs them by position — the first zone hosts the first vSwitch — so the instance could be created with a vSwitch bound to a zone it does not belong to, and the create fails. The order in the configuration was correct; the provider reordered it.

### Change

- Both fields become `TypeList`, so the configured order reaches the API verbatim.
- Each field gets a `DiffSuppressFunc` that drops order-only differences. This is load-bearing rather than defensive: `GetKmsInstance` returns `ZoneIds` with the primary zone first regardless of the order the instance was created with, and `Read` writes that back into state unconditionally. Since both fields are `ForceNew`, without the suppression a single refresh would plan a destroy/recreate of a live instance holding keys.
- No count validation is added — the supported combinations are documented and the API stays the authority.
- No state migration: a `TypeSet` and a `TypeList` of strings serialize identically in state, so existing state files are read as is and no `SchemaVersion` bump is needed.

### Behaviour for existing instances

Because the API does not report the order back, a difference in order alone never produces a diff. Upgrading does not replace existing instances, and equally, reordering either list in the configuration of an existing instance has no effect — it keeps the pairing it was created with. Re-pairing means recreating it, with `terraform apply -replace`. Only instances created from this version on honour the configured order. The website doc states this.

The doc also records the supported combinations (`vswitch_ids` count to `zone_ids` count: `1:2` and `2:2`) and a separate trap: declaring a single zone is accepted by the API, which then selects the second zone itself, leaving the instance spanning two zones while the configuration lists one. That is a difference in the *number* of zones rather than in their order, so the suppression deliberately does not hide it, and with a `ForceNew` field it becomes a replacement proposed on every plan.

### Test

A plan-only step reverses `zone_ids` against an instance created in the opposite order and asserts an empty plan — the regression guard for the destroy/recreate hazard above.

Full acceptance suite for the resource:

```
PASS: TestAccAliCloudKmsInstance_basic4048               (841.82s)
PASS: TestAccAliCloudKmsInstance_basic4048_twin          (432.84s)
PASS: TestAccAliCloudKmsInstance_basic4048_postpaid      (430.21s)
PASS: TestAccAliCloudKmsInstance_postpaid_log_enabled    (368.28s)
SKIP: TestAccAliCloudKmsInstance_basic4048_intl          (0.00s)
SKIP: TestAccAliCloudKmsInstance_basic4048_postpaid_intl (0.00s)
SKIP: TestAccAliCloudKmsInstance_basic5405               (0.00s)
SKIP: TestAccAliCloudKmsInstance_basic5405_twin          (0.00s)

4 passed, 0 failed, 4 skipped (8 total)
```

The four skips are unrelated to this change: those cases call `testAccPreCheckWithAccountSiteType(t, IntlSite)` and the test account is a domestic-site one, so they exit in `PreCheck` before any API call. They skip identically on `master`.

The run's debug log confirms both halves of the mechanism: the configured order reaches the API unchanged, and the read path does return an order that differs from the one the instance was created with.

Coverage gap, stated plainly: every case in this test file uses one vSwitch and two zones, so the `2:2` shape — where positional pairing decides which zone hosts which vSwitch, i.e. the reported scenario — is not covered by an acceptance test before or after this change. The positional pairing rule for `2:2` comes from the service behaviour, not from a test assertion.
