### PR TITLE
New Resource: alicloud_sls_metric_store; New Data Source: alicloud_sls_metric_stores

### DIFF
--- a/alicloud/data_source_alicloud_sls_metric_stores.go
+++ b/alicloud/data_source_alicloud_sls_metric_stores.go
@@ -1,0 +1,223 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAliCloudSlsMetricStores() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudSlsMetricStoresRead,
+		Schema: map[string]*schema.Schema{
+			"project_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsValidRegExp,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"metric_stores": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"metric_store_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ttl": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"shard_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"auto_split": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"max_split_shard_count": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"append_meta": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"hot_ttl": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"last_modify_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudSlsMetricStoresRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	projectName := d.Get("project_name").(string)
+
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	action := "/logstores"
+	query := make(map[string]*string)
+	telemetryType := "Metrics"
+	query["telemetryType"] = &telemetryType
+	hostMap := map[string]*string{
+		"project": StringPointer(projectName),
+	}
+
+	var response map[string]interface{}
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		resp, err := client.Do("Sls", roaParam("GET", "2020-12-30", "ListLogStores", action), query, nil, nil, hostMap, true)
+		if err != nil {
+			if NeedRetry(err) {
+				time.Sleep(5 * time.Second)
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		response = resp
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_sls_metric_stores", "ListLogStores", AlibabaCloudSdkGoERROR)
+	}
+	addDebug(action, response)
+
+	logstoresRaw, _ := response["logstores"].([]interface{})
+
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	ids := make([]string, 0)
+	slsServiceV2 := SlsServiceV2{client}
+	for _, v := range logstoresRaw {
+		name, ok := v.(string)
+		if !ok || name == "" {
+			continue
+		}
+		if nameRegex != nil && !nameRegex.MatchString(name) {
+			continue
+		}
+		id := fmt.Sprintf("%s:%s", projectName, name)
+		if len(idsMap) > 0 {
+			_, hitID := idsMap[id]
+			_, hitName := idsMap[name]
+			if !hitID && !hitName {
+				continue
+			}
+		}
+		mapping := map[string]interface{}{
+			"id":                id,
+			"metric_store_name": name,
+		}
+		objectRaw, err := slsServiceV2.DescribeSlsLogStore(id)
+		if err == nil {
+			if v, ok := objectRaw["ttl"]; ok {
+				mapping["ttl"] = v
+			}
+			if v, ok := objectRaw["shardCount"]; ok {
+				mapping["shard_count"] = v
+			}
+			if v, ok := objectRaw["autoSplit"]; ok {
+				mapping["auto_split"] = v
+			}
+			if v, ok := objectRaw["maxSplitShard"]; ok {
+				mapping["max_split_shard_count"] = v
+			}
+			if v, ok := objectRaw["appendMeta"]; ok {
+				mapping["append_meta"] = v
+			}
+			if v, ok := objectRaw["hot_ttl"]; ok {
+				mapping["hot_ttl"] = v
+			}
+			if v, ok := objectRaw["mode"]; ok {
+				mapping["mode"] = v
+			}
+			if v, ok := objectRaw["createTime"]; ok {
+				mapping["create_time"] = v
+			}
+			if v, ok := objectRaw["lastModifyTime"]; ok {
+				mapping["last_modify_time"] = v
+			}
+		}
+		ids = append(ids, id)
+		names = append(names, name)
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("metric_stores", s); err != nil {
+		return WrapError(err)
+	}
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+
+	return nil
+}

--- a/alicloud/data_source_alicloud_sls_metric_stores_test.go
+++ b/alicloud/data_source_alicloud_sls_metric_stores_test.go
@@ -1,0 +1,112 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudSlsMetricStoresDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, connectivity.SlsTestRegions)
+	rand := acctest.RandIntRange(10000, 99999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudSlsMetricStoresDataSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_sls_metric_store.default.id}"]`,
+			"project_name": `"${alicloud_log_project.default.project_name}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudSlsMetricStoresDataSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_sls_metric_store.default.id}_fake"]`,
+			"project_name": `"${alicloud_log_project.default.project_name}"`,
+		}),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudSlsMetricStoresDataSourceConfig(rand, map[string]string{
+			"name_regex":   `"${alicloud_sls_metric_store.default.metric_store_name}"`,
+			"project_name": `"${alicloud_log_project.default.project_name}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudSlsMetricStoresDataSourceConfig(rand, map[string]string{
+			"name_regex":   `"${alicloud_sls_metric_store.default.metric_store_name}_fake"`,
+			"project_name": `"${alicloud_log_project.default.project_name}"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudSlsMetricStoresDataSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_sls_metric_store.default.id}"]`,
+			"name_regex":   `"${alicloud_sls_metric_store.default.metric_store_name}"`,
+			"project_name": `"${alicloud_log_project.default.project_name}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudSlsMetricStoresDataSourceConfig(rand, map[string]string{
+			"ids":          `["${alicloud_sls_metric_store.default.id}_fake"]`,
+			"name_regex":   `"${alicloud_sls_metric_store.default.metric_store_name}_fake"`,
+			"project_name": `"${alicloud_log_project.default.project_name}"`,
+		}),
+	}
+
+	SlsMetricStoresCheckInfo.dataSourceTestCheck(t, rand, idsConf, nameRegexConf, allConf)
+}
+
+var existSlsMetricStoresMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"ids.#":                                 "1",
+		"names.#":                               "1",
+		"metric_stores.#":                       "1",
+		"metric_stores.0.id":                    CHECKSET,
+		"metric_stores.0.metric_store_name":     CHECKSET,
+		"metric_stores.0.ttl":                   CHECKSET,
+		"metric_stores.0.shard_count":           CHECKSET,
+		"metric_stores.0.auto_split":            CHECKSET,
+		"metric_stores.0.max_split_shard_count": CHECKSET,
+		"metric_stores.0.mode":                  CHECKSET,
+		"metric_stores.0.create_time":           CHECKSET,
+		"metric_stores.0.last_modify_time":      CHECKSET,
+	}
+}
+
+var fakeSlsMetricStoresMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"ids.#":           "0",
+		"names.#":         "0",
+		"metric_stores.#": "0",
+	}
+}
+
+var SlsMetricStoresCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_sls_metric_stores.default",
+	existMapFunc: existSlsMetricStoresMapFunc,
+	fakeMapFunc:  fakeSlsMetricStoresMapFunc,
+}
+
+func testAccCheckAliCloudSlsMetricStoresDataSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testacc-sls-msds-%d"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+  description  = "terraform test project for metric store datasource"
+}
+
+resource "alicloud_sls_metric_store" "default" {
+  project_name      = alicloud_log_project.default.project_name
+  metric_store_name = var.name
+  ttl               = 30
+  shard_count       = 2
+}
+
+data "alicloud_sls_metric_stores" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n  "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -958,6 +958,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_vpc_ipam_ipams":                                   dataSourceAliCloudVpcIpamIpams(),
 			"alicloud_das_sql_log_configs":                              dataSourceAliCloudDasSqlLogConfigs(),
 			"alicloud_apig_plugin_classes":                              dataSourceAliCloudApigPluginClasses(),
+			"alicloud_sls_metric_stores":                                dataSourceAliCloudSlsMetricStores(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_gpdb_db_extension":                                    resourceAliCloudGpdbDbExtension(),
@@ -2150,6 +2151,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_polardb_zonal_db_cluster":                              resourceAliCloudPolarDbZonalCluster(),
 			"alicloud_polardb_zonal_endpoint":                                resourceAlicloudPolarDBZonalEndpoint(),
 			"alicloud_polardb_zonal_account":                                 resourceAlicloudPolarDBZonalAccount(),
+			"alicloud_sls_metric_store":                                      resourceAliCloudSlsMetricStore(),
 		},
 	}
 	provider.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {

--- a/alicloud/resource_alicloud_sls_metric_store.go
+++ b/alicloud/resource_alicloud_sls_metric_store.go
@@ -1,0 +1,381 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	sls "github.com/aliyun/aliyun-log-go-sdk"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudSlsMetricStore() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudSlsMetricStoreCreate,
+		Read:   resourceAliCloudSlsMetricStoreRead,
+		Update: resourceAliCloudSlsMetricStoreUpdate,
+		Delete: resourceAliCloudSlsMetricStoreDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"project_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"metric_store_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ttl": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"shard_count": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"auto_split": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"max_split_shard_count": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      64,
+				ValidateFunc: IntBetween(0, 256),
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if v, ok := d.GetOkExists("auto_split"); ok && !v.(bool) {
+						return true
+					}
+					return false
+				},
+			},
+			"append_meta": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"hot_ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"infrequent_access_ttl": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntAtLeast(61),
+			},
+			"mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if new == "" {
+						return true
+					}
+					return old != "" && new != "" && old == new
+				},
+			},
+			"encrypt_conf": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"encrypt_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"user_cmk_info": {
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cmk_key_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+									"arn": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"region_id": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"last_modify_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildSlsMetricStore(d *schema.ResourceData) *sls.MetricStore {
+	metricStore := &sls.MetricStore{
+		Name:          d.Get("metric_store_name").(string),
+		TTL:           d.Get("ttl").(int),
+		ShardCount:    d.Get("shard_count").(int),
+		AutoSplit:     d.Get("auto_split").(bool),
+		MaxSplitShard: d.Get("max_split_shard_count").(int),
+		AppendMeta:    d.Get("append_meta").(bool),
+		Mode:          d.Get("mode").(string),
+	}
+	if hotTTL, ok := d.GetOk("hot_ttl"); ok {
+		metricStore.HotTTL = int32(hotTTL.(int))
+	}
+	if infrequentAccessTTL, ok := d.GetOk("infrequent_access_ttl"); ok {
+		ttl := int32(infrequentAccessTTL.(int))
+		metricStore.InfrequentAccessTTL = &ttl
+	}
+	if encrypt := buildSlsMetricStoreEncrypt(d); encrypt != nil {
+		metricStore.EncryptConf = encrypt
+	}
+	return metricStore
+}
+
+func buildSlsMetricStoreEncrypt(d *schema.ResourceData) *sls.MetricStoreEncryptConf {
+	if field, ok := d.GetOk("encrypt_conf"); ok {
+		list, ok := field.([]interface{})
+		if !ok || len(list) == 0 {
+			return nil
+		}
+		values, ok := list[0].(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		encryptConf := &sls.MetricStoreEncryptConf{}
+		if v, ok := values["enable"].(bool); ok {
+			encryptConf.Enable = v
+		}
+		if v, ok := values["encrypt_type"].(string); ok && v != "" {
+			encryptConf.EncryptType = v
+		}
+		cmkInfoList, _ := values["user_cmk_info"].([]interface{})
+		if len(cmkInfoList) > 0 {
+			if cmkInfo, ok := cmkInfoList[0].(map[string]interface{}); ok {
+				userCmkInfo := &sls.MetricStoreEncryptUserCmkConf{}
+				if v, ok := cmkInfo["cmk_key_id"].(string); ok {
+					userCmkInfo.CmkKeyId = v
+				}
+				if v, ok := cmkInfo["arn"].(string); ok {
+					userCmkInfo.Arn = v
+				}
+				if v, ok := cmkInfo["region_id"].(string); ok {
+					userCmkInfo.RegionId = v
+				}
+				encryptConf.UserCmkInfo = userCmkInfo
+			}
+		}
+		return encryptConf
+	}
+	return nil
+}
+
+func resourceAliCloudSlsMetricStoreCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	projectName := d.Get("project_name").(string)
+	metricStoreName := d.Get("metric_store_name").(string)
+	metricStore := buildSlsMetricStore(d)
+
+	var requestinfo *sls.Client
+	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		raw, err := client.WithLogClient(func(slsClient *sls.Client) (interface{}, error) {
+			return nil, slsClient.CreateMetricStoreV2(projectName, metricStore)
+		})
+		if err != nil {
+			if IsExpectedErrors(err, []string{"InternalServerError", LogClientTimeout}) {
+				time.Sleep(10 * time.Second)
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug("CreateMetricStoreV2", raw, requestinfo, map[string]interface{}{
+			"project":     projectName,
+			"metricStore": metricStore,
+		})
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_sls_metric_store", "CreateMetricStoreV2", AliyunLogGoSdkERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%s:%s", projectName, metricStoreName))
+	return resourceAliCloudSlsMetricStoreRead(d, meta)
+}
+
+func resourceAliCloudSlsMetricStoreRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	slsServiceV2 := SlsServiceV2{client}
+
+	objectRaw, err := slsServiceV2.DescribeSlsLogStore(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			log.Printf("[WARN] Resource alicloud_sls_metric_store %s not found, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("metric_store_name", objectRaw["logstoreName"])
+	if objectRaw["ttl"] != nil {
+		d.Set("ttl", objectRaw["ttl"])
+	}
+	if objectRaw["shardCount"] != nil {
+		d.Set("shard_count", objectRaw["shardCount"])
+	}
+	if objectRaw["autoSplit"] != nil {
+		d.Set("auto_split", objectRaw["autoSplit"])
+	}
+	if objectRaw["maxSplitShard"] != nil {
+		d.Set("max_split_shard_count", objectRaw["maxSplitShard"])
+	}
+	if objectRaw["appendMeta"] != nil {
+		d.Set("append_meta", objectRaw["appendMeta"])
+	}
+	if objectRaw["hot_ttl"] != nil {
+		d.Set("hot_ttl", objectRaw["hot_ttl"])
+	}
+	if objectRaw["infrequentAccessTTL"] != nil {
+		d.Set("infrequent_access_ttl", objectRaw["infrequentAccessTTL"])
+	}
+	if objectRaw["mode"] != nil {
+		d.Set("mode", objectRaw["mode"])
+	}
+	if objectRaw["createTime"] != nil {
+		d.Set("create_time", objectRaw["createTime"])
+	}
+	if objectRaw["lastModifyTime"] != nil {
+		d.Set("last_modify_time", objectRaw["lastModifyTime"])
+	}
+
+	encryptConfMaps := make([]map[string]interface{}, 0)
+	if encryptConfRaw, ok := objectRaw["encrypt_conf"].(map[string]interface{}); ok && len(encryptConfRaw) > 0 {
+		encryptConfMap := map[string]interface{}{
+			"enable":       encryptConfRaw["enable"],
+			"encrypt_type": encryptConfRaw["encrypt_type"],
+		}
+		userCmkInfoMaps := make([]map[string]interface{}, 0)
+		if userCmkInfoRaw, ok := encryptConfRaw["user_cmk_info"].(map[string]interface{}); ok && len(userCmkInfoRaw) > 0 {
+			userCmkInfoMaps = append(userCmkInfoMaps, map[string]interface{}{
+				"cmk_key_id": userCmkInfoRaw["cmk_key_id"],
+				"arn":        userCmkInfoRaw["arn"],
+				"region_id":  userCmkInfoRaw["region_id"],
+			})
+		}
+		encryptConfMap["user_cmk_info"] = userCmkInfoMaps
+		encryptConfMaps = append(encryptConfMaps, encryptConfMap)
+	}
+	if objectRaw["encrypt_conf"] != nil {
+		if err := d.Set("encrypt_conf", encryptConfMaps); err != nil {
+			return err
+		}
+	}
+
+	parts := strings.Split(d.Id(), ":")
+	d.Set("project_name", parts[0])
+
+	return nil
+}
+
+func resourceAliCloudSlsMetricStoreUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	projectName := parts[0]
+
+	metricStore := buildSlsMetricStore(d)
+	var requestinfo *sls.Client
+	err := resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		raw, err := client.WithLogClient(func(slsClient *sls.Client) (interface{}, error) {
+			return nil, slsClient.UpdateMetricStoreV2(projectName, metricStore)
+		})
+		if err != nil {
+			if IsExpectedErrors(err, []string{"InternalServerError", LogClientTimeout}) {
+				time.Sleep(10 * time.Second)
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug("UpdateMetricStoreV2", raw, requestinfo, map[string]interface{}{
+			"project":     projectName,
+			"metricStore": metricStore,
+		})
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), "UpdateMetricStoreV2", AliyunLogGoSdkERROR)
+	}
+
+	return resourceAliCloudSlsMetricStoreRead(d, meta)
+}
+
+func resourceAliCloudSlsMetricStoreDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	projectName := parts[0]
+	metricStoreName := parts[1]
+
+	action := fmt.Sprintf("/logstores/%s", metricStoreName)
+	var request map[string]interface{}
+	request = make(map[string]interface{})
+	hostMap := map[string]*string{
+		"project": StringPointer(projectName),
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err := client.Do("Sls", roaParam("DELETE", "2020-12-30", "DeleteMetricStore", action), make(map[string]*string), nil, nil, hostMap, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), "DeleteMetricStore", AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_sls_metric_store_test.go
+++ b/alicloud/resource_alicloud_sls_metric_store_test.go
@@ -1,0 +1,153 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Sls MetricStore.
+func TestAccAliCloudSlsMetricStore_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_sls_metric_store.default"
+	ra := resourceAttrInit(resourceId, AlicloudSlsMetricStoreMap)
+	serviceFunc := func() interface{} {
+		return &SlsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serviceFunc, "DescribeSlsLogStore")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sslsms%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudSlsMetricStoreBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.SlsTestRegions)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"project_name":          "${alicloud_log_project.default.project_name}",
+					"metric_store_name":     name,
+					"ttl":                   "30",
+					"shard_count":           "2",
+					"auto_split":            "true",
+					"max_split_shard_count": "64",
+					"append_meta":           "false",
+					"hot_ttl":               "7",
+					"mode":                  "standard",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"project_name":          CHECKSET,
+						"metric_store_name":     name,
+						"ttl":                   "30",
+						"shard_count":           "2",
+						"auto_split":            "true",
+						"max_split_shard_count": "64",
+						"append_meta":           "false",
+						"hot_ttl":               "7",
+						"mode":                  "standard",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ttl":                   "180",
+					"max_split_shard_count": "128",
+					"append_meta":           "true",
+					"hot_ttl":               "14",
+					"infrequent_access_ttl": "90",
+					"encrypt_conf": []map[string]interface{}{
+						{
+							"enable":       "true",
+							"encrypt_type": "default",
+							"user_cmk_info": []map[string]string{
+								{
+									"cmk_key_id": "${alicloud_kms_key.key.id}",
+									"arn":        "acs:ram::${data.alicloud_account.default.id}:role/aliyunlogdefaultrole",
+									"region_id":  "${data.alicloud_regions.default.regions.0.id}",
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ttl":                   "180",
+						"max_split_shard_count": "128",
+						"append_meta":           "true",
+						"hot_ttl":               "14",
+						"infrequent_access_ttl": "90",
+						"encrypt_conf.#":        "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto_split": "false",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"auto_split":            "false",
+						"max_split_shard_count": REMOVEKEY,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"encrypt_conf",
+				},
+			},
+		},
+	})
+}
+
+var AlicloudSlsMetricStoreMap = map[string]string{
+	"project_name":          CHECKSET,
+	"metric_store_name":     CHECKSET,
+	"ttl":                   CHECKSET,
+	"shard_count":           CHECKSET,
+	"auto_split":            CHECKSET,
+	"max_split_shard_count": CHECKSET,
+	"append_meta":           CHECKSET,
+	"hot_ttl":               CHECKSET,
+	"mode":                  CHECKSET,
+	"create_time":           CHECKSET,
+	"last_modify_time":      CHECKSET,
+}
+
+func AlicloudSlsMetricStoreBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+	default = "%s"
+}
+
+data "alicloud_account" "default" {}
+
+data "alicloud_regions" "default" {
+  current = true
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+  description  = "terraform test project for metric store"
+}
+
+resource "alicloud_kms_key" "key" {
+  description            = "${var.name}-kms"
+  pending_window_in_days = "7"
+  status                 = "Enabled"
+}
+`, name)
+}

--- a/website/docs/d/sls_metric_stores.html.markdown
+++ b/website/docs/d/sls_metric_stores.html.markdown
@@ -1,0 +1,63 @@
+---
+subcategory: "Log Service (SLS)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_sls_metric_stores"
+description: |-
+  Provides a list of SLS MetricStores to the user.
+---
+
+# alicloud_sls_metric_stores
+
+This data source provides the SLS MetricStores of the current Alibaba Cloud user.
+
+-> **NOTE:** Available since v1.291.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+data "alicloud_sls_metric_stores" "default" {
+  project_name = "your-project-name"
+  name_regex   = ".*"
+}
+
+output "first_metric_store_name" {
+  value = data.alicloud_sls_metric_stores.default.names.0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_name` - (Required) The name of the SLS project.
+* `ids` - (Optional) A list of MetricStore names to filter results.
+* `name_regex` - (Optional) A regex string to apply to the MetricStore name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform apply`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `names` - A list of MetricStore names.
+* `metric_stores` - A list of MetricStores. Each element contains the following attributes:
+  * `id` - The ID of the MetricStore. The value is formatted as `<project_name>:<metric_store_name>`.
+  * `metric_store_name` - The name of the MetricStore.
+  * `ttl` - The data retention period in days.
+  * `shard_count` - The number of shards.
+  * `auto_split` - Whether automatic shard splitting is enabled.
+  * `max_split_shard_count` - The maximum number of shards to split.
+  * `append_meta` - Whether to record the IP address of the requester.
+  * `hot_ttl` - The data retention period in the hot storage tier, in days.
+  * `mode` - The type of the MetricStore.
+  * `create_time` - The time when the MetricStore was created.
+  * `last_modify_time` - The time when the MetricStore was last modified.

--- a/website/docs/r/sls_metric_store.html.markdown
+++ b/website/docs/r/sls_metric_store.html.markdown
@@ -1,0 +1,105 @@
+---
+subcategory: "Log Service (SLS)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_sls_metric_store"
+description: |-
+  Provides a Alicloud SLS MetricStore resource.
+---
+
+# alicloud_sls_metric_store
+
+Provides a SLS MetricStore resource. A MetricStore is a dedicated time-series data store in Simple Log Service for storing and querying metrics.
+
+For information about SLS MetricStore and how to use it, see [MetricStore](https://www.alibabacloud.com/help/en/sls/developer-reference/api-sls-2020-12-30-dir-metricstore/).
+
+-> **NOTE:** Available since v1.291.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "random_integer" "default" {
+  min = 10000
+  max = 99999
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = "${var.name}-${random_integer.default.result}"
+  description  = "terraform example project for metric store"
+}
+
+resource "alicloud_sls_metric_store" "default" {
+  project_name          = alicloud_log_project.default.project_name
+  metric_store_name     = "${var.name}-metric-store"
+  ttl                   = 30
+  shard_count           = 2
+  auto_split            = true
+  max_split_shard_count = 64
+  append_meta           = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_name` - (Required, ForceNew) The name of the SLS project.
+* `metric_store_name` - (Required, ForceNew) The name of the MetricStore.
+* `ttl` - (Required) The data retention period in days. Minimum value is 1.
+* `shard_count` - (Required, ForceNew) The number of shards for the MetricStore.
+* `auto_split` - (Optional) Specifies whether to automatically split shards. Default value: `true`.
+* `max_split_shard_count` - (Optional) The maximum number of shards to split when auto-split is enabled. Valid values: `0` to `256`. Default value: `64`.
+* `append_meta` - (Optional) Specifies whether to record the IP address of the requester. Default value: `false`.
+* `hot_ttl` - (Optional) The data retention period in the hot storage tier, in days. Minimum value is `7`. Set to `-1` to retain data in the hot storage tier for the entire TTL.
+* `infrequent_access_ttl` - (Optional) The data retention period in the Infrequent Access (IA) storage tier, in days. It must be greater than `60`, and `hot_ttl + infrequent_access_ttl` must not be greater than `ttl`.
+* `mode` - (Optional, ForceNew) The type of the MetricStore. Valid values: `standard`. Default value: `standard`.
+* `encrypt_conf` - (Optional) The encryption configuration. See [`encrypt_conf`](#encrypt_conf) below.
+
+### `encrypt_conf`
+
+The `encrypt_conf` block supports:
+
+* `enable` - (Required) Specifies whether to enable encryption.
+* `encrypt_type` - (Optional, ForceNew) The encryption algorithm. Valid values: `default`.
+* `user_cmk_info` - (Optional, ForceNew) The BYOK (Bring Your Own Key) configuration. See [`user_cmk_info`](#encrypt_conf-user_cmk_info) below.
+
+### `encrypt_conf-user_cmk_info`
+
+The encrypt_conf-user_cmk_info supports the following:
+
+* `cmk_key_id` - (Optional, ForceNew) The ID of the CMK (Customer Master Key).
+* `arn` - (Optional) The ARN of the RAM role that is authorized to use the CMK.
+* `region_id` - (Optional, ForceNew) The region ID of the CMK.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the MetricStore. The value is formatted as `<project_name>:<metric_store_name>`.
+* `create_time` - The time when the MetricStore was created.
+* `last_modify_time` - The time when the MetricStore was last modified.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration-0-11/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 5 minutes) Used when creating the MetricStore.
+* `update` - (Defaults to 5 minutes) Used when updating the MetricStore.
+* `delete` - (Defaults to 5 minutes) Used when deleting the MetricStore.
+
+## Import
+
+SLS MetricStore can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_sls_metric_store.example <project_name>:<metric_store_name>
+```


### PR DESCRIPTION
### What this PR does

Adds support for SLS MetricStore management in the Terraform Alibaba Cloud Provider.

A MetricStore is a dedicated time-series data store in Simple Log Service for storing and querying metrics.

### New Resource

`alicloud_sls_metric_store` — manages the full lifecycle (create / update / delete) of an SLS MetricStore, with support for:

- `ttl` (data retention period in days)
- `shard_count` (number of shards)
- `auto_split` / `max_split_shard_count` (automatic shard splitting)
- `append_meta` (record requester IP)
- `hot_ttl` / `infrequent_access_ttl` (tiered storage: hot tier and Infrequent Access tier)
- `mode` (store type, e.g. standard, immutable after creation)
- `encrypt_conf` (encryption configuration incl. BYOK with KMS)

### New Data Source

`alicloud_sls_metric_stores` — lists MetricStores under a project, with `ids` / `name_regex` filtering and full attribute output.

### Acceptance Tests

All acceptance tests pass with real API calls (including KMS-encrypted store creation):

=== RUN   TestAccAliCloudSlsMetricStore_basic
--- PASS: TestAccAliCloudSlsMetricStore_basic (30.21s)

=== RUN   TestAccAliCloudSlsMetricStoresDataSource
--- PASS: TestAccAliCloudSlsMetricStoresDataSource (44.20s)

PASS=2 FAIL=0 SKIP=0