### PR TITLE
resource/alicloud_ecs_deployment_set: support group_count, type, affinity

### DIFF
--- a/alicloud/resource_alicloud_ecs_deployment_set.go
+++ b/alicloud/resource_alicloud_ecs_deployment_set.go
@@ -43,6 +43,27 @@ func resourceAliCloudEcsDeploymentSet() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: StringInSlice([]string{"CancelMembershipAndStart", "KeepStopped"}, false),
 			},
+			"group_count": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: IntBetween(1, 7),
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"host", "sw", "rack"}, false),
+			},
+			"affinity": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: IntBetween(1, 10),
+			},
 			"domain": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -87,6 +108,18 @@ func resourceAliCloudEcsDeploymentSetCreate(d *schema.ResourceData, meta interfa
 
 	if v, ok := d.GetOk("on_unable_to_redeploy_failed_instance"); ok {
 		request["OnUnableToRedeployFailedInstance"] = v
+	}
+
+	if v, ok := d.GetOk("group_count"); ok {
+		request["GroupCount"] = v
+	}
+
+	if v, ok := d.GetOk("type"); ok {
+		request["Type"] = v
+	}
+
+	if v, ok := d.GetOk("affinity"); ok {
+		request["Affinity"] = v
 	}
 
 	if v, ok := d.GetOk("domain"); ok {
@@ -137,6 +170,13 @@ func resourceAliCloudEcsDeploymentSetRead(d *schema.ResourceData, meta interface
 	d.Set("strategy", object["DeploymentStrategy"])
 	d.Set("deployment_set_name", object["DeploymentSetName"])
 	d.Set("description", object["DeploymentSetDescription"])
+	if v, ok := object["GroupCount"]; ok && v != nil {
+		d.Set("group_count", v)
+	}
+	d.Set("type", convertEcsDeploymentSetTypeResponse(object["Type"]))
+	if v, ok := object["Affinity"]; ok && v != nil {
+		d.Set("affinity", v)
+	}
 	d.Set("domain", convertEcsDeploymentSetDomainResponse(object["Domain"]))
 	d.Set("granularity", convertEcsDeploymentSetGranularityResponse(object["Granularity"]))
 
@@ -237,6 +277,19 @@ func convertEcsDeploymentSetGranularityResponse(source interface{}) interface{} 
 	switch source {
 	case "host":
 		return "Host"
+	}
+
+	return source
+}
+
+func convertEcsDeploymentSetTypeResponse(source interface{}) interface{} {
+	switch source {
+	case "Host":
+		return "host"
+	case "Sw":
+		return "sw"
+	case "Rack":
+		return "rack"
 	}
 
 	return source

--- a/alicloud/resource_alicloud_ecs_deployment_set_test.go
+++ b/alicloud/resource_alicloud_ecs_deployment_set_test.go
@@ -194,12 +194,33 @@ func TestAccAliCloudECSDeploymentSet_basic0_twin(t *testing.T) {
 					"deployment_set_name":                   name,
 					"description":                           name,
 					"on_unable_to_redeploy_failed_instance": "CancelMembershipAndStart",
+					"group_count":                           "3",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"strategy":            "AvailabilityGroup",
 						"deployment_set_name": name,
 						"description":         name,
+						"group_count":         "3",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"strategy":                              "Availability",
+					"deployment_set_name":                   name,
+					"description":                           name,
+					"on_unable_to_redeploy_failed_instance": "CancelMembershipAndStart",
+					"type":                                  "host",
+					"affinity":                              "2",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"strategy":            "Availability",
+						"deployment_set_name": name,
+						"description":         name,
+						"type":                "host",
+						"affinity":            "2",
 					}),
 				),
 			},
@@ -289,6 +310,9 @@ func TestUnitAliCloudECSDeploymentSet(t *testing.T) {
 		"deployment_set_name":                   "deployment_set_name",
 		"description":                           "description",
 		"on_unable_to_redeploy_failed_instance": "CancelMembershipAndStart",
+		"group_count":                           3,
+		"type":                                  "host",
+		"affinity":                              2,
 	} {
 		err := dCreate.Set(key, value)
 		assert.Nil(t, err)
@@ -311,6 +335,9 @@ func TestUnitAliCloudECSDeploymentSet(t *testing.T) {
 					"DeploymentSetDescription": "description",
 					"DeploymentStrategy":       "Availability",
 					"DeploymentSetId":          "MockDeploymentSetId",
+					"GroupCount":               3,
+					"Type":                     "host",
+					"Affinity":                 2,
 				},
 			},
 		},

--- a/website/docs/r/ecs_deployment_set.html.markdown
+++ b/website/docs/r/ecs_deployment_set.html.markdown
@@ -49,6 +49,9 @@ The following arguments are supported:
 * `on_unable_to_redeploy_failed_instance` - (Optional) The emergency solution to use in the situation where instances in the deployment set cannot be evenly distributed to different zones due to resource insufficiency after the instances failover. Valid values:
   - `CancelMembershipAndStart` - Removes the instances from the deployment set and starts the instances immediately after they are failed over.
   - `KeepStopped`- Leaves the instances in the Stopped state and starts them after resources are replenished.
+* `group_count` - (Optional, ForceNew) The number of groups for the deployment set group high availability policy. Valid values: `1` to `7`. Default value: `3`. This parameter takes effect only when `strategy` is `AvailabilityGroup`.
+* `type` - (Optional, ForceNew) The deployment type. Valid values: `host`, `sw`, `rack`. Default value: `host`.
+* `affinity` - (Optional, ForceNew) The affinity level of the deployment set. Instances in the deployment set are distributed based on this affinity. Valid values: `1` to `10`. Default value: `1`.
 * `domain` - (Deprecated since v1.243.0) Field `domain` has been deprecated from provider version 1.243.0.
 * `granularity` - (Deprecated since v1.243.0) Field `granularity` has been deprecated from provider version 1.243.0.
 


### PR DESCRIPTION
Adds three optional fields to the `alicloud_ecs_deployment_set` resource, aligning the provider with the backing CreateDeploymentSet/DescribeDeploymentSets APIs.

## Changes

- `group_count` (Optional, ForceNew, int, valid 1-7, default 3): the number of groups for the deployment set group high availability policy. Takes effect only when `strategy` is `AvailabilityGroup`.
- `type` (Optional, ForceNew, string, valid `host`/`sw`/`rack`, default `host`): the deployment type.
- `affinity` (Optional, ForceNew, int, valid 1-10, default 1): the affinity level of the deployment set.

All three fields are create-only (`ForceNew`) because `ModifyDeploymentSetAttribute` only updates `deployment_set_name` and `description`. They are marked `Computed` so the API-applied defaults are read back into state when not set in config.

## Schema

- Create sends `GroupCount`/`Type`/`Affinity` to `CreateDeploymentSet` when set.
- Read populates them from the `DescribeDeploymentSets` response item.
- Update is unchanged (the three fields are `ForceNew`).

## Tests

- `TestAccAliCloudECSDeploymentSet_basic0_twin` now sets and verifies `group_count`, `type`, and `affinity` (with import state verification).
- `TestUnitAliCloudECSDeploymentSet` mocks the three response fields and sets them on the create data.

Remote acceptance tests will be run separately.