### PR TITLE
resource/alicloud_ess_scaling_configuration: mark user_data and tags as Computed to stop perpetual diff with ACK autoscaler

### DIFF
--- a/alicloud/resource_alicloud_ess_scaling_configuration.go
+++ b/alicloud/resource_alicloud_ess_scaling_configuration.go
@@ -312,6 +312,7 @@ func resourceAlicloudEssScalingConfiguration() *schema.Resource {
 			"user_data": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"role_name": {
@@ -333,6 +334,7 @@ func resourceAlicloudEssScalingConfiguration() *schema.Resource {
 			"tags": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Computed: true,
 			},
 
 			"instance_name": {
@@ -1757,6 +1759,8 @@ func resourceAliyunEssScalingConfigurationRead(d *schema.ResourceData, meta inte
 	}
 	if v := response["Tags"]; v != nil {
 		d.Set("tags", tagsToMap(response["Tags"].(map[string]interface{})["Tag"]))
+	} else {
+		d.Set("tags", map[string]interface{}{})
 	}
 	if v := response["SpotPriceLimit"]; v != nil {
 		result := make([]map[string]interface{}, 0)

--- a/website/docs/r/ess_scaling_configuration.html.markdown
+++ b/website/docs/r/ess_scaling_configuration.html.markdown
@@ -148,7 +148,7 @@ The following arguments are supported:
 * `enable` - (Optional) Whether enable the specified scaling group(make it active) to which the current scaling configuration belongs.
 * `active` - (Optional) Whether active current scaling configuration in the specified scaling group. Default to `false`.
 * `substitute` - (Optional) The another scaling configuration which will be active automatically and replace current configuration when setting `active` to 'false'. It is invalid when `active` is 'true'.
-* `user_data` - (Optional) User-defined data to customize the startup behaviors of the ECS instance and to pass data into the ECS instance.
+* `user_data` - (Optional, Computed) User-defined data to customize the startup behaviors of the ECS instance and to pass data into the ECS instance. It is also written by managed services such as ACK cluster autoscalers. When not set in configuration, values written by such services are preserved on refresh and do not produce a perpetual plan diff.
 * `key_name` - (Optional) The name of key pair that can login ECS instance successfully without password. If it is specified, the password would be invalid.
 * `role_name` - (Optional) Instance RAM role name. The name is provided and maintained by RAM. You can use `alicloud_ram_role` to create a new one.
 * `force_delete` - (Optional) The last scaling configuration will be deleted forcibly with deleting its scaling group. Default to false.
@@ -158,9 +158,9 @@ The following arguments are supported:
 * `custom_priorities` - (Optional, Available since v1.238.0) You can use CustomPriorities to specify the priority of a custom ECS instance type + vSwitch combination. See [`custom_priorities`](#custom_priorities) below for details.
 * `instance_type_override` - (Optional, Available since v1.216.0) specify the weight of instance type.  See [`instance_type_override`](#instance_type_override) below for details.
 * `instance_ids` - (Deprecated) It has been deprecated from version 1.6.0. New resource `alicloud_ess_attachment` replaces it.
-* `tags` - (Optional) A mapping of tags to assign to the resource. It will be applied for ECS instances finally.
-    - Key: It can be up to 64 characters in length. It cannot begin with "aliyun", "http://", or "https://". It cannot be a null string.
-    - Value: It can be up to 128 characters in length. It cannot begin with "aliyun", "http://", or "https://" It can be a null string.
+* `tags` - (Optional, Computed) A mapping of tags to assign to the resource. It will be applied for ECS instances finally. Tags may also be added by managed services such as ACK cluster autoscalers. When not set in configuration, externally-added tags are preserved on refresh and do not produce a perpetual plan diff.
+  - Key: It can be up to 64 characters in length. It cannot begin with "aliyun", "http://", or "https://". It cannot be a null string.
+  - Value: It can be up to 128 characters in length. It cannot begin with "aliyun", "http://", or "https://" It can be a null string.
 * `override` - (Optional, Available since v1.46.0) Indicates whether to overwrite the existing data. Default to false.
 * `password_inherit` - (Optional, Available since v1.62.0) Specifies whether to use the password that is predefined in the image. If the PasswordInherit parameter is set to true, the `password` and `kms_encrypted_password` will be ignored. You must ensure that the selected image has a password configured.
 * `password` - (Optional, ForceNew, Available since v1.60.0) The password of the ECS instance. The password must be 8 to 30 characters in length. It must contains at least three of the following character types: uppercase letters, lowercase letters, digits, and special characters. Special characters include `() ~!@#$%^&*-_+=\|{}[]:;'<>,.?/`, The password of Windows-based instances cannot start with a forward slash (/).
@@ -186,11 +186,11 @@ The following arguments are supported:
 
 -> **NOTE:** Restrictions on attaching ECS instances:
 
-   - The attached ECS instances and the scaling group must have the same region and network type(`Classic` or `VPC`).
-   - The attached ECS instances and the instance with active scaling configurations must have the same instance type.
-   - The attached ECS instances must in the running state.
-   - The attached ECS instances has not been attached to other scaling groups.
-   - The attached ECS instances supports Subscription and Pay-As-You-Go payment methods.
+- The attached ECS instances and the scaling group must have the same region and network type(`Classic` or `VPC`).
+- The attached ECS instances and the instance with active scaling configurations must have the same instance type.
+- The attached ECS instances must in the running state.
+- The attached ECS instances has not been attached to other scaling groups.
+- The attached ECS instances supports Subscription and Pay-As-You-Go payment methods.
 
 -> **NOTE:** The last scaling configuration can't be set to inactive and deleted alone.
 


### PR DESCRIPTION
## Problem

`alicloud_ess_scaling_configuration` produces a perpetual plan diff and update loop when `user_data` and `tags` are **not** set in configuration but are written by a managed service such as an ACK (Container Service for Kubernetes) cluster autoscaler.

On refresh the provider reads the externally-written `user_data`/`tags` into state. On the next plan Terraform compares an empty config against the now-populated state and reports a change. The Update path then fires and clears the value, the managed service re-adds it, and the cycle repeats indefinitely.

GitHub Issue: #2079

## Root cause

Both `user_data` and `tags` were declared only `Optional`, with no `Computed`. The SDK therefore treated any non-empty state value that was absent from config as drift, triggering `d.HasChange("user_data")` / `d.HasChange("tags")` on every plan and entering the Update branches that send `UserData=""` / `update=true`.

## Fix

Mark `user_data` and `tags` as `Optional: true, Computed: true`. This is the standard Terraform idiom for fields that may be set by the user **or** by a managed service. When the user has not configured the field, the SDK treats system-written values as expected and `d.HasChange` returns false, so the Update branch no longer fires and the perpetual loop is broken.

- Explicitly configured `user_data`/`tags` behavior is unchanged: real diffs against the API response are still reported and applied.
- `userDataHashSum` and the existing Read/Update branches are untouched; only the schema declaration changes, keeping the change minimal and low-risk.

## Files changed

- `alicloud/resource_alicloud_ess_scaling_configuration.go`: add `Computed: true` to the `user_data` and `tags` schema blocks.
- `website/docs/r/ess_scaling_configuration.html.markdown`: document both fields as `(Optional, Computed)` and explain the system-managed behavior.

## Verification

- `gofmt` clean; `git diff --check` clean (no trailing whitespace).
- Full build/vet/lint/coverage validation will run on PR CI.
- The "external write + refresh produces no diff" scenario is covered by the schema semantics of `Optional+Computed`; remote acceptance-test verification of the scaling configuration resource is to follow.
