### PR TITLE
New Resource: alicloud_ens_load_balancer_udp_listener; New Data Source: alicloud_ens_load_balancer_udp_listeners

### DIFF
--- a/alicloud/data_source_alicloud_ens_load_balancer_udp_listeners.go
+++ b/alicloud/data_source_alicloud_ens_load_balancer_udp_listeners.go
@@ -1,0 +1,261 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudEnsLoadBalancerUdpListeners() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudEnsLoadBalancerUdpListenerRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"load_balancer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"listeners": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"backend_server_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"eip_transmit": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"established_timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"health_check_connect_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"health_check_connect_timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"health_check_exp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"health_check_interval": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"health_check_req": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"healthy_threshold": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"listener_port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"load_balancer_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"scheduler": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"unhealthy_threshold": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudEnsLoadBalancerUdpListenerRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeLoadBalancerListeners"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if v, ok := d.GetOk("load_balancer_id"); ok {
+		request["LoadBalancerId"] = v
+	}
+	request["LoadBalancerId"] = d.Get("load_balancer_id")
+	request["PageSize"] = PageSizeLarge
+	request["PageNumber"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.Listeners.Listener[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if fmt.Sprint(item["Protocol"]) != "udp" {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(request["LoadBalancerId"], ":", item["ListenerPort"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = fmt.Sprint(request["LoadBalancerId"], ":", objectRaw["ListenerPort"])
+
+		mapping["description"] = objectRaw["Description"]
+		mapping["status"] = objectRaw["Status"]
+		mapping["listener_port"] = formatInt(objectRaw["ListenerPort"])
+		mapping["load_balancer_id"] = objectRaw["LoadBalancerId"]
+		mapping["protocol"] = objectRaw["Protocol"]
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(request["LoadBalancerId"], ":", objectRaw["ListenerPort"])
+		mapping, err = dataSourceAliCloudEnsLoadBalancerUdpListenerReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("listeners", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudEnsLoadBalancerUdpListenerReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	ensServiceV2 := EnsServiceV2{client}
+	getResp, err := ensServiceV2.DescribeEnsLoadBalancerUdpListener(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["backend_server_port"] = objectRaw["BackendServerPort"]
+	mapping["description"] = objectRaw["Description"]
+	mapping["eip_transmit"] = objectRaw["EipTransmit"]
+	mapping["established_timeout"] = objectRaw["EstablishedTimeout"]
+	mapping["health_check_connect_port"] = objectRaw["HealthCheckConnectPort"]
+	mapping["health_check_connect_timeout"] = objectRaw["HealthCheckConnectTimeout"]
+	mapping["health_check_exp"] = objectRaw["HealthCheckExp"]
+	mapping["health_check_interval"] = objectRaw["HealthCheckInterval"]
+	mapping["health_check_req"] = objectRaw["HealthCheckReq"]
+	mapping["healthy_threshold"] = objectRaw["HealthyThreshold"]
+	mapping["scheduler"] = objectRaw["Scheduler"]
+	mapping["status"] = objectRaw["Status"]
+	mapping["unhealthy_threshold"] = objectRaw["UnhealthyThreshold"]
+	mapping["listener_port"] = objectRaw["ListenerPort"]
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_ens_load_balancer_udp_listeners_test.go
+++ b/alicloud/data_source_alicloud_ens_load_balancer_udp_listeners_test.go
@@ -1,0 +1,136 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudEnsLoadBalancerUdpListenerDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsLoadBalancerUdpListenerSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_load_balancer_udp_listener.default.id}"]`,
+			"load_balancer_id": `"${alicloud_ens_load_balancer.defaultgNxO1j.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsLoadBalancerUdpListenerSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_load_balancer_udp_listener.default.id}_fake"]`,
+			"load_balancer_id": `"${alicloud_ens_load_balancer.defaultgNxO1j.id}"`,
+		}),
+	}
+
+	LoadBalancerIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsLoadBalancerUdpListenerSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_load_balancer_udp_listener.default.id}"]`,
+			"load_balancer_id": `"${alicloud_ens_load_balancer.defaultgNxO1j.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsLoadBalancerUdpListenerSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_load_balancer_udp_listener.default.id}_fake"]`,
+			"load_balancer_id": `"${alicloud_ens_load_balancer.defaultgNxO1j.id}"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsLoadBalancerUdpListenerSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_load_balancer_udp_listener.default.id}"]`,
+			"load_balancer_id": `"${alicloud_ens_load_balancer.defaultgNxO1j.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsLoadBalancerUdpListenerSourceConfig(rand, map[string]string{
+			"ids":              `["${alicloud_ens_load_balancer_udp_listener.default.id}_fake"]`,
+			"load_balancer_id": `"${alicloud_ens_load_balancer.defaultgNxO1j.id}"`,
+		}),
+	}
+
+	EnsLoadBalancerUdpListenerCheckInfo.dataSourceTestCheck(t, rand, idsConf, LoadBalancerIdConf, allConf)
+}
+
+var existEnsLoadBalancerUdpListenerMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"listeners.#":                  "1",
+		"listeners.0.status":           CHECKSET,
+		"listeners.0.protocol":         "udp",
+		"listeners.0.listener_port":    CHECKSET,
+		"listeners.0.description":      CHECKSET,
+		"listeners.0.load_balancer_id": CHECKSET,
+	}
+}
+
+var fakeEnsLoadBalancerUdpListenerMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"listeners.#": "0",
+	}
+}
+
+var EnsLoadBalancerUdpListenerCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_ens_load_balancer_udp_listeners.default",
+	existMapFunc: existEnsLoadBalancerUdpListenerMapFunc,
+	fakeMapFunc:  fakeEnsLoadBalancerUdpListenerMapFunc,
+}
+
+func testAccCheckAlicloudEnsLoadBalancerUdpListenerSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccEnsLoadBalancerUdpListener%d"
+}
+variable "ens_region_id" {
+    default = "cn-chenzhou-telecom_unicom_cmcc"
+}
+
+resource "alicloud_ens_network" "default8QXHtu" {
+        network_name = "测试用例-测试udp监听"
+        cidr_block = "10.0.0.0/8"
+        ens_region_id = "${var.ens_region_id}"
+}
+
+resource "alicloud_ens_vswitch" "defaultN8wZgT" {
+        cidr_block = "10.0.6.0/24"
+        vswitch_name = "测试用例-测试udp监听"
+        ens_region_id = "${alicloud_ens_network.default8QXHtu.ens_region_id}"
+        network_id = "${alicloud_ens_network.default8QXHtu.id}"
+}
+
+resource "alicloud_ens_load_balancer" "defaultgNxO1j" {
+        load_balancer_name = "测试用例-测试udp监听"
+        vswitch_id = "${alicloud_ens_vswitch.defaultN8wZgT.id}"
+        payment_type = "PayAsYouGo"
+        ens_region_id = "${alicloud_ens_vswitch.defaultN8wZgT.ens_region_id}"
+        network_id = "${alicloud_ens_vswitch.defaultN8wZgT.network_id}"
+        load_balancer_spec = "elb.s1.small"
+}
+
+
+
+resource "alicloud_ens_load_balancer_udp_listener" "default" {
+        listener_port = "53"
+        health_check_interval = "1"
+        description = "test1"
+        unhealthy_threshold = "2"
+        scheduler = "rr"
+        health_check_connect_timeout = "1"
+        load_balancer_id = "${alicloud_ens_load_balancer.defaultgNxO1j.id}"
+        backend_server_port = "53"
+        health_check_connect_port = "53"
+        health_check_req = "hello"
+        healthy_threshold = "2"
+        health_check_exp = "rep"
+        eip_transmit = "on"
+        status = "Stopped"
+        established_timeout = "100"
+}
+
+data "alicloud_ens_load_balancer_udp_listeners" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_ens_load_balancer_udp_listeners":                dataSourceAliCloudEnsLoadBalancerUdpListeners(),
 			"alicloud_ecd_desktop_groups":                             dataSourceAliCloudEcdDesktopGroups(),
 			"alicloud_redis_global_security_ip_groups":                dataSourceAliCloudRedisGlobalSecurityIpGroups(),
 			"alicloud_cr_artifact_subscription_rules":                 dataSourceAliCloudCrArtifactSubscriptionRules(),
@@ -964,6 +965,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_sls_metric_stores":                                dataSourceAliCloudSlsMetricStores(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_ens_load_balancer_udp_listener":                       resourceAliCloudEnsLoadBalancerUdpListener(),
 			"alicloud_gpdb_db_extension":                                    resourceAliCloudGpdbDbExtension(),
 			"alicloud_ecd_desktop_group":                                    resourceAliCloudEcdDesktopGroup(),
 			"alicloud_redis_global_security_ip_group":                       resourceAliCloudRedisGlobalSecurityIpGroup(),

--- a/alicloud/resource_alicloud_ens_load_balancer_udp_listener.go
+++ b/alicloud/resource_alicloud_ens_load_balancer_udp_listener.go
@@ -1,0 +1,448 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudEnsLoadBalancerUdpListener() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudEnsLoadBalancerUdpListenerCreate,
+		Read:   resourceAliCloudEnsLoadBalancerUdpListenerRead,
+		Update: resourceAliCloudEnsLoadBalancerUdpListenerUpdate,
+		Delete: resourceAliCloudEnsLoadBalancerUdpListenerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"backend_server_port": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: IntBetween(0, 65535),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"eip_transmit": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"established_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntBetween(10, 900),
+			},
+			"health_check_connect_port": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntBetween(0, 65535),
+			},
+			"health_check_connect_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntBetween(0, 300),
+			},
+			"health_check_exp": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"health_check_interval": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntBetween(0, 50),
+			},
+			"health_check_req": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"healthy_threshold": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntBetween(2, 10),
+			},
+			"listener_port": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"load_balancer_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"scheduler": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"wrr", "wlc", "rr", "sch", "qch", "iqch", "tch"}, false),
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"unhealthy_threshold": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntBetween(2, 10),
+			},
+		},
+	}
+}
+
+func resourceAliCloudEnsLoadBalancerUdpListenerCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateLoadBalancerUDPListener"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	if v, ok := d.GetOk("load_balancer_id"); ok {
+		request["LoadBalancerId"] = v
+	}
+	if v, ok := d.GetOk("listener_port"); ok {
+		request["ListenerPort"] = v
+	}
+
+	if v, ok := d.GetOkExists("health_check_connect_port"); ok {
+		request["HealthCheckConnectPort"] = v
+	}
+	if v, ok := d.GetOk("description"); ok {
+		request["Description"] = v
+	}
+	if v, ok := d.GetOkExists("established_timeout"); ok && v.(int) > 0 {
+		request["EstablishedTimeout"] = v
+	}
+	if v, ok := d.GetOkExists("health_check_connect_timeout"); ok && v.(int) > 0 {
+		request["HealthCheckConnectTimeout"] = v
+	}
+	if v, ok := d.GetOk("scheduler"); ok {
+		request["Scheduler"] = v
+	}
+	if v, ok := d.GetOk("health_check_req"); ok {
+		request["HealthCheckReq"] = v
+	}
+	if v, ok := d.GetOk("health_check_exp"); ok {
+		request["HealthCheckExp"] = v
+	}
+	if v, ok := d.GetOk("eip_transmit"); ok {
+		request["EipTransmit"] = v
+	}
+	if v, ok := d.GetOkExists("health_check_interval"); ok && v.(int) > 0 {
+		request["HealthCheckInterval"] = v
+	}
+	if v, ok := d.GetOkExists("backend_server_port"); ok {
+		request["BackendServerPort"] = v
+	}
+	if v, ok := d.GetOkExists("unhealthy_threshold"); ok && v.(int) > 0 {
+		request["UnhealthyThreshold"] = v
+	}
+	if v, ok := d.GetOkExists("healthy_threshold"); ok && v.(int) > 0 {
+		request["HealthyThreshold"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ens_load_balancer_udp_listener", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", request["LoadBalancerId"], request["ListenerPort"]))
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{"Stopped"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, ensServiceV2.EnsLoadBalancerUdpListenerStateRefreshFunc(d.Id(), "Status", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return resourceAliCloudEnsLoadBalancerUdpListenerUpdate(d, meta)
+}
+
+func resourceAliCloudEnsLoadBalancerUdpListenerRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ensServiceV2 := EnsServiceV2{client}
+
+	objectRaw, err := ensServiceV2.DescribeEnsLoadBalancerUdpListener(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ens_load_balancer_udp_listener DescribeEnsLoadBalancerUdpListener Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("backend_server_port", objectRaw["BackendServerPort"])
+	d.Set("description", objectRaw["Description"])
+	d.Set("eip_transmit", objectRaw["EipTransmit"])
+	d.Set("established_timeout", objectRaw["EstablishedTimeout"])
+	d.Set("health_check_connect_port", objectRaw["HealthCheckConnectPort"])
+	d.Set("health_check_connect_timeout", objectRaw["HealthCheckConnectTimeout"])
+	d.Set("health_check_exp", objectRaw["HealthCheckExp"])
+	d.Set("health_check_interval", objectRaw["HealthCheckInterval"])
+	d.Set("health_check_req", objectRaw["HealthCheckReq"])
+	d.Set("healthy_threshold", objectRaw["HealthyThreshold"])
+	d.Set("scheduler", objectRaw["Scheduler"])
+	d.Set("status", objectRaw["Status"])
+	d.Set("unhealthy_threshold", objectRaw["UnhealthyThreshold"])
+	d.Set("listener_port", objectRaw["ListenerPort"])
+
+	parts := strings.Split(d.Id(), ":")
+	d.Set("load_balancer_id", parts[0])
+
+	return nil
+}
+
+func resourceAliCloudEnsLoadBalancerUdpListenerUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	ensServiceV2 := EnsServiceV2{client}
+	objectRaw, _ := ensServiceV2.DescribeEnsLoadBalancerUdpListener(d.Id())
+
+	if d.HasChange("status") {
+		var err error
+		target := d.Get("status").(string)
+
+		currentStatus, err := jsonpath.Get("Status", objectRaw)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, d.Id(), "Status", objectRaw)
+		}
+		if fmt.Sprint(currentStatus) != target {
+			if target == "Running" {
+				parts := strings.Split(d.Id(), ":")
+				action := "StartLoadBalancerListener"
+				request = make(map[string]interface{})
+				query = make(map[string]interface{})
+				request["LoadBalancerId"] = parts[0]
+				request["ListenerPort"] = parts[1]
+
+				request["ListenerProtocol"] = "udp"
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+				ensServiceV2 := EnsServiceV2{client}
+				stateConf := BuildStateConf([]string{}, []string{"Running"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ensServiceV2.EnsLoadBalancerUdpListenerStateRefreshFunc(d.Id(), "Status", []string{}))
+				if _, err := stateConf.WaitForState(); err != nil {
+					return WrapErrorf(err, IdMsg, d.Id())
+				}
+
+			}
+			if target == "Stopped" {
+				parts := strings.Split(d.Id(), ":")
+				action := "StopLoadBalancerListener"
+				request = make(map[string]interface{})
+				query = make(map[string]interface{})
+				request["LoadBalancerId"] = parts[0]
+				request["ListenerPort"] = parts[1]
+
+				request["ListenerProtocol"] = "udp"
+				wait := incrementalWait(3*time.Second, 5*time.Second)
+				err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+					if err != nil {
+						if NeedRetry(err) {
+							wait()
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+				}
+				ensServiceV2 := EnsServiceV2{client}
+				stateConf := BuildStateConf([]string{}, []string{"Stopped"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ensServiceV2.EnsLoadBalancerUdpListenerStateRefreshFunc(d.Id(), "Status", []string{}))
+				if _, err := stateConf.WaitForState(); err != nil {
+					return WrapErrorf(err, IdMsg, d.Id())
+				}
+
+			}
+		}
+	}
+
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	action := "SetLoadBalancerUDPListenerAttribute"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["LoadBalancerId"] = parts[0]
+	request["ListenerPort"] = parts[1]
+
+	if !d.IsNewResource() && d.HasChange("health_check_connect_port") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("health_check_connect_port"); ok || d.HasChange("health_check_connect_port") {
+		request["HealthCheckConnectPort"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("description") {
+		update = true
+	}
+	if v, ok := d.GetOk("description"); ok || d.HasChange("description") {
+		request["Description"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("established_timeout") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("established_timeout"); (ok || d.HasChange("established_timeout")) && v.(int) > 0 {
+		request["EstablishedTimeout"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("health_check_connect_timeout") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("health_check_connect_timeout"); (ok || d.HasChange("health_check_connect_timeout")) && v.(int) > 0 {
+		request["HealthCheckConnectTimeout"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("scheduler") {
+		update = true
+	}
+	if v, ok := d.GetOk("scheduler"); ok || d.HasChange("scheduler") {
+		request["Scheduler"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("health_check_req") {
+		update = true
+	}
+	if v, ok := d.GetOk("health_check_req"); ok || d.HasChange("health_check_req") {
+		request["HealthCheckReq"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("health_check_exp") {
+		update = true
+	}
+	if v, ok := d.GetOk("health_check_exp"); ok || d.HasChange("health_check_exp") {
+		request["HealthCheckExp"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("eip_transmit") {
+		update = true
+	}
+	if v, ok := d.GetOk("eip_transmit"); ok || d.HasChange("eip_transmit") {
+		request["EipTransmit"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("health_check_interval") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("health_check_interval"); (ok || d.HasChange("health_check_interval")) && v.(int) > 0 {
+		request["HealthCheckInterval"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("unhealthy_threshold") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("unhealthy_threshold"); (ok || d.HasChange("unhealthy_threshold")) && v.(int) > 0 {
+		request["UnhealthyThreshold"] = v
+	}
+	if !d.IsNewResource() && d.HasChange("healthy_threshold") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("healthy_threshold"); (ok || d.HasChange("healthy_threshold")) && v.(int) > 0 {
+		request["HealthyThreshold"] = v
+	}
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudEnsLoadBalancerUdpListenerRead(d, meta)
+}
+
+func resourceAliCloudEnsLoadBalancerUdpListenerDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := "DeleteLoadBalancerListener"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["LoadBalancerId"] = parts[0]
+	request["ListenerPort"] = parts[1]
+
+	request["ListenerProtocol"] = "udp"
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"ListenerNotFound", "LoadBalancerNotFound"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 5*time.Second, ensServiceV2.EnsLoadBalancerUdpListenerStateRefreshFunc(d.Id(), "ListenerPort", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ens_load_balancer_udp_listener_test.go
+++ b/alicloud/resource_alicloud_ens_load_balancer_udp_listener_test.go
@@ -1,0 +1,172 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Ens LoadBalancerUdpListener. >>> Resource test cases, automatically generated.
+// Case 负载均衡实例-UDP监听_20240430 6636
+func TestAccAliCloudEnsLoadBalancerUdpListener_basic6636(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_load_balancer_udp_listener.default"
+	ra := resourceAttrInit(resourceId, AlicloudEnsLoadBalancerUdpListenerMap6636)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsLoadBalancerUdpListener")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccens%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudEnsLoadBalancerUdpListenerBasicDependence6636)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"listener_port":                "53",
+					"health_check_interval":        "1",
+					"description":                  "test1",
+					"unhealthy_threshold":          "2",
+					"scheduler":                    "rr",
+					"health_check_connect_timeout": "1",
+					"load_balancer_id":             "${alicloud_ens_load_balancer.defaultgNxO1j.id}",
+					"backend_server_port":          "53",
+					"health_check_connect_port":    "53",
+					"health_check_req":             "hello",
+					"healthy_threshold":            "2",
+					"health_check_exp":             "rep",
+					"eip_transmit":                 "on",
+					"status":                       "Stopped",
+					"established_timeout":          "100",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"listener_port":                "53",
+						"health_check_interval":        "1",
+						"description":                  "test1",
+						"unhealthy_threshold":          "2",
+						"scheduler":                    "rr",
+						"health_check_connect_timeout": "1",
+						"load_balancer_id":             CHECKSET,
+						"backend_server_port":          "53",
+						"health_check_connect_port":    "53",
+						"health_check_req":             "hello",
+						"healthy_threshold":            "2",
+						"health_check_exp":             "rep",
+						"eip_transmit":                 "on",
+						"status":                       "Stopped",
+						"established_timeout":          "100",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"health_check_interval":        "10",
+					"description":                  "test2",
+					"unhealthy_threshold":          "10",
+					"scheduler":                    "sch",
+					"health_check_connect_timeout": "300",
+					"health_check_connect_port":    "1000",
+					"health_check_req":             "hello210",
+					"healthy_threshold":            "10",
+					"health_check_exp":             "exp2",
+					"eip_transmit":                 "off",
+					"established_timeout":          "200",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"health_check_interval":        "10",
+						"description":                  "test2",
+						"unhealthy_threshold":          "10",
+						"scheduler":                    "sch",
+						"health_check_connect_timeout": "300",
+						"health_check_connect_port":    "1000",
+						"health_check_req":             "hello210",
+						"healthy_threshold":            "10",
+						"health_check_exp":             "exp2",
+						"eip_transmit":                 "off",
+						"established_timeout":          "200",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "Running",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "Running",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "Stopped",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "Stopped",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudEnsLoadBalancerUdpListenerMap6636 = map[string]string{}
+
+func AlicloudEnsLoadBalancerUdpListenerBasicDependence6636(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "ens_region_id" {
+    default = "cn-chenzhou-telecom_unicom_cmcc"
+}
+
+resource "alicloud_ens_network" "default8QXHtu" {
+        network_name = "测试用例-测试udp监听"
+        cidr_block = "10.0.0.0/8"
+        ens_region_id = "${var.ens_region_id}"
+}
+
+resource "alicloud_ens_vswitch" "defaultN8wZgT" {
+        cidr_block = "10.0.6.0/24"
+        vswitch_name = "测试用例-测试udp监听"
+        ens_region_id = "${alicloud_ens_network.default8QXHtu.ens_region_id}"
+        network_id = "${alicloud_ens_network.default8QXHtu.id}"
+}
+
+resource "alicloud_ens_load_balancer" "defaultgNxO1j" {
+        load_balancer_name = "测试用例-测试udp监听"
+        vswitch_id = "${alicloud_ens_vswitch.defaultN8wZgT.id}"
+        payment_type = "PayAsYouGo"
+        ens_region_id = "${alicloud_ens_vswitch.defaultN8wZgT.ens_region_id}"
+        network_id = "${alicloud_ens_vswitch.defaultN8wZgT.network_id}"
+        load_balancer_spec = "elb.s1.small"
+}
+
+
+`, name)
+}
+
+// Test Ens LoadBalancerUdpListener. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_ens_v2.go
+++ b/alicloud/service_alicloud_ens_v2.go
@@ -1491,3 +1491,80 @@ func (s *EnsServiceV2) EnsBucketLifecycleStateRefreshFunc(id string, field strin
 }
 
 // DescribeEnsBucketLifecycle >>> Encapsulated.
+
+// DescribeEnsLoadBalancerUdpListener <<< Encapsulated get interface for Ens LoadBalancerUdpListener.
+
+func (s *EnsServiceV2) DescribeEnsLoadBalancerUdpListener(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ListenerPort"] = parts[1]
+	request["LoadBalancerId"] = parts[0]
+
+	action := "DescribeLoadBalancerUDPListenerAttribute"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"ListenerNotFound", "LoadBalancerNotFound"}) {
+			return object, WrapErrorf(NotFoundErr("LoadBalancerUdpListener", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *EnsServiceV2) EnsLoadBalancerUdpListenerStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.EnsLoadBalancerUdpListenerStateRefreshFuncWithApi(id, field, failStates, s.DescribeEnsLoadBalancerUdpListener)
+}
+
+func (s *EnsServiceV2) EnsLoadBalancerUdpListenerStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeEnsLoadBalancerUdpListener >>> Encapsulated.

--- a/website/docs/d/ens_load_balancer_udp_listeners.html.markdown
+++ b/website/docs/d/ens_load_balancer_udp_listeners.html.markdown
@@ -1,0 +1,101 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_load_balancer_udp_listeners"
+sidebar_current: "docs-alicloud-datasource-ens-load-balancer-udp-listeners"
+description: |-
+  Provides a list of ENS Load Balancer Udp Listener owned by an Alibaba Cloud account.
+---
+
+# alicloud_ens_load_balancer_udp_listeners
+
+This data source provides ENS Load Balancer Udp Listener available to the user. [What is Load Balancer Udp Listener](https://www.alibabacloud.com/help/en/ens/developer-reference/api-ens-2017-11-10-createloadbalancerudplistener)
+
+-> **NOTE:** Available since v1.291.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "ens_region_id" {
+  default = "cn-chenzhou-telecom_unicom_cmcc"
+}
+
+resource "alicloud_ens_network" "default" {
+  network_name  = var.name
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default" {
+  cidr_block    = "10.0.6.0/24"
+  vswitch_name  = var.name
+  ens_region_id = alicloud_ens_network.default.ens_region_id
+  network_id    = alicloud_ens_network.default.id
+}
+
+resource "alicloud_ens_load_balancer" "default" {
+  load_balancer_name = var.name
+  vswitch_id         = alicloud_ens_vswitch.default.id
+  payment_type       = "PayAsYouGo"
+  ens_region_id      = alicloud_ens_vswitch.default.ens_region_id
+  network_id         = alicloud_ens_vswitch.default.network_id
+  load_balancer_spec = "elb.s1.small"
+}
+
+resource "alicloud_ens_load_balancer_udp_listener" "default" {
+  load_balancer_id    = alicloud_ens_load_balancer.default.id
+  listener_port       = 53
+  backend_server_port = 53
+  description         = "example-udp-listener"
+  status              = "Stopped"
+}
+
+data "alicloud_ens_load_balancer_udp_listeners" "default" {
+  load_balancer_id = alicloud_ens_load_balancer.default.id
+  ids              = [alicloud_ens_load_balancer_udp_listener.default.id]
+}
+
+output "udp_listener_id" {
+  value = data.alicloud_ens_load_balancer_udp_listeners.default.listeners.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `load_balancer_id` - (Required) The ID of the load balancer instance.
+* `ids` - (Optional, Computed) A list of Load Balancer Udp Listener IDs. The value is formulated as `<load_balancer_id>:<listener_port>`.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Load Balancer Udp Listener IDs.
+* `listeners` - A list of Load Balancer Udp Listener Entries. Each element contains the following attributes:
+  * `id` - The ID of the listener. The value is formulated as `<load_balancer_id>:<listener_port>`.
+  * `listener_port` - The frontend port used by the load balancer instance.
+  * `load_balancer_id` - The ID of the load balancer instance.
+  * `protocol` - The protocol of the listener. The value is `udp`.
+  * `description` - The description of the listener.
+  * `status` - The status of the listener.
+  * `backend_server_port` - **NOTE:** This field is only available when `enable_details` is `true`. The port used by the backend server of the load balancer instance.
+  * `eip_transmit` - **NOTE:** This field is only available when `enable_details` is `true`. Whether EIP transparent transmission is enabled.
+  * `established_timeout` - **NOTE:** This field is only available when `enable_details` is `true`. The timeout period of the connection. Unit: seconds.
+  * `health_check_connect_port` - **NOTE:** This field is only available when `enable_details` is `true`. The port used for health checks.
+  * `health_check_connect_timeout` - **NOTE:** This field is only available when `enable_details` is `true`. The amount of time to wait for a response from the health check. Unit: seconds.
+  * `health_check_exp` - **NOTE:** This field is only available when `enable_details` is `true`. The expected response string for the UDP listener health check.
+  * `health_check_interval` - **NOTE:** This field is only available when `enable_details` is `true`. The interval between two consecutive health checks. Unit: seconds.
+  * `health_check_req` - **NOTE:** This field is only available when `enable_details` is `true`. The request string for the UDP listener health check.
+  * `healthy_threshold` - **NOTE:** This field is only available when `enable_details` is `true`. The number of consecutive successful health checks that must occur before a backend server is declared healthy.
+  * `scheduler` - **NOTE:** This field is only available when `enable_details` is `true`. The scheduling algorithm.
+  * `unhealthy_threshold` - **NOTE:** This field is only available when `enable_details` is `true`. The number of consecutive failed health checks that must occur before a backend server is declared unhealthy.

--- a/website/docs/r/ens_load_balancer_udp_listener.html.markdown
+++ b/website/docs/r/ens_load_balancer_udp_listener.html.markdown
@@ -1,0 +1,129 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_load_balancer_udp_listener"
+description: |-
+  Provides a Alicloud ENS Load Balancer Udp Listener resource.
+---
+
+# alicloud_ens_load_balancer_udp_listener
+
+Provides a ENS Load Balancer Udp Listener resource.
+
+Load-balanced UDP listener.
+
+For information about ENS Load Balancer Udp Listener and how to use it, see [What is Load Balancer Udp Listener](https://www.alibabacloud.com/help/en/ens/developer-reference/api-ens-2017-11-10-createloadbalancerudplistener).
+
+-> **NOTE:** Available since v1.291.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "ens_region_id" {
+  default = "cn-chenzhou-telecom_unicom_cmcc"
+}
+
+resource "alicloud_ens_network" "default" {
+  network_name  = var.name
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default" {
+  cidr_block    = "10.0.6.0/24"
+  vswitch_name  = var.name
+  ens_region_id = alicloud_ens_network.default.ens_region_id
+  network_id    = alicloud_ens_network.default.id
+}
+
+resource "alicloud_ens_load_balancer" "default" {
+  load_balancer_name = var.name
+  vswitch_id         = alicloud_ens_vswitch.default.id
+  payment_type       = "PayAsYouGo"
+  ens_region_id      = alicloud_ens_vswitch.default.ens_region_id
+  network_id         = alicloud_ens_vswitch.default.network_id
+  load_balancer_spec = "elb.s1.small"
+}
+
+resource "alicloud_ens_load_balancer_udp_listener" "default" {
+  load_balancer_id             = alicloud_ens_load_balancer.default.id
+  listener_port                = 53
+  backend_server_port          = 53
+  description                  = "example-udp-listener"
+  scheduler                    = "wrr"
+  healthy_threshold            = 2
+  unhealthy_threshold          = 2
+  health_check_connect_timeout = 5
+  health_check_interval        = 2
+  health_check_connect_port    = 53
+  health_check_req             = "hello"
+  health_check_exp             = "rep"
+  eip_transmit                 = "off"
+  established_timeout          = 900
+  status                       = "Stopped"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `backend_server_port` - (Optional, ForceNew, Int) The port used by the backend server of the load balancer instance. Valid values: `1` to `65535`.
+* `description` - (Optional) The description of the listener. The description must be `1` to `80` characters in length and cannot start with `http://` or `https://`.
+* `eip_transmit` - (Optional) Whether to enable EIP transparent transmission. Valid values:
+  - `on`: enabled.
+  - `off` (default): disabled.
+* `established_timeout` - (Optional, Int) The timeout period of the connection. Unit: seconds. Valid values: `10` to `900`. Default value: `900`.
+* `health_check_connect_port` - (Optional, Int) The port used for health checks. Valid values: `1` to `65535`. If this parameter is not set, the backend server port (`backend_server_port`) is used.
+* `health_check_connect_timeout` - (Optional, Int) The amount of time to wait for a response from the health check. If the backend server does not respond within the specified time, the health check fails. Unit: seconds. Valid values: `1` to `300`. Default value: `5`. If the value of `health_check_connect_timeout` is smaller than the value of `health_check_interval`, `health_check_connect_timeout` is invalid and the timeout period is the value of `health_check_interval`.
+* `health_check_exp` - (Optional) The expected response string for the UDP listener health check. It can contain only letters and digits. Maximum length: 64 characters.
+* `health_check_interval` - (Optional, Int) The interval between two consecutive health checks. Unit: seconds. Valid values: `1` to `50`. Default value: `2`.
+* `health_check_req` - (Optional) The request string for the UDP listener health check. It can contain only letters and digits. Maximum length: 64 characters.
+* `healthy_threshold` - (Optional, Int) The number of consecutive successful health checks that must occur before a backend server is declared healthy (from `fail` to `success`). Valid values: `2` to `10`. Default value: `3`.
+* `listener_port` - (Required, ForceNew, Int) The frontend port used by the load balancer instance. Valid values: `1` to `65535`. Ports `250`, `4789`, and `4790` are reserved and cannot be used.
+* `load_balancer_id` - (Required, ForceNew) The ID of the load balancer instance.
+* `scheduler` - (Optional) The scheduling algorithm. Valid values:
+  - `wrr` (default): Backend servers with higher weights receive more requests.
+  - `wlc`: Requests are distributed based on the weights and the actual load (number of connections) of each backend server.
+  - `rr`: Requests are distributed to backend servers in sequence.
+  - `sch`: Consistent hashing based on source IP addresses. Requests from the same source IP address are distributed to the same backend server.
+  - `tch`: Consistent hashing based on the four-tuple (source IP address, destination IP address, source port, and destination port). The same flow is distributed to the same backend server.
+  - `qch`: Consistent hashing based on QUIC Connection IDs. Requests with the same QUIC Connection ID are distributed to the same backend server.
+  - `iqch`: Consistent hashing based on three specific bytes of the iQUIC CID. Requests whose second to fourth bytes are the same are distributed to the same backend server.
+* `status` - (Optional, Computed) The status of the listener. Valid values:
+  - `Running`: The listener is running.
+  - `Stopped`: The listener is stopped.
+  - `Starting`: The listener is starting.
+  - `Configuring`: The listener is being configured.
+  - `Stopping`: The listener is being stopped.
+* `unhealthy_threshold` - (Optional, Int) The number of consecutive failed health checks that must occur before a backend server is declared unhealthy (from `success` to `fail`). Valid values: `2` to `10`. Default value: `3`.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<load_balancer_id>:<listener_port>`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Load Balancer Udp Listener.
+* `delete` - (Defaults to 5 mins) Used when delete the Load Balancer Udp Listener.
+* `update` - (Defaults to 5 mins) Used when update the Load Balancer Udp Listener.
+
+## Import
+
+ENS Load Balancer Udp Listener can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ens_load_balancer_udp_listener.example <load_balancer_id>:<listener_port>
+```


### PR DESCRIPTION
### New Resource
`alicloud_ens_load_balancer_udp_listener` - Manages an ENS load balancer UDP listener.

### New Data Source
`alicloud_ens_load_balancer_udp_listeners` - Lists ENS load balancer UDP listeners of a load balancer instance.

### Supported operations
- Create / Read / Update / Delete / Import for the UDP listener resource, including `status`-based start/stop lifecycle (`Running` / `Stopped`).
- The data source filters listeners by `load_balancer_id` and `ids`, and only returns UDP protocol listeners.

### Test results (remote AccTest)

=== RUN TestAccAliCloudEnsLoadBalancerUdpListener_basic6636
--- PASS: TestAccAliCloudEnsLoadBalancerUdpListener_basic6636 (217.65s)

=== RUN TestAccAlicloudEnsLoadBalancerUdpListenerDataSource
--- PASS: TestAccAlicloudEnsLoadBalancerUdpListenerDataSource (210.98s)