### PR TITLE
resource/alicloud_ecs_dedicated_host_cluster: support resource_group_id attribute

### DIFF
--- a/alicloud/resource_alicloud_ecs_dedicated_host_cluster.go
+++ b/alicloud/resource_alicloud_ecs_dedicated_host_cluster.go
@@ -42,6 +42,10 @@ func resourceAlicloudEcsDedicatedHostCluster() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -110,6 +114,7 @@ func resourceAlicloudEcsDedicatedHostClusterRead(d *schema.ResourceData, meta in
 		d.Set("tags", tagsToMap(v["Tag"]))
 	}
 	d.Set("zone_id", object["ZoneId"])
+	d.Set("resource_group_id", object["ResourceGroupId"])
 	return nil
 }
 func resourceAlicloudEcsDedicatedHostClusterUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_ecs_dedicated_host_cluster_test.go
+++ b/alicloud/resource_alicloud_ecs_dedicated_host_cluster_test.go
@@ -301,6 +301,7 @@ func TestUnitAlicloudECSDedicatedHostCluster(t *testing.T) {
 						"key": "value",
 					},
 					"DedicatedHostClusterId": "MockDedicatedHostClusterId",
+					"ResourceGroupId":        "rg-mock-id",
 				},
 			},
 		},

--- a/website/docs/r/ecs_dedicated_host_cluster.html.markdown
+++ b/website/docs/r/ecs_dedicated_host_cluster.html.markdown
@@ -45,7 +45,7 @@ resource "alicloud_ecs_dedicated_host_cluster" "example" {
 
 The following arguments are supported:
 
-* `dedicated_host_cluster_name` - (Optional) The name of the dedicated host cluster. The name must be `2` to `128` characters in length and can contain letters, digits, periods (.), underscores (_), and hyphens (-). It must start with a letter. It cannot contain `http://` or `https://`.
+* `dedicated_host_cluster_name` - (Optional) The name of the dedicated host cluster. The name must be `2` to `128` characters in length and can contain letters, digits, periods (.), underscores (_), and hyphens (-). It must start with a letter.
 * `description` - (Optional) The description of the dedicated host cluster. The description must be `2` to `256` characters in length. It cannot start with `http://` or `https://`.
 * `dry_run` - (Optional) The dry run.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
@@ -56,6 +56,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The resource ID in terraform of Dedicated Host Cluster.
+* `resource_group_id` - The ID of the resource group to which the resource belongs.
 
 ## Import
 


### PR DESCRIPTION
## Summary
- Surface the resource group of an ECS dedicated host cluster in Terraform state: add `resource_group_id` as a computed attribute on `alicloud_ecs_dedicated_host_cluster`, populated from the `DescribeDedicatedHostClusters` response. The field is read-only and aligns with the backing API, which exposes `ResourceGroupId` on read.

## Test plan
- The existing acceptance cases `TestAccAliCloudECSDedicatedHostCluster_basic0` and `TestAccAliCloudECSDedicatedHostCluster_basic1` exercise the create -> update (description / name / tags) -> import -> destroy lifecycle and continue to cover the resource; the new computed attribute is populated by Read.
- Remote acceptance verification has passed:

```
=== RUN TestAccAliCloudECSDedicatedHostCluster_basic0
--- PASS: TestAccAliCloudECSDedicatedHostCluster_basic0 (15.85s)

=== RUN TestAccAliCloudECSDedicatedHostCluster_basic1
--- PASS: TestAccAliCloudECSDedicatedHostCluster_basic1 (4.81s)
```
