### PR TITLE
provider: preserve inner diagnostics across the interceptor layer

### DIFF
--- a/alicloud/assemble_provider.go
+++ b/alicloud/assemble_provider.go
@@ -1,0 +1,71 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+	providerregistry "github.com/aliyun/terraform-provider-alicloud/alicloud/provider/registry"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/sdkv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Wraps what the provider.go map literals already hold with its per-name chain,
+// then appends the registry's declarations. A declaration shadowing a map literal
+// entry is a startup hard error, detectable only here.
+func assembleProvider(p *schema.Provider) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	for name, r := range p.ResourcesMap {
+		p.ResourcesMap[name] = sdkv2.WrapResource(name, r, intercept.ChainOf(name, nil))
+	}
+	for name, ds := range p.DataSourcesMap {
+		p.DataSourcesMap[name] = sdkv2.WrapDataSource(name, ds, intercept.ChainOf(name, nil))
+	}
+
+	for _, sp := range providerregistry.ServicePackages() {
+		for _, reg := range sp.SDKResources {
+			name := reg.TypeName
+			if _, dup := p.ResourcesMap[name]; dup {
+				diags = append(diags, duplicateDeclaration("resource", name, sp.Name))
+				continue
+			}
+			p.ResourcesMap[name] = sdkv2.WrapResource(name, reg.Factory(), intercept.ChainOf(name, reg.Interceptors))
+		}
+		for _, reg := range sp.SDKDataSources {
+			name := reg.TypeName
+			if _, dup := p.DataSourcesMap[name]; dup {
+				diags = append(diags, duplicateDeclaration("data source", name, sp.Name))
+				continue
+			}
+			p.DataSourcesMap[name] = sdkv2.WrapDataSource(name, reg.Factory(), intercept.ChainOf(name, reg.Interceptors))
+		}
+	}
+
+	return diags
+}
+
+func duplicateDeclaration(noun, typeName, service string) diag.Diagnostic {
+	return diag.Diagnostic{
+		Severity: diag.Error,
+		Summary:  fmt.Sprintf("duplicate %s %q", noun, typeName),
+		Detail: fmt.Sprintf("declared both in the provider.go map literal and in the %s ServicePackage(); remove the map literal entry",
+			service),
+	}
+}
+
+func formatRegistrationDiags(diags diag.Diagnostics) string {
+	lines := make([]string, 0, len(diags))
+	for _, d := range diags {
+		if d.Severity != diag.Error {
+			continue
+		}
+		if d.Detail != "" {
+			lines = append(lines, d.Summary+": "+d.Detail)
+			continue
+		}
+		lines = append(lines, d.Summary)
+	}
+	return strings.Join(lines, "\n  ")
+}

--- a/alicloud/assemble_provider_test.go
+++ b/alicloud/assemble_provider_test.go
@@ -1,0 +1,31 @@
+package alicloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func TestAssembleProviderIdentityOnEmptyRegistries(t *testing.T) {
+	res := &schema.Resource{
+		Create: func(d *schema.ResourceData, meta interface{}) error { return nil },
+	}
+	ds := &schema.Resource{
+		Read: func(d *schema.ResourceData, meta interface{}) error { return nil },
+	}
+	p := &schema.Provider{
+		ResourcesMap:   map[string]*schema.Resource{"alicloud_test": res},
+		DataSourcesMap: map[string]*schema.Resource{"alicloud_test": ds},
+	}
+
+	diags := assembleProvider(p)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if p.ResourcesMap["alicloud_test"] != res {
+		t.Fatal("resource pointer changed under empty registries")
+	}
+	if p.DataSourcesMap["alicloud_test"] != ds {
+		t.Fatal("data source pointer changed under empty registries")
+	}
+}

--- a/alicloud/function/register.go
+++ b/alicloud/function/register.go
@@ -1,0 +1,23 @@
+package function
+
+import (
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/conns"
+)
+
+// ServicePackage returns the registration declaration of the provider-level
+// utility functions.
+func ServicePackage() conns.ServicePackage {
+	return conns.ServicePackage{
+		Name: "Core",
+		Functions: []conns.Function{
+			{
+				TypeName: "arn_build",
+				Factory:  NewARNBuildFunction,
+			},
+			{
+				TypeName: "arn_parse",
+				Factory:  NewARNParseFunction,
+			},
+		},
+	}
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -2148,6 +2148,14 @@ func Provider() *schema.Provider {
 	provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		return providerConfigure(ctx, d, provider)
 	}
+
+	if diags := assembleProvider(provider); diags.HasError() {
+		// Registration duplicates are a startup hard error: no configuration
+		// can make them work, and the provider is still being built, so there
+		// is nowhere to return diagnostics to.
+		panic("provider registration error: " + formatRegistrationDiags(diags))
+	}
+
 	return provider
 }
 

--- a/alicloud/provider/conns/conns.go
+++ b/alicloud/provider/conns/conns.go
@@ -1,0 +1,19 @@
+// Package conns defines the types a service package fills in to state what it
+// offers: one ServicePackage per product, plus the per-category item types (SDK v2
+// in sdkv2.go, Framework in framework.go). Separate from package registry to avoid
+// the cycle registry -> product -> registry. The name mirrors
+// terraform-provider-aws; the client itself is alicloud/connectivity.
+package conns
+
+type ServicePackage struct {
+	Name string // API product code, e.g. "Ims", "Vpc"
+
+	SDKResources       []SDKResource
+	SDKDataSources     []SDKDataSource
+	Resources          []Resource
+	DataSources        []DataSource
+	Functions          []Function
+	EphemeralResources []EphemeralResource
+	ListResources      []ListResource
+	Actions            []Action
+}

--- a/alicloud/provider/conns/conns_test.go
+++ b/alicloud/provider/conns/conns_test.go
@@ -1,0 +1,42 @@
+package conns_test
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/conns"
+)
+
+var consumers = map[string]string{
+	"Name":               "registry.ServicePackages, for the duplicate-name error messages",
+	"SDKResources":       "alicloud.assembleProvider, which rewrites Provider.ResourcesMap",
+	"SDKDataSources":     "alicloud.assembleProvider, which rewrites Provider.DataSourcesMap",
+	"Resources":          "framework.(*alicloudProvider).Resources",
+	"DataSources":        "framework.(*alicloudProvider).DataSources",
+	"Functions":          "framework.(*alicloudProvider).Functions",
+	"EphemeralResources": "framework.(*alicloudProvider).EphemeralResources",
+	"ListResources":      "framework.(*alicloudProvider).ListResources",
+	"Actions":            "framework.(*alicloudProvider).Actions",
+}
+
+func TestUnitEveryServicePackageFieldHasAConsumer(t *testing.T) {
+	rt := reflect.TypeOf(conns.ServicePackage{})
+
+	declared := make([]string, 0, rt.NumField())
+	for i := 0; i < rt.NumField(); i++ {
+		declared = append(declared, rt.Field(i).Name)
+	}
+
+	for _, name := range declared {
+		if _, ok := consumers[name]; !ok {
+			t.Errorf("ServicePackage.%s has no registered consumer: add one and record it in this table, "+
+				"or the category is declared by product packages and never registered", name)
+		}
+	}
+	for name := range consumers {
+		if !slices.Contains(declared, name) {
+			t.Errorf("this table names ServicePackage.%s, which no longer exists: drop the entry", name)
+		}
+	}
+}

--- a/alicloud/provider/conns/framework.go
+++ b/alicloud/provider/conns/framework.go
@@ -1,0 +1,47 @@
+package conns
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+)
+
+type Resource struct {
+	TypeName string
+	// Called once per RPC; contrast SDKResource.Factory, called once.
+	Factory      func() resource.Resource
+	Interceptors []intercept.Interceptor
+}
+
+type DataSource struct {
+	TypeName     string
+	Factory      func() datasource.DataSource
+	Interceptors []intercept.Interceptor
+}
+
+type Function struct {
+	TypeName string // short name: "arn_build" → provider::alicloud::arn_build
+	Factory  func() function.Function
+}
+
+// No Interceptors field, here or on Function, ListResource and Action: these have
+// no wrapper yet, so the field would accept interceptors that never run.
+type EphemeralResource struct {
+	TypeName string
+	Factory  func() ephemeral.EphemeralResource
+}
+
+type ListResource struct {
+	TypeName string // matches the managed resource type name it lists
+	Factory  func() list.ListResource
+}
+
+type Action struct {
+	TypeName string
+	Factory  func() action.Action
+}

--- a/alicloud/provider/conns/sdkv2.go
+++ b/alicloud/provider/conns/sdkv2.go
@@ -1,0 +1,21 @@
+package conns
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+)
+
+type SDKResource struct {
+	TypeName string // e.g. "alicloud_vpc"
+	// Called once, at build time, and the result reused for every operation.
+	// Contrast Resource.Factory, called once per RPC.
+	Factory      func() *schema.Resource
+	Interceptors []intercept.Interceptor
+}
+
+type SDKDataSource struct {
+	TypeName     string
+	Factory      func() *schema.Resource
+	Interceptors []intercept.Interceptor
+}

--- a/alicloud/provider/framework/client_guard_test.go
+++ b/alicloud/provider/framework/client_guard_test.go
@@ -1,0 +1,97 @@
+package framework
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/fwadapt"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+)
+
+type carrier struct {
+	fwadapt.DataSourceBase
+}
+
+type notCarrier struct{}
+
+type observer struct{}
+
+func (observer) Before(context.Context, intercept.Call) error { return nil }
+
+func (observer) After(_ context.Context, _ intercept.Call, err error) error { return err }
+
+func TestAppendUnlessClientCapable(t *testing.T) {
+	if got := appendUnlessClientCapable(nil, "data source", "alicloud_unit_test", "DataSourceBase", &carrier{}); got != nil {
+		t.Fatalf("a pointer to an embedder must pass the guard, got %v", got)
+	}
+
+	problems := appendUnlessClientCapable(nil, "data source", "alicloud_unit_test", "DataSourceBase", carrier{})
+	if len(problems) != 1 {
+		t.Fatalf("a value must fail the guard, got %d problems: %v", len(problems), problems)
+	}
+
+	problems = appendUnlessClientCapable(problems, "resource", "alicloud_unit_test_two", "ResourceBase", &notCarrier{})
+	if len(problems) != 2 {
+		t.Fatalf("got %d problems, want 2 (the guard accumulates rather than stopping at the first)", len(problems))
+	}
+
+	for _, want := range []string{"alicloud_unit_test_two", "fwadapt.ResourceBase", "return a pointer"} {
+		if !strings.Contains(problems[1], want) {
+			t.Errorf("problem %q does not mention %q", problems[1], want)
+		}
+	}
+}
+
+func TestAppendIfInterceptorsDropped(t *testing.T) {
+	if got := appendIfInterceptorsDropped(nil, "action", "alicloud_unit_test", nil); got != nil {
+		t.Fatalf("an empty chain must pass the guard, got %v", got)
+	}
+	if got := appendIfInterceptorsDropped(nil, "action", "alicloud_unit_test", []intercept.Interceptor{}); got != nil {
+		t.Fatalf("a non-nil empty chain must pass the guard, got %v", got)
+	}
+
+	chain := []intercept.Interceptor{observer{}, observer{}}
+	problems := appendIfInterceptorsDropped(nil, "action", "alicloud_unit_test", chain)
+	if len(problems) != 1 {
+		t.Fatalf("a non-empty chain must fail the guard, got %d problems: %v", len(problems), problems)
+	}
+	for _, want := range []string{"alicloud_unit_test", "never run", "wrapper"} {
+		if !strings.Contains(problems[0], want) {
+			t.Errorf("problem %q does not mention %q", problems[0], want)
+		}
+	}
+
+	problems = appendUnlessClientCapable(problems, "action", "alicloud_unit_test_two", "ActionBase", &notCarrier{})
+	if len(problems) != 2 {
+		t.Fatalf("got %d problems, want 2 (the two guards accumulate into one list)", len(problems))
+	}
+}
+
+func TestMustRegisterSilentWhenClean(t *testing.T) {
+	mustRegister(nil)
+	mustRegister([]string{})
+}
+
+func TestMustRegisterPanicsOnProblems(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("mustRegister did not panic on a non-empty problem list")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("panicked with %T, want string", r)
+		}
+		if !strings.HasPrefix(msg, "provider registration error:") {
+			t.Errorf("panic message %q does not carry the registration-error prefix", msg)
+		}
+		for _, want := range []string{"first problem", "second problem"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("panic message %q does not mention %q", msg, want)
+			}
+		}
+	}()
+
+	mustRegister([]string{"first problem", "second problem"})
+}

--- a/alicloud/provider/framework/provider.go
+++ b/alicloud/provider/framework/provider.go
@@ -2,9 +2,13 @@ package framework
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
-	tffunction "github.com/aliyun/terraform-provider-alicloud/alicloud/function"
-	"github.com/aliyun/terraform-provider-alicloud/alicloud/service/ims"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/conns"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/fwadapt"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+	providerregistry "github.com/aliyun/terraform-provider-alicloud/alicloud/provider/registry"
 	"github.com/hashicorp/terraform-plugin-framework/action"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
@@ -27,7 +31,6 @@ type alicloudProvider struct {
 	primary *sdkschema.Provider
 }
 
-// NewProvider returns the framework provider to be muxed with the SDK v2 provider.
 func NewProvider(primary *sdkschema.Provider) provider.Provider {
 	return &alicloudProvider{
 		primary: primary,
@@ -46,10 +49,6 @@ func (p *alicloudProvider) Schema(ctx context.Context, req provider.SchemaReques
 }
 
 func (p *alicloudProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
-	// The provider's parsed configuration is available through the primary provider's
-	// Meta method: tf5muxserver configures its servers in the order they were passed to
-	// NewMuxServer, and the SDK v2 one goes first. Credential resolution lives in
-	// alicloud.providerConfigure and is not duplicated here.
 	meta := p.primary.Meta()
 
 	resp.ResourceData = meta
@@ -59,31 +58,121 @@ func (p *alicloudProvider) Configure(ctx context.Context, req provider.Configure
 	resp.ActionData = meta
 }
 
-func (p *alicloudProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{
-		ims.NewDefaultDomainDataSource,
-	}
-}
+// Resources and data sources go through fwadapt so their chain applies. Ephemeral
+// resources, list resources and actions have no wrapper yet — each needs its own,
+// capability detection being by type assertion. Functions differ in kind: no
+// FunctionWithConfigure, and a function call is not one of intercept's CRUD ops.
 
 func (p *alicloudProvider) Resources(ctx context.Context) []func() resource.Resource {
-	return []func() resource.Resource{}
+	var problems []string
+	factories := collect(
+		func(sp conns.ServicePackage) []conns.Resource { return sp.Resources },
+		func(d conns.Resource) func() resource.Resource {
+			problems = appendUnlessClientCapable(problems, "resource", d.TypeName, "ResourceBase", d.Factory())
+			chain := intercept.ChainOf(d.TypeName, d.Interceptors)
+			return func() resource.Resource {
+				return fwadapt.WrapResource(d.TypeName, d.Factory(), chain)
+			}
+		})
+	mustRegister(problems)
+	return factories
 }
 
-func (p *alicloudProvider) EphemeralResources(ctx context.Context) []func() ephemeral.EphemeralResource {
-	return []func() ephemeral.EphemeralResource{}
+func (p *alicloudProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
+	var problems []string
+	factories := collect(
+		func(sp conns.ServicePackage) []conns.DataSource { return sp.DataSources },
+		func(d conns.DataSource) func() datasource.DataSource {
+			problems = appendUnlessClientCapable(problems, "data source", d.TypeName, "DataSourceBase", d.Factory())
+			chain := intercept.ChainOf(d.TypeName, d.Interceptors)
+			return func() datasource.DataSource {
+				return fwadapt.WrapDataSource(d.TypeName, d.Factory(), chain)
+			}
+		})
+	mustRegister(problems)
+	return factories
 }
 
 func (p *alicloudProvider) Functions(ctx context.Context) []func() function.Function {
-	return []func() function.Function{
-		tffunction.NewARNBuildFunction,
-		tffunction.NewARNParseFunction,
-	}
+	return collect(
+		func(sp conns.ServicePackage) []conns.Function { return sp.Functions },
+		func(d conns.Function) func() function.Function { return d.Factory })
+}
+
+func (p *alicloudProvider) EphemeralResources(ctx context.Context) []func() ephemeral.EphemeralResource {
+	var problems []string
+	factories := collect(
+		func(sp conns.ServicePackage) []conns.EphemeralResource { return sp.EphemeralResources },
+		func(d conns.EphemeralResource) func() ephemeral.EphemeralResource {
+			problems = appendUnlessClientCapable(problems, "ephemeral resource", d.TypeName, "EphemeralResourceBase", d.Factory())
+			problems = appendIfInterceptorsDropped(problems, "ephemeral resource", d.TypeName, intercept.ChainOf(d.TypeName, nil))
+			return d.Factory
+		})
+	mustRegister(problems)
+	return factories
 }
 
 func (p *alicloudProvider) ListResources(ctx context.Context) []func() list.ListResource {
-	return []func() list.ListResource{}
+	var problems []string
+	factories := collect(
+		func(sp conns.ServicePackage) []conns.ListResource { return sp.ListResources },
+		func(d conns.ListResource) func() list.ListResource {
+			problems = appendUnlessClientCapable(problems, "list resource", d.TypeName, "ListResourceBase", d.Factory())
+			problems = appendIfInterceptorsDropped(problems, "list resource", d.TypeName, intercept.ChainOf(d.TypeName, nil))
+			return d.Factory
+		})
+	mustRegister(problems)
+	return factories
 }
 
 func (p *alicloudProvider) Actions(ctx context.Context) []func() action.Action {
-	return []func() action.Action{}
+	var problems []string
+	factories := collect(
+		func(sp conns.ServicePackage) []conns.Action { return sp.Actions },
+		func(d conns.Action) func() action.Action {
+			problems = appendUnlessClientCapable(problems, "action", d.TypeName, "ActionBase", d.Factory())
+			problems = appendIfInterceptorsDropped(problems, "action", d.TypeName, intercept.ChainOf(d.TypeName, nil))
+			return d.Factory
+		})
+	mustRegister(problems)
+	return factories
+}
+
+func collect[D, T any](category func(conns.ServicePackage) []D, constructor func(D) func() T) []func() T {
+	var result []func() T
+	for _, sp := range providerregistry.ServicePackages() {
+		for _, d := range category(sp) {
+			result = append(result, constructor(d))
+		}
+	}
+	return result
+}
+
+func appendUnlessClientCapable(problems []string, namespace, typeName, base string, instance interface{}) []string {
+	if _, ok := instance.(fwadapt.WithClient); ok {
+		return problems
+	}
+	return append(problems, fmt.Sprintf(
+		"%s %q: %T does not implement fwadapt.WithClient — embed fwadapt.%s, and return a pointer from the factory",
+		namespace, typeName, instance, base))
+}
+
+// The chain is a parameter because intercept's registry has no setter.
+func appendIfInterceptorsDropped(problems []string, namespace, typeName string, chain []intercept.Interceptor) []string {
+	if len(chain) == 0 {
+		return problems
+	}
+	return append(problems, fmt.Sprintf(
+		"%s %q: %d interceptor(s) resolve for this name but %ss are not wrapped, so they would never run — "+
+			"write the fwadapt wrapper for this category, or drop the registration",
+		namespace, typeName, len(chain), namespace))
+}
+
+// Panics: these aggregator methods return a bare slice, with no diagnostics channel.
+func mustRegister(problems []string) {
+	if len(problems) == 0 {
+		return
+	}
+	panic(fmt.Sprintf("provider registration error: %d framework declaration(s) rejected:\n  %s",
+		len(problems), strings.Join(problems, "\n  ")))
 }

--- a/alicloud/provider/fwadapt/client.go
+++ b/alicloud/provider/fwadapt/client.go
@@ -1,0 +1,151 @@
+package fwadapt
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// WithClient makes "this resource can receive a client" assertable at
+// registration; a field would not be.
+type WithClient interface {
+	Client() *connectivity.AliyunClient
+}
+
+type injectedClient struct {
+	client *connectivity.AliyunClient
+}
+
+// A resource declaring its own Configure must call this one from it, or the
+// promoted method is shadowed and the client never arrives.
+type ResourceBase struct {
+	injectedClient
+}
+
+type DataSourceBase struct {
+	injectedClient
+}
+
+// These three have no wrapper yet, so clientNotInjected does not cover them: a
+// shadowed Configure stays invisible until Client() returns nil.
+type EphemeralResourceBase struct {
+	injectedClient
+}
+
+type ListResourceBase struct {
+	injectedClient
+}
+
+type ActionBase struct {
+	injectedClient
+}
+
+var (
+	_ WithClient = (*ResourceBase)(nil)
+	_ WithClient = (*DataSourceBase)(nil)
+	_ WithClient = (*EphemeralResourceBase)(nil)
+	_ WithClient = (*ListResourceBase)(nil)
+	_ WithClient = (*ActionBase)(nil)
+	_ interface {
+		Configure(context.Context, resource.ConfigureRequest, *resource.ConfigureResponse)
+	} = (*ResourceBase)(nil)
+	_ interface {
+		Configure(context.Context, datasource.ConfigureRequest, *datasource.ConfigureResponse)
+	} = (*DataSourceBase)(nil)
+	_ interface {
+		Configure(context.Context, ephemeral.ConfigureRequest, *ephemeral.ConfigureResponse)
+	} = (*EphemeralResourceBase)(nil)
+	_ interface {
+		Configure(context.Context, list.ConfigureRequest, *list.ConfigureResponse)
+	} = (*ListResourceBase)(nil)
+	_ interface {
+		Configure(context.Context, action.ConfigureRequest, *action.ConfigureResponse)
+	} = (*ActionBase)(nil)
+)
+
+// The pointer receiver matters: a factory returning a value then fails the
+// registration guard instead of keeping a nil client forever.
+func (w *injectedClient) Client() *connectivity.AliyunClient { return w.client }
+
+func (b *ResourceBase) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	client, diags := clientFromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if client != nil {
+		b.client = client
+	}
+}
+
+func (b *DataSourceBase) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	client, diags := clientFromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if client != nil {
+		b.client = client
+	}
+}
+
+func (b *EphemeralResourceBase) Configure(ctx context.Context, req ephemeral.ConfigureRequest, resp *ephemeral.ConfigureResponse) {
+	client, diags := clientFromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if client != nil {
+		b.client = client
+	}
+}
+
+func (b *ListResourceBase) Configure(ctx context.Context, req list.ConfigureRequest, resp *list.ConfigureResponse) {
+	client, diags := clientFromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if client != nil {
+		b.client = client
+	}
+}
+
+func (b *ActionBase) Configure(ctx context.Context, req action.ConfigureRequest, resp *action.ConfigureResponse) {
+	client, diags := clientFromProviderData(req.ProviderData)
+	resp.Diagnostics.Append(diags...)
+	if client != nil {
+		b.client = client
+	}
+}
+
+// Reports a resource that came out of Configure with no client although one was on
+// offer. A nil providerData is normal; an existing error is more specific.
+func clientNotInjected(name string, inner interface{}, providerData interface{}, existing diag.Diagnostics) diag.Diagnostics {
+	if providerData == nil || existing.HasError() {
+		return nil
+	}
+	carrier, ok := inner.(WithClient)
+	if !ok || carrier.Client() != nil {
+		return nil
+	}
+	return diag.Diagnostics{
+		diag.NewErrorDiagnostic(
+			"Provider Client Not Injected",
+			fmt.Sprintf("%s (%T) ended Configure without a provider client. This happens when a resource declares its own "+
+				"Configure and does not call the embedded fwadapt base's. Please report this issue to the provider developers.",
+				name, inner),
+		),
+	}
+}
+
+func clientFromProviderData(providerData interface{}) (*connectivity.AliyunClient, diag.Diagnostics) {
+	if providerData == nil {
+		return nil, nil
+	}
+	client, ok := providerData.(*connectivity.AliyunClient)
+	if !ok {
+		return nil, diag.Diagnostics{
+			diag.NewErrorDiagnostic(
+				"Unexpected Configure Type",
+				fmt.Sprintf("Expected *connectivity.AliyunClient, got %T. Please report this issue to the provider developers.", providerData),
+			),
+		}
+	}
+	return client, nil
+}

--- a/alicloud/provider/fwadapt/client_test.go
+++ b/alicloud/provider/fwadapt/client_test.go
@@ -1,0 +1,226 @@
+package fwadapt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+)
+
+type stubResourceEmbeddingBase struct{ ResourceBase }
+
+type stubDataSourceEmbeddingBase struct{ DataSourceBase }
+
+func TestResourceBaseConfigureInjectsClient(t *testing.T) {
+	r := &stubResourceEmbeddingBase{}
+	client := &connectivity.AliyunClient{}
+
+	var resp resource.ConfigureResponse
+	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: client}, &resp)
+
+	if r.Client() != client {
+		t.Fatal("Configure did not inject the client")
+	}
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diags: %v", resp.Diagnostics)
+	}
+}
+
+func TestDataSourceBaseConfigureInjectsClient(t *testing.T) {
+	ds := &stubDataSourceEmbeddingBase{}
+	client := &connectivity.AliyunClient{}
+
+	var resp datasource.ConfigureResponse
+	ds.Configure(context.Background(), datasource.ConfigureRequest{ProviderData: client}, &resp)
+
+	if ds.Client() != client {
+		t.Fatal("Configure did not inject the client")
+	}
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diags: %v", resp.Diagnostics)
+	}
+}
+
+func TestResourceBaseConfigureNilProviderData(t *testing.T) {
+	r := &stubResourceEmbeddingBase{}
+
+	var resp resource.ConfigureResponse
+	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: nil}, &resp)
+
+	if r.Client() != nil {
+		t.Fatal("nil ProviderData must not set a client")
+	}
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diags: %v", resp.Diagnostics)
+	}
+}
+
+func TestResourceBaseConfigureWrongProviderDataType(t *testing.T) {
+	r := &stubResourceEmbeddingBase{}
+
+	var resp resource.ConfigureResponse
+	r.Configure(context.Background(), resource.ConfigureRequest{ProviderData: "not a client"}, &resp)
+
+	if r.Client() != nil {
+		t.Fatal("wrong ProviderData type must not set a client")
+	}
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diag for wrong ProviderData type")
+	}
+}
+
+func TestBasesPromoteConfigure(t *testing.T) {
+	var _ interface {
+		Configure(context.Context, resource.ConfigureRequest, *resource.ConfigureResponse)
+	} = &stubResourceEmbeddingBase{}
+	var _ interface {
+		Configure(context.Context, datasource.ConfigureRequest, *datasource.ConfigureResponse)
+	} = &stubDataSourceEmbeddingBase{}
+}
+
+func TestBasesImplementWithClient(t *testing.T) {
+	var _ WithClient = &stubResourceEmbeddingBase{}
+	var _ WithClient = &stubDataSourceEmbeddingBase{}
+
+	if _, ok := interface{}(stubResourceEmbeddingBase{}).(WithClient); ok {
+		t.Error("a value satisfies WithClient: the registration guard would pass a value-returning factory whose Configure never runs")
+	}
+	if _, ok := interface{}(stubDataSourceEmbeddingBase{}).(WithClient); ok {
+		t.Error("a value satisfies WithClient: the registration guard would pass a value-returning factory whose Configure never runs")
+	}
+}
+
+type stubEphemeralEmbeddingBase struct{ EphemeralResourceBase }
+
+type stubListEmbeddingBase struct{ ListResourceBase }
+
+type stubActionEmbeddingBase struct{ ActionBase }
+
+func TestRemainingBasesConfigure(t *testing.T) {
+	cases := []struct {
+		name      string
+		configure func(providerData interface{}) (*connectivity.AliyunClient, diag.Diagnostics)
+	}{
+		{
+			name: "ephemeral resource",
+			configure: func(providerData interface{}) (*connectivity.AliyunClient, diag.Diagnostics) {
+				e := &stubEphemeralEmbeddingBase{}
+				var resp ephemeral.ConfigureResponse
+				e.Configure(context.Background(), ephemeral.ConfigureRequest{ProviderData: providerData}, &resp)
+				return e.Client(), resp.Diagnostics
+			},
+		},
+		{
+			name: "list resource",
+			configure: func(providerData interface{}) (*connectivity.AliyunClient, diag.Diagnostics) {
+				l := &stubListEmbeddingBase{}
+				var resp list.ConfigureResponse
+				l.Configure(context.Background(), list.ConfigureRequest{ProviderData: providerData}, &resp)
+				return l.Client(), resp.Diagnostics
+			},
+		},
+		{
+			name: "action",
+			configure: func(providerData interface{}) (*connectivity.AliyunClient, diag.Diagnostics) {
+				a := &stubActionEmbeddingBase{}
+				var resp action.ConfigureResponse
+				a.Configure(context.Background(), action.ConfigureRequest{ProviderData: providerData}, &resp)
+				return a.Client(), resp.Diagnostics
+			},
+		},
+	}
+
+	client := &connectivity.AliyunClient{}
+	for _, tc := range cases {
+		t.Run(tc.name+" injects the client", func(t *testing.T) {
+			got, diags := tc.configure(client)
+			if got != client {
+				t.Fatal("Configure did not inject the client")
+			}
+			if diags.HasError() {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+		})
+
+		t.Run(tc.name+" tolerates nil provider data", func(t *testing.T) {
+			got, diags := tc.configure(nil)
+			if got != nil {
+				t.Fatal("nil ProviderData must not set a client")
+			}
+			if diags.HasError() {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+		})
+
+		t.Run(tc.name+" reports a wrong provider data type", func(t *testing.T) {
+			got, diags := tc.configure("not a client")
+			if got != nil {
+				t.Fatal("wrong ProviderData type must not set a client")
+			}
+			if !diags.HasError() {
+				t.Fatal("expected error diag for wrong ProviderData type")
+			}
+		})
+	}
+}
+
+type notACarrier struct{}
+
+func TestClientNotInjected(t *testing.T) {
+	client := &connectivity.AliyunClient{}
+	injected := &stubResourceEmbeddingBase{}
+	injected.client = client
+
+	cases := []struct {
+		name         string
+		inner        interface{}
+		providerData interface{}
+		existing     diag.Diagnostics
+		wantError    bool
+	}{
+		{
+			name:         "shadowed Configure left the client nil",
+			inner:        &stubResourceEmbeddingBase{},
+			providerData: client,
+			wantError:    true,
+		},
+		{
+			name:         "client arrived",
+			inner:        injected,
+			providerData: client,
+		},
+		{
+			name:         "no provider data on offer",
+			inner:        &stubResourceEmbeddingBase{},
+			providerData: nil,
+		},
+		{
+			name:         "existing error is not buried",
+			inner:        &stubResourceEmbeddingBase{},
+			providerData: client,
+			existing:     diag.Diagnostics{diag.NewErrorDiagnostic("Unexpected Configure Type", "")},
+			wantError:    false,
+		},
+		{
+			name:         "not a carrier is the registration guard's case",
+			inner:        &notACarrier{},
+			providerData: client,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := clientNotInjected("alicloud_unit_test", tc.inner, tc.providerData, tc.existing)
+			if got.HasError() != tc.wantError {
+				t.Fatalf("HasError() = %t, want %t (diags: %v)", got.HasError(), tc.wantError, got)
+			}
+		})
+	}
+}

--- a/alicloud/provider/fwadapt/wrap.go
+++ b/alicloud/provider/fwadapt/wrap.go
@@ -1,0 +1,277 @@
+// Package fwadapt adapts the interceptor chain to Framework resources and data
+// sources, and injects the client into them (see client.go).
+//
+// The Framework detects optional capabilities by type-asserting the registered
+// resource, so the wrapper's method set decides which capabilities the resource
+// appears to have. Seven of the nine forward an absent implementation harmlessly.
+// Two do not: a silent ImportState imports empty state, a silent IdentitySchema
+// fails every plan — hence the four wrapper types.
+package fwadapt
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+func WrapResource(name string, r resource.Resource, chain []intercept.Interceptor) resource.Resource {
+	if r == nil || len(chain) == 0 {
+		return r
+	}
+	core := &wrappedResource{name: name, inner: r, chain: chain}
+	_, withImportState := r.(resource.ResourceWithImportState)
+	_, withIdentity := r.(resource.ResourceWithIdentity)
+	switch {
+	case withImportState && withIdentity:
+		return &resourceWithImportStateAndIdentity{wrappedResource: core}
+	case withImportState:
+		return &resourceWithImportState{wrappedResource: core}
+	case withIdentity:
+		return &resourceWithIdentity{wrappedResource: core}
+	default:
+		return core
+	}
+}
+
+func WrapDataSource(name string, ds datasource.DataSource, chain []intercept.Interceptor) datasource.DataSource {
+	if ds == nil || len(chain) == 0 {
+		return ds
+	}
+	return &wrappedDataSource{name: name, inner: ds, chain: chain}
+}
+
+type wrappedResource struct {
+	name  string
+	inner resource.Resource
+	chain []intercept.Interceptor
+
+	// Not shared across operations: the Framework builds a fresh resource per RPC.
+	providerData interface{}
+}
+
+var (
+	_ resource.Resource                     = (*wrappedResource)(nil)
+	_ resource.ResourceWithConfigure        = (*wrappedResource)(nil)
+	_ resource.ResourceWithConfigValidators = (*wrappedResource)(nil)
+	_ resource.ResourceWithModifyPlan       = (*wrappedResource)(nil)
+	_ resource.ResourceWithValidateConfig   = (*wrappedResource)(nil)
+	_ resource.ResourceWithUpgradeState     = (*wrappedResource)(nil)
+	_ resource.ResourceWithMoveState        = (*wrappedResource)(nil)
+	_ resource.ResourceWithUpgradeIdentity  = (*wrappedResource)(nil)
+)
+
+func (w *wrappedResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	w.inner.Metadata(ctx, req, resp)
+}
+
+func (w *wrappedResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	w.inner.Schema(ctx, req, resp)
+}
+
+func (w *wrappedResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	runIntercepted(ctx, w.name, intercept.OpCreate, w.chain, &resp.Diagnostics, w.providerData,
+		func() { w.inner.Create(ctx, req, resp) })
+}
+
+func (w *wrappedResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	runIntercepted(ctx, w.name, intercept.OpRead, w.chain, &resp.Diagnostics, w.providerData,
+		func() { w.inner.Read(ctx, req, resp) })
+}
+
+func (w *wrappedResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	runIntercepted(ctx, w.name, intercept.OpUpdate, w.chain, &resp.Diagnostics, w.providerData,
+		func() { w.inner.Update(ctx, req, resp) })
+}
+
+func (w *wrappedResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	runIntercepted(ctx, w.name, intercept.OpDelete, w.chain, &resp.Diagnostics, w.providerData,
+		func() { w.inner.Delete(ctx, req, resp) })
+}
+
+func (w *wrappedResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	w.providerData = req.ProviderData
+	if c, ok := w.inner.(resource.ResourceWithConfigure); ok {
+		c.Configure(ctx, req, resp)
+	}
+	resp.Diagnostics.Append(clientNotInjected(w.name, w.inner, req.ProviderData, resp.Diagnostics)...)
+}
+
+func (w *wrappedResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	if c, ok := w.inner.(resource.ResourceWithConfigValidators); ok {
+		return c.ConfigValidators(ctx)
+	}
+	return nil
+}
+
+func (w *wrappedResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if c, ok := w.inner.(resource.ResourceWithModifyPlan); ok {
+		c.ModifyPlan(ctx, req, resp)
+	}
+}
+
+func (w *wrappedResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	if c, ok := w.inner.(resource.ResourceWithValidateConfig); ok {
+		c.ValidateConfig(ctx, req, resp)
+	}
+}
+
+func (w *wrappedResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	if c, ok := w.inner.(resource.ResourceWithUpgradeState); ok {
+		return c.UpgradeState(ctx)
+	}
+	return nil
+}
+
+func (w *wrappedResource) MoveState(ctx context.Context) []resource.StateMover {
+	if c, ok := w.inner.(resource.ResourceWithMoveState); ok {
+		return c.MoveState(ctx)
+	}
+	return nil
+}
+
+func (w *wrappedResource) UpgradeIdentity(ctx context.Context) map[int64]resource.IdentityUpgrader {
+	if c, ok := w.inner.(resource.ResourceWithUpgradeIdentity); ok {
+		return c.UpgradeIdentity(ctx)
+	}
+	return nil
+}
+
+func (w *wrappedResource) importState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	w.inner.(resource.ResourceWithImportState).ImportState(ctx, req, resp)
+}
+
+func (w *wrappedResource) identitySchema(ctx context.Context, req resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
+	w.inner.(resource.ResourceWithIdentity).IdentitySchema(ctx, req, resp)
+}
+
+type resourceWithImportState struct {
+	*wrappedResource
+}
+
+var _ resource.ResourceWithImportState = (*resourceWithImportState)(nil)
+
+func (w *resourceWithImportState) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	w.importState(ctx, req, resp)
+}
+
+type resourceWithIdentity struct {
+	*wrappedResource
+}
+
+var _ resource.ResourceWithIdentity = (*resourceWithIdentity)(nil)
+
+func (w *resourceWithIdentity) IdentitySchema(ctx context.Context, req resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
+	w.identitySchema(ctx, req, resp)
+}
+
+// Declares both rather than embedding the two variants above: embedding both makes
+// the promoted *wrappedResource methods ambiguous and drops them.
+type resourceWithImportStateAndIdentity struct {
+	*wrappedResource
+}
+
+var (
+	_ resource.ResourceWithImportState = (*resourceWithImportStateAndIdentity)(nil)
+	_ resource.ResourceWithIdentity    = (*resourceWithImportStateAndIdentity)(nil)
+)
+
+func (w *resourceWithImportStateAndIdentity) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	w.importState(ctx, req, resp)
+}
+
+func (w *resourceWithImportStateAndIdentity) IdentitySchema(ctx context.Context, req resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
+	w.identitySchema(ctx, req, resp)
+}
+
+type wrappedDataSource struct {
+	name  string
+	inner datasource.DataSource
+	chain []intercept.Interceptor
+
+	providerData interface{}
+}
+
+var (
+	_ datasource.DataSource                     = (*wrappedDataSource)(nil)
+	_ datasource.DataSourceWithConfigure        = (*wrappedDataSource)(nil)
+	_ datasource.DataSourceWithConfigValidators = (*wrappedDataSource)(nil)
+	_ datasource.DataSourceWithValidateConfig   = (*wrappedDataSource)(nil)
+)
+
+func (w *wrappedDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	w.inner.Metadata(ctx, req, resp)
+}
+
+func (w *wrappedDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	w.inner.Schema(ctx, req, resp)
+}
+
+func (w *wrappedDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	runIntercepted(ctx, w.name, intercept.OpRead, w.chain, &resp.Diagnostics, w.providerData,
+		func() { w.inner.Read(ctx, req, resp) })
+}
+
+func (w *wrappedDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	w.providerData = req.ProviderData
+	if c, ok := w.inner.(datasource.DataSourceWithConfigure); ok {
+		c.Configure(ctx, req, resp)
+	}
+	resp.Diagnostics.Append(clientNotInjected(w.name, w.inner, req.ProviderData, resp.Diagnostics)...)
+}
+
+func (w *wrappedDataSource) ConfigValidators(ctx context.Context) []datasource.ConfigValidator {
+	if c, ok := w.inner.(datasource.DataSourceWithConfigValidators); ok {
+		return c.ConfigValidators(ctx)
+	}
+	return nil
+}
+
+func (w *wrappedDataSource) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	if c, ok := w.inner.(datasource.DataSourceWithValidateConfig); ok {
+		c.ValidateConfig(ctx, req, resp)
+	}
+}
+
+// The Framework reports through resp.Diagnostics, so that pointer is both the
+// input and the output of the bridge.
+func runIntercepted(ctx context.Context, name string, op intercept.Op, chain []intercept.Interceptor, diags *diag.Diagnostics, meta interface{}, inner func()) {
+	*diags = intercept.Around(ctx, chain, intercept.Call{Name: name, Op: op, Meta: meta},
+		func() diag.Diagnostics {
+			inner()
+			return *diags
+		}, bridge)
+}
+
+var bridge = intercept.DiagBridge[diag.Diagnostics]{
+	ToError:   diagToErr,
+	WithError: replaceDiagErrors,
+}
+
+func diagToErr(diags diag.Diagnostics) error {
+	for _, d := range diags {
+		if d.Severity() == diag.SeverityError {
+			if d.Detail() != "" {
+				return errors.New(d.Summary() + ": " + d.Detail())
+			}
+			return errors.New(d.Summary())
+		}
+	}
+	return nil
+}
+
+func replaceDiagErrors(diags diag.Diagnostics, err error) diag.Diagnostics {
+	out := make(diag.Diagnostics, 0, len(diags)+1)
+	for _, d := range diags {
+		if d.Severity() != diag.SeverityError {
+			out = append(out, d)
+		}
+	}
+	if err != nil {
+		out = append(out, diag.NewErrorDiagnostic(err.Error(), ""))
+	}
+	return out
+}

--- a/alicloud/provider/fwadapt/wrap.go
+++ b/alicloud/provider/fwadapt/wrap.go
@@ -11,6 +11,7 @@ package fwadapt
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -248,30 +249,48 @@ func runIntercepted(ctx context.Context, name string, op intercept.Op, chain []i
 
 var bridge = intercept.DiagBridge[diag.Diagnostics]{
 	ToError:   diagToErr,
-	WithError: replaceDiagErrors,
+	WithError: appendDiagError,
 }
 
 func diagToErr(diags diag.Diagnostics) error {
+	var errs diag.Diagnostics
 	for _, d := range diags {
 		if d.Severity() == diag.SeverityError {
-			if d.Detail() != "" {
-				return errors.New(d.Summary() + ": " + d.Detail())
-			}
-			return errors.New(d.Summary())
+			errs = append(errs, d)
 		}
 	}
-	return nil
+	if len(errs) == 0 {
+		return nil
+	}
+	return &diagsErr{diags: errs}
 }
 
-func replaceDiagErrors(diags diag.Diagnostics, err error) diag.Diagnostics {
-	out := make(diag.Diagnostics, 0, len(diags)+1)
-	for _, d := range diags {
-		if d.Severity() != diag.SeverityError {
-			out = append(out, d)
+func appendDiagError(diags diag.Diagnostics, err error) diag.Diagnostics {
+	if err == nil {
+		return diags
+	}
+	// A hook that only carried the originals forward has nothing of its own to say.
+	var de *diagsErr
+	if errors.As(err, &de) && err.Error() == de.Error() {
+		return diags
+	}
+	return append(diags, diag.NewErrorDiagnostic(err.Error(), ""))
+}
+
+// diagsErr carries every error-severity diagnostic across the hop through the
+// interceptor contract's single error.
+type diagsErr struct {
+	diags diag.Diagnostics
+}
+
+func (e *diagsErr) Error() string {
+	msgs := make([]string, 0, len(e.diags))
+	for _, d := range e.diags {
+		if d.Detail() != "" {
+			msgs = append(msgs, d.Summary()+": "+d.Detail())
+			continue
 		}
+		msgs = append(msgs, d.Summary())
 	}
-	if err != nil {
-		out = append(out, diag.NewErrorDiagnostic(err.Error(), ""))
-	}
-	return out
+	return strings.Join(msgs, "; ")
 }

--- a/alicloud/provider/fwadapt/wrap_test.go
+++ b/alicloud/provider/fwadapt/wrap_test.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-
-	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
 )
 
 type stubResource struct {
@@ -62,6 +62,18 @@ func (s *stubResource) Delete(_ context.Context, _ resource.DeleteRequest, resp 
 	}
 }
 
+// diagsResource reports diagnostics the AddError helpers cannot build, such as one
+// carrying an attribute path.
+type diagsResource struct {
+	stubResource
+	diags diag.Diagnostics
+}
+
+func (s *diagsResource) Create(_ context.Context, _ resource.CreateRequest, resp *resource.CreateResponse) {
+	s.createCalled = true
+	resp.Diagnostics.Append(s.diags...)
+}
+
 type stubDataSource struct {
 	readCalled bool
 	readErr    string
@@ -87,6 +99,7 @@ type recordInterceptor struct {
 	beforeErr  error
 	afterErr   error
 	rewriteErr error
+	wrapMsg    string
 	swallow    bool
 	metaSeen   interface{}
 }
@@ -104,6 +117,9 @@ func (r *recordInterceptor) After(ctx context.Context, call intercept.Call, err 
 	}
 	if r.rewriteErr != nil {
 		return r.rewriteErr
+	}
+	if r.wrapMsg != "" && err != nil {
+		return fmt.Errorf("%s: %w", r.wrapMsg, err)
 	}
 	return err
 }
@@ -264,15 +280,18 @@ func TestWrapResourceAfterRewritesError(t *testing.T) {
 	var resp resource.CreateResponse
 	wr.Create(context.Background(), resource.CreateRequest{}, &resp)
 
-	if got, want := len(resp.Diagnostics), 1; got != want {
+	if got, want := len(resp.Diagnostics), 2; got != want {
 		t.Fatalf("len(diagnostics) = %d, want %d: %v", got, want, resp.Diagnostics)
 	}
-	if got := resp.Diagnostics[0].Summary(); got != "rewritten" {
+	if got := resp.Diagnostics[0].Summary(); got != "inner error" {
+		t.Fatalf("the inner error was replaced, summary = %q", got)
+	}
+	if got := resp.Diagnostics[1].Summary(); got != "rewritten" {
 		t.Fatalf("summary = %q, want %q", got, "rewritten")
 	}
 }
 
-func TestWrapResourceAfterSwallowsError(t *testing.T) {
+func TestWrapResourceAfterCannotSwallowError(t *testing.T) {
 	rec := &recordInterceptor{name: "rec", swallow: true}
 	r := &stubResource{readErr: "resource not found"}
 	got := WrapResource("test", r, []intercept.Interceptor{rec})
@@ -281,8 +300,14 @@ func TestWrapResourceAfterSwallowsError(t *testing.T) {
 	var resp resource.ReadResponse
 	wr.Read(context.Background(), resource.ReadRequest{}, &resp)
 
-	if resp.Diagnostics.HasError() {
-		t.Fatalf("After returned nil, so the error must be gone: %v", resp.Diagnostics)
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("After returned nil, but a failure must not be reported as success")
+	}
+	if got, want := len(resp.Diagnostics), 1; got != want {
+		t.Fatalf("len(diagnostics) = %d, want %d: %v", got, want, resp.Diagnostics)
+	}
+	if got := resp.Diagnostics[0].Summary(); got != "resource not found" {
+		t.Fatalf("summary = %q, want the inner one restored verbatim", got)
 	}
 	if !r.readCalled {
 		t.Fatal("inner Read not called")
@@ -290,7 +315,7 @@ func TestWrapResourceAfterSwallowsError(t *testing.T) {
 }
 
 func TestWrapResourceWarningsSurviveRewrite(t *testing.T) {
-	rec := &recordInterceptor{name: "rec", swallow: true}
+	rec := &recordInterceptor{name: "rec", rewriteErr: errors.New("rewritten")}
 	r := &stubResource{readErr: "resource not found"}
 	got := WrapResource("test", r, []intercept.Interceptor{rec})
 	wr := got.(*wrappedResource)
@@ -299,11 +324,42 @@ func TestWrapResourceWarningsSurviveRewrite(t *testing.T) {
 	resp.Diagnostics.AddWarning("deprecated field", "use the other one")
 	wr.Read(context.Background(), resource.ReadRequest{}, &resp)
 
-	if got, want := len(resp.Diagnostics), 1; got != want {
+	if got := resp.Diagnostics[0].Summary(); got != "deprecated field" {
+		t.Fatalf("the warning must come first and unchanged, diagnostics = %v", resp.Diagnostics)
+	}
+}
+
+// The bridge hands the chain a plain error, so a hook that only wraps it must not
+// cost the attribute path and detail that error came from.
+func TestWrapResourceWrapKeepsEveryInnerErrorIntact(t *testing.T) {
+	rec := &recordInterceptor{name: "rec", wrapMsg: "retry gave up"}
+	r := &diagsResource{diags: diag.Diagnostics{
+		diag.NewAttributeErrorDiagnostic(path.Root("cidr_block"), "invalid CIDR", "must be a /16 or narrower"),
+		diag.NewErrorDiagnostic("second failure", "with a detail"),
+	}}
+	got := WrapResource("test", r, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	var resp resource.CreateResponse
+	wr.Create(context.Background(), resource.CreateRequest{}, &resp)
+
+	if got, want := len(resp.Diagnostics), 3; got != want {
 		t.Fatalf("len(diagnostics) = %d, want %d: %v", got, want, resp.Diagnostics)
 	}
-	if got := resp.Diagnostics[0].Summary(); got != "deprecated field" {
-		t.Fatalf("the warning was dropped, diagnostics = %v", resp.Diagnostics)
+	first, ok := resp.Diagnostics[0].(diag.DiagnosticWithPath)
+	if !ok {
+		t.Fatalf("the attribute path was lost: %#v", resp.Diagnostics[0])
+	}
+	if got := first.Path().String(); got != "cidr_block" {
+		t.Fatalf("path = %q, want %q", got, "cidr_block")
+	}
+	if got := resp.Diagnostics[1].Detail(); got != "with a detail" {
+		t.Fatalf("detail = %q, want it preserved", got)
+	}
+	// The hook's own wording arrives on top, carrying both messages it saw.
+	want := "retry gave up: invalid CIDR: must be a /16 or narrower; second failure: with a detail"
+	if got := resp.Diagnostics[2].Summary(); got != want {
+		t.Fatalf("summary = %q, want %q", got, want)
 	}
 }
 

--- a/alicloud/provider/fwadapt/wrap_test.go
+++ b/alicloud/provider/fwadapt/wrap_test.go
@@ -1,0 +1,536 @@
+package fwadapt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+)
+
+type stubResource struct {
+	createCalled bool
+	readCalled   bool
+	updateCalled bool
+	deleteCalled bool
+	createErr    string
+	readErr      string
+	updateErr    string
+	deleteErr    string
+
+	importStateCalled    bool
+	identitySchemaCalled bool
+}
+
+func (s *stubResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "test_stub"
+}
+
+func (s *stubResource) Schema(_ context.Context, _ resource.SchemaRequest, _ *resource.SchemaResponse) {
+}
+
+func (s *stubResource) Create(_ context.Context, _ resource.CreateRequest, resp *resource.CreateResponse) {
+	s.createCalled = true
+	if s.createErr != "" {
+		resp.Diagnostics.AddError(s.createErr, "")
+	}
+}
+
+func (s *stubResource) Read(_ context.Context, _ resource.ReadRequest, resp *resource.ReadResponse) {
+	s.readCalled = true
+	if s.readErr != "" {
+		resp.Diagnostics.AddError(s.readErr, "")
+	}
+}
+
+func (s *stubResource) Update(_ context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) {
+	s.updateCalled = true
+	if s.updateErr != "" {
+		resp.Diagnostics.AddError(s.updateErr, "")
+	}
+}
+
+func (s *stubResource) Delete(_ context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse) {
+	s.deleteCalled = true
+	if s.deleteErr != "" {
+		resp.Diagnostics.AddError(s.deleteErr, "")
+	}
+}
+
+type stubDataSource struct {
+	readCalled bool
+	readErr    string
+}
+
+func (s *stubDataSource) Metadata(_ context.Context, _ datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "test_stub"
+}
+
+func (s *stubDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, _ *datasource.SchemaResponse) {
+}
+
+func (s *stubDataSource) Read(_ context.Context, _ datasource.ReadRequest, resp *datasource.ReadResponse) {
+	s.readCalled = true
+	if s.readErr != "" {
+		resp.Diagnostics.AddError(s.readErr, "")
+	}
+}
+
+type recordInterceptor struct {
+	name       string
+	ops        []string
+	beforeErr  error
+	afterErr   error
+	rewriteErr error
+	swallow    bool
+	metaSeen   interface{}
+}
+
+func (r *recordInterceptor) Before(ctx context.Context, call intercept.Call) error {
+	r.ops = append(r.ops, "before:"+r.name)
+	r.metaSeen = call.Meta
+	return r.beforeErr
+}
+
+func (r *recordInterceptor) After(ctx context.Context, call intercept.Call, err error) error {
+	r.ops = append(r.ops, "after:"+r.name)
+	if r.swallow {
+		return nil
+	}
+	if r.rewriteErr != nil {
+		return r.rewriteErr
+	}
+	return err
+}
+
+type importStateStub struct{ stubResource }
+
+func (s *importStateStub) ImportState(_ context.Context, _ resource.ImportStateRequest, _ *resource.ImportStateResponse) {
+	s.importStateCalled = true
+}
+
+type identityStub struct{ stubResource }
+
+func (s *identityStub) IdentitySchema(_ context.Context, _ resource.IdentitySchemaRequest, _ *resource.IdentitySchemaResponse) {
+	s.identitySchemaCalled = true
+}
+
+type importStateAndIdentityStub struct{ stubResource }
+
+func (s *importStateAndIdentityStub) ImportState(_ context.Context, _ resource.ImportStateRequest, _ *resource.ImportStateResponse) {
+	s.importStateCalled = true
+}
+
+func (s *importStateAndIdentityStub) IdentitySchema(_ context.Context, _ resource.IdentitySchemaRequest, _ *resource.IdentitySchemaResponse) {
+	s.identitySchemaCalled = true
+}
+
+type upgradeStateStub struct{ stubResource }
+
+func (s *upgradeStateStub) UpgradeState(_ context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{0: {}}
+}
+
+type configureStub struct {
+	stubResource
+	configuredWith interface{}
+}
+
+func (s *configureStub) Configure(_ context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+	s.configuredWith = req.ProviderData
+}
+
+func TestWrapResourceNilChainIsIdentity(t *testing.T) {
+	r := &stubResource{}
+	got := WrapResource("test", r, nil)
+	if got != resource.Resource(r) {
+		t.Fatal("nil chain must return the same resource")
+	}
+	got = WrapResource("test", r, []intercept.Interceptor{})
+	if got != resource.Resource(r) {
+		t.Fatal("empty chain must return the same resource")
+	}
+}
+
+func TestWrapResourceCreate(t *testing.T) {
+	rec := &recordInterceptor{name: "rec"}
+	r := &stubResource{}
+	got := WrapResource("test", r, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	var resp resource.CreateResponse
+	wr.Create(context.Background(), resource.CreateRequest{}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diags: %v", resp.Diagnostics)
+	}
+	if !r.createCalled {
+		t.Fatal("inner Create not called")
+	}
+	want := []string{"before:rec", "after:rec"}
+	if fmt.Sprint(rec.ops) != fmt.Sprint(want) {
+		t.Fatalf("ops = %v, want %v", rec.ops, want)
+	}
+}
+
+func TestWrapResourceRead(t *testing.T) {
+	rec := &recordInterceptor{name: "rec"}
+	r := &stubResource{}
+	got := WrapResource("test", r, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	var resp resource.ReadResponse
+	wr.Read(context.Background(), resource.ReadRequest{}, &resp)
+
+	if !r.readCalled {
+		t.Fatal("inner Read not called")
+	}
+}
+
+func TestWrapResourceUpdate(t *testing.T) {
+	rec := &recordInterceptor{name: "rec"}
+	r := &stubResource{}
+	got := WrapResource("test", r, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	var resp resource.UpdateResponse
+	wr.Update(context.Background(), resource.UpdateRequest{}, &resp)
+
+	if !r.updateCalled {
+		t.Fatal("inner Update not called")
+	}
+}
+
+func TestWrapResourceDelete(t *testing.T) {
+	rec := &recordInterceptor{name: "rec"}
+	r := &stubResource{}
+	got := WrapResource("test", r, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	var resp resource.DeleteResponse
+	wr.Delete(context.Background(), resource.DeleteRequest{}, &resp)
+
+	if !r.deleteCalled {
+		t.Fatal("inner Delete not called")
+	}
+}
+
+func TestWrapResourceBeforeAbort(t *testing.T) {
+	rec := &recordInterceptor{name: "rec", beforeErr: errors.New("abort")}
+	r := &stubResource{}
+	got := WrapResource("test", r, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	var resp resource.CreateResponse
+	wr.Create(context.Background(), resource.CreateRequest{}, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error from Before abort")
+	}
+	if r.createCalled {
+		t.Fatal("inner must be skipped after Before abort")
+	}
+}
+
+func TestWrapResourceAfterSeesInnerError(t *testing.T) {
+	rec := &recordInterceptor{name: "rec"}
+	r := &stubResource{createErr: "inner error"}
+	got := WrapResource("test", r, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	var resp resource.CreateResponse
+	wr.Create(context.Background(), resource.CreateRequest{}, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected diagnostics from inner error")
+	}
+	want := []string{"before:rec", "after:rec"}
+	if fmt.Sprint(rec.ops) != fmt.Sprint(want) {
+		t.Fatalf("ops = %v, want %v", rec.ops, want)
+	}
+}
+
+func TestWrapResourceAfterRewritesError(t *testing.T) {
+	rec := &recordInterceptor{name: "rec", rewriteErr: errors.New("rewritten")}
+	r := &stubResource{createErr: "inner error"}
+	got := WrapResource("test", r, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	var resp resource.CreateResponse
+	wr.Create(context.Background(), resource.CreateRequest{}, &resp)
+
+	if got, want := len(resp.Diagnostics), 1; got != want {
+		t.Fatalf("len(diagnostics) = %d, want %d: %v", got, want, resp.Diagnostics)
+	}
+	if got := resp.Diagnostics[0].Summary(); got != "rewritten" {
+		t.Fatalf("summary = %q, want %q", got, "rewritten")
+	}
+}
+
+func TestWrapResourceAfterSwallowsError(t *testing.T) {
+	rec := &recordInterceptor{name: "rec", swallow: true}
+	r := &stubResource{readErr: "resource not found"}
+	got := WrapResource("test", r, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	var resp resource.ReadResponse
+	wr.Read(context.Background(), resource.ReadRequest{}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("After returned nil, so the error must be gone: %v", resp.Diagnostics)
+	}
+	if !r.readCalled {
+		t.Fatal("inner Read not called")
+	}
+}
+
+func TestWrapResourceWarningsSurviveRewrite(t *testing.T) {
+	rec := &recordInterceptor{name: "rec", swallow: true}
+	r := &stubResource{readErr: "resource not found"}
+	got := WrapResource("test", r, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	var resp resource.ReadResponse
+	resp.Diagnostics.AddWarning("deprecated field", "use the other one")
+	wr.Read(context.Background(), resource.ReadRequest{}, &resp)
+
+	if got, want := len(resp.Diagnostics), 1; got != want {
+		t.Fatalf("len(diagnostics) = %d, want %d: %v", got, want, resp.Diagnostics)
+	}
+	if got := resp.Diagnostics[0].Summary(); got != "deprecated field" {
+		t.Fatalf("the warning was dropped, diagnostics = %v", resp.Diagnostics)
+	}
+}
+
+func TestWrapResourceForwardsProviderDataAsMeta(t *testing.T) {
+	rec := &recordInterceptor{name: "rec"}
+	r := &configureStub{}
+	got := WrapResource("test", r, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	meta := struct{ client string }{client: "stub"}
+	wr.Configure(context.Background(), resource.ConfigureRequest{ProviderData: meta}, &resource.ConfigureResponse{})
+	if r.configuredWith != interface{}(meta) {
+		t.Fatal("inner Configure did not receive the provider data")
+	}
+
+	var resp resource.CreateResponse
+	wr.Create(context.Background(), resource.CreateRequest{}, &resp)
+	if rec.metaSeen != interface{}(meta) {
+		t.Fatalf("interceptor meta = %v, want the provider data %v", rec.metaSeen, meta)
+	}
+}
+
+func TestWrapResourceMetaIsNilBeforeConfigure(t *testing.T) {
+	rec := &recordInterceptor{name: "rec"}
+	got := WrapResource("test", &stubResource{}, []intercept.Interceptor{rec})
+	wr := got.(*wrappedResource)
+
+	var resp resource.ReadResponse
+	wr.Read(context.Background(), resource.ReadRequest{}, &resp)
+	if rec.metaSeen != nil {
+		t.Fatalf("meta = %v, want nil before Configure", rec.metaSeen)
+	}
+}
+
+func TestWrapResourceNilSafeInterfacesAlwaysPresent(t *testing.T) {
+	got := WrapResource("test", &stubResource{}, []intercept.Interceptor{&recordInterceptor{name: "rec"}})
+
+	if _, ok := got.(resource.ResourceWithConfigure); !ok {
+		t.Error("wrapper must implement ResourceWithConfigure")
+	}
+	if _, ok := got.(resource.ResourceWithConfigValidators); !ok {
+		t.Error("wrapper must implement ResourceWithConfigValidators")
+	}
+	if _, ok := got.(resource.ResourceWithModifyPlan); !ok {
+		t.Error("wrapper must implement ResourceWithModifyPlan")
+	}
+	if _, ok := got.(resource.ResourceWithValidateConfig); !ok {
+		t.Error("wrapper must implement ResourceWithValidateConfig")
+	}
+}
+
+func TestWrapResourceDoesNotInventCapabilities(t *testing.T) {
+	got := WrapResource("test", &stubResource{}, []intercept.Interceptor{&recordInterceptor{name: "rec"}})
+
+	if _, ok := got.(resource.ResourceWithImportState); ok {
+		t.Error("wrapper must not add ResourceWithImportState")
+	}
+	if _, ok := got.(resource.ResourceWithIdentity); ok {
+		t.Error("wrapper must not add ResourceWithIdentity")
+	}
+}
+
+func TestWrapResourceStateMigrationCapabilities(t *testing.T) {
+	chain := []intercept.Interceptor{&recordInterceptor{name: "rec"}}
+
+	plain := WrapResource("test", &stubResource{}, chain).(*wrappedResource)
+	if got := plain.UpgradeState(context.Background()); got != nil {
+		t.Errorf("UpgradeState = %v, want nil for a resource without it", got)
+	}
+	if got := plain.MoveState(context.Background()); got != nil {
+		t.Errorf("MoveState = %v, want nil for a resource without it", got)
+	}
+	if got := plain.UpgradeIdentity(context.Background()); got != nil {
+		t.Errorf("UpgradeIdentity = %v, want nil for a resource without it", got)
+	}
+
+	wrapped := WrapResource("test", &upgradeStateStub{}, chain)
+	withUpgrade, ok := wrapped.(resource.ResourceWithUpgradeState)
+	if !ok {
+		t.Fatal("wrapper must implement ResourceWithUpgradeState")
+	}
+	if got := withUpgrade.UpgradeState(context.Background()); len(got) != 1 {
+		t.Errorf("UpgradeState = %v, want the inner resource's single upgrader", got)
+	}
+
+	rec := &recordInterceptor{name: "rec"}
+	inner := &upgradeStateStub{}
+	got := WrapResource("test", inner, []intercept.Interceptor{rec})
+	var resp resource.ReadResponse
+	got.Read(context.Background(), resource.ReadRequest{}, &resp)
+	if !inner.readCalled {
+		t.Error("inner Read not called")
+	}
+	want := []string{"before:rec", "after:rec"}
+	if fmt.Sprint(rec.ops) != fmt.Sprint(want) {
+		t.Errorf("ops = %v, want %v", rec.ops, want)
+	}
+}
+
+func TestWrapResourceCapabilitySplit(t *testing.T) {
+	cases := []struct {
+		name        string
+		inner       resource.Resource
+		importState bool
+		identity    bool
+	}{
+		{name: "plain", inner: &stubResource{}},
+		{name: "import state", inner: &importStateStub{}, importState: true},
+		{name: "identity", inner: &identityStub{}, identity: true},
+		{name: "both", inner: &importStateAndIdentityStub{}, importState: true, identity: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := &recordInterceptor{name: "rec"}
+			got := WrapResource("test", tc.inner, []intercept.Interceptor{rec})
+
+			withImportState, hasImportState := got.(resource.ResourceWithImportState)
+			if hasImportState != tc.importState {
+				t.Fatalf("ResourceWithImportState = %v, want %v", hasImportState, tc.importState)
+			}
+			withIdentity, hasIdentity := got.(resource.ResourceWithIdentity)
+			if hasIdentity != tc.identity {
+				t.Fatalf("ResourceWithIdentity = %v, want %v", hasIdentity, tc.identity)
+			}
+
+			var resp resource.ReadResponse
+			got.Read(context.Background(), resource.ReadRequest{}, &resp)
+			want := []string{"before:rec", "after:rec"}
+			if fmt.Sprint(rec.ops) != fmt.Sprint(want) {
+				t.Fatalf("ops = %v, want %v", rec.ops, want)
+			}
+
+			if tc.importState {
+				withImportState.ImportState(context.Background(), resource.ImportStateRequest{}, &resource.ImportStateResponse{})
+			}
+			if tc.identity {
+				withIdentity.IdentitySchema(context.Background(), resource.IdentitySchemaRequest{}, &resource.IdentitySchemaResponse{})
+			}
+			inner := innerStub(tc.inner)
+			if inner.importStateCalled != tc.importState {
+				t.Errorf("inner ImportState called = %v, want %v", inner.importStateCalled, tc.importState)
+			}
+			if inner.identitySchemaCalled != tc.identity {
+				t.Errorf("inner IdentitySchema called = %v, want %v", inner.identitySchemaCalled, tc.identity)
+			}
+		})
+	}
+}
+
+func innerStub(r resource.Resource) *stubResource {
+	switch v := r.(type) {
+	case *stubResource:
+		return v
+	case *importStateStub:
+		return &v.stubResource
+	case *identityStub:
+		return &v.stubResource
+	case *importStateAndIdentityStub:
+		return &v.stubResource
+	}
+	panic("unknown stub type")
+}
+
+func TestWrapDataSourceRead(t *testing.T) {
+	rec := &recordInterceptor{name: "rec"}
+	ds := &stubDataSource{}
+	got := WrapDataSource("test", ds, []intercept.Interceptor{rec})
+	wd := got.(*wrappedDataSource)
+
+	var resp datasource.ReadResponse
+	wd.Read(context.Background(), datasource.ReadRequest{}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diags: %v", resp.Diagnostics)
+	}
+	if !ds.readCalled {
+		t.Fatal("inner Read not called")
+	}
+	want := []string{"before:rec", "after:rec"}
+	if fmt.Sprint(rec.ops) != fmt.Sprint(want) {
+		t.Fatalf("ops = %v, want %v", rec.ops, want)
+	}
+}
+
+func TestWrapDataSourceNilChainIsIdentity(t *testing.T) {
+	ds := &stubDataSource{}
+	got := WrapDataSource("test", ds, nil)
+	if got != datasource.DataSource(ds) {
+		t.Fatal("nil chain must return the same data source")
+	}
+}
+
+func TestWrapDataSourceBeforeAbort(t *testing.T) {
+	rec := &recordInterceptor{name: "rec", beforeErr: errors.New("abort")}
+	ds := &stubDataSource{}
+	got := WrapDataSource("test", ds, []intercept.Interceptor{rec})
+	wd := got.(*wrappedDataSource)
+
+	var resp datasource.ReadResponse
+	wd.Read(context.Background(), datasource.ReadRequest{}, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error from Before abort")
+	}
+	if ds.readCalled {
+		t.Fatal("inner must be skipped after Before abort")
+	}
+}
+
+func TestDiagToErr(t *testing.T) {
+	var diags diag.Diagnostics
+	diags.AddError("summary", "detail")
+	err := diagToErr(diags)
+	if err == nil || err.Error() != "summary: detail" {
+		t.Fatalf("expected 'summary: detail', got %v", err)
+	}
+
+	diags = diag.Diagnostics{}
+	diags.AddError("summary only", "")
+	err = diagToErr(diags)
+	if err == nil || err.Error() != "summary only" {
+		t.Fatalf("expected 'summary only', got %v", err)
+	}
+
+	err = diagToErr(diag.Diagnostics{})
+	if err != nil {
+		t.Fatalf("expected nil for empty diagnostics, got %v", err)
+	}
+}

--- a/alicloud/provider/intercept/around.go
+++ b/alicloud/provider/intercept/around.go
@@ -6,10 +6,10 @@ import "context"
 // contract speaks. Supplied by the adapter, the two stacks having incompatible
 // diagnostics types.
 type DiagBridge[D any] struct {
-	// The first error-severity entry of d, or nil.
+	// The error-severity entries of d as one error, or nil if there are none.
 	ToError func(d D) error
-	// d with its error-severity entries replaced by one describing err, or dropped
-	// if err is nil. Warnings must survive in their original order.
+	// d with err folded in on top. Nothing already in d may be dropped: a hook can
+	// add to what the inner call reported, never hide it.
 	WithError func(d D, err error) D
 }
 

--- a/alicloud/provider/intercept/around.go
+++ b/alicloud/provider/intercept/around.go
@@ -1,0 +1,37 @@
+package intercept
+
+import "context"
+
+// DiagBridge adapts a diagnostics collection D to the plain error the interceptor
+// contract speaks. Supplied by the adapter, the two stacks having incompatible
+// diagnostics types.
+type DiagBridge[D any] struct {
+	// The first error-severity entry of d, or nil.
+	ToError func(d D) error
+	// d with its error-severity entries replaced by one describing err, or dropped
+	// if err is nil. Warnings must survive in their original order.
+	WithError func(d D, err error) D
+}
+
+// Around runs the chain around a diagnostics-returning inner function and folds
+// the chain's error back in. Only a *change* is folded back: hand the error back
+// unaltered and inner's diagnostics are returned verbatim, wording intact.
+func Around[D any](ctx context.Context, chain []Interceptor, call Call, inner func() D, bridge DiagBridge[D]) D {
+	if len(chain) == 0 {
+		return inner()
+	}
+	var (
+		out      D
+		innerErr error
+	)
+	outErr := Execute(ctx, chain, call, func() error {
+		out = inner()
+		innerErr = bridge.ToError(out)
+		return innerErr
+	})
+	// Identity, not errors.Is: a hook that wraps the error means to reword it.
+	if outErr == innerErr {
+		return out
+	}
+	return bridge.WithError(out, outErr)
+}

--- a/alicloud/provider/intercept/around_test.go
+++ b/alicloud/provider/intercept/around_test.go
@@ -1,0 +1,125 @@
+package intercept
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type fakeDiags []string
+
+func fakeToError(d fakeDiags) error {
+	for _, e := range d {
+		if strings.HasPrefix(e, "E:") {
+			return errors.New(strings.TrimPrefix(e, "E:"))
+		}
+	}
+	return nil
+}
+
+func fakeWithError(d fakeDiags, err error) fakeDiags {
+	out := make(fakeDiags, 0, len(d)+1)
+	for _, e := range d {
+		if !strings.HasPrefix(e, "E:") {
+			out = append(out, e)
+		}
+	}
+	if err != nil {
+		out = append(out, "E:"+err.Error())
+	}
+	return out
+}
+
+var fakeBridge = DiagBridge[fakeDiags]{ToError: fakeToError, WithError: fakeWithError}
+
+type funcInterceptor struct {
+	before func() error
+	after  func(err error) error
+}
+
+func (f *funcInterceptor) Before(ctx context.Context, call Call) error {
+	if f.before == nil {
+		return nil
+	}
+	return f.before()
+}
+
+func (f *funcInterceptor) After(ctx context.Context, call Call, err error) error {
+	if f.after == nil {
+		return err
+	}
+	return f.after(err)
+}
+
+var testCall = Call{Name: "alicloud_test", Op: OpRead}
+
+func around(t *testing.T, it Interceptor, inner fakeDiags) fakeDiags {
+	t.Helper()
+	return Around(context.Background(), []Interceptor{it}, testCall,
+		func() fakeDiags { return inner }, fakeBridge)
+}
+
+func TestAroundPassesDiagnosticsThroughVerbatim(t *testing.T) {
+	inner := fakeDiags{"W:careful", "E:the API said no", "E:and again"}
+	got := around(t, &funcInterceptor{}, inner)
+	if fmt.Sprint(got) != fmt.Sprint(inner) {
+		t.Fatalf("diagnostics were rewritten: got %v, want %v", got, inner)
+	}
+}
+
+func TestAroundAfterSwallowsError(t *testing.T) {
+	it := &funcInterceptor{after: func(error) error { return nil }}
+	got := around(t, it, fakeDiags{"W:careful", "E:the API said no"})
+	want := fakeDiags{"W:careful"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAroundAfterRewritesError(t *testing.T) {
+	it := &funcInterceptor{after: func(error) error { return errors.New("normalised") }}
+	got := around(t, it, fakeDiags{"W:careful", "E:the API said no"})
+	want := fakeDiags{"W:careful", "E:normalised"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAroundBeforeAbort(t *testing.T) {
+	innerRan := false
+	it := &funcInterceptor{before: func() error { return errors.New("abort") }}
+	got := Around(context.Background(), []Interceptor{it}, testCall,
+		func() fakeDiags { innerRan = true; return fakeDiags{"W:careful"} }, fakeBridge)
+	if innerRan {
+		t.Fatal("inner must be skipped after a Before abort")
+	}
+	want := fakeDiags{"E:abort"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAroundAfterRaisesOnSuccess(t *testing.T) {
+	it := &funcInterceptor{after: func(err error) error {
+		if err != nil {
+			t.Fatalf("expected no inner error, got %v", err)
+		}
+		return errors.New("post-condition failed")
+	}}
+	got := around(t, it, nil)
+	want := fakeDiags{"E:post-condition failed"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestAroundEmptyChainIsIdentity(t *testing.T) {
+	inner := fakeDiags{"E:untouched"}
+	got := Around(context.Background(), nil, testCall,
+		func() fakeDiags { return inner }, fakeBridge)
+	if fmt.Sprint(got) != fmt.Sprint(inner) {
+		t.Fatalf("got %v, want %v", got, inner)
+	}
+}

--- a/alicloud/provider/intercept/around_test.go
+++ b/alicloud/provider/intercept/around_test.go
@@ -11,25 +11,23 @@ import (
 type fakeDiags []string
 
 func fakeToError(d fakeDiags) error {
+	var msgs []string
 	for _, e := range d {
 		if strings.HasPrefix(e, "E:") {
-			return errors.New(strings.TrimPrefix(e, "E:"))
+			msgs = append(msgs, strings.TrimPrefix(e, "E:"))
 		}
 	}
-	return nil
+	if len(msgs) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(msgs, "; "))
 }
 
 func fakeWithError(d fakeDiags, err error) fakeDiags {
-	out := make(fakeDiags, 0, len(d)+1)
-	for _, e := range d {
-		if !strings.HasPrefix(e, "E:") {
-			out = append(out, e)
-		}
+	if err == nil {
+		return d
 	}
-	if err != nil {
-		out = append(out, "E:"+err.Error())
-	}
-	return out
+	return append(d, "E:"+err.Error())
 }
 
 var fakeBridge = DiagBridge[fakeDiags]{ToError: fakeToError, WithError: fakeWithError}
@@ -69,19 +67,21 @@ func TestAroundPassesDiagnosticsThroughVerbatim(t *testing.T) {
 	}
 }
 
-func TestAroundAfterSwallowsError(t *testing.T) {
+// Execute restores the error it returned nil for, which makes it identical to
+// inner's, so the diagnostics come back verbatim rather than through the bridge.
+func TestAroundAfterCannotSwallowError(t *testing.T) {
 	it := &funcInterceptor{after: func(error) error { return nil }}
-	got := around(t, it, fakeDiags{"W:careful", "E:the API said no"})
-	want := fakeDiags{"W:careful"}
-	if fmt.Sprint(got) != fmt.Sprint(want) {
-		t.Fatalf("got %v, want %v", got, want)
+	inner := fakeDiags{"W:careful", "E:the API said no"}
+	got := around(t, it, inner)
+	if fmt.Sprint(got) != fmt.Sprint(inner) {
+		t.Fatalf("got %v, want %v", got, inner)
 	}
 }
 
 func TestAroundAfterRewritesError(t *testing.T) {
 	it := &funcInterceptor{after: func(error) error { return errors.New("normalised") }}
 	got := around(t, it, fakeDiags{"W:careful", "E:the API said no"})
-	want := fakeDiags{"W:careful", "E:normalised"}
+	want := fakeDiags{"W:careful", "E:the API said no", "E:normalised"}
 	if fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("got %v, want %v", got, want)
 	}

--- a/alicloud/provider/intercept/chain.go
+++ b/alicloud/provider/intercept/chain.go
@@ -1,0 +1,11 @@
+package intercept
+
+// ChainOf merges the three sources in fixed order: global, declared,
+// registry[name]. An empty result makes every wrapper the identity function.
+func ChainOf(name string, declared []Interceptor) []Interceptor {
+	chain := make([]Interceptor, 0, len(global)+len(declared)+len(registry[name]))
+	chain = append(chain, global...)
+	chain = append(chain, declared...)
+	chain = append(chain, registry[name]...)
+	return chain
+}

--- a/alicloud/provider/intercept/chain_test.go
+++ b/alicloud/provider/intercept/chain_test.go
@@ -1,0 +1,60 @@
+package intercept
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+type namedStub struct {
+	name string
+}
+
+func (s *namedStub) Before(ctx context.Context, call Call) error {
+	return nil
+}
+
+func (s *namedStub) After(ctx context.Context, call Call, err error) error {
+	return err
+}
+
+func setRegistries(t *testing.T, g []Interceptor, r map[string][]Interceptor) {
+	t.Helper()
+	oldGlobal, oldRegistry := global, registry
+	t.Cleanup(func() { global, registry = oldGlobal, oldRegistry })
+	global, registry = g, r
+}
+
+func TestChainOfEmpty(t *testing.T) {
+	setRegistries(t, nil, map[string][]Interceptor{})
+	if chain := ChainOf("alicloud_none", nil); len(chain) != 0 {
+		t.Fatalf("ChainOf on empty registries: want empty chain, got %v", chain)
+	}
+}
+
+func TestChainOfOrder(t *testing.T) {
+	setRegistries(t,
+		[]Interceptor{&namedStub{name: "g1"}, &namedStub{name: "g2"}},
+		map[string][]Interceptor{"alicloud_x": {&namedStub{name: "r1"}}})
+
+	chain := ChainOf("alicloud_x", []Interceptor{&namedStub{name: "d1"}})
+	var got []string
+	for _, i := range chain {
+		got = append(got, i.(*namedStub).name)
+	}
+	want := []string{"g1", "g2", "d1", "r1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ChainOf order: got %v, want %v", got, want)
+	}
+}
+
+func TestChainOfUnregisteredNameSeesGlobalOnly(t *testing.T) {
+	setRegistries(t,
+		[]Interceptor{&namedStub{name: "g1"}},
+		map[string][]Interceptor{"alicloud_x": {&namedStub{name: "r1"}}})
+
+	chain := ChainOf("alicloud_y", nil)
+	if len(chain) != 1 || chain[0].(*namedStub).name != "g1" {
+		t.Fatalf("ChainOf for unregistered name: want global only, got %v", chain)
+	}
+}

--- a/alicloud/provider/intercept/exec.go
+++ b/alicloud/provider/intercept/exec.go
@@ -1,0 +1,31 @@
+package intercept
+
+import (
+	"context"
+	"slices"
+)
+
+// Before hooks run in forward order and a non-nil return aborts the operation,
+// inner never executing. After hooks always run, in reverse order, and may rewrite
+// the error.
+func Execute(ctx context.Context, chain []Interceptor, call Call, inner func() error) error {
+	if len(chain) == 0 {
+		return inner()
+	}
+	var err error
+	aborted := false
+	for _, o := range chain {
+		if e := o.Before(ctx, call); e != nil {
+			err = e
+			aborted = true
+			break
+		}
+	}
+	if !aborted {
+		err = inner()
+	}
+	for _, o := range slices.Backward(chain) {
+		err = o.After(ctx, call, err)
+	}
+	return err
+}

--- a/alicloud/provider/intercept/exec.go
+++ b/alicloud/provider/intercept/exec.go
@@ -2,12 +2,12 @@ package intercept
 
 import (
 	"context"
+	"log"
 	"slices"
 )
 
-// Before hooks run in forward order and a non-nil return aborts the operation,
-// inner never executing. After hooks always run, in reverse order, and may rewrite
-// the error.
+// Execute runs the chain around inner and restores any error an After hook
+// dropped, so a failed operation is never reported as success.
 func Execute(ctx context.Context, chain []Interceptor, call Call, inner func() error) error {
 	if len(chain) == 0 {
 		return inner()
@@ -25,7 +25,11 @@ func Execute(ctx context.Context, chain []Interceptor, call Call, inner func() e
 		err = inner()
 	}
 	for _, o := range slices.Backward(chain) {
-		err = o.After(ctx, call, err)
+		prev := err
+		if err = o.After(ctx, call, err); err == nil && prev != nil {
+			log.Printf("[ERROR] intercept: %T dropped %s %s error, restoring it: %s", o, call.Op, call.Name, prev)
+			err = prev
+		}
 	}
 	return err
 }

--- a/alicloud/provider/intercept/exec_test.go
+++ b/alicloud/provider/intercept/exec_test.go
@@ -1,0 +1,42 @@
+package intercept
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// The plain error form of SDK v2 CRUD reaches Execute directly, with no bridge
+// in between.
+func TestExecuteAfterCannotSwallowError(t *testing.T) {
+	inner := errors.New("the API said no")
+	it := &funcInterceptor{after: func(error) error { return nil }}
+	got := Execute(context.Background(), []Interceptor{it}, testCall, func() error { return inner })
+	if got != inner {
+		t.Fatalf("got %v, want the inner error restored", got)
+	}
+}
+
+func TestExecuteAfterRewriteIsHonoured(t *testing.T) {
+	rewritten := errors.New("normalised")
+	it := &funcInterceptor{after: func(error) error { return rewritten }}
+	got := Execute(context.Background(), []Interceptor{it}, testCall,
+		func() error { return errors.New("the API said no") })
+	if got != rewritten {
+		t.Fatalf("got %v, want %v", got, rewritten)
+	}
+}
+
+// The restore happens per hook, so a hook further out still sees the failure the
+// one before it tried to drop.
+func TestExecuteRestoredErrorReachesOuterHook(t *testing.T) {
+	inner := errors.New("the API said no")
+	var outerSaw error
+	outer := &funcInterceptor{after: func(err error) error { outerSaw = err; return err }}
+	dropper := &funcInterceptor{after: func(error) error { return nil }}
+
+	Execute(context.Background(), []Interceptor{outer, dropper}, testCall, func() error { return inner })
+	if outerSaw != inner {
+		t.Fatalf("outer hook saw %v, want the restored error", outerSaw)
+	}
+}

--- a/alicloud/provider/intercept/intercept.go
+++ b/alicloud/provider/intercept/intercept.go
@@ -1,0 +1,46 @@
+// Package intercept provides the interceptor mechanism: Op, Call, Interceptor and
+// two registries. An Interceptor sees the call only, never resource data, which is
+// what lets one implementation work on both stacks.
+package intercept
+
+import (
+	"context"
+)
+
+type Op string
+
+const (
+	OpCreate Op = "Create"
+	OpRead   Op = "Read"
+	OpUpdate Op = "Update"
+	OpDelete Op = "Delete"
+)
+
+// Call describes one intercepted invocation, in fields both stacks have.
+type Call struct {
+	Name string // Terraform type name, e.g. "alicloud_vpc"
+	Op   Op
+	Meta interface{} // *connectivity.AliyunClient on both stacks
+}
+
+// Interceptor wraps one invocation: Before runs in forward order and aborts the
+// operation on error, After always runs in reverse order and owns the error.
+type Interceptor interface {
+	Before(ctx context.Context, call Call) error
+	After(ctx context.Context, call Call, err error) error
+}
+
+// Literals with no setter: ChainOf snapshots chains while the provider server is
+// being built, so adding an interceptor is an edit here.
+var (
+	registry = map[string][]Interceptor{}
+	global   = []Interceptor{}
+)
+
+func Registry(name string) []Interceptor {
+	return registry[name]
+}
+
+func Global() []Interceptor {
+	return global
+}

--- a/alicloud/provider/intercept/intercept.go
+++ b/alicloud/provider/intercept/intercept.go
@@ -24,7 +24,10 @@ type Call struct {
 }
 
 // Interceptor wraps one invocation: Before runs in forward order and aborts the
-// operation on error, After always runs in reverse order and owns the error.
+// operation on error, After always runs in reverse order and may reword or replace
+// the error. It cannot make one disappear: Execute restores an error a hook
+// returned nil for, since the operation would otherwise be reported as successful
+// with whatever state the failure left behind.
 type Interceptor interface {
 	Before(ctx context.Context, call Call) error
 	After(ctx context.Context, call Call, err error) error

--- a/alicloud/provider/maximal_fixture_test.go
+++ b/alicloud/provider/maximal_fixture_test.go
@@ -1,0 +1,101 @@
+// One fixture per stack, each using as many optional capabilities as it offers.
+package provider_test
+
+import (
+	"context"
+	"slices"
+	"sync"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+)
+
+type hookLog struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (l *hookLog) record(name string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.calls = append(l.calls, name)
+}
+
+func (l *hookLog) has(name string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return slices.Contains(l.calls, name)
+}
+
+func (l *hookLog) all() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.calls...)
+}
+
+func (l *hookLog) reset() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.calls = nil
+}
+
+type chainRecorder struct {
+	mu     sync.Mutex
+	before []intercept.Call
+	after  []intercept.Call
+	errs   []error
+}
+
+var _ intercept.Interceptor = (*chainRecorder)(nil)
+
+func (c *chainRecorder) Before(ctx context.Context, call intercept.Call) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.before = append(c.before, call)
+	return nil
+}
+
+func (c *chainRecorder) After(ctx context.Context, call intercept.Call, err error) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.after = append(c.after, call)
+	c.errs = append(c.errs, err)
+	return err
+}
+
+func (c *chainRecorder) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.before, c.after, c.errs = nil, nil, nil
+}
+
+func (c *chainRecorder) beforeOps() []string { return opsOf(c.snapshotBefore()) }
+
+func (c *chainRecorder) afterOps() []string { return opsOf(c.snapshotAfter()) }
+
+func (c *chainRecorder) snapshotBefore() []intercept.Call {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]intercept.Call(nil), c.before...)
+}
+
+func (c *chainRecorder) snapshotAfter() []intercept.Call {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]intercept.Call(nil), c.after...)
+}
+
+func opsOf(calls []intercept.Call) []string {
+	out := make([]string, 0, len(calls))
+	for _, c := range calls {
+		out = append(out, string(c.Op))
+	}
+	return out
+}
+
+func namesOf(calls []intercept.Call) []string {
+	out := make([]string, 0, len(calls))
+	for _, c := range calls {
+		out = append(out, c.Name)
+	}
+	return out
+}

--- a/alicloud/provider/maximal_framework_test.go
+++ b/alicloud/provider/maximal_framework_test.go
@@ -1,0 +1,628 @@
+// The Framework counterpart of maximal_sdkv2_test.go.
+package provider_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
+	fwschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/fwadapt"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+)
+
+const (
+	maximalFrameworkName           = "alicloud_unit_test_fw_maximal"
+	maximalFrameworkDataSourceName = "alicloud_unit_test_fw_maximal_data"
+)
+
+type maximalFrameworkModel struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}
+
+type maximalFrameworkIdentityModel struct {
+	ID types.String `tfsdk:"id"`
+}
+
+func setMaximalFrameworkIdentity(ctx context.Context, identity *tfsdk.ResourceIdentity, id types.String) diag.Diagnostics {
+	if identity == nil {
+		return nil
+	}
+	return identity.Set(ctx, maximalFrameworkIdentityModel{ID: id})
+}
+
+type maximalFrameworkResource struct {
+	fwadapt.ResourceBase
+
+	log *hookLog
+}
+
+var (
+	_ resource.Resource                     = (*maximalFrameworkResource)(nil)
+	_ resource.ResourceWithConfigure        = (*maximalFrameworkResource)(nil)
+	_ resource.ResourceWithConfigValidators = (*maximalFrameworkResource)(nil)
+	_ resource.ResourceWithModifyPlan       = (*maximalFrameworkResource)(nil)
+	_ resource.ResourceWithValidateConfig   = (*maximalFrameworkResource)(nil)
+	_ resource.ResourceWithUpgradeState     = (*maximalFrameworkResource)(nil)
+	_ resource.ResourceWithMoveState        = (*maximalFrameworkResource)(nil)
+	_ resource.ResourceWithUpgradeIdentity  = (*maximalFrameworkResource)(nil)
+	_ resource.ResourceWithImportState      = (*maximalFrameworkResource)(nil)
+	_ resource.ResourceWithIdentity         = (*maximalFrameworkResource)(nil)
+	_ fwadapt.WithClient                    = (*maximalFrameworkResource)(nil)
+)
+
+func newMaximalFrameworkResource(log *hookLog) *maximalFrameworkResource {
+	return &maximalFrameworkResource{log: log}
+}
+
+func (r *maximalFrameworkResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_unit_test_fw_maximal"
+}
+
+func (r *maximalFrameworkResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = fwschema.Schema{
+		Version: 2,
+		Attributes: map[string]fwschema.Attribute{
+			"id": fwschema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"name": fwschema.StringAttribute{Required: true},
+		},
+		Description:         "Feature-maximal Framework fixture for the interceptor layer.",
+		MarkdownDescription: "Feature-maximal Framework fixture for the interceptor layer.",
+		DeprecationMessage:  "This is a unit test fixture and is never registered in the real provider.",
+	}
+}
+
+func (r *maximalFrameworkResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	r.recordCRUD("Create")
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+	var plan maximalFrameworkModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ID = types.StringValue("unit-test")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	resp.Diagnostics.Append(setMaximalFrameworkIdentity(ctx, resp.Identity, plan.ID)...)
+}
+
+func (r *maximalFrameworkResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	r.recordCRUD("Read")
+	if req.State.Raw.IsNull() {
+		return
+	}
+	var state maximalFrameworkModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	resp.Diagnostics.Append(setMaximalFrameworkIdentity(ctx, resp.Identity, state.ID)...)
+}
+
+func (r *maximalFrameworkResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	r.recordCRUD("Update")
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+	var plan maximalFrameworkModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	resp.Diagnostics.Append(setMaximalFrameworkIdentity(ctx, resp.Identity, plan.ID)...)
+}
+
+func (r *maximalFrameworkResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	r.recordCRUD("Delete")
+}
+
+func (r *maximalFrameworkResource) recordCRUD(op string) {
+	r.log.record(op)
+	if r.Client() != nil {
+		r.log.record(op + "/client")
+	}
+}
+
+func (r *maximalFrameworkResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+	r.log.record("ConfigValidators")
+	return []resource.ConfigValidator{recordingResourceValidator{log: r.log}}
+}
+
+func (r *maximalFrameworkResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	r.log.record("ModifyPlan")
+}
+
+func (r *maximalFrameworkResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	r.log.record("ValidateConfig")
+}
+
+func (r *maximalFrameworkResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	r.log.record("UpgradeState")
+	priorSchema := fwschema.Schema{
+		Attributes: map[string]fwschema.Attribute{
+			"id":   fwschema.StringAttribute{Computed: true},
+			"name": fwschema.StringAttribute{Required: true},
+		},
+	}
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema: &priorSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				r.log.record("UpgradeState0")
+				r.carryStateForward(ctx, req, resp)
+			},
+		},
+		1: {
+			PriorSchema: &priorSchema,
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				r.log.record("UpgradeState1")
+				r.carryStateForward(ctx, req, resp)
+			},
+		},
+	}
+}
+
+func (r *maximalFrameworkResource) carryStateForward(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+	if resp.State.Schema == nil || req.State == nil {
+		return
+	}
+	var prior maximalFrameworkModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &prior)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &prior)...)
+}
+
+func (r *maximalFrameworkResource) MoveState(ctx context.Context) []resource.StateMover {
+	r.log.record("MoveState")
+	return []resource.StateMover{
+		{
+			StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+				r.log.record("MoveState0")
+				if resp.TargetState.Schema == nil {
+					return
+				}
+				resp.Diagnostics.Append(resp.TargetState.Set(ctx, maximalFrameworkModel{
+					ID:   types.StringValue("unit-test"),
+					Name: types.StringValue("moved"),
+				})...)
+			},
+		},
+	}
+}
+
+func (r *maximalFrameworkResource) UpgradeIdentity(ctx context.Context) map[int64]resource.IdentityUpgrader {
+	r.log.record("UpgradeIdentity")
+	return map[int64]resource.IdentityUpgrader{
+		0: {
+			IdentityUpgrader: func(ctx context.Context, req resource.UpgradeIdentityRequest, resp *resource.UpgradeIdentityResponse) {
+				r.log.record("UpgradeIdentity0")
+				resp.Diagnostics.Append(setMaximalFrameworkIdentity(ctx, resp.Identity, types.StringValue("unit-test"))...)
+			},
+		},
+	}
+}
+
+func (r *maximalFrameworkResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	r.log.record("ImportState")
+	if resp.State.Schema == nil {
+		return
+	}
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *maximalFrameworkResource) IdentitySchema(ctx context.Context, req resource.IdentitySchemaRequest, resp *resource.IdentitySchemaResponse) {
+	r.log.record("IdentitySchema")
+	resp.IdentitySchema = identityschema.Schema{
+		Version: 1,
+		Attributes: map[string]identityschema.Attribute{
+			"id": identityschema.StringAttribute{RequiredForImport: true},
+		},
+	}
+}
+
+type recordingResourceValidator struct {
+	log *hookLog
+}
+
+var _ resource.ConfigValidator = recordingResourceValidator{}
+
+func (v recordingResourceValidator) Description(context.Context) string { return "records that it ran" }
+
+func (v recordingResourceValidator) MarkdownDescription(context.Context) string {
+	return "records that it ran"
+}
+
+func (v recordingResourceValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	v.log.record("ConfigValidator")
+}
+
+type maximalFrameworkDataSource struct {
+	fwadapt.DataSourceBase
+
+	log *hookLog
+}
+
+var (
+	_ datasource.DataSource                     = (*maximalFrameworkDataSource)(nil)
+	_ datasource.DataSourceWithConfigure        = (*maximalFrameworkDataSource)(nil)
+	_ datasource.DataSourceWithConfigValidators = (*maximalFrameworkDataSource)(nil)
+	_ datasource.DataSourceWithValidateConfig   = (*maximalFrameworkDataSource)(nil)
+	_ fwadapt.WithClient                        = (*maximalFrameworkDataSource)(nil)
+)
+
+func newMaximalFrameworkDataSource(log *hookLog) *maximalFrameworkDataSource {
+	return &maximalFrameworkDataSource{log: log}
+}
+
+func (d *maximalFrameworkDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_unit_test_fw_maximal_data"
+}
+
+func (d *maximalFrameworkDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = dsschema.Schema{
+		Attributes: map[string]dsschema.Attribute{
+			"id":   dsschema.StringAttribute{Computed: true},
+			"name": dsschema.StringAttribute{Required: true},
+		},
+		Description: "Feature-maximal Framework data source fixture for the interceptor layer.",
+	}
+}
+
+func (d *maximalFrameworkDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	d.log.record("Read")
+	if d.Client() != nil {
+		d.log.record("Read/client")
+	}
+	if req.Config.Raw.IsNull() {
+		return
+	}
+	var config maximalFrameworkModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	config.ID = types.StringValue("unit-test")
+	resp.Diagnostics.Append(resp.State.Set(ctx, &config)...)
+}
+
+func (d *maximalFrameworkDataSource) ConfigValidators(ctx context.Context) []datasource.ConfigValidator {
+	d.log.record("ConfigValidators")
+	return []datasource.ConfigValidator{recordingDataSourceValidator{log: d.log}}
+}
+
+func (d *maximalFrameworkDataSource) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	d.log.record("ValidateConfig")
+}
+
+type recordingDataSourceValidator struct {
+	log *hookLog
+}
+
+var _ datasource.ConfigValidator = recordingDataSourceValidator{}
+
+func (v recordingDataSourceValidator) Description(context.Context) string {
+	return "records that it ran"
+}
+
+func (v recordingDataSourceValidator) MarkdownDescription(context.Context) string {
+	return "records that it ran"
+}
+
+func (v recordingDataSourceValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	v.log.record("ConfigValidator")
+}
+
+func TestUnitProviderMaximalFrameworkWrapKeepsEveryCapability(t *testing.T) {
+	log := &hookLog{}
+	inner := newMaximalFrameworkResource(log)
+	wrapped := fwadapt.WrapResource(maximalFrameworkName, inner, []intercept.Interceptor{&chainRecorder{}})
+
+	if wrapped == resource.Resource(inner) {
+		t.Fatal("WrapResource returned the input: nothing would be intercepted")
+	}
+
+	if _, ok := wrapped.(resource.ResourceWithConfigure); !ok {
+		t.Error("the wrapper lost ResourceWithConfigure")
+	}
+	if _, ok := wrapped.(resource.ResourceWithConfigValidators); !ok {
+		t.Error("the wrapper lost ResourceWithConfigValidators")
+	}
+	if _, ok := wrapped.(resource.ResourceWithModifyPlan); !ok {
+		t.Error("the wrapper lost ResourceWithModifyPlan")
+	}
+	if _, ok := wrapped.(resource.ResourceWithValidateConfig); !ok {
+		t.Error("the wrapper lost ResourceWithValidateConfig")
+	}
+	if _, ok := wrapped.(resource.ResourceWithUpgradeState); !ok {
+		t.Error("the wrapper lost ResourceWithUpgradeState")
+	}
+	if _, ok := wrapped.(resource.ResourceWithMoveState); !ok {
+		t.Error("the wrapper lost ResourceWithMoveState")
+	}
+	if _, ok := wrapped.(resource.ResourceWithUpgradeIdentity); !ok {
+		t.Error("the wrapper lost ResourceWithUpgradeIdentity")
+	}
+	if _, ok := wrapped.(resource.ResourceWithImportState); !ok {
+		t.Error("the wrapper lost ResourceWithImportState")
+	}
+	if _, ok := wrapped.(resource.ResourceWithIdentity); !ok {
+		t.Error("the wrapper lost ResourceWithIdentity")
+	}
+}
+
+func TestUnitProviderMaximalFrameworkWrapForwardsEveryCapability(t *testing.T) {
+	ctx := context.Background()
+	log := &hookLog{}
+	wrapped := fwadapt.WrapResource(maximalFrameworkName, newMaximalFrameworkResource(log), []intercept.Interceptor{&chainRecorder{}})
+
+	t.Run("Metadata", func(t *testing.T) {
+		var resp resource.MetadataResponse
+		wrapped.Metadata(ctx, resource.MetadataRequest{ProviderTypeName: "alicloud"}, &resp)
+		if resp.TypeName != maximalFrameworkName {
+			t.Errorf("TypeName = %q, want %q", resp.TypeName, maximalFrameworkName)
+		}
+	})
+
+	t.Run("Schema", func(t *testing.T) {
+		var resp resource.SchemaResponse
+		wrapped.Schema(ctx, resource.SchemaRequest{}, &resp)
+		if resp.Schema.Version != 2 {
+			t.Errorf("Schema.Version = %d, want 2", resp.Schema.Version)
+		}
+		if resp.Schema.DeprecationMessage == "" {
+			t.Error("the schema's DeprecationMessage was lost")
+		}
+	})
+
+	t.Run("ConfigValidators", func(t *testing.T) {
+		validators := wrapped.(resource.ResourceWithConfigValidators).ConfigValidators(ctx)
+		if len(validators) != 1 {
+			t.Fatalf("got %d validators, want 1", len(validators))
+		}
+		validators[0].ValidateResource(ctx, resource.ValidateConfigRequest{}, &resource.ValidateConfigResponse{})
+		if !log.has("ConfigValidator") {
+			t.Error("the returned validator is not the fixture's")
+		}
+	})
+
+	t.Run("ModifyPlan", func(t *testing.T) {
+		wrapped.(resource.ResourceWithModifyPlan).ModifyPlan(ctx, resource.ModifyPlanRequest{}, &resource.ModifyPlanResponse{})
+		if !log.has("ModifyPlan") {
+			t.Error("ModifyPlan was not forwarded")
+		}
+	})
+
+	t.Run("ValidateConfig", func(t *testing.T) {
+		wrapped.(resource.ResourceWithValidateConfig).ValidateConfig(ctx, resource.ValidateConfigRequest{}, &resource.ValidateConfigResponse{})
+		if !log.has("ValidateConfig") {
+			t.Error("ValidateConfig was not forwarded")
+		}
+	})
+
+	t.Run("UpgradeState", func(t *testing.T) {
+		upgraders := wrapped.(resource.ResourceWithUpgradeState).UpgradeState(ctx)
+		if len(upgraders) != 2 {
+			t.Fatalf("got %d upgraders, want 2", len(upgraders))
+		}
+		for _, version := range []int64{0, 1} {
+			u, ok := upgraders[version]
+			if !ok {
+				t.Fatalf("no upgrader for version %d", version)
+			}
+			if u.PriorSchema == nil {
+				t.Errorf("upgrader %d lost its PriorSchema", version)
+			}
+			u.StateUpgrader(ctx, resource.UpgradeStateRequest{}, &resource.UpgradeStateResponse{})
+		}
+		if !log.has("UpgradeState0") || !log.has("UpgradeState1") {
+			t.Errorf("an upgrader function did not run: %v", log.all())
+		}
+	})
+
+	t.Run("MoveState", func(t *testing.T) {
+		movers := wrapped.(resource.ResourceWithMoveState).MoveState(ctx)
+		if len(movers) != 1 {
+			t.Fatalf("got %d movers, want 1", len(movers))
+		}
+		movers[0].StateMover(ctx, resource.MoveStateRequest{}, &resource.MoveStateResponse{})
+		if !log.has("MoveState0") {
+			t.Error("the mover function did not run")
+		}
+	})
+
+	t.Run("UpgradeIdentity", func(t *testing.T) {
+		upgraders := wrapped.(resource.ResourceWithUpgradeIdentity).UpgradeIdentity(ctx)
+		if len(upgraders) != 1 {
+			t.Fatalf("got %d identity upgraders, want 1", len(upgraders))
+		}
+		u, ok := upgraders[0]
+		if !ok {
+			t.Fatal("no identity upgrader for version 0")
+		}
+		u.IdentityUpgrader(ctx, resource.UpgradeIdentityRequest{}, &resource.UpgradeIdentityResponse{})
+		if !log.has("UpgradeIdentity0") {
+			t.Error("the identity upgrader function did not run")
+		}
+	})
+
+	t.Run("ImportState", func(t *testing.T) {
+		var resp resource.ImportStateResponse
+		wrapped.(resource.ResourceWithImportState).ImportState(ctx, resource.ImportStateRequest{ID: "unit-test"}, &resp)
+		if !log.has("ImportState") {
+			t.Error("ImportState was not forwarded")
+		}
+	})
+
+	t.Run("IdentitySchema", func(t *testing.T) {
+		var resp resource.IdentitySchemaResponse
+		wrapped.(resource.ResourceWithIdentity).IdentitySchema(ctx, resource.IdentitySchemaRequest{}, &resp)
+		if !log.has("IdentitySchema") {
+			t.Fatal("IdentitySchema was not forwarded")
+		}
+		if resp.IdentitySchema.Version != 1 {
+			t.Errorf("IdentitySchema.Version = %d, want 1", resp.IdentitySchema.Version)
+		}
+		if _, ok := resp.IdentitySchema.Attributes["id"]; !ok {
+			t.Error("the identity schema lost its attributes")
+		}
+	})
+}
+
+func TestUnitProviderMaximalFrameworkWrapRunsChainOnlyOnCRUD(t *testing.T) {
+	ctx := context.Background()
+	log := &hookLog{}
+	rec := &chainRecorder{}
+	client := &connectivity.AliyunClient{}
+	wrapped := fwadapt.WrapResource(maximalFrameworkName, newMaximalFrameworkResource(log), []intercept.Interceptor{rec})
+
+	var configureResp resource.ConfigureResponse
+	wrapped.(resource.ResourceWithConfigure).Configure(ctx, resource.ConfigureRequest{ProviderData: client}, &configureResp)
+	if configureResp.Diagnostics.HasError() {
+		t.Fatalf("Configure through the wrapper failed: %v", configureResp.Diagnostics)
+	}
+
+	var schemaResp resource.SchemaResponse
+	wrapped.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	wrapped.(resource.ResourceWithModifyPlan).ModifyPlan(ctx, resource.ModifyPlanRequest{}, &resource.ModifyPlanResponse{})
+	wrapped.(resource.ResourceWithValidateConfig).ValidateConfig(ctx, resource.ValidateConfigRequest{}, &resource.ValidateConfigResponse{})
+	wrapped.(resource.ResourceWithUpgradeState).UpgradeState(ctx)
+	wrapped.(resource.ResourceWithMoveState).MoveState(ctx)
+	wrapped.(resource.ResourceWithUpgradeIdentity).UpgradeIdentity(ctx)
+	wrapped.(resource.ResourceWithImportState).ImportState(ctx, resource.ImportStateRequest{ID: "unit-test"}, &resource.ImportStateResponse{})
+	wrapped.(resource.ResourceWithIdentity).IdentitySchema(ctx, resource.IdentitySchemaRequest{}, &resource.IdentitySchemaResponse{})
+
+	if got := rec.snapshotBefore(); len(got) != 0 {
+		t.Fatalf("the chain ran outside CRUD: %v", got)
+	}
+
+	log.reset()
+	var (
+		createResp resource.CreateResponse
+		readResp   resource.ReadResponse
+		updateResp resource.UpdateResponse
+		deleteResp resource.DeleteResponse
+	)
+	wrapped.Create(ctx, resource.CreateRequest{}, &createResp)
+	wrapped.Read(ctx, resource.ReadRequest{}, &readResp)
+	wrapped.Update(ctx, resource.UpdateRequest{}, &updateResp)
+	wrapped.Delete(ctx, resource.DeleteRequest{}, &deleteResp)
+
+	for _, diags := range []interface{ HasError() bool }{
+		createResp.Diagnostics, readResp.Diagnostics, updateResp.Diagnostics, deleteResp.Diagnostics,
+	} {
+		if diags.HasError() {
+			t.Errorf("a CRUD method reported an error: %v", diags)
+		}
+	}
+
+	wantOps := []string{"Create", "Read", "Update", "Delete"}
+	if got := rec.beforeOps(); !reflect.DeepEqual(got, wantOps) {
+		t.Errorf("Before ops = %v, want %v", got, wantOps)
+	}
+	if got := rec.afterOps(); !reflect.DeepEqual(got, wantOps) {
+		t.Errorf("After ops = %v, want %v", got, wantOps)
+	}
+	for _, name := range namesOf(rec.snapshotBefore()) {
+		if name != maximalFrameworkName {
+			t.Errorf("the chain saw name %q, want %q", name, maximalFrameworkName)
+		}
+	}
+
+	for _, call := range rec.snapshotBefore() {
+		if call.Meta != interface{}(client) {
+			t.Errorf("Call.Meta = %v, want the injected client", call.Meta)
+		}
+	}
+
+	want := []string{
+		"Create", "Create/client",
+		"Read", "Read/client",
+		"Update", "Update/client",
+		"Delete", "Delete/client",
+	}
+	if got := log.all(); !reflect.DeepEqual(got, want) {
+		t.Errorf("inner CRUD ran as %v, want %v", got, want)
+	}
+}
+
+func TestUnitProviderMaximalFrameworkDataSourceWrap(t *testing.T) {
+	ctx := context.Background()
+	log := &hookLog{}
+	rec := &chainRecorder{}
+	client := &connectivity.AliyunClient{}
+	wrapped := fwadapt.WrapDataSource(maximalFrameworkDataSourceName, newMaximalFrameworkDataSource(log), []intercept.Interceptor{rec})
+
+	var metadataResp datasource.MetadataResponse
+	wrapped.Metadata(ctx, datasource.MetadataRequest{ProviderTypeName: "alicloud"}, &metadataResp)
+	if metadataResp.TypeName != maximalFrameworkDataSourceName {
+		t.Errorf("TypeName = %q, want %q", metadataResp.TypeName, maximalFrameworkDataSourceName)
+	}
+
+	var configureResp datasource.ConfigureResponse
+	wrapped.(datasource.DataSourceWithConfigure).Configure(ctx, datasource.ConfigureRequest{ProviderData: client}, &configureResp)
+	if configureResp.Diagnostics.HasError() {
+		t.Fatalf("Configure through the wrapper failed: %v", configureResp.Diagnostics)
+	}
+
+	validators := wrapped.(datasource.DataSourceWithConfigValidators).ConfigValidators(ctx)
+	if len(validators) != 1 {
+		t.Fatalf("got %d validators, want 1", len(validators))
+	}
+	validators[0].ValidateDataSource(ctx, datasource.ValidateConfigRequest{}, &datasource.ValidateConfigResponse{})
+	if !log.has("ConfigValidator") {
+		t.Error("the returned validator is not the fixture's")
+	}
+
+	wrapped.(datasource.DataSourceWithValidateConfig).ValidateConfig(ctx, datasource.ValidateConfigRequest{}, &datasource.ValidateConfigResponse{})
+	if !log.has("ValidateConfig") {
+		t.Error("ValidateConfig was not forwarded")
+	}
+
+	if got := rec.snapshotBefore(); len(got) != 0 {
+		t.Fatalf("the chain ran outside Read: %v", got)
+	}
+
+	log.reset()
+	var readResp datasource.ReadResponse
+	wrapped.Read(ctx, datasource.ReadRequest{}, &readResp)
+	if readResp.Diagnostics.HasError() {
+		t.Errorf("Read reported an error: %v", readResp.Diagnostics)
+	}
+
+	wantOps := []string{"Read"}
+	if got := rec.beforeOps(); !reflect.DeepEqual(got, wantOps) {
+		t.Errorf("Before ops = %v, want %v", got, wantOps)
+	}
+	if got := rec.afterOps(); !reflect.DeepEqual(got, wantOps) {
+		t.Errorf("After ops = %v, want %v", got, wantOps)
+	}
+	if got := log.all(); !reflect.DeepEqual(got, []string{"Read", "Read/client"}) {
+		t.Errorf("inner Read ran as %v, want [Read Read/client]", got)
+	}
+	for _, call := range rec.snapshotBefore() {
+		if call.Meta != interface{}(client) {
+			t.Errorf("Call.Meta = %v, want the injected client", call.Meta)
+		}
+	}
+}

--- a/alicloud/provider/maximal_sdkv2_test.go
+++ b/alicloud/provider/maximal_sdkv2_test.go
@@ -1,0 +1,641 @@
+// Direct-call coverage: does the SDK v2 wrapper drop anything the fixture holds?
+package provider_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/sdkv2"
+)
+
+const (
+	maximalSDKv2Name           = "alicloud_unit_test_maximal"
+	maximalSDKv2ContextName    = "alicloud_unit_test_maximal_context"
+	maximalSDKv2NoTimeoutName  = "alicloud_unit_test_maximal_no_timeout"
+	maximalSDKv2DataSourceName = "alicloud_unit_test_maximal_data_source"
+)
+
+var crudFieldNames = map[string]bool{
+	"Create": true, "CreateContext": true, "CreateWithoutTimeout": true,
+	"Read": true, "ReadContext": true, "ReadWithoutTimeout": true,
+	"Update": true, "UpdateContext": true, "UpdateWithoutTimeout": true,
+	"Delete": true, "DeleteContext": true, "DeleteWithoutTimeout": true,
+}
+
+func maximalSDKv2SchemaV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name":     {Type: schema.TypeString, Required: true},
+			"image_id": {Type: schema.TypeString, Optional: true},
+		},
+	}
+}
+
+func maximalSDKv2SchemaV1() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name":     {Type: schema.TypeString, Required: true},
+			"image_id": {Type: schema.TypeString, Optional: true},
+			"tags":     {Type: schema.TypeMap, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+		},
+	}
+}
+
+func maximalSDKv2Resource(log *hookLog) *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name":     {Type: schema.TypeString, Required: true},
+			"image_id": {Type: schema.TypeString, Optional: true},
+			"tags":     {Type: schema.TypeMap, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+			"status":   {Type: schema.TypeString, Computed: true},
+		},
+		SchemaVersion: 2,
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"name": {Type: schema.TypeString, RequiredForImport: true},
+				}
+			},
+			IdentityUpgraders: []schema.IdentityUpgrader{
+				{
+					Version: 0,
+					Type:    tftypes.Object{AttributeTypes: map[string]tftypes.Type{"name": tftypes.String}},
+					Upgrade: func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+						log.record("IdentityUpgrade0")
+						return rawState, nil
+					},
+				},
+			},
+		},
+		MigrateState: func(version int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+			log.record("MigrateState")
+			return is, nil
+		},
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    maximalSDKv2SchemaV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+					log.record("StateUpgrade0")
+					rawState["tags"] = map[string]interface{}{}
+					return rawState, nil
+				},
+			},
+			{
+				Version: 1,
+				Type:    maximalSDKv2SchemaV1().CoreConfigSchema().ImpliedType(),
+				Upgrade: func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+					log.record("StateUpgrade1")
+					rawState["status"] = "Running"
+					return rawState, nil
+				},
+			},
+		},
+		Create: func(d *schema.ResourceData, meta interface{}) error {
+			log.record("Create")
+			d.SetId("unit-test")
+			return setMaximalSDKv2Identity(d)
+		},
+		Read: func(d *schema.ResourceData, meta interface{}) error {
+			log.record("Read")
+			return setMaximalSDKv2Identity(d)
+		},
+		Update: func(d *schema.ResourceData, meta interface{}) error {
+			log.record("Update")
+			return setMaximalSDKv2Identity(d)
+		},
+		Delete: func(d *schema.ResourceData, meta interface{}) error {
+			log.record("Delete")
+			return nil
+		},
+		Exists: func(d *schema.ResourceData, meta interface{}) (bool, error) {
+			log.record("Exists")
+			return true, nil
+		},
+		CustomizeDiff: func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			log.record("CustomizeDiff")
+			if diff.HasChange("image_id") {
+				return diff.ForceNew("image_id")
+			}
+			return nil
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				log.record("ImportState")
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+		DeprecationMessage: "This is a unit test fixture and is never registered in the real provider.",
+		Timeouts: &schema.ResourceTimeout{
+			Create:  durationPtr(11 * time.Minute),
+			Read:    durationPtr(12 * time.Minute),
+			Update:  durationPtr(13 * time.Minute),
+			Delete:  durationPtr(14 * time.Minute),
+			Default: durationPtr(15 * time.Minute),
+		},
+		Description:                       "Feature-maximal SDK v2 fixture for the interceptor layer.",
+		UseJSONNumber:                     true,
+		EnableLegacyTypeSystemApplyErrors: true,
+		EnableLegacyTypeSystemPlanErrors:  true,
+		ResourceBehavior:                  schema.ResourceBehavior{MutableIdentity: true},
+		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
+			func(ctx context.Context, req schema.ValidateResourceConfigFuncRequest, resp *schema.ValidateResourceConfigFuncResponse) {
+				log.record("ValidateRawResourceConfig")
+				resp.Diagnostics = append(resp.Diagnostics, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "the raw config validator ran",
+				})
+			},
+		},
+	}
+}
+
+func maximalSDKv2ContextResource(log *hookLog) *schema.Resource {
+	return &schema.Resource{
+		SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+				"name": {Type: schema.TypeString, Required: true},
+			}
+		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    maximalSDKv2SchemaV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+					log.record("ContextStateUpgrade0")
+					return rawState, nil
+				},
+			},
+		},
+		CreateContext: recordContext(log, "ContextCreate"),
+		ReadContext:   recordContext(log, "ContextRead"),
+		UpdateContext: recordContext(log, "ContextUpdate"),
+		DeleteContext: recordContext(log, "ContextDelete"),
+	}
+}
+
+func maximalSDKv2WithoutTimeoutResource(log *hookLog) *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {Type: schema.TypeString, Required: true},
+		},
+		CreateWithoutTimeout: recordContext(log, "NoTimeoutCreate"),
+		ReadWithoutTimeout:   recordContext(log, "NoTimeoutRead"),
+		UpdateWithoutTimeout: recordContext(log, "NoTimeoutUpdate"),
+		DeleteWithoutTimeout: recordContext(log, "NoTimeoutDelete"),
+	}
+}
+
+func maximalSDKv2DataSource(log *hookLog) *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: func(v interface{}, k string) ([]string, []error) {
+					log.record("ValidateName")
+					return []string{"the data source config validator ran"}, nil
+				},
+			},
+			"image_id": {Type: schema.TypeString, Optional: true},
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id":     {Type: schema.TypeString, Computed: true},
+						"status": {Type: schema.TypeString, Computed: true},
+					},
+				},
+			},
+			"output_file": {Type: schema.TypeString, Optional: true},
+		},
+		DeprecationMessage: "This is a unit test fixture and is never registered in the real provider.",
+		Description:        "Feature-maximal SDK v2 data source fixture for the interceptor layer.",
+		Read: func(d *schema.ResourceData, meta interface{}) error {
+			log.record("Read")
+			d.SetId("unit-test")
+			if err := d.Set("ids", []string{"unit-test"}); err != nil {
+				return err
+			}
+			return d.Set("instances", []map[string]interface{}{
+				{"id": "unit-test", "status": "Running"},
+			})
+		},
+	}
+}
+
+func setMaximalSDKv2Identity(d *schema.ResourceData) error {
+	identity, err := d.Identity()
+	if err != nil {
+		return err
+	}
+	return identity.Set("name", d.Get("name"))
+}
+
+func recordContext(log *hookLog, name string) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		log.record(name)
+		d.SetId("unit-test")
+		return nil
+	}
+}
+
+func durationPtr(d time.Duration) *time.Duration { return &d }
+
+func maximalSDKv2Provider(log *hookLog, chain []intercept.Interceptor) *schema.Provider {
+	resources := map[string]*schema.Resource{
+		maximalSDKv2Name:          maximalSDKv2Resource(log),
+		maximalSDKv2ContextName:   maximalSDKv2ContextResource(log),
+		maximalSDKv2NoTimeoutName: maximalSDKv2WithoutTimeoutResource(log),
+	}
+	dataSources := map[string]*schema.Resource{
+		maximalSDKv2DataSourceName: maximalSDKv2DataSource(log),
+	}
+	if len(chain) > 0 {
+		for name, r := range resources {
+			resources[name] = sdkv2.WrapResource(name, r, chain)
+		}
+		for name, ds := range dataSources {
+			dataSources[name] = sdkv2.WrapDataSource(name, ds, chain)
+		}
+	}
+	return &schema.Provider{ResourcesMap: resources, DataSourcesMap: dataSources}
+}
+
+func TestUnitProviderMaximalSDKv2FixturesAreLegal(t *testing.T) {
+	log := &hookLog{}
+
+	if err := maximalSDKv2Provider(log, nil).InternalValidate(); err != nil {
+		t.Fatalf("the unwrapped fixtures are not legal resources: %s", err)
+	}
+	if err := maximalSDKv2Provider(log, []intercept.Interceptor{&chainRecorder{}}).InternalValidate(); err != nil {
+		t.Fatalf("wrapping produced an illegal resource: %s", err)
+	}
+}
+
+func TestUnitProviderMaximalSDKv2FixturesCoverEveryField(t *testing.T) {
+	log := &hookLog{}
+	fixtures := []*schema.Resource{
+		maximalSDKv2Resource(log),
+		maximalSDKv2ContextResource(log),
+		maximalSDKv2WithoutTimeoutResource(log),
+	}
+
+	rt := reflect.TypeOf(schema.Resource{})
+	var uncovered []string
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		covered := false
+		for _, fixture := range fixtures {
+			if !reflect.ValueOf(*fixture).Field(i).IsZero() {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			uncovered = append(uncovered, f.Name)
+		}
+	}
+
+	if len(uncovered) > 0 {
+		t.Fatalf("no fixture populates %v: the wrapper sweep cannot observe a zero field, so add these to a fixture", uncovered)
+	}
+}
+
+func TestUnitProviderMaximalSDKv2WrapCopiesEveryNonCRUDField(t *testing.T) {
+	log := &hookLog{}
+	chain := []intercept.Interceptor{&chainRecorder{}}
+
+	for _, tc := range []struct {
+		name  string
+		build func(*hookLog) *schema.Resource
+		wrap  func(string, *schema.Resource, []intercept.Interceptor) *schema.Resource
+	}{
+		{maximalSDKv2Name, maximalSDKv2Resource, sdkv2.WrapResource},
+		{maximalSDKv2ContextName, maximalSDKv2ContextResource, sdkv2.WrapResource},
+		{maximalSDKv2NoTimeoutName, maximalSDKv2WithoutTimeoutResource, sdkv2.WrapResource},
+		{maximalSDKv2DataSourceName, maximalSDKv2DataSource, sdkv2.WrapDataSource},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			original := tc.build(log)
+			wrapped := tc.wrap(tc.name, original, chain)
+
+			if wrapped == original {
+				t.Fatal("wrapping returned the input pointer: the shared map literal would be mutated")
+			}
+
+			ov, wv := reflect.ValueOf(*original), reflect.ValueOf(*wrapped)
+			rt := ov.Type()
+			for i := 0; i < rt.NumField(); i++ {
+				f := rt.Field(i)
+				if !f.IsExported() || crudFieldNames[f.Name] {
+					continue
+				}
+				of, wf := ov.Field(i), wv.Field(i)
+
+				if f.Type.Kind() == reflect.Func {
+					if of.Pointer() != wf.Pointer() {
+						t.Errorf("%s was not copied", f.Name)
+					}
+					continue
+				}
+				if !reflect.DeepEqual(of.Interface(), wf.Interface()) {
+					t.Errorf("%s was not copied: original %v, wrapped %v", f.Name, of.Interface(), wf.Interface())
+				}
+			}
+		})
+	}
+}
+
+func TestUnitProviderMaximalSDKv2WrapPreservesEveryHook(t *testing.T) {
+	ctx := context.Background()
+	log := &hookLog{}
+	wrapped := sdkv2.WrapResource(maximalSDKv2Name, maximalSDKv2Resource(log), []intercept.Interceptor{&chainRecorder{}})
+
+	t.Run("CustomizeDiff", func(t *testing.T) {
+		state := &terraform.InstanceState{
+			ID: "unit-test",
+			Attributes: map[string]string{
+				"id":       "unit-test",
+				"name":     "tf-testacc-maximal",
+				"image_id": "image-one",
+			},
+		}
+		config := terraform.NewResourceConfigRaw(map[string]interface{}{
+			"name":     "tf-testacc-maximal",
+			"image_id": "image-two",
+		})
+
+		diff, err := wrapped.Diff(ctx, state, config, nil)
+		if err != nil {
+			t.Fatalf("Diff: %s", err)
+		}
+		if !log.has("CustomizeDiff") {
+			t.Fatal("CustomizeDiff did not run on the wrapped resource")
+		}
+		if diff == nil || diff.Attributes["image_id"] == nil || !diff.Attributes["image_id"].RequiresNew {
+			t.Fatalf("CustomizeDiff ran but its ForceNew was lost: %#v", diff)
+		}
+	})
+
+	t.Run("StateUpgraders", func(t *testing.T) {
+		if len(wrapped.StateUpgraders) != 2 {
+			t.Fatalf("got %d state upgraders, want 2", len(wrapped.StateUpgraders))
+		}
+		raw := map[string]interface{}{"name": "tf-testacc-maximal", "image_id": "image-one"}
+		for i, u := range wrapped.StateUpgraders {
+			out, err := u.Upgrade(ctx, raw, nil)
+			if err != nil {
+				t.Fatalf("upgrader %d: %s", i, err)
+			}
+			raw = out
+		}
+		if !log.has("StateUpgrade0") || !log.has("StateUpgrade1") {
+			t.Fatalf("an upgrader did not run: %v", log.all())
+		}
+		if _, ok := raw["tags"]; !ok {
+			t.Error("the v0 upgrader's output was discarded")
+		}
+		if raw["status"] != "Running" {
+			t.Error("the v1 upgrader's output was discarded")
+		}
+	})
+
+	t.Run("MigrateState", func(t *testing.T) {
+		if wrapped.MigrateState == nil {
+			t.Fatal("MigrateState was dropped")
+		}
+		in := &terraform.InstanceState{ID: "unit-test"}
+		out, err := wrapped.MigrateState(0, in, nil)
+		if err != nil {
+			t.Fatalf("MigrateState: %s", err)
+		}
+		if out != in {
+			t.Error("MigrateState's return value was not the fixture's")
+		}
+		if !log.has("MigrateState") {
+			t.Fatal("MigrateState did not run")
+		}
+	})
+
+	t.Run("Identity", func(t *testing.T) {
+		if wrapped.Identity == nil {
+			t.Fatal("Identity was dropped")
+		}
+		if got := wrapped.Identity.Version; got != 1 {
+			t.Errorf("Identity.Version = %d, want 1", got)
+		}
+		if _, ok := wrapped.Identity.SchemaMap()["name"]; !ok {
+			t.Error("Identity.SchemaFunc was dropped")
+		}
+		if len(wrapped.Identity.IdentityUpgraders) != 1 {
+			t.Fatalf("got %d identity upgraders, want 1", len(wrapped.Identity.IdentityUpgraders))
+		}
+		if _, err := wrapped.Identity.IdentityUpgraders[0].Upgrade(ctx, map[string]interface{}{"name": "tf-testacc-maximal"}, nil); err != nil {
+			t.Fatalf("identity upgrader: %s", err)
+		}
+		if !log.has("IdentityUpgrade0") {
+			t.Fatal("the identity upgrader did not run")
+		}
+	})
+
+	t.Run("Importer", func(t *testing.T) {
+		if wrapped.Importer == nil || wrapped.Importer.StateContext == nil {
+			t.Fatal("Importer was dropped")
+		}
+		d := wrapped.Data(&terraform.InstanceState{ID: "unit-test"})
+		out, err := wrapped.Importer.StateContext(ctx, d, nil)
+		if err != nil {
+			t.Fatalf("ImportState: %s", err)
+		}
+		if len(out) != 1 || out[0] != d {
+			t.Error("the importer's return value was not the fixture's")
+		}
+		if !log.has("ImportState") {
+			t.Fatal("the importer did not run")
+		}
+	})
+
+	t.Run("Exists", func(t *testing.T) {
+		if wrapped.Exists == nil {
+			t.Fatal("Exists was dropped")
+		}
+		ok, err := wrapped.Exists(wrapped.Data(&terraform.InstanceState{ID: "unit-test"}), nil)
+		if err != nil || !ok {
+			t.Fatalf("Exists returned (%t, %v), want (true, nil)", ok, err)
+		}
+		if !log.has("Exists") {
+			t.Fatal("Exists did not run")
+		}
+	})
+
+	t.Run("ValidateRawResourceConfigFuncs", func(t *testing.T) {
+		if len(wrapped.ValidateRawResourceConfigFuncs) != 1 {
+			t.Fatalf("got %d raw config validators, want 1", len(wrapped.ValidateRawResourceConfigFuncs))
+		}
+		var resp schema.ValidateResourceConfigFuncResponse
+		wrapped.ValidateRawResourceConfigFuncs[0](ctx, schema.ValidateResourceConfigFuncRequest{}, &resp)
+		if !log.has("ValidateRawResourceConfig") {
+			t.Fatal("the raw config validator did not run")
+		}
+		if len(resp.Diagnostics) != 1 {
+			t.Errorf("the validator's diagnostics were lost: %v", resp.Diagnostics)
+		}
+	})
+
+	t.Run("scalar fields", func(t *testing.T) {
+		if wrapped.SchemaVersion != 2 {
+			t.Errorf("SchemaVersion = %d, want 2", wrapped.SchemaVersion)
+		}
+		if wrapped.DeprecationMessage == "" || wrapped.Description == "" {
+			t.Error("DeprecationMessage or Description was dropped")
+		}
+		if !wrapped.UseJSONNumber || !wrapped.EnableLegacyTypeSystemApplyErrors || !wrapped.EnableLegacyTypeSystemPlanErrors {
+			t.Error("a behaviour flag was dropped")
+		}
+		if !wrapped.ResourceBehavior.MutableIdentity {
+			t.Error("ResourceBehavior was dropped")
+		}
+		if wrapped.Timeouts == nil || wrapped.Timeouts.Create == nil || *wrapped.Timeouts.Create != 11*time.Minute {
+			t.Error("Timeouts was dropped")
+		}
+	})
+}
+
+func TestUnitProviderMaximalSDKv2WrapRunsChainOnlyOnCRUD(t *testing.T) {
+	ctx := context.Background()
+	log := &hookLog{}
+	rec := &chainRecorder{}
+	wrapped := sdkv2.WrapResource(maximalSDKv2Name, maximalSDKv2Resource(log), []intercept.Interceptor{rec})
+
+	d := wrapped.Data(&terraform.InstanceState{ID: "unit-test"})
+	if _, err := wrapped.Importer.StateContext(ctx, d, nil); err != nil {
+		t.Fatalf("ImportState: %s", err)
+	}
+	if _, err := wrapped.Exists(d, nil); err != nil {
+		t.Fatalf("Exists: %s", err)
+	}
+	if _, err := wrapped.MigrateState(0, &terraform.InstanceState{ID: "unit-test"}, nil); err != nil {
+		t.Fatalf("MigrateState: %s", err)
+	}
+	if _, err := wrapped.StateUpgraders[0].Upgrade(ctx, map[string]interface{}{}, nil); err != nil {
+		t.Fatalf("StateUpgrade0: %s", err)
+	}
+	var validateResp schema.ValidateResourceConfigFuncResponse
+	wrapped.ValidateRawResourceConfigFuncs[0](ctx, schema.ValidateResourceConfigFuncRequest{}, &validateResp)
+
+	if got := rec.snapshotBefore(); len(got) != 0 {
+		t.Fatalf("the chain ran outside CRUD: %v", got)
+	}
+
+	client := &struct{ name string }{name: "stand-in for the client"}
+	if err := wrapped.Create(d, client); err != nil {
+		t.Fatalf("Create: %s", err)
+	}
+	if err := wrapped.Read(d, client); err != nil {
+		t.Fatalf("Read: %s", err)
+	}
+	if err := wrapped.Update(d, client); err != nil {
+		t.Fatalf("Update: %s", err)
+	}
+	if err := wrapped.Delete(d, client); err != nil {
+		t.Fatalf("Delete: %s", err)
+	}
+
+	wantOps := []string{"Create", "Read", "Update", "Delete"}
+	if got := rec.beforeOps(); !reflect.DeepEqual(got, wantOps) {
+		t.Errorf("Before ops = %v, want %v", got, wantOps)
+	}
+	if got := rec.afterOps(); !reflect.DeepEqual(got, wantOps) {
+		t.Errorf("After ops = %v, want %v", got, wantOps)
+	}
+	for _, name := range namesOf(rec.snapshotBefore()) {
+		if name != maximalSDKv2Name {
+			t.Errorf("the chain saw name %q, want %q", name, maximalSDKv2Name)
+		}
+	}
+	for _, call := range rec.snapshotBefore() {
+		if call.Meta != interface{}(client) {
+			t.Errorf("Call.Meta = %v, want the meta the CRUD function was given", call.Meta)
+		}
+	}
+	if got := log.all(); !reflect.DeepEqual(got[len(got)-4:], wantOps) {
+		t.Errorf("the inner CRUD functions ran as %v, want %v", got[len(got)-4:], wantOps)
+	}
+}
+
+func TestUnitProviderMaximalSDKv2WrapCoversEveryCRUDForm(t *testing.T) {
+	ctx := context.Background()
+	wantOps := []string{"Create", "Read", "Update", "Delete"}
+
+	t.Run("context form", func(t *testing.T) {
+		log := &hookLog{}
+		rec := &chainRecorder{}
+		wrapped := sdkv2.WrapResource(maximalSDKv2ContextName, maximalSDKv2ContextResource(log), []intercept.Interceptor{rec})
+
+		if wrapped.Create != nil || wrapped.CreateWithoutTimeout != nil {
+			t.Error("wrapping moved the create function to another declaration form")
+		}
+		d := wrapped.Data(&terraform.InstanceState{ID: "unit-test"})
+		for _, call := range []func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics{
+			wrapped.CreateContext, wrapped.ReadContext, wrapped.UpdateContext, wrapped.DeleteContext,
+		} {
+			if diags := call(ctx, d, nil); diags.HasError() {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+		}
+
+		if got := rec.beforeOps(); !reflect.DeepEqual(got, wantOps) {
+			t.Errorf("Before ops = %v, want %v", got, wantOps)
+		}
+		want := []string{"ContextCreate", "ContextRead", "ContextUpdate", "ContextDelete"}
+		if got := log.all(); !reflect.DeepEqual(got, want) {
+			t.Errorf("inner functions ran as %v, want %v", got, want)
+		}
+	})
+
+	t.Run("without-timeout form", func(t *testing.T) {
+		log := &hookLog{}
+		rec := &chainRecorder{}
+		wrapped := sdkv2.WrapResource(maximalSDKv2NoTimeoutName, maximalSDKv2WithoutTimeoutResource(log), []intercept.Interceptor{rec})
+
+		if wrapped.Create != nil || wrapped.CreateContext != nil {
+			t.Error("wrapping moved the create function to another declaration form")
+		}
+		d := wrapped.Data(&terraform.InstanceState{ID: "unit-test"})
+		for _, call := range []func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics{
+			wrapped.CreateWithoutTimeout, wrapped.ReadWithoutTimeout, wrapped.UpdateWithoutTimeout, wrapped.DeleteWithoutTimeout,
+		} {
+			if diags := call(ctx, d, nil); diags.HasError() {
+				t.Fatalf("unexpected diags: %v", diags)
+			}
+		}
+
+		if got := rec.beforeOps(); !reflect.DeepEqual(got, wantOps) {
+			t.Errorf("Before ops = %v, want %v", got, wantOps)
+		}
+		want := []string{"NoTimeoutCreate", "NoTimeoutRead", "NoTimeoutUpdate", "NoTimeoutDelete"}
+		if got := log.all(); !reflect.DeepEqual(got, want) {
+			t.Errorf("inner functions ran as %v, want %v", got, want)
+		}
+	})
+}

--- a/alicloud/provider/maximal_sdkv2_test.go
+++ b/alicloud/provider/maximal_sdkv2_test.go
@@ -62,6 +62,7 @@ func maximalSDKv2Resource(log *hookLog) *schema.Resource {
 			Version: 1,
 			SchemaFunc: func() map[string]*schema.Schema {
 				return map[string]*schema.Schema{
+					// lintignore: S013
 					"name": {Type: schema.TypeString, RequiredForImport: true},
 				}
 			},
@@ -117,6 +118,7 @@ func maximalSDKv2Resource(log *hookLog) *schema.Resource {
 			log.record("Delete")
 			return nil
 		},
+		// lintignore: R003
 		Exists: func(d *schema.ResourceData, meta interface{}) (bool, error) {
 			log.record("Exists")
 			return true, nil

--- a/alicloud/provider/maximal_sdkv2_test.go
+++ b/alicloud/provider/maximal_sdkv2_test.go
@@ -49,6 +49,7 @@ func maximalSDKv2SchemaV1() *schema.Resource {
 	}
 }
 
+// lintignore: R003
 func maximalSDKv2Resource(log *hookLog) *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -118,7 +119,6 @@ func maximalSDKv2Resource(log *hookLog) *schema.Resource {
 			log.record("Delete")
 			return nil
 		},
-		// lintignore: R003
 		Exists: func(d *schema.ResourceData, meta interface{}) (bool, error) {
 			log.record("Exists")
 			return true, nil

--- a/alicloud/provider/maximal_wire_test.go
+++ b/alicloud/provider/maximal_wire_test.go
@@ -1,0 +1,1105 @@
+// The two fixtures driven through real protocol-v5 servers — the only place
+// non-CRUD RPCs are testable. Not muxed: factory_test.go covers that.
+package provider_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	fwprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	providerschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/fwadapt"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+)
+
+var (
+	maximalSDKv2Type = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"id":       tftypes.String,
+		"name":     tftypes.String,
+		"image_id": tftypes.String,
+		"status":   tftypes.String,
+		"tags":     tftypes.Map{ElementType: tftypes.String},
+		"timeouts": tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+			"create":  tftypes.String,
+			"read":    tftypes.String,
+			"update":  tftypes.String,
+			"delete":  tftypes.String,
+			"default": tftypes.String,
+		}},
+	}}
+	maximalSDKv2IdentityType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"name": tftypes.String,
+	}}
+	maximalSDKv2DataSourceType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"id":       tftypes.String,
+		"name":     tftypes.String,
+		"image_id": tftypes.String,
+		"ids":      tftypes.List{ElementType: tftypes.String},
+		"instances": tftypes.List{ElementType: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+			"id":     tftypes.String,
+			"status": tftypes.String,
+		}}},
+		"output_file": tftypes.String,
+	}}
+	maximalFrameworkType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"id":   tftypes.String,
+		"name": tftypes.String,
+	}}
+	maximalFrameworkIdentityType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"id": tftypes.String,
+	}}
+	emptyObjectType = tftypes.Object{AttributeTypes: map[string]tftypes.Type{}}
+)
+
+var wantCRUDOps = []string{"Create", "Read", "Update", "Delete"}
+
+type maximalFrameworkTestProvider struct {
+	log    *hookLog
+	chain  []intercept.Interceptor
+	client *connectivity.AliyunClient
+}
+
+var _ fwprovider.Provider = (*maximalFrameworkTestProvider)(nil)
+
+func (p *maximalFrameworkTestProvider) Metadata(ctx context.Context, req fwprovider.MetadataRequest, resp *fwprovider.MetadataResponse) {
+	resp.TypeName = "alicloud"
+}
+
+func (p *maximalFrameworkTestProvider) Schema(ctx context.Context, req fwprovider.SchemaRequest, resp *fwprovider.SchemaResponse) {
+	resp.Schema = providerschema.Schema{}
+}
+
+func (p *maximalFrameworkTestProvider) Configure(ctx context.Context, req fwprovider.ConfigureRequest, resp *fwprovider.ConfigureResponse) {
+	resp.ResourceData = p.client
+	resp.DataSourceData = p.client
+}
+
+func (p *maximalFrameworkTestProvider) Resources(ctx context.Context) []func() resource.Resource {
+	return []func() resource.Resource{
+		func() resource.Resource {
+			return fwadapt.WrapResource(maximalFrameworkName, newMaximalFrameworkResource(p.log), p.chain)
+		},
+	}
+}
+
+func (p *maximalFrameworkTestProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
+	return []func() datasource.DataSource{
+		func() datasource.DataSource {
+			return fwadapt.WrapDataSource(maximalFrameworkDataSourceName, newMaximalFrameworkDataSource(p.log), p.chain)
+		},
+	}
+}
+
+func TestUnitProviderMaximalWireSDKv2(t *testing.T) {
+	ctx := context.Background()
+	log, chain, client := &hookLog{}, &chainRecorder{}, &connectivity.AliyunClient{}
+	server := newMaximalSDKv2Server(t, log, chain, client)
+
+	t.Run("GetProviderSchema", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+		if err != nil {
+			t.Fatalf("GetProviderSchema: %s", err)
+		}
+		requireNoDiagErrors(t, "GetProviderSchema", resp.Diagnostics)
+
+		schema, ok := resp.ResourceSchemas[maximalSDKv2Name]
+		if !ok {
+			t.Fatalf("the wrapped fixture is not in the schema: %v", resp.ResourceSchemas)
+		}
+		if schema.Version != 2 {
+			t.Errorf("the served schema version is %d, want 2", schema.Version)
+		}
+		if !schema.Block.Deprecated {
+			t.Error("the served schema is not marked deprecated")
+		}
+
+		dataSchema, ok := resp.DataSourceSchemas[maximalSDKv2DataSourceName]
+		if !ok {
+			t.Fatalf("the wrapped data source fixture is not in the schema: %v", resp.DataSourceSchemas)
+		}
+		if got := dataSchema.ValueType(); !got.Equal(maximalSDKv2DataSourceType) {
+			t.Errorf("the served data source type is %s, want %s", got, maximalSDKv2DataSourceType)
+		}
+	})
+
+	t.Run("GetResourceIdentitySchemas", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.GetResourceIdentitySchemas(ctx, &tfprotov5.GetResourceIdentitySchemasRequest{})
+		if err != nil {
+			t.Fatalf("GetResourceIdentitySchemas: %s", err)
+		}
+		requireNoDiagErrors(t, "GetResourceIdentitySchemas", resp.Diagnostics)
+
+		schema, ok := resp.IdentitySchemas[maximalSDKv2Name]
+		if !ok {
+			t.Fatalf("the wrapped fixture has no identity schema: %v", resp.IdentitySchemas)
+		}
+		if schema.Version != 1 {
+			t.Errorf("the served identity version is %d, want 1", schema.Version)
+		}
+		if len(schema.IdentityAttributes) != 1 {
+			t.Fatalf("the served identity has %d attributes, want 1", len(schema.IdentityAttributes))
+		}
+		if got := schema.IdentityAttributes[0]; got.Name != "name" || !got.RequiredForImport {
+			t.Errorf("the served identity attribute is %+v, want name/RequiredForImport", got)
+		}
+	})
+
+	t.Run("ValidateResourceTypeConfig", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		config := dynamic(t, maximalSDKv2Type, object(t, maximalSDKv2Type, map[string]tftypes.Value{
+			"name": tftypes.NewValue(tftypes.String, "fixture"),
+		}))
+		resp, err := server.ValidateResourceTypeConfig(ctx, &tfprotov5.ValidateResourceTypeConfigRequest{
+			TypeName: maximalSDKv2Name,
+			Config:   config,
+		})
+		if err != nil {
+			t.Fatalf("ValidateResourceTypeConfig: %s", err)
+		}
+		requireNoDiagErrors(t, "ValidateResourceTypeConfig", resp.Diagnostics)
+
+		if !log.has("ValidateRawResourceConfig") {
+			t.Error("the raw config validator did not run")
+		}
+		if !hasWarning(resp.Diagnostics, "the raw config validator ran") {
+			t.Errorf("the validator's warning did not survive: %v", resp.Diagnostics)
+		}
+		assertChainSilent(t, chain, "validating a config")
+	})
+
+	t.Run("UpgradeResourceState/json", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.UpgradeResourceState(ctx, &tfprotov5.UpgradeResourceStateRequest{
+			TypeName: maximalSDKv2Name,
+			Version:  0,
+			RawState: &tfprotov5.RawState{
+				JSON: []byte(`{"id":"unit-test","name":"fixture","image_id":"image-one"}`),
+			},
+		})
+		if err != nil {
+			t.Fatalf("UpgradeResourceState: %s", err)
+		}
+		requireNoDiagErrors(t, "UpgradeResourceState", resp.Diagnostics)
+
+		if !log.has("StateUpgrade0") || !log.has("StateUpgrade1") {
+			t.Errorf("the upgrader chain did not run to completion: %v", log.all())
+		}
+		attrs := attrsOf(t, maximalSDKv2Type, resp.UpgradedState)
+		if got := stringOf(t, attrs["status"]); got != "Running" {
+			t.Errorf("status after upgrading is %q, want %q — the second upgrader's write was lost", got, "Running")
+		}
+		if attrs["tags"].IsNull() {
+			t.Error("tags after upgrading is null — the first upgrader's write was lost")
+		}
+		assertChainSilent(t, chain, "upgrading a JSON state")
+	})
+
+	t.Run("UpgradeResourceState/flatmap", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.UpgradeResourceState(ctx, &tfprotov5.UpgradeResourceStateRequest{
+			TypeName: maximalSDKv2Name,
+			Version:  0,
+			RawState: &tfprotov5.RawState{
+				Flatmap: map[string]string{
+					"id":       "unit-test",
+					"name":     "fixture",
+					"image_id": "image-one",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("UpgradeResourceState: %s", err)
+		}
+		requireNoDiagErrors(t, "UpgradeResourceState", resp.Diagnostics)
+
+		if !log.has("StateUpgrade0") || !log.has("StateUpgrade1") {
+			t.Errorf("the upgrader chain did not run to completion: %v", log.all())
+		}
+		if log.has("MigrateState") {
+			t.Error("MigrateState ran, but no version is low enough to reach it")
+		}
+		if got := stringOf(t, attrsOf(t, maximalSDKv2Type, resp.UpgradedState)["status"]); got != "Running" {
+			t.Errorf("status after upgrading a flatmap is %q, want %q", got, "Running")
+		}
+		assertChainSilent(t, chain, "upgrading a flatmap state")
+	})
+
+	t.Run("UpgradeResourceIdentity", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.UpgradeResourceIdentity(ctx, &tfprotov5.UpgradeResourceIdentityRequest{
+			TypeName:    maximalSDKv2Name,
+			Version:     0,
+			RawIdentity: &tfprotov5.RawState{JSON: []byte(`{"name":"fixture"}`)},
+		})
+		if err != nil {
+			t.Fatalf("UpgradeResourceIdentity: %s", err)
+		}
+		requireNoDiagErrors(t, "UpgradeResourceIdentity", resp.Diagnostics)
+
+		if !log.has("IdentityUpgrade0") {
+			t.Errorf("the identity upgrader did not run: %v", log.all())
+		}
+		if resp.UpgradedIdentity == nil {
+			t.Fatal("the upgraded identity is missing")
+		}
+		if got := stringOf(t, attrsOf(t, maximalSDKv2IdentityType, resp.UpgradedIdentity.IdentityData)["name"]); got != "fixture" {
+			t.Errorf("the upgraded identity name is %q, want %q", got, "fixture")
+		}
+		assertChainSilent(t, chain, "upgrading an identity")
+	})
+
+	t.Run("ImportResourceState", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.ImportResourceState(ctx, &tfprotov5.ImportResourceStateRequest{
+			TypeName: maximalSDKv2Name,
+			ID:       "unit-test",
+		})
+		if err != nil {
+			t.Fatalf("ImportResourceState: %s", err)
+		}
+		requireNoDiagErrors(t, "ImportResourceState", resp.Diagnostics)
+
+		if len(resp.ImportedResources) != 1 {
+			t.Fatalf("importing produced %d resources, want 1", len(resp.ImportedResources))
+		}
+		if !log.has("ImportState") {
+			t.Errorf("the importer did not run: %v", log.all())
+		}
+		if log.has("Read") {
+			t.Errorf("importing also ran Read: %v", log.all())
+		}
+		assertChainSilent(t, chain, "importing")
+	})
+
+	t.Run("ValidateDataSourceConfig", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.ValidateDataSourceConfig(ctx, &tfprotov5.ValidateDataSourceConfigRequest{
+			TypeName: maximalSDKv2DataSourceName,
+			Config: dynamic(t, maximalSDKv2DataSourceType, object(t, maximalSDKv2DataSourceType, map[string]tftypes.Value{
+				"name": tftypes.NewValue(tftypes.String, "fixture"),
+			})),
+		})
+		if err != nil {
+			t.Fatalf("ValidateDataSourceConfig: %s", err)
+		}
+		requireNoDiagErrors(t, "ValidateDataSourceConfig", resp.Diagnostics)
+
+		if !log.has("ValidateName") {
+			t.Errorf("the schema validator did not run: %v", log.all())
+		}
+		if !hasWarning(resp.Diagnostics, "the data source config validator ran") {
+			t.Errorf("the validator's warning did not survive: %v", resp.Diagnostics)
+		}
+		if !hasWarning(resp.Diagnostics, "Deprecated Resource") {
+			t.Errorf("the deprecation warning did not survive: %v", resp.Diagnostics)
+		}
+		if log.has("Read") {
+			t.Errorf("validation also ran Read: %v", log.all())
+		}
+		assertChainSilent(t, chain, "validating a data source config")
+	})
+
+	t.Run("ReadDataSource", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.ReadDataSource(ctx, &tfprotov5.ReadDataSourceRequest{
+			TypeName: maximalSDKv2DataSourceName,
+			Config: dynamic(t, maximalSDKv2DataSourceType, object(t, maximalSDKv2DataSourceType, map[string]tftypes.Value{
+				"name": tftypes.NewValue(tftypes.String, "fixture"),
+			})),
+		})
+		if err != nil {
+			t.Fatalf("ReadDataSource: %s", err)
+		}
+		requireNoDiagErrors(t, "ReadDataSource", resp.Diagnostics)
+
+		attrs := attrsOf(t, maximalSDKv2DataSourceType, resp.State)
+		if got := stringOf(t, attrs["id"]); got != "unit-test" {
+			t.Errorf("the data source produced id %q, want %q", got, "unit-test")
+		}
+		var ids []tftypes.Value
+		if err := attrs["ids"].As(&ids); err != nil {
+			t.Fatalf("reading ids: %s", err)
+		}
+		if len(ids) != 1 || stringOf(t, ids[0]) != "unit-test" {
+			t.Errorf("the data source produced ids %v, want one element %q", ids, "unit-test")
+		}
+		if attrs["instances"].IsNull() {
+			t.Error("the nested list is null: the schema the read wrote to is not the one being served")
+		}
+		if got := chain.beforeOps(); !slices.Equal(got, []string{"Read"}) {
+			t.Errorf("the chain saw %v for a data source read, want [Read]", got)
+		}
+		if got := chain.afterOps(); !slices.Equal(got, []string{"Read"}) {
+			t.Errorf("the chain saw %v after a data source read, want [Read]", got)
+		}
+		for _, call := range chain.snapshotBefore() {
+			if call.Name != maximalSDKv2DataSourceName {
+				t.Errorf("the read was described as %q, want %q", call.Name, maximalSDKv2DataSourceName)
+			}
+			if call.Meta != client {
+				t.Errorf("the read carried meta %v, want the configured client", call.Meta)
+			}
+		}
+	})
+
+	t.Run("lifecycle", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		runMaximalSDKv2Lifecycle(t, server)
+
+		assertChainSawLifecycle(t, chain, maximalSDKv2Name, client)
+		if !log.has("CustomizeDiff") {
+			t.Errorf("CustomizeDiff never ran during a full lifecycle: %v", log.all())
+		}
+		if !log.has("Exists") {
+			t.Errorf("Exists never ran during a full lifecycle: %v", log.all())
+		}
+	})
+}
+
+func TestUnitProviderMaximalWireFramework(t *testing.T) {
+	ctx := context.Background()
+	log, chain, client := &hookLog{}, &chainRecorder{}, &connectivity.AliyunClient{}
+	server := newMaximalFrameworkServer(t, log, chain, client)
+
+	t.Run("GetProviderSchema", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+		if err != nil {
+			t.Fatalf("GetProviderSchema: %s", err)
+		}
+		requireNoDiagErrors(t, "GetProviderSchema", resp.Diagnostics)
+
+		schema, ok := resp.ResourceSchemas[maximalFrameworkName]
+		if !ok {
+			t.Fatalf("the wrapped fixture is not in the schema: %v", resp.ResourceSchemas)
+		}
+		if schema.Version != 2 {
+			t.Errorf("the served schema version is %d, want 2", schema.Version)
+		}
+		if _, ok := resp.DataSourceSchemas[maximalFrameworkDataSourceName]; !ok {
+			t.Errorf("the wrapped data source is not in the schema: %v", resp.DataSourceSchemas)
+		}
+	})
+
+	t.Run("GetResourceIdentitySchemas", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.GetResourceIdentitySchemas(ctx, &tfprotov5.GetResourceIdentitySchemasRequest{})
+		if err != nil {
+			t.Fatalf("GetResourceIdentitySchemas: %s", err)
+		}
+		requireNoDiagErrors(t, "GetResourceIdentitySchemas", resp.Diagnostics)
+
+		schema, ok := resp.IdentitySchemas[maximalFrameworkName]
+		if !ok {
+			t.Fatalf("the wrapped fixture has no identity schema: %v", resp.IdentitySchemas)
+		}
+		if schema.Version != 1 {
+			t.Errorf("the served identity version is %d, want 1", schema.Version)
+		}
+		if len(schema.IdentityAttributes) != 1 {
+			t.Fatalf("the served identity has %d attributes, want 1", len(schema.IdentityAttributes))
+		}
+		if got := schema.IdentityAttributes[0]; got.Name != "id" || !got.RequiredForImport {
+			t.Errorf("the served identity attribute is %+v, want id/RequiredForImport", got)
+		}
+	})
+
+	t.Run("ValidateResourceTypeConfig", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		config := dynamic(t, maximalFrameworkType, object(t, maximalFrameworkType, map[string]tftypes.Value{
+			"name": tftypes.NewValue(tftypes.String, "fixture"),
+		}))
+		resp, err := server.ValidateResourceTypeConfig(ctx, &tfprotov5.ValidateResourceTypeConfigRequest{
+			TypeName: maximalFrameworkName,
+			Config:   config,
+		})
+		if err != nil {
+			t.Fatalf("ValidateResourceTypeConfig: %s", err)
+		}
+		requireNoDiagErrors(t, "ValidateResourceTypeConfig", resp.Diagnostics)
+
+		for _, hook := range []string{"ConfigValidators", "ConfigValidator", "ValidateConfig"} {
+			if !log.has(hook) {
+				t.Errorf("%s did not run while validating: %v", hook, log.all())
+			}
+		}
+		assertChainSilent(t, chain, "validating a config")
+	})
+
+	t.Run("UpgradeResourceState", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		for version := int64(0); version <= 1; version++ {
+			resp, err := server.UpgradeResourceState(ctx, &tfprotov5.UpgradeResourceStateRequest{
+				TypeName: maximalFrameworkName,
+				Version:  version,
+				RawState: &tfprotov5.RawState{
+					JSON: []byte(`{"id":"unit-test","name":"fixture"}`),
+				},
+			})
+			if err != nil {
+				t.Fatalf("UpgradeResourceState from version %d: %s", version, err)
+			}
+			requireNoDiagErrors(t, "UpgradeResourceState", resp.Diagnostics)
+
+			if got := stringOf(t, attrsOf(t, maximalFrameworkType, resp.UpgradedState)["id"]); got != "unit-test" {
+				t.Errorf("the state upgraded from version %d has id %q, want %q", version, got, "unit-test")
+			}
+		}
+		if !log.has("UpgradeState0") || !log.has("UpgradeState1") {
+			t.Errorf("not every upgrader was reachable: %v", log.all())
+		}
+		assertChainSilent(t, chain, "upgrading a state")
+	})
+
+	t.Run("UpgradeResourceIdentity", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.UpgradeResourceIdentity(ctx, &tfprotov5.UpgradeResourceIdentityRequest{
+			TypeName:    maximalFrameworkName,
+			Version:     0,
+			RawIdentity: &tfprotov5.RawState{JSON: []byte(`{"id":"unit-test"}`)},
+		})
+		if err != nil {
+			t.Fatalf("UpgradeResourceIdentity: %s", err)
+		}
+		requireNoDiagErrors(t, "UpgradeResourceIdentity", resp.Diagnostics)
+
+		if !log.has("UpgradeIdentity0") {
+			t.Errorf("the identity upgrader did not run: %v", log.all())
+		}
+		if resp.UpgradedIdentity == nil {
+			t.Fatal("the upgraded identity is missing")
+		}
+		if got := stringOf(t, attrsOf(t, maximalFrameworkIdentityType, resp.UpgradedIdentity.IdentityData)["id"]); got != "unit-test" {
+			t.Errorf("the upgraded identity id is %q, want %q", got, "unit-test")
+		}
+		assertChainSilent(t, chain, "upgrading an identity")
+	})
+
+	t.Run("MoveResourceState", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.MoveResourceState(ctx, &tfprotov5.MoveResourceStateRequest{
+			SourceProviderAddress: "registry.terraform.io/hashicorp/null",
+			SourceTypeName:        "null_resource",
+			SourceSchemaVersion:   0,
+			SourceState:           &tfprotov5.RawState{JSON: []byte(`{"id":"unit-test"}`)},
+			TargetTypeName:        maximalFrameworkName,
+		})
+		if err != nil {
+			t.Fatalf("MoveResourceState: %s", err)
+		}
+		requireNoDiagErrors(t, "MoveResourceState", resp.Diagnostics)
+
+		if !log.has("MoveState0") {
+			t.Errorf("the state mover did not run: %v", log.all())
+		}
+		if got := stringOf(t, attrsOf(t, maximalFrameworkType, resp.TargetState)["name"]); got != "moved" {
+			t.Errorf("the moved state has name %q, want %q", got, "moved")
+		}
+		assertChainSilent(t, chain, "moving a state")
+	})
+
+	t.Run("ImportResourceState", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.ImportResourceState(ctx, &tfprotov5.ImportResourceStateRequest{
+			TypeName: maximalFrameworkName,
+			ID:       "unit-test",
+		})
+		if err != nil {
+			t.Fatalf("ImportResourceState: %s", err)
+		}
+		requireNoDiagErrors(t, "ImportResourceState", resp.Diagnostics)
+
+		if len(resp.ImportedResources) != 1 {
+			t.Fatalf("importing produced %d resources, want 1", len(resp.ImportedResources))
+		}
+		if !log.has("ImportState") {
+			t.Errorf("the importer did not run: %v", log.all())
+		}
+		if log.has("Read") {
+			t.Errorf("importing also ran Read: %v", log.all())
+		}
+		assertChainSilent(t, chain, "importing")
+	})
+
+	t.Run("ValidateDataSourceConfig", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		resp, err := server.ValidateDataSourceConfig(ctx, &tfprotov5.ValidateDataSourceConfigRequest{
+			TypeName: maximalFrameworkDataSourceName,
+			Config: dynamic(t, maximalFrameworkType, object(t, maximalFrameworkType, map[string]tftypes.Value{
+				"name": tftypes.NewValue(tftypes.String, "fixture"),
+			})),
+		})
+		if err != nil {
+			t.Fatalf("ValidateDataSourceConfig: %s", err)
+		}
+		requireNoDiagErrors(t, "ValidateDataSourceConfig", resp.Diagnostics)
+
+		for _, hook := range []string{"ConfigValidators", "ConfigValidator", "ValidateConfig"} {
+			if !log.has(hook) {
+				t.Errorf("%s did not run during validation: %v", hook, log.all())
+			}
+		}
+		if log.has("Read") {
+			t.Errorf("validation also ran Read: %v", log.all())
+		}
+		assertChainSilent(t, chain, "validating a data source config")
+	})
+
+	t.Run("ReadDataSource", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		config := dynamic(t, maximalFrameworkType, object(t, maximalFrameworkType, map[string]tftypes.Value{
+			"name": tftypes.NewValue(tftypes.String, "fixture"),
+		}))
+		resp, err := server.ReadDataSource(ctx, &tfprotov5.ReadDataSourceRequest{
+			TypeName: maximalFrameworkDataSourceName,
+			Config:   config,
+		})
+		if err != nil {
+			t.Fatalf("ReadDataSource: %s", err)
+		}
+		requireNoDiagErrors(t, "ReadDataSource", resp.Diagnostics)
+
+		if got := stringOf(t, attrsOf(t, maximalFrameworkType, resp.State)["id"]); got != "unit-test" {
+			t.Errorf("the data source produced id %q, want %q", got, "unit-test")
+		}
+		if got := chain.beforeOps(); !slices.Equal(got, []string{"Read"}) {
+			t.Errorf("the chain saw %v for a data source read, want [Read]", got)
+		}
+		if got := chain.afterOps(); !slices.Equal(got, []string{"Read"}) {
+			t.Errorf("the chain saw %v after a data source read, want [Read]", got)
+		}
+		if !log.has("Read/client") {
+			t.Errorf("the data source read without a client: %v", log.all())
+		}
+	})
+
+	t.Run("lifecycle", func(t *testing.T) {
+		log.reset()
+		chain.reset()
+
+		runMaximalFrameworkLifecycle(t, server)
+
+		assertChainSawLifecycle(t, chain, maximalFrameworkName, client)
+		for _, op := range wantCRUDOps {
+			if !log.has(op + "/client") {
+				t.Errorf("%s ran without a client: %v", op, log.all())
+			}
+		}
+		if !log.has("ModifyPlan") {
+			t.Errorf("ModifyPlan never ran during a full lifecycle: %v", log.all())
+		}
+	})
+}
+
+func TestUnitProviderMaximalWireOneInterceptorBothStacks(t *testing.T) {
+	chain := &chainRecorder{}
+	client := &connectivity.AliyunClient{}
+
+	sdkServer := newMaximalSDKv2Server(t, &hookLog{}, chain, client)
+	fwServer := newMaximalFrameworkServer(t, &hookLog{}, chain, client)
+
+	runMaximalSDKv2Lifecycle(t, sdkServer)
+	runMaximalFrameworkLifecycle(t, fwServer)
+
+	want := slices.Concat(wantCRUDOps, wantCRUDOps)
+	if got := chain.beforeOps(); !slices.Equal(got, want) {
+		t.Errorf("Before saw %v across both stacks, want %v", got, want)
+	}
+	if got := chain.afterOps(); !slices.Equal(got, want) {
+		t.Errorf("After saw %v across both stacks, want %v", got, want)
+	}
+
+	wantNames := []string{
+		maximalSDKv2Name, maximalSDKv2Name, maximalSDKv2Name, maximalSDKv2Name,
+		maximalFrameworkName, maximalFrameworkName, maximalFrameworkName, maximalFrameworkName,
+	}
+	if got := namesOf(chain.snapshotBefore()); !slices.Equal(got, wantNames) {
+		t.Errorf("Before saw names %v, want %v", got, wantNames)
+	}
+
+	for _, call := range chain.snapshotBefore() {
+		if call.Meta != client {
+			t.Errorf("%s on %s carried meta %v, want the configured client", call.Op, call.Name, call.Meta)
+		}
+	}
+}
+
+func newMaximalSDKv2Server(t *testing.T, log *hookLog, chain *chainRecorder, client *connectivity.AliyunClient) tfprotov5.ProviderServer {
+	t.Helper()
+
+	p := maximalSDKv2Provider(log, []intercept.Interceptor{chain})
+	p.SetMeta(client)
+
+	return p.GRPCProvider()
+}
+
+func newMaximalFrameworkServer(t *testing.T, log *hookLog, chain *chainRecorder, client *connectivity.AliyunClient) tfprotov5.ProviderServer {
+	t.Helper()
+
+	server := providerserver.NewProtocol5(&maximalFrameworkTestProvider{
+		log:    log,
+		chain:  []intercept.Interceptor{chain},
+		client: client,
+	})()
+
+	resp, err := server.ConfigureProvider(context.Background(), &tfprotov5.ConfigureProviderRequest{
+		Config: dynamic(t, emptyObjectType, tftypes.NewValue(emptyObjectType, map[string]tftypes.Value{})),
+	})
+	if err != nil {
+		t.Fatalf("ConfigureProvider: %s", err)
+	}
+	requireNoDiagErrors(t, "ConfigureProvider", resp.Diagnostics)
+
+	return server
+}
+
+func runMaximalSDKv2Lifecycle(t *testing.T, server tfprotov5.ProviderServer) {
+	t.Helper()
+	ctx := context.Background()
+
+	name := tftypes.NewValue(tftypes.String, "fixture")
+	imageID := tftypes.NewValue(tftypes.String, "image-one")
+	tagsBefore := tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
+		"Created": tftypes.NewValue(tftypes.String, "terraform"),
+	})
+	tagsAfter := tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
+		"Created": tftypes.NewValue(tftypes.String, "terraform"),
+		"Updated": tftypes.NewValue(tftypes.String, "yes"),
+	})
+
+	createConfig := dynamic(t, maximalSDKv2Type, object(t, maximalSDKv2Type, map[string]tftypes.Value{
+		"name":     name,
+		"image_id": imageID,
+		"tags":     tagsBefore,
+	}))
+	createPlan, err := server.PlanResourceChange(ctx, &tfprotov5.PlanResourceChangeRequest{
+		TypeName:         maximalSDKv2Name,
+		PriorState:       nullOf(t, maximalSDKv2Type),
+		ProposedNewState: createConfig,
+		Config:           createConfig,
+	})
+	if err != nil {
+		t.Fatalf("PlanResourceChange (create): %s", err)
+	}
+	requireNoDiagErrors(t, "PlanResourceChange (create)", createPlan.Diagnostics)
+
+	created, err := server.ApplyResourceChange(ctx, &tfprotov5.ApplyResourceChangeRequest{
+		TypeName:        maximalSDKv2Name,
+		PriorState:      nullOf(t, maximalSDKv2Type),
+		PlannedState:    createPlan.PlannedState,
+		Config:          createConfig,
+		PlannedPrivate:  createPlan.PlannedPrivate,
+		PlannedIdentity: createPlan.PlannedIdentity,
+	})
+	if err != nil {
+		t.Fatalf("ApplyResourceChange (create): %s", err)
+	}
+	requireNoDiagErrors(t, "ApplyResourceChange (create)", created.Diagnostics)
+
+	if got := stringOf(t, attrsOf(t, maximalSDKv2Type, created.NewState)["id"]); got != "unit-test" {
+		t.Fatalf("the created resource has id %q, want %q", got, "unit-test")
+	}
+	if created.NewIdentity == nil {
+		t.Fatal("the created resource has no identity")
+	}
+	if got := stringOf(t, attrsOf(t, maximalSDKv2IdentityType, created.NewIdentity.IdentityData)["name"]); got != "fixture" {
+		t.Errorf("the created identity has name %q, want %q", got, "fixture")
+	}
+
+	refreshed, err := server.ReadResource(ctx, &tfprotov5.ReadResourceRequest{
+		TypeName:        maximalSDKv2Name,
+		CurrentState:    created.NewState,
+		Private:         created.Private,
+		CurrentIdentity: created.NewIdentity,
+	})
+	if err != nil {
+		t.Fatalf("ReadResource: %s", err)
+	}
+	requireNoDiagErrors(t, "ReadResource", refreshed.Diagnostics)
+
+	if got := stringOf(t, attrsOf(t, maximalSDKv2Type, refreshed.NewState)["id"]); got != "unit-test" {
+		t.Fatalf("the refreshed resource has id %q, want %q", got, "unit-test")
+	}
+
+	prior := attrsOf(t, maximalSDKv2Type, refreshed.NewState)
+	updateConfig := dynamic(t, maximalSDKv2Type, object(t, maximalSDKv2Type, map[string]tftypes.Value{
+		"name":     name,
+		"image_id": imageID,
+		"tags":     tagsAfter,
+	}))
+	updateProposed := dynamic(t, maximalSDKv2Type, object(t, maximalSDKv2Type, map[string]tftypes.Value{
+		"id":       prior["id"],
+		"status":   prior["status"],
+		"name":     name,
+		"image_id": imageID,
+		"tags":     tagsAfter,
+	}))
+	updatePlan, err := server.PlanResourceChange(ctx, &tfprotov5.PlanResourceChangeRequest{
+		TypeName:         maximalSDKv2Name,
+		PriorState:       refreshed.NewState,
+		ProposedNewState: updateProposed,
+		Config:           updateConfig,
+		PriorPrivate:     refreshed.Private,
+		PriorIdentity:    refreshed.NewIdentity,
+	})
+	if err != nil {
+		t.Fatalf("PlanResourceChange (update): %s", err)
+	}
+	requireNoDiagErrors(t, "PlanResourceChange (update)", updatePlan.Diagnostics)
+
+	if len(updatePlan.RequiresReplace) != 0 {
+		t.Errorf("planning a tags-only change requires replacing %v", updatePlan.RequiresReplace)
+	}
+
+	updated, err := server.ApplyResourceChange(ctx, &tfprotov5.ApplyResourceChangeRequest{
+		TypeName:        maximalSDKv2Name,
+		PriorState:      refreshed.NewState,
+		PlannedState:    updatePlan.PlannedState,
+		Config:          updateConfig,
+		PlannedPrivate:  updatePlan.PlannedPrivate,
+		PlannedIdentity: updatePlan.PlannedIdentity,
+	})
+	if err != nil {
+		t.Fatalf("ApplyResourceChange (update): %s", err)
+	}
+	requireNoDiagErrors(t, "ApplyResourceChange (update)", updated.Diagnostics)
+
+	if got := stringOf(t, attrsOf(t, maximalSDKv2Type, updated.NewState)["id"]); got != "unit-test" {
+		t.Fatalf("the updated resource has id %q, want %q", got, "unit-test")
+	}
+
+	destroyPlan, err := server.PlanResourceChange(ctx, &tfprotov5.PlanResourceChangeRequest{
+		TypeName:         maximalSDKv2Name,
+		PriorState:       updated.NewState,
+		ProposedNewState: nullOf(t, maximalSDKv2Type),
+		Config:           nullOf(t, maximalSDKv2Type),
+		PriorPrivate:     updated.Private,
+		PriorIdentity:    updated.NewIdentity,
+	})
+	if err != nil {
+		t.Fatalf("PlanResourceChange (destroy): %s", err)
+	}
+	requireNoDiagErrors(t, "PlanResourceChange (destroy)", destroyPlan.Diagnostics)
+
+	destroyed, err := server.ApplyResourceChange(ctx, &tfprotov5.ApplyResourceChangeRequest{
+		TypeName:        maximalSDKv2Name,
+		PriorState:      updated.NewState,
+		PlannedState:    destroyPlan.PlannedState,
+		Config:          nullOf(t, maximalSDKv2Type),
+		PlannedPrivate:  destroyPlan.PlannedPrivate,
+		PlannedIdentity: destroyPlan.PlannedIdentity,
+	})
+	if err != nil {
+		t.Fatalf("ApplyResourceChange (destroy): %s", err)
+	}
+	requireNoDiagErrors(t, "ApplyResourceChange (destroy)", destroyed.Diagnostics)
+
+	assertStateIsNull(t, maximalSDKv2Type, destroyed.NewState)
+}
+
+func runMaximalFrameworkLifecycle(t *testing.T, server tfprotov5.ProviderServer) {
+	t.Helper()
+	ctx := context.Background()
+
+	name := tftypes.NewValue(tftypes.String, "fixture")
+	renamed := tftypes.NewValue(tftypes.String, "fixture-updated")
+
+	createConfig := dynamic(t, maximalFrameworkType, object(t, maximalFrameworkType, map[string]tftypes.Value{
+		"name": name,
+	}))
+	createPlan, err := server.PlanResourceChange(ctx, &tfprotov5.PlanResourceChangeRequest{
+		TypeName:         maximalFrameworkName,
+		PriorState:       nullOf(t, maximalFrameworkType),
+		ProposedNewState: createConfig,
+		Config:           createConfig,
+	})
+	if err != nil {
+		t.Fatalf("PlanResourceChange (create): %s", err)
+	}
+	requireNoDiagErrors(t, "PlanResourceChange (create)", createPlan.Diagnostics)
+
+	created, err := server.ApplyResourceChange(ctx, &tfprotov5.ApplyResourceChangeRequest{
+		TypeName:        maximalFrameworkName,
+		PriorState:      nullOf(t, maximalFrameworkType),
+		PlannedState:    createPlan.PlannedState,
+		Config:          createConfig,
+		PlannedPrivate:  createPlan.PlannedPrivate,
+		PlannedIdentity: createPlan.PlannedIdentity,
+	})
+	if err != nil {
+		t.Fatalf("ApplyResourceChange (create): %s", err)
+	}
+	requireNoDiagErrors(t, "ApplyResourceChange (create)", created.Diagnostics)
+
+	if got := stringOf(t, attrsOf(t, maximalFrameworkType, created.NewState)["id"]); got != "unit-test" {
+		t.Fatalf("the created resource has id %q, want %q", got, "unit-test")
+	}
+	if created.NewIdentity == nil {
+		t.Fatal("the created resource has no identity")
+	}
+	if got := stringOf(t, attrsOf(t, maximalFrameworkIdentityType, created.NewIdentity.IdentityData)["id"]); got != "unit-test" {
+		t.Errorf("the created identity has id %q, want %q", got, "unit-test")
+	}
+
+	refreshed, err := server.ReadResource(ctx, &tfprotov5.ReadResourceRequest{
+		TypeName:        maximalFrameworkName,
+		CurrentState:    created.NewState,
+		Private:         created.Private,
+		CurrentIdentity: created.NewIdentity,
+	})
+	if err != nil {
+		t.Fatalf("ReadResource: %s", err)
+	}
+	requireNoDiagErrors(t, "ReadResource", refreshed.Diagnostics)
+
+	if got := stringOf(t, attrsOf(t, maximalFrameworkType, refreshed.NewState)["id"]); got != "unit-test" {
+		t.Fatalf("the refreshed resource has id %q, want %q", got, "unit-test")
+	}
+
+	prior := attrsOf(t, maximalFrameworkType, refreshed.NewState)
+	updateConfig := dynamic(t, maximalFrameworkType, object(t, maximalFrameworkType, map[string]tftypes.Value{
+		"name": renamed,
+	}))
+	updateProposed := dynamic(t, maximalFrameworkType, object(t, maximalFrameworkType, map[string]tftypes.Value{
+		"id":   prior["id"],
+		"name": renamed,
+	}))
+	updatePlan, err := server.PlanResourceChange(ctx, &tfprotov5.PlanResourceChangeRequest{
+		TypeName:         maximalFrameworkName,
+		PriorState:       refreshed.NewState,
+		ProposedNewState: updateProposed,
+		Config:           updateConfig,
+		PriorPrivate:     refreshed.Private,
+		PriorIdentity:    refreshed.NewIdentity,
+	})
+	if err != nil {
+		t.Fatalf("PlanResourceChange (update): %s", err)
+	}
+	requireNoDiagErrors(t, "PlanResourceChange (update)", updatePlan.Diagnostics)
+
+	if len(updatePlan.RequiresReplace) != 0 {
+		t.Errorf("planning a name change requires replacing %v", updatePlan.RequiresReplace)
+	}
+
+	updated, err := server.ApplyResourceChange(ctx, &tfprotov5.ApplyResourceChangeRequest{
+		TypeName:        maximalFrameworkName,
+		PriorState:      refreshed.NewState,
+		PlannedState:    updatePlan.PlannedState,
+		Config:          updateConfig,
+		PlannedPrivate:  updatePlan.PlannedPrivate,
+		PlannedIdentity: updatePlan.PlannedIdentity,
+	})
+	if err != nil {
+		t.Fatalf("ApplyResourceChange (update): %s", err)
+	}
+	requireNoDiagErrors(t, "ApplyResourceChange (update)", updated.Diagnostics)
+
+	if got := stringOf(t, attrsOf(t, maximalFrameworkType, updated.NewState)["name"]); got != "fixture-updated" {
+		t.Errorf("the updated resource has name %q, want %q", got, "fixture-updated")
+	}
+
+	destroyPlan, err := server.PlanResourceChange(ctx, &tfprotov5.PlanResourceChangeRequest{
+		TypeName:         maximalFrameworkName,
+		PriorState:       updated.NewState,
+		ProposedNewState: nullOf(t, maximalFrameworkType),
+		Config:           nullOf(t, maximalFrameworkType),
+		PriorPrivate:     updated.Private,
+		PriorIdentity:    updated.NewIdentity,
+	})
+	if err != nil {
+		t.Fatalf("PlanResourceChange (destroy): %s", err)
+	}
+	requireNoDiagErrors(t, "PlanResourceChange (destroy)", destroyPlan.Diagnostics)
+
+	destroyed, err := server.ApplyResourceChange(ctx, &tfprotov5.ApplyResourceChangeRequest{
+		TypeName:        maximalFrameworkName,
+		PriorState:      updated.NewState,
+		PlannedState:    destroyPlan.PlannedState,
+		Config:          nullOf(t, maximalFrameworkType),
+		PlannedPrivate:  destroyPlan.PlannedPrivate,
+		PlannedIdentity: destroyPlan.PlannedIdentity,
+	})
+	if err != nil {
+		t.Fatalf("ApplyResourceChange (destroy): %s", err)
+	}
+	requireNoDiagErrors(t, "ApplyResourceChange (destroy)", destroyed.Diagnostics)
+
+	assertStateIsNull(t, maximalFrameworkType, destroyed.NewState)
+}
+
+func assertChainSawLifecycle(t *testing.T, chain *chainRecorder, name string, client *connectivity.AliyunClient) {
+	t.Helper()
+
+	if got := chain.beforeOps(); !slices.Equal(got, wantCRUDOps) {
+		t.Errorf("Before saw %v, want %v", got, wantCRUDOps)
+	}
+	if got := chain.afterOps(); !slices.Equal(got, wantCRUDOps) {
+		t.Errorf("After saw %v, want %v", got, wantCRUDOps)
+	}
+	for _, call := range chain.snapshotBefore() {
+		if call.Name != name {
+			t.Errorf("%s was described as %q, want %q", call.Op, call.Name, name)
+		}
+		if call.Meta != client {
+			t.Errorf("%s carried meta %v, want the configured client", call.Op, call.Meta)
+		}
+	}
+}
+
+func assertChainSilent(t *testing.T, chain *chainRecorder, doing string) {
+	t.Helper()
+
+	if got := chain.beforeOps(); len(got) != 0 {
+		t.Errorf("%s ran the chain: %v", doing, got)
+	}
+	if got := chain.afterOps(); len(got) != 0 {
+		t.Errorf("%s ran the chain: %v", doing, got)
+	}
+}
+
+func assertStateIsNull(t *testing.T, ty tftypes.Type, dv *tfprotov5.DynamicValue) {
+	t.Helper()
+
+	if dv == nil {
+		t.Fatal("the destroy response carried no state at all")
+	}
+	val, err := dv.Unmarshal(ty)
+	if err != nil {
+		t.Fatalf("unmarshalling the destroyed state: %s", err)
+	}
+	if !val.IsNull() {
+		t.Errorf("the state after destroy is %s, want null", val)
+	}
+}
+
+func requireNoDiagErrors(t *testing.T, step string, diags []*tfprotov5.Diagnostic) {
+	t.Helper()
+
+	for _, d := range diags {
+		if d.Severity == tfprotov5.DiagnosticSeverityError {
+			t.Fatalf("%s: %s: %s", step, d.Summary, d.Detail)
+		}
+	}
+}
+
+func hasWarning(diags []*tfprotov5.Diagnostic, summary string) bool {
+	for _, d := range diags {
+		if d.Severity == tfprotov5.DiagnosticSeverityWarning && d.Summary == summary {
+			return true
+		}
+	}
+	return false
+}
+
+func object(t *testing.T, ty tftypes.Object, attrs map[string]tftypes.Value) tftypes.Value {
+	t.Helper()
+
+	for name := range attrs {
+		if _, ok := ty.AttributeTypes[name]; !ok {
+			t.Fatalf("%q is not an attribute of %s", name, ty)
+		}
+	}
+	full := make(map[string]tftypes.Value, len(ty.AttributeTypes))
+	for name, attrType := range ty.AttributeTypes {
+		if v, ok := attrs[name]; ok {
+			full[name] = v
+			continue
+		}
+		full[name] = tftypes.NewValue(attrType, nil)
+	}
+	return tftypes.NewValue(ty, full)
+}
+
+func dynamic(t *testing.T, ty tftypes.Type, v tftypes.Value) *tfprotov5.DynamicValue {
+	t.Helper()
+
+	dv, err := tfprotov5.NewDynamicValue(ty, v)
+	if err != nil {
+		t.Fatalf("encoding a %s: %s", ty, err)
+	}
+	return &dv
+}
+
+func nullOf(t *testing.T, ty tftypes.Type) *tfprotov5.DynamicValue {
+	t.Helper()
+
+	return dynamic(t, ty, tftypes.NewValue(ty, nil))
+}
+
+func attrsOf(t *testing.T, ty tftypes.Type, dv *tfprotov5.DynamicValue) map[string]tftypes.Value {
+	t.Helper()
+
+	if dv == nil {
+		t.Fatal("the response carried no value")
+	}
+	val, err := dv.Unmarshal(ty)
+	if err != nil {
+		t.Fatalf("decoding a %s: %s", ty, err)
+	}
+	attrs := map[string]tftypes.Value{}
+	if err := val.As(&attrs); err != nil {
+		t.Fatalf("reading the attributes of a %s: %s", ty, err)
+	}
+	return attrs
+}
+
+func stringOf(t *testing.T, v tftypes.Value) string {
+	t.Helper()
+
+	if v.IsNull() {
+		return ""
+	}
+	var s string
+	if err := v.As(&s); err != nil {
+		t.Fatalf("reading a string: %s", err)
+	}
+	return s
+}

--- a/alicloud/provider/registry/registry.go
+++ b/alicloud/provider/registry/registry.go
@@ -1,0 +1,109 @@
+// Package registry aggregates the service package declarations consumed by the
+// provider assembly loop, and validates uniqueness, this being the only place both
+// provider servers agree on.
+package registry
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	alicloudfunction "github.com/aliyun/terraform-provider-alicloud/alicloud/function"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/conns"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/service/ims"
+)
+
+// A managed resource and a data source may share a name; two managed resources may
+// not, whichever server implements them.
+const (
+	nsResource          = "resource"
+	nsDataSource        = "data source"
+	nsFunction          = "function"
+	nsEphemeralResource = "ephemeral resource"
+	nsListResource      = "list resource"
+	nsAction            = "action"
+)
+
+var servicePackages = []conns.ServicePackage{
+	ims.ServicePackage(),
+	alicloudfunction.ServicePackage(),
+}
+
+var validateOnce sync.Once
+
+// Validates the set once on first use, and panics on a violation: failing at
+// startup beats a nil dereference on a later RPC.
+func ServicePackages() []conns.ServicePackage {
+	validateOnce.Do(func() {
+		if err := validate(servicePackages); err != nil {
+			panic("provider registration error: " + err.Error())
+		}
+	})
+	return servicePackages
+}
+
+// Reports every violation at once. A declaration colliding with a provider.go map
+// literal is assembleProvider's to find, not visible here.
+func validate(sps []conns.ServicePackage) error {
+	v := &validator{seen: map[string]map[string]string{}}
+	for _, sp := range sps {
+		for _, d := range sp.SDKResources {
+			v.claim(nsResource, d.TypeName, sp.Name, "SDKResources", d.Factory != nil)
+		}
+		for _, d := range sp.Resources {
+			v.claim(nsResource, d.TypeName, sp.Name, "Resources", d.Factory != nil)
+		}
+		for _, d := range sp.SDKDataSources {
+			v.claim(nsDataSource, d.TypeName, sp.Name, "SDKDataSources", d.Factory != nil)
+		}
+		for _, d := range sp.DataSources {
+			v.claim(nsDataSource, d.TypeName, sp.Name, "DataSources", d.Factory != nil)
+		}
+		for _, d := range sp.Functions {
+			v.claim(nsFunction, d.TypeName, sp.Name, "Functions", d.Factory != nil)
+		}
+		for _, d := range sp.EphemeralResources {
+			v.claim(nsEphemeralResource, d.TypeName, sp.Name, "EphemeralResources", d.Factory != nil)
+		}
+		for _, d := range sp.ListResources {
+			v.claim(nsListResource, d.TypeName, sp.Name, "ListResources", d.Factory != nil)
+		}
+		for _, d := range sp.Actions {
+			v.claim(nsAction, d.TypeName, sp.Name, "Actions", d.Factory != nil)
+		}
+	}
+	return v.err()
+}
+
+type validator struct {
+	seen     map[string]map[string]string // namespace → type name → "Service.Category"
+	problems []string
+}
+
+func (v *validator) claim(namespace, typeName, service, category string, hasFactory bool) {
+	origin := service + "." + category
+	if typeName == "" {
+		v.problems = append(v.problems, fmt.Sprintf("%s declared in %s has an empty TypeName", namespace, origin))
+		return
+	}
+	if !hasFactory {
+		v.problems = append(v.problems, fmt.Sprintf("%s %q declared in %s has a nil Factory", namespace, typeName, origin))
+	}
+	names := v.seen[namespace]
+	if names == nil {
+		names = map[string]string{}
+		v.seen[namespace] = names
+	}
+	if prev, dup := names[typeName]; dup {
+		v.problems = append(v.problems, fmt.Sprintf("%s %q is declared twice: %s and %s", namespace, typeName, prev, origin))
+		return
+	}
+	names[typeName] = origin
+}
+
+func (v *validator) err() error {
+	if len(v.problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%d invalid service package declaration(s):\n  %s", len(v.problems), strings.Join(v.problems, "\n  "))
+}

--- a/alicloud/provider/registry/registry_test.go
+++ b/alicloud/provider/registry/registry_test.go
@@ -1,0 +1,208 @@
+package registry
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	fwdatasource "github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	sdkschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/conns"
+)
+
+func sdkFactory() *sdkschema.Resource               { return &sdkschema.Resource{} }
+func resourceFactory() fwresource.Resource          { return nil }
+func dataSourceFactory() fwdatasource.DataSource    { return nil }
+func functionFactory() function.Function            { return nil }
+func ephemeralFactory() ephemeral.EphemeralResource { return nil }
+func listFactory() list.ListResource                { return nil }
+func actionFactory() action.Action                  { return nil }
+
+func TestValidateRealDeclarations(t *testing.T) {
+	if err := validate(servicePackages); err != nil {
+		t.Fatalf("the shipped service package declarations are invalid: %v", err)
+	}
+}
+
+func TestValidateAcceptsOneOfEachCategory(t *testing.T) {
+	sp := conns.ServicePackage{
+		Name:               "Vpc",
+		SDKResources:       []conns.SDKResource{{TypeName: "alicloud_vpc", Factory: sdkFactory}},
+		Resources:          []conns.Resource{{TypeName: "alicloud_vpc_v2", Factory: resourceFactory}},
+		SDKDataSources:     []conns.SDKDataSource{{TypeName: "alicloud_vpcs", Factory: sdkFactory}},
+		DataSources:        []conns.DataSource{{TypeName: "alicloud_vpcs_v2", Factory: dataSourceFactory}},
+		Functions:          []conns.Function{{TypeName: "arn_build", Factory: functionFactory}},
+		EphemeralResources: []conns.EphemeralResource{{TypeName: "alicloud_vpc_token", Factory: ephemeralFactory}},
+		ListResources:      []conns.ListResource{{TypeName: "alicloud_vpc", Factory: listFactory}},
+		Actions:            []conns.Action{{TypeName: "alicloud_vpc_flush", Factory: actionFactory}},
+	}
+	if err := validate([]conns.ServicePackage{sp}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateNamespaces(t *testing.T) {
+	cases := []struct {
+		name string
+		sps  []conns.ServicePackage
+		want string
+	}{
+		{
+			name: "two SDK resources",
+			sps: []conns.ServicePackage{{Name: "Vpc",
+				SDKResources: []conns.SDKResource{
+					{TypeName: "alicloud_vpc", Factory: sdkFactory},
+					{TypeName: "alicloud_vpc", Factory: sdkFactory},
+				}}},
+			want: `resource "alicloud_vpc" is declared twice: Vpc.SDKResources and Vpc.SDKResources`,
+		},
+		{
+			name: "SDK and framework resource share the managed resource namespace",
+			sps: []conns.ServicePackage{{Name: "Vpc",
+				SDKResources: []conns.SDKResource{{TypeName: "alicloud_vpc", Factory: sdkFactory}},
+				Resources:    []conns.Resource{{TypeName: "alicloud_vpc", Factory: resourceFactory}},
+			}},
+			want: `resource "alicloud_vpc" is declared twice: Vpc.SDKResources and Vpc.Resources`,
+		},
+		{
+			name: "SDK and framework data source share the data source namespace",
+			sps: []conns.ServicePackage{{Name: "Vpc",
+				SDKDataSources: []conns.SDKDataSource{{TypeName: "alicloud_vpcs", Factory: sdkFactory}},
+				DataSources:    []conns.DataSource{{TypeName: "alicloud_vpcs", Factory: dataSourceFactory}},
+			}},
+			want: `data source "alicloud_vpcs" is declared twice`,
+		},
+		{
+			name: "two service packages claim the same resource",
+			sps: []conns.ServicePackage{
+				{Name: "Vpc", SDKResources: []conns.SDKResource{{TypeName: "alicloud_vpc", Factory: sdkFactory}}},
+				{Name: "Vpc2", Resources: []conns.Resource{{TypeName: "alicloud_vpc", Factory: resourceFactory}}},
+			},
+			want: `resource "alicloud_vpc" is declared twice: Vpc.SDKResources and Vpc2.Resources`,
+		},
+		{
+			name: "a resource and a data source may share a name",
+			sps: []conns.ServicePackage{{Name: "Vpc",
+				SDKResources:   []conns.SDKResource{{TypeName: "alicloud_vpc", Factory: sdkFactory}},
+				SDKDataSources: []conns.SDKDataSource{{TypeName: "alicloud_vpc", Factory: sdkFactory}},
+			}},
+		},
+		{
+			name: "a list resource shares its managed resource's name",
+			sps: []conns.ServicePackage{{Name: "Vpc",
+				SDKResources:  []conns.SDKResource{{TypeName: "alicloud_vpc", Factory: sdkFactory}},
+				ListResources: []conns.ListResource{{TypeName: "alicloud_vpc", Factory: listFactory}},
+			}},
+		},
+		{
+			name: "two list resources may not",
+			sps: []conns.ServicePackage{{Name: "Vpc",
+				ListResources: []conns.ListResource{
+					{TypeName: "alicloud_vpc", Factory: listFactory},
+					{TypeName: "alicloud_vpc", Factory: listFactory},
+				}}},
+			want: `list resource "alicloud_vpc" is declared twice`,
+		},
+		{
+			name: "two functions",
+			sps: []conns.ServicePackage{{Name: "Arn",
+				Functions: []conns.Function{
+					{TypeName: "arn_build", Factory: functionFactory},
+					{TypeName: "arn_build", Factory: functionFactory},
+				}}},
+			want: `function "arn_build" is declared twice`,
+		},
+		{
+			name: "two ephemeral resources",
+			sps: []conns.ServicePackage{{Name: "Sts",
+				EphemeralResources: []conns.EphemeralResource{
+					{TypeName: "alicloud_sts_token", Factory: ephemeralFactory},
+					{TypeName: "alicloud_sts_token", Factory: ephemeralFactory},
+				}}},
+			want: `ephemeral resource "alicloud_sts_token" is declared twice`,
+		},
+		{
+			name: "two actions",
+			sps: []conns.ServicePackage{{Name: "Ecs",
+				Actions: []conns.Action{
+					{TypeName: "alicloud_instance_reboot", Factory: actionFactory},
+					{TypeName: "alicloud_instance_reboot", Factory: actionFactory},
+				}}},
+			want: `action "alicloud_instance_reboot" is declared twice`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validate(tc.sps)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected an error containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateEmptyTypeName(t *testing.T) {
+	err := validate([]conns.ServicePackage{{Name: "Vpc",
+		SDKResources: []conns.SDKResource{{Factory: sdkFactory}}}})
+	if err == nil || !strings.Contains(err.Error(), "resource declared in Vpc.SDKResources has an empty TypeName") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestValidateEmptyTypeNameDoesNotCollide(t *testing.T) {
+	err := validate([]conns.ServicePackage{{Name: "Vpc",
+		SDKResources: []conns.SDKResource{{Factory: sdkFactory}, {Factory: sdkFactory}}}})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := strings.Count(err.Error(), "empty TypeName"); got != 2 {
+		t.Fatalf("expected 2 empty-TypeName problems, got %d: %v", got, err)
+	}
+	if strings.Contains(err.Error(), "declared twice") {
+		t.Fatalf("an empty name must not be reported as a duplicate: %v", err)
+	}
+}
+
+func TestValidateNilFactory(t *testing.T) {
+	err := validate([]conns.ServicePackage{{Name: "Vpc",
+		Resources: []conns.Resource{{TypeName: "alicloud_vpc"}}}})
+	if err == nil || !strings.Contains(err.Error(), `resource "alicloud_vpc" declared in Vpc.Resources has a nil Factory`) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestValidateReportsEveryProblem(t *testing.T) {
+	err := validate([]conns.ServicePackage{{Name: "Vpc",
+		SDKResources: []conns.SDKResource{
+			{TypeName: "alicloud_vpc", Factory: sdkFactory},
+			{TypeName: "alicloud_vpc", Factory: sdkFactory},
+			{TypeName: "alicloud_route"},
+			{Factory: sdkFactory},
+		}}})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.HasPrefix(err.Error(), "3 invalid service package declaration(s):") {
+		t.Fatalf("expected a 3-problem summary line, got %v", err)
+	}
+	for _, want := range []string{"declared twice", "nil Factory", "empty TypeName"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error is missing %q: %v", want, err)
+		}
+	}
+}

--- a/alicloud/provider/sdkv2/wrap.go
+++ b/alicloud/provider/sdkv2/wrap.go
@@ -1,8 +1,8 @@
 // Package sdkv2 adapts the interceptor chain to SDK v2 resources and data sources.
 //
-// The three CRUD forms are wrapped in the SDK's own dispatch order —
-// *WithoutTimeout, *Context, plain — and only the highest-priority one that is
-// set, since the SDK never reaches the others. A plain form is never promoted to
+// The three CRUD forms are wrapped in the SDK's own dispatch order — plain,
+// *WithoutTimeout, *Context — and only the highest-priority one that is set,
+// since the SDK never reaches the others. A plain form is never promoted to
 // *Context: that would silently change timeout semantics.
 //
 // Everything outside CRUD reaches the SDK unchanged because the wrapper starts
@@ -11,6 +11,8 @@ package sdkv2
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -39,42 +41,42 @@ func WrapDataSource(name string, ds *schema.Resource, chain []intercept.Intercep
 }
 
 func wrapCreate(r *schema.Resource, name string, chain []intercept.Interceptor) {
-	if r.CreateWithoutTimeout != nil {
+	if r.Create != nil {
+		r.Create = wrapOp(name, intercept.OpCreate, chain, r.Create)
+	} else if r.CreateWithoutTimeout != nil {
 		r.CreateWithoutTimeout = wrapOpContext(name, intercept.OpCreate, chain, r.CreateWithoutTimeout)
 	} else if r.CreateContext != nil {
 		r.CreateContext = wrapOpContext(name, intercept.OpCreate, chain, r.CreateContext)
-	} else if r.Create != nil {
-		r.Create = wrapOp(name, intercept.OpCreate, chain, r.Create)
 	}
 }
 
 func wrapRead(r *schema.Resource, name string, chain []intercept.Interceptor) {
-	if r.ReadWithoutTimeout != nil {
+	if r.Read != nil {
+		r.Read = wrapOp(name, intercept.OpRead, chain, r.Read)
+	} else if r.ReadWithoutTimeout != nil {
 		r.ReadWithoutTimeout = wrapOpContext(name, intercept.OpRead, chain, r.ReadWithoutTimeout)
 	} else if r.ReadContext != nil {
 		r.ReadContext = wrapOpContext(name, intercept.OpRead, chain, r.ReadContext)
-	} else if r.Read != nil {
-		r.Read = wrapOp(name, intercept.OpRead, chain, r.Read)
 	}
 }
 
 func wrapUpdate(r *schema.Resource, name string, chain []intercept.Interceptor) {
-	if r.UpdateWithoutTimeout != nil {
+	if r.Update != nil {
+		r.Update = wrapOp(name, intercept.OpUpdate, chain, r.Update)
+	} else if r.UpdateWithoutTimeout != nil {
 		r.UpdateWithoutTimeout = wrapOpContext(name, intercept.OpUpdate, chain, r.UpdateWithoutTimeout)
 	} else if r.UpdateContext != nil {
 		r.UpdateContext = wrapOpContext(name, intercept.OpUpdate, chain, r.UpdateContext)
-	} else if r.Update != nil {
-		r.Update = wrapOp(name, intercept.OpUpdate, chain, r.Update)
 	}
 }
 
 func wrapDelete(r *schema.Resource, name string, chain []intercept.Interceptor) {
-	if r.DeleteWithoutTimeout != nil {
+	if r.Delete != nil {
+		r.Delete = wrapOp(name, intercept.OpDelete, chain, r.Delete)
+	} else if r.DeleteWithoutTimeout != nil {
 		r.DeleteWithoutTimeout = wrapOpContext(name, intercept.OpDelete, chain, r.DeleteWithoutTimeout)
 	} else if r.DeleteContext != nil {
 		r.DeleteContext = wrapOpContext(name, intercept.OpDelete, chain, r.DeleteContext)
-	} else if r.Delete != nil {
-		r.Delete = wrapOp(name, intercept.OpDelete, chain, r.Delete)
 	}
 }
 
@@ -94,40 +96,49 @@ func wrapOpContext(name string, op intercept.Op, chain []intercept.Interceptor, 
 }
 
 var bridge = intercept.DiagBridge[diag.Diagnostics]{
-	ToError:   fmtDiagError,
-	WithError: replaceDiagErrors,
+	ToError:   diagsToErr,
+	WithError: appendDiagError,
 }
 
-func fmtDiagError(diags diag.Diagnostics) error {
+func diagsToErr(diags diag.Diagnostics) error {
+	var errs diag.Diagnostics
 	for _, d := range diags {
 		if d.Severity == diag.Error {
-			return &diagErr{summary: d.Summary, detail: d.Detail}
+			errs = append(errs, d)
 		}
 	}
-	return nil
+	if len(errs) == 0 {
+		return nil
+	}
+	return &diagsErr{diags: errs}
 }
 
-func replaceDiagErrors(diags diag.Diagnostics, err error) diag.Diagnostics {
-	out := make(diag.Diagnostics, 0, len(diags)+1)
-	for _, d := range diags {
-		if d.Severity != diag.Error {
-			out = append(out, d)
+func appendDiagError(diags diag.Diagnostics, err error) diag.Diagnostics {
+	if err == nil {
+		return diags
+	}
+	// A hook that only carried the originals forward has nothing of its own to say.
+	var de *diagsErr
+	if errors.As(err, &de) && err.Error() == de.Error() {
+		return diags
+	}
+	return append(diags, diag.FromErr(err)...)
+}
+
+// diagsErr carries every error-severity diagnostic across the hop through the
+// interceptor contract's single error.
+type diagsErr struct {
+	diags diag.Diagnostics
+}
+
+func (e *diagsErr) Error() string {
+	msgs := make([]string, 0, len(e.diags))
+	for _, d := range e.diags {
+		if d.Detail != "" {
+			msgs = append(msgs, d.Summary+": "+d.Detail)
+			continue
 		}
+		msgs = append(msgs, d.Summary)
 	}
-	if err != nil {
-		out = append(out, diag.FromErr(err)...)
-	}
-	return out
-}
-
-type diagErr struct {
-	summary string
-	detail  string
-}
-
-func (e *diagErr) Error() string {
-	if e.detail != "" {
-		return e.summary + ": " + e.detail
-	}
-	return e.summary
+	return strings.Join(msgs, "; ")
 }

--- a/alicloud/provider/sdkv2/wrap.go
+++ b/alicloud/provider/sdkv2/wrap.go
@@ -1,0 +1,133 @@
+// Package sdkv2 adapts the interceptor chain to SDK v2 resources and data sources.
+//
+// The three CRUD forms are wrapped in the SDK's own dispatch order —
+// *WithoutTimeout, *Context, plain — and only the highest-priority one that is
+// set, since the SDK never reaches the others. A plain form is never promoted to
+// *Context: that would silently change timeout semantics.
+//
+// Everything outside CRUD reaches the SDK unchanged because the wrapper starts
+// from a full struct copy and reassigns only the CRUD fields.
+package sdkv2
+
+import (
+	"context"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func WrapResource(name string, r *schema.Resource, chain []intercept.Interceptor) *schema.Resource {
+	if r == nil || len(chain) == 0 {
+		return r
+	}
+	cp := *r
+	wrapCreate(&cp, name, chain)
+	wrapRead(&cp, name, chain)
+	wrapUpdate(&cp, name, chain)
+	wrapDelete(&cp, name, chain)
+	return &cp
+}
+
+func WrapDataSource(name string, ds *schema.Resource, chain []intercept.Interceptor) *schema.Resource {
+	if ds == nil || len(chain) == 0 {
+		return ds
+	}
+	cp := *ds
+	wrapRead(&cp, name, chain)
+	return &cp
+}
+
+func wrapCreate(r *schema.Resource, name string, chain []intercept.Interceptor) {
+	if r.CreateWithoutTimeout != nil {
+		r.CreateWithoutTimeout = wrapOpContext(name, intercept.OpCreate, chain, r.CreateWithoutTimeout)
+	} else if r.CreateContext != nil {
+		r.CreateContext = wrapOpContext(name, intercept.OpCreate, chain, r.CreateContext)
+	} else if r.Create != nil {
+		r.Create = wrapOp(name, intercept.OpCreate, chain, r.Create)
+	}
+}
+
+func wrapRead(r *schema.Resource, name string, chain []intercept.Interceptor) {
+	if r.ReadWithoutTimeout != nil {
+		r.ReadWithoutTimeout = wrapOpContext(name, intercept.OpRead, chain, r.ReadWithoutTimeout)
+	} else if r.ReadContext != nil {
+		r.ReadContext = wrapOpContext(name, intercept.OpRead, chain, r.ReadContext)
+	} else if r.Read != nil {
+		r.Read = wrapOp(name, intercept.OpRead, chain, r.Read)
+	}
+}
+
+func wrapUpdate(r *schema.Resource, name string, chain []intercept.Interceptor) {
+	if r.UpdateWithoutTimeout != nil {
+		r.UpdateWithoutTimeout = wrapOpContext(name, intercept.OpUpdate, chain, r.UpdateWithoutTimeout)
+	} else if r.UpdateContext != nil {
+		r.UpdateContext = wrapOpContext(name, intercept.OpUpdate, chain, r.UpdateContext)
+	} else if r.Update != nil {
+		r.Update = wrapOp(name, intercept.OpUpdate, chain, r.Update)
+	}
+}
+
+func wrapDelete(r *schema.Resource, name string, chain []intercept.Interceptor) {
+	if r.DeleteWithoutTimeout != nil {
+		r.DeleteWithoutTimeout = wrapOpContext(name, intercept.OpDelete, chain, r.DeleteWithoutTimeout)
+	} else if r.DeleteContext != nil {
+		r.DeleteContext = wrapOpContext(name, intercept.OpDelete, chain, r.DeleteContext)
+	} else if r.Delete != nil {
+		r.Delete = wrapOp(name, intercept.OpDelete, chain, r.Delete)
+	}
+}
+
+func wrapOp(name string, op intercept.Op, chain []intercept.Interceptor, inner func(*schema.ResourceData, interface{}) error) func(*schema.ResourceData, interface{}) error {
+	return func(d *schema.ResourceData, meta interface{}) error {
+		return intercept.Execute(context.Background(), chain, intercept.Call{Name: name, Op: op, Meta: meta}, func() error {
+			return inner(d, meta)
+		})
+	}
+}
+
+func wrapOpContext(name string, op intercept.Op, chain []intercept.Interceptor, inner func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+		return intercept.Around(ctx, chain, intercept.Call{Name: name, Op: op, Meta: meta},
+			func() diag.Diagnostics { return inner(ctx, d, meta) }, bridge)
+	}
+}
+
+var bridge = intercept.DiagBridge[diag.Diagnostics]{
+	ToError:   fmtDiagError,
+	WithError: replaceDiagErrors,
+}
+
+func fmtDiagError(diags diag.Diagnostics) error {
+	for _, d := range diags {
+		if d.Severity == diag.Error {
+			return &diagErr{summary: d.Summary, detail: d.Detail}
+		}
+	}
+	return nil
+}
+
+func replaceDiagErrors(diags diag.Diagnostics, err error) diag.Diagnostics {
+	out := make(diag.Diagnostics, 0, len(diags)+1)
+	for _, d := range diags {
+		if d.Severity != diag.Error {
+			out = append(out, d)
+		}
+	}
+	if err != nil {
+		out = append(out, diag.FromErr(err)...)
+	}
+	return out
+}
+
+type diagErr struct {
+	summary string
+	detail  string
+}
+
+func (e *diagErr) Error() string {
+	if e.detail != "" {
+		return e.summary + ": " + e.detail
+	}
+	return e.summary
+}

--- a/alicloud/provider/sdkv2/wrap_test.go
+++ b/alicloud/provider/sdkv2/wrap_test.go
@@ -61,6 +61,7 @@ func TestWrapResourceWrapsOnlyUsedFields(t *testing.T) {
 	rec := &recordInterceptor{name: "rec"}
 	r := &schema.Resource{
 		Create: func(d *schema.ResourceData, meta interface{}) error { called = true; return nil },
+		// lintignore: S013
 		Schema: map[string]*schema.Schema{"id": {Type: schema.TypeString}},
 	}
 	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})

--- a/alicloud/provider/sdkv2/wrap_test.go
+++ b/alicloud/provider/sdkv2/wrap_test.go
@@ -1,0 +1,407 @@
+package sdkv2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+)
+
+type recordInterceptor struct {
+	name       string
+	ops        []string
+	beforeErr  error
+	afterErr   error
+	rewriteErr error
+	swallow    bool
+}
+
+func (r *recordInterceptor) Before(ctx context.Context, call intercept.Call) error {
+	r.ops = append(r.ops, "before:"+r.name)
+	return r.beforeErr
+}
+
+func (r *recordInterceptor) After(ctx context.Context, call intercept.Call, err error) error {
+	r.ops = append(r.ops, "after:"+r.name)
+	if r.swallow {
+		return nil
+	}
+	if r.rewriteErr != nil {
+		return r.rewriteErr
+	}
+	return err
+}
+
+func TestWrapResourceNilChainIsIdentity(t *testing.T) {
+	r := &schema.Resource{
+		Create: func(d *schema.ResourceData, meta interface{}) error { return nil },
+	}
+	got := WrapResource("alicloud_test", r, nil)
+	if got != r {
+		t.Fatalf("expected same pointer, got %p != %p", got, r)
+	}
+	got = WrapResource("alicloud_test", r, []intercept.Interceptor{})
+	if got != r {
+		t.Fatalf("expected same pointer for empty chain, got %p != %p", got, r)
+	}
+}
+
+func TestWrapResourceWrapsOnlyUsedFields(t *testing.T) {
+	called := false
+	rec := &recordInterceptor{name: "rec"}
+	r := &schema.Resource{
+		Create: func(d *schema.ResourceData, meta interface{}) error { called = true; return nil },
+		Schema: map[string]*schema.Schema{"id": {Type: schema.TypeString}},
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
+	if got == r {
+		t.Fatal("expected a shallow copy when chain is non-empty")
+	}
+	if got.Create == nil || got.Read != nil || got.Update != nil || got.Delete != nil {
+		t.Fatal("only the used fields may be wrapped")
+	}
+	if got.Schema["id"] != r.Schema["id"] {
+		t.Fatal("schema map must be shared with the original")
+	}
+	if err := got.Create(nil, nil); err != nil || !called {
+		t.Fatalf("inner create not invoked: called=%v err=%v", called, err)
+	}
+}
+
+func TestWrapResourcePreservesNonCRUDBehaviour(t *testing.T) {
+	upgraderCalled := false
+	customizeDiffCalled := false
+	importerCalled := false
+
+	r := &schema.Resource{
+		Read:          func(d *schema.ResourceData, meta interface{}) error { return nil },
+		SchemaVersion: 3,
+		StateUpgraders: []schema.StateUpgrader{{
+			Version: 2,
+			Type:    cty.EmptyObject,
+			Upgrade: func(ctx context.Context, st map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+				upgraderCalled = true
+				return st, nil
+			},
+		}},
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			customizeDiffCalled = true
+			return nil
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				importerCalled = true
+				return nil, nil
+			},
+		},
+		DeprecationMessage: "use the other one",
+		Timeouts:           &schema.ResourceTimeout{},
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{&recordInterceptor{name: "rec"}})
+
+	if got.SchemaVersion != r.SchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", got.SchemaVersion, r.SchemaVersion)
+	}
+	if got.DeprecationMessage != r.DeprecationMessage {
+		t.Errorf("DeprecationMessage = %q, want %q", got.DeprecationMessage, r.DeprecationMessage)
+	}
+	if got.Timeouts != r.Timeouts {
+		t.Error("Timeouts must be carried over")
+	}
+	if got.Importer != r.Importer {
+		t.Error("Importer must be carried over")
+	}
+	if len(got.StateUpgraders) != 1 || got.StateUpgraders[0].Version != 2 {
+		t.Fatalf("StateUpgraders = %v, want the declared one", got.StateUpgraders)
+	}
+
+	if _, err := got.StateUpgraders[0].Upgrade(context.Background(), nil, nil); err != nil || !upgraderCalled {
+		t.Errorf("StateUpgraders[0].Upgrade not forwarded: called=%v err=%v", upgraderCalled, err)
+	}
+	if err := got.CustomizeDiff(context.Background(), nil, nil); err != nil || !customizeDiffCalled {
+		t.Errorf("CustomizeDiff not forwarded: called=%v err=%v", customizeDiffCalled, err)
+	}
+	if _, err := got.Importer.StateContext(context.Background(), nil, nil); err != nil || !importerCalled {
+		t.Errorf("Importer.StateContext not forwarded: called=%v err=%v", importerCalled, err)
+	}
+}
+
+func TestWrapDataSourceWrapsReadOnly(t *testing.T) {
+	rec := &recordInterceptor{name: "rec"}
+	ds := &schema.Resource{
+		Read: func(d *schema.ResourceData, meta interface{}) error { return nil },
+	}
+	got := WrapDataSource("alicloud_test", ds, []intercept.Interceptor{rec})
+	if got.Read == nil {
+		t.Fatal("Read must be wrapped")
+	}
+	if err := got.Read(nil, nil); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := []string{"before:rec", "after:rec"}
+	if fmt.Sprint(rec.ops) != fmt.Sprint(want) {
+		t.Fatalf("ops = %v, want %v", rec.ops, want)
+	}
+}
+
+func TestBeforeAbortSkipsInnerAndRunsAllAfters(t *testing.T) {
+	innerCalled := false
+	a := &recordInterceptor{name: "a"}
+	b := &recordInterceptor{name: "b", beforeErr: errors.New("abort")}
+	c := &recordInterceptor{name: "c"}
+	chain := []intercept.Interceptor{a, b, c}
+	r := &schema.Resource{
+		Create: func(d *schema.ResourceData, meta interface{}) error { innerCalled = true; return nil },
+	}
+	got := WrapResource("alicloud_test", r, chain)
+	err := got.Create(nil, nil)
+	if err == nil {
+		t.Fatal("expected the abort error")
+	}
+	if innerCalled {
+		t.Fatal("inner must be skipped after a Before abort")
+	}
+	want := []string{"before:a", "before:b", "after:c", "after:b", "after:a"}
+	if fmt.Sprint(a.ops) != fmt.Sprint([]string{"before:a", "after:a"}) ||
+		fmt.Sprint(b.ops) != fmt.Sprint([]string{"before:b", "after:b"}) ||
+		fmt.Sprint(c.ops) != fmt.Sprint([]string{"after:c"}) {
+		t.Fatalf("ops out of contract: a=%v b=%v c=%v, want %v", a.ops, b.ops, c.ops, want)
+	}
+}
+
+func TestAfterRewritesError(t *testing.T) {
+	rec := &recordInterceptor{name: "rec", rewriteErr: errors.New("rewritten")}
+	r := &schema.Resource{
+		Create: func(d *schema.ResourceData, meta interface{}) error { return errors.New("inner") },
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
+	if err := got.Create(nil, nil); err == nil || err.Error() != "rewritten" {
+		t.Fatalf("expected rewritten error, got %v", err)
+	}
+}
+
+func TestAfterSeesInnerError(t *testing.T) {
+	inner := errors.New("inner")
+	rec := &recordInterceptor{name: "rec"}
+	r := &schema.Resource{
+		Create: func(d *schema.ResourceData, meta interface{}) error { return inner },
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
+	if err := got.Create(nil, nil); err != inner {
+		t.Fatalf("expected the inner error unchanged, got %v", err)
+	}
+}
+
+func TestWrapResourceCreateContext(t *testing.T) {
+	innerCalled := false
+	rec := &recordInterceptor{name: "rec"}
+	r := &schema.Resource{
+		CreateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			innerCalled = true
+			return nil
+		},
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
+	if got.CreateContext == nil {
+		t.Fatal("CreateContext must be wrapped")
+	}
+	if got.Create != nil {
+		t.Fatal("plain Create must be left untouched when CreateContext is wrapped")
+	}
+	diags := got.CreateContext(context.Background(), nil, nil)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if !innerCalled {
+		t.Fatal("inner not called")
+	}
+	want := []string{"before:rec", "after:rec"}
+	if fmt.Sprint(rec.ops) != fmt.Sprint(want) {
+		t.Fatalf("ops = %v, want %v", rec.ops, want)
+	}
+}
+
+func TestWrapResourceCreateWithoutTimeout(t *testing.T) {
+	withoutCalled := false
+	contextCalled := false
+	rec := &recordInterceptor{name: "rec"}
+	r := &schema.Resource{
+		CreateWithoutTimeout: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			withoutCalled = true
+			return nil
+		},
+		CreateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			contextCalled = true
+			return nil
+		},
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
+	if got.CreateWithoutTimeout == nil {
+		t.Fatal("CreateWithoutTimeout must be wrapped")
+	}
+	diags := got.CreateWithoutTimeout(context.Background(), nil, nil)
+	if diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+	if !withoutCalled {
+		t.Fatal("WithoutTimeout inner not called")
+	}
+	if contextCalled {
+		t.Fatal("CreateContext must not be called — SDK dispatches to WithoutTimeout")
+	}
+}
+
+func TestWrapResourceMixedForms(t *testing.T) {
+	createCalled, readCalled, updateCalled := false, false, false
+	rec := &recordInterceptor{name: "rec"}
+	r := &schema.Resource{
+		CreateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			createCalled = true
+			return nil
+		},
+		Read: func(d *schema.ResourceData, meta interface{}) error {
+			readCalled = true
+			return nil
+		},
+		UpdateWithoutTimeout: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			updateCalled = true
+			return nil
+		},
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
+	if got.CreateContext == nil {
+		t.Fatal("CreateContext must be wrapped")
+	}
+	if got.Read == nil {
+		t.Fatal("Read must be wrapped")
+	}
+	if got.UpdateWithoutTimeout == nil {
+		t.Fatal("UpdateWithoutTimeout must be wrapped")
+	}
+	if d := got.CreateContext(context.Background(), nil, nil); d.HasError() || !createCalled {
+		t.Fatal("CreateContext failed")
+	}
+	if err := got.Read(nil, nil); err != nil || !readCalled {
+		t.Fatal("Read failed")
+	}
+	if d := got.UpdateWithoutTimeout(context.Background(), nil, nil); d.HasError() || !updateCalled {
+		t.Fatal("UpdateWithoutTimeout failed")
+	}
+}
+
+func TestWrapResourceContextBeforeAbort(t *testing.T) {
+	innerCalled := false
+	rec := &recordInterceptor{name: "rec", beforeErr: errors.New("abort")}
+	r := &schema.Resource{
+		CreateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			innerCalled = true
+			return nil
+		},
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
+	diags := got.CreateContext(context.Background(), nil, nil)
+	if !diags.HasError() {
+		t.Fatal("expected error from Before abort")
+	}
+	if innerCalled {
+		t.Fatal("inner must be skipped after Before abort")
+	}
+}
+
+func TestContextFormDiagnosticsPassThroughVerbatim(t *testing.T) {
+	rec := &recordInterceptor{name: "rec"}
+	r := &schema.Resource{
+		CreateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			return diag.Diagnostics{{Severity: diag.Error, Summary: "the API said no", Detail: "code: Throttling"}}
+		},
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
+	diags := got.CreateContext(context.Background(), nil, nil)
+
+	if len(diags) != 1 {
+		t.Fatalf("len(diags) = %d, want 1: %v", len(diags), diags)
+	}
+	if diags[0].Summary != "the API said no" || diags[0].Detail != "code: Throttling" {
+		t.Fatalf("diagnostic was rewritten: %+v", diags[0])
+	}
+}
+
+func TestContextFormAfterSwallowsError(t *testing.T) {
+	rec := &recordInterceptor{name: "rec", swallow: true}
+	r := &schema.Resource{
+		ReadContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			return diag.Errorf("resource not found")
+		},
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
+	if diags := got.ReadContext(context.Background(), nil, nil); diags.HasError() {
+		t.Fatalf("After returned nil, so the error must be gone: %v", diags)
+	}
+}
+
+func TestContextFormAfterRewritesError(t *testing.T) {
+	rec := &recordInterceptor{name: "rec", rewriteErr: errors.New("rewritten")}
+	r := &schema.Resource{
+		CreateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			return diag.Errorf("inner")
+		},
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
+	diags := got.CreateContext(context.Background(), nil, nil)
+
+	if len(diags) != 1 {
+		t.Fatalf("len(diags) = %d, want 1: %v", len(diags), diags)
+	}
+	if diags[0].Summary != "rewritten" {
+		t.Fatalf("summary = %q, want %q", diags[0].Summary, "rewritten")
+	}
+}
+
+func TestContextFormWarningsSurvive(t *testing.T) {
+	warning := diag.Diagnostic{Severity: diag.Warning, Summary: "deprecated field"}
+	for _, tc := range []struct {
+		name string
+		rec  *recordInterceptor
+	}{
+		{name: "swallow", rec: &recordInterceptor{name: "rec", swallow: true}},
+		{name: "rewrite", rec: &recordInterceptor{name: "rec", rewriteErr: errors.New("rewritten")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &schema.Resource{
+				CreateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+					return diag.Diagnostics{warning, {Severity: diag.Error, Summary: "inner"}}
+				},
+			}
+			got := WrapResource("alicloud_test", r, []intercept.Interceptor{tc.rec})
+			diags := got.CreateContext(context.Background(), nil, nil)
+
+			if len(diags) == 0 || diags[0].Severity != diag.Warning || diags[0].Summary != warning.Summary {
+				t.Fatalf("the warning must come first and unchanged, got %v", diags)
+			}
+		})
+	}
+}
+
+func TestWrapDataSourceReadContext(t *testing.T) {
+	innerCalled := false
+	rec := &recordInterceptor{name: "rec"}
+	ds := &schema.Resource{
+		ReadContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			innerCalled = true
+			return nil
+		},
+	}
+	got := WrapDataSource("alicloud_test", ds, []intercept.Interceptor{rec})
+	if got.ReadContext == nil {
+		t.Fatal("ReadContext must be wrapped")
+	}
+	if d := got.ReadContext(context.Background(), nil, nil); d.HasError() || !innerCalled {
+		t.Fatal("ReadContext failed")
+	}
+}

--- a/alicloud/provider/sdkv2/wrap_test.go
+++ b/alicloud/provider/sdkv2/wrap_test.go
@@ -19,6 +19,7 @@ type recordInterceptor struct {
 	beforeErr  error
 	afterErr   error
 	rewriteErr error
+	wrapMsg    string
 	swallow    bool
 }
 
@@ -34,6 +35,9 @@ func (r *recordInterceptor) After(ctx context.Context, call intercept.Call, err 
 	}
 	if r.rewriteErr != nil {
 		return r.rewriteErr
+	}
+	if r.wrapMsg != "" && err != nil {
+		return fmt.Errorf("%s: %w", r.wrapMsg, err)
 	}
 	return err
 }
@@ -332,7 +336,7 @@ func TestContextFormDiagnosticsPassThroughVerbatim(t *testing.T) {
 	}
 }
 
-func TestContextFormAfterSwallowsError(t *testing.T) {
+func TestContextFormAfterCannotSwallowError(t *testing.T) {
 	rec := &recordInterceptor{name: "rec", swallow: true}
 	r := &schema.Resource{
 		ReadContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -340,8 +344,13 @@ func TestContextFormAfterSwallowsError(t *testing.T) {
 		},
 	}
 	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
-	if diags := got.ReadContext(context.Background(), nil, nil); diags.HasError() {
-		t.Fatalf("After returned nil, so the error must be gone: %v", diags)
+	diags := got.ReadContext(context.Background(), nil, nil)
+
+	if !diags.HasError() {
+		t.Fatal("After returned nil, but a failure must not be reported as success")
+	}
+	if len(diags) != 1 || diags[0].Summary != "resource not found" {
+		t.Fatalf("want the inner error restored verbatim, got %v", diags)
 	}
 }
 
@@ -355,11 +364,50 @@ func TestContextFormAfterRewritesError(t *testing.T) {
 	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
 	diags := got.CreateContext(context.Background(), nil, nil)
 
-	if len(diags) != 1 {
-		t.Fatalf("len(diags) = %d, want 1: %v", len(diags), diags)
+	if len(diags) != 2 {
+		t.Fatalf("len(diags) = %d, want 2 (inner kept, rewritten appended): %v", len(diags), diags)
 	}
-	if diags[0].Summary != "rewritten" {
-		t.Fatalf("summary = %q, want %q", diags[0].Summary, "rewritten")
+	if diags[0].Summary != "inner" {
+		t.Fatalf("the inner error was replaced, summary = %q", diags[0].Summary)
+	}
+	if diags[1].Summary != "rewritten" {
+		t.Fatalf("summary = %q, want %q", diags[1].Summary, "rewritten")
+	}
+}
+
+// A hook that only wraps the chain's error must not cost the attribute path and
+// detail that error came from.
+func TestContextFormWrapKeepsInnerErrorsIntact(t *testing.T) {
+	rec := &recordInterceptor{name: "rec", wrapMsg: "retry gave up"}
+	r := &schema.Resource{
+		CreateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+			return diag.Diagnostics{
+				{
+					Severity:      diag.Error,
+					Summary:       "the API said no",
+					Detail:        "code: Throttling",
+					AttributePath: cty.GetAttrPath("cidr_block"),
+				},
+				{Severity: diag.Error, Summary: "second failure", Detail: "with a detail"},
+			}
+		},
+	}
+	got := WrapResource("alicloud_test", r, []intercept.Interceptor{rec})
+	diags := got.CreateContext(context.Background(), nil, nil)
+
+	if len(diags) != 3 {
+		t.Fatalf("len(diags) = %d, want 3: %v", len(diags), diags)
+	}
+	if got := diags[0].AttributePath; !got.Equals(cty.GetAttrPath("cidr_block")) {
+		t.Fatalf("the attribute path was lost: %v", got)
+	}
+	if got := diags[1].Detail; got != "with a detail" {
+		t.Fatalf("detail = %q, want it preserved", got)
+	}
+	// The hook's own wording arrives on top, carrying both messages it saw.
+	want := "retry gave up: the API said no: code: Throttling; second failure: with a detail"
+	if got := diags[2].Summary; got != want {
+		t.Fatalf("summary = %q, want %q", got, want)
 	}
 }
 

--- a/alicloud/sdkv2_wrap_real_resource_test.go
+++ b/alicloud/sdkv2_wrap_real_resource_test.go
@@ -1,0 +1,249 @@
+package alicloud
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/features"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/intercept"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/sdkv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var crudFields = map[string]bool{
+	"Create": true, "Read": true, "Update": true, "Delete": true,
+	"CreateContext": true, "ReadContext": true, "UpdateContext": true, "DeleteContext": true,
+	"CreateWithoutTimeout": true, "ReadWithoutTimeout": true,
+	"UpdateWithoutTimeout": true, "DeleteWithoutTimeout": true,
+}
+
+type recordingInterceptor struct {
+	before []intercept.Call
+	after  []intercept.Call
+}
+
+func (r *recordingInterceptor) Before(_ context.Context, call intercept.Call) error {
+	r.before = append(r.before, call)
+	return nil
+}
+
+func (r *recordingInterceptor) After(_ context.Context, call intercept.Call, err error) error {
+	r.after = append(r.after, call)
+	return err
+}
+
+func TestUnitAliCloudSdkV2WrapPreservesCustomizeDiff(t *testing.T) {
+	rec := &recordingInterceptor{}
+	wrapped := sdkv2.WrapResource("alicloud_instance", resourceAliCloudInstance(), []intercept.Interceptor{rec})
+
+	state := &terraform.InstanceState{
+		ID:         "i-unit-test",
+		Attributes: map[string]string{"image_id": "image-before"},
+	}
+	config := terraform.NewResourceConfigRaw(map[string]interface{}{"image_id": "image-after"})
+	client := &connectivity.AliyunClient{
+		Features: features.Features{
+			EcsInstance: features.EcsInstance{ReplaceOnImageUpdate: true},
+		},
+	}
+
+	diff, err := wrapped.Diff(context.Background(), state, config, client)
+	if err != nil {
+		t.Fatalf("diff through the wrapper: %s", err)
+	}
+	attribute, ok := diff.Attributes["image_id"]
+	if !ok {
+		t.Fatalf("expected image_id in the diff, got %#v", diff.Attributes)
+	}
+	if !attribute.RequiresNew {
+		t.Error("image_id RequiresNew = false through the wrapper, want true: the CustomizeDiff did not run")
+	}
+
+	unwrapped := resourceAliCloudInstance()
+	controlState := &terraform.InstanceState{
+		ID:         "i-unit-test",
+		Attributes: map[string]string{"image_id": "image-before"},
+	}
+	controlDiff, err := unwrapped.Diff(context.Background(), controlState, config, client)
+	if err != nil {
+		t.Fatalf("diff without the wrapper: %s", err)
+	}
+	controlAttribute, ok := controlDiff.Attributes["image_id"]
+	if !ok {
+		t.Fatalf("expected image_id in the unwrapped diff, got %#v", controlDiff.Attributes)
+	}
+	if controlAttribute.RequiresNew != attribute.RequiresNew {
+		t.Errorf("wrapped RequiresNew = %t, unwrapped = %t: the wrapper changed the plan",
+			attribute.RequiresNew, controlAttribute.RequiresNew)
+	}
+
+	if len(rec.before) != 0 || len(rec.after) != 0 {
+		t.Errorf("the chain ran during Diff: before=%v after=%v; only CRUD is intercepted", rec.before, rec.after)
+	}
+}
+
+func TestUnitAliCloudSdkV2WrapPreservesStateUpgraders(t *testing.T) {
+	rec := &recordingInterceptor{}
+	original := resourceAliCloudApiGatewayInstance()
+	wrapped := sdkv2.WrapResource("alicloud_api_gateway_instance", original, []intercept.Interceptor{rec})
+
+	if wrapped.SchemaVersion != original.SchemaVersion {
+		t.Fatalf("SchemaVersion = %d, want %d", wrapped.SchemaVersion, original.SchemaVersion)
+	}
+	if len(wrapped.StateUpgraders) != len(original.StateUpgraders) {
+		t.Fatalf("StateUpgraders = %d, want %d", len(wrapped.StateUpgraders), len(original.StateUpgraders))
+	}
+	if len(wrapped.StateUpgraders) == 0 {
+		t.Fatal("alicloud_api_gateway_instance no longer declares a StateUpgrader; pick another resource for this test")
+	}
+
+	upgrader := wrapped.StateUpgraders[0]
+	if upgrader.Version != original.StateUpgraders[0].Version {
+		t.Errorf("upgrader Version = %d, want %d", upgrader.Version, original.StateUpgraders[0].Version)
+	}
+	if !upgrader.Type.Equals(original.StateUpgraders[0].Type) {
+		t.Error("upgrader Type changed: the v0 state would no longer decode")
+	}
+
+	rawState := map[string]interface{}{
+		"to_connect_vpc_ip_block": map[string]interface{}{"cidr_block": "10.0.0.0/24"},
+	}
+	upgraded, err := upgrader.Upgrade(context.Background(), rawState, nil)
+	if err != nil {
+		t.Fatalf("upgrade through the wrapper: %s", err)
+	}
+	block, ok := upgraded["to_connect_vpc_ip_block"].([]interface{})
+	if !ok {
+		t.Fatalf("to_connect_vpc_ip_block = %#v, want []interface{}: the upgrade did not run",
+			upgraded["to_connect_vpc_ip_block"])
+	}
+	if len(block) != 1 {
+		t.Errorf("to_connect_vpc_ip_block has %d element(s), want 1", len(block))
+	}
+
+	if len(rec.before) != 0 || len(rec.after) != 0 {
+		t.Errorf("the chain ran during the state upgrade: before=%v after=%v; only CRUD is intercepted",
+			rec.before, rec.after)
+	}
+}
+
+func TestUnitAliCloudSdkV2WrapCopiesEveryNonCRUDField(t *testing.T) {
+	cases := []struct {
+		name    string
+		factory func() *schema.Resource
+	}{
+		{"alicloud_instance", resourceAliCloudInstance},
+		{"alicloud_api_gateway_instance", resourceAliCloudApiGatewayInstance},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := tc.factory()
+			originalCreate := reflect.ValueOf(original.Create).Pointer()
+
+			rec := &recordingInterceptor{}
+			wrapped := sdkv2.WrapResource(tc.name, original, []intercept.Interceptor{rec})
+
+			if wrapped == original {
+				t.Fatal("wrapper returned the input pointer: the shared map literal value would be mutated")
+			}
+			if reflect.ValueOf(original.Create).Pointer() != originalCreate {
+				t.Error("the original resource was mutated by the wrapper")
+			}
+
+			originalValue := reflect.ValueOf(*original)
+			wrappedValue := reflect.ValueOf(*wrapped)
+			resourceType := originalValue.Type()
+
+			var checked int
+			for i := 0; i < resourceType.NumField(); i++ {
+				field := resourceType.Field(i)
+				originalField, wrappedField := originalValue.Field(i), wrappedValue.Field(i)
+				checked++
+
+				if crudFields[field.Name] {
+					switch {
+					case originalField.IsNil() && !wrappedField.IsNil():
+						t.Errorf("%s: the wrapper populated a CRUD form the resource does not use", field.Name)
+					case !originalField.IsNil() && wrappedField.IsNil():
+						t.Errorf("%s: the wrapper dropped a CRUD form the resource uses", field.Name)
+					case !originalField.IsNil() && originalField.Pointer() == wrappedField.Pointer():
+						t.Errorf("%s: set CRUD field was not wrapped", field.Name)
+					}
+					continue
+				}
+
+				if field.Type.Kind() == reflect.Func {
+					if originalField.Pointer() != wrappedField.Pointer() {
+						t.Errorf("%s: non-CRUD func field changed", field.Name)
+					}
+					continue
+				}
+				if !reflect.DeepEqual(originalField.Interface(), wrappedField.Interface()) {
+					t.Errorf("%s: non-CRUD field changed", field.Name)
+				}
+			}
+			if checked != resourceType.NumField() {
+				t.Fatalf("checked %d of %d fields", checked, resourceType.NumField())
+			}
+		})
+	}
+}
+
+func TestUnitAliCloudSdkV2WrapRewritesThePlainCRUDForm(t *testing.T) {
+	resource := resourceAliCloudInstance()
+	if resource.Create == nil || resource.CreateContext != nil || resource.CreateWithoutTimeout != nil {
+		t.Fatalf("alicloud_instance no longer uses the plain CRUD form (Create=%t CreateContext=%t CreateWithoutTimeout=%t)",
+			resource.Create != nil, resource.CreateContext != nil, resource.CreateWithoutTimeout != nil)
+	}
+
+	var inner []string
+	stub := func(op string) func(*schema.ResourceData, interface{}) error {
+		return func(*schema.ResourceData, interface{}) error {
+			inner = append(inner, op)
+			return nil
+		}
+	}
+	resource.Create = stub("Create")
+	resource.Read = stub("Read")
+	resource.Update = stub("Update")
+	resource.Delete = stub("Delete")
+
+	rec := &recordingInterceptor{}
+	wrapped := sdkv2.WrapResource("alicloud_instance", resource, []intercept.Interceptor{rec})
+
+	client := &connectivity.AliyunClient{}
+	data := wrapped.Data(nil)
+	for _, call := range []struct {
+		op intercept.Op
+		fn func(*schema.ResourceData, interface{}) error
+	}{
+		{intercept.OpCreate, wrapped.Create},
+		{intercept.OpRead, wrapped.Read},
+		{intercept.OpUpdate, wrapped.Update},
+		{intercept.OpDelete, wrapped.Delete},
+	} {
+		if err := call.fn(data, client); err != nil {
+			t.Fatalf("%s through the wrapper: %s", call.op, err)
+		}
+	}
+
+	want := []intercept.Call{
+		{Name: "alicloud_instance", Op: intercept.OpCreate, Meta: client},
+		{Name: "alicloud_instance", Op: intercept.OpRead, Meta: client},
+		{Name: "alicloud_instance", Op: intercept.OpUpdate, Meta: client},
+		{Name: "alicloud_instance", Op: intercept.OpDelete, Meta: client},
+	}
+	if !reflect.DeepEqual(rec.before, want) {
+		t.Errorf("Before calls = %v, want %v", rec.before, want)
+	}
+	if !reflect.DeepEqual(rec.after, want) {
+		t.Errorf("After calls = %v, want %v", rec.after, want)
+	}
+	if got := []string{"Create", "Read", "Update", "Delete"}; !reflect.DeepEqual(inner, got) {
+		t.Errorf("inner functions ran %v, want %v", inner, got)
+	}
+}

--- a/alicloud/service/ims/data_source_default_domain.go
+++ b/alicloud/service/ims/data_source_default_domain.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/fwadapt"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -22,7 +22,7 @@ func NewDefaultDomainDataSource() datasource.DataSource {
 }
 
 type defaultDomainDataSource struct {
-	client *connectivity.AliyunClient
+	fwadapt.DataSourceBase
 }
 
 type defaultDomainModel struct {
@@ -50,27 +50,10 @@ func (d *defaultDomainDataSource) Schema(ctx context.Context, req datasource.Sch
 	}
 }
 
-func (d *defaultDomainDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	if req.ProviderData == nil {
-		return
-	}
-
-	client, ok := req.ProviderData.(*connectivity.AliyunClient)
-	if !ok {
-		resp.Diagnostics.AddError(
-			"Unexpected Data Source Configure Type",
-			fmt.Sprintf("Expected *connectivity.AliyunClient, got %T. Please report this issue to the provider developers.", req.ProviderData),
-		)
-		return
-	}
-
-	d.client = client
-}
-
 func (d *defaultDomainDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	const action = "GetDefaultDomain"
 
-	response, err := d.client.RpcPost("Ims", "2019-08-15", action, nil, map[string]interface{}{}, true)
+	response, err := d.Client().RpcPost("Ims", "2019-08-15", action, nil, map[string]interface{}{}, true)
 	if err != nil {
 		resp.Diagnostics.AddError(fmt.Sprintf("Reading %s: calling %s", defaultDomainTypeName, action), err.Error())
 		return

--- a/alicloud/service/ims/register.go
+++ b/alicloud/service/ims/register.go
@@ -1,0 +1,18 @@
+package ims
+
+import (
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/conns"
+)
+
+// ServicePackage returns the registration declaration of the IMS service.
+func ServicePackage() conns.ServicePackage {
+	return conns.ServicePackage{
+		Name: "Ims",
+		DataSources: []conns.DataSource{
+			{
+				TypeName: "alicloud_ims_default_domain",
+				Factory:  NewDefaultDomainDataSource,
+			},
+		},
+	}
+}


### PR DESCRIPTION
Follow-up to the interceptor middleware layer: makes the error path lossless on both stacks.

- Execute restores an error an After hook dropped, so a failed operation is never reported as success (with a log line)
- Around folds only a changed error back through DiagBridge; a carried-over error returns inner diagnostics verbatim
- both bridges carry all error-severity diagnostics as one diagsErr and append, never substitute, preserving attribute paths and details
- sdkv2 wrapper order now mirrors the SDK's actual dispatch: plain, *WithoutTimeout, *Context

Tests: `go test ./alicloud/provider/... -v`, `go test ./alicloud -run 'TestUnitAliCloudSdkV2Wrap' -v`, `go test ./alicloud/function -v`, and `TestAccAliCloudImsDefaultDomainDataSource` all pass.