### PR TITLE
resource/alicloud_log_store: validate retention_period, max_split_shard_count and hot_ttl

### DIFF
--- a/alicloud/resource_alicloud_log_store.go
+++ b/alicloud/resource_alicloud_log_store.go
@@ -28,6 +28,20 @@ func resourceAliCloudSlsLogStore() *schema.Resource {
 			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
+		CustomizeDiff: func(d *schema.ResourceDiff, meta interface{}) error {
+			// When hot storage is enabled (hot_ttl > 0), the hot storage retention
+			// period must not exceed the data retention period (retention_period).
+			if hotTTL, ok := d.GetOk("hot_ttl"); ok {
+				hotTTLInt := hotTTL.(int)
+				if hotTTLInt > 0 {
+					retentionPeriod := d.Get("retention_period").(int)
+					if retentionPeriod > 0 && hotTTLInt > retentionPeriod {
+						return fmt.Errorf("hot_ttl (%d) must be less than or equal to retention_period (%d)", hotTTLInt, retentionPeriod)
+					}
+				}
+			}
+			return nil
+		},
 		Schema: map[string]*schema.Schema{
 			"append_meta": {
 				Type:     schema.TypeBool,
@@ -99,6 +113,18 @@ func resourceAliCloudSlsLogStore() *schema.Resource {
 			"hot_ttl": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				ValidateFunc: func(v interface{}, k string) ([]string, []error) {
+					i, ok := v.(int)
+					if !ok {
+						return nil, []error{fmt.Errorf("expected type of %s to be int", k)}
+					}
+					// 0 disables hot storage; otherwise the hot storage retention
+					// period is an integer from 7 to retention_period.
+					if i != 0 && i < 7 {
+						return nil, []error{fmt.Errorf("expected %s to be 0 (disable hot storage) or at least 7, got %d", k, i)}
+					}
+					return nil, nil
+				},
 			},
 			"infrequent_access_ttl": {
 				Type:     schema.TypeInt,
@@ -114,7 +140,7 @@ func resourceAliCloudSlsLogStore() *schema.Resource {
 			"max_split_shard_count": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ValidateFunc: IntBetween(0, 256),
+				ValidateFunc: IntBetween(1, 256),
 			},
 			"metering_mode": {
 				Type:     schema.TypeString,
@@ -140,9 +166,10 @@ func resourceAliCloudSlsLogStore() *schema.Resource {
 				ForceNew:     true,
 			},
 			"retention_period": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  30,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      30,
+				ValidateFunc: IntBetween(1, 3650),
 			},
 			"shard_count": {
 				Type:     schema.TypeInt,

--- a/alicloud/resource_alicloud_log_store_test.go
+++ b/alicloud/resource_alicloud_log_store_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	sls "github.com/aliyun/aliyun-log-go-sdk"
@@ -1231,6 +1232,89 @@ func TestAccAliCloudLogStore_multi(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(nil),
 				),
+			},
+		},
+	})
+}
+
+// testAccLogStoreValidationConfig builds a minimal alicloud_log_store config for
+// schema-validation tests. Empty values omit the attribute so each step only
+// exercises the field under test (no state accumulation across steps).
+func testAccLogStoreValidationConfig(retentionPeriod, maxSplitShardCount, hotTTL string) string {
+	config := `
+resource "alicloud_log_project" "foo" {
+  name        = "tf-testacc-log-store-validation"
+  description = "validation test"
+}
+
+resource "alicloud_log_store" "default" {
+  project = "${alicloud_log_project.foo.name}"
+  name    = "tf-testacc-log-store-validation"
+`
+	if retentionPeriod != "" {
+		config += fmt.Sprintf("  retention_period = %s\n", retentionPeriod)
+	}
+	if maxSplitShardCount != "" {
+		config += fmt.Sprintf("  max_split_shard_count = %s\n", maxSplitShardCount)
+	}
+	if hotTTL != "" {
+		config += fmt.Sprintf("  hot_ttl = %s\n", hotTTL)
+	}
+	config += "}\n"
+	return config
+}
+
+// TestAccAliCloudLogStore_fieldValidation verifies that out-of-range values for
+// retention_period, max_split_shard_count and hot_ttl are rejected at plan time.
+func TestAccAliCloudLogStore_fieldValidation(t *testing.T) {
+	var v *sls.LogStore
+	resourceId := "alicloud_log_store.default"
+	ra := resourceAttrInit(resourceId, logStoreMap)
+	serviceFunc := func() interface{} {
+		return &LogService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+	rac := resourceAttrCheckInit(rc, ra)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// retention_period below the minimum (valid range: 1-3650)
+			{
+				Config:      testAccLogStoreValidationConfig("0", "", ""),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`expected retention_period to be in the range \(1 - 3650\), got 0`),
+			},
+			// retention_period above the maximum
+			{
+				Config:      testAccLogStoreValidationConfig("3651", "", ""),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`expected retention_period to be in the range \(1 - 3650\), got 3651`),
+			},
+			// max_split_shard_count below the minimum (valid range: 1-256)
+			{
+				Config:      testAccLogStoreValidationConfig("", "0", ""),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`expected max_split_shard_count to be in the range \(1 - 256\), got 0`),
+			},
+			// max_split_shard_count above the maximum
+			{
+				Config:      testAccLogStoreValidationConfig("", "257", ""),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`expected max_split_shard_count to be in the range \(1 - 256\), got 257`),
+			},
+			// hot_ttl between 1 and 6 is invalid (must be 0 to disable, or >= 7)
+			{
+				Config:      testAccLogStoreValidationConfig("3650", "", "5"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`expected hot_ttl to be 0 \(disable hot storage\) or at least 7, got 5`),
+			},
+			// hot_ttl must not exceed retention_period
+			{
+				Config:      testAccLogStoreValidationConfig("30", "", "100"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`hot_ttl \(100\) must be less than or equal to retention_period \(30\)`),
 			},
 		},
 	})

--- a/website/docs/r/log_store.html.markdown
+++ b/website/docs/r/log_store.html.markdown
@@ -144,7 +144,7 @@ The following arguments are supported:
 * `auto_split` - (Optional) Determines whether to automatically split a shard. Default to `false`.
 * `enable_web_tracking` - (Optional) Whether open webtracking. webtracking network tracing, support the collection of HTML log, H5, Ios and android platforms.
 * `encrypt_conf` - (Optional, Computed, List, Available since 1.124.0) Encrypted storage of data, providing data static protection capability, encrypt_conf can be updated since 1.188.0 (only enable change is supported when updating logstore). See [`encrypt_conf`](#encrypt_conf) below.
-* `hot_ttl` - (Optional, Int, Available since 1.202.0) The ttl of hot storage. Default to 30, at least 30, hot storage ttl must be less than ttl.
+* `hot_ttl` - (Optional, Int, Available since 1.202.0) The ttl of hot storage. Set to `0` to disable hot storage; otherwise an integer from `7` to the value of `retention_period`. The hot storage retention period cannot exceed the data retention period.
 * `infrequent_access_ttl` - (Optional, Int, Available since v1.229.0) Low frequency storage time
 * `logstore_name` - (Optional, ForceNew, Available since v1.215.0) The log store, which is unique in the same project. You need to specify one of the attributes: `logstore_name`, `name`.
 * `max_split_shard_count` - (Optional, Int) The maximum number of shards for automatic split, which is in the range of 1 to 256. You must specify this parameter when autoSplit is true.


### PR DESCRIPTION
## What this PR does

Adds schema validation to `alicloud_log_store` so out-of-range values are rejected at `terraform plan` time instead of surfacing as opaque apply-time API errors.

- **`retention_period`**: `ValidateFunc` constraining to valid values `[1-3650]` (data retention in days; `3650` stores data permanently). The field was previously unbounded.
- **`max_split_shard_count`**: fixes an off-by-one lower bound — the valid range is `[1-256]` (previously `0-256`); `0` is not a valid value.
- **`hot_ttl`**: `0` disables hot storage; otherwise the value must be an integer from `7` to `retention_period`. The hot storage retention period cannot exceed the data retention period, enforced with a `CustomizeDiff` check.

Also updates the resource documentation to describe the correct `hot_ttl` range.

## Why

These fields previously accepted values outside the API-supported ranges and only failed at apply with low-level API errors. Plan-time validation gives users clear, immediate feedback.

## Tests

Adds `TestAccAliCloudLogStore_fieldValidation` with plan-phase (`PlanOnly`) steps that assert each out-of-range value is rejected:

- `retention_period = 0` and `= 3651`
- `max_split_shard_count = 0` and `= 257`
- `hot_ttl = 5` (below the minimum of 7 when hot storage is enabled)
- `hot_ttl = 100` with `retention_period = 30` (exceeds the data retention period)

Existing acceptance tests continue to use in-range values (`hot_ttl` of 0/7/10/30, `retention_period` of 30/35/3000, `max_split_shard_count` of 1/6/60) and remain valid.

## Notes

The `hot_ttl` lower bound follows the SLS CreateLogStore/UpdateLogStore API, where `hot_ttl` is "an integer from 7 to the value of `ttl`"; `0` is the value used to disable hot storage.
