### PR TITLE
docs: fix typo in gpdb_db_extension example attribute name

### DIFF
--- a/website/docs/r/gpdb_db_extension.html.markdown
+++ b/website/docs/r/gpdb_db_extension.html.markdown
@@ -78,7 +78,7 @@ resource "alicloud_gpdb_db_extension" "default" {
   extension_name       = "uuid-ossp"
   db_instance_id       = alicloud_gpdb_instance.defaultqsmpIy.id
   database_name        = alicloud_gpdb_database.defaultPPmRVa.database_name
-  is_laexample_version = true
+  is_latest_version = true
 }
 ```
 


### PR DESCRIPTION
The example block in the gpdb_db_extension resource documentation used a misspelled attribute name `is_laexample_version` instead of the correct `is_latest_version`. The argument reference section already uses the correct name; this fixes the example so copied configs are valid.