### PR TITLE
resource/alicloud_message_service_queue: support server-side encryption (SSE)

### DIFF
--- a/alicloud/resource_alicloud_message_service_queue.go
+++ b/alicloud/resource_alicloud_message_service_queue.go
@@ -59,6 +59,20 @@ func resourceAliCloudMessageServiceQueue() *schema.Resource {
 					},
 				},
 			},
+			"enable_sse": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"encryption_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"logging_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -92,6 +106,18 @@ func resourceAliCloudMessageServiceQueue() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: StringInSlice([]string{"normal", "fifo"}, false),
+			},
+			"sse_algorithm": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"AES-256-GCM"}, false),
+			},
+			"sse_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"SMQ", "KMS"}, false),
 			},
 			"tags": tagsSchema(),
 			"visibility_timeout": {
@@ -133,6 +159,21 @@ func resourceAliCloudMessageServiceQueueCreate(d *schema.ResourceData, meta inte
 	}
 	if v, ok := d.GetOkExists("logging_enabled"); ok {
 		request["EnableLogging"] = v
+	}
+	// A new queue has SSE off by default, so EnableSSE is only sent when
+	// true. d.Get is used instead of GetOkExists, which may treat an
+	// existing value as non-existent.
+	if v := d.Get("enable_sse"); v.(bool) {
+		request["EnableSSE"] = v
+	}
+	if v, ok := d.GetOk("sse_type"); ok {
+		request["SseType"] = v
+	}
+	if v, ok := d.GetOk("sse_algorithm"); ok {
+		request["SseAlgorithm"] = v
+	}
+	if v, ok := d.GetOk("kms_key_id"); ok {
+		request["KmsKeyId"] = v
 	}
 	if v, ok := d.GetOk("queue_type"); ok {
 		request["QueueType"] = v
@@ -205,11 +246,16 @@ func resourceAliCloudMessageServiceQueueRead(d *schema.ResourceData, meta interf
 
 	d.Set("create_time", objectRaw["CreateTime"])
 	d.Set("delay_seconds", objectRaw["DelaySeconds"])
+	d.Set("enable_sse", objectRaw["EnableSSE"])
+	d.Set("encryption_enabled", objectRaw["EncryptionEnabled"])
+	d.Set("kms_key_id", objectRaw["KmsKeyId"])
 	d.Set("logging_enabled", objectRaw["LoggingEnabled"])
 	d.Set("maximum_message_size", objectRaw["MaximumMessageSize"])
 	d.Set("message_retention_period", objectRaw["MessageRetentionPeriod"])
 	d.Set("polling_wait_seconds", objectRaw["PollingWaitSeconds"])
 	d.Set("queue_type", objectRaw["QueueType"])
+	d.Set("sse_algorithm", objectRaw["SseAlgorithm"])
+	d.Set("sse_type", objectRaw["SseType"])
 	d.Set("visibility_timeout", objectRaw["VisibilityTimeout"])
 	d.Set("queue_name", objectRaw["QueueName"])
 
@@ -293,6 +339,25 @@ func resourceAliCloudMessageServiceQueueUpdate(d *schema.ResourceData, meta inte
 	}
 	if v, ok := d.GetOkExists("logging_enabled"); ok {
 		request["EnableLogging"] = v
+	}
+
+	if !d.IsNewResource() && (d.HasChange("enable_sse") || d.HasChange("sse_type") || d.HasChange("sse_algorithm") || d.HasChange("kms_key_id")) {
+		update = true
+
+		// The whole SSE family is sent together on any SSE change. EnableSSE
+		// is set unconditionally via d.Get (not GetOkExists, which may treat
+		// an existing value as non-existent), so the current switch value is
+		// always sent, including the explicit false that disables SSE.
+		request["EnableSSE"] = d.Get("enable_sse")
+		if v, ok := d.GetOk("sse_type"); ok {
+			request["SseType"] = v
+		}
+		if v, ok := d.GetOk("sse_algorithm"); ok {
+			request["SseAlgorithm"] = v
+		}
+		if v, ok := d.GetOk("kms_key_id"); ok {
+			request["KmsKeyId"] = v
+		}
 	}
 
 	if !d.IsNewResource() && d.HasChange("dlq_policy") {

--- a/alicloud/resource_alicloud_message_service_queue_test.go
+++ b/alicloud/resource_alicloud_message_service_queue_test.go
@@ -625,6 +625,101 @@ func TestAccAliCloudMessageServiceQueue_basic1_twin(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudMessageServiceQueue_sse(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_message_service_queue.default"
+	ra := resourceAttrInit(resourceId, AliCloudMessageServiceQueueMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &MessageServiceServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeMessageServiceQueue")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccMessageServiceQueue-name%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudMessageServiceQueueSSEDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			// SSE runs in cn-shanghai: it is the only probed region where the
+			// SSE create/read round trip works without an account whitelist.
+			// Other regions either hide the SSE fields in the response
+			// (cn-hangzhou, cn-beijing, cn-shenzhen, cn-hongkong,
+			// cn-zhangjiakou) or reject SSE with FeatureNotEnabled behind an
+			// account whitelist (cn-qingdao).
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-shanghai"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"queue_name":    name,
+					"enable_sse":    "true",
+					"sse_type":      "SMQ",
+					"sse_algorithm": "AES-256-GCM",
+					"tags": map[string]string{
+						"Created": "TF",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"queue_name":         name,
+						"enable_sse":         "true",
+						"sse_type":           "SMQ",
+						"sse_algorithm":      "AES-256-GCM",
+						"encryption_enabled": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"enable_sse":    "false",
+					"sse_type":      REMOVEKEY,
+					"sse_algorithm": REMOVEKEY,
+					"tags":          REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						// EncryptionEnabled stays true after SSE is disabled: it
+						// reports the residual encryption state, not the switch. The
+						// check map accumulates across steps, so sse_type and
+						// sse_algorithm are REMOVEKEYed here: the response no longer
+						// reports them once SSE is off.
+						"enable_sse":         "false",
+						"encryption_enabled": "true",
+						"sse_type":           REMOVEKEY,
+						"sse_algorithm":      REMOVEKEY,
+					}),
+				),
+			},
+			{
+				// SSE-SMQ does not use a KMS key: kms_key_id is explicitly set to
+				// empty here, which also keeps the attribute covered in tests.
+				Config: testAccConfig(map[string]interface{}{
+					"enable_sse":    "true",
+					"sse_type":      "SMQ",
+					"sse_algorithm": "AES-256-GCM",
+					"kms_key_id":    "",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable_sse":         "true",
+						"sse_type":           "SMQ",
+						"sse_algorithm":      "AES-256-GCM",
+						"encryption_enabled": "true",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 var AliCloudMessageServiceQueueMap0 = map[string]string{
 	"create_time":              CHECKSET,
 	"delay_seconds":            CHECKSET,
@@ -657,6 +752,14 @@ resource "alicloud_message_service_queue" "fifo" {
   queue_name = "${var.name}-fifo"
   queue_type = "fifo"
 }
+`, name)
+}
+
+func AliCloudMessageServiceQueueSSEDependence(name string) string {
+	return fmt.Sprintf(`
+	variable "name" {
+		default = "%s"
+	}
 `, name)
 }
 

--- a/website/docs/r/message_service_queue.html.markdown
+++ b/website/docs/r/message_service_queue.html.markdown
@@ -48,6 +48,10 @@ resource "alicloud_message_service_queue" "default" {
 The following arguments are supported:
 * `delay_seconds` - (Optional, Int) The period after which all messages sent to the queue are consumed. Default value: `0`. Valid values: `0` to `604800`. Unit: seconds.
 * `dlq_policy` - (Optional, Set, Available since v1.244.0) The dead-letter queue policy. See [`dlq_policy`](#dlq_policy) below.
+* `enable_sse` - (Optional, Bool, Available since v1.291.0) Specifies whether to enable server-side encryption (SSE) for the messages in the queue. Default value: `false`. Valid values:
+  - `true`: Enable.
+  - `false`: Disable.
+* `kms_key_id` - (Optional, Available since v1.291.0) The ID of the customer master key (CMK) in Key Management Service (KMS). This parameter is required when `sse_type` is set to `KMS`.
 * `logging_enabled` - (Optional, Bool) Specifies whether to enable the logging feature. Default value: `false`. Valid values:
   - `true`: Enable.
   - `false`: Disable.
@@ -58,8 +62,16 @@ The following arguments are supported:
 * `queue_type` - (Optional, ForceNew, Available since v1.283.0) The type of the queue. Default value: `normal`. Valid values:
   - `normal`: Standard queue.
   - `fifo`: FIFO queue.
+* `sse_algorithm` - (Optional, Available since v1.291.0) The encryption algorithm that is used to encrypt the messages in the queue. Valid value: `AES-256-GCM`.
+* `sse_type` - (Optional, Available since v1.291.0) The type of server-side encryption (SSE). Valid values:
+  - `SMQ`: The keys that are managed by Message Service are used to encrypt and decrypt messages.
+  - `KMS`: The customer master key (CMK) that is managed by Key Management Service (KMS) is used to encrypt and decrypt messages.
 * `tags` - (Optional, Map, Available since v1.241.0) A mapping of tags to assign to the resource.
 * `visibility_timeout` - (Optional, Int) The duration for which a message stays in the Inactive state after the message is received from the queue. Valid values: `1` to `43200`. Unit: seconds. Default value: `30`.
+
+-> **NOTE:** Server-side encryption (SSE) is available only after the feature is enabled for your account. To enable the feature, submit a ticket. Before you set `sse_type` to `KMS`, make sure that a symmetric key of the AES-256 key spec is created in KMS in the same region and within the same account as the queue, and that the service-linked role `AliyunMNSAccessingKMSRole` is authorized.
+
+-> **NOTE:** To disable SSE, you must set `enable_sse` to `false` and remove `sse_type`, `sse_algorithm`, and `kms_key_id` from the configuration at the same time. SSE takes effect only on the messages that are sent after SSE is enabled or disabled, and existing messages are not encrypted or decrypted again.
 
 ### `dlq_policy`
 
@@ -73,6 +85,7 @@ The dlq_policy supports the following:
 The following attributes are exported:
 * `id` - The resource ID in terraform of Queue.
 * `create_time` - (Available since v1.223.2) The time when the queue was created.
+* `encryption_enabled` - (Available since v1.291.0) Indicates whether server-side encryption is applied to the queue. The value remains `true` after server-side encryption is disabled because existing messages are still stored as encrypted.
 
 ## Timeouts
 


### PR DESCRIPTION
### Description

Adds server-side encryption (SSE) support to `alicloud_message_service_queue`.

New arguments:

- `enable_sse` - (Optional, Bool) Specifies whether to enable server-side encryption (SSE) for the messages in the queue. Default: `false`.
- `sse_type` - (Optional) The type of SSE. Valid values: `SMQ`, `KMS`.
- `sse_algorithm` - (Optional) The encryption algorithm. Valid value: `AES-256-GCM`.
- `kms_key_id` - (Optional) The ID of the customer master key (CMK) in KMS. Required when `sse_type` is `KMS`.

New computed attribute:

- `encryption_enabled` - Indicates whether server-side encryption is applied to the queue. It remains `true` after SSE is disabled, because existing messages are still stored as encrypted.

On update, the whole SSE family is sent together whenever any SSE argument changes, and `enable_sse` is always sent with its current value — including the explicit `false` that disables SSE.

### Changes

- `alicloud/resource_alicloud_message_service_queue.go`: 5 new schema attributes; Create sends the SSE family when enabled; Read maps `EnableSSE` / `EncryptionEnabled` / `SseType` / `SseAlgorithm` / `KmsKeyId` back into state; Update sends the family, guarded by a `HasChange` check on any of the four arguments.
- `alicloud/resource_alicloud_message_service_queue_test.go`: new `TestAccAliCloudMessageServiceQueue_sse` covering enable → disable → re-enable → import.
- `website/docs/r/message_service_queue.html.markdown`: argument/attribute reference entries plus `-> **NOTE:**` blocks covering the KMS prerequisites and the disable semantics.

### Acceptance tests

PASS: TestAccAliCloudMessageServiceQueue_sse (10.13s), TestAccAliCloudMessageServiceQueue_basic0 (36.71s), TestAccAliCloudMessageServiceQueue_basic0_twin (5.07s), TestAccAliCloudMessageServiceQueue_basic1 (32.97s), TestAccAliCloudMessageServiceQueue_basic1_twin (4.84s)

5 PASS / 0 FAIL / 0 SKIP.

Notes for reviewers:

- The SSE case pins `cn-shanghai`: the `GetQueueAttributes` response currently reports the SSE fields only in that region; in several other regions the gateway accepts the parameters but never returns them, which would make the read-back assertions fail.
- The `KMS` type path is not covered by an acceptance test: it requires a real CMK and the `AliyunMNSAccessingKMSRole` service-linked role. The `SMQ` path is covered end-to-end, including the disable transition (the response keeps `EncryptionEnabled=true` after disable, which the test asserts) and import.
