### PR TITLE
resource/alicloud_alikafka_sasl_acl: wait for ACL consistency before post-Create Read

### DIFF
--- a/alicloud/resource_alicloud_alikafka_sasl_acl.go
+++ b/alicloud/resource_alicloud_alikafka_sasl_acl.go
@@ -138,6 +138,21 @@ func resourceAliCloudAlikafkaSaslAclCreate(d *schema.ResourceData, meta interfac
 
 	d.SetId(fmt.Sprintf("%v:%v:%v:%v:%v:%v", request["InstanceId"], request["Username"], request["AclResourceType"], request["AclResourceName"], request["AclResourcePatternType"], request["AclOperationType"]))
 
+	// DescribeAcls is eventually consistent: after CreateAcl returns, the Kafka
+	// backend may need tens of seconds before the new ACL shows up in DescribeAcls
+	// results (an empty KafkaAclVO list, which the service maps to NotFound).
+	// Wait for the ACL to become queryable before the first Read; otherwise batch
+	// creation with for_each intermittently fails with ResourceNotfound when the
+	// post-Create Read races ahead of the backend sync. AlikafkaSaslAclStateRefreshFunc
+	// treats the not-yet-synced (empty list) state as pending, so WaitForState polls
+	// until the ACL is readable. Real delete/not-found semantics in Read are
+	// preserved because that path is only reached when d.IsNewResource() is false.
+	alikafkaServiceV2 := AlikafkaServiceV2{client}
+	stateConf := BuildStateConf([]string{""}, []string{"#CHECKSET"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, alikafkaServiceV2.AlikafkaSaslAclStateRefreshFunc(d.Id(), "#AclOperationType", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
 	return resourceAliCloudAlikafkaSaslAclRead(d, meta)
 }
 


### PR DESCRIPTION
### What

`alicloud_alikafka_sasl_acl` intermittently failed with `ResourceNotfound` during batch creation (`for_each`), even though the ACLs were actually created on the Kafka backend.

### Why

`CreateAcl` is eventually consistent: after it returns success, the Kafka backend may need tens of seconds before the new ACL shows up in `DescribeAcls` results. The service maps an empty `KafkaAclVO` list to `NotFound`, and the post-Create `Read` ran immediately after `SetId` with no wait, so it raced ahead of the backend sync. Under `for_each`, concurrent creates amplify the race (Write is slower than Read, so the not-yet-synced window is hit more often), matching the observed pattern where Reads succeed but batch Writes intermittently fail.

### How

Wait for the ACL to become queryable before the first `Read` by reusing the existing `AlikafkaSaslAclStateRefreshFunc` (which treats the not-yet-synced / empty-list state as pending) with a `BuildStateConf` `WaitForState`. The Create timeout (5m) bounds the wait.

Real delete / not-found semantics in `Read` are preserved: the `d.SetId("")` on NotFound is only reached when `d.IsNewResource()` is `false`, so genuine deletes and missing resources still behave as before.

### Tests

The resource is covered by existing acceptance tests, including `TestAccAliCloudAlikafkaSaslAcl_multi` which exercises batch creation — the scenario that surfaced this race.
