### PR TITLE
New Resource: alicloud_ens_nat_gateway_snat_entry; New Data Source: alicloud_ens_nat_gateway_snat_entries; resource/alicloud_ens_eip: add ip_address attribute and OrderFailed retry

### DIFF
--- a/alicloud/data_source_alicloud_ens_nat_gateway_snat_entries.go
+++ b/alicloud/data_source_alicloud_ens_nat_gateway_snat_entries.go
@@ -1,0 +1,289 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudEnsNatGatewaySnatEntries() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudEnsNatGatewaySnatEntryRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"nat_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"snat_entry_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"snat_entry_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"snat_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"source_cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"entries": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"creation_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"dest_cidr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"eip_affinity": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"idle_timeout": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"isp_affinity": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"nat_gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"snat_entry_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"snat_entry_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"snat_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_cidr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"standby_snat_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"standby_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudEnsNatGatewaySnatEntryRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "DescribeSnatTableEntries"
+	var err error
+	query = make(map[string]interface{})
+
+	if v, ok := d.GetOk("snat_entry_id"); ok {
+		query["SnatEntryId"] = v
+	}
+	if v, ok := d.GetOk("nat_gateway_id"); ok {
+		query["NatGatewayId"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("snat_entry_id"); ok {
+		query["SnatEntryId"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("snat_entry_name"); ok {
+		query["SnatEntryName"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("snat_ip"); ok {
+		query["SnatIp"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("source_cidr"); ok {
+		query["SourceCIDR"] = v.(string)
+	}
+
+	query["PageSize"] = PageSizeLarge
+	query["PageNumber"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcGet("Ens", "2017-11-10", action, query, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, query)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.SnatTableEntries[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["SnatEntryId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		query["PageNumber"] = query["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["SnatEntryId"]
+
+		mapping["eip_affinity"] = objectRaw["EipAffinity"]
+		mapping["idle_timeout"] = objectRaw["IdleTimeout"]
+		mapping["isp_affinity"] = objectRaw["IspAffinity"]
+		mapping["nat_gateway_id"] = objectRaw["NatGatewayId"]
+		mapping["snat_entry_name"] = objectRaw["SnatEntryName"]
+		mapping["snat_ip"] = objectRaw["SnatIp"]
+		mapping["source_cidr"] = objectRaw["SourceCIDR"]
+		mapping["standby_snat_ip"] = objectRaw["StandbySnatIp"]
+		mapping["standby_status"] = objectRaw["StandbyStatus"]
+		mapping["status"] = objectRaw["Status"]
+		mapping["snat_entry_id"] = objectRaw["SnatEntryId"]
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["SnatEntryId"])
+		mapping, err = dataSourceAliCloudEnsNatGatewaySnatEntryReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("entries", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudEnsNatGatewaySnatEntryReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	ensServiceV2 := EnsServiceV2{client}
+	getResp, err := ensServiceV2.DescribeEnsNatGatewaySnatEntry(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["creation_time"] = objectRaw["CreationTime"]
+	mapping["dest_cidr"] = objectRaw["DestCIDR"]
+	mapping["eip_affinity"] = objectRaw["EipAffinity"]
+	mapping["idle_timeout"] = objectRaw["IdleTimeout"]
+	mapping["isp_affinity"] = objectRaw["IspAffinity"]
+	mapping["nat_gateway_id"] = objectRaw["NatGatewayId"]
+	mapping["snat_entry_name"] = objectRaw["SnatEntryName"]
+	mapping["snat_ip"] = objectRaw["SnatIp"]
+	mapping["source_cidr"] = objectRaw["SourceCIDR"]
+	mapping["standby_snat_ip"] = objectRaw["StandbySnatIp"]
+	mapping["standby_status"] = objectRaw["StandbyStatus"]
+	mapping["status"] = objectRaw["Status"]
+	mapping["type"] = objectRaw["Type"]
+	mapping["snat_entry_id"] = objectRaw["SnatEntryId"]
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_ens_nat_gateway_snat_entries_test.go
+++ b/alicloud/data_source_alicloud_ens_nat_gateway_snat_entries_test.go
@@ -1,0 +1,186 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudEnsNatGatewaySnatEntryDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":            `["snat-fake0000"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+		}),
+	}
+
+	SnatEntryNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":             `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"nat_gateway_id":  `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+			"snat_entry_name": `"${var.name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":             `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"nat_gateway_id":  `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+			"snat_entry_name": `"${var.name}_fake"`,
+		}),
+	}
+	SourceCidrConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+			"source_cidr":    `"10.0.0.0/8"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+			"source_cidr":    `"192.0.2.0/24"`,
+		}),
+	}
+	SnatIpConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+			"snat_ip":        `"${alicloud_ens_eip.defaultiUbwh0.ip_address}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+			"snat_ip":        `"192.0.2.254"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":             `["${alicloud_ens_nat_gateway_snat_entry.default.id}"]`,
+			"snat_entry_name": `"${var.name}"`,
+
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+
+			"source_cidr": `"10.0.0.0/8"`,
+
+			"snat_ip": `"${alicloud_ens_eip.defaultiUbwh0.ip_address}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand, map[string]string{
+			"ids":             `["snat-fake0000"]`,
+			"snat_entry_name": `"${var.name}_fake"`,
+
+			"nat_gateway_id": `"${alicloud_ens_nat_gateway.default2Kn0nu.id}"`,
+
+			"source_cidr": `"192.0.2.0/24"`,
+
+			"snat_ip": `"192.0.2.254"`,
+		}),
+	}
+
+	EnsNatGatewaySnatEntryCheckInfo.dataSourceTestCheck(t, rand, idsConf, SnatEntryNameConf, SourceCidrConf, SnatIpConf, allConf)
+}
+
+var existEnsNatGatewaySnatEntryMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"entries.#":                 "1",
+		"entries.0.status":          CHECKSET,
+		"entries.0.source_cidr":     CHECKSET,
+		"entries.0.idle_timeout":    CHECKSET,
+		"entries.0.snat_ip":         CHECKSET,
+		"entries.0.eip_affinity":    CHECKSET,
+		"entries.0.snat_entry_name": CHECKSET,
+		"entries.0.isp_affinity":    CHECKSET,
+		"entries.0.snat_entry_id":   CHECKSET,
+		"entries.0.nat_gateway_id":  CHECKSET,
+	}
+}
+
+var fakeEnsNatGatewaySnatEntryMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"entries.#": "0",
+	}
+}
+
+var EnsNatGatewaySnatEntryCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_ens_nat_gateway_snat_entries.default",
+	existMapFunc: existEnsNatGatewaySnatEntryMapFunc,
+	fakeMapFunc:  fakeEnsNatGatewaySnatEntryMapFunc,
+}
+
+func testAccCheckAlicloudEnsNatGatewaySnatEntrySourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccEnsNatGatewaySnatEntry%d"
+}
+variable "ens_region_id" {
+    default = "cn-chenzhou-telecom_unicom_cmcc"
+}
+
+resource "alicloud_ens_network" "defaultXqhlfk" {
+        network_name = "${var.name}"
+        cidr_block = "10.0.0.0/8"
+        ens_region_id = "${var.ens_region_id}"
+}
+
+resource "alicloud_ens_vswitch" "defaultzkXvut" {
+        cidr_block = "10.0.0.0/24"
+        vswitch_name = "${var.name}"
+        ens_region_id = "${alicloud_ens_network.defaultXqhlfk.ens_region_id}"
+        network_id = "${alicloud_ens_network.defaultXqhlfk.id}"
+}
+
+resource "alicloud_ens_eip" "defaultiUbwh0" {
+        depends_on = [alicloud_ens_nat_gateway.default2Kn0nu]
+        bandwidth = "5"
+        payment_type = "PayAsYouGo"
+        ens_region_id = "${alicloud_ens_vswitch.defaultzkXvut.ens_region_id}"
+        eip_name = "${var.name}"
+        internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_nat_gateway" "default2Kn0nu" {
+        vswitch_id = "${alicloud_ens_vswitch.defaultzkXvut.id}"
+        ens_region_id = "${alicloud_ens_vswitch.defaultzkXvut.ens_region_id}"
+        network_id = "${alicloud_ens_vswitch.defaultzkXvut.network_id}"
+        instance_type = "enat.default"
+        nat_name = "${var.name}"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultlI0M0t" {
+        instance_id = "${alicloud_ens_nat_gateway.default2Kn0nu.id}"
+        allocation_id = "${alicloud_ens_eip.defaultiUbwh0.id}"
+        instance_type = "Nat"
+        standby = false
+}
+
+
+
+resource "alicloud_ens_nat_gateway_snat_entry" "default" {
+        depends_on = [alicloud_ens_eip_instance_attachment.defaultlI0M0t]
+        snat_entry_name = "${var.name}"
+        source_cidr = "10.0.0.0/8"
+        snat_ip = "${alicloud_ens_eip.defaultiUbwh0.ip_address}"
+        nat_gateway_id = "${alicloud_ens_nat_gateway.default2Kn0nu.id}"
+        idle_timeout = "50"
+        isp_affinity = false
+        eip_affinity = false
+}
+
+data "alicloud_ens_nat_gateway_snat_entries" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_ens_nat_gateway_snat_entries":                   dataSourceAliCloudEnsNatGatewaySnatEntries(),
 			"alicloud_ens_load_balancer_udp_listeners":                dataSourceAliCloudEnsLoadBalancerUdpListeners(),
 			"alicloud_ecd_desktop_groups":                             dataSourceAliCloudEcdDesktopGroups(),
 			"alicloud_redis_global_security_ip_groups":                dataSourceAliCloudRedisGlobalSecurityIpGroups(),
@@ -965,6 +966,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_sls_metric_stores":                                dataSourceAliCloudSlsMetricStores(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_ens_nat_gateway_snat_entry":                           resourceAliCloudEnsNatGatewaySnatEntry(),
 			"alicloud_ens_load_balancer_udp_listener":                       resourceAliCloudEnsLoadBalancerUdpListener(),
 			"alicloud_gpdb_db_extension":                                    resourceAliCloudGpdbDbExtension(),
 			"alicloud_ecd_desktop_group":                                    resourceAliCloudEcdDesktopGroup(),

--- a/alicloud/resource_alicloud_ens_eip.go
+++ b/alicloud/resource_alicloud_ens_eip.go
@@ -70,6 +70,10 @@ func resourceAliCloudEnsEip() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -106,7 +110,7 @@ func resourceAliCloudEnsEipCreate(d *schema.ResourceData, meta interface{}) erro
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
 		if err != nil {
-			if NeedRetry(err) {
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"OrderFailed"}) {
 				wait()
 				return resource.RetryableError(err)
 			}
@@ -154,6 +158,7 @@ func resourceAliCloudEnsEipRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("isp", objectRaw["Isp"])
 	d.Set("payment_type", convertEnsEipAddressesEipAddressChargeTypeResponse(objectRaw["ChargeType"]))
 	d.Set("status", objectRaw["Status"])
+	d.Set("ip_address", objectRaw["IpAddress"])
 
 	return nil
 }

--- a/alicloud/resource_alicloud_ens_nat_gateway_snat_entry.go
+++ b/alicloud/resource_alicloud_ens_nat_gateway_snat_entry.go
@@ -1,0 +1,298 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudEnsNatGatewaySnatEntry() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudEnsNatGatewaySnatEntryCreate,
+		Read:   resourceAliCloudEnsNatGatewaySnatEntryRead,
+		Update: resourceAliCloudEnsNatGatewaySnatEntryUpdate,
+		Delete: resourceAliCloudEnsNatGatewaySnatEntryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"dest_cidr": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"eip_affinity": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"idle_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: IntBetween(1, 86400),
+			},
+			"isp_affinity": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"nat_gateway_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"snat_entry_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"snat_ip": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"source_cidr": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"source_network_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"source_vswitch_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"standby_snat_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"standby_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudEnsNatGatewaySnatEntryCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateSnatEntry"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	if v, ok := d.GetOk("source_vswitch_id"); ok {
+		request["SourceVSwitchId"] = v
+	}
+	if v, ok := d.GetOk("source_network_id"); ok {
+		request["SourceNetworkId"] = v
+	}
+	if v, ok := d.GetOkExists("eip_affinity"); ok {
+		request["EipAffinity"] = v
+	}
+	if v, ok := d.GetOk("snat_entry_name"); ok {
+		request["SnatEntryName"] = v
+	}
+	request["NatGatewayId"] = d.Get("nat_gateway_id")
+	if v, ok := d.GetOk("source_cidr"); ok {
+		request["SourceCIDR"] = v
+	}
+	request["SnatIp"] = d.Get("snat_ip")
+	if v, ok := d.GetOkExists("isp_affinity"); ok {
+		request["IspAffinity"] = v
+	}
+	if v, ok := d.GetOk("standby_snat_ip"); ok {
+		request["StandbySnatIp"] = v
+	}
+	if v, ok := d.GetOkExists("idle_timeout"); ok && v.(int) > 0 {
+		request["IdleTimeout"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"InvalidParameter.SnatIp"}) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ens_nat_gateway_snat_entry", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["SnatEntryId"]))
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, ensServiceV2.EnsNatGatewaySnatEntryStateRefreshFunc(d.Id(), "Status", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return resourceAliCloudEnsNatGatewaySnatEntryRead(d, meta)
+}
+
+func resourceAliCloudEnsNatGatewaySnatEntryRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ensServiceV2 := EnsServiceV2{client}
+
+	objectRaw, err := ensServiceV2.DescribeEnsNatGatewaySnatEntry(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ens_nat_gateway_snat_entry DescribeEnsNatGatewaySnatEntry Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("creation_time", objectRaw["CreationTime"])
+	d.Set("dest_cidr", objectRaw["DestCIDR"])
+	d.Set("eip_affinity", objectRaw["EipAffinity"])
+	d.Set("idle_timeout", objectRaw["IdleTimeout"])
+	d.Set("isp_affinity", objectRaw["IspAffinity"])
+	d.Set("nat_gateway_id", objectRaw["NatGatewayId"])
+	d.Set("snat_entry_name", objectRaw["SnatEntryName"])
+	d.Set("snat_ip", objectRaw["SnatIp"])
+	d.Set("source_cidr", objectRaw["SourceCIDR"])
+	d.Set("standby_snat_ip", objectRaw["StandbySnatIp"])
+	d.Set("standby_status", objectRaw["StandbyStatus"])
+	d.Set("status", objectRaw["Status"])
+	d.Set("type", objectRaw["Type"])
+
+	return nil
+}
+
+func resourceAliCloudEnsNatGatewaySnatEntryUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "ModifySnatEntry"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["SnatEntryId"] = d.Id()
+
+	if d.HasChange("eip_affinity") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("eip_affinity"); ok || d.HasChange("eip_affinity") {
+		request["EipAffinity"] = v
+	}
+	if d.HasChange("snat_entry_name") {
+		update = true
+	}
+	if v, ok := d.GetOk("snat_entry_name"); ok || d.HasChange("snat_entry_name") {
+		request["SnatEntryName"] = v
+	}
+	if d.HasChange("snat_ip") {
+		update = true
+	}
+	request["SnatIp"] = d.Get("snat_ip")
+	if d.HasChange("isp_affinity") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("isp_affinity"); ok || d.HasChange("isp_affinity") {
+		request["IspAffinity"] = v
+	}
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		ensServiceV2 := EnsServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ensServiceV2.EnsNatGatewaySnatEntryStateRefreshFunc(d.Id(), "Status", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+
+	return resourceAliCloudEnsNatGatewaySnatEntryRead(d, meta)
+}
+
+func resourceAliCloudEnsNatGatewaySnatEntryDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteSnatEntry"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["SnatEntryId"] = d.Id()
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"InvalidParameter.SnatNotFound"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	ensServiceV2 := EnsServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 5*time.Second, ensServiceV2.EnsNatGatewaySnatEntryStateRefreshFunc(d.Id(), "$.SnatEntryId", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ens_nat_gateway_snat_entry_test.go
+++ b/alicloud/resource_alicloud_ens_nat_gateway_snat_entry_test.go
@@ -1,0 +1,184 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Ens NatGatewaySnatEntry. >>> Resource test cases, automatically generated.
+// Case Snat_20241218 9626
+// NOTE: ENS 订单系统对同一账号串行处理下单，NAT 网关与 EIP 并发创建会被拒绝（OrderFailed），
+// 因此依赖链全串行：network -> vswitch -> nat_gateway -> eip -> attach -> snat_entry。
+// standby_snat_ip 需要 FullCone 型 NAT/备用 EIP 池，enat.default（对称型）不支持
+// （StartSnatStandbySnatIp 返回 SnatNotSupport），配置中以空串占位保持字段可见性。
+func TestAccAliCloudEnsNatGatewaySnatEntry_basic9626(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ens_nat_gateway_snat_entry.default"
+	ra := resourceAttrInit(resourceId, AlicloudEnsNatGatewaySnatEntryMap9626)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EnsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEnsNatGatewaySnatEntry")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccens%d", rand)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: AlicloudEnsNatGatewaySnatEntryConfigStep1(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"snat_entry_name":   name,
+						"source_cidr":       "10.0.0.0/8",
+						"nat_gateway_id":    CHECKSET,
+						"idle_timeout":      "50",
+						"isp_affinity":      "false",
+						"eip_affinity":      "false",
+						"source_vswitch_id": CHECKSET,
+						"source_network_id": CHECKSET,
+						"standby_snat_ip":   "",
+					}),
+				),
+			},
+			{
+				Config: AlicloudEnsNatGatewaySnatEntryConfigStep2(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"snat_entry_name": name + "update",
+						"snat_ip":         CHECKSET,
+						"isp_affinity":    "true",
+						"eip_affinity":    "true",
+						"standby_snat_ip": "",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"source_vswitch_id", "source_network_id"},
+			},
+		},
+	})
+}
+
+var AlicloudEnsNatGatewaySnatEntryMap9626 = map[string]string{
+	"status":        CHECKSET,
+	"creation_time": CHECKSET,
+}
+
+func AlicloudEnsNatGatewaySnatEntryDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "ens_region_id" {
+    default = "cn-chenzhou-telecom_unicom_cmcc"
+}
+
+resource "alicloud_ens_network" "defaultXqhlfk" {
+        network_name = "${var.name}"
+        cidr_block = "10.0.0.0/8"
+        ens_region_id = "${var.ens_region_id}"
+}
+
+resource "alicloud_ens_vswitch" "defaultzkXvut" {
+        cidr_block = "10.0.0.0/24"
+        vswitch_name = "${var.name}"
+        ens_region_id = "${alicloud_ens_network.defaultXqhlfk.ens_region_id}"
+        network_id = "${alicloud_ens_network.defaultXqhlfk.id}"
+}
+
+resource "alicloud_ens_nat_gateway" "default2Kn0nu" {
+        vswitch_id = "${alicloud_ens_vswitch.defaultzkXvut.id}"
+        ens_region_id = "${alicloud_ens_vswitch.defaultzkXvut.ens_region_id}"
+        network_id = "${alicloud_ens_vswitch.defaultzkXvut.network_id}"
+        instance_type = "enat.default"
+        nat_name = "${var.name}"
+}
+
+resource "alicloud_ens_eip" "defaultiUbwh0" {
+        depends_on = [alicloud_ens_nat_gateway.default2Kn0nu]
+        bandwidth = "5"
+        payment_type = "PayAsYouGo"
+        ens_region_id = "${alicloud_ens_vswitch.defaultzkXvut.ens_region_id}"
+        eip_name = "${var.name}"
+        internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultlI0M0t" {
+        instance_id = "${alicloud_ens_nat_gateway.default2Kn0nu.id}"
+        allocation_id = "${alicloud_ens_eip.defaultiUbwh0.id}"
+        instance_type = "Nat"
+        standby = false
+}
+
+`, name)
+}
+
+func AlicloudEnsNatGatewaySnatEntryConfigStep1(name string) string {
+	return AlicloudEnsNatGatewaySnatEntryDependence(name) + `
+resource "alicloud_ens_nat_gateway_snat_entry" "default" {
+        depends_on = [alicloud_ens_eip_instance_attachment.defaultlI0M0t]
+        snat_entry_name = "${var.name}"
+        source_cidr = "10.0.0.0/8"
+        snat_ip = "${alicloud_ens_eip.defaultiUbwh0.ip_address}"
+        standby_snat_ip = ""
+        nat_gateway_id = "${alicloud_ens_nat_gateway.default2Kn0nu.id}"
+        idle_timeout = "50"
+        isp_affinity = false
+        eip_affinity = false
+        source_vswitch_id = "${alicloud_ens_vswitch.defaultzkXvut.id}"
+        source_network_id = "${alicloud_ens_network.defaultXqhlfk.id}"
+}
+`
+}
+
+func AlicloudEnsNatGatewaySnatEntryConfigStep2(name string) string {
+	return AlicloudEnsNatGatewaySnatEntryDependence(name) + `
+resource "alicloud_ens_eip" "eip3" {
+        depends_on = [alicloud_ens_eip_instance_attachment.defaultlI0M0t]
+        bandwidth = "5"
+        payment_type = "PayAsYouGo"
+        ens_region_id = "${var.ens_region_id}"
+        eip_name = "${var.name}-update"
+        internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_eip_instance_attachment" "defaultEip3" {
+        instance_id = "${alicloud_ens_nat_gateway.default2Kn0nu.id}"
+        allocation_id = "${alicloud_ens_eip.eip3.id}"
+        instance_type = "Nat"
+        standby = false
+}
+
+resource "alicloud_ens_nat_gateway_snat_entry" "default" {
+        depends_on = [alicloud_ens_eip_instance_attachment.defaultlI0M0t, alicloud_ens_eip_instance_attachment.defaultEip3]
+        snat_entry_name = "${var.name}update"
+        source_cidr = "10.0.0.0/8"
+        snat_ip = "${alicloud_ens_eip.eip3.ip_address}"
+        standby_snat_ip = ""
+        nat_gateway_id = "${alicloud_ens_nat_gateway.default2Kn0nu.id}"
+        idle_timeout = "50"
+        isp_affinity = true
+        eip_affinity = true
+        source_vswitch_id = "${alicloud_ens_vswitch.defaultzkXvut.id}"
+        source_network_id = "${alicloud_ens_network.defaultXqhlfk.id}"
+}
+`
+}
+
+// Test Ens NatGatewaySnatEntry. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_ens_v2.go
+++ b/alicloud/service_alicloud_ens_v2.go
@@ -1568,3 +1568,73 @@ func (s *EnsServiceV2) EnsLoadBalancerUdpListenerStateRefreshFuncWithApi(id stri
 }
 
 // DescribeEnsLoadBalancerUdpListener >>> Encapsulated.
+// DescribeEnsNatGatewaySnatEntry <<< Encapsulated get interface for Ens NatGatewaySnatEntry.
+
+func (s *EnsServiceV2) DescribeEnsNatGatewaySnatEntry(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["SnatEntryId"] = id
+
+	action := "DescribeSnatAttribute"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Ens", "2017-11-10", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"InvalidParameter.SnatNotFound"}) {
+			return object, WrapErrorf(NotFoundErr("NatGatewaySnatEntry", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *EnsServiceV2) EnsNatGatewaySnatEntryStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.EnsNatGatewaySnatEntryStateRefreshFuncWithApi(id, field, failStates, s.DescribeEnsNatGatewaySnatEntry)
+}
+
+func (s *EnsServiceV2) EnsNatGatewaySnatEntryStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeEnsNatGatewaySnatEntry >>> Encapsulated.

--- a/website/docs/d/ens_nat_gateway_snat_entries.html.markdown
+++ b/website/docs/d/ens_nat_gateway_snat_entries.html.markdown
@@ -1,0 +1,116 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_nat_gateway_snat_entries"
+sidebar_current: "docs-alicloud-datasource-ens-nat-gateway-snat-entries"
+description: |-
+  Provides a list of ENS Nat Gateway Snat Entry owned by an Alibaba Cloud account.
+---
+
+# alicloud_ens_nat_gateway_snat_entries
+
+This data source provides ENS Nat Gateway Snat Entry available to the user.[What is Nat Gateway Snat Entry](https://next.api.alibabacloud.com/document/Ens/2017-11-10/CreateSnatEntry)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-44"
+}
+
+resource "alicloud_ens_network" "default" {
+  network_name  = var.name
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default" {
+  cidr_block    = "10.0.0.0/24"
+  vswitch_name  = var.name
+  ens_region_id = alicloud_ens_network.default.ens_region_id
+  network_id    = alicloud_ens_network.default.id
+}
+
+resource "alicloud_ens_eip" "default" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = alicloud_ens_vswitch.default.ens_region_id
+  eip_name             = var.name
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_nat_gateway" "default" {
+  vswitch_id    = alicloud_ens_vswitch.default.id
+  ens_region_id = alicloud_ens_vswitch.default.ens_region_id
+  network_id    = alicloud_ens_vswitch.default.network_id
+  instance_type = "enat.default"
+  nat_name      = var.name
+}
+
+resource "alicloud_ens_eip_instance_attachment" "default" {
+  instance_id   = alicloud_ens_nat_gateway.default.id
+  allocation_id = alicloud_ens_eip.default.id
+  instance_type = "Nat"
+  standby       = false
+}
+
+resource "alicloud_ens_nat_gateway_snat_entry" "default" {
+  snat_entry_name = var.name
+  source_cidr     = "10.0.0.0/8"
+  snat_ip         = alicloud_ens_eip.default.ip_address
+  nat_gateway_id  = alicloud_ens_nat_gateway.default.id
+}
+
+data "alicloud_ens_nat_gateway_snat_entries" "default" {
+  nat_gateway_id = alicloud_ens_nat_gateway.default.id
+  ids            = [alicloud_ens_nat_gateway_snat_entry.default.id]
+}
+
+output "snat_entry_status" {
+  value = data.alicloud_ens_nat_gateway_snat_entries.default.entries.0.status
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `nat_gateway_id` - (Required) The ID of the NAT gateway.
+* `snat_entry_id` - (Optional) SNAT entry ID.
+* `snat_entry_name` - (Optional) The name of the SNAT entry.
+* `snat_ip` - (Optional) The EIPs in the SNAT entry. Separate multiple EIPs with commas (,).
+* `source_cidr` - (Optional) The source CIDR block of the SNAT entry.
+* `ids` - (Optional, Computed) A list of Nat Gateway Snat Entry IDs.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Nat Gateway Snat Entry IDs.
+* `entries` - A list of Nat Gateway Snat Entry Entries. Each element contains the following attributes:
+  * `creation_time` - **NOTE:** This field is only available when `enable_details` is `true`. The creation time, in UTC.
+  * `dest_cidr` - **NOTE:** This field is only available when `enable_details` is `true`. The destination CIDR block.
+  * `eip_affinity` - Whether to enable IP affinity.
+  * `idle_timeout` - The idle timeout.
+  * `isp_affinity` - Whether to open the operator affinity.
+  * `nat_gateway_id` - The ID of the NAT gateway.
+  * `snat_entry_id` - SNAT entry ID.
+  * `snat_entry_name` - The name of the SNAT entry.
+  * `snat_ip` - The EIPs in the SNAT entry.
+  * `source_cidr` - The source CIDR block of the SNAT entry.
+  * `standby_snat_ip` - The standby EIPs in the SNAT entry.
+  * `standby_status` - The status of the standby EIP.
+  * `status` - SNAT entry status.
+  * `type` - **NOTE:** This field is only available when `enable_details` is `true`. The NAT type.
+  * `id` - The ID of the resource supplied above.

--- a/website/docs/r/ens_eip.html.markdown
+++ b/website/docs/r/ens_eip.html.markdown
@@ -61,6 +61,7 @@ The following attributes are exported:
 * `id` - The ID of the resource supplied above.
 * `create_time` - The creation time of the EIP instance.
 * `status` - The status of the EIP.
+* `ip_address` - The IP address of the EIP.
 
 ## Timeouts
 

--- a/website/docs/r/ens_nat_gateway_snat_entry.html.markdown
+++ b/website/docs/r/ens_nat_gateway_snat_entry.html.markdown
@@ -1,0 +1,122 @@
+---
+subcategory: "ENS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ens_nat_gateway_snat_entry"
+description: |-
+  Provides a Alicloud ENS Nat Gateway Snat Entry resource.
+---
+
+# alicloud_ens_nat_gateway_snat_entry
+
+Provides a ENS Nat Gateway Snat Entry resource.
+
+
+
+For information about ENS Nat Gateway Snat Entry and how to use it, see [What is Nat Gateway Snat Entry](https://next.api.alibabacloud.com/document/Ens/2017-11-10/CreateSnatEntry).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "ens_region_id" {
+  default = "cn-hangzhou-44"
+}
+
+resource "alicloud_ens_network" "default" {
+  network_name  = var.name
+  cidr_block    = "10.0.0.0/8"
+  ens_region_id = var.ens_region_id
+}
+
+resource "alicloud_ens_vswitch" "default" {
+  cidr_block    = "10.0.0.0/24"
+  vswitch_name  = var.name
+  ens_region_id = alicloud_ens_network.default.ens_region_id
+  network_id    = alicloud_ens_network.default.id
+}
+
+resource "alicloud_ens_eip" "default" {
+  bandwidth            = "5"
+  payment_type         = "PayAsYouGo"
+  ens_region_id        = alicloud_ens_vswitch.default.ens_region_id
+  eip_name             = var.name
+  internet_charge_type = "95BandwidthByMonth"
+}
+
+resource "alicloud_ens_nat_gateway" "default" {
+  vswitch_id    = alicloud_ens_vswitch.default.id
+  ens_region_id = alicloud_ens_vswitch.default.ens_region_id
+  network_id    = alicloud_ens_vswitch.default.network_id
+  instance_type = "enat.default"
+  nat_name      = var.name
+}
+
+resource "alicloud_ens_eip_instance_attachment" "default" {
+  instance_id   = alicloud_ens_nat_gateway.default.id
+  allocation_id = alicloud_ens_eip.default.id
+  instance_type = "Nat"
+  standby       = false
+}
+
+resource "alicloud_ens_nat_gateway_snat_entry" "default" {
+  snat_entry_name = var.name
+  source_cidr     = "10.0.0.0/8"
+  snat_ip         = alicloud_ens_eip.default.ip_address
+  nat_gateway_id  = alicloud_ens_nat_gateway.default.id
+  idle_timeout    = "50"
+  isp_affinity    = false
+  eip_affinity    = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `eip_affinity` - (Optional) Whether to enable IP affinity.
+* `idle_timeout` - (Optional, ForceNew, Int) The idle timeout. Valid values: 1 to 86400. Unit: seconds.
+* `isp_affinity` - (Optional) Whether to open the operator affinity. Value:
+false: disable Operator affinity.
+true: Turn on operator affinity.
+* `nat_gateway_id` - (Required, ForceNew) The ID of the NAT gateway.
+* `snat_entry_name` - (Optional) The name of the SNAT entry.
+* `snat_ip` - (Required) The EIPs in the SNAT entry. Separate multiple EIPs with commas (,).
+* `source_cidr` - (Optional, ForceNew) The source CIDR block of the SNAT entry.
+* `source_network_id` - (Optional, ForceNew) The ID of the network. This parameter indicates that all ENS instances in the network can access the Internet through SNAT rules.
+* `source_vswitch_id` - (Optional, ForceNew) The ID of the vSwitch that needs to access the Internet. This parameter indicates that all ENS instances in the vSwitch can access the Internet through SNAT rules.
+* `standby_snat_ip` - (Optional, ForceNew) The standby EIPs in the SNAT entry. Separate multiple standby EIPs with commas (,).
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+* `creation_time` - The creation time, in UTC.
+* `dest_cidr` - The destination CIDR block.
+* `standby_status` - The status of the standby EIP.
+* `status` - SNAT entry status.
+* `type` - The NAT type.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Nat Gateway Snat Entry.
+* `delete` - (Defaults to 5 mins) Used when delete the Nat Gateway Snat Entry.
+* `update` - (Defaults to 5 mins) Used when update the Nat Gateway Snat Entry.
+
+## Import
+
+ENS Nat Gateway Snat Entry can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ens_nat_gateway_snat_entry.example <snat_entry_id>
+```


### PR DESCRIPTION
## Summary
- New resource `alicloud_ens_nat_gateway_snat_entry` to manage ENS NAT gateway SNAT entries (create/read/update/delete + import).
- New data source `alicloud_ens_nat_gateway_snat_entries` to list and filter SNAT entries by ids, name, snat_ip, and source_cidr.
- Supporting change: `alicloud_ens_eip` now exports the `ip_address` attribute (returned by `DescribeEnsEipAddresses`) so configurations can reference an EIP's address, and its Create retries the transient `OrderFailed` error that ENS returns when several order-placing calls race.

## Test plan
- [x] `TestAccAliCloudEnsNatGatewaySnatEntry_basic9626` PASS in cn-hangzhou (292.11s): create with full attribute set (source_cidr/source_vswitch_id/source_network_id/idle_timeout/isp_affinity/eip_affinity) → update name/snat_ip/affinity → import → destroy.
- [x] `TestAccAliCloudEnsNatGatewaySnatEntryDataSource` PASS (234.02s): ids/name/nat_gateway_id/source_cidr/snat_ip exist & fake filter combinations.

```
=== RUN   TestAccAliCloudEnsNatGatewaySnatEntry_basic9626
--- PASS: TestAccAliCloudEnsNatGatewaySnatEntry_basic9626 (292.11s)

=== RUN   TestAccAliCloudEnsNatGatewaySnatEntryDataSource
--- PASS: TestAccAliCloudEnsNatGatewaySnatEntryDataSource (234.02s)
```

Note: `standby_snat_ip` is kept in the schema (documented public API parameter) but is asserted with an empty value in tests: standby SNAT IPs require a full-cone NAT / standby EIP pool that cannot be provisioned through the public APIs (the only NAT instance type available is `enat.default`, symmetric NAT, whose standby operations return SnatNotSupport).