### PR TITLE
resource/alicloud_security_group_rule: wait for rule visibility and paginate rule list

### DIFF
--- a/alicloud/resource_alicloud_security_group_rule.go
+++ b/alicloud/resource_alicloud_security_group_rule.go
@@ -310,7 +310,23 @@ func resourceAliyunSecurityGroupRuleRead(d *schema.ResourceData, meta interface{
 	sgId := parts[0]
 	direction := parts[1]
 
-	object, err := ecsService.DescribeSecurityGroupRule(d.Id())
+	// Wait for the rule to be visible: the rule list API may lag behind the
+	// just-issued AuthorizeSecurityGroup call, especially in batch creation.
+	var object ecs.Permission
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
+		obj, err := ecsService.DescribeSecurityGroupRule(d.Id())
+		if err != nil {
+			// Only the not-found case is retried; other errors fail fast.
+			if d.IsNewResource() && NotFoundError(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		object = obj
+		return nil
+	})
 	if err != nil {
 		if NotFoundError(err) && !d.IsNewResource() {
 			log.Printf("[DEBUG] Resource alicloud_security_group_rule ecsService.DescribeSecurityGroupRule Failed!!! %s", err)

--- a/alicloud/resource_alicloud_security_group_rule_test.go
+++ b/alicloud/resource_alicloud_security_group_rule_test.go
@@ -167,6 +167,39 @@ func TestAccAliCloudECSSecurityGroupRuleMulti(t *testing.T) {
 
 }
 
+func TestAccAliCloudECSSecurityGroupRuleBatch(t *testing.T) {
+	var v ecs.Permission
+	resourceId := "alicloud_security_group_rule.test.0"
+	name := acctest.RandString(4)
+	ra := resourceAttrInit(resourceId, testAccCheckSecurityGroupRuleBasicMap)
+	serviceFunc := func() interface{} {
+		return &EcsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckSecurityGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: hclSecurityGroupRuleBatch(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cidr_ip":                  "192.168.0.0/24",
+						"source_security_group_id": REMOVEKEY,
+					}),
+				),
+			},
+		},
+	})
+
+}
+
 func TestAccAliCloudECSSecurityGroupRulePrefixList(t *testing.T) {
 	var v ecs.Permission
 	resourceId := "alicloud_security_group_rule.test"
@@ -906,6 +939,45 @@ resource "alicloud_security_group_rule" "test" {
   cidr_ip           = element(var.cidr_ip_list, count.index)
 }
 `, name)
+}
+
+func hclSecurityGroupRuleBatch(name string) string {
+	cidrIpList := make([]string, 0, 40)
+	for i := 0; i < 40; i++ {
+		cidrIpList = append(cidrIpList, fmt.Sprintf(`"192.168.%d.0/24"`, i))
+	}
+	return fmt.Sprintf(`
+variable "name" {
+  default = "tf-testAccSGRBatch%s"
+}
+
+variable "cidr_ip_list" {
+  type    = "list"
+  default = [%s]
+}
+
+data "alicloud_vpcs" "test" {
+  name_regex = "^default-NODELETING$"
+}
+
+resource "alicloud_security_group" "test" {
+  security_group_name = var.name
+  description         = "Security group for batch rules"
+  vpc_id              = data.alicloud_vpcs.test.ids.0
+}
+
+resource "alicloud_security_group_rule" "test" {
+  count             = length(compact(var.cidr_ip_list))
+  security_group_id = alicloud_security_group.test.id
+  type              = "ingress"
+  policy            = "drop"
+  port_range        = "22/22"
+  ip_protocol       = "tcp"
+  nic_type          = "intranet"
+  priority          = 100
+  cidr_ip           = element(var.cidr_ip_list, count.index)
+}
+`, name, strings.Join(cidrIpList, ", "))
 }
 
 func hclSecurityGroupIngressRuleIpv6(name string) string {

--- a/alicloud/service_alicloud_ecs.go
+++ b/alicloud/service_alicloud_ecs.go
@@ -349,38 +349,52 @@ func (s *EcsService) DescribeSecurityGroupRule(id string) (rule ecs.Permission, 
 	request.SecurityGroupId = groupId
 	request.Direction = direction
 	request.NicType = nicType
+	// Fetch a full page at a time and follow NextToken so that rules beyond
+	// the first page are still visible for matching.
+	request.MaxResults = requests.NewInteger(1000)
 
-	var raw interface{}
-	wait := incrementalWait(3*time.Second, 5*time.Second)
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-		raw, err = s.client.WithEcsClient(func(ecsClient *ecs.Client) (interface{}, error) {
-			return ecsClient.DescribeSecurityGroupAttribute(request)
-		})
-		if err != nil {
-			if NeedRetry(err) {
-				wait()
-				return resource.RetryableError(err)
+	permissions := make([]ecs.Permission, 0)
+	var response *ecs.DescribeSecurityGroupAttributeResponse
+	for {
+		var raw interface{}
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			raw, err = s.client.WithEcsClient(func(ecsClient *ecs.Client) (interface{}, error) {
+				return ecsClient.DescribeSecurityGroupAttribute(request)
+			})
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
 			}
-			return resource.NonRetryableError(err)
-		}
-		return nil
-	})
-	addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+			return nil
+		})
+		addDebug(request.GetActionName(), raw, request.RpcRequest, request)
 
-	response, _ := raw.(*ecs.DescribeSecurityGroupAttributeResponse)
+		response, _ = raw.(*ecs.DescribeSecurityGroupAttributeResponse)
 
-	if err != nil {
-		if IsExpectedErrors(err, []string{"InvalidSecurityGroupId.NotFound"}) {
-			return rule, WrapErrorf(NotFoundErr("SecurityGroup:Rule", id), NotFoundMsg, ProviderERROR, fmt.Sprint(response.RequestId))
+		if err != nil {
+			if IsExpectedErrors(err, []string{"InvalidSecurityGroupId.NotFound"}) {
+				return rule, WrapErrorf(NotFoundErr("SecurityGroup:Rule", id), NotFoundMsg, ProviderERROR, fmt.Sprint(response.RequestId))
+			}
+			return rule, WrapErrorf(err, DefaultErrorMsg, id, request.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
-		return rule, WrapErrorf(err, DefaultErrorMsg, id, request.GetActionName(), AlibabaCloudSdkGoERROR)
+
+		if response == nil {
+			return rule, GetNotFoundErrorFromString(GetNotFoundMessage("Security Group", groupId))
+		}
+
+		permissions = append(permissions, response.Permissions.Permission...)
+
+		if response.NextToken == "" {
+			break
+		}
+		request.NextToken = response.NextToken
 	}
 
-	if response == nil {
-		return rule, GetNotFoundErrorFromString(GetNotFoundMessage("Security Group", groupId))
-	}
-
-	for _, ru := range response.Permissions.Permission {
+	for _, ru := range permissions {
 		if strings.ToLower(string(ru.IpProtocol)) == ipProtocol && ru.PortRange == portRange {
 
 			var cidr string


### PR DESCRIPTION
### Description

Fixes #3079

`alicloud_security_group_rule` fails during batch creation with:

```
Error: Provider produced inconsistent result after apply
... alicloud_security_group_rule.xxx: "id": was present, but now absent
```

Two contributing problems:

1. **Read-after-write visibility gap** — `DescribeSecurityGroupAttribute` may not immediately return a just-created rule (the rule list lags behind `AuthorizeSecurityGroup`, especially when many rules are created in a row). The Read path had no tolerance for this on new resources, so the post-Create read-back reported the rule missing and removed the ID from state mid-apply. A wait gated on `d.IsNewResource()` existed historically but was dropped in v1.254.0.
2. **Single-page rule matching** — `DescribeSecurityGroupAttribute` returns at most one page of same-direction rules; the provider never set `MaxResults` or followed `NextToken`, so on security groups with many rules the match could miss an existing rule and report it not found.

### Changes

- `resource_alicloud_security_group_rule.go` — Read: retry `DescribeSecurityGroupRule` for up to 10 minutes when a **new** resource is reported not found (`NotFoundError` only). Refresh keeps existing behavior (missing rule → removed from state).
- `service_alicloud_ecs.go` — `DescribeSecurityGroupRule`: `MaxResults=1000` + follow `NextToken` to collect all pages before matching.
- `resource_alicloud_security_group_rule_test.go` — new `TestAccAliCloudECSSecurityGroupRuleBatch` covering `count`-based batch creation of 40 rules.

### ACC Test

PASS: TestAccAliCloudECSSecurityGroupRuleBasic (54.23s), TestAccAliCloudECSSecurityGroupRuleMulti (24.52s), TestAccAliCloudECSSecurityGroupRuleBatch (28.87s), TestAccAliCloudECSSecurityGroupRuleEgress (27.61s), TestAccAliCloudECSSecurityGroupRulePrefixList (14.29s), TestAccAliCloudECSSecurityGroupRuleIngressIpv6 (15.11s), TestAccAliCloudECSSecurityGroupRuleIngressOtherIpv6 (14.57s), TestAccAliCloudECSSecurityGroupRuleSourceGroupOwnerIDCrossAccount (26.88s)
