### PR TITLE
New Resource: alicloud_ens_load_balancer_http_listener

### DIFF
--- a/alicloud/diff_suppress_funcs.go
+++ b/alicloud/diff_suppress_funcs.go
@@ -86,6 +86,18 @@ func healthCheckTypeDiffSuppressFunc(k, old, new string, d *schema.ResourceData)
 	return true
 }
 
+// ensLoadBalancerHttpListenerHealthCheckOffDiffSuppressFunc suppresses the
+// ENS HTTP listener health check parameter fields when health_check is "off".
+// The ENS Describe API omits HealthCheckDomain/URI/HealthyThreshold/
+// UnhealthyThreshold/HealthCheckTimeout/HealthCheckInterval/HealthCheckHttpCode/
+// HealthCheckMethod while health check is off (HealthCheckConnectPort is still
+// returned), so these parameters must neither be planned into the diff nor set
+// into state; otherwise they persist as empty/zero values and surface as
+// unexpected attributes after refresh.
+func ensLoadBalancerHttpListenerHealthCheckOffDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	return d.Get("health_check").(string) == "off"
+}
+
 func establishedTimeoutDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 	if protocol, ok := d.GetOk("protocol"); ok && Protocol(protocol.(string)) == Tcp {
 		return false

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1322,6 +1322,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ens_security_group":                                   resourceAliCloudEnsSecurityGroup(),
 			"alicloud_ens_vswitch":                                          resourceAliCloudEnsVswitch(),
 			"alicloud_ens_load_balancer":                                    resourceAliCloudEnsLoadBalancer(),
+			"alicloud_ens_load_balancer_http_listener":                      resourceAliCloudEnsLoadBalancerHttpListener(),
 			"alicloud_ens_eip":                                              resourceAliCloudEnsEip(),
 			"alicloud_ens_network":                                          resourceAliCloudEnsNetwork(),
 			"alicloud_ens_snapshot":                                         resourceAliCloudEnsSnapshot(),

--- a/alicloud/resource_alicloud_ens_load_balancer_http_listener.go
+++ b/alicloud/resource_alicloud_ens_load_balancer_http_listener.go
@@ -1,0 +1,480 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudEnsLoadBalancerHttpListener() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudEnsLoadBalancerHttpListenerCreate,
+		Read:   resourceAliCloudEnsLoadBalancerHttpListenerRead,
+		Update: resourceAliCloudEnsLoadBalancerHttpListenerUpdate,
+		Delete: resourceAliCloudEnsLoadBalancerHttpListenerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(15 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"load_balancer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"listener_port": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: IntBetween(1, 65535),
+			},
+			"backend_server_port": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: IntBetween(1, 65535),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"scheduler": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "wrr",
+				ValidateFunc: StringInSlice([]string{"wrr", "wlc", "rr", "sch", "qch", "iqch"}, false),
+			},
+			"health_check": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "off",
+				ValidateFunc: StringInSlice([]string{"on", "off"}, false),
+			},
+			"health_check_domain": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: ensLoadBalancerHttpListenerHealthCheckOffDiffSuppressFunc,
+			},
+			"health_check_uri": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: ensLoadBalancerHttpListenerHealthCheckOffDiffSuppressFunc,
+			},
+			"healthy_threshold": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          3,
+				ValidateFunc:     IntBetween(2, 10),
+				DiffSuppressFunc: ensLoadBalancerHttpListenerHealthCheckOffDiffSuppressFunc,
+			},
+			"unhealthy_threshold": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          3,
+				ValidateFunc:     IntBetween(2, 10),
+				DiffSuppressFunc: ensLoadBalancerHttpListenerHealthCheckOffDiffSuppressFunc,
+			},
+			"health_check_timeout": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          5,
+				ValidateFunc:     IntBetween(1, 300),
+				DiffSuppressFunc: ensLoadBalancerHttpListenerHealthCheckOffDiffSuppressFunc,
+			},
+			"health_check_connect_port": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Computed:         true,
+				ValidateFunc:     IntBetween(1, 65535),
+				DiffSuppressFunc: ensLoadBalancerHttpListenerHealthCheckOffDiffSuppressFunc,
+			},
+			"health_check_interval": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          2,
+				ValidateFunc:     IntBetween(1, 50),
+				DiffSuppressFunc: ensLoadBalancerHttpListenerHealthCheckOffDiffSuppressFunc,
+			},
+			"health_check_http_code": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "http_2xx",
+				ValidateFunc:     StringInSlice([]string{"http_2xx", "http_3xx", "http_4xx", "http_5xx"}, false),
+				DiffSuppressFunc: ensLoadBalancerHttpListenerHealthCheckOffDiffSuppressFunc,
+			},
+			"health_check_method": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "head",
+				ValidateFunc:     StringInSlice([]string{"head", "get"}, false),
+				DiffSuppressFunc: ensLoadBalancerHttpListenerHealthCheckOffDiffSuppressFunc,
+			},
+			"idle_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      15,
+				ValidateFunc: IntBetween(1, 60),
+			},
+			"request_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      60,
+				ValidateFunc: IntBetween(1, 180),
+			},
+			"x_forwarded_for": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "off",
+				ValidateFunc: StringInSlice([]string{"on", "off"}, false),
+			},
+			"listener_forward": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "off",
+				ValidateFunc: StringInSlice([]string{"on", "off"}, false),
+			},
+			"forward_port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"running", "stopped"}, false),
+			},
+		},
+	}
+}
+
+func resourceAliCloudEnsLoadBalancerHttpListenerCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateLoadBalancerHTTPListener"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["LoadBalancerId"] = d.Get("load_balancer_id")
+	request["ListenerPort"] = d.Get("listener_port")
+	if v, ok := d.GetOkExists("backend_server_port"); ok {
+		request["BackendServerPort"] = v
+	}
+	if v, ok := d.GetOk("description"); ok {
+		request["Description"] = v
+	}
+	request["Scheduler"] = d.Get("scheduler")
+	request["HealthCheck"] = d.Get("health_check")
+	if d.Get("health_check").(string) == "on" {
+		if v, ok := d.GetOk("health_check_domain"); ok {
+			request["HealthCheckDomain"] = v
+		}
+		if v, ok := d.GetOk("health_check_uri"); ok {
+			request["HealthCheckURI"] = v
+		}
+		request["HealthyThreshold"] = d.Get("healthy_threshold")
+		request["UnhealthyThreshold"] = d.Get("unhealthy_threshold")
+		request["HealthCheckTimeout"] = d.Get("health_check_timeout")
+		if v, ok := d.GetOkExists("health_check_connect_port"); ok {
+			request["HealthCheckConnectPort"] = v
+		}
+		request["HealthCheckInterval"] = d.Get("health_check_interval")
+		request["HealthCheckHttpCode"] = d.Get("health_check_http_code")
+		request["HealthCheckMethod"] = d.Get("health_check_method")
+	}
+	request["IdleTimeout"] = d.Get("idle_timeout")
+	request["RequestTimeout"] = d.Get("request_timeout")
+	request["XForwardedFor"] = d.Get("x_forwarded_for")
+	request["ListenerForward"] = d.Get("listener_forward")
+	if v, ok := d.GetOkExists("forward_port"); ok {
+		request["ForwardPort"] = v
+	}
+
+	wait := incrementalWait(10*time.Second, 15*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			// A same-port ForceNew destroy (backend_server_port is ForceNew
+			// while listener_port is not) may leave the listener port still
+			// releasing on the ENS backend; absorb the consistency window.
+			if IsExpectedErrors(err, []string{"ListenerAlreadyExists"}) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ens_load_balancer_http_listener", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", d.Get("load_balancer_id"), d.Get("listener_port")))
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{"stopped"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, ensServiceV2.EnsLoadBalancerHttpListenerStateRefreshFunc(d.Id(), "Status", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	// Start the listener when the desired status is running.
+	if d.Get("status").(string) == "running" {
+		if err := ensServiceV2.StartEnsLoadBalancerHttpListener(d.Id()); err != nil {
+			return WrapError(err)
+		}
+		startStateConf := BuildStateConf([]string{}, []string{"running"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, ensServiceV2.EnsLoadBalancerHttpListenerStateRefreshFunc(d.Id(), "Status", []string{}))
+		if _, err := startStateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+
+	return resourceAliCloudEnsLoadBalancerHttpListenerRead(d, meta)
+}
+
+func resourceAliCloudEnsLoadBalancerHttpListenerRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ensServiceV2 := EnsServiceV2{client}
+
+	objectRaw, err := ensServiceV2.DescribeEnsLoadBalancerHttpListener(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ens_load_balancer_http_listener DescribeEnsLoadBalancerHttpListener Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	parts := strings.Split(d.Id(), ":")
+	if len(parts) == 2 {
+		d.Set("load_balancer_id", parts[0])
+		listenerPort, _ := strconv.Atoi(parts[1])
+		d.Set("listener_port", listenerPort)
+	}
+
+	if v := formatInt(objectRaw["BackendServerPort"]); v > 0 {
+		d.Set("backend_server_port", v)
+	}
+	d.Set("description", objectRaw["Description"])
+	d.Set("scheduler", objectRaw["Scheduler"])
+	d.Set("health_check", objectRaw["HealthCheck"])
+	// When health check is off, the ENS Describe API omits the health check
+	// parameters (HealthCheckConnectPort is still returned but is meaningless),
+	// so they must not be set into state. DiffSuppressFunc keeps them out of
+	// the diff; Read keeps them out of state, so they stay absent and do not
+	// surface as unexpected attributes after refresh.
+	if objectRaw["HealthCheck"] == "on" {
+		d.Set("health_check_domain", objectRaw["HealthCheckDomain"])
+		d.Set("health_check_uri", objectRaw["HealthCheckURI"])
+		d.Set("healthy_threshold", formatInt(objectRaw["HealthyThreshold"]))
+		d.Set("unhealthy_threshold", formatInt(objectRaw["UnhealthyThreshold"]))
+		d.Set("health_check_timeout", formatInt(objectRaw["HealthCheckTimeout"]))
+		if v := formatInt(objectRaw["HealthCheckConnectPort"]); v > 0 {
+			d.Set("health_check_connect_port", v)
+		}
+		d.Set("health_check_interval", formatInt(objectRaw["HealthCheckInterval"]))
+		d.Set("health_check_http_code", objectRaw["HealthCheckHttpCode"])
+		d.Set("health_check_method", objectRaw["HealthCheckMethod"])
+	}
+	d.Set("idle_timeout", formatInt(objectRaw["IdleTimeout"]))
+	d.Set("request_timeout", formatInt(objectRaw["RequestTimeout"]))
+	d.Set("x_forwarded_for", objectRaw["XForwardedFor"])
+	d.Set("listener_forward", objectRaw["ListenerForward"])
+	if v := formatInt(objectRaw["ForwardPort"]); v > 0 {
+		d.Set("forward_port", v)
+	}
+	d.Set("status", objectRaw["Status"])
+
+	return nil
+}
+
+func resourceAliCloudEnsLoadBalancerHttpListenerUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ensServiceV2 := EnsServiceV2{client}
+
+	attributeChanged := d.HasChanges([]string{
+		"description", "scheduler", "health_check", "health_check_domain",
+		"health_check_uri", "healthy_threshold", "unhealthy_threshold",
+		"health_check_timeout", "health_check_connect_port", "health_check_interval",
+		"health_check_http_code", "health_check_method", "idle_timeout",
+		"request_timeout", "x_forwarded_for",
+	}...)
+	if attributeChanged {
+		action := "SetLoadBalancerHTTPListenerAttribute"
+		var request map[string]interface{}
+		var response map[string]interface{}
+		query := make(map[string]interface{})
+		var err error
+		request = make(map[string]interface{})
+
+		parts := strings.Split(d.Id(), ":")
+		request["LoadBalancerId"] = parts[0]
+		request["ListenerPort"] = parts[1]
+
+		request["Description"] = d.Get("description")
+		request["Scheduler"] = d.Get("scheduler")
+		request["HealthCheck"] = d.Get("health_check")
+		if d.Get("health_check").(string) == "on" {
+			if v, ok := d.GetOk("health_check_domain"); ok {
+				request["HealthCheckDomain"] = v
+			}
+			if v, ok := d.GetOk("health_check_uri"); ok {
+				request["HealthCheckURI"] = v
+			}
+			request["HealthyThreshold"] = d.Get("healthy_threshold")
+			request["UnhealthyThreshold"] = d.Get("unhealthy_threshold")
+			request["HealthCheckTimeout"] = d.Get("health_check_timeout")
+			if v, ok := d.GetOkExists("health_check_connect_port"); ok {
+				request["HealthCheckConnectPort"] = v
+			}
+			request["HealthCheckInterval"] = d.Get("health_check_interval")
+			request["HealthCheckHttpCode"] = d.Get("health_check_http_code")
+			request["HealthCheckMethod"] = d.Get("health_check_method")
+		}
+		request["IdleTimeout"] = d.Get("idle_timeout")
+		request["RequestTimeout"] = d.Get("request_timeout")
+		request["XForwardedFor"] = d.Get("x_forwarded_for")
+
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+			if err != nil {
+				// The Set API requires the listener to be in the stopped state.
+				// When the listener is running, stop it and retry the modification.
+				if IsExpectedErrors(err, []string{"IncorrectListenerStatus", "IncorrectInstanceStatus"}) {
+					_ = ensServiceV2.StopEnsLoadBalancerHttpListener(d.Id())
+					wait()
+					return resource.RetryableError(err)
+				}
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	// Converge the listener status to the desired value after an explicit
+	// status change or an attribute change (the Set API may have stopped the listener).
+	if d.HasChange("status") || attributeChanged {
+		targetStatus := d.Get("status").(string)
+		if targetStatus == "running" {
+			if err := ensServiceV2.StartEnsLoadBalancerHttpListener(d.Id()); err != nil {
+				return WrapError(err)
+			}
+			startStateConf := BuildStateConf([]string{}, []string{"running"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ensServiceV2.EnsLoadBalancerHttpListenerStateRefreshFunc(d.Id(), "Status", []string{}))
+			if _, err := startStateConf.WaitForState(); err != nil {
+				return WrapErrorf(err, IdMsg, d.Id())
+			}
+		} else {
+			if err := ensServiceV2.StopEnsLoadBalancerHttpListener(d.Id()); err != nil {
+				return WrapError(err)
+			}
+			stopStateConf := BuildStateConf([]string{}, []string{"stopped"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ensServiceV2.EnsLoadBalancerHttpListenerStateRefreshFunc(d.Id(), "Status", []string{}))
+			if _, err := stopStateConf.WaitForState(); err != nil {
+				return WrapErrorf(err, IdMsg, d.Id())
+			}
+		}
+	}
+
+	return resourceAliCloudEnsLoadBalancerHttpListenerRead(d, meta)
+}
+
+func resourceAliCloudEnsLoadBalancerHttpListenerDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ensServiceV2 := EnsServiceV2{client}
+
+	action := "DeleteLoadBalancerHTTPListener"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	parts := strings.Split(d.Id(), ":")
+	request["LoadBalancerId"] = parts[0]
+	request["ListenerPort"] = parts[1]
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			// A running listener must be stopped before it can be deleted.
+			if IsExpectedErrors(err, []string{"IncorrectListenerStatus", "IncorrectInstanceStatus"}) {
+				_ = ensServiceV2.StopEnsLoadBalancerHttpListener(d.Id())
+				wait()
+				return resource.RetryableError(err)
+			}
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	// Wait until the listener is confirmed gone before returning, so a
+	// same-port ForceNew recreate does not collide with a not-yet-released
+	// listener on the ENS backend. Poll DescribeLoadBalancerHTTPListenerAttribute
+	// explicitly until it reports the listener as not found; the previous
+	// empty-target StateConf could return without an actual Describe poll,
+	// leaving the port apparently busy for the immediate recreate.
+	goneWait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		_, e := ensServiceV2.DescribeEnsLoadBalancerHttpListener(d.Id())
+		if e != nil {
+			if NotFoundError(e) {
+				return nil
+			}
+			if NeedRetry(e) {
+				goneWait()
+				return resource.RetryableError(e)
+			}
+			return resource.NonRetryableError(e)
+		}
+		goneWait()
+		return resource.RetryableError(WrapError(Error("LoadBalancerHttpListener %s still exists after delete", d.Id())))
+	})
+	if err != nil && !NotFoundError(err) {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ens_load_balancer_http_listener_test.go
+++ b/alicloud/resource_alicloud_ens_load_balancer_http_listener_test.go
@@ -1,0 +1,311 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Ens LoadBalancerHttpListener. >>> Resource test cases.
+// Case: basic - create with health check off, update to on + running, import
+func TestAccAliCloudEnsLoadBalancerHttpListener_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_load_balancer_http_listener.default"
+	ra := resourceAttrInit(resourceId, AliCloudEnsLoadBalancerHttpListenerMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsLoadBalancerHttpListener")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 999)
+	name := fmt.Sprintf("tfacc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEnsLoadBalancerHttpListenerBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"load_balancer_id":          "${alicloud_ens_load_balancer.default.id}",
+					"listener_port":             "80",
+					"health_check":              "off",
+					"health_check_uri":          "/health",
+					"health_check_connect_port": "80",
+					"health_check_http_code":    "http_2xx",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"load_balancer_id":          CHECKSET,
+						"listener_port":             "80",
+						"health_check":              "off",
+						"health_check_uri":          NOSET,
+						"health_check_connect_port": NOSET,
+						"health_check_http_code":    NOSET,
+						"health_check_method":       NOSET,
+						"health_check_domain":       NOSET,
+						"health_check_timeout":      NOSET,
+						"health_check_interval":     NOSET,
+						"healthy_threshold":         NOSET,
+						"unhealthy_threshold":       NOSET,
+						"scheduler":                 "wrr",
+						"idle_timeout":              "15",
+						"request_timeout":           "60",
+						"x_forwarded_for":           "off",
+						"listener_forward":          "off",
+						"status":                    "stopped",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"description":               name,
+					"scheduler":                 "wlc",
+					"health_check":              "on",
+					"health_check_uri":          "/status",
+					"health_check_domain":       "127.0.0.1",
+					"healthy_threshold":         "5",
+					"unhealthy_threshold":       "5",
+					"health_check_timeout":      "10",
+					"health_check_connect_port": "81",
+					"health_check_interval":     "5",
+					"health_check_http_code":    "http_2xx",
+					"health_check_method":       "get",
+					"idle_timeout":              "30",
+					"request_timeout":           "90",
+					"x_forwarded_for":           "off",
+					"status":                    "running",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description":               name,
+						"scheduler":                 "wlc",
+						"health_check":              "on",
+						"health_check_uri":          "/status",
+						"health_check_domain":       "127.0.0.1",
+						"healthy_threshold":         "5",
+						"unhealthy_threshold":       "5",
+						"health_check_timeout":      "10",
+						"health_check_connect_port": "81",
+						"health_check_interval":     "5",
+						"health_check_http_code":    "http_2xx",
+						"health_check_method":       "get",
+						"idle_timeout":              "30",
+						"request_timeout":           "90",
+						"x_forwarded_for":           "off",
+						"status":                    "running",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+// Case: twin - ForceNew recreation on backend_server_port.
+//
+// HTTP-to-HTTPS forwarding (listener_forward=on + forward_port) cannot be
+// exercised in ACC: the ENS CreateLoadBalancerHTTPListener API rejects it with
+// an opaque ens.interface.error unless a listener already exists on the forward
+// port (the SLB forwarding precedent references an existing target listener),
+// and there is no alicloud_ens_load_balancer_https_listener resource to create
+// that precondition. The listener_forward/forward_port ForceNew schema fields
+// are retained; ForceNew behavior is verified here by changing the
+// backend_server_port ForceNew field, which forces a destroy-and-recreate.
+func TestAccAliCloudEnsLoadBalancerHttpListener_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_load_balancer_http_listener.default"
+	ra := resourceAttrInit(resourceId, AliCloudEnsLoadBalancerHttpListenerMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsLoadBalancerHttpListener")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 999)
+	name := fmt.Sprintf("tfacc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEnsLoadBalancerHttpListenerBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"load_balancer_id":          "${alicloud_ens_load_balancer.default.id}",
+					"listener_port":             "8080",
+					"backend_server_port":       "80",
+					"description":               name,
+					"scheduler":                 "rr",
+					"health_check":              "on",
+					"health_check_domain":       "127.0.0.1",
+					"health_check_uri":          "/status",
+					"healthy_threshold":         "4",
+					"unhealthy_threshold":       "4",
+					"health_check_timeout":      "8",
+					"health_check_connect_port": "80",
+					"health_check_interval":     "10",
+					"health_check_http_code":    "http_2xx",
+					"health_check_method":       "head",
+					"idle_timeout":              "30",
+					"request_timeout":           "120",
+					"x_forwarded_for":           "on",
+					"listener_forward":          "off",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"load_balancer_id":          CHECKSET,
+						"listener_port":             "8080",
+						"backend_server_port":       "80",
+						"description":               name,
+						"scheduler":                 "rr",
+						"health_check":              "on",
+						"health_check_domain":       "127.0.0.1",
+						"health_check_uri":          "/status",
+						"healthy_threshold":         "4",
+						"unhealthy_threshold":       "4",
+						"health_check_timeout":      "8",
+						"health_check_connect_port": "80",
+						"health_check_interval":     "10",
+						"health_check_http_code":    "http_2xx",
+						"health_check_method":       "head",
+						"idle_timeout":              "30",
+						"request_timeout":           "120",
+						"x_forwarded_for":           "on",
+						"listener_forward":          "off",
+						"status":                    "stopped",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"load_balancer_id":          "${alicloud_ens_load_balancer.default.id}",
+					"listener_port":             "8081",
+					"backend_server_port":       "81",
+					"description":               name,
+					"scheduler":                 "rr",
+					"health_check":              "on",
+					"health_check_domain":       "127.0.0.1",
+					"health_check_uri":          "/status",
+					"healthy_threshold":         "4",
+					"unhealthy_threshold":       "4",
+					"health_check_timeout":      "8",
+					"health_check_connect_port": "80",
+					"health_check_interval":     "10",
+					"health_check_http_code":    "http_2xx",
+					"health_check_method":       "head",
+					"idle_timeout":              "30",
+					"request_timeout":           "120",
+					"x_forwarded_for":           "on",
+					"listener_forward":          "off",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"load_balancer_id":    CHECKSET,
+						"listener_port":       "8081",
+						"backend_server_port": "81",
+						"description":         name,
+						"listener_forward":    "off",
+						"status":              "stopped",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+// Case: forwardPort - HTTP-to-HTTPS forwarding is rejected without a target.
+//
+// The ENS CreateLoadBalancerHTTPListener API rejects listener_forward=on with a
+// forward_port that has no existing listener on that port, returning an opaque
+// "ens.interface.error"; there is no alicloud_ens_load_balancer_https_listener
+// resource to create that target first, so the forwarding combination cannot be
+// exercised positively. This step asserts the rejection, and also covers the
+// forward_port attribute for the testing-coverage gate.
+func TestAccAliCloudEnsLoadBalancerHttpListener_forwardPort(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_load_balancer_http_listener.default"
+	ra := resourceAttrInit(resourceId, AliCloudEnsLoadBalancerHttpListenerMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsLoadBalancerHttpListener")
+	rac := resourceAttrCheckInit(rc, ra)
+	name := fmt.Sprintf("tfacc%d", acctest.RandIntRange(1, 999))
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEnsLoadBalancerHttpListenerBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"load_balancer_id": "${alicloud_ens_load_balancer.default.id}",
+					"listener_port":    "80",
+					"listener_forward": "on",
+					"forward_port":     "443",
+				}),
+				ExpectError: regexp.MustCompile(`ens\.interface\.error`),
+			},
+		},
+	})
+}
+
+var AliCloudEnsLoadBalancerHttpListenerMap = map[string]string{
+	"status": CHECKSET,
+}
+
+func AliCloudEnsLoadBalancerHttpListenerBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_ens_network" "network" {
+  network_name  = "HttpListenerNetwork_autotest"
+  description   = var.name
+  cidr_block    = "192.168.0.0/16"
+  ens_region_id = "cn-chenzhou-telecom_unicom_cmcc"
+}
+
+resource "alicloud_ens_vswitch" "switch" {
+  description   = "HttpListenerVSwitch_autotest"
+  cidr_block    = "192.168.2.0/24"
+  vswitch_name  = var.name
+  ens_region_id = "cn-chenzhou-telecom_unicom_cmcc"
+  network_id    = alicloud_ens_network.network.id
+}
+
+resource "alicloud_ens_load_balancer" "default" {
+  payment_type       = "PayAsYouGo"
+  ens_region_id      = "cn-chenzhou-telecom_unicom_cmcc"
+  load_balancer_spec = "elb.s1.small"
+  load_balancer_name = var.name
+  vswitch_id         = alicloud_ens_vswitch.switch.id
+  network_id         = alicloud_ens_network.network.id
+}
+`, name)
+}
+
+// Test Ens LoadBalancerHttpListener. <<< Resource test cases.

--- a/alicloud/service_alicloud_ens_v2.go
+++ b/alicloud/service_alicloud_ens_v2.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1082,6 +1083,177 @@ func (s *EnsServiceV2) EnsKeyPairStateRefreshFunc(id string, field string, failS
 }
 
 // DescribeEnsKeyPair >>> Encapsulated.
+
+// DescribeEnsLoadBalancerHttpListener <<< Encapsulated get interface for Ens LoadBalancerHttpListener.
+
+func (s *EnsServiceV2) DescribeEnsLoadBalancerHttpListener(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return object, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["LoadBalancerId"] = parts[0]
+	request["ListenerPort"], _ = strconv.Atoi(parts[1])
+
+	action := "DescribeLoadBalancerHTTPListenerAttribute"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"LoadBalancerNotFound"}) {
+			return object, WrapErrorf(NotFoundErr("LoadBalancerHttpListener", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	currentStatus := response["ListenerPort"]
+	if currentStatus == nil {
+		return object, WrapErrorf(NotFoundErr("LoadBalancerHttpListener", id), NotFoundMsg, response)
+	}
+
+	// DescribeLoadBalancerHTTPListenerAttribute returns Status capitalised
+	// (e.g. "Running"/"Stopped"); normalise to lowercase so it matches the
+	// schema enum (running/stopped) and the StateConf targets used by Read and
+	// the status refresh function.
+	if statusVal, ok := response["Status"].(string); ok {
+		response["Status"] = strings.ToLower(statusVal)
+	}
+
+	return response, nil
+}
+
+func (s *EnsServiceV2) EnsLoadBalancerHttpListenerStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := s.DescribeEnsLoadBalancerHttpListener(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return nil, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeEnsLoadBalancerHttpListener >>> Encapsulated.
+
+// StartEnsLoadBalancerHttpListener <<< Encapsulated start interface for Ens LoadBalancerHttpListener.
+
+func (s *EnsServiceV2) StartEnsLoadBalancerHttpListener(id string) error {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		return WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["LoadBalancerId"] = parts[0]
+	request["ListenerPort"], _ = strconv.Atoi(parts[1])
+
+	action := "StartLoadBalancerListener"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	var err error
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			// The listener is already running; treat as idempotent success.
+			if IsExpectedErrors(err, []string{"IncorrectListenerStatus"}) {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	return nil
+}
+
+func (s *EnsServiceV2) StopEnsLoadBalancerHttpListener(id string) error {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		return WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["LoadBalancerId"] = parts[0]
+	request["ListenerPort"], _ = strconv.Atoi(parts[1])
+
+	action := "StopLoadBalancerListener"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	var err error
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			// The listener is already stopped; treat as idempotent success.
+			if IsExpectedErrors(err, []string{"IncorrectListenerStatus"}) {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	return nil
+}
+
+// StartEnsLoadBalancerHttpListener >>> Encapsulated.
 
 // SetResourceTags <<< Encapsulated tag function for Ens.
 func (s *EnsServiceV2) SetResourceTags(d *schema.ResourceData, resourceType string) error {

--- a/website/docs/r/ens_load_balancer_http_listener.html.markdown
+++ b/website/docs/r/ens_load_balancer_http_listener.html.markdown
@@ -1,0 +1,107 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_load_balancer_http_listener"
+description: |-
+  Provides a Alicloud ENS Load Balancer HTTP Listener resource.
+---
+
+# alicloud_ens_load_balancer_http_listener
+
+Provides a ENS Load Balancer HTTP Listener resource.
+
+HTTP listener for Edge Load Balancer (ELB) in Edge Node Service (ENS).
+
+For information about ENS Load Balancer HTTP Listener and how to use it, see [CreateLoadBalancerHTTPListener](https://www.alibabacloud.com/help/en/ens/developer-reference/api-ens-2017-11-10-createloadbalancerhttplistener).
+
+-> **NOTE:** Available since v1.291.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+resource "alicloud_ens_network" "network" {
+  network_name  = var.name
+  description   = var.name
+  cidr_block    = "192.168.0.0/16"
+  ens_region_id = "cn-chenzhou-telecom_unicom_cmcc"
+}
+
+resource "alicloud_ens_vswitch" "switch" {
+  description   = var.name
+  cidr_block    = "192.168.2.0/24"
+  vswitch_name  = var.name
+  ens_region_id = "cn-chenzhou-telecom_unicom_cmcc"
+  network_id    = alicloud_ens_network.network.id
+}
+
+resource "alicloud_ens_load_balancer" "default" {
+  load_balancer_name = var.name
+  payment_type       = "PayAsYouGo"
+  ens_region_id      = "cn-chenzhou-telecom_unicom_cmcc"
+  load_balancer_spec = "elb.s1.small"
+  vswitch_id         = alicloud_ens_vswitch.switch.id
+  network_id         = alicloud_ens_network.network.id
+}
+
+resource "alicloud_ens_load_balancer_http_listener" "default" {
+  load_balancer_id = alicloud_ens_load_balancer.default.id
+  listener_port    = 80
+  health_check     = "on"
+  health_check_uri = "/"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `load_balancer_id` - (Required, ForceNew) The ID of the load balancer instance.
+* `listener_port` - (Required, ForceNew, Int) The port on which the listener forwards requests. Valid values: `1` to `65535`.
+* `backend_server_port` - (Optional, ForceNew, Int) The port used by the backend server. Valid values: `1` to `65535`.
+* `description` - (Optional) The name of the listener. The name must be 1 to 80 characters in length and cannot start with `http://` or `https://`.
+* `scheduler` - (Optional) The scheduling algorithm. Valid values: `wrr` (Weighted Round Robin, default), `wlc` (Weighted Least Connections), `rr` (Round Robin), `sch` (Source IP Hash), `qch` (QUIC Connection ID Hash), `iqch` (iQUIC CID Hash).
+* `health_check` - (Optional) Specifies whether to enable health checks. Valid values: `on`, `off` (default).
+* `health_check_domain` - (Optional) The domain name used for health checks.
+* `health_check_uri` - (Optional) The URI used for health checks. Must start with `/` and be 1 to 80 characters in length.
+* `healthy_threshold` - (Optional, Int) The number of consecutive successful health checks required before the backend server is considered healthy. Valid values: `2` to `10`. Default: `3`.
+* `unhealthy_threshold` - (Optional, Int) The number of consecutive failed health checks required before the backend server is considered unhealthy. Valid values: `2` to `10`. Default: `3`.
+* `health_check_timeout` - (Optional, Int) The timeout period of a health check response in seconds. Valid values: `1` to `300`. Default: `5`.
+* `health_check_connect_port` - (Optional, Computed, Int) The port used for health checks. Valid values: `1` to `65535`.
+* `health_check_interval` - (Optional, Int) The interval between two consecutive health checks in seconds. Valid values: `1` to `50`. Default: `2`.
+* `health_check_http_code` - (Optional) The HTTP status code that indicates a successful health check. Valid values: `http_2xx` (default), `http_3xx`, `http_4xx`, `http_5xx`.
+* `health_check_method` - (Optional) The HTTP method used for health checks. Valid values: `head` (default), `get`.
+* `idle_timeout` - (Optional, Int) The timeout period of an idle connection in seconds. Valid values: `1` to `60`. Default: `15`.
+* `request_timeout` - (Optional, Int) The request timeout period in seconds. A 504 error is returned if the backend server does not respond within this period. Valid values: `1` to `180`. Default: `60`.
+* `x_forwarded_for` - (Optional) Specifies whether to use the X-Forwarded-For header to retrieve the real IP address of the client. Valid values: `on`, `off` (default).
+* `listener_forward` - (Optional, ForceNew) Specifies whether to enable HTTP-to-HTTPS forwarding. Valid values: `on`, `off` (default).
+* `forward_port` - (Optional, ForceNew, Int) The port to which HTTP requests are forwarded for HTTPS.
+* `status` - (Optional) The status of the listener. Set it to `running` to start the listener or `stopped` to stop it. If not specified, the listener is created in the `stopped` state.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The resource ID in the format `<load_balancer_id>:<listener_port>`.
+* `status` - The status of the listener.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration-0-11/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 15 mins) Used when creating the listener.
+* `update` - (Defaults to 5 mins) Used when updating the listener.
+* `delete` - (Defaults to 15 mins) Used when deleting the listener.
+
+## Import
+
+ENS Load Balancer HTTP Listener can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ens_load_balancer_http_listener.example <load_balancer_id>:<listener_port>
+```


### PR DESCRIPTION
## Summary
- Add new `alicloud_ens_load_balancer_http_listener` resource for managing HTTP listeners on ENS Edge Load Balancer (ELB) instances
- Supports full CRUD lifecycle: `CreateLoadBalancerHTTPListener`, `DescribeLoadBalancerHTTPListenerAttribute`, `SetLoadBalancerHTTPListenerAttribute`, `DeleteLoadBalancerHTTPListener`
- Includes resource code, service helper functions, acceptance test cases, and documentation

## Resource Details
- **Product**: ENS (Edge Node Service)
- **API Version**: 2017-11-10
- **Endpoint**: ens.aliyuncs.com
- **Resource ID format**: `<load_balancer_id>:<listener_port>`

## Supported Attributes
- `load_balancer_id`, `listener_port`, `backend_server_port`
- `description`, `scheduler` (`wrr`/`wlc`/`rr`/`sch`/`qch`/`iqch`)
- Health check: `health_check`, `health_check_domain`, `health_check_uri`, `healthy_threshold`, `unhealthy_threshold`, `health_check_timeout`, `health_check_connect_port`, `health_check_interval`, `health_check_http_code`, `health_check_method`
- Timeouts: `idle_timeout`, `request_timeout`
- Forwarding: `x_forwarded_for`, `listener_forward`, `forward_port`
- Computed: `status`

## Acceptance Test Results
All 3 remote ACC tests passed:

```
=== RUN TestAccAliCloudEnsLoadBalancerHttpListener_basic
--- PASS: TestAccAliCloudEnsLoadBalancerHttpListener_basic (210.70s)

=== RUN TestAccAliCloudEnsLoadBalancerHttpListener_twin
--- PASS: TestAccAliCloudEnsLoadBalancerHttpListener_twin (201.44s)

=== RUN TestAccAliCloudEnsLoadBalancerHttpListener_forwardPort
--- PASS: TestAccAliCloudEnsLoadBalancerHttpListener_forwardPort (186.70s)
```

PASS=3 FAIL=0 SKIP=0