### PR TITLE
resource/alicloud_instance: Fixed the unexpected diff of security_enhancement_strategy and credit_specification for imported instances

### DIFF
--- a/alicloud/resource_alicloud_instance.go
+++ b/alicloud/resource_alicloud_instance.go
@@ -56,6 +56,13 @@ func resourceAliCloudInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				// CreditSpecification is only supported by burstable instance families (e.g. t5, t6).
+				// The ECS API returns an empty value for other instances and ModifyInstanceAttribute
+				// would fail with `Credit.NotFound`, so suppress the diff when the existing instance
+				// has no credit specification in its state (e.g. after importing).
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return d.Id() != "" && old == ""
+				},
 				ValidateFunc: StringInSlice([]string{
 					string(CreditSpecificationStandard),
 					string(CreditSpecificationUnlimited),
@@ -492,6 +499,13 @@ func resourceAliCloudInstance() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
+				// SecurityEnhancementStrategy is a create-only attribute which the ECS API never
+				// returns, so the state value of an imported instance is always empty. Suppress
+				// the diff in that case, otherwise applying a configuration containing this field
+				// after importing would force a replacement of the instance.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return d.Id() != "" && old == ""
+				},
 				ValidateFunc: StringInSlice([]string{
 					string(ActiveSecurityEnhancementStrategy),
 					string(DeactiveSecurityEnhancementStrategy),

--- a/alicloud/resource_alicloud_instance_test.go
+++ b/alicloud/resource_alicloud_instance_test.go
@@ -491,6 +491,104 @@ func TestAccAliCloudECSInstanceBasic(t *testing.T) {
 	})
 }
 
+// The case is used to verify that configuring `security_enhancement_strategy` or
+// `credit_specification` on an instance whose state does not contain these attributes
+// (e.g. an imported instance) does not trigger any change.
+func TestAccAliCloudECSInstanceImportedAttributeDiff(t *testing.T) {
+	var v ecs.Instance
+	resourceId := "alicloud_instance.default"
+	ra := resourceAttrInit(resourceId, testAccInstanceCheckMap)
+	serviceFunc := func() interface{} {
+		return &EcsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+	rac := resourceAttrCheckInit(rc, ra)
+	rand := acctest.RandIntRange(1000, 9999)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testAcc%sEcsInstanceImportDiff%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceInstanceImportDiffDependence)
+	var instanceId string
+	captureInstanceId := func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceId]
+		if !ok {
+			return fmt.Errorf("can't find resource by id: %s", resourceId)
+		}
+		instanceId = rs.Primary.ID
+		return nil
+	}
+	checkInstanceNotReplaced := func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceId]
+		if !ok {
+			return fmt.Errorf("can't find resource by id: %s", resourceId)
+		}
+		if rs.Primary.ID != instanceId {
+			return fmt.Errorf("the instance %s should not have been replaced, but it was recreated as %s", instanceId, rs.Primary.ID)
+		}
+		return nil
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.TestSalveRegions)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Create an instance without `security_enhancement_strategy` and `credit_specification`,
+				// so that both state values are empty, the same situation as after importing an instance.
+				Config: testAccConfig(map[string]interface{}{
+					"image_id":             "${data.alicloud_images.default.images.0.id}",
+					"security_groups":      []string{"${alicloud_security_group.default.id}"},
+					"instance_type":        "${data.alicloud_instance_types.default.instance_types.0.id}",
+					"availability_zone":    "${data.alicloud_instance_types.default.instance_types.0.availability_zones.0}",
+					"system_disk_category": "cloud_efficiency",
+					"instance_name":        "${var.name}",
+					"spot_strategy":        "NoSpot",
+					"spot_price_limit":     "0",
+					"instance_charge_type": "PostPaid",
+					"vswitch_id":           "${alicloud_vswitch.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_name": name,
+						"user_data":     REMOVEKEY,
+					}),
+					captureInstanceId,
+				),
+			},
+			{
+				// The ECS API never returns `security_enhancement_strategy`, and `credit_specification`
+				// is not supported by non-burstable instance families (e.g. ecs.g6), so adding them
+				// to the configuration must not trigger any change.
+				Config: testAccConfig(map[string]interface{}{
+					"security_enhancement_strategy": "Active",
+					"credit_specification":          "Standard",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+					checkInstanceNotReplaced,
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"security_enhancement_strategy", "dry_run"},
+			},
+			{
+				// Applying the same configuration after importing must not trigger any change either.
+				Config: testAccConfig(map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{}),
+					checkInstanceNotReplaced,
+				),
+			},
+		},
+	})
+}
+
 func TestAccAliCloudECSInstanceVpc(t *testing.T) {
 	var v ecs.Instance
 	resourceId := "alicloud_instance.default"
@@ -2685,6 +2783,43 @@ func resourceInstanceMetadataOptionsDependence(name string) string {
   		instance_type = data.alicloud_instance_types.default.instance_types.0.id
 	}
 
+
+resource "alicloud_vpc" "default" {
+  cidr_block = "192.168.0.0/16"
+  vpc_name   = var.name
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id            = alicloud_vpc.default.id
+  cidr_block        = cidrsubnet(alicloud_vpc.default.cidr_block, 8, 2)
+  zone_id           = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
+  vswitch_name      = var.name
+}
+
+resource "alicloud_security_group" "default" {
+  name   = "${var.name}"
+  vpc_id = alicloud_vpc.default.id
+}
+
+variable "name" {
+	default = "%s"
+}
+
+`, name)
+}
+
+func resourceInstanceImportDiffDependence(name string) string {
+	return fmt.Sprintf(`
+	data "alicloud_instance_types" "default" {
+  		instance_type_family = "ecs.g6"
+	}
+
+	data "alicloud_images" "default" {
+  		name_regex    = "^ubuntu_[0-9]+_[0-9]+_x64*"
+  		most_recent   = true
+  		owners        = "system"
+  		instance_type = data.alicloud_instance_types.default.instance_types.0.id
+	}
 
 resource "alicloud_vpc" "default" {
   cidr_block = "192.168.0.0/16"

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -191,6 +191,7 @@ The following arguments are supported:
   - false: A request is sent. If the validation succeeds, the instance is created.
 * `private_ip` - (Optional) Instance private IP address can be specified when you creating new instance. It is valid when `vswitch_id` is specified. When it is changed, the instance will reboot to make the change take effect.
 * `credit_specification` - (Optional, Available since v1.57.1) Performance mode of the t5 burstable instance. Valid values: 'Standard', 'Unlimited'.
+-> **NOTE:** `credit_specification` is only supported by burstable instance families (e.g. `t5`, `t6`). For an existing or imported instance whose instance type does not support credit specification, this field is empty in the state and configuring it does not take effect; no change will be applied, which avoids the `Credit.NotFound` error from the API.
 * `spot_strategy` - (Optional, ForceNew) The spot strategy of a Pay-As-You-Go instance, and it takes effect only when parameter `instance_charge_type` is 'PostPaid'. Value range:
   - NoSpot: A regular Pay-As-You-Go instance.
   - SpotWithPriceLimit: A price threshold for a spot instance
@@ -211,6 +212,8 @@ The following arguments are supported:
 * `security_enhancement_strategy` - (Optional, ForceNew) The security enhancement strategy.
   - Active: Enable security enhancement strategy, it only works on system images.
   - Deactive: Disable security enhancement strategy, it works on all images.
+
+-> **NOTE:** The ECS API does not return `security_enhancement_strategy`, so the provider cannot read it back into the state. For an imported instance (or an instance created without this field), the state value is empty; in this case, configuring or changing `security_enhancement_strategy` is ignored and will not force the instance to be recreated.
 * `data_disks` - (Optional, ForceNew, Available since v1.23.1) The list of data disks created with instance. See [`data_disks`](#data_disks) below.
 * `network_interfaces` - (Optional, ForceNew, Available since v1.212.0) The list of network interfaces created with instance. See [`network_interfaces`](#network_interfaces) below.
 * `status` - (Optional 1.85.0) The instance status. Valid values: ["Running", "Stopped"]. You can control the instance start and stop through this parameter. Default to `Running`.


### PR DESCRIPTION
## Summary
- Fix the unexpected diff triggered by `security_enhancement_strategy` when applying a configuration after importing an instance (fixes #2131). The ECS API never returns this create-only attribute, so the state of an imported instance is always empty; a `DiffSuppressFunc` now suppresses the diff in that case instead of forcing a replacement.
- Fix the `Credit.NotFound` error from `ModifyInstanceAttribute` when `credit_specification` is configured on an existing or imported instance whose instance type does not support it (only burstable families such as `t5`/`t6` do). The diff is suppressed when the state value is empty.
- Both suppress functions only take effect for existing instances (`d.Id() != ""`), so creating a new instance with these attributes keeps the previous behavior.

## Test plan
- [x] `TestAccAliCloudECSInstanceImportedAttributeDiff` PASS (95.06s): create without the two attributes -> add `security_enhancement_strategy`/`credit_specification` (no change, instance not replaced) -> import -> apply again (no change).
- [x] `TestAccAliCloudECSInstanceVpc` PASS (889.43s): existing regression case.
- [ ] `TestAccAliCloudECSInstanceBasic` SKIP: the test account does not support the classic network (pre-existing environment limitation, unrelated to this change).
