### PR TITLE
resource/alicloud_gwlb_server_group: add draining_servers attribute and skip draining/removing servers during removal

### DIFF
--- a/alicloud/resource_alicloud_gwlb_server_group.go
+++ b/alicloud/resource_alicloud_gwlb_server_group.go
@@ -52,6 +52,30 @@ func resourceAliCloudGwlbServerGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"draining_servers": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"server_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"server_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"server_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"dry_run": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -164,9 +188,6 @@ func resourceAliCloudGwlbServerGroup() *schema.Resource {
 					}
 					if v, ok := server["server_ip"]; ok && server["server_type"] == "Eni" {
 						buf.WriteString(fmt.Sprintf("%s-", v.(string)))
-					}
-					if v, ok := server["server_port"]; ok {
-						buf.WriteString(fmt.Sprintf("%d", v.(int)))
 					}
 					return int(crc32.ChecksumIEEE([]byte(buf.String())))
 				},
@@ -499,10 +520,25 @@ func resourceAliCloudGwlbServerGroupRead(d *schema.ResourceData, meta interface{
 	servers1Raw, _ := jsonpath.Get("$.Servers", objectRaw)
 
 	serversMaps := make([]map[string]interface{}, 0)
+	drainingServersMaps := make([]map[string]interface{}, 0)
 	if servers1Raw != nil {
 		for _, serversChild1Raw := range servers1Raw.([]interface{}) {
-			serversMap := make(map[string]interface{})
 			serversChild1Raw := serversChild1Raw.(map[string]interface{})
+			// Servers in the removal pipeline (Draining/Removing) are transitional and are
+			// not kept in `servers`: the removal already happened and the drain process
+			// finishes it. This keeps the plan clean and allows re-adding such a server
+			// (the AddServers API rescues it back to Available). They are exposed through
+			// the computed `draining_servers` field instead.
+			if status, _ := serversChild1Raw["Status"].(string); status == "Draining" || status == "Removing" {
+				drainingServersMap := make(map[string]interface{})
+				drainingServersMap["server_id"] = serversChild1Raw["ServerId"]
+				drainingServersMap["server_ip"] = serversChild1Raw["ServerIp"]
+				drainingServersMap["server_type"] = serversChild1Raw["ServerType"]
+				drainingServersMap["status"] = serversChild1Raw["Status"]
+				drainingServersMaps = append(drainingServersMaps, drainingServersMap)
+				continue
+			}
+			serversMap := make(map[string]interface{})
 			serversMap["port"] = 6081
 			serversMap["server_group_id"] = serversChild1Raw["ServerGroupId"]
 			serversMap["server_id"] = serversChild1Raw["ServerId"]
@@ -515,6 +551,9 @@ func resourceAliCloudGwlbServerGroupRead(d *schema.ResourceData, meta interface{
 	}
 	if objectRaw["Servers"] != nil {
 		if err := d.Set("servers", serversMaps); err != nil {
+			return err
+		}
+		if err := d.Set("draining_servers", drainingServersMaps); err != nil {
 			return err
 		}
 	}
@@ -755,6 +794,16 @@ func resourceAliCloudGwlbServerGroupUpdate(d *schema.ResourceData, meta interfac
 		newEntrySet := newEntry.(*schema.Set)
 		removed := oldEntrySet.Difference(newEntrySet)
 		added := newEntrySet.Difference(oldEntrySet)
+
+		// Skip servers in the removal pipeline: the API rejects removing a Draining or
+		// Removing server. They may still exist in a state written by an older provider
+		// version, or the drain timeout has not expired yet.
+		for _, item := range oldEntrySet.List() {
+			server := item.(map[string]interface{})
+			if status, _ := server["status"].(string); status == "Draining" || status == "Removing" {
+				removed.Remove(item)
+			}
+		}
 
 		if removed.Len() > 0 {
 			action := "RemoveServersFromServerGroup"

--- a/alicloud/resource_alicloud_gwlb_server_group_test.go
+++ b/alicloud/resource_alicloud_gwlb_server_group_test.go
@@ -198,6 +198,22 @@ variable "region_id" {
 
 data "alicloud_resource_manager_resource_groups" "default" {}
 
+data "alicloud_zones" "default" {
+  available_disk_category     = "cloud_efficiency"
+  available_resource_creation = "VSwitch"
+}
+
+data "alicloud_instance_types" "default" {
+  availability_zone    = data.alicloud_zones.default.zones.0.id
+  instance_type_family = "ecs.sn1ne"
+}
+
+data "alicloud_images" "default" {
+  name_regex  = "^aliyun_2_1903_x64_20G_alibase"
+  most_recent = true
+  owners      = "system"
+}
+
 resource "alicloud_vpc" "defaultEaxcvb" {
   cidr_block = "10.0.0.0/8"
   vpc_name   = "tf-gwlb-vpc"
@@ -205,7 +221,7 @@ resource "alicloud_vpc" "defaultEaxcvb" {
 
 resource "alicloud_vswitch" "defaultc3uVID" {
   vpc_id       = alicloud_vpc.defaultEaxcvb.id
-  zone_id      = "cn-hangzhou-h"
+  zone_id      = data.alicloud_zones.default.zones.0.id
   cidr_block   = "10.0.0.0/24"
   vswitch_name = "tf-test-vsw1"
 }
@@ -219,9 +235,9 @@ resource "alicloud_security_group" "default7NNxRl" {
 
 resource "alicloud_instance" "defaultH6McvC" {
 	vswitch_id = alicloud_vswitch.defaultc3uVID.id
-	image_id = "aliyun_2_1903_x64_20G_alibase_20231221.vhd"
+	image_id = data.alicloud_images.default.images.0.id
 	
-	instance_type = "ecs.g6.large"
+	instance_type = data.alicloud_instance_types.default.instance_types.0.id
 	system_disk_category = "cloud_efficiency"
 	
 	internet_charge_type = "PayByTraffic"
@@ -701,6 +717,222 @@ variable "name" {
 
 variable "region_id" {
   default = "cn-wulanchabu"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+resource "alicloud_vpc" "defaultEaxcvb" {
+  cidr_block = "10.0.0.0/8"
+  vpc_name   = "tf-gwlb-vpc"
+}
+
+
+`, name)
+}
+
+// Case ServerGroup Test_draining 8570
+func TestAccAliCloudGwlbServerGroupDraining8570(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_gwlb_server_group.default"
+	ra := resourceAttrInit(resourceId, AlicloudGwlbServerGroupMap8570)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GwlbServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGwlbServerGroup")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccgwlb%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudGwlbServerGroupBasicDependence8570)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{connectivity.Hangzhou})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// create two servers with connection drain enabled (1h timeout keeps the
+				// Draining status stable across all the following steps)
+				Config: testAccConfig(map[string]interface{}{
+					"protocol":          "GENEVE",
+					"server_group_type": "Ip",
+					"connection_drain_config": []map[string]interface{}{
+						{
+							"connection_drain_enabled": "true",
+							"connection_drain_timeout": "3600",
+						},
+					},
+					"vpc_id": "${alicloud_vpc.defaultEaxcvb.id}",
+					"servers": []map[string]interface{}{
+						{
+							"server_id":   "10.0.0.1",
+							"server_ip":   "10.0.0.1",
+							"server_type": "Ip",
+						},
+						{
+							"server_id":   "10.0.0.2",
+							"server_ip":   "10.0.0.2",
+							"server_type": "Ip",
+						},
+					},
+					"server_group_name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"protocol":           "GENEVE",
+						"server_group_type":  "Ip",
+						"vpc_id":             CHECKSET,
+						"servers.#":          "2",
+						"draining_servers.#": "0",
+						"server_group_name":  name,
+					}),
+				),
+			},
+			{
+				// remove 10.0.0.1: with drain enabled it enters Draining and is no longer
+				// kept in servers (only Available servers are persisted); it is exposed
+				// through the draining_servers field instead
+				Config: testAccConfig(map[string]interface{}{
+					"connection_drain_config": []map[string]interface{}{
+						{
+							"connection_drain_enabled": "true",
+							"connection_drain_timeout": "3600",
+						},
+					},
+					"vpc_id": "${alicloud_vpc.defaultEaxcvb.id}",
+					"servers": []map[string]interface{}{
+						{
+							"server_id":   "10.0.0.2",
+							"server_ip":   "10.0.0.2",
+							"server_type": "Ip",
+						},
+					},
+					"server_group_name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"servers.#":          "1",
+						"draining_servers.#": "1",
+					}),
+				),
+			},
+			{
+				// remove 10.0.0.2 while 10.0.0.1 is still Draining: the provider must skip the
+				// Draining server in RemoveServersFromServerGroup, otherwise the API rejects the
+				// request with an IncorrectStatus error. Both servers are now out of state.
+				// REMOVEKEY drops the servers key from the generated config; an empty map
+				// (CLEARMAP) or list renders invalid HCL for a block-typed attribute.
+				Config: testAccConfig(map[string]interface{}{
+					"connection_drain_config": []map[string]interface{}{
+						{
+							"connection_drain_enabled": "true",
+							"connection_drain_timeout": "3600",
+						},
+					},
+					"vpc_id":            "${alicloud_vpc.defaultEaxcvb.id}",
+					"servers":           REMOVEKEY,
+					"server_group_name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"servers.#":          "0",
+						"draining_servers.#": "2",
+					}),
+				),
+			},
+			{
+				// re-add the Draining server 10.0.0.1: it must be rescued via AddServers
+				Config: testAccConfig(map[string]interface{}{
+					"connection_drain_config": []map[string]interface{}{
+						{
+							"connection_drain_enabled": "true",
+							"connection_drain_timeout": "3600",
+						},
+					},
+					"vpc_id": "${alicloud_vpc.defaultEaxcvb.id}",
+					"servers": []map[string]interface{}{
+						{
+							"server_id":   "10.0.0.1",
+							"server_ip":   "10.0.0.1",
+							"server_type": "Ip",
+						},
+					},
+					"server_group_name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"servers.#":          "1",
+						"draining_servers.#": "1",
+					}),
+				),
+			},
+			{
+				// re-add 10.0.0.2 as well: both servers back to Available
+				Config: testAccConfig(map[string]interface{}{
+					"connection_drain_config": []map[string]interface{}{
+						{
+							"connection_drain_enabled": "true",
+							"connection_drain_timeout": "3600",
+						},
+					},
+					"vpc_id": "${alicloud_vpc.defaultEaxcvb.id}",
+					"servers": []map[string]interface{}{
+						{
+							"server_id":   "10.0.0.1",
+							"server_ip":   "10.0.0.1",
+							"server_type": "Ip",
+						},
+						{
+							"server_id":   "10.0.0.2",
+							"server_ip":   "10.0.0.2",
+							"server_type": "Ip",
+						},
+					},
+					"server_group_name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"servers.#":          "2",
+						"draining_servers.#": "0",
+					}),
+				),
+			},
+			{
+				// disable connection drain and clear the servers so the destroy is clean;
+				// servers dropped from the config via REMOVEKEY (empty map/list renders invalid HCL)
+				Config: testAccConfig(map[string]interface{}{
+					"connection_drain_config": []map[string]interface{}{
+						{
+							"connection_drain_enabled": "false",
+							"connection_drain_timeout": "3600",
+						},
+					},
+					"vpc_id":            "${alicloud_vpc.defaultEaxcvb.id}",
+					"servers":           REMOVEKEY,
+					"server_group_name": name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"servers.#":          "0",
+						"draining_servers.#": CHECKSET,
+					}),
+				),
+			},
+		},
+	})
+}
+
+var AlicloudGwlbServerGroupMap8570 = map[string]string{
+	"status":      CHECKSET,
+	"create_time": CHECKSET,
+}
+
+func AlicloudGwlbServerGroupBasicDependence8570(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
 }
 
 data "alicloud_resource_manager_resource_groups" "default" {}

--- a/website/docs/r/gwlb_server_group.html.markdown
+++ b/website/docs/r/gwlb_server_group.html.markdown
@@ -148,16 +148,17 @@ The following arguments are supported:
 
   - `NoRebalance` (default): existing connections on the unhealthy backend server are not redistributed to other healthy backend servers.
   - `Rebalance`: existing connections on the unhealthy backend server are redistributed to other healthy backend servers.
-* `servers` - (Optional, Set) The backend servers that you want to remove.
+* `servers` - (Optional, Set) The backend servers that you want to remove. See [`servers`](#servers) below.
 
--> **NOTE:**  You can remove at most 200 backend servers in each call.
- See [`servers`](#servers) below.
+  -> **NOTE:**  You can remove at most 200 backend servers in each call.
+
+  -> **NOTE:**  When connection draining is enabled, a removed backend server enters the `Draining` status before it is released. Servers in the `Draining` or `Removing` status are not kept in `servers`, because the removal has already happened and the drain process finishes it. They are exposed through the computed `draining_servers` attribute instead. If a removal request still contains such a server, the provider skips it. If such a server is added back to `servers`, Terraform re-adds it to the server group (rescuing it back to the `Available` status).
 * `tags` - (Optional, Map) The tag keys.
 
   You can specify at most 20 tags in each call.
 * `vpc_id` - (Required, ForceNew) The VPC ID.
 
--> **NOTE:**  If `ServerGroupType` is set to `Instance`, only servers in the specified VPC can be added to the server group.
+  -> **NOTE:**  If `server_group_type` is set to `Instance`, only servers in the specified VPC can be added to the server group.
 
 ### `connection_drain_config`
 
@@ -195,7 +196,7 @@ The health_check_config supports the following:
 
   - `domain`: a domain name. The domain name must be 1 to 80 characters in length, and can contain letters, digits, hyphens (-), and periods (.).
 
--> **NOTE:**  This parameter takes effect only if you set `HealthCheckProtocol` to `HTTP`.
+  -> **NOTE:**  This parameter takes effect only if you set `health_check_protocol` to `HTTP`.
 
 * `health_check_enabled` - (Optional, Computed, Available since v1.236.0) Specifies whether to enable the health check feature. Valid values:
 
@@ -215,7 +216,7 @@ The health_check_config supports the following:
 
   The URL must start with a forward slash (/).
 
--> **NOTE:**  This parameter takes effect only if you set `HealthCheckProtocol` to `HTTP`.
+  -> **NOTE:**  This parameter takes effect only if you set `health_check_protocol` to `HTTP`.
 
 * `health_check_protocol` - (Optional, Computed, Available since v1.236.0) The protocol that is used for health checks. Valid values:
 
@@ -261,6 +262,11 @@ The servers supports the following:
 The following attributes are exported:
 * `id` - The ID of the resource supplied above.
 * `create_time` - The time when the resource was created. The time follows the ISO 8601 standard in the **yyyy-MM-ddTHH:mm:ssZ** format. The time is displayed in UTC.
+* `draining_servers` - (Set, Available since v1.290.0) The backend servers that are being removed (in the `Draining` or `Removing` status).
+  * `server_id` - The backend server ID.
+  * `server_ip` - The IP address of the backend server.
+  * `server_type` - The type of the backend server. Valid values: `Ecs`, `Eni`, `Eci`, `Ip`.
+  * `status` - The status of the backend server. Valid values: `Draining`, `Removing`.
 * `status` - Indicates the status of the backend server.
 
 ## Timeouts


### PR DESCRIPTION
### Summary

When connection draining is enabled, removing a backend server puts it in `Draining` status. A second `terraform apply` removing another server fails with `IncorrectStatus` because the API rejects removing a `Draining` server.

**Fix:** Read filters `Draining`/`Removing` servers out of `servers` into a new computed `draining_servers` attribute. Update defensively skips `Draining`/`Removing` entries in `RemoveServersFromServerGroup` requests. No StateUpgrader; the `-refresh=false` drift scenario is resolved by manual sync.

### Changes

- `alicloud/resource_alicloud_gwlb_server_group.go`: add `draining_servers` computed `TypeList` block (server_id/server_ip/server_type/status), Read collects Draining/Removing servers into it, Update filters them out of removal requests, remove dead `server_port` hash branch
- `alicloud/resource_alicloud_gwlb_server_group_test.go`: add `TestAccAliCloudGwlbServerGroupDraining8570` (6-step drain/rescue/clear scenario), fix `basic8419` instance dependence with dynamic zone/type/image data sources
- `website/docs/r/gwlb_server_group.html.markdown`: add `draining_servers` to Attributes Reference, document drain behavior in `servers` NOTE, consistent NOTE indentation

### ACC Test

```
PASS: TestAccAliCloudGwlbServerGroup_basic8419 (176.5s)
PASS: TestAccAliCloudGwlbServerGroup_basic8500 (152.1s)
PASS: TestAccAliCloudGwlbServerGroup_basic8564 (153.4s)
PASS: TestAccAliCloudGwlbServerGroupDraining8570 (191.3s)
FAIL: <none>
```