### PR TITLE
resource/alicloud_rocketmq_instance: support deleting subscription instances, deprecate maintain_time; resource/alicloud_polardb_gateway: use literal attribute keys in Read

### DIFF
--- a/alicloud/resource_alicloud_polardb_gateway.go
+++ b/alicloud/resource_alicloud_polardb_gateway.go
@@ -199,15 +199,49 @@ func resourceAlicloudPolarDBGatewayRead(d *schema.ResourceData, meta interface{}
 	if err = d.Set("region_id", client.RegionId); err != nil {
 		return WrapError(err)
 	}
-	for key, responseKey := range map[string]string{
-		"status": "Status", "description": "GwDescription", "create_time": "CreateTime",
-		"modify_time": "ModifyTime", "expire_time": "ExpireTime", "expired": "Expired",
-		"latest_version": "LatestVersion", "current_version": "CurrentVersion", "running_version": "RunningVersion",
-	} {
-		if value, ok := object[responseKey]; ok && value != nil {
-			if err = d.Set(key, value); err != nil {
-				return WrapError(err)
-			}
+	if value, ok := object["Status"]; ok && value != nil {
+		if err = d.Set("status", value); err != nil {
+			return WrapError(err)
+		}
+	}
+	if value, ok := object["GwDescription"]; ok && value != nil {
+		if err = d.Set("description", value); err != nil {
+			return WrapError(err)
+		}
+	}
+	if value, ok := object["CreateTime"]; ok && value != nil {
+		if err = d.Set("create_time", value); err != nil {
+			return WrapError(err)
+		}
+	}
+	if value, ok := object["ModifyTime"]; ok && value != nil {
+		if err = d.Set("modify_time", value); err != nil {
+			return WrapError(err)
+		}
+	}
+	if value, ok := object["ExpireTime"]; ok && value != nil {
+		if err = d.Set("expire_time", value); err != nil {
+			return WrapError(err)
+		}
+	}
+	if value, ok := object["Expired"]; ok && value != nil {
+		if err = d.Set("expired", value); err != nil {
+			return WrapError(err)
+		}
+	}
+	if value, ok := object["LatestVersion"]; ok && value != nil {
+		if err = d.Set("latest_version", value); err != nil {
+			return WrapError(err)
+		}
+	}
+	if value, ok := object["CurrentVersion"]; ok && value != nil {
+		if err = d.Set("current_version", value); err != nil {
+			return WrapError(err)
+		}
+	}
+	if value, ok := object["RunningVersion"]; ok && value != nil {
+		if err = d.Set("running_version", value); err != nil {
+			return WrapError(err)
 		}
 	}
 	if err = d.Set("endpoints", flattenPolarDBGatewayEndpoints(object["Endpoints"])); err != nil {

--- a/alicloud/resource_alicloud_rocketmq_instance.go
+++ b/alicloud/resource_alicloud_rocketmq_instance.go
@@ -292,9 +292,10 @@ func resourceAliCloudRocketmqInstance() *schema.Resource {
 							Computed: true,
 						},
 						"maintain_time": {
-							Type:     schema.TypeString,
-							Optional: true,
-							Computed: true,
+							Type:       schema.TypeString,
+							Optional:   true,
+							Computed:   true,
+							Deprecated: "Field 'maintain_time' has been deprecated from provider version 1.291.0. The GetInstance operation no longer returns this field. Although the value is still accepted on write, it cannot be read back. Manage the maintenance window of the instance in the ApsaraMQ for RocketMQ console.",
 						},
 					},
 				},
@@ -859,6 +860,11 @@ func resourceAliCloudRocketmqInstanceUpdate(d *schema.ResourceData, meta interfa
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
+		rocketmqServiceV2 := RocketmqServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{"RUNNING"}, d.Timeout(schema.TimeoutUpdate), 2*time.Minute, rocketmqServiceV2.RocketmqInstanceStateRefreshFunc(d.Id(), "status", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
 	}
 
 	update = false
@@ -998,12 +1004,83 @@ func resourceAliCloudRocketmqInstanceUpdate(d *schema.ResourceData, meta interfa
 
 func resourceAliCloudRocketmqInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 
+	client := meta.(*connectivity.AliyunClient)
+
 	if d.Get("payment_type").(string) == "Subscription" {
-		log.Printf("[WARN] Cannot destroy Subscription resource: alicloud_rocketmq_instance. Terraform will remove this resource from the state file, however resources may remain.")
+		// The RocketMQ DeleteInstance operation only releases pay-as-you-go instances,
+		// so a subscription instance is refunded and released through BssOpenApi.
+		// Otherwise `terraform destroy` would succeed silently while the instance
+		// keeps existing (and billing) until it expires.
+		bssOpenApiService := BssOpenApiService{client}
+		queryAvailableInstancesObject, err := bssOpenApiService.QueryAvailableInstancesWithoutProductType(d.Id(), client.RegionId, "ons", "ons")
+		if err != nil {
+			if NotFoundError(err) {
+				rocketmqServiceV2 := RocketmqServiceV2{client}
+				if _, err := rocketmqServiceV2.DescribeRocketmqInstance(d.Id()); err != nil {
+					if NotFoundError(err) {
+						return nil
+					}
+					return WrapError(err)
+				}
+				return WrapError(Error("The subscription RocketMQ instance %s still exists but its billing record was not found, so it cannot be refunded and released automatically. Please release it manually or wait for it to expire.", d.Id()))
+			}
+			return WrapError(err)
+		}
+
+		action := "RefundInstance"
+		var request map[string]interface{}
+		var response map[string]interface{}
+		query := make(map[string]interface{})
+		var endpoint string
+		request = make(map[string]interface{})
+		request["InstanceId"] = d.Id()
+
+		request["ClientToken"] = buildClientToken(action)
+
+		request["ImmediatelyRelease"] = "1"
+		request["ProductCode"] = "ons"
+		if v, ok := queryAvailableInstancesObject["ProductCode"]; ok && fmt.Sprint(v) != "" {
+			request["ProductCode"] = fmt.Sprint(v)
+		}
+		request["ProductType"] = ""
+		if v, ok := queryAvailableInstancesObject["ProductType"]; ok {
+			request["ProductType"] = fmt.Sprint(v)
+		}
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+			response, err = client.RpcPostWithEndpoint("BssOpenApi", "2017-12-14", action, query, request, true, endpoint)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				if !client.IsInternationalAccount() && IsExpectedErrors(err, []string{"NotApplicable"}) {
+					endpoint = connectivity.BssOpenAPIEndpointInternational
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+
+		if err != nil {
+			// ResourceNotExists / ExistRefundingOrderError mean the instance has already
+			// been refunded, expired or released; still verify below that it is gone.
+			if !IsExpectedErrors(err, []string{"ResourceNotExists", "ExistRefundingOrderError"}) && !NotFoundError(err) {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+		}
+
+		rocketmqServiceV2 := RocketmqServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{}, d.Timeout(schema.TimeoutDelete), 5*time.Minute, rocketmqServiceV2.RocketmqInstanceStateRefreshFunc(d.Id(), "$.instanceId", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+
 		return nil
 	}
 
-	client := meta.(*connectivity.AliyunClient)
 	instanceId := d.Id()
 	action := fmt.Sprintf("/instances/%s", instanceId)
 	var request map[string]interface{}

--- a/alicloud/resource_alicloud_rocketmq_instance_test.go
+++ b/alicloud/resource_alicloud_rocketmq_instance_test.go
@@ -43,8 +43,9 @@ func TestAccAliCloudRocketmqInstance_SendReceiveRatioValidation(t *testing.T) {
 					"instance_name": name,
 					"product_info": []map[string]interface{}{
 						{
-							"msg_process_spec":       "rmq.p2.4xlarge",
-							"send_receive_ratio":     "0.03", // This should be out of range [0.05, 0.5] to test validation
+							"msg_process_spec": "rmq.p2.4xlarge",
+							// This value is out of range [0.05, 0.5] to test validation
+							"send_receive_ratio":     "0.03",
 							"message_retention_time": "70",
 						},
 					},
@@ -451,6 +452,19 @@ func TestAccAliCloudRocketmqInstance_basic4665(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"software": []map[string]interface{}{
+						{},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"software.0.software_version": CHECKSET,
+						"software.0.upgrade_method":   CHECKSET,
+					}),
+				),
+			},
+			{
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -797,7 +811,7 @@ func TestAccAliCloudRocketmqInstance_basic4128(t *testing.T) {
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
-		CheckDestroy:  nil, // bypass linter, prepaid (Subscription) resource cannot destroy
+		CheckDestroy:  rac.checkResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -1629,7 +1643,7 @@ func TestAccAliCloudRocketmqInstance_basic4128_twin(t *testing.T) {
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
-		CheckDestroy:  nil, // bypass linter, postpay resource cannot destroy
+		CheckDestroy:  rac.checkResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{

--- a/website/docs/r/rocketmq_instance.html.markdown
+++ b/website/docs/r/rocketmq_instance.html.markdown
@@ -69,9 +69,6 @@ resource "alicloud_rocketmq_instance" "default" {
   resource_group_id = data.alicloud_resource_manager_resource_groups.default.ids.0
   remark            = "example"
   ip_whitelists     = ["192.168.0.0/16", "10.10.0.0/16", "172.168.0.0/16"]
-  software {
-    maintain_time = "02:00-06:00"
-  }
   tags = {
     Created = "TF"
     For     = "example"
@@ -95,9 +92,8 @@ resource "alicloud_rocketmq_instance" "default" {
 
 ### Deleting `alicloud_rocketmq_instance` or removing it from your configuration
 
-The `alicloud_rocketmq_instance` resource allows you to manage  `payment_type = "Subscription"`  instance, but Terraform cannot destroy it.
-Deleting the subscription resource or removing it from your configuration will remove it from your state file and management, but will not destroy the Instance.
-You can resume managing the subscription instance via the AlibabaCloud Console.
+The `alicloud_rocketmq_instance` resource allows you to manage  `payment_type = "Subscription"`  instance.
+Destroying a subscription instance unsubscribes it through the billing API and releases it, and the unused prepaid amount is refunded. Pay-as-you-go instances are released directly through the RocketMQ API.
 
 📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_rocketmq_instance&spm=docs.r.rocketmq_instance.example&intl_lang=EN_US)
 
@@ -216,7 +212,7 @@ The product_info supports the following:
 ### `software`
 
 The software supports the following:
-* `maintain_time` - (Optional) Upgrade time period.
+* `maintain_time` - (Optional, Deprecated since v1.291.0) Field `maintain_time` has been deprecated from provider version 1.291.0. The GetInstance operation no longer returns this field. Although the value is still accepted on write, it cannot be read back. Manage the maintenance window of the instance in the ApsaraMQ for RocketMQ console.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary
- `alicloud_rocketmq_instance` previously skipped deletion for `payment_type = "Subscription"` instances: `terraform destroy` succeeded silently, removed the resource from the state, but left the cloud instance (and its billing) alive until expiration.
- The RocketMQ DeleteInstance operation only releases pay-as-you-go instances. Subscription instances are now unsubscribed through `BssOpenApi::RefundInstance` with `ImmediatelyRelease = 1`, so the instance is actually released and the unused prepaid amount is refunded.
- The refund request reads the instance's `ProductCode`/`ProductType` from its billing record via `QueryAvailableInstances` (the same lookup the resource Read already uses), instead of hardcoding commodity codes.
- Deletion stays idempotent: destroy succeeds when the billing record or the instance is already gone, and when the refund API reports the instance was already refunded/released the provider still waits until the instance disappears. If the instance cannot be refunded automatically, destroy now returns a descriptive error instead of silently leaking the instance.
- Documentation and acceptance tests are updated accordingly: the Subscription test cases now use the standard destroy check, and `software.maintain_time` coverage is added.
- `alicloud_polardb_gateway`: replace the loop-variable `d.Set` key in Read with literal attribute keys (tfproviderlint R001).

## Test plan
- [x] Local: `go build ./alicloud/` and `go vet -p=1 ./alicloud/` pass.
- [x] Local: testing coverage rate check reports 100% test coverage and 100% modified coverage for `alicloud_rocketmq_instance`.
- [ ] `TestAccAliCloudRocketmqInstance_basic4128` / `TestAccAliCloudRocketmqInstance_basic4128_twin` (Subscription, create -> update auto_renew -> destroy via refund) pending acceptance run.
- [ ] `TestAccAliCloudRocketmqInstance_basic4665` (PayAsYouGo regression + `software.maintain_time` update) pending acceptance run.
