### PR TITLE
docs: correct the Available since version of alicloud_ecd_desktop_group and alicloud_ecd_desktop_groups

### DIFF
--- a/website/docs/d/ecd_desktop_groups.html.markdown
+++ b/website/docs/d/ecd_desktop_groups.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 This data source provides Elastic Desktop Service (ECD) Desktop Groups available to the user. For information about Elastic Desktop Service (ECD) Desktop Group, see [What is Desktop Group](https://next.api.alibabacloud.com/document/ecd/2020-09-30/CreateDesktopGroup).
 
--> **NOTE:** Available since v1.289.0.
+-> **NOTE:** Available since v1.291.0.
 
 ## Example Usage
 

--- a/website/docs/r/ecd_desktop_group.html.markdown
+++ b/website/docs/r/ecd_desktop_group.html.markdown
@@ -16,7 +16,7 @@ connect.
 
 For information about Elastic Desktop Service (ECD) Desktop Group and how to use it, see [What is Desktop Group](https://next.api.alibabacloud.com/document/ecd/2020-09-30/CreateDesktopGroup).
 
--> **NOTE:** Available since v1.289.0.
+-> **NOTE:** Available since v1.291.0.
 
 ## Example Usage
 


### PR DESCRIPTION
### docs: correct the `Available since` version

`alicloud_ecd_desktop_group` and `alicloud_ecd_desktop_groups` were introduced in #10230, which was merged on August 27, 2026 — after v1.290.0 (August 25, 2026) had already been released. Their docs state `Available since v1.289.0.`, which is wrong: they will first ship in the current unreleased version, v1.291.0.

This PR updates the note in both documents:

- `website/docs/r/ecd_desktop_group.html.markdown`
- `website/docs/d/ecd_desktop_groups.html.markdown`

Docs-only change; no provider code is touched.
