### PR TITLE
resource/alicloud_cen_bandwidth_package: support South-America geographic region

### DIFF
--- a/alicloud/resource_alicloud_cen_bandwidth_package.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_package.go
@@ -58,7 +58,7 @@ func resourceAlicloudCenBandwidthPackage() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
-				ValidateFunc:  validation.StringInSlice([]string{"Asia-Pacific", "Australia", "China", "Europe", "Middle-East", "North-America"}, false),
+				ValidateFunc:  validation.StringInSlice([]string{"Asia-Pacific", "Australia", "China", "Europe", "Middle-East", "North-America", "South-America"}, false),
 				ConflictsWith: []string{"geographic_region_ids"},
 			},
 			"geographic_region_b_id": {
@@ -66,7 +66,7 @@ func resourceAlicloudCenBandwidthPackage() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				Computed:      true,
-				ValidateFunc:  validation.StringInSlice([]string{"Asia-Pacific", "Australia", "China", "Europe", "Middle-East", "North-America"}, false),
+				ValidateFunc:  validation.StringInSlice([]string{"Asia-Pacific", "Australia", "China", "Europe", "Middle-East", "North-America", "South-America"}, false),
 				ConflictsWith: []string{"geographic_region_ids"},
 			},
 			"geographic_region_ids": {
@@ -376,6 +376,8 @@ func convertGeographicRegionAIdResponse(source string) string {
 		return "North-America"
 	case "australia":
 		return "Australia"
+	case "south-america":
+		return "South-America"
 	}
 	return source
 }
@@ -393,6 +395,8 @@ func convertGeographicRegionBIdResponse(source string) string {
 		return "North-America"
 	case "australia":
 		return "Australia"
+	case "south-america":
+		return "South-America"
 	}
 	return source
 }

--- a/alicloud/resource_alicloud_cen_bandwidth_package_test.go
+++ b/alicloud/resource_alicloud_cen_bandwidth_package_test.go
@@ -351,6 +351,55 @@ func TestAccAliCloudCenBandwidthPackage_upgrade(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudCenBandwidthPackage_southAmerica(t *testing.T) {
+	var v cbn.CenBandwidthPackage
+	resourceId := "alicloud_cen_bandwidth_package.default"
+	ra := resourceAttrInit(resourceId, nil)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CbnService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCenBandwidthPackage")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccCen%sBandwidthPackage-%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceCenBandwidthPackageConfigDependence_upgrade)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			// Cross-continent CEN bandwidth packages (e.g. South-America<->China) can only be
+			// purchased on International accounts; Domestic accounts return ParameterIllegal.BandwidthPackage.
+			testAccPreCheckWithAccountSiteType(t, IntlSite)
+		},
+
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"bandwidth":              "2",
+					"geographic_region_a_id": "South-America",
+					"geographic_region_b_id": "China",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"bandwidth":              "2",
+						"geographic_region_a_id": "South-America",
+						"geographic_region_b_id": "China",
+					}),
+					testAccCheckCenBandwidthPackageRegionId(&v, "South-America", "China"),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"period", "auto_renew"},
+			},
+		},
+	})
+}
+
 func TestAccAliCloudCenBandwidthPackage_basic1(t *testing.T) {
 	var v cbn.CenBandwidthPackage
 	resourceId := "alicloud_cen_bandwidth_package.default"

--- a/website/docs/r/cen_bandwidth_package.html.markdown
+++ b/website/docs/r/cen_bandwidth_package.html.markdown
@@ -53,8 +53,8 @@ The following arguments are supported:
 * `charge_type` - (Optional, Deprecated from 1.98.0+) Field `charge_type` has been deprecated from version 1.97.0. Use `payment_type` and instead.
 * `period` - (Optional) The purchase period in month. Valid value: `1`, `2`, `3`, `6`, `12`.
 -> **NOTE:** The attribute `period` is only used to create Subscription instance or modify the PayAsYouGo instance to Subscription. Once effect, it will not be modified that means running `terraform apply` will not effect the resource.
-* `geographic_region_a_id` - (Optional, ForceNew, Available since v1.98.0) The area A to which the network instance belongs. Valid values: `China` | `North-America` | `Asia-Pacific` | `Europe` | `Australia`.
-* `geographic_region_b_id` - (Optional, ForceNew, Available since v1.98.0) The area B to which the network instance belongs. Valid values: `China` | `North-America` | `Asia-Pacific` | `Europe` | `Australia`.
+* `geographic_region_a_id` - (Optional, ForceNew, Available since v1.98.0) The area A to which the network instance belongs. Valid values: `China` | `North-America` | `Asia-Pacific` | `Europe` | `Australia` | `Middle-East` | `South-America`.
+* `geographic_region_b_id` - (Optional, ForceNew, Available since v1.98.0) The area B to which the network instance belongs. Valid values: `China` | `North-America` | `Asia-Pacific` | `Europe` | `Australia` | `Middle-East` | `South-America`.
 * `payment_type` - (Optional, ForceNew, Available since v1.98.0) The billing method. Valid value: `PostPaid` | `PrePaid`. Default to `PrePaid`. If set to PrePaid, the bandwidth package can't be deleted before expired time.
 * `cen_bandwidth_package_name` - (Optional, Available since v1.98.0) The name of the bandwidth package. Defaults to null.
 * `auto_renew` - (Optional, Available since v1.267.0) Whether to enable auto-renewal for the bandwidth package. Only applicable when `payment_type` is `PrePaid`. Valid values: `true`, `false`. Default to `false`.


### PR DESCRIPTION
### What does this PR do?

Adds `South-America` to the `geographic_region_a_id` and `geographic_region_b_id` schema validation whitelist of `alicloud_cen_bandwidth_package`, and adds the matching case to the Read response convert functions (`convertGeographicRegionAIdResponse` / `convertGeographicRegionBIdResponse`) so that CEN bandwidth packages connecting the South-America area can be created and imported without schema validation errors.

Also syncs the missing `Middle-East` value into the resource docs to keep the valid values list aligned with the provider whitelist.

### Motivation

The CEN bandwidth package API already supports the South-America area, but the provider schema whitelist did not include it, causing `geographic_region_a_id` / `geographic_region_b_id` set to `South-America` to fail schema validation.

### Test

- Added `TestAccAliCloudCenBandwidthPackage_southAmerica` covering Create -> Read -> Import round-trip with `geographic_region_a_id = "South-America"` and `geographic_region_b_id = "China"`, asserting the Read response convert functions map the API value back to `South-America`.
