### PR TITLE
resource/alicloud_instance: suppress spurious security_enhancement_strategy ForceNew diff after import

### DIFF
--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -2717,10 +2717,23 @@ func resourceAliCloudInstanceDelete(d *schema.ResourceData, meta interface{}) er
 	return nil
 }
 
-// resourceAliCloudInstanceCustomizeDiff turns an image_id change into a replacement when the
-// provider is configured with features.ecs_instance.replace_on_image_update. Without it, such a
-// change is applied in place by modifyInstanceImage, which the plan can only describe as an update.
+// resourceAliCloudInstanceCustomizeDiff does two jobs:
+//   - Suppress the spurious ForceNew diff on security_enhancement_strategy after import. The
+//     field is create-only (RunInstances/CreateInstance/ReplaceSystemDisk accept it, but
+//     DescribeInstance does not return it), so Read never writes it back; after import the state
+//     value is always empty and a config that declares the field would otherwise recreate the
+//     instance. For an existing instance we clear the diff and treat the config value as truth.
+//   - Turn an image_id change into a replacement when the provider is configured with
+//     features.ecs_instance.replace_on_image_update. Without it, such a change is applied in
+//     place by modifyInstanceImage, which the plan can only describe as an update.
 func resourceAliCloudInstanceCustomizeDiff(diff *schema.ResourceDiff, meta interface{}) error {
+	if diff.Id() != "" {
+		oldSes, newSes := diff.GetChange("security_enhancement_strategy")
+		if oldSes.(string) == "" && newSes.(string) != "" {
+			diff.Clear("security_enhancement_strategy")
+		}
+	}
+
 	client, ok := meta.(*connectivity.AliyunClient)
 	if !ok || client == nil || !client.Features.EcsInstance.ReplaceOnImageUpdate {
 		return nil

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -491,6 +491,72 @@ func TestAccAliCloudECSInstanceBasic(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudECSInstanceSesImportNoop(t *testing.T) {
+	var v ecs.Instance
+	resourceId := "alicloud_instance.default"
+	ra := resourceAttrInit(resourceId, testAccInstanceCheckMap)
+	serviceFunc := func() interface{} {
+		return &EcsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+	rac := resourceAttrCheckInit(rc, ra)
+
+	rand := acctest.RandIntRange(1000, 9999)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAccEcsInstanceSesImport%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceECSInstanceVpcDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.TestSalveRegions)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"image_id":                      "${data.alicloud_images.default.images.0.id}",
+					"security_groups":               []string{"${alicloud_security_group.default.0.id}"},
+					"instance_type":                 "${data.alicloud_instance_types.default.instance_types.0.id}",
+					"availability_zone":             "${data.alicloud_instance_types.default.instance_types.0.availability_zones.0}",
+					"system_disk_category":          "cloud_efficiency",
+					"instance_name":                 "${var.name}",
+					"key_name":                      "${alicloud_key_pair.default.key_name}",
+					"spot_strategy":                 "NoSpot",
+					"spot_price_limit":              "0",
+					"security_enhancement_strategy": "Active",
+					"user_data":                     "I_am_user_data",
+					"vswitch_id":                    "${alicloud_vswitch.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_name": name,
+						"key_name":      name,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// security_enhancement_strategy is create-only and not returned by
+				// DescribeInstance, so it cannot be verified against state after import.
+				ImportStateVerifyIgnore: []string{"security_enhancement_strategy", "dry_run"},
+			},
+			{
+				// After import, security_enhancement_strategy is null in state (DescribeInstance
+				// does not return it) while the config still declares "Active". The CustomizeDiff
+				// hook must suppress the spurious ForceNew diff so that re-applying the same
+				// config is a no-op; without the hook this step would recreate the instance.
+				Config: testAccConfig(map[string]interface{}{
+					"security_enhancement_strategy": "Active",
+				}),
+			},
+		},
+	})
+}
+
 func TestAccAliCloudECSInstanceVpc(t *testing.T) {
 	var v ecs.Instance
 	resourceId := "alicloud_instance.default"


### PR DESCRIPTION
## Summary

`alicloud_instance.security_enhancement_strategy` is a create-only field: it is accepted by
RunInstances/CreateInstance/ReplaceSystemDisk, but `DescribeInstance` does not return it, so the
resource `Read` never writes it back to state.

After `terraform import`, the state value is always empty. When the config still declares the
field (e.g. `security_enhancement_strategy = "Active"`), the plan shows a spurious ForceNew diff
that needlessly recreates the instance on every apply.

## Fix

Extend the existing `resourceAliCloudInstanceCustomizeDiff` hook to clear the
`security_enhancement_strategy` diff for any existing instance (non-create pass) when the state
value is empty and the config value is non-empty, treating the config value as the source of
truth the way import does. The create-time behavior is unchanged (the field is still sent on
RunInstances); only the post-import spurious diff is suppressed.

## Test

A new acceptance test `TestAccAliCloudECSInstanceSesImportNoop` is added:

1. Create an instance with `security_enhancement_strategy = "Active"`.
2. Import it (the field is ignored in ImportStateVerify since it is not returned by
   DescribeInstance).
3. Re-apply the same config; the step expects an empty plan. Without the hook this step would
   recreate the instance (ForceNew diff); with the hook it is a no-op.
