### PR TITLE
resource/alicloud_ecs_disk: wait for Category field after ESSD->AutoPL conversion

### DIFF
--- a/alicloud/resource_alicloud_ecs_disk.go
+++ b/alicloud/resource_alicloud_ecs_disk.go
@@ -601,13 +601,37 @@ func resourceAliCloudEcsDiskUpdate(d *schema.ResourceData, meta interface{}) err
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
 
-		stateConf := BuildStateConf([]string{}, []string{"Available", "In_use"}, d.Timeout(schema.TimeoutUpdate), 10*time.Second, ecsServiceV2.EcsDiskStateRefreshFunc(d.Id(), "Status", []string{}))
+		// ESSD -> AutoPL (cloud_auto) category conversion is asynchronous: after
+		// ModifyDiskSpec returns, DescribeDisks reports Status "Modifying" while the
+		// disk transitions between categories. This transition can exceed the default
+		// 15m Update timeout, so when the category is changing, use a longer wait and
+		// list "Modifying" as a known pending state to avoid a premature timeout.
+		pending := []string{}
+		waitTimeout := d.Timeout(schema.TimeoutUpdate)
+		if d.HasChange("category") {
+			pending = []string{"Modifying"}
+			waitTimeout = 2 * waitTimeout
+		}
+		stateConf := BuildStateConf(pending, []string{"Available", "In_use"}, waitTimeout, 10*time.Second, ecsServiceV2.EcsDiskStateRefreshFunc(d.Id(), "Status", []string{}))
 		if _, err := stateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
+
+		// After the Status wait confirms the disk has left the "Modifying" transition,
+		// poll the Category field until it reaches the target value (e.g. cloud_auto).
+		// This second confirmation ensures operations that depend on the new category
+		// (such as setting BurstingEnabled on a cloud_auto disk) do not fire before the
+		// category conversion is truly complete.
+		if d.HasChange("category") {
+			categoryConf := BuildStateConf([]string{}, []string{d.Get("category").(string)}, d.Timeout(schema.TimeoutUpdate), 10*time.Second, ecsServiceV2.EcsDiskStateRefreshFunc(d.Id(), "Category", []string{}))
+			if _, err := categoryConf.WaitForState(); err != nil {
+				return WrapErrorf(err, IdMsg, d.Id())
+			}
+		}
 	}
 	// Deferred BurstingEnabled set: category has just been changed to cloud_auto and
-	// WaitForState confirmed the disk is now cloud_auto, so BurstingEnabled is valid.
+	// the Status + Category WaitForState above confirmed the disk reached the target
+	// category, so BurstingEnabled is valid.
 	if needBurstingPost {
 		update = true
 		action = "ModifyDiskAttribute"

--- a/alicloud/resource_alicloud_ecs_disk_test.go
+++ b/alicloud/resource_alicloud_ecs_disk_test.go
@@ -1678,8 +1678,14 @@ func TestAccAliCloudECSDisk_basic8019_twin(t *testing.T) {
 // bursting_enabled update combinations across the Update path.
 // Covers the distinct code paths in the bursting_enabled Update logic:
 //  1. needBurstingPost defer: category changes TO cloud_auto in the same apply,
-//     so BurstingEnabled is deferred until after ModifyDiskSpec + WaitForState
-//     confirms the disk is cloud_auto (Step2 ESSD->cloud_auto bursting=true).
+//     so BurstingEnabled is deferred until after ModifyDiskSpec + a Status
+//     WaitForState (with "Modifying" pending and a doubled timeout) and a
+//     Category-field WaitForState confirm the disk has truly reached cloud_auto
+//     (Step2 ESSD->cloud_auto bursting=true). The category conversion enters a
+//     "Modifying" transition that can exceed the default 15m Update timeout, so
+//     the Status wait uses a longer timeout and lists "Modifying" as pending; the
+//     Category wait then confirms the target category before BurstingEnabled is
+//     applied.
 //  2. else branch, category unchanged: BurstingEnabled is set directly while the
 //     disk is already cloud_auto (Step3 disable, Step4 re-enable).
 //  3. import: round-trip the resource through Read to confirm state is stable


### PR DESCRIPTION
## Problem

When updating an `alicloud_ecs_disk` from `cloud_essd` to `cloud_auto` and enabling `bursting_enabled` in the same apply, the deferred `BurstingEnabled` API call (`ModifyDiskAttribute`) could fail with `BurstingEnabledForDiskCategoryUnsupported` because the disk had not yet completed the asynchronous category conversion.

## Root cause

The `Update` path's `WaitForState` after `ModifyDiskSpec` polled the `Status` field with the default 15m Update timeout. During an ESSD -> AutoPL category conversion, DescribeDisks reports `Status` as `Modifying` while the asynchronous category transition is in progress. This `Modifying` state is not in the wait's target list (`Available`, `In_use`), so the SDK treats it as pending and continues polling until the 15m timeout expires, at which point the wait fails with a timeout error. The subsequent deferred `BurstingEnabled` set is never reached because the Status wait already returned an error.

The initial fix attempt added a Category-field `WaitForState` after the Status wait, but that Category wait is unreachable when the Status wait times out first (which is exactly the failure scenario).

## Fix

1. When the category is changing (`d.HasChange("category")`), the Status `WaitForState` now uses a doubled timeout (default 15m -> 30m) and lists `Modifying` as a known pending state. This prevents the wait from timing out while the asynchronous category conversion is still in progress.

2. A Category-field `WaitForState` is retained after the Status wait (when the category has changed) to confirm the disk has truly reached the target category (e.g. `cloud_auto`) before the deferred `BurstingEnabled` set runs. This guards against any window where Status has returned to `Available` but the Category field has not yet been updated.

3. Non-category updates retain the original Status wait behavior (unchanged).

## Test

The existing acceptance test `TestAccAliCloudECSDisk_basic8019_essd_to_autopl_burst` covers this scenario:

- Step 1: create a `cloud_essd` disk
- Step 2: change category to `cloud_auto` + enable `bursting_enabled` + set `provisioned_iops` (exercises the deferred BurstingEnabled path, the doubled Status timeout with `Modifying` pending, and the Category-field wait)
- Step 3-4: toggle `bursting_enabled` while category is unchanged (else branch)
- Step 5: import round-trip

Note: the `Modifying` transition duration depends on the cloud backend and cannot be deterministically reproduced in a test. The fix increases the timeout ceiling and makes the pending state explicit so that real-world conversions that exceed the default 15m no longer time out. The acceptance test exercises the exact code path (ESSD -> AutoPL + bursting) to confirm the logic is wired correctly.
