### PR TITLE
ci: re-run PR title check when the title is edited

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -2,6 +2,7 @@ name: Pull Request Checks
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     branches:
       - master
 


### PR DESCRIPTION
### Description

The `Pull Request Title` check in `.github/workflows/pull_requests.yml` validates the PR title against the changed files, but the workflow only triggers on the default activity types (`opened`, `synchronize`, `reopened`):

- Editing a PR title fires an `edited` event that nobody listens to → the check never re-runs, and a previously failed result stays pinned to the PR until a new `opened`/`synchronize`/`reopened` event fires (today this requires pushing a commit or closing + reopening the PR).
- Re-running the failed job does not help either: re-runs replay the trigger-time event payload, so the script still validates the old title.

### Changes

Add the `edited` activity type so the title check re-validates immediately when the title is changed:

```yaml
on:
  pull_request:
    types: [opened, synchronize, reopened, edited]
    branches:
      - master
```

Note: `types:` replaces the default set, so all three defaults are listed explicitly. Since `edited` also fires on PR body edits, this cheap workflow (~10s, title + max-commits jobs) may re-run a few extra times; all other workflows keep their own triggers.
