### PR TITLE
resource/alicloud_vpn_gateway: Fixed the issue where multiple VPN gateways were created when deploying alicloud_vpn_gateway

### DIFF
--- a/alicloud/resource_alicloud_vpn_gateway.go
+++ b/alicloud/resource_alicloud_vpn_gateway.go
@@ -226,7 +226,6 @@ func resourceAliCloudVPNGatewayVPNGatewayCreate(d *schema.ResourceData, meta int
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("Vpc", "2016-04-28", action, query, request, true)
-		request["ClientToken"] = buildClientToken(action)
 
 		if err != nil {
 			if IsExpectedErrors(err, []string{"OperationFailed.SslNotSupport"}) || NeedRetry(err) {
@@ -340,7 +339,6 @@ func resourceAliCloudVPNGatewayVPNGatewayUpdate(d *schema.ResourceData, meta int
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			response, err = client.RpcPost("Vpc", "2016-04-28", action, query, request, true)
-			request["ClientToken"] = buildClientToken(action)
 
 			if err != nil {
 				if NeedRetry(err) {
@@ -430,7 +428,6 @@ func resourceAliCloudVPNGatewayVPNGatewayDelete(d *schema.ResourceData, meta int
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		response, err = client.RpcPost("Vpc", "2016-04-28", action, query, request, true)
-		request["ClientToken"] = buildClientToken(action)
 
 		if err != nil {
 			if IsExpectedErrors(err, []string{"VpnGateway.Configuring"}) || NeedRetry(err) {


### PR DESCRIPTION
## Problem

Fixes #2145 — deploying a single `alicloud_vpn_gateway` could create 4-6 duplicate VPN gateway instances.

## Root Cause

In `resourceAliCloudVPNGatewayVPNGatewayCreate` / `Update` / `Delete`, the `ClientToken` was **regenerated inside the `resource.Retry` closure** on every attempt:

```go
err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
    response, err = client.RpcPost("Vpc", "2016-04-28", action, query, request, true)
    request["ClientToken"] = buildClientToken(action)  // <-- new token per retry
    ...
})
```

`CreateVpnGateway` relies on `ClientToken` for server-side idempotency: requests carrying the **same** token are deduplicated, while requests with **different** tokens are treated as brand-new creation requests. When the first attempt hit a retryable error (e.g. throttling, `OperationFailed.SslNotSupport`, transient 5xx) after the backend had actually accepted the order, the retry went out with a fresh token, so the VPC backend created another gateway. Repeated retries produced multiple gateways with identical configuration, exactly as reported in #2145.

## Fix

Build the `ClientToken` once **before** entering the retry loop, so all retries of the same logical operation reuse one token and the API stays idempotent (3-line deletion; the token assignment lines already exist above each retry block):

- `resourceAliCloudVPNGatewayVPNGatewayCreate` (CreateVpnGateway)
- `resourceAliCloudVPNGatewayVPNGatewayUpdate` (ModifyVpnGatewayAttribute)
- `resourceAliCloudVPNGatewayVPNGatewayDelete` (DeleteVpnGateway)

## Verification

Remote ACC (dedicated acceptance account, cn-beijing):

| Task | Case | Scenario | Result |
|------|------|----------|--------|
| 10062 | temp repro (reporter's exact shape: Subscription + 5M + dual-AZ vswitches + auto_pay) | Apply / Read | Apply+Read passed; single gateway created, no duplicates (destroy phase fails by design — Subscription gateways cannot be released within validity period) |
| 10075 | temp update regression (Create → Update name/description via ModifyVpnGatewayAttribute → Read) | full CRU | **PASS=1 FAIL=0 SKIP=0** |

- Legacy cases `basic2/3/4` are gated to International-Site accounts (`testAccPreCheckWithAccountSiteType(t, IntlSite)`) and SKIP on the domestic acceptance account — pre-existing gate, unrelated to this change.
- Generated cases (`basic5658` etc.) fail at plan in cn-beijing because the shared fixture VPC `default-NODELETING` has no vswitches in `zones.0/zones.1` (cn-beijing-a/c) — pre-existing fixture gap, unrelated to this change (fails identically without this patch).
- Both temporary verification cases were removed after the runs and are not part of this PR.

## Notes

- Behavior is unchanged on the first attempt; only retry attempts now reuse the same token instead of generating a new one.
