### PR TITLE
New Resource: alicloud_gpdb_db_extension, New Data Source: alicloud_gpdb_db_extensions

### DIFF
--- a/alicloud/data_source_alicloud_gpdb_db_extensions.go
+++ b/alicloud/data_source_alicloud_gpdb_db_extensions.go
@@ -1,0 +1,217 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudGpdbDbExtensions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudGpdbDbExtensionRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"db_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"extensions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"current_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"extension_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"extension_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"is_install_need_restart": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"is_latest_version": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"latest_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudGpdbDbExtensionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListDatabaseExtensions"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if v, ok := d.GetOk("db_instance_id"); ok {
+		request["DBInstanceId"] = v
+	}
+	if v, ok := d.GetOk("database_name"); ok {
+		request["DatabaseName"] = v
+	}
+	request["DBInstanceId"] = d.Get("db_instance_id")
+	request["DatabaseName"] = d.Get("database_name")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+		response, err = client.RpcPost("gpdb", "2016-05-03", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	resp, _ := jsonpath.Get("$.Extensions[*]", response)
+
+	result, _ := resp.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		if len(idsMap) > 0 {
+			if _, ok := idsMap[fmt.Sprint(request["DBInstanceId"], ":", request["DatabaseName"], ":", item["ExtensionName"])]; !ok {
+				continue
+			}
+		}
+		objects = append(objects, item)
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(request["DBInstanceId"], ":", request["DatabaseName"], ":", objectRaw["ExtensionName"])
+
+		mapping["description"] = objectRaw["Description"]
+		mapping["status"] = objectRaw["Status"]
+		mapping["extension_name"] = objectRaw["ExtensionName"]
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(request["DBInstanceId"], ":", request["DatabaseName"], ":", objectRaw["ExtensionName"])
+		mapping, err = dataSourceAliCloudGpdbDbExtensionReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("extensions", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudGpdbDbExtensionReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	gpdbServiceV2 := GpdbServiceV2{client}
+	getResp, err := gpdbServiceV2.DescribeGpdbDbExtension(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["current_version"] = objectRaw["CurrentVersion"]
+	mapping["description"] = objectRaw["Description"]
+	mapping["extension_id"] = objectRaw["ExtensionId"]
+	mapping["is_install_need_restart"] = objectRaw["IsInstallNeedRestart"]
+	mapping["is_latest_version"] = objectRaw["IsLatestVersion"]
+	mapping["latest_version"] = objectRaw["LatestVersion"]
+	mapping["status"] = objectRaw["Status"]
+	mapping["extension_name"] = objectRaw["ExtensionName"]
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_gpdb_db_extensions_test.go
+++ b/alicloud/data_source_alicloud_gpdb_db_extensions_test.go
@@ -1,0 +1,134 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudGpdbDbExtensionDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	// db_instance_id and database_name are required request parameters of
+	// ListDatabaseExtensions rather than client-side filters, so they stay real in
+	// every case; ids is the filter that is exercised against a non-matching value.
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudGpdbDbExtensionSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_gpdb_db_extension.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudGpdbDbExtensionSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_gpdb_db_extension.default.id}_fake"]`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudGpdbDbExtensionSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_gpdb_db_extension.default.id}"]`,
+			"enable_details": `"true"`,
+		}),
+		fakeConfig: testAccCheckAlicloudGpdbDbExtensionSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_gpdb_db_extension.default.id}_fake"]`,
+			"enable_details": `"true"`,
+		}),
+	}
+
+	GpdbDbExtensionCheckInfo.dataSourceTestCheck(t, rand, idsConf, allConf)
+}
+
+var existGpdbDbExtensionMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"ids.#":                       "1",
+		"extensions.#":                "1",
+		"extensions.0.id":             CHECKSET,
+		"extensions.0.status":         CHECKSET,
+		"extensions.0.extension_name": CHECKSET,
+		"extensions.0.description":    CHECKSET,
+	}
+}
+
+var fakeGpdbDbExtensionMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"ids.#":        "0",
+		"extensions.#": "0",
+	}
+}
+
+var GpdbDbExtensionCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_gpdb_db_extensions.default",
+	existMapFunc: existGpdbDbExtensionMapFunc,
+	fakeMapFunc:  fakeGpdbDbExtensionMapFunc,
+}
+
+func testAccCheckAlicloudGpdbDbExtensionSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccGpdbDbExtension%d"
+}
+resource "alicloud_vpc" "defaultiYyNGW" {
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vswitch" "defaultPlruct" {
+  vpc_id     = alicloud_vpc.defaultiYyNGW.id
+  zone_id    = "cn-beijing-h"
+  cidr_block = "192.168.1.0/24"
+}
+
+resource "alicloud_gpdb_instance" "defaultqsmpIy" {
+  instance_spec         = "2C8G"
+  seg_node_num          = "2"
+  seg_storage_type      = "cloud_essd"
+  instance_network_type = "VPC"
+  db_instance_category  = "Basic"
+  payment_type          = "PayAsYouGo"
+  ssl_enabled           = "0"
+  engine_version        = "6.0"
+  engine                = "gpdb"
+  zone_id               = "cn-beijing-h"
+  vswitch_id            = alicloud_vswitch.defaultPlruct.id
+  storage_size          = "50"
+  master_cu             = "4"
+  vpc_id                = alicloud_vpc.defaultiYyNGW.id
+  db_instance_mode      = "StorageElastic"
+}
+
+resource "alicloud_gpdb_account" "defaultOwner" {
+  account_name        = "tf_example"
+  account_password    = "Example1234"
+  account_description = "tf_example"
+  db_instance_id      = alicloud_gpdb_instance.defaultqsmpIy.id
+}
+
+resource "alicloud_gpdb_database" "defaultPPmRVa" {
+  owner              = alicloud_gpdb_account.defaultOwner.account_name
+  database_name      = "seagull"
+  db_instance_id     = alicloud_gpdb_instance.defaultqsmpIy.id
+  character_set_name = "UTF8"
+  collate            = "en_US.utf8"
+  ctype              = "en_US.utf8"
+}
+
+resource "alicloud_gpdb_db_extension" "default" {
+  extension_name    = "uuid-ossp"
+  db_instance_id    = alicloud_gpdb_instance.defaultqsmpIy.id
+  database_name     = alicloud_gpdb_database.defaultPPmRVa.database_name
+  is_latest_version = true
+}
+
+data "alicloud_gpdb_db_extensions" "default" {
+  db_instance_id = alicloud_gpdb_instance.defaultqsmpIy.id
+  database_name  = alicloud_gpdb_db_extension.default.database_name
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -326,6 +326,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_mongo_instances":                                  dataSourceAliCloudMongoDBInstances(),
 			"alicloud_mongodb_instances":                                dataSourceAliCloudMongoDBInstances(),
 			"alicloud_mongodb_zones":                                    dataSourceAlicloudMongoDBZones(),
+			"alicloud_gpdb_db_extensions":                               dataSourceAliCloudGpdbDbExtensions(),
 			"alicloud_gpdb_instances":                                   dataSourceAlicloudGpdbInstances(),
 			"alicloud_gpdb_zones":                                       dataSourceAlicloudGpdbZones(),
 			"alicloud_kvstore_instances":                                dataSourceAlicloudKvstoreInstances(),
@@ -957,6 +958,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_gpdb_db_extension":                                    resourceAliCloudGpdbDbExtension(),
 			"alicloud_redis_global_security_ip_group":                       resourceAliCloudRedisGlobalSecurityIpGroup(),
 			"alicloud_cr_artifact_subscription_rule":                        resourceAliCloudCrArtifactSubscriptionRule(),
 			"alicloud_cms_event_notify_policy":                              resourceAliCloudCmsEventNotifyPolicy(),

--- a/alicloud/resource_alicloud_gpdb_db_extension.go
+++ b/alicloud/resource_alicloud_gpdb_db_extension.go
@@ -1,0 +1,253 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudGpdbDbExtension() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudGpdbDbExtensionCreate,
+		Read:   resourceAliCloudGpdbDbExtensionRead,
+		Update: resourceAliCloudGpdbDbExtensionUpdate,
+		Delete: resourceAliCloudGpdbDbExtensionDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"current_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"extension_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"extension_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"is_install_need_restart": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"is_latest_version": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"latest_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudGpdbDbExtensionCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateExtensions"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("extension_name"); ok {
+		request["Extensions"] = v
+	}
+	if v, ok := d.GetOk("database_name"); ok {
+		request["DBNames"] = v
+	}
+	if v, ok := d.GetOk("db_instance_id"); ok {
+		request["DBInstanceId"] = v
+	}
+	request["RegionId"] = client.RegionId
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("gpdb", "2016-05-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_gpdb_db_extension", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v:%v", request["DBInstanceId"], request["DBNames"], request["Extensions"]))
+
+	gpdbServiceV2 := GpdbServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{"installed"}, d.Timeout(schema.TimeoutCreate), 20*time.Second, gpdbServiceV2.GpdbDbExtensionStateRefreshFunc(d.Id(), "Status", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return resourceAliCloudGpdbDbExtensionUpdate(d, meta)
+}
+
+func resourceAliCloudGpdbDbExtensionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	gpdbServiceV2 := GpdbServiceV2{client}
+
+	objectRaw, err := gpdbServiceV2.DescribeGpdbDbExtension(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_gpdb_db_extension DescribeGpdbDbExtension Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("current_version", objectRaw["CurrentVersion"])
+	d.Set("description", objectRaw["Description"])
+	d.Set("extension_id", objectRaw["ExtensionId"])
+	d.Set("is_install_need_restart", objectRaw["IsInstallNeedRestart"])
+	d.Set("is_latest_version", objectRaw["IsLatestVersion"])
+	d.Set("latest_version", objectRaw["LatestVersion"])
+	d.Set("status", objectRaw["Status"])
+	d.Set("extension_name", objectRaw["ExtensionName"])
+
+	parts := strings.Split(d.Id(), ":")
+	d.Set("db_instance_id", parts[0])
+	d.Set("database_name", parts[1])
+
+	return nil
+}
+
+func resourceAliCloudGpdbDbExtensionUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+
+	gpdbServiceV2 := GpdbServiceV2{client}
+	objectRaw, err := gpdbServiceV2.DescribeGpdbDbExtension(d.Id())
+	if err != nil {
+		return WrapError(err)
+	}
+
+	initedIsLatestVersion := false
+	if _, ok := d.GetOkExists("is_latest_version"); ok && d.IsNewResource() {
+		initedIsLatestVersion = true
+	}
+	if initedIsLatestVersion || d.HasChange("is_latest_version") {
+		target := d.Get("is_latest_version").(bool)
+
+		currentStatus, err := jsonpath.Get("IsLatestVersion", objectRaw)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, d.Id(), "IsLatestVersion", objectRaw)
+		}
+		if formatBool(currentStatus) != target {
+			if target == true {
+				parts := strings.Split(d.Id(), ":")
+				action := "UpgradeExtensions"
+				request = make(map[string]interface{})
+				query = make(map[string]interface{})
+				request["Extensions"] = parts[2]
+				request["DatabaseName"] = parts[1]
+				request["DBInstanceId"] = parts[0]
+				request["RegionId"] = client.RegionId
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = client.RpcPost("gpdb", "2016-05-03", action, query, request, true)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+
+			}
+		}
+	}
+
+	return resourceAliCloudGpdbDbExtensionRead(d, meta)
+}
+
+func resourceAliCloudGpdbDbExtensionDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := "DeleteExtension"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["Extension"] = parts[2]
+	request["DBNames"] = parts[1]
+	request["DBInstanceId"] = parts[0]
+	request["RegionId"] = client.RegionId
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("gpdb", "2016-05-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"Extension.NotInstalled"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_gpdb_db_extension_test.go
+++ b/alicloud/resource_alicloud_gpdb_db_extension_test.go
@@ -1,0 +1,129 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Gpdb DbExtension. >>> Resource test cases, automatically generated.
+// Case 插件 - 跳过更新版本测试 7888
+func TestAccAliCloudGpdbDbExtension_basic7888(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_gpdb_db_extension.default"
+	ra := resourceAttrInit(resourceId, AlicloudGpdbDbExtensionMap7888)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GpdbServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGpdbDbExtension")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccgpdb%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudGpdbDbExtensionBasicDependence7888)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-beijing"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"extension_name":    "uuid-ossp",
+					"db_instance_id":    "${alicloud_gpdb_instance.defaultqsmpIy.id}",
+					"database_name":     "${alicloud_gpdb_database.defaultPPmRVa.database_name}",
+					"is_latest_version": true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"extension_name":    "uuid-ossp",
+						"db_instance_id":    CHECKSET,
+						"database_name":     CHECKSET,
+						"is_latest_version": "true",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// CreateExtensions always installs the newest available version, so a
+				// freshly created extension already reports IsLatestVersion = true and
+				// there is no API to install an older one. The false -> true transition
+				// this attribute drives therefore cannot be produced in a test.
+				ImportStateVerifyIgnore: []string{"is_latest_version"},
+			},
+		},
+	})
+}
+
+var AlicloudGpdbDbExtensionMap7888 = map[string]string{
+	"status":                  CHECKSET,
+	"description":             CHECKSET,
+	"is_install_need_restart": CHECKSET,
+	"latest_version":          CHECKSET,
+	"current_version":         CHECKSET,
+	"extension_id":            CHECKSET,
+}
+
+func AlicloudGpdbDbExtensionBasicDependence7888(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_vpc" "defaultiYyNGW" {
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vswitch" "defaultPlruct" {
+  vpc_id     = alicloud_vpc.defaultiYyNGW.id
+  zone_id    = "cn-beijing-h"
+  cidr_block = "192.168.1.0/24"
+}
+
+resource "alicloud_gpdb_instance" "defaultqsmpIy" {
+  instance_spec         = "2C8G"
+  seg_node_num          = "2"
+  seg_storage_type      = "cloud_essd"
+  instance_network_type = "VPC"
+  db_instance_category  = "Basic"
+  payment_type          = "PayAsYouGo"
+  ssl_enabled           = "0"
+  engine_version        = "6.0"
+  engine                = "gpdb"
+  zone_id               = "cn-beijing-h"
+  vswitch_id            = alicloud_vswitch.defaultPlruct.id
+  storage_size          = "50"
+  master_cu             = "4"
+  vpc_id                = alicloud_vpc.defaultiYyNGW.id
+  db_instance_mode      = "StorageElastic"
+}
+
+resource "alicloud_gpdb_account" "defaultOwner" {
+  account_name        = "tf_example"
+  account_password    = "Example1234"
+  account_description = "tf_example"
+  db_instance_id      = alicloud_gpdb_instance.defaultqsmpIy.id
+}
+
+resource "alicloud_gpdb_database" "defaultPPmRVa" {
+  owner              = alicloud_gpdb_account.defaultOwner.account_name
+  database_name      = "seagull"
+  db_instance_id     = alicloud_gpdb_instance.defaultqsmpIy.id
+  character_set_name = "UTF8"
+  collate            = "en_US.utf8"
+  ctype              = "en_US.utf8"
+}
+
+
+`, name)
+}
+
+// Test Gpdb DbExtension. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_gpdb_v2.go
+++ b/alicloud/service_alicloud_gpdb_v2.go
@@ -1076,3 +1076,88 @@ func (s *GpdbServiceV2) GpdbApiKeyStateRefreshFuncWithApi(id string, field strin
 }
 
 // DescribeGpdbApiKey >>> Encapsulated.
+
+// DescribeGpdbDbExtension <<< Encapsulated get interface for Gpdb DbExtension.
+
+func (s *GpdbServiceV2) DescribeGpdbDbExtension(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 3 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 3, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["DBInstanceId"] = parts[0]
+	request["DatabaseName"] = parts[1]
+	request["ExtensionName"] = parts[2]
+
+	action := "DescribeExtension"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("gpdb", "2016-05-03", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"Extension.NotInstalled"}) {
+			return object, WrapErrorf(NotFoundErr("DbExtension", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	// DescribeExtension describes the instance's extension catalog: an extension that is
+	// not installed comes back with HTTP 200 and Status "uninstalled" rather than an error
+	// code, so that status is what marks the resource as absent.
+	if fmt.Sprint(response["Status"]) == "uninstalled" {
+		return object, WrapErrorf(NotFoundErr("DbExtension", id), NotFoundMsg, response)
+	}
+
+	return response, nil
+}
+
+func (s *GpdbServiceV2) GpdbDbExtensionStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.GpdbDbExtensionStateRefreshFuncWithApi(id, field, failStates, s.DescribeGpdbDbExtension)
+}
+
+func (s *GpdbServiceV2) GpdbDbExtensionStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeGpdbDbExtension >>> Encapsulated.

--- a/website/docs/d/gpdb_db_extensions.html.markdown
+++ b/website/docs/d/gpdb_db_extensions.html.markdown
@@ -1,0 +1,116 @@
+---
+subcategory: "AnalyticDB for PostgreSQL (GPDB)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_gpdb_db_extensions"
+sidebar_current: "docs-alicloud-datasource-gpdb-db-extensions"
+description: |-
+  Provides a list of Gpdb Db Extension owned by an Alibaba Cloud account.
+---
+
+# alicloud_gpdb_db_extensions
+
+This data source provides Gpdb Db Extension available to the user.[What is Db Extension](https://next.api.alibabacloud.com/document/gpdb/2016-05-03/CreateExtensions)
+
+-> **NOTE:** Available since v1.291.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-beijing"
+}
+
+resource "alicloud_vpc" "defaultiYyNGW" {
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vswitch" "defaultPlruct" {
+  vpc_id     = alicloud_vpc.defaultiYyNGW.id
+  zone_id    = "cn-beijing-h"
+  cidr_block = "192.168.1.0/24"
+}
+
+resource "alicloud_gpdb_instance" "defaultqsmpIy" {
+  instance_spec         = "2C8G"
+  seg_node_num          = "2"
+  seg_storage_type      = "cloud_essd"
+  instance_network_type = "VPC"
+  db_instance_category  = "Basic"
+  payment_type          = "PayAsYouGo"
+  ssl_enabled           = "0"
+  engine_version        = "6.0"
+  engine                = "gpdb"
+  zone_id               = "cn-beijing-h"
+  vswitch_id            = alicloud_vswitch.defaultPlruct.id
+  storage_size          = "50"
+  master_cu             = "4"
+  vpc_id                = alicloud_vpc.defaultiYyNGW.id
+  db_instance_mode      = "StorageElastic"
+}
+
+resource "alicloud_gpdb_account" "defaultOwner" {
+  account_name        = "tf_example"
+  account_password    = "Example1234"
+  account_description = "tf_example"
+  db_instance_id      = alicloud_gpdb_instance.defaultqsmpIy.id
+}
+
+resource "alicloud_gpdb_database" "defaultPPmRVa" {
+  owner              = alicloud_gpdb_account.defaultOwner.account_name
+  database_name      = "seagull"
+  db_instance_id     = alicloud_gpdb_instance.defaultqsmpIy.id
+  character_set_name = "UTF8"
+  collate            = "en_US.utf8"
+  ctype              = "en_US.utf8"
+}
+
+
+resource "alicloud_gpdb_db_extension" "default" {
+  extension_name    = "uuid-ossp"
+  db_instance_id    = alicloud_gpdb_instance.defaultqsmpIy.id
+  database_name     = alicloud_gpdb_database.defaultPPmRVa.database_name
+  is_latest_version = true
+}
+
+data "alicloud_gpdb_db_extensions" "default" {
+  ids            = ["${alicloud_gpdb_db_extension.default.id}"]
+  db_instance_id = alicloud_gpdb_instance.defaultqsmpIy.id
+  database_name  = alicloud_gpdb_database.defaultPPmRVa.database_name
+}
+
+output "alicloud_gpdb_db_extension_example_id" {
+  value = data.alicloud_gpdb_db_extensions.default.extensions.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `db_instance_id` - (Required) The instance ID.
+
+-> **NOTE:**   You can call the [DescribeDBInstances](https://www.alibabacloud.com/help/en/doc-detail/86911.html) operation to query the information about all AnalyticDB for PostgreSQL instances within a region, including instance IDs.
+
+* `database_name` - (Required) The name of the database.
+* `ids` - (Optional, Computed) A list of Db Extension IDs. The value is formulated as `<db_instance_id>:<database_name>:<extension_name>`.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Db Extension IDs.
+* `extensions` - A list of Db Extension Entries. Each element contains the following attributes:
+  * `current_version` - **NOTE:** This field is only available when `enable_details` is `true`. Plug-in current version.
+  * `description` - Plug-in description.
+  * `extension_id` - **NOTE:** This field is only available when `enable_details` is `true`. Plug-in id.
+  * `extension_name` - The name of the extension to install.
+  * `is_install_need_restart` - **NOTE:** This field is only available when `enable_details` is `true`. Whether the instance needs to be restarted for installation.
+  * `is_latest_version` - **NOTE:** This field is only available when `enable_details` is `true`. Whether the extension is at its latest version.
+  * `latest_version` - **NOTE:** This field is only available when `enable_details` is `true`. Plug-in latest version.
+  * `status` - The status of the extension.
+  * `id` - The ID of the resource supplied above.

--- a/website/docs/r/gpdb_db_extension.html.markdown
+++ b/website/docs/r/gpdb_db_extension.html.markdown
@@ -1,0 +1,120 @@
+---
+subcategory: "AnalyticDB for PostgreSQL (GPDB)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_gpdb_db_extension"
+description: |-
+  Provides a Alicloud AnalyticDB for PostgreSQL (GPDB) Db Extension resource.
+---
+
+# alicloud_gpdb_db_extension
+
+Provides a AnalyticDB for PostgreSQL (GPDB) Db Extension resource.
+
+
+
+For information about AnalyticDB for PostgreSQL (GPDB) Db Extension and how to use it, see [What is Db Extension](https://next.api.alibabacloud.com/document/gpdb/2016-05-03/CreateExtensions).
+
+-> **NOTE:** Available since v1.291.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-beijing"
+}
+
+resource "alicloud_vpc" "defaultiYyNGW" {
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vswitch" "defaultPlruct" {
+  vpc_id     = alicloud_vpc.defaultiYyNGW.id
+  zone_id    = "cn-beijing-h"
+  cidr_block = "192.168.1.0/24"
+}
+
+resource "alicloud_gpdb_instance" "defaultqsmpIy" {
+  instance_spec         = "2C8G"
+  seg_node_num          = "2"
+  seg_storage_type      = "cloud_essd"
+  instance_network_type = "VPC"
+  db_instance_category  = "Basic"
+  payment_type          = "PayAsYouGo"
+  ssl_enabled           = "0"
+  engine_version        = "6.0"
+  engine                = "gpdb"
+  zone_id               = "cn-beijing-h"
+  vswitch_id            = alicloud_vswitch.defaultPlruct.id
+  storage_size          = "50"
+  master_cu             = "4"
+  vpc_id                = alicloud_vpc.defaultiYyNGW.id
+  db_instance_mode      = "StorageElastic"
+}
+
+resource "alicloud_gpdb_account" "defaultOwner" {
+  account_name        = "tf_example"
+  account_password    = "Example1234"
+  account_description = "tf_example"
+  db_instance_id      = alicloud_gpdb_instance.defaultqsmpIy.id
+}
+
+resource "alicloud_gpdb_database" "defaultPPmRVa" {
+  owner              = alicloud_gpdb_account.defaultOwner.account_name
+  database_name      = "seagull"
+  db_instance_id     = alicloud_gpdb_instance.defaultqsmpIy.id
+  character_set_name = "UTF8"
+  collate            = "en_US.utf8"
+  ctype              = "en_US.utf8"
+}
+
+
+resource "alicloud_gpdb_db_extension" "default" {
+  extension_name       = "uuid-ossp"
+  db_instance_id       = alicloud_gpdb_instance.defaultqsmpIy.id
+  database_name        = alicloud_gpdb_database.defaultPPmRVa.database_name
+  is_laexample_version = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `db_instance_id` - (Required, ForceNew) The instance ID.
+
+-> **NOTE:**   You can call the [DescribeDBInstances](https://www.alibabacloud.com/help/en/doc-detail/86911.html) operation to query the information about all AnalyticDB for PostgreSQL instances within a region, including instance IDs.
+
+* `database_name` - (Required, ForceNew) The name of the database.
+* `extension_name` - (Required, ForceNew) The name of the extension to install. Each resource manages exactly one extension; multiple extension names are not supported.
+* `is_latest_version` - (Optional) Whether the extension is at its latest version. Setting it to true calls UpgradeExtensions to upgrade the extension to the latest version. Leaving it unset or setting it to false triggers no upgrade and does not downgrade the extension. On read, this field is refreshed with the actual value returned by the server.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<db_instance_id>:<database_name>:<extension_name>`.
+* `current_version` - Plug-in current version.
+* `description` - Plug-in description.
+* `extension_id` - Plug-in id.
+* `is_install_need_restart` - Whether the instance needs to be restarted for installation.
+* `latest_version` - Plug-in latest version.
+* `status` - The status of the extension.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Db Extension.
+* `delete` - (Defaults to 5 mins) Used when delete the Db Extension.
+* `update` - (Defaults to 5 mins) Used when update the Db Extension.
+
+## Import
+
+AnalyticDB for PostgreSQL (GPDB) Db Extension can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_gpdb_db_extension.example <db_instance_id>:<database_name>:<extension_name>
+```


### PR DESCRIPTION
This PR adds the `alicloud_gpdb_db_extension` resource and `alicloud_gpdb_db_extensions` data source for managing AnalyticDB for PostgreSQL database extensions.

### Resource: alicloud_gpdb_db_extension

Manages a database extension installed on a GPDB instance database.

**Arguments:**
- `db_instance_id` - (Required, ForceNew) The instance ID.
- `database_name` - (Required, ForceNew) The name of the database.
- `extension_name` - (Required, ForceNew) The name of the extension.
- `is_latest_version` - (Optional) Whether to upgrade the extension to the latest version.

**Attributes (computed):**
- `current_version` - The current version of the extension.
- `description` - The description of the extension.
- `extension_id` - The extension ID.
- `is_install_need_restart` - Whether a restart is required after installation.
- `latest_version` - The latest version of the extension.
- `status` - The status of the extension.

**API mapping:**
- Create: `CreateExtensions`
- Read: `DescribeExtension`
- Update: `UpgradeExtensions` (triggered when `is_latest_version` is set to true and the extension is not already on the latest version)
- Delete: `DeleteExtension`

**Import:**

```shell
$ terraform import alicloud_gpdb_db_extension.example <db_instance_id>:<database_name>:<extension_name>
```

### Data Source: alicloud_gpdb_db_extensions

Lists the extensions of a GPDB instance database via the `ListDatabaseExtensions` API, matching the granularity of the resource.

**Arguments:**
- `db_instance_id` - (Required) The instance ID.
- `database_name` - (Required) The name of the database.
- `ids` - (Optional) A list of extension IDs, formulated as `<db_instance_id>:<database_name>:<extension_name>`.
- `enable_details` - (Optional) Set to `true` to fetch the full attribute set for each entry.
- `output_file` - (Optional) File name where to save data source results.

### Test cases

```
=== RUN TestAccAliCloudGpdbDbExtension_basic7888
--- PASS: TestAccAliCloudGpdbDbExtension_basic7888 (727.35s)

=== RUN TestAccAlicloudGpdbDbExtensionDataSource
--- PASS: TestAccAlicloudGpdbDbExtensionDataSource (875.40s)
```


### Note on the failing `tflint` check

`tflint` reports:

```
alicloud/resource_alicloud_polardb_gateway.go:208:19: R001: ResourceData.Set() key argument should be string literal
```

This violation is **pre-existing on `master`** and is **not introduced by this PR** — this PR does not touch `alicloud/resource_alicloud_polardb_gateway.go` at all. The file was added to `master` in `75bfc8b27` already containing the map-driven `d.Set(key, value)` loop that R001 flags.

`scripts/run-tflint.sh` runs `tfproviderlint` over the whole `./alicloud/...` package and then filters findings down to the files changed in the PR. In this PR's CI environment that filter does not exclude the file, so the pre-existing finding surfaces here.

Suggested handling: fix `resource_alicloud_polardb_gateway.go` on `master` separately (expand the loop into literal `d.Set("status", ...)` calls). This PR is intentionally scoped to the GPDB extension resource and data source only.
