### PR TITLE
resource/alicloud_pvtz_user_vpc_authorization: fix nil auth_type in resource ID

### DIFF
--- a/alicloud/resource_alicloud_pvtz_user_vpc_authorization.go
+++ b/alicloud/resource_alicloud_pvtz_user_vpc_authorization.go
@@ -33,6 +33,7 @@ func resourceAlicloudPvtzUserVpcAuthorization() *schema.Resource {
 			"auth_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{"NORMAL", "CLOUD_PRODUCT"}, false),
 			},
@@ -75,24 +76,39 @@ func resourceAlicloudPvtzUserVpcAuthorizationCreate(d *schema.ResourceData, meta
 		return WrapErrorf(err, DefaultErrorMsg, "alicloud_pvtz_user_vpc_authorization", action, AlibabaCloudSdkGoERROR)
 	}
 
-	d.SetId(fmt.Sprint(request["AuthorizedUserId"], ":", request["AuthType"]))
+	// Default auth_type to NORMAL when omitted, matching the API default for
+	// DeleteUserVpcAuthorization. Reading request["AuthType"] would yield nil
+	// and produce a "<nil>" literal in the resource ID when the optional field
+	// is unset, breaking subsequent Read and Delete operations.
+	authType := d.Get("auth_type").(string)
+	if authType == "" {
+		authType = "NORMAL"
+	}
+	d.SetId(fmt.Sprintf("%s:%s", d.Get("authorized_user_id"), authType))
 
 	return resourceAlicloudPvtzUserVpcAuthorizationRead(d, meta)
 }
 func resourceAlicloudPvtzUserVpcAuthorizationRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	pvtzService := PvtzService{client}
-	_, err := pvtzService.DescribePvtzUserVpcAuthorization(d.Id())
+	parts, err := ParseResourceId(d.Id(), 2)
+	if err != nil {
+		return WrapError(err)
+	}
+	// Migrate legacy state IDs produced by a previous bug where unset auth_type
+	// resulted in ID = "<authorized_user_id>:<nil>". Treat "<nil>" as "NORMAL"
+	// so Read/Delete send the correct AuthType to the API.
+	if parts[1] == "<nil>" {
+		parts[1] = "NORMAL"
+		d.SetId(fmt.Sprintf("%s:%s", parts[0], parts[1]))
+	}
+	_, err = pvtzService.DescribePvtzUserVpcAuthorization(d.Id())
 	if err != nil {
 		if NotFoundError(err) {
 			log.Printf("[DEBUG] Resource alicloud_pvtz_user_vpc_authorization pvtzService.DescribePvtzUserVpcAuthorization Failed!!! %s", err)
 			d.SetId("")
 			return nil
 		}
-		return WrapError(err)
-	}
-	parts, err := ParseResourceId(d.Id(), 2)
-	if err != nil {
 		return WrapError(err)
 	}
 	d.Set("auth_type", parts[1])
@@ -108,6 +124,10 @@ func resourceAlicloudPvtzUserVpcAuthorizationDelete(d *schema.ResourceData, meta
 	parts, err := ParseResourceId(d.Id(), 2)
 	if err != nil {
 		return WrapError(err)
+	}
+	// Migrate legacy state IDs where auth_type was "<nil>" (see Read for details).
+	if parts[1] == "<nil>" {
+		parts[1] = "NORMAL"
 	}
 	action := "DeleteUserVpcAuthorization"
 	var response map[string]interface{}

--- a/alicloud/resource_alicloud_pvtz_user_vpc_authorization_test.go
+++ b/alicloud/resource_alicloud_pvtz_user_vpc_authorization_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAccAlicloudPvtzUserVpcAuthorization_basic0(t *testing.T) {
+func TestAccAliCloudPvtzUserVpcAuthorization_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_pvtz_user_vpc_authorization.default"
 	ra := resourceAttrInit(resourceId, AlicloudPrivateZoneUserVpcAuthorizationMap0)
@@ -43,6 +43,51 @@ func TestAccAlicloudPvtzUserVpcAuthorization_basic0(t *testing.T) {
 					"authorized_user_id": "1359528198477648",
 					"auth_channel":       "RESOURCE_DIRECTORY",
 					"auth_type":          "NORMAL",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"authorized_user_id": CHECKSET,
+						"auth_type":          "NORMAL",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true, ImportStateVerifyIgnore: []string{"auth_channel"},
+			},
+		},
+	})
+}
+
+// defaultAuthType exercises the bug-fix path: auth_type is omitted so the
+// resource ID must default to "<authorized_user_id>:NORMAL" instead of the
+// previous buggy "<authorized_user_id>:<nil>".
+func TestAccAliCloudPvtzUserVpcAuthorization_defaultAuthType(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_pvtz_user_vpc_authorization.default"
+	ra := resourceAttrInit(resourceId, AlicloudPrivateZoneUserVpcAuthorizationMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &PvtzService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribePvtzUserVpcAuthorization")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sprivatezoneuservpcauthorization%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudPrivateZoneUserVpcAuthorizationBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckEnterpriseAccountEnabled(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"authorized_user_id": "1359528198477648",
+					"auth_channel":       "RESOURCE_DIRECTORY",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -184,6 +229,51 @@ func TestUnitAlicloudPvtzUserVpcAuthorization(t *testing.T) {
 			return responseMock["CreateNormal"]("")
 		})
 		err := resourceAlicloudPvtzUserVpcAuthorizationCreate(dCreate, rawClient)
+		patches.Reset()
+		assert.Nil(t, err)
+	})
+
+	// Create with auth_type omitted: the resource ID must default to
+	// "<authorized_user_id>:NORMAL" instead of the previous buggy
+	// "<authorized_user_id>:<nil>".
+	t.Run("CreateNormalWithDefaultAuthType", func(t *testing.T) {
+		dDefault, _ := schema.InternalMap(p["alicloud_pvtz_user_vpc_authorization"].Schema).Data(nil, nil)
+		dDefault.MarkNewResource()
+		err := dDefault.Set("authorized_user_id", "authorized_user_id")
+		assert.Nil(t, err)
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, _ *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			return responseMock["CreateNormal"]("")
+		})
+		err = resourceAlicloudPvtzUserVpcAuthorizationCreate(dDefault, rawClient)
+		patches.Reset()
+		assert.Nil(t, err)
+		assert.Equal(t, "authorized_user_id:NORMAL", dDefault.Id())
+	})
+
+	// Read with a legacy "<nil>" AuthType in the ID: the migration must
+	// rewrite it to "NORMAL" so the API receives the correct AuthType.
+	t.Run("ReadMigrateLegacyNilAuthType", func(t *testing.T) {
+		dLegacy, _ := schema.InternalMap(p["alicloud_pvtz_user_vpc_authorization"].Schema).Data(nil, nil)
+		dLegacy.SetId("authorized_user_id:<nil>")
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, _ *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			return responseMock["ReadNormal"]("")
+		})
+		err := resourceAlicloudPvtzUserVpcAuthorizationRead(dLegacy, rawClient)
+		patches.Reset()
+		assert.Nil(t, err)
+		assert.Equal(t, "authorized_user_id:NORMAL", dLegacy.Id())
+		assert.Equal(t, "NORMAL", dLegacy.Get("auth_type"))
+	})
+
+	// Delete with a legacy "<nil>" AuthType in the ID: the migration must
+	// send "NORMAL" to the DeleteUserVpcAuthorization API.
+	t.Run("DeleteMigrateLegacyNilAuthType", func(t *testing.T) {
+		dLegacy, _ := schema.InternalMap(p["alicloud_pvtz_user_vpc_authorization"].Schema).Data(nil, nil)
+		dLegacy.SetId("authorized_user_id:<nil>")
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, _ *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			return responseMock["DeleteNormal"]("")
+		})
+		err := resourceAlicloudPvtzUserVpcAuthorizationDelete(dLegacy, rawClient)
 		patches.Reset()
 		assert.Nil(t, err)
 	})

--- a/website/docs/r/pvtz_user_vpc_authorization.html.markdown
+++ b/website/docs/r/pvtz_user_vpc_authorization.html.markdown
@@ -33,6 +33,18 @@ resource "alicloud_pvtz_user_vpc_authorization" "example" {
 }
 ```
 
+Omit `auth_type` to use the default `NORMAL`
+
+When `auth_type` is not set, the server defaults to `NORMAL` and the resource ID formats as `<authorized_user_id>:NORMAL`.
+
+```terraform
+resource "alicloud_pvtz_user_vpc_authorization" "default" {
+  authorized_user_id = 123456789
+  auth_channel       = "RESOURCE_DIRECTORY"
+  # auth_type omitted; defaults to NORMAL
+}
+```
+
 📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_pvtz_user_vpc_authorization&spm=docs.r.pvtz_user_vpc_authorization.example&intl_lang=EN_US)
 
 ## Argument Reference
@@ -41,7 +53,7 @@ The following arguments are supported:
 
 * `auth_channel` - (Optional) The auth channel. Valid values: `RESOURCE_DIRECTORY`.
 * `authorized_user_id` - (Required, ForceNew) The primary account ID of the user who authorizes the resource.
-* `auth_type` - (Optional, ForceNew) The type of Authorization. Valid values: `NORMAL` and `CLOUD_PRODUCT`.
+* `auth_type` - (Optional, ForceNew) The type of Authorization. Valid values: `NORMAL` and `CLOUD_PRODUCT`. If omitted, defaults to `NORMAL`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Problem

When `auth_type` is omitted, the resource ID was built using `request["AuthType"]`, which returns nil for the unset map key. `fmt.Sprint(nil)` produces the literal string `<nil>`, so the state ID becomes `<authorized_user_id>:<nil>`. Subsequent Read and Delete operations parse this ID and send `<nil>` as `AuthType` to the `DescribeUserVpcAuthorizations` and `DeleteUserVpcAuthorization` APIs, causing failures.

## Fix

- **Create**: Use `d.Get("auth_type")` instead of `request["AuthType"]` to build the ID, defaulting to `NORMAL` when the optional field is omitted. This matches the `DeleteUserVpcAuthorization` API default.
- **Read/Delete**: Migrate legacy state IDs containing `<nil>` to `NORMAL` so existing resources continue to work without manual state edits.
- **Docs**: Note that `auth_type` defaults to `NORMAL`.

## Test

Added unit test `CreateNormalWithDefaultAuthType` that creates the resource without setting `auth_type` and asserts the ID is `<authorized_user_id>:NORMAL` rather than `<authorized_user_id>:<nil>`.
