### PR TITLE
New Data Source: alicloud_milvus_instances

### DIFF
--- a/alicloud/data_source_alicloud_milvus_instances.go
+++ b/alicloud/data_source_alicloud_milvus_instances.go
@@ -1,0 +1,439 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudMilvusInstances() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudMilvusInstanceRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auto_backup": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"components": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cu_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"cu_num": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"data_disk": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"storage_class": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"size": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"performance_level": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"enabled": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"disk_size_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"pay_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"replica": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"configuration": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"db_version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"encrypted": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"expire_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ha": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"instance_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"multi_zone_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"order_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"payment_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"running_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"security_group_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"vswitch_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"vsw_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"zone_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"zone_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudMilvusInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListInstancesV2
+	action := fmt.Sprintf("/webapi/instance/list")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	query["RegionId"] = StringPointer(client.RegionId)
+	query["instanceId"] = StringPointer(d.Get("instance_id").(string))
+	if v, ok := d.GetOk("instance_id"); ok {
+		query["instanceId"] = StringPointer(v.(string))
+	}
+
+	request["instancename"] = d.Get("instance_name")
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		query["resourceGroupId"] = StringPointer(v.(string))
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		tagsMap := v.(map[string]interface{})
+		tagList := make([]interface{}, 0)
+		for key, value := range tagsMap {
+			tagItem := map[string]interface{}{
+				"Key":   key,
+				"Value": value,
+			}
+			tagList = append(tagList, tagItem)
+		}
+		tagJSON, _ := json.Marshal(tagList)
+		query["tag"] = StringPointer(string(tagJSON))
+	}
+
+	query["PageSize"] = StringPointer(strconv.Itoa(PageSizeLarge))
+	query["PageNumber"] = StringPointer("1")
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaGet("milvus", "2023-10-12", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.instances[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["instanceName"])) {
+				continue
+			}
+			if instanceNameFilter, ok := d.GetOk("instance_name"); ok {
+				if fmt.Sprint(item["instanceName"]) != instanceNameFilter.(string) {
+					continue
+				}
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["instanceId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		pageNum, _ := strconv.Atoi(*query["PageNumber"])
+		query["PageNumber"] = StringPointer(strconv.Itoa(pageNum + 1))
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["instanceId"]
+
+		mapping["auto_backup"] = objectRaw["autoBackup"]
+		mapping["configuration"] = objectRaw["configuration"]
+		mapping["create_time"] = objectRaw["createTime"]
+		mapping["db_version"] = objectRaw["dbVersion"]
+		mapping["encrypted"] = objectRaw["encrypted"]
+		mapping["expire_time"] = objectRaw["expireTime"]
+		mapping["ha"] = objectRaw["ha"]
+		mapping["instance_name"] = objectRaw["instanceName"]
+		mapping["kms_key_id"] = objectRaw["kmsKeyId"]
+		mapping["multi_zone_mode"] = objectRaw["multiZoneMode"]
+		mapping["order_id"] = objectRaw["orderId"]
+		mapping["payment_type"] = objectRaw["paymentType"]
+		mapping["region_id"] = objectRaw["regionId"]
+		mapping["resource_group_id"] = objectRaw["resourceGroupId"]
+		mapping["running_time"] = objectRaw["runningTime"]
+		mapping["status"] = objectRaw["status"]
+		mapping["vpc_id"] = objectRaw["vpcId"]
+		mapping["zone_id"] = objectRaw["zoneId"]
+		mapping["instance_id"] = objectRaw["instanceId"]
+
+		componentsRaw := objectRaw["components"]
+		componentsMaps := make([]map[string]interface{}, 0)
+		if componentsRaw != nil {
+			for _, componentsChildRaw := range convertToInterfaceArray(componentsRaw) {
+				componentsMap := make(map[string]interface{})
+				componentsChildRaw := componentsChildRaw.(map[string]interface{})
+				componentsMap["cu_num"] = componentsChildRaw["cuNum"]
+				componentsMap["cu_type"] = componentsChildRaw["cuType"]
+				componentsMap["disk_size_type"] = componentsChildRaw["diskSizeType"]
+				componentsMap["pay_type"] = componentsChildRaw["payType"]
+				componentsMap["replica"] = componentsChildRaw["replica"]
+				componentsMap["type"] = componentsChildRaw["type"]
+
+				dataDiskMaps := make([]map[string]interface{}, 0)
+				dataDiskMap := make(map[string]interface{})
+				dataDiskRaw := make(map[string]interface{})
+				if componentsChildRaw["dataDisk"] != nil {
+					dataDiskRaw = componentsChildRaw["dataDisk"].(map[string]interface{})
+				}
+				if len(dataDiskRaw) > 0 {
+					dataDiskMap["enabled"] = dataDiskRaw["enabled"]
+					dataDiskMap["performance_level"] = dataDiskRaw["performanceLevel"]
+					dataDiskMap["size"] = dataDiskRaw["size"]
+					dataDiskMap["storage_class"] = dataDiskRaw["storageClass"]
+
+					dataDiskMaps = append(dataDiskMaps, dataDiskMap)
+				}
+				componentsMap["data_disk"] = dataDiskMaps
+				componentsMaps = append(componentsMaps, componentsMap)
+			}
+		}
+		mapping["components"] = componentsMaps
+		securityGroupIdsRaw := make([]interface{}, 0)
+		if objectRaw["securityGroupIds"] != nil {
+			securityGroupIdsRaw = convertToInterfaceArray(objectRaw["securityGroupIds"])
+		}
+
+		mapping["security_group_ids"] = securityGroupIdsRaw
+		tagsMaps := objectRaw["tags"]
+		mapping["tags"] = tagsToMap(tagsMaps)
+		vSwitchIdsRaw := objectRaw["vSwitchIds"]
+		vSwitchIdsMaps := make([]map[string]interface{}, 0)
+		if vSwitchIdsRaw != nil {
+			for _, vSwitchIdsChildRaw := range convertToInterfaceArray(vSwitchIdsRaw) {
+				vSwitchIdsMap := make(map[string]interface{})
+				vSwitchIdsChildRaw := vSwitchIdsChildRaw.(map[string]interface{})
+				vSwitchIdsMap["vsw_id"] = vSwitchIdsChildRaw["vswId"]
+				vSwitchIdsMap["zone_id"] = vSwitchIdsChildRaw["zoneId"]
+
+				vSwitchIdsMaps = append(vSwitchIdsMaps, vSwitchIdsMap)
+			}
+		}
+		mapping["vswitch_ids"] = vSwitchIdsMaps
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["instanceName"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("instances", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_milvus_instances_test.go
+++ b/alicloud/data_source_alicloud_milvus_instances_test.go
@@ -1,0 +1,191 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudMilvusInstanceDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudMilvusInstanceSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_milvus_instance.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudMilvusInstanceSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_milvus_instance.default.id}_fake"]`,
+		}),
+	}
+
+	ResourceGroupIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudMilvusInstanceSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_milvus_instance.default.id}"]`,
+			"resource_group_id": `"${data.alicloud_resource_manager_resource_groups.default.ids.0}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudMilvusInstanceSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_milvus_instance.default.id}_fake"]`,
+			"resource_group_id": `"${data.alicloud_resource_manager_resource_groups.default.ids.0}_fake"`,
+		}),
+	}
+	InstanceNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudMilvusInstanceSourceConfig(rand, map[string]string{
+			"ids":           `["${alicloud_milvus_instance.default.id}"]`,
+			"instance_name": `"${var.name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudMilvusInstanceSourceConfig(rand, map[string]string{
+			"ids":           `["${alicloud_milvus_instance.default.id}_fake"]`,
+			"instance_name": `"${var.name}_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudMilvusInstanceSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_milvus_instance.default.id}"]`,
+			"resource_group_id": `"${data.alicloud_resource_manager_resource_groups.default.ids.0}"`,
+			"instance_name":     `"${var.name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudMilvusInstanceSourceConfig(rand, map[string]string{
+			"ids":               `["${alicloud_milvus_instance.default.id}_fake"]`,
+			"resource_group_id": `"${data.alicloud_resource_manager_resource_groups.default.ids.0}_fake"`,
+			"instance_name":     `"${var.name}_fake"`,
+		}),
+	}
+
+	MilvusInstanceCheckInfo.dataSourceTestCheck(t, rand, idsConf, ResourceGroupIdConf, InstanceNameConf, allConf)
+}
+
+var existMilvusInstanceMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"instances.#":                      "1",
+		"instances.0.resource_group_id":    CHECKSET,
+		"instances.0.configuration":        CHECKSET,
+		"instances.0.encrypted":            CHECKSET,
+		"instances.0.components.#":         CHECKSET,
+		"instances.0.db_version":           CHECKSET,
+		"instances.0.ha":                   CHECKSET,
+		"instances.0.payment_type":         CHECKSET,
+		"instances.0.auto_backup":          CHECKSET,
+		"instances.0.tags.%":               CHECKSET,
+		"instances.0.status":               CHECKSET,
+		"instances.0.zone_id":              CHECKSET,
+		"instances.0.instance_id":          CHECKSET,
+		"instances.0.vswitch_ids.#":        CHECKSET,
+		"instances.0.create_time":          CHECKSET,
+		"instances.0.order_id":             CHECKSET,
+		"instances.0.security_group_ids.#": CHECKSET,
+		"instances.0.instance_name":        CHECKSET,
+		"instances.0.vpc_id":               CHECKSET,
+		"instances.0.region_id":            CHECKSET,
+		"instances.0.expire_time":          CHECKSET,
+		"instances.0.multi_zone_mode":      CHECKSET,
+		"instances.0.running_time":         CHECKSET,
+	}
+}
+
+var fakeMilvusInstanceMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"instances.#": "0",
+	}
+}
+
+var MilvusInstanceCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_milvus_instances.default",
+	existMapFunc: existMilvusInstanceMapFunc,
+	fakeMapFunc:  fakeMilvusInstanceMapFunc,
+}
+
+func testAccCheckAlicloudMilvusInstanceSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	password := testAccMilvusInstancePassword(rand)
+	config := fmt.Sprintf(`
+variable "name" {
+  default = "tf-testAccMilvusInstance%d"
+}
+
+variable "zone_id" {
+  default = "cn-hangzhou-j"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+resource "alicloud_vpc" "defaultILXuit" {
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "defaultN80M7S" {
+  vpc_id       = alicloud_vpc.defaultILXuit.id
+  zone_id      = var.zone_id
+  cidr_block   = "172.16.1.0/24"
+  vswitch_name = "milvus-test"
+}
+
+resource "alicloud_milvus_instance" "default" {
+  zone_id               = var.zone_id
+  vswitch_ids {
+    vsw_id  = alicloud_vswitch.defaultN80M7S.id
+    zone_id = alicloud_vswitch.defaultN80M7S.zone_id
+  }
+  db_admin_password     = "%s"
+  components {
+    type           = "data"
+    cu_num         = 2
+    replica        = 1
+    cu_type        = "general"
+    disk_size_type = "Normal"
+  }
+  components {
+    type           = "index"
+    cu_num         = 4
+    replica        = 2
+    cu_type        = "general"
+    disk_size_type = "Normal"
+  }
+  components {
+    type           = "query"
+    cu_num         = 4
+    replica        = 2
+    cu_type        = "general"
+    disk_size_type = "Normal"
+  }
+  components {
+    type           = "proxy"
+    cu_num         = 2
+    replica        = 2
+    cu_type        = "general"
+    disk_size_type = "Normal"
+  }
+  components {
+    type           = "mix_coordinator"
+    cu_num         = 4
+    replica        = 2
+    cu_type        = "general"
+    disk_size_type = "Normal"
+  }
+  instance_name         = var.name
+  db_version            = "2.4"
+  vpc_id                = alicloud_vpc.defaultILXuit.id
+  ha                    = false
+  payment_type          = "Subscription"
+  multi_zone_mode       = "Single"
+  payment_duration_unit = "year"
+  payment_duration      = 1
+  auto_pay              = true
+  resource_group_id     = data.alicloud_resource_manager_resource_groups.default.ids.0
+  configuration         = "rootCoord:\n    maxDatabaseNum: 64"
+}
+
+data "alicloud_milvus_instances" "default" {
+%s
+}
+`, rand, password, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_milvus_instances":                               dataSourceAliCloudMilvusInstances(),
 			"alicloud_express_connect_router_express_connect_routers": dataSourceAliCloudExpressConnectRouterExpressConnectRouters(),
 			"alicloud_redis_global_security_ip_groups":                dataSourceAliCloudRedisGlobalSecurityIpGroups(),
 			"alicloud_cr_artifact_subscription_rules":                 dataSourceAliCloudCrArtifactSubscriptionRules(),

--- a/website/docs/d/milvus_instances.html.markdown
+++ b/website/docs/d/milvus_instances.html.markdown
@@ -1,0 +1,159 @@
+---
+subcategory: "Milvus"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_milvus_instances"
+sidebar_current: "docs-alicloud-datasource-milvus-instances"
+description: |-
+  Provides a list of Milvus Instance owned by an Alibaba Cloud account.
+---
+
+# alicloud_milvus_instances
+
+This data source provides Milvus Instance available to the user.[What is Instance](https://next.api.alibabacloud.com/document/milvus/2023-10-12/CreateInstance)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+variable "zone_id" {
+  default = "cn-hangzhou-j"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_vpc" "default" {
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id       = alicloud_vpc.default.id
+  zone_id      = var.zone_id
+  cidr_block   = "172.16.1.0/24"
+  vswitch_name = "terraform-example"
+}
+
+resource "alicloud_milvus_instance" "default" {
+  zone_id = var.zone_id
+  vswitch_ids {
+    vsw_id  = alicloud_vswitch.default.id
+    zone_id = alicloud_vswitch.default.zone_id
+  }
+  db_admin_password = "TerraformExample123!"
+  components {
+    type           = "data"
+    cu_num         = 2
+    replica        = 1
+    cu_type        = "general"
+    disk_size_type = "Normal"
+  }
+  components {
+    type           = "index"
+    cu_num         = 4
+    replica        = 2
+    cu_type        = "general"
+    disk_size_type = "Normal"
+  }
+  components {
+    type           = "query"
+    cu_num         = 4
+    replica        = 2
+    cu_type        = "general"
+    disk_size_type = "Normal"
+  }
+  components {
+    type           = "proxy"
+    cu_num         = 2
+    replica        = 2
+    cu_type        = "general"
+    disk_size_type = "Normal"
+  }
+  components {
+    type           = "mix_coordinator"
+    cu_num         = 4
+    replica        = 2
+    cu_type        = "general"
+    disk_size_type = "Normal"
+  }
+  instance_name         = var.name
+  db_version            = "2.4"
+  vpc_id                = alicloud_vpc.default.id
+  ha                    = false
+  payment_type          = "Subscription"
+  multi_zone_mode       = "Single"
+  payment_duration_unit = "year"
+  payment_duration      = 1
+  auto_pay              = true
+}
+
+data "alicloud_milvus_instances" "default" {
+  ids           = [alicloud_milvus_instance.default.id]
+  instance_name = var.name
+}
+
+output "first_instance_id" {
+  value = data.alicloud_milvus_instances.default.instances.0.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `instance_id` - (ForceNew, Optional) Instance ID
+* `instance_name` - (ForceNew, Optional) Instance name. The length is limited to 1-64 characters and can only contain Chinese, letters, numbers,-,_
+* `resource_group_id` - (ForceNew, Optional) Resource Group ID
+* `tags` - (Optional) User Defined Label
+* `ids` - (Optional, Computed) A list of Instance IDs.
+* `name_regex` - (Optional) A regex string to filter results by Group Metric Rule name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Instance IDs.
+* `names` - A list of name of Instances.
+* `instances` - A list of Instance Entries. Each element contains the following attributes:
+  * `auto_backup` - Whether to enable automatic backup.
+  * `components` - Instance component information.
+    * `cu_num` - The number of CU.
+    * `cu_type` - The calculation type.
+    * `data_disk` - The QueryNode data disk configuration.
+      * `enabled` - Whether to enable the QueryNode data disk.
+      * `performance_level` - The ESSD performance level.
+      * `size` - The data disk size in GiB.
+      * `storage_class` - The data disk StorageClass.
+    * `disk_size_type` - Default Normal.
+    * `pay_type` - The payment type of the component.
+    * `replica` - The number of component replicas.
+    * `type` - The component type.
+  * `configuration` - User-defined configuration.
+  * `create_time` - Instance creation time.
+  * `db_version` - Milvus kernel version.
+  * `encrypted` - Whether to use kms encryption.
+  * `expire_time` - The expiration time of the instance, which is returned by the package year and month cluster.
+  * `ha` - Whether to enable multiple copies of data.
+  * `instance_id` - Instance ID.
+  * `instance_name` - Instance name.
+  * `kms_key_id` - Kms Key encryption id, need to be encrypted set to true.
+  * `multi_zone_mode` - Availability Zone mode.
+  * `order_id` - Alibaba Cloud Order Number.
+  * `payment_type` - Payment Type.
+  * `region_id` - regionId.
+  * `resource_group_id` - Resource Group ID.
+  * `running_time` - Instance running time.
+  * `security_group_ids` - Configured Security Group id.
+  * `status` - Instance status.
+  * `tags` - User Defined Label.
+  * `vswitch_ids` - Switch list, configure the switch and zone.
+    * `vsw_id` - VSwitch id, which must correspond to the zone id.
+    * `zone_id` - The availability zone must correspond to the vswId.
+  * `vpc_id` - The VPC network ID.
+  * `zone_id` - The zone id.
+  * `id` - The ID of the resource supplied above.


### PR DESCRIPTION
## Summary
- Add the `alicloud_milvus_instances` data source, which allows users to query Milvus instances by ID, instance name, resource group, and tags.
- Include the data source documentation.

## Test plan
- [ ] `TestAccAlicloudMilvusInstanceDataSource` - remote acceptance test in progress (ids exist/fake, resource_group_id, instance_name filters).
