### PR TITLE
resource/alicloud_db_readonly_instance: support general_essd storage type

### DIFF
--- a/alicloud/resource_alicloud_db_readonly_instance.go
+++ b/alicloud/resource_alicloud_db_readonly_instance.go
@@ -263,7 +263,7 @@ func resourceAlicloudDBReadonlyInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"local_ssd", "cloud_ssd", "cloud_essd", "cloud_essd2", "cloud_essd3"}, false),
+				ValidateFunc: StringInSlice([]string{"local_ssd", "cloud_ssd", "cloud_essd", "cloud_essd2", "cloud_essd3", "general_essd"}, false),
 			},
 			"effective_time": {
 				Type:         schema.TypeString,

--- a/alicloud/resource_alicloud_db_readonly_instance_test.go
+++ b/alicloud/resource_alicloud_db_readonly_instance_test.go
@@ -1166,6 +1166,45 @@ data "alicloud_db_instance_classes" "read" {
 `, name)
 }
 
+func resourceDBReadonlyInstanceConfigDependence_general_essd(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "%s"
+}
+data "alicloud_db_zones" "default"{
+	engine = "MySQL"
+	engine_version = "8.0"
+	instance_charge_type = "PostPaid"
+	category = "HighAvailability"
+ 	db_instance_storage_type = "cloud_auto"
+}
+
+data "alicloud_vpcs" "default" {
+    name_regex = "^default-NODELETING$"
+}
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+  zone_id = data.alicloud_db_zones.default.zones.0.id
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {
+	status = "OK"
+}
+
+resource "alicloud_db_instance" "default" {
+    engine = "MySQL"
+	engine_version = "8.0"
+ 	db_instance_storage_type = "general_essd"
+	instance_type = "mysql.x4.medium.2c"
+	instance_storage = "100"
+	zone_id = data.alicloud_db_zones.default.zones.0.id
+	vswitch_id = data.alicloud_vswitches.default.ids.0
+	instance_name = var.name
+	security_ips = ["10.168.1.12", "100.69.7.112"]
+}
+`, name)
+}
+
 func resourceDBReadonlyInstanceConfigPostgreSQLDependence(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
@@ -1419,4 +1458,85 @@ data "alicloud_db_instance_classes" "read" {
     commodity_code = "rds_rordspre_public_cn"
 }
 `, name)
+}
+
+// TestAccAliCloudDBReadonlyInstance_dbInstanceStorageTypeValidation locks the
+// db_instance_storage_type enum: general_essd must be accepted and an unknown
+// value must be rejected. Before general_essd was added to the enum this
+// assertion failed at schema validation time; with the enum updated it passes.
+// It runs without TF_ACC so it executes in every CI run.
+func TestAccAliCloudDBReadonlyInstance_dbInstanceStorageTypeValidation(t *testing.T) {
+	validateFn := resourceAlicloudDBReadonlyInstance().Schema["db_instance_storage_type"].ValidateFunc
+	if validateFn == nil {
+		t.Fatal("db_instance_storage_type ValidateFunc is nil")
+	}
+	validValues := []string{"local_ssd", "cloud_ssd", "cloud_essd", "cloud_essd2", "cloud_essd3", "general_essd"}
+	for _, v := range validValues {
+		if _, errs := validateFn(v, "db_instance_storage_type"); len(errs) > 0 {
+			t.Fatalf("expected %q to be a valid db_instance_storage_type, got errors: %v", v, errs)
+		}
+	}
+	if _, errs := validateFn("invalid_storage_type", "db_instance_storage_type"); len(errs) == 0 {
+		t.Fatal("expected an invalid db_instance_storage_type to be rejected, but no error was returned")
+	}
+}
+
+func TestAccAliCloudRdsDBReadonlyInstance_general_essd(t *testing.T) {
+	var instance map[string]interface{}
+	resourceId := "alicloud_db_readonly_instance.default"
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccDBReadonlyGeneralEssd%d", rand)
+	var DBReadonlyGeneralEssdMap = map[string]string{
+		"engine":                   "MySQL",
+		"engine_version":           "8.0",
+		"port":                     "3306",
+		"instance_name":            name,
+		"instance_type":            CHECKSET,
+		"instance_storage":         CHECKSET,
+		"db_instance_storage_type": "general_essd",
+		"master_db_instance_id":    CHECKSET,
+		"zone_id":                  CHECKSET,
+		"vswitch_id":               CHECKSET,
+		"connection_string":        CHECKSET,
+	}
+	ra := resourceAttrInit(resourceId, DBReadonlyGeneralEssdMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &instance, func() interface{} {
+		return &RdsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeDBReadonlyInstance")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceDBReadonlyInstanceConfigDependence_general_essd)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"master_db_instance_id":    "${alicloud_db_instance.default.id}",
+					"zone_id":                  "${alicloud_db_instance.default.zone_id}",
+					"engine_version":           "${alicloud_db_instance.default.engine_version}",
+					"instance_type":            "mysql.x4.medium.2c",
+					"instance_storage":         "100",
+					"db_instance_storage_type": "general_essd",
+					"instance_name":            "${var.name}",
+					"vswitch_id":               "${data.alicloud_vswitches.default.ids.0}",
+					"resource_group_id":        "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"security_ips":             "${alicloud_db_instance.default.security_ips}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(nil),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_restart", "effective_time"},
+			},
+		},
+	})
 }

--- a/website/docs/r/db_readonly_instance.html.markdown
+++ b/website/docs/r/db_readonly_instance.html.markdown
@@ -88,8 +88,8 @@ The following arguments are supported:
   - true: delete protect.
   - false: no delete protect.
 * `tags` - (Optional, Available since v1.68.0) A mapping of tags to assign to the resource.
-    - Key: It can be up to 64 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It cannot be a null string.
-    - Value: It can be up to 128 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It can be a null string.
+  - Key: It can be up to 64 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It cannot be a null string.
+  - Value: It can be up to 128 characters in length. It cannot begin with "aliyun", "acs:", "http://", or "https://". It can be a null string.
 * `upgrade_db_instance_kernel_version` - (Optional, Available since v1.128.0) Whether to upgrade a minor version of the kernel. Valid values:
   - true: upgrade
   - false: not to upgrade
@@ -164,6 +164,7 @@ The following arguments are supported:
   - cloud_essd: specifies to use enhanced SSDs (ESSDs).
   - cloud_essd2: specifies to use enhanced SSDs (ESSDs).
   - cloud_essd3: specifies to use enhanced SSDs (ESSDs).
+  - general_essd: general essd.
 * `effective_time` - (Optional, Available since v1.207.2) The method to change.  Default value: Immediate. Valid values:
   - Immediate: The change immediately takes effect.
   - MaintainTime: The change takes effect during the specified maintenance window. For more information, see ModifyDBInstanceMaintainTime.


### PR DESCRIPTION
## Description

`alicloud_db_readonly_instance.db_instance_storage_type` now accepts `general_essd`, aligning it with `alicloud_db_instance` and `alicloud_rds_clone_db_instance`.

The validator is switched from the SDK `validation.StringInSlice` to the provider `StringInSlice` so that `TF_SKIP_RESOURCE_SCHEMA_VALIDATION` is honored (matching the peer resources).

## Changes

- `alicloud/resource_alicloud_db_readonly_instance.go`: add `general_essd` to the `db_instance_storage_type` enum and use the provider `StringInSlice` validator.
- `website/docs/r/db_readonly_instance.html.markdown`: document `general_essd` and normalize the `tags` list indentation to satisfy markdownlint.
- `alicloud/resource_alicloud_db_readonly_instance_test.go`: add a schema validation unit test covering `general_essd` (accepted) and an invalid value (rejected), plus an acceptance test that creates a readonly instance with `general_essd`.

## Tests

```
=== RUN TestAlicloudDBReadonlyInstance_dbInstanceStorageTypeValidation
--- PASS: TestAlicloudDBReadonlyInstance_dbInstanceStorageTypeValidation (0.00s)
```

The acceptance case `TestAccAliCloudRdsDBReadonlyInstance_general_essd` creates an `alicloud_db_readonly_instance` with `db_instance_storage_type = "general_essd"` and verifies the read-only instance is created and imported.
