### PR TITLE
New Resource: alicloud_ehpc_user

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -965,6 +965,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_sls_metric_stores":                                dataSourceAliCloudSlsMetricStores(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_ehpc_user":                                            resourceAliCloudEhpcUser(),
 			"alicloud_ens_load_balancer_udp_listener":                       resourceAliCloudEnsLoadBalancerUdpListener(),
 			"alicloud_gpdb_db_extension":                                    resourceAliCloudGpdbDbExtension(),
 			"alicloud_ecd_desktop_group":                                    resourceAliCloudEcdDesktopGroup(),

--- a/alicloud/resource_alicloud_ehpc_user.go
+++ b/alicloud/resource_alicloud_ehpc_user.go
@@ -1,0 +1,221 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudEhpcUser() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudEhpcUserCreate,
+		Read:   resourceAliCloudEhpcUserRead,
+		Update: resourceAliCloudEhpcUserUpdate,
+		Delete: resourceAliCloudEhpcUserDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"async": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"group": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				ForceNew:  true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudEhpcUserCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "AddUsers"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var err error
+	request = make(map[string]interface{})
+	request["ClusterId"] = d.Get("cluster_id")
+
+	userMap := map[string]interface{}{
+		"Name":  d.Get("user_name"),
+		"Group": d.Get("group"),
+	}
+	if v, ok := d.GetOk("password"); ok {
+		userMap["Password"] = v
+	}
+
+	request["User"] = []map[string]interface{}{userMap}
+
+	if v, ok := d.GetOk("async"); ok {
+		request["Async"] = v
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcGet("EHPC", "2018-04-12", action, request, nil)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ehpc_user", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", request["ClusterId"], d.Get("user_name")))
+
+	return resourceAliCloudEhpcUserRead(d, meta)
+}
+
+func resourceAliCloudEhpcUserRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ehpcServiceV2 := EhpcServiceV2{client}
+
+	objectRaw, err := ehpcServiceV2.DescribeEhpcUser(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_ehpc_user DescribeEhpcUser Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("group", objectRaw["Group"])
+	d.Set("user_name", objectRaw["Name"])
+	d.Set("region_id", client.RegionId)
+
+	parts := strings.Split(d.Id(), ":")
+	d.Set("cluster_id", parts[0])
+
+	return nil
+}
+
+func resourceAliCloudEhpcUserUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var err error
+	parts := strings.Split(d.Id(), ":")
+	action := "ModifyUserGroups"
+	request = make(map[string]interface{})
+	request["ClusterId"] = parts[0]
+
+	userMap := map[string]interface{}{
+		"Name":  parts[1],
+		"Group": d.Get("group"),
+	}
+
+	request["User"] = []map[string]interface{}{userMap}
+
+	if v, ok := d.GetOk("async"); ok {
+		request["Async"] = v
+	}
+
+	if d.HasChange("group") {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcGet("EHPC", "2018-04-12", action, request, nil)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudEhpcUserRead(d, meta)
+}
+
+func resourceAliCloudEhpcUserDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.Split(d.Id(), ":")
+	action := "DeleteUsers"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var err error
+	request = make(map[string]interface{})
+	request["ClusterId"] = parts[0]
+
+	userMap := map[string]interface{}{
+		"Name": parts[1],
+	}
+
+	request["User"] = []map[string]interface{}{userMap}
+
+	if v, ok := d.GetOk("async"); ok {
+		request["Async"] = v
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcGet("EHPC", "2018-04-12", action, request, nil)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_ehpc_user_test.go
+++ b/alicloud/resource_alicloud_ehpc_user_test.go
@@ -1,0 +1,587 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Ehpc User. >>> Resource test cases, automatically generated.
+// Case User_password_test 13038
+func TestAccAliCloudEhpcUser_basic13038(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ehpc_user.default"
+	ra := resourceAttrInit(resourceId, AliCloudEhpcUserMap13038)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EhpcServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEhpcUser")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 100)
+	name := fmt.Sprintf("tfacc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEhpcUserBasicDependence13038)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group":      "users",
+					"user_name":  name,
+					"cluster_id": "${alicloud_ehpc_cluster_v2.user_cluster_test.id}",
+					"password":   "YourPassword1234!",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group":      "users",
+						"user_name":  name,
+						"cluster_id": CHECKSET,
+						"password":   "YourPassword1234!",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group": "wheel",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group": "wheel",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group": "users",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group": "users",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"password": "YourPassword1234!update",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"password": "YourPassword1234!update",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"async", "password"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudEhpcUser_basic13038_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ehpc_user.default"
+	ra := resourceAttrInit(resourceId, AliCloudEhpcUserMap13038)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EhpcServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEhpcUser")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 100)
+	name := fmt.Sprintf("tfacc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEhpcUserBasicDependence13038)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group":      "users",
+					"user_name":  name,
+					"cluster_id": "${alicloud_ehpc_cluster_v2.user_cluster_test.id}",
+					"password":   "YourPassword1234!",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group":      "users",
+						"user_name":  name,
+						"cluster_id": CHECKSET,
+						"password":   "YourPassword1234!",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"async", "password"},
+			},
+		},
+	})
+}
+
+var AliCloudEhpcUserMap13038 = map[string]string{
+	"region_id": CHECKSET,
+}
+
+func AliCloudEhpcUserBasicDependence13038(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_ecs_key_pair" "default" {
+  key_pair_name = var.name
+}
+
+resource "alicloud_vpc" "user_test_vpc" {
+  is_default = false
+  cidr_block = "10.0.0.0/24"
+  vpc_name   = var.name
+}
+
+resource "alicloud_vswitch" "user_test_vswitch" {
+  is_default   = false
+  vpc_id       = alicloud_vpc.user_test_vpc.id
+  zone_id      = "cn-hangzhou-k"
+  cidr_block   = "10.0.0.0/24"
+  vswitch_name = var.name
+}
+
+resource "alicloud_nas_file_system" "user_test_nas" {
+  description  = var.name
+  storage_type = "Capacity"
+  nfs_acl {
+    enabled = false
+  }
+  zone_id          = "cn-hangzhou-k"
+  encrypt_type     = "0"
+  protocol_type    = "NFS"
+  file_system_type = "standard"
+}
+
+resource "alicloud_nas_access_group" "user_test_access_group" {
+  access_group_type = "Vpc"
+  description       = "挂载点创建测试"
+  access_group_name = var.name
+  file_system_type  = "standard"
+}
+
+resource "alicloud_security_group" "user_test_security_group" {
+  vpc_id              = alicloud_vpc.user_test_vpc.id
+  security_group_type = "normal"
+}
+
+resource "alicloud_nas_mount_target" "user_test_mount_domain" {
+  vpc_id            = alicloud_vpc.user_test_vpc.id
+  network_type      = "Vpc"
+  access_group_name = alicloud_nas_access_group.user_test_access_group.access_group_name
+  vswitch_id        = alicloud_vswitch.user_test_vswitch.id
+  file_system_id    = alicloud_nas_file_system.user_test_nas.id
+}
+
+resource "alicloud_nas_access_rule" "user_test_access_rule" {
+  priority          = "1"
+  access_group_name = alicloud_nas_access_group.user_test_access_group.access_group_name
+  file_system_type  = alicloud_nas_file_system.user_test_nas.file_system_type
+  source_cidr_ip    = "10.0.0.0/24"
+}
+
+resource "alicloud_ehpc_cluster_v2" "user_cluster_test" {
+  depends_on = [alicloud_nas_access_rule.user_test_access_rule]
+  cluster_credentials {
+    password = "aliHPC123"
+  }
+  cluster_vpc_id    = alicloud_vpc.user_test_vpc.id
+  cluster_category  = "Standard"
+  cluster_mode      = "Integrated"
+  security_group_id = alicloud_security_group.user_test_security_group.id
+  addons {
+    version        = "1.0"
+    services_spec  = <<EOF
+      [
+        {
+          "ServiceName": "SSH",
+          "NetworkACL": [
+            {
+              "Port": 22,
+              "SourceCidrIp": "0.0.0.0/0",
+              "IpProtocol": "TCP"
+            }
+          ]
+        },
+        {
+          "ServiceName": "VNC",
+          "NetworkACL": [
+            {
+              "Port": 12016,
+              "SourceCidrIp": "0.0.0.0/0",
+              "IpProtocol": "TCP"
+            }
+          ]
+        },
+        {
+          "ServiceName": "CLIENT",
+          "ServiceAccessType": "URL",
+          "ServiceAccessUrl": "https://ehpc-app.oss-cn-hangzhou.aliyuncs.com/ClientRelease/E-HPC-Client-Mac-zh-cn.zip",
+          "NetworkACL": [
+            {
+              "Port": 12011,
+              "SourceCidrIp": "0.0.0.0/0",
+              "IpProtocol": "TCP"
+            }
+          ]
+        }
+      ]
+  EOF
+    resources_spec = <<EOF
+      {
+        "EipResource": {
+          "AutoCreate": true
+        },
+        "EcsResources": [
+          {
+            "ImageId": "centos_7_6_x64_20G_alibase_20211130.vhd",
+            "EnableHT": true,
+            "InstanceChargeType": "PostPaid",
+            "InstanceType": "ecs.c7.xlarge",
+            "SpotStrategy": "NoSpot",
+            "SystemDisk": {
+              "Category": "cloud_essd",
+              "Size": 40,
+              "Level": "PL0"
+            },
+            "DataDisks": [
+              {
+                "Category": "cloud_essd",
+                "Size": 40,
+                "Level": "PL0"
+              }
+            ]
+          }
+        ]
+      }
+  EOF
+    name           = "Login"
+  }
+  cluster_name        = "minimal-test-cluster"
+  deletion_protection = false
+  shared_storages {
+    mount_directory     = "/home"
+    nas_directory       = "/"
+    mount_target_domain = alicloud_nas_mount_target.user_test_mount_domain.mount_target_domain
+    protocol_type       = "NFS"
+    file_system_id      = alicloud_nas_file_system.user_test_nas.id
+    mount_options       = "-t nfs -o vers=3,nolock,proto=tcp,noresvport"
+  }
+  shared_storages {
+    mount_directory     = "/opt"
+    nas_directory       = "/"
+    mount_target_domain = alicloud_nas_mount_target.user_test_mount_domain.mount_target_domain
+    protocol_type       = "NFS"
+    file_system_id      = alicloud_nas_file_system.user_test_nas.id
+    mount_options       = "-t nfs -o vers=3,nolock,proto=tcp,noresvport"
+  }
+  shared_storages {
+    mount_directory     = "/ehpcdata"
+    nas_directory       = "/"
+    mount_target_domain = alicloud_nas_mount_target.user_test_mount_domain.mount_target_domain
+    protocol_type       = "NFS"
+    file_system_id      = alicloud_nas_file_system.user_test_nas.id
+    mount_options       = "-t nfs -o vers=3,nolock,proto=tcp,noresvport"
+  }
+  cluster_vswitch_id = alicloud_vswitch.user_test_vswitch.id
+  manager {
+    manager_node {
+      system_disk {
+        category = "cloud_essd"
+        size     = "40"
+        level    = "PL0"
+      }
+      enable_ht            = true
+      instance_charge_type = "PostPaid"
+      image_id             = "centos_7_6_x64_20G_alibase_20211130.vhd"
+      instance_type        = "ecs.c6.xlarge"
+      spot_strategy        = "NoSpot"
+    }
+    scheduler {
+      type    = "SLURM"
+      version = "22.05.8"
+    }
+    dns {
+      type    = "nis"
+      version = "1.0"
+    }
+    directory_service {
+      type    = "nis"
+      version = "1.0"
+    }
+  }
+}
+
+resource "alicloud_ehpc_cluster_v2" "user_cluster_test_auth_key" {
+  depends_on = [alicloud_nas_access_rule.user_test_access_rule]
+  cluster_credentials {
+    key_pair_name = alicloud_ecs_key_pair.default.id
+  }
+  cluster_vpc_id    = alicloud_vpc.user_test_vpc.id
+  cluster_category  = "Standard"
+  cluster_mode      = "Integrated"
+  security_group_id = alicloud_security_group.user_test_security_group.id
+  addons {
+    version        = "1.0"
+    services_spec  = <<EOF
+      [
+        {
+          "ServiceName": "SSH",
+          "NetworkACL": [
+            {
+              "Port": 22,
+              "SourceCidrIp": "0.0.0.0/0",
+              "IpProtocol": "TCP"
+            }
+          ]
+        },
+        {
+          "ServiceName": "VNC",
+          "NetworkACL": [
+            {
+              "Port": 12016,
+              "SourceCidrIp": "0.0.0.0/0",
+              "IpProtocol": "TCP"
+            }
+          ]
+        },
+        {
+          "ServiceName": "CLIENT",
+          "ServiceAccessType": "URL",
+          "ServiceAccessUrl": "https://ehpc-app.oss-cn-hangzhou.aliyuncs.com/ClientRelease/E-HPC-Client-Mac-zh-cn.zip",
+          "NetworkACL": [
+            {
+              "Port": 12011,
+              "SourceCidrIp": "0.0.0.0/0",
+              "IpProtocol": "TCP"
+            }
+          ]
+        }
+      ]
+  EOF
+    resources_spec = <<EOF
+      {
+        "EipResource": {
+          "AutoCreate": true
+        },
+        "EcsResources": [
+          {
+            "ImageId": "centos_7_6_x64_20G_alibase_20211130.vhd",
+            "EnableHT": true,
+            "InstanceChargeType": "PostPaid",
+            "InstanceType": "ecs.c7.xlarge",
+            "SpotStrategy": "NoSpot",
+            "SystemDisk": {
+              "Category": "cloud_essd",
+              "Size": 40,
+              "Level": "PL0"
+            },
+            "DataDisks": [
+              {
+                "Category": "cloud_essd",
+                "Size": 40,
+                "Level": "PL0"
+              }
+            ]
+          }
+        ]
+      }
+  EOF
+    name           = "Login"
+  }
+  cluster_name        = "minimal-test-cluster"
+  deletion_protection = false
+  shared_storages {
+    mount_directory     = "/home"
+    nas_directory       = "/"
+    mount_target_domain = alicloud_nas_mount_target.user_test_mount_domain.mount_target_domain
+    protocol_type       = "NFS"
+    file_system_id      = alicloud_nas_file_system.user_test_nas.id
+    mount_options       = "-t nfs -o vers=3,nolock,proto=tcp,noresvport"
+  }
+  shared_storages {
+    mount_directory     = "/opt"
+    nas_directory       = "/"
+    mount_target_domain = alicloud_nas_mount_target.user_test_mount_domain.mount_target_domain
+    protocol_type       = "NFS"
+    file_system_id      = alicloud_nas_file_system.user_test_nas.id
+    mount_options       = "-t nfs -o vers=3,nolock,proto=tcp,noresvport"
+  }
+  shared_storages {
+    mount_directory     = "/ehpcdata"
+    nas_directory       = "/"
+    mount_target_domain = alicloud_nas_mount_target.user_test_mount_domain.mount_target_domain
+    protocol_type       = "NFS"
+    file_system_id      = alicloud_nas_file_system.user_test_nas.id
+    mount_options       = "-t nfs -o vers=3,nolock,proto=tcp,noresvport"
+  }
+  cluster_vswitch_id = alicloud_vswitch.user_test_vswitch.id
+  manager {
+    manager_node {
+      system_disk {
+        category = "cloud_essd"
+        size     = "40"
+        level    = "PL0"
+      }
+      enable_ht            = true
+      instance_charge_type = "PostPaid"
+      image_id             = "centos_7_6_x64_20G_alibase_20211130.vhd"
+      instance_type        = "ecs.c6.xlarge"
+      spot_strategy        = "NoSpot"
+    }
+    scheduler {
+      type    = "SLURM"
+      version = "22.05.8"
+    }
+    dns {
+      type    = "nis"
+      version = "1.0"
+    }
+    directory_service {
+      type    = "nis"
+      version = "1.0"
+    }
+  }
+}
+`, name)
+}
+
+// Case User_authkey_test 13039
+func TestAccAliCloudEhpcUser_basic13039(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ehpc_user.default"
+	ra := resourceAttrInit(resourceId, AliCloudEhpcUserMap13038)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EhpcServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEhpcUser")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 100)
+	name := fmt.Sprintf("tfacc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEhpcUserBasicDependence13038)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group":      "users",
+					"user_name":  name,
+					"cluster_id": "${alicloud_ehpc_cluster_v2.user_cluster_test_auth_key.id}",
+					"password":   "YourPassword1234!",
+					"async":      true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group":      "users",
+						"user_name":  name,
+						"cluster_id": CHECKSET,
+						"password":   "YourPassword1234!",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group": "wheel",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group": "wheel",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group": "users",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group": "users",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"async", "password"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudEhpcUser_basic13039_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ehpc_user.default"
+	ra := resourceAttrInit(resourceId, AliCloudEhpcUserMap13038)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EhpcServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEhpcUser")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 100)
+	name := fmt.Sprintf("tfacc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEhpcUserBasicDependence13038)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group":      "users",
+					"user_name":  name,
+					"cluster_id": "${alicloud_ehpc_cluster_v2.user_cluster_test_auth_key.id}",
+					"password":   "YourPassword1234!",
+					"async":      true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group":      "users",
+						"user_name":  name,
+						"cluster_id": CHECKSET,
+						"password":   "YourPassword1234!",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"async", "password"},
+			},
+		},
+	})
+}

--- a/alicloud/service_alicloud_ehpc_v2.go
+++ b/alicloud/service_alicloud_ehpc_v2.go
@@ -205,3 +205,105 @@ func (s *EhpcServiceV2) EhpcQueueStateRefreshFuncWithApi(id string, field string
 }
 
 // DescribeEhpcQueue >>> Encapsulated.
+
+// DescribeEhpcUser <<< Encapsulated get interface for Ehpc User.
+
+func (s *EhpcServiceV2) DescribeEhpcUser(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var response map[string]interface{}
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return nil, err
+	}
+	request := map[string]interface{}{
+		"ClusterId":  parts[0],
+		"PageSize":   PageSizeLarge,
+		"PageNumber": 1,
+	}
+
+	action := "ListUsers"
+	idExist := false
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcGet("EHPC", "2018-04-12", action, request, nil)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"ClusterNotFound", "UserNotFound"}) {
+				return object, WrapErrorf(NotFoundErr("User", id), NotFoundMsg, response)
+			}
+			return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+		}
+
+		v, err := jsonpath.Get("$.Users.UserInfo", response)
+		if err != nil {
+			return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Users.UserInfo", response)
+		}
+		users, ok := v.([]interface{})
+		if !ok || len(users) < 1 {
+			return object, WrapErrorf(NotFoundErr("User", id), NotFoundWithResponse, response)
+		}
+		for _, u := range users {
+			user, ok := u.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if fmt.Sprint(user["Name"]) == parts[1] {
+				idExist = true
+				return user, nil
+			}
+		}
+		if len(users) < request["PageSize"].(int) {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+	if !idExist {
+		return object, WrapErrorf(NotFoundErr("User", id), NotFoundWithResponse, response)
+	}
+	return
+}
+
+func (s *EhpcServiceV2) EhpcUserStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.EhpcUserStateRefreshFuncWithApi(id, field, failStates, s.DescribeEhpcUser)
+}
+
+func (s *EhpcServiceV2) EhpcUserStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeEhpcUser >>> Encapsulated.

--- a/website/docs/r/ehpc_user.html.markdown
+++ b/website/docs/r/ehpc_user.html.markdown
@@ -1,0 +1,194 @@
+---
+subcategory: "Elastic High Performance Computing (Ehpc)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ehpc_user"
+description: |-
+  Provides a Alicloud Ehpc User resource.
+---
+
+# alicloud_ehpc_user
+
+Provides a Ehpc User resource.
+
+A user in an E-HPC cluster.
+
+For information about Ehpc User and how to use it, see [AddUsers](https://next.api.alibabacloud.com/document/EHPC/2018-04-12/AddUsers).
+
+-> **NOTE:** Available since v1.290.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_vpc" "user_password_example_vpc" {
+  is_default = false
+  cidr_block = "10.0.0.0/8"
+  vpc_name   = "user-password-example-vpc"
+}
+
+resource "alicloud_vswitch" "user_password_example_vswitch" {
+  is_default   = false
+  vpc_id       = alicloud_vpc.user_password_example_vpc.id
+  zone_id      = "cn-hangzhou-k"
+  cidr_block   = "10.0.0.0/24"
+  vswitch_name = "user-password-example-vsw"
+}
+
+resource "alicloud_nas_file_system" "user_password_example_nas" {
+  description  = "user-password-example-nas"
+  storage_type = "Capacity"
+  nfs_acl {
+    enabled = false
+  }
+  zone_id          = "cn-hangzhou-k"
+  encrypt_type     = "0"
+  protocol_type    = "NFS"
+  file_system_type = "standard"
+  recycle_bin {
+    status        = "Disable"
+    reserved_days = "7"
+  }
+}
+
+resource "alicloud_nas_access_group" "user_password_example_access_group" {
+  access_group_type = "Vpc"
+  description       = "user password example access group"
+  access_group_name = "UserPasswordTest"
+  file_system_type  = "standard"
+}
+
+resource "alicloud_nas_mount_target" "user_password_example_mount_domain" {
+  vpc_id            = alicloud_vpc.user_password_example_vpc.id
+  network_type      = "Vpc"
+  access_group_name = alicloud_nas_access_group.user_password_example_access_group.access_group_name
+  vswitch_id        = alicloud_vswitch.user_password_example_vswitch.id
+  file_system_id    = alicloud_nas_file_system.user_password_example_nas.id
+}
+
+resource "alicloud_security_group" "user_password_example_security_group" {
+  vpc_id              = alicloud_vpc.user_password_example_vpc.id
+  security_group_type = "normal"
+}
+
+resource "alicloud_nas_access_rule" "user_password_example_access_rule" {
+  priority          = "1"
+  access_group_name = alicloud_nas_access_group.user_password_example_access_group.access_group_name
+  file_system_type  = alicloud_nas_file_system.user_password_example_nas.file_system_type
+  source_cidr_ip    = "10.0.0.0/8"
+}
+
+resource "alicloud_ehpc_cluster_v2" "user_password_example_cluster" {
+  cluster_credentials {
+    password = "aliHPC123"
+  }
+  cluster_vpc_id      = alicloud_vpc.user_password_example_vpc.id
+  cluster_category    = "Standard"
+  cluster_mode        = "Integrated"
+  security_group_id   = alicloud_security_group.user_password_example_security_group.id
+  cluster_name        = "user-password-example-cluster"
+  deletion_protection = false
+  shared_storages {
+    mount_directory     = "/home"
+    nas_directory       = "/"
+    mount_target_domain = alicloud_nas_mount_target.user_password_example_mount_domain.mount_target_domain
+    protocol_type       = "NFS"
+    file_system_id      = alicloud_nas_file_system.user_password_example_nas.id
+    mount_options       = "-t nfs -o vers=3,nolock,proto=tcp,noresvport"
+  }
+  shared_storages {
+    mount_directory     = "/opt"
+    nas_directory       = "/"
+    mount_target_domain = alicloud_nas_mount_target.user_password_example_mount_domain.mount_target_domain
+    protocol_type       = "NFS"
+    file_system_id      = alicloud_nas_file_system.user_password_example_nas.id
+    mount_options       = "-t nfs -o vers=3,nolock,proto=tcp,noresvport"
+  }
+  shared_storages {
+    mount_directory     = "/ehpcdata"
+    nas_directory       = "/"
+    mount_target_domain = alicloud_nas_mount_target.user_password_example_mount_domain.mount_target_domain
+    protocol_type       = "NFS"
+    file_system_id      = alicloud_nas_file_system.user_password_example_nas.id
+    mount_options       = "-t nfs -o vers=3,nolock,proto=tcp,noresvport"
+  }
+  cluster_vswitch_id = alicloud_vswitch.user_password_example_vswitch.id
+  manager {
+    manager_node {
+      system_disk {
+        category = "cloud_essd"
+        size     = "40"
+        level    = "PL0"
+      }
+      enable_ht            = true
+      instance_charge_type = "PostPaid"
+      image_id             = "centos_7_6_x64_20G_alibase_20211130.vhd"
+      instance_type        = "ecs.c6.xlarge"
+      spot_strategy        = "NoSpot"
+    }
+    scheduler {
+      type    = "SLURM"
+      version = "22.05.8"
+    }
+    dns {
+      type    = "nis"
+      version = "1.0"
+    }
+    directory_service {
+      type    = "nis"
+      version = "1.0"
+    }
+  }
+}
+
+
+resource "alicloud_ehpc_user" "default" {
+  group      = "users"
+  user_name  = "passworduser1"
+  cluster_id = alicloud_ehpc_cluster_v2.user_password_example_cluster.id
+  password   = "UserPass123"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `async` - (Optional) Whether to use asynchronous message links to perform user operations.
+* `cluster_id` - (Required, ForceNew) The ID of the E-HPC cluster.
+* `group` - (Required) The group to which the E-HPC cluster user belongs. Valid values: `users`, `wheel`.
+* `password` - (Optional, Sensitive, ForceNew) The password of the E-HPC cluster user.
+
+-> **NOTE:** The `password` is accepted only during resource creation and is never returned. Changing it forces a new resource.
+* `user_name` - (Required, ForceNew) The name of the E-HPC cluster user.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The resource ID in terraform of User. It formats as `<cluster_id>:<user_name>`.
+* `region_id` - The region ID of the resource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 5 mins) Used when create the User.
+* `update` - (Defaults to 5 mins) Used when update the User.
+* `delete` - (Defaults to 5 mins) Used when delete the User.
+
+## Import
+
+Ehpc User can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ehpc_user.example <cluster_id>:<user_name>
+```


### PR DESCRIPTION
New Resource: alicloud_ehpc_user

Adds the `alicloud_ehpc_user` resource to manage users in an E-HPC (Elastic High Performance Computing) cluster.

This rebases and corrects the earlier work in #10284 (which had merge conflicts and targeted an incorrect API version) onto the latest master, aligned with the converged E-HPC 2018-04-12 API surface.

## Schema

- `cluster_id` - (Required, ForceNew) The ID of the E-HPC cluster.
- `user_name` - (Required, ForceNew) The name of the E-HPC cluster user.
- `group` - (Required) The user group. Valid values: `users`, `wheel`.
- `password` - (Optional, Sensitive, ForceNew) The password of the user.
- `async` - (Optional) Whether to use asynchronous message links to perform user operations.
- `region_id` - (Computed) The region ID.

The resource supports create (AddUsers), read (ListUsers), update (ModifyUserGroups), and delete (DeleteUsers) against the E-HPC 2018-04-12 API, and can be imported via `<cluster_id>:<user_name>`.

## Test cases

Test cases cover create, group update, password change (forces new), and import. Remote acceptance test verification is in progress.
