### PR TITLE
resource/alicloud_db_backup_policy: wait for instance running after modify

### DIFF
--- a/alicloud/resource_alicloud_db_backup_policy.go
+++ b/alicloud/resource_alicloud_db_backup_policy.go
@@ -322,6 +322,13 @@ func resourceAlicloudDBBackupPolicyUpdate(d *schema.ResourceData, meta interface
 		}); err != nil {
 			return WrapError(err)
 		}
+		// Wait for the instance to return to Running after the backup policy
+		// modification so that downstream resources (e.g. alicloud_db_account)
+		// do not race into an intermediate instance state and time out waiting
+		// for Running.
+		if err := rdsService.WaitForDBInstance(d.Id(), Running, DefaultTimeoutMedium); err != nil {
+			return WrapError(err)
+		}
 	}
 
 	return resourceAlicloudDBBackupPolicyRead(d, meta)

--- a/alicloud/service_alicloud_rds.go
+++ b/alicloud/service_alicloud_rds.go
@@ -1465,8 +1465,18 @@ func (s *RdsService) WaitForDBInstance(id string, status Status, timeout int) er
 				return WrapError(err)
 			}
 		}
-		if object != nil && strings.ToLower(fmt.Sprint(object["DBInstanceStatus"])) == strings.ToLower(string(status)) {
-			break
+		if object != nil {
+			current := fmt.Sprint(object["DBInstanceStatus"])
+			if strings.ToLower(current) == strings.ToLower(string(status)) {
+				break
+			}
+			// A deleting instance cannot transition back to Running (or any other
+			// non-Deleted status). Fail fast instead of polling until the timeout
+			// so callers surface the real cause and concurrent/downstream resources
+			// do not wait in vain for an instance that is already being deleted.
+			if status != Deleted && strings.ToLower(current) == strings.ToLower(string(Deleting)) {
+				return WrapErrorf(err, WaitTimeoutMsg, id, GetFunc(1), timeout, current, status, ProviderERROR)
+			}
 		}
 		time.Sleep(DefaultIntervalShort * time.Second)
 		if time.Now().After(deadline) {


### PR DESCRIPTION
## Summary
- `alicloud_db_backup_policy` Update now waits for the RDS instance to return to Running after `ModifyDBBackupPolicy`, so concurrent/downstream resources (e.g. `alicloud_db_account`) no longer race into the intermediate instance state caused by the backup policy change and time out waiting for Running.
- `RdsService.WaitForDBInstance` now fails fast when the instance is in the terminal `Deleting` status (it cannot transition back to Running) instead of polling until the timeout.

## Motivation
Previously the Update of `alicloud_db_backup_policy` only waited for the instance to reach Running **before** calling `ModifyDBBackupPolicy`, and returned right after the modification without waiting for the instance to stabilize again. When a downstream resource such as `alicloud_db_account` was applied concurrently, it could hit the intermediate instance state triggered by the backup policy change and time out waiting for Running (`Got: Creating Expected: Running`).

This adds a symmetric post-modify wait (mirroring the existing pre-modify wait) so the instance is Running before control is handed back to concurrent/downstream resources.

## Test plan
- [ ] `TestAccAliCloudRdsDBBackupPolicyMySql`: create → multi-step update (backup_retention_period, backup_time, compress_type, backup_interval, log_backup_retention_period, archive_backup_keep_count, released_keep_policy, ...) → import → destroy. Each update step exercises the new post-modify wait via `ModifyDBBackupPolicy`.
