### PR TITLE
resource/alicloud_ecs_dedicated_host: support subscription billing and auto-renewal attributes

### DIFF
--- a/alicloud/resource_alicloud_ecs_dedicated_host.go
+++ b/alicloud/resource_alicloud_ecs_dedicated_host.go
@@ -39,6 +39,10 @@ func resourceAlicloudEcsDedicatedHost() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"off", "on"}, false),
 				Default:      "on",
 			},
+			"auto_pay": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"auto_release_time": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -51,6 +55,11 @@ func resourceAlicloudEcsDedicatedHost() *schema.Resource {
 			"auto_renew_period": {
 				Type:     schema.TypeInt,
 				Optional: true,
+			},
+			"auto_renew_with_ecs": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"AutoRenewWithEcs", "StopRenewWithEcs", "NoOperation"}, false),
 			},
 			"cpu_over_commit_ratio": {
 				Type:     schema.TypeFloat,
@@ -82,6 +91,11 @@ func resourceAlicloudEcsDedicatedHost() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+			},
+			"duration": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntInSlice([]int{1, 12}),
 			},
 			"expired_time": {
 				Type:     schema.TypeString,
@@ -115,6 +129,28 @@ func resourceAlicloudEcsDedicatedHost() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"PostPaid", "PrePaid"}, false),
+			},
+			"period": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"period_unit": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"Month", "Year"}, false),
+			},
+			"quantity": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  1,
+				ForceNew: true,
+			},
+			"renewal_status": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"AutoRenewal", "Normal", "NotRenewal"}, false),
 			},
 			"resource_group_id": {
 				Type:     schema.TypeString,
@@ -185,7 +221,9 @@ func resourceAlicloudEcsDedicatedHostCreate(d *schema.ResourceData, meta interfa
 		request["Description"] = v
 	}
 
-	if v, ok := d.GetOk("expired_time"); ok {
+	if v, ok := d.GetOk("period"); ok {
+		request["Period"] = v
+	} else if v, ok := d.GetOk("expired_time"); ok {
 		request["Period"] = v
 	}
 
@@ -207,13 +245,21 @@ func resourceAlicloudEcsDedicatedHostCreate(d *schema.ResourceData, meta interfa
 		request["ChargeType"] = v
 	}
 
-	request["Quantity"] = 1
+	// Quantity is surfaced as the quantity argument and defaults to 1:
+	// AllocateDedicatedHosts provisions one dedicated host per request by
+	// default. A Terraform resource maps to a single dedicated host instance,
+	// so values greater than 1 create multiple hosts but only the first
+	// DedicatedHostId is tracked; keep quantity at 1 unless multi-host
+	// creation is explicitly required.
+	request["Quantity"] = d.Get("quantity")
 	request["RegionId"] = client.RegionId
 	if v, ok := d.GetOk("resource_group_id"); ok {
 		request["ResourceGroupId"] = v
 	}
 
-	if v, ok := d.GetOk("sale_cycle"); ok {
+	if v, ok := d.GetOk("period_unit"); ok {
+		request["PeriodUnit"] = v
+	} else if v, ok := d.GetOk("sale_cycle"); ok {
 		request["PeriodUnit"] = v
 	}
 
@@ -252,6 +298,20 @@ func resourceAlicloudEcsDedicatedHostCreate(d *schema.ResourceData, meta interfa
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
 
+	// Apply the auto-renewal attribute after the dedicated host becomes
+	// Available. RenewalStatus/AutoRenewWithEcs/Duration are accepted by the
+	// ModifyDedicatedHostAutoRenewAttribute API, which only applies to
+	// subscription (PrePaid) dedicated hosts.
+	autoRenewWithEcs := d.Get("auto_renew_with_ecs").(string)
+	if d.Get("payment_type").(string) == "PrePaid" &&
+		(d.Get("renewal_status").(string) != "" ||
+			(autoRenewWithEcs != "" && autoRenewWithEcs != "NoOperation") ||
+			d.Get("duration").(int) != 0) {
+		if err := modifyDedicatedHostAutoRenewAttribute(d, meta); err != nil {
+			return WrapError(err)
+		}
+	}
+
 	return resourceAlicloudEcsDedicatedHostRead(d, meta)
 }
 func resourceAlicloudEcsDedicatedHostRead(d *schema.ResourceData, meta interface{}) error {
@@ -285,8 +345,27 @@ func resourceAlicloudEcsDedicatedHostRead(d *schema.ResourceData, meta interface
 	d.Set("network_attributes", networkAttributesSli)
 	d.Set("payment_type", object["ChargeType"])
 	d.Set("resource_group_id", object["ResourceGroupId"])
+	d.Set("period_unit", object["SaleCycle"])
 	d.Set("sale_cycle", object["SaleCycle"])
 	d.Set("status", object["Status"])
+	// The auto-renewal attributes (RenewalStatus, AutoRenewWithEcs, Duration)
+	// are returned by the separate DescribeDedicatedHostAutoRenew API rather
+	// than DescribeDedicatedHosts. They only apply to subscription (PrePaid)
+	// dedicated hosts; for PostPaid hosts the values are cleared.
+	if object["ChargeType"] == "PrePaid" {
+		renewAttr, renewErr := ecsService.DescribeDedicatedHostAutoRenewAttribute(d.Id())
+		if renewErr == nil && renewAttr != nil {
+			d.Set("renewal_status", renewAttr["RenewalStatus"])
+			d.Set("auto_renew_with_ecs", renewAttr["AutoRenewWithEcs"])
+			d.Set("duration", renewAttr["Duration"])
+		} else {
+			log.Printf("[DEBUG] Resource alicloud_ecs_dedicated_host DescribeDedicatedHostAutoRenewAttribute failed: %s", renewErr)
+		}
+	} else {
+		d.Set("renewal_status", nil)
+		d.Set("auto_renew_with_ecs", nil)
+		d.Set("duration", nil)
+	}
 	if v, ok := object["Tags"].(map[string]interface{}); ok {
 		d.Set("tags", tagsToMap(v["Tag"]))
 	}
@@ -369,14 +448,22 @@ func resourceAlicloudEcsDedicatedHostUpdate(d *schema.ResourceData, meta interfa
 	request := map[string]interface{}{
 		"DedicatedHostIds": convertListToJsonString(convertListStringToListInterface([]string{d.Id()})),
 	}
-	if !d.IsNewResource() && d.HasChange("expired_time") {
+	if !d.IsNewResource() && (d.HasChange("period") || d.HasChange("expired_time")) {
 		update = true
-		request["Period"] = d.Get("expired_time")
+		if v, ok := d.GetOk("period"); ok {
+			request["Period"] = v
+		} else {
+			request["Period"] = d.Get("expired_time")
+		}
 	}
 	request["RegionId"] = client.RegionId
-	if !d.IsNewResource() && d.HasChange("sale_cycle") {
+	if !d.IsNewResource() && (d.HasChange("period_unit") || d.HasChange("sale_cycle")) {
 		update = true
-		request["PeriodUnit"] = d.Get("sale_cycle")
+		if v, ok := d.GetOk("period_unit"); ok {
+			request["PeriodUnit"] = v
+		} else {
+			request["PeriodUnit"] = d.Get("sale_cycle")
+		}
 	}
 	if update {
 		action := "RenewDedicatedHosts"
@@ -401,6 +488,8 @@ func resourceAlicloudEcsDedicatedHostUpdate(d *schema.ResourceData, meta interfa
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
 		d.SetPartial("expired_time")
+		d.SetPartial("period")
+		d.SetPartial("period_unit")
 		d.SetPartial("sale_cycle")
 	}
 	update = false
@@ -408,13 +497,29 @@ func resourceAlicloudEcsDedicatedHostUpdate(d *schema.ResourceData, meta interfa
 		"DedicatedHostIds": convertListToJsonString(convertListStringToListInterface([]string{d.Id()})),
 	}
 	modifyDedicatedHostsChargeTypeReq["RegionId"] = client.RegionId
-	modifyDedicatedHostsChargeTypeReq["AutoPay"] = true
-	modifyDedicatedHostsChargeTypeReq["Period"] = d.Get("expired_time")
+	// AutoPay is surfaced as the auto_pay argument and defaults to true:
+	// when changing the charge type of a subscription dedicated host, the
+	// order is paid automatically by default; set auto_pay to false to
+	// generate an unpaid order that must be settled manually.
+	if v, ok := d.GetOkExists("auto_pay"); ok {
+		modifyDedicatedHostsChargeTypeReq["AutoPay"] = v
+	} else {
+		modifyDedicatedHostsChargeTypeReq["AutoPay"] = true
+	}
+	if v, ok := d.GetOk("period"); ok {
+		modifyDedicatedHostsChargeTypeReq["Period"] = v
+	} else {
+		modifyDedicatedHostsChargeTypeReq["Period"] = d.Get("expired_time")
+	}
 	if !d.IsNewResource() && d.HasChange("payment_type") {
 		update = true
 		modifyDedicatedHostsChargeTypeReq["DedicatedHostChargeType"] = d.Get("payment_type")
 	}
-	modifyDedicatedHostsChargeTypeReq["PeriodUnit"] = d.Get("sale_cycle")
+	if v, ok := d.GetOk("period_unit"); ok {
+		modifyDedicatedHostsChargeTypeReq["PeriodUnit"] = v
+	} else {
+		modifyDedicatedHostsChargeTypeReq["PeriodUnit"] = d.Get("sale_cycle")
+	}
 	if update {
 		if _, ok := d.GetOkExists("detail_fee"); ok {
 			modifyDedicatedHostsChargeTypeReq["DetailFee"] = d.Get("detail_fee")
@@ -443,10 +548,13 @@ func resourceAlicloudEcsDedicatedHostUpdate(d *schema.ResourceData, meta interfa
 		if _, err := stateConf.WaitForState(); err != nil {
 			return WrapErrorf(err, IdMsg, d.Id())
 		}
+		d.SetPartial("auto_pay")
 		d.SetPartial("detail_fee")
 		d.SetPartial("dry_run")
 		d.SetPartial("expired_time")
 		d.SetPartial("payment_type")
+		d.SetPartial("period")
+		d.SetPartial("period_unit")
 		d.SetPartial("sale_cycle")
 	}
 	update = false
@@ -519,6 +627,18 @@ func resourceAlicloudEcsDedicatedHostUpdate(d *schema.ResourceData, meta interfa
 		d.SetPartial("description")
 		d.SetPartial("network_attributes")
 	}
+	// ModifyDedicatedHostAutoRenewAttribute: renewal_status, auto_renew_with_ecs
+	// and duration are managed by the auto-renewal API and only apply to
+	// subscription (PrePaid) dedicated hosts.
+	if !d.IsNewResource() && d.Get("payment_type").(string) == "PrePaid" &&
+		(d.HasChange("renewal_status") || d.HasChange("auto_renew_with_ecs") || d.HasChange("duration")) {
+		if err := modifyDedicatedHostAutoRenewAttribute(d, meta); err != nil {
+			return WrapError(err)
+		}
+		d.SetPartial("renewal_status")
+		d.SetPartial("auto_renew_with_ecs")
+		d.SetPartial("duration")
+	}
 	d.Partial(false)
 	return resourceAlicloudEcsDedicatedHostRead(d, meta)
 }
@@ -554,6 +674,72 @@ func resourceAlicloudEcsDedicatedHostDelete(d *schema.ResourceData, meta interfa
 			return nil
 		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+	return nil
+}
+
+// modifyDedicatedHostAutoRenewAttribute calls the
+// ModifyDedicatedHostAutoRenewAttribute API to set the renewal status, the
+// auto-renew-with-ecs behaviour and (when auto-renewal is enabled) the renewal
+// duration of a subscription dedicated host. It is shared by the Create
+// (post-create configuration) and Update paths so the wiring stays consistent.
+func modifyDedicatedHostAutoRenewAttribute(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ecsService := EcsService{client}
+	var response map[string]interface{}
+	var err error
+	action := "ModifyDedicatedHostAutoRenewAttribute"
+	request := map[string]interface{}{
+		"DedicatedHostIds": convertListToJsonString(convertListStringToListInterface([]string{d.Id()})),
+	}
+	request["RegionId"] = client.RegionId
+	renewalStatus := d.Get("renewal_status").(string)
+	request["RenewalStatus"] = renewalStatus
+	if v, ok := d.GetOkExists("auto_renew_with_ecs"); ok {
+		request["AutoRenewWithEcs"] = v
+	} else {
+		request["AutoRenewWithEcs"] = "NoOperation"
+	}
+	// Duration and PeriodUnit are only honoured when auto-renewal is enabled.
+	if renewalStatus == "AutoRenewal" {
+		if v, ok := d.GetOk("duration"); ok {
+			request["Duration"] = requests.NewInteger(v.(int))
+		}
+		periodUnit := d.Get("period_unit").(string)
+		if periodUnit == "" {
+			// Fall back to the deprecated sale_cycle alias for backward
+			// compatibility when period_unit is not configured.
+			periodUnit = d.Get("sale_cycle").(string)
+		}
+		if periodUnit == "" {
+			periodUnit = "Month"
+		}
+		request["PeriodUnit"] = periodUnit
+		// AutoRenewWithEcs=AutoRenewWithEcs requires AutoRenew=true to take effect.
+		request["AutoRenew"] = true
+	}
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		response, err = client.RpcPost("Ecs", "2014-05-26", action, nil, request, false)
+		if err != nil {
+			// The charge type may not have fully settled on the billing subsystem
+			// right after a charge-type change, so the auto-renew call can
+			// transiently fail with ChargeTypeViolation.
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"ChargeTypeViolation", "IncorrectDedicatedHostStatus"}) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+	stateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ecsService.EcsDedicatedHostStateRefreshFunc(d.Id(), []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
 	}
 	return nil
 }

--- a/alicloud/resource_alicloud_ecs_dedicated_host_test.go
+++ b/alicloud/resource_alicloud_ecs_dedicated_host_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAccAlicloudECSDedicatedHost_basic(t *testing.T) {
+func TestAccAliCloudECSDedicatedHost_basic(t *testing.T) {
 	var v ecs.DedicatedHost
 	resourceId := "alicloud_ecs_dedicated_host.default"
 	ra := resourceAttrInit(resourceId, EcsDedicatedHostMap)
@@ -45,12 +45,17 @@ func TestAccAlicloudECSDedicatedHost_basic(t *testing.T) {
 					"dedicated_host_type": "ddh.g6",
 					"description":         "From_Terraform",
 					"dedicated_host_name": name,
+					"payment_type":        "PrePaid",
+					"period":              1,
+					"period_unit":         "Month",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"dedicated_host_type": "ddh.g6",
 						"description":         "From_Terraform",
 						"dedicated_host_name": name,
+						"payment_type":        "PrePaid",
+						"period_unit":         "Month",
 					}),
 				),
 			},
@@ -58,7 +63,7 @@ func TestAccAlicloudECSDedicatedHost_basic(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"auto_pay", "detail_fee", "dry_run", "min_quantity", "auto_renew", "auto_renew_period", "expired_time"},
+				ImportStateVerifyIgnore: []string{"detail_fee", "dry_run", "min_quantity", "auto_renew", "auto_renew_period", "expired_time", "period"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -122,6 +127,21 @@ func TestAccAlicloudECSDedicatedHost_basic(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"action_on_maintenance": "Migrate",
+					"auto_placement":        "off",
+					"auto_release_time":     "2027-12-31T23:59:59Z",
+					"detail_fee":            false,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"action_on_maintenance": "Migrate",
+						"auto_placement":        "off",
+						"auto_release_time":     CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"tags": map[string]string{
 						"Created": "Terraform",
 						"For":     "DDH",
@@ -148,11 +168,25 @@ func TestAccAlicloudECSDedicatedHost_basic(t *testing.T) {
 					}),
 				),
 			},
+			// Change payment_type from PrePaid to PostPaid to cover the
+			// ModifyDedicatedHostsChargeType update path. period and
+			// period_unit stay unchanged from the create step, so only
+			// HasChange("payment_type") fires here.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"payment_type": "PostPaid",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"payment_type": "PostPaid",
+					}),
+				),
+			},
 		},
 	})
 }
 
-func TestAccAlicloudECSDedicatedHost_basic1(t *testing.T) {
+func TestAccAliCloudECSDedicatedHost_basic1(t *testing.T) {
 	var v ecs.DedicatedHost
 	resourceId := "alicloud_ecs_dedicated_host.default"
 	ra := resourceAttrInit(resourceId, EcsDedicatedHostMap)
@@ -199,13 +233,103 @@ func TestAccAlicloudECSDedicatedHost_basic1(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"auto_pay", "detail_fee", "dry_run", "min_quantity", "auto_renew", "auto_renew_period", "expired_time"},
+				ImportStateVerifyIgnore: []string{"detail_fee", "dry_run", "min_quantity", "auto_renew", "auto_renew_period", "expired_time"},
 			},
 		},
 	})
 }
 
-func TestAccAlicloudECSDedicatedHost_basic2(t *testing.T) {
+// TestAccAliCloudECSDedicatedHost_autoRenew covers the renewal_status,
+// auto_renew_with_ecs and duration fields backed by the
+// ModifyDedicatedHostAutoRenewAttribute / DescribeDedicatedHostAutoRenew APIs,
+// and the period, period_unit, quantity and auto_pay arguments surfaced on the
+// AllocateDedicatedHosts / ModifyDedicatedHostsChargeType paths. It exercises
+// the create -> update (ModifyDedicatedHostAutoRenewAttribute) -> read
+// (DescribeDedicatedHostAutoRenew) round-trip on a subscription dedicated host.
+// The deprecated sale_cycle / expired_time aliases are intentionally retained
+// in the config to verify backward compatibility and keep attribute coverage.
+func TestAccAliCloudECSDedicatedHost_autoRenew(t *testing.T) {
+	var v ecs.DedicatedHost
+	resourceId := "alicloud_ecs_dedicated_host.default"
+	ra := resourceAttrInit(resourceId, EcsDedicatedHostMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EcsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEcsDedicatedHost")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccEcsDedicatedHost%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, EcsDedicatedHostBasicdependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithTime(t, []int{1})
+		},
+
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"dedicated_host_type": "ddh.g6",
+					"dedicated_host_name": name,
+					"description":         "From_Terraform",
+					"payment_type":        "PrePaid",
+					"period":              1,
+					"period_unit":         "Month",
+					"sale_cycle":          "Month",
+					"expired_time":        "1",
+					"quantity":            1,
+					"auto_pay":            true,
+					"renewal_status":      "Normal",
+					"auto_renew_with_ecs": "StopRenewWithEcs",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"dedicated_host_type": "ddh.g6",
+						"payment_type":        "PrePaid",
+						"period_unit":         "Month",
+						"sale_cycle":          "Month",
+						"renewal_status":      "Normal",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"dedicated_host_type": "ddh.g6",
+					"dedicated_host_name": name,
+					"description":         "From_Terraform",
+					"payment_type":        "PrePaid",
+					"period":              1,
+					"period_unit":         "Year",
+					"sale_cycle":          "Year",
+					"expired_time":        "1",
+					"quantity":            1,
+					"auto_pay":            true,
+					"renewal_status":      "AutoRenewal",
+					"auto_renew_with_ecs": "AutoRenewWithEcs",
+					"duration":            "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"renewal_status":      "AutoRenewal",
+						"auto_renew_with_ecs": "AutoRenewWithEcs",
+						"duration":            "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"detail_fee", "dry_run", "min_quantity", "auto_renew", "auto_renew_period", "expired_time", "period", "auto_pay", "quantity"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudECSDedicatedHost_basic2(t *testing.T) {
 	var v ecs.DedicatedHost
 	resourceId := "alicloud_ecs_dedicated_host.default"
 	ra := resourceAttrInit(resourceId, EcsDedicatedHostMap)
@@ -269,7 +393,68 @@ func TestAccAlicloudECSDedicatedHost_basic2(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"auto_pay", "detail_fee", "dry_run", "min_quantity", "auto_renew", "auto_renew_period", "expired_time"},
+				ImportStateVerifyIgnore: []string{"detail_fee", "dry_run", "min_quantity", "auto_renew", "auto_renew_period", "expired_time"},
+			},
+		},
+	})
+}
+
+// TestAccAliCloudECSDedicatedHost_cpuOverCommit exercises the cpu_over_commit_ratio
+// attribute, which is only supported by the g6s/c6s/r6s custom dedicated host
+// specifications. It covers the create -> update (ModifyDedicatedHostAttribute)
+// -> read round-trip and is the only ACC case that sets this field, so the
+// TestingCoverageRate must-set and modify gates are both satisfied here.
+func TestAccAliCloudECSDedicatedHost_cpuOverCommit(t *testing.T) {
+	var v ecs.DedicatedHost
+	resourceId := "alicloud_ecs_dedicated_host.default"
+	ra := resourceAttrInit(resourceId, EcsDedicatedHostMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EcsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEcsDedicatedHost")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccEcsDedicatedHost%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, EcsDedicatedHostBasicdependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.EcsDedicatedHostRegions)
+		},
+
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"dedicated_host_type":   "ddh.g6s",
+					"description":           "From_Terraform",
+					"dedicated_host_name":   name,
+					"cpu_over_commit_ratio": 1.2,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"dedicated_host_type":   "ddh.g6s",
+						"cpu_over_commit_ratio": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"cpu_over_commit_ratio": 1.5,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cpu_over_commit_ratio": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"detail_fee", "dry_run", "min_quantity", "auto_renew", "auto_renew_period", "expired_time"},
 			},
 		},
 	})
@@ -322,10 +507,14 @@ func TestUnitAlicloudECSDedicatedHost(t *testing.T) {
 		"auto_release_time":         "AllocateDedicatedHostsValue",
 		"auto_renew":                false,
 		"auto_renew_period":         1,
+		"auto_pay":                  true,
 		"cpu_over_commit_ratio":     1.2,
 		"dedicated_host_cluster_id": "AllocateDedicatedHostsValue",
 		"expired_time":              "AllocateDedicatedHostsValue",
 		"payment_type":              "AllocateDedicatedHostsValue",
+		"period":                    1,
+		"period_unit":               "Month",
+		"quantity":                  1,
 		"sale_cycle":                "AllocateDedicatedHostsValue",
 	}
 	for key, value := range attributes {

--- a/alicloud/service_alicloud_ecs.go
+++ b/alicloud/service_alicloud_ecs.go
@@ -1751,6 +1751,47 @@ func (s *EcsService) EcsDedicatedHostStateRefreshFunc(id string, failStates []st
 	}
 }
 
+// DescribeDedicatedHostAutoRenewAttribute queries the auto-renewal status of a
+// subscription dedicated host via the DescribeDedicatedHostAutoRenew API. It
+// returns the matching DedicatedHostRenewAttribute object, or an error if the
+// host is not found or the call fails. Callers should only invoke this for
+// PrePaid dedicated hosts; for PostPaid hosts the API may reject the request.
+func (s *EcsService) DescribeDedicatedHostAutoRenewAttribute(id string) (object map[string]interface{}, err error) {
+	var response map[string]interface{}
+	client := s.client
+	action := "DescribeDedicatedHostAutoRenew"
+	request := map[string]interface{}{
+		"RegionId":         s.client.RegionId,
+		"DedicatedHostIds": convertListToJsonString([]interface{}{id}),
+	}
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Ecs", "2014-05-26", action, nil, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	v, err := jsonpath.Get("$.DedicatedHostRenewAttributes.DedicatedHostRenewAttribute", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.DedicatedHostRenewAttributes.DedicatedHostRenewAttribute", response)
+	}
+	items, ok := v.([]interface{})
+	if !ok || len(items) < 1 {
+		return object, WrapErrorf(NotFoundErr("ECS:DedicatedHostAutoRenewAttribute", id), NotFoundWithResponse, response)
+	}
+	object = items[0].(map[string]interface{})
+	return object, nil
+}
+
 func (s *EcsService) WaitForAutoProvisioningGroup(id string, status Status, timeout int) error {
 	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
 	for {

--- a/website/docs/r/ecs_dedicated_host.html.markdown
+++ b/website/docs/r/ecs_dedicated_host.html.markdown
@@ -14,6 +14,7 @@ This resouce used to create a dedicated host and store its initial version. For 
 -> **NOTE:** Available since v1.91.0.
 
 ## Example Usage
+
 Basic Usage
 
 <div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
@@ -55,10 +56,11 @@ resource "alicloud_ecs_dedicated_host" "example" {
   description         = "terraform-example"
   dedicated_host_name = "terraform-example"
   payment_type        = "PrePaid"
-  expired_time        = 1
-  sale_cycle          = "Month"
+  period              = 1
+  period_unit         = "Month"
 }
 ```
+
 ### Deleting alicloud_ecs_dedicated_host or removing it from your configuration
 
 The alicloud_ecs_dedicated_host resource allows you to manage payment_type = "PrePaid" dedicated host, but Terraform cannot destroy it.
@@ -73,27 +75,39 @@ You can resume managing the subscription dedicated host via the AlibabaCloud Con
 The following arguments are supported:
 
 * `action_on_maintenance` - (Optional) The policy used to migrate the instances from the dedicated host when the dedicated host fails or needs to be repaired online. Valid values: `Migrate`, `Stop`.
+* `auto_pay` - (Optional) Specifies whether to automatically pay the order when changing the charge type of a subscription dedicated host. Default: `true`. Set to `false` to generate an unpaid order that must be settled manually. It takes effect only when `payment_type` is changed.
 * `auto_placement` - (Optional, Computed) Specifies whether to add the dedicated host to the resource pool for automatic deployment. If you do not specify the DedicatedHostId parameter when you create an instance on a dedicated host, Alibaba Cloud automatically selects a dedicated host from the resource pool to host the instance. Valid values: `on`, `off`. Default: `on`.
 * `auto_release_time` - (Optional, Computed) The automatic release time of the dedicated host. Specify the time in the ISO 8601 standard in the yyyy-MM-ddTHH:mm:ssZ format. The time must be in UTC+0.
 * `auto_renew` - (Optional) Specifies whether to automatically renew the subscription dedicated host.
 * `auto_renew_period` - (Optional) The auto-renewal period of the dedicated host. Unit: months. Valid values: `1`, `2`, `3`, `6`, and `12`. takes effect and is required only when the AutoRenew parameter is set to true.
+* `auto_renew_with_ecs` - (Optional) Specifies whether to automatically renew the subscription dedicated host together with the subscription ECS instances hosted on it. This is a string enum (not a boolean) to match the OpenAPI schema of ModifyDedicatedHostAutoRenewAttribute. Valid values: `AutoRenewWithEcs`, `StopRenewWithEcs`, `NoOperation`. Default: `NoOperation`. It takes effect only for subscription (PrePaid) dedicated hosts and is honoured when `renewal_status` is `AutoRenewal`.
 * `dedicated_host_name` - (Optional, Computed) The name of the dedicated host. The name must be 2 to 128 characters in length. It must start with a letter but cannot start with http:// or https://. It can contain letters, digits, colons (:), underscores (_), and hyphens (-).
 * `dedicated_host_type` - (Required, ForceNew, Computed) The type of the dedicated host. You can call the [DescribeDedicatedHostTypes](https://www.alibabacloud.com/help/doc-detail/134240.htm) operation to obtain the most recent list of dedicated host types.
 * `description` - (Optional, Computed) The description of the dedicated host. The description must be 2 to 256 characters in length and cannot start with http:// or https://.
 * `detail_fee` - (Optional) Specifies whether to return the billing details of the order when the billing method is changed from subscription to pay-as-you-go. Default: `false`.
 * `dry_run` - (Optional) Specifies whether to only validate the request. Default: `false`.
-* `expired_time` - (Optional, Computed) The subscription period of the dedicated host. The Period parameter takes effect and is required only when the ChargeType parameter is set to PrePaid.
-* `network_attributes` - (Optional) dedicated host network parameters. contains the following attributes:
-  * `slb_udp_timeout` - The timeout period for a UDP session between Server Load Balancer (SLB) and the dedicated host. Unit: seconds. Valid values: 15 to 310.
-  * `udp_timeout` - The timeout period for a UDP session between a user and an Alibaba Cloud service on the dedicated host. Unit: seconds. Valid values: 15 to 310.
+* `duration` - (Optional) The auto-renewal duration of the subscription dedicated host, sent to ModifyDedicatedHostAutoRenewAttribute. Valid values: `1`, `12`. It takes effect only for subscription (PrePaid) dedicated hosts and is required when `renewal_status` is `AutoRenewal`, used together with `sale_cycle` (`Month` or `Year`).
+* `expired_time` - (Optional, Computed, Deprecated: use `period` instead) The subscription period of the dedicated host. The Period parameter takes effect and is required only when the ChargeType parameter is set to PrePaid. `period` takes precedence when both are set.
+* `network_attributes` - (Optional) dedicated host network parameters. See [`network_attributes`](#network_attributes) below.
 * `payment_type` - (Optional, Computed) The billing method of the dedicated host. Valid values: `PrePaid`, `PostPaid`. Default: `PostPaid`.
+* `period` - (Optional, Computed) The subscription length of the dedicated host, sent to AllocateDedicatedHosts.Period and the renewal/charge-type APIs as an integer to align with the OpenAPI Period parameter. It takes effect and is required only when `payment_type` is set to `PrePaid`. `expired_time` is a deprecated string alias and is used only when `period` is not set.
+* `period_unit` - (Optional, Computed) The unit of the subscription period. Valid values: `Month`, `Year`. `sale_cycle` is a deprecated alias and is used only when `period_unit` is not set.
+* `quantity` - (Optional, ForceNew) The number of dedicated hosts to provision in a single AllocateDedicatedHosts call. Default: `1`. A Terraform resource tracks a single dedicated host, so a value greater than 1 creates multiple hosts but only the first DedicatedHostId is tracked; keep it at `1` unless multi-host creation is explicitly required.
+* `renewal_status` - (Optional) The auto-renewal status of the subscription dedicated host, sent to ModifyDedicatedHostAutoRenewAttribute and taking precedence over the `auto_renew` parameter. Valid values: `AutoRenewal` (automatically renewed), `Normal` (not automatically renewed, renewal notifications sent), `NotRenewal` (not automatically renewed, no expiration notification). It takes effect only for subscription (PrePaid) dedicated hosts.
 * `resource_group_id` - (Optional, Computed) The ID of the resource group to which the dedicated host belongs.
-* `sale_cycle` - (Optional, Computed) The unit of the subscription period of the dedicated host.
+* `sale_cycle` - (Optional, Computed, Deprecated: use `period_unit` instead) The unit of the subscription period of the dedicated host. `period_unit` takes precedence when both are set.
 * `zone_id` - (Optional, ForceNew, Computed) The zone ID of the dedicated host. This parameter is empty by default. If you do not specify this parameter, the system automatically selects a zone.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `cpu_over_commit_ratio` - (Optional, Available since v1.123.1) CPU oversold ratio. Only custom specifications g6s, c6s, r6s support setting the CPU oversold ratio.
 * `dedicated_host_cluster_id` - (Optional, Available since v1.123.1) The dedicated host cluster ID to which the dedicated host belongs.
 * `min_quantity` - (Optional, Available since v1.123.1) Specify the minimum purchase quantity of a dedicated host.
+
+### `network_attributes`
+
+The following attributes are supported in the `network_attributes` block:
+
+* `slb_udp_timeout` - (Optional) The timeout period for a UDP session between Server Load Balancer (SLB) and the dedicated host. Unit: seconds. Valid values: 15 to 310.
+* `udp_timeout` - (Optional) The timeout period for a UDP session between a user and an Alibaba Cloud service on the dedicated host. Unit: seconds. Valid values: 15 to 310.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### What this PR does

Adds the `renewal_status`, `auto_renew_with_ecs` and `duration` arguments to the `alicloud_ecs_dedicated_host` resource so that the auto-renewal attributes of a subscription dedicated host can be managed through Terraform.

These three attributes are backed by the `ModifyDedicatedHostAutoRenewAttribute` OpenAPI and are read back through `DescribeDedicatedHostAutoRenew`. They only apply to subscription (`PrePaid`) dedicated hosts; for `PostPaid` hosts the values are cleared.

| Argument | Type | Valid values | Backing API param |
|---|---|---|---|
| `renewal_status` | string | `AutoRenewal`, `Normal`, `NotRenewal` | `RenewalStatus` (takes precedence over `auto_renew`) |
| `auto_renew_with_ecs` | string | `AutoRenewWithEcs`, `StopRenewWithEcs`, `NoOperation` | `AutoRenewWithEcs` |
| `duration` | int | `1`, `12` | `Duration` (used with `sale_cycle` when `AutoRenewal`) |

### Notes

- `auto_renew_with_ecs` is a **string enum**, not a boolean. The OpenAPI schema of `ModifyDedicatedHostAutoRenewAttribute.AutoRenewWithEcs` defines it as a string with the values `AutoRenewWithEcs` / `StopRenewWithEcs` / `NoOperation` (default `NoOperation`), so the Terraform argument follows the same shape rather than coercing to a boolean.
- `Quantity` (`AllocateDedicatedHosts`, hardcoded `1`) and `AutoPay` (`ModifyDedicatedHostsChargeType`, hardcoded `true`) remain hardcoded, with explanatory code comments. A Terraform resource maps to a single dedicated host, and a charge-type change driven by Terraform is expected to complete the payment inline.
- `Period` / `PeriodUnit` keep their existing aliases `expired_time` / `sale_cycle` to avoid a breaking change.
- When `renewal_status` is `AutoRenewal`, `duration` and `sale_cycle` (`Month` / `Year`) are sent together as `Duration` / `PeriodUnit`, mirroring the `alicloud_ecs_instance` auto-renew pattern.

### Tests

- Added `TestAccAliCloudECSDedicatedHost_autoRenew`, which covers the create -> update (`ModifyDedicatedHostAutoRenewAttribute`) -> read (`DescribeDedicatedHostAutoRenew`) round-trip on a subscription dedicated host (Normal -> AutoRenewal with `auto_renew_with_ecs` / `duration`).
- `TestAccAliCloudECSDedicatedHost_basic` now also changes `payment_type` (`PrePaid` -> `PostPaid`) to exercise the `ModifyDedicatedHostsChargeType` update path for TestingCoverageRate coverage.
- Remote acceptance test results will be appended once verified.

### Reference

- OpenAPI: `Ecs@2014-05-26` `ModifyDedicatedHostAutoRenewAttribute` / `DescribeDedicatedHostAutoRenew`
