### PR TITLE
resource/alicloud_ga_accelerator: support ip_set_config and bandwidth; data-source/alicloud_ga_accelerators: support ip_set_config and bandwidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## 1.292.0 (Unreleased)
+
+ENHANCEMENTS:
+
+- resource/alicloud_ga_endpoint_group: Added the fields `vpc_id` and `vswitch_ids` for `IpTarget` endpoint type. ([#10345](https://github.com/aliyun/terraform-provider-alicloud/pull/10345))
+- resource/alicloud_ga_accelerator: Added the field `ip_set_config` and `bandwidth`. ([#10345](https://github.com/aliyun/terraform-provider-alicloud/pull/10345))
+- data-source/alicloud_ga_endpoint_groups: Added the fields `vpc_id` and `vswitch_ids` in response. ([#10345](https://github.com/aliyun/terraform-provider-alicloud/pull/10345))
+- data-source/alicloud_ga_accelerators: Added the field `ip_set_config` and `bandwidth` in response. ([#10345](https://github.com/aliyun/terraform-provider-alicloud/pull/10345))
+
 ## 1.291.0 (September 1, 2026)
 
 - **New Resource:** `alicloud_ecd_desktop_group` ([#10230](https://github.com/aliyun/terraform-provider-alicloud/issues/10230))

--- a/alicloud/data_source_alicloud_ga_accelerators.go
+++ b/alicloud/data_source_alicloud_ga_accelerators.go
@@ -61,6 +61,14 @@ func dataSourceAlicloudGaAccelerators() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"bandwidth": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"bandwidth_billing_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"basic_bandwidth_package": {
 							Type:     schema.TypeList,
 							Computed: true,
@@ -128,6 +136,18 @@ func dataSourceAlicloudGaAccelerators() *schema.Resource {
 						"spec": {
 							Type:     schema.TypeString,
 							Computed: true,
+						},
+						"ip_set_config": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"access_mode": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
 						},
 						"status": {
 							Type:     schema.TypeString,
@@ -216,6 +236,8 @@ func dataSourceAlicloudGaAcceleratorsRead(d *schema.ResourceData, meta interface
 			"id":               fmt.Sprint(object["AcceleratorId"]),
 			"accelerator_id":   fmt.Sprint(object["AcceleratorId"]),
 			"accelerator_name": object["Name"],
+			"bandwidth":        formatInt(object["Bandwidth"]),
+			"bandwidth_billing_type": object["BandwidthBillingType"],
 			"cen_id":           object["CenId"],
 			"ddos_id":          object["DdosId"],
 			"description":      object["Description"],
@@ -226,6 +248,15 @@ func dataSourceAlicloudGaAcceleratorsRead(d *schema.ResourceData, meta interface
 			"spec":             object["Spec"],
 			"status":           object["State"],
 		}
+
+		ipSetConfigSli := make([]map[string]interface{}, 0)
+		if v, ok := object["IpSetConfig"].(map[string]interface{}); ok && len(v) > 0 {
+			ipSetConfig := object["IpSetConfig"]
+			ipSetConfigMap := make(map[string]interface{})
+			ipSetConfigMap["access_mode"] = ipSetConfig.(map[string]interface{})["AccessMode"]
+			ipSetConfigSli = append(ipSetConfigSli, ipSetConfigMap)
+		}
+		mapping["ip_set_config"] = ipSetConfigSli
 
 		basicBandwidthPackageSli := make([]map[string]interface{}, 0)
 		if v, ok := object["BasicBandwidthPackage"].(map[string]interface{}); ok && len(v) > 0 {

--- a/alicloud/data_source_alicloud_ga_accelerators_test.go
+++ b/alicloud/data_source_alicloud_ga_accelerators_test.go
@@ -81,6 +81,51 @@ func TestAccAlicloudGaAcceleratorsDataSource(t *testing.T) {
 	CheckInfo.dataSourceTestCheck(t, rand, idsConf, nameRegexConf, allConf)
 }
 
+func TestAccAlicloudGaAcceleratorsDataSource_withAnycast(t *testing.T) {
+	rand := acctest.RandInt()
+	checkoutSupportedRegions(t, true, connectivity.GaSupportRegions)
+	resourceId := "data.alicloud_ga_accelerators.default"
+	name := fmt.Sprintf("tf-testAccelerators-anycast-%d", rand)
+	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceGaAcceleratorsConfigDependenceWithAnycast)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"ids": []string{"${alicloud_ga_accelerator.default.id}"},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"ids": []string{"${alicloud_ga_accelerator.default.id}_fake"},
+		}),
+	}
+
+	var existMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":                                  "1",
+			"accelerators.#":                         CHECKSET,
+			"accelerators.0.id":                      CHECKSET,
+			"accelerators.0.payment_type":            "POSTPAY",
+			"accelerators.0.bandwidth_billing_type":  "CDT",
+			"accelerators.0.bandwidth":               "200",
+			"accelerators.0.ip_set_config.#":         "1",
+			"accelerators.0.ip_set_config.0.access_mode": "Anycast",
+		}
+	}
+
+	var fakeMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"accelerators.#": "0",
+			"ids.#":          "0",
+		}
+	}
+
+	var CheckInfo = dataSourceAttr{
+		resourceId:   resourceId,
+		existMapFunc: existMapFunc,
+		fakeMapFunc:  fakeMapFunc,
+	}
+
+	CheckInfo.dataSourceTestCheck(t, rand, idsConf)
+}
+
 func dataSourceGaAcceleratorsConfigDependence(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
@@ -92,6 +137,22 @@ resource "alicloud_ga_accelerator" "default" {
   accelerator_name = var.name
   auto_use_coupon  = true
   description      = var.name
+}
+`, name)
+}
+
+func dataSourceGaAcceleratorsConfigDependenceWithAnycast(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+resource "alicloud_ga_accelerator" "default" {
+  bandwidth_billing_type = "CDT"
+  payment_type           = "PayAsYouGo"
+  bandwidth              = 200
+  ip_set_config {
+    access_mode = "Anycast"
+  }
 }
 `, name)
 }

--- a/alicloud/data_source_alicloud_ga_endpoint_groups_test.go
+++ b/alicloud/data_source_alicloud_ga_endpoint_groups_test.go
@@ -109,6 +109,51 @@ func TestAccAliCloudGaEndpointGroupsDataSource(t *testing.T) {
 	alicloudGaEndpointGroupsCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, idsConf, nameRegexConf, listenerIdConf, endpointGroupTypeConf, statusConf, allConf)
 }
 
+func TestAccAliCloudGaEndpointGroupsDataSource_withIpTarget(t *testing.T) {
+	rand := acctest.RandInt()
+	checkoutSupportedRegions(t, true, connectivity.GaSupportRegions)
+	resourceId := "data.alicloud_ga_endpoint_groups.default"
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudGaEndpointGroupsDataSourceIpTarget(rand, map[string]string{
+			"ids": `["${alicloud_ga_endpoint_group.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAliCloudGaEndpointGroupsDataSourceIpTarget(rand, map[string]string{
+			"ids": `["${alicloud_ga_endpoint_group.default.id}_fake"]`,
+		}),
+	}
+
+	var existMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":                                       "1",
+			"groups.#":                                    "1",
+			"groups.0.id":                                 CHECKSET,
+			"groups.0.endpoint_group_id":                  CHECKSET,
+			"groups.0.endpoint_group_region":              CHECKSET,
+			"groups.0.status":                             "active",
+			"groups.0.endpoint_configurations.#":          "1",
+			"groups.0.endpoint_configurations.0.type":     "IpTarget",
+			"groups.0.endpoint_configurations.0.vpc_id":   CHECKSET,
+			"groups.0.endpoint_configurations.0.vswitch_ids.#": CHECKSET,
+		}
+	}
+
+	var fakeMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"groups.#": "0",
+			"ids.#":    "0",
+		}
+	}
+
+	var CheckInfo = dataSourceAttr{
+		resourceId:   resourceId,
+		existMapFunc: existMapFunc,
+		fakeMapFunc:  fakeMapFunc,
+	}
+
+	CheckInfo.dataSourceTestCheck(t, rand, idsConf)
+}
+
 func testAccCheckAliCloudGaEndpointGroupsDataSourceName(rand int, attrMap map[string]string) string {
 	var pairs []string
 	for k, v := range attrMap {
@@ -187,4 +232,66 @@ func testAccCheckAliCloudGaEndpointGroupsDataSourceName(rand int, attrMap map[st
 	}
 `, rand, defaultRegionToTest, strings.Join(pairs, " \n "))
 	return config
+}
+
+func testAccCheckAliCloudGaEndpointGroupsDataSourceIpTarget(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+
+	return fmt.Sprintf(`
+variable "name" {
+  default = "tf-testAccGaEndpointGroup-ipTarget-%d"
+}
+
+resource "alicloud_ga_accelerator" "default" {
+  bandwidth_billing_type = "CDT"
+  payment_type           = "PayAsYouGo"
+}
+
+resource "alicloud_ga_listener" "default" {
+  accelerator_id = alicloud_ga_accelerator.default.id
+  port_ranges {
+    from_port = 8080
+    to_port   = 8080
+  }
+  client_affinity = "SOURCE_IP"
+  protocol        = "HTTP"
+}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+  vswitch_name = var.name
+  vpc_id       = alicloud_vpc.default.id
+  cidr_block   = "192.168.0.0/24"
+  zone_id      = data.alicloud_zones.default.zones.0.id
+}
+
+resource "alicloud_ga_endpoint_group" "default" {
+  accelerator_id        = alicloud_ga_listener.default.accelerator_id
+  listener_id           = alicloud_ga_listener.default.id
+  endpoint_group_region = "%s"
+  endpoint_configurations {
+    endpoint = "192.168.0.100"
+    type     = "IpTarget"
+    weight   = 20
+    vpc_id   = alicloud_vpc.default.id
+    vswitch_ids = [alicloud_vswitch.default.id]
+  }
+}
+
+data "alicloud_zones" "default" {
+  available_resource_creation = "VSwitch"
+}
+
+data "alicloud_ga_endpoint_groups" "default" {
+  accelerator_id = alicloud_ga_endpoint_group.default.accelerator_id
+  %s
+}
+`, rand, defaultRegionToTest, strings.Join(pairs, " \n "))
 }

--- a/alicloud/resource_alicloud_ga_accelerator.go
+++ b/alicloud/resource_alicloud_ga_accelerator.go
@@ -20,7 +20,7 @@ func resourceAliCloudGaAccelerator() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(1 * time.Minute),
+			Create: schema.DefaultTimeout(3 * time.Minute),
 			Update: schema.DefaultTimeout(6 * time.Minute),
 			Delete: schema.DefaultTimeout(3 * time.Minute),
 		},
@@ -36,6 +36,11 @@ func resourceAliCloudGaAccelerator() *schema.Resource {
 				ForceNew:     true,
 				Computed:     true,
 				ValidateFunc: StringInSlice([]string{"BandwidthPackage", "CDT"}, false),
+			},
+			"bandwidth": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntBetween(200, 5000),
 			},
 			"payment_type": {
 				Type:         schema.TypeString,
@@ -99,6 +104,21 @@ func resourceAliCloudGaAccelerator() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"ip_set_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"access_mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: StringInSlice([]string{"UserDefine", "Anycast"}, false),
+						},
+					},
+				},
+			},
 			"tags": tagsSchema(),
 			"status": {
 				Type:     schema.TypeString,
@@ -158,6 +178,33 @@ func resourceAliCloudGaAcceleratorCreate(d *schema.ResourceData, meta interface{
 		request["ResourceGroupId"] = v
 	}
 
+	if v, ok := d.GetOk("ip_set_config"); ok {
+		ipSetConfigList := v.([]interface{})
+		if len(ipSetConfigList) > 0 {
+			ipSetConfigMap := ipSetConfigList[0].(map[string]interface{})
+			if accessMode, ok := ipSetConfigMap["access_mode"]; ok {
+				request["IpSetConfig.AccessMode"] = accessMode
+			}
+		}
+	}
+
+	if v, ok := d.GetOkExists("bandwidth"); ok {
+		// bandwidth is required and valid only when access_mode is Anycast
+		if accessMode, ok := d.GetOk("ip_set_config"); ok {
+			ipSetConfigList := accessMode.([]interface{})
+			if len(ipSetConfigList) > 0 {
+				ipSetConfigMap := ipSetConfigList[0].(map[string]interface{})
+				if mode, ok := ipSetConfigMap["access_mode"]; ok && mode.(string) == "Anycast" {
+					request["Bandwidth"] = v
+				} else {
+					return WrapErrorf(nil, DefaultErrorMsg, "alicloud_ga_accelerator", "bandwidth is valid only when access_mode is set to Anycast", AlibabaCloudSdkGoERROR)
+				}
+			}
+		} else {
+			return WrapErrorf(nil, DefaultErrorMsg, "alicloud_ga_accelerator", "bandwidth is valid only when ip_set_config.access_mode is set to Anycast", AlibabaCloudSdkGoERROR)
+		}
+	}
+
 	response, err = client.RpcPost("Ga", "2019-11-20", action, nil, request, true)
 	if err != nil {
 		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ga_accelerator", action, AlibabaCloudSdkGoERROR)
@@ -190,12 +237,26 @@ func resourceAliCloudGaAcceleratorRead(d *schema.ResourceData, meta interface{})
 
 	d.Set("spec", object["Spec"])
 	d.Set("bandwidth_billing_type", object["BandwidthBillingType"])
+	if v, ok := object["Bandwidth"]; ok {
+		d.Set("bandwidth", formatInt(v))
+	}
 	d.Set("payment_type", convertGaAcceleratorPaymentTypeResponse(object["InstanceChargeType"]))
 	d.Set("cross_border_status", object["CrossBorderStatus"])
 	d.Set("cross_border_mode", object["CrossBorderMode"])
 	d.Set("resource_group_id", object["ResourceGroupId"])
 	d.Set("accelerator_name", object["Name"])
 	d.Set("description", object["Description"])
+	if ipSetConfig, ok := object["IpSetConfig"]; ok {
+		ipSetConfigMaps := make([]map[string]interface{}, 0)
+		ipSetConfigMap := make(map[string]interface{})
+		if ipSetConfigMapData, ok := ipSetConfig.(map[string]interface{}); ok {
+			if accessMode, ok := ipSetConfigMapData["AccessMode"]; ok {
+				ipSetConfigMap["access_mode"] = accessMode
+			}
+		}
+		ipSetConfigMaps = append(ipSetConfigMaps, ipSetConfigMap)
+		d.Set("ip_set_config", ipSetConfigMaps)
+	}
 	d.Set("status", object["State"])
 
 	describeAcceleratorAutoRenewAttributeObject, err := gaService.DescribeAcceleratorAutoRenewAttribute(d.Id())

--- a/alicloud/resource_alicloud_ga_accelerator_test.go
+++ b/alicloud/resource_alicloud_ga_accelerator_test.go
@@ -582,6 +582,58 @@ func TestAccAliCloudGaAccelerator_basic1_twin(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudGaAccelerator_withAnycast(t *testing.T) {
+	var v map[string]interface{}
+	checkoutSupportedRegions(t, true, connectivity.GaSupportRegions)
+	resourceId := "alicloud_ga_accelerator.default"
+	ra := resourceAttrInit(resourceId, AliCloudGaAcceleratorMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &GaService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeGaAccelerator")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAcc%sAliCloudGaAccelerator%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudGaAcceleratorBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"bandwidth_billing_type": "CDT",
+					"payment_type":           "PayAsYouGo",
+					"bandwidth":              "200",
+					"ip_set_config": []map[string]interface{}{
+						{
+							"access_mode": "Anycast",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"bandwidth_billing_type":      "CDT",
+						"payment_type":                "PayAsYouGo",
+						"bandwidth":                   "200",
+						"ip_set_config.#":             "1",
+						"ip_set_config.0.access_mode": "Anycast",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"duration", "pricing_cycle", "auto_use_coupon", "promotion_option_no"},
+			},
+		},
+	})
+}
+
 var AliCloudGaAcceleratorMap0 = map[string]string{
 	"bandwidth_billing_type": CHECKSET,
 	"payment_type":           CHECKSET,

--- a/website/docs/r/ga_accelerator.html.markdown
+++ b/website/docs/r/ga_accelerator.html.markdown
@@ -49,6 +49,7 @@ The following arguments are supported:
 * `bandwidth_billing_type` - (Optional, ForceNew, Available since v1.205.0) The bandwidth billing method. Default value: `BandwidthPackage`. Valid values:
   - `BandwidthPackage`: billed based on bandwidth plans.
   - `CDT`: billed based on data transfer.
+* `bandwidth` - (Optional, Int, Available since v1.287.0) The bandwidth of the GA instance. Unit: Mbps. Valid values: `200` to `5000`. **NOTE:** This parameter is required only when `access_mode` in `ip_set_config` is set to `Anycast`.
 * `payment_type` - (Optional, ForceNew, Available since v1.208.1) The payment type. Default value: `Subscription`. Valid values: `PayAsYouGo`, `Subscription`.
 * `cross_border_status` - (Optional, Bool, Available since v1.208.1) Indicates whether cross-border acceleration is enabled. Default value: `false`. Valid values:
   - `true`: Enable.
@@ -73,7 +74,16 @@ The following arguments are supported:
 * `resource_group_id` - (Optional, Available since v1.226.0) The ID of the resource group. **Note:** Once you set a value of this property, you cannot set it to an empty string anymore.
 * `accelerator_name` - (Optional) The Name of the GA instance.
 * `description` - (Optional) Descriptive information of the global acceleration instance.
+* `ip_set_config` - (Optional, ForceNew, Available since v1.287.0) The configurations of the acceleration area. See [`ip_set_config`](#ip_set_config) below.
 * `tags` - (Optional, Available since v1.207.1) A mapping of tags to assign to the resource.
+
+### `ip_set_config`
+
+The ip_set_config supports the following:
+
+* `access_mode` - (Optional, ForceNew) The access mode of the acceleration area. Valid values:
+  - `UserDefine`: Custom nearby access mode. Select acceleration areas and regions as needed. Global Accelerator provides a separate elastic IP address (EIP) for each acceleration region.
+  - `Anycast`: Automatic nearby access mode. You do not need to configure an acceleration area. Global Accelerator provides an Anycast EIP for multiple regions. Users connect to the nearest access point of the Alibaba Cloud network using the Anycast EIP.
 
 ## Attributes Reference
 
@@ -86,7 +96,7 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 1 mins) Used when creating the Ga Accelerator.
+* `create` - (Defaults to 3 mins) Used when creating the Ga Accelerator.
 * `update` - (Defaults to 6 mins) Used when updating the Ga Accelerator.
 * `delete` - (Defaults to 3 mins) Used when deleting the Ga Accelerator.
 

--- a/website/docs/r/ga_endpoint_group.html.markdown
+++ b/website/docs/r/ga_endpoint_group.html.markdown
@@ -142,7 +142,7 @@ The endpoint_configurations supports the following:
 * `type` - (Required) The type of Endpoint N in the endpoint group. Valid values:
   - `Domain`: A custom domain name.
   - `Ip`: A custom IP address.
-  - `IpTarget`: (Available since v1.262.0) An Alibaba Cloud public IP address.
+  - `IpTarget`: (Available since v1.262.0) a custom private IP address.
   - `PublicIp`: An Alibaba Cloud public IP address.
   - `ECS`: An Elastic Compute Service (ECS) instance.
   - `SLB`: A Classic Load Balancer (CLB) instance.
@@ -160,8 +160,8 @@ The endpoint_configurations supports the following:
 * `enable_clientip_preservation` - (Optional, Bool) Indicates whether client IP addresses are reserved. Default Value: `false`. Valid values:
   - `true`: Client IP addresses are reserved.
   - `false`: Client IP addresses are not reserved.
-* `vpc_id` - (Optional, Available since v1.262.0) The ID of the VPC.
-* `vswitch_ids` - (Optional, List, Available since v1.262.0) The IDs of vSwitches that are deployed in the VPC.
+* `vpc_id` - (Optional, Available since v1.262.0) The ID of the Virtual Private Cloud (VPC). This parameter is required only when the endpoint type is set to IpTarget.
+* `vswitch_ids` - (Optional, List, Available since v1.262.0) A list of vSwitches in the VPC. You can specify a maximum of two vSwitch IDs for an endpoint group of an intelligent routing listener. This parameter is required when the endpoint type is IpTarget. The vSwitch must belong to the VPC specified by the VpcId parameter.
 
 ### `port_overrides`
 


### PR DESCRIPTION
## Summary

Cherry-pick of internal commit `311d68a94ae8807b912f6f20c7c96528339deea0` to bring GA IpTarget endpoint type and Anycast acceleration mode support into the external open-source provider. Author and commit message are preserved verbatim — no code modifications were made on the external side.

### Changes included (all from the original internal commit)

- **`alicloud/resource_alicloud_ga_accelerator.go`** — add `bandwidth` (Optional, IntBetween 200–5000) and `ip_set_config` block (`access_mode`, ForceNew, MaxItems 1); extend Create timeout from 1 min to 3 min; server-side validation for Anycast + bandwidth dependency.
- **`alicloud/data_source_alicloud_ga_accelerators.go`** — expose `bandwidth`, `bandwidth_billing_type`, and `ip_set_config` read-only attributes.
- **`alicloud/resource_alicloud_ga_accelerator_test.go`** — add `TestAccAliCloudGaAccelerator_withAnycast`.
- **`alicloud/data_source_alicloud_ga_accelerators_test.go`** — add `TestAccAlicloudGaAcceleratorsDataSource_withAnycast`.
- **`alicloud/data_source_alicloud_ga_endpoint_groups_test.go`** — add `TestAccAliCloudGaEndpointGroupsDataSource_withIpTarget`.
- **`website/docs/r/ga_accelerator.html.markdown`** — document new fields and `ip_set_config` block.
- **`website/docs/r/ga_endpoint_group.html.markdown`** — add IpTarget usage example and clarify that `vpc_id` / `vswitch_ids` are required for the IpTarget endpoint type.
- **`CHANGELOG.md`** — add 4 ENHANCEMENTS entries.

## Compliance review

Full scan covered 8 changed files / 331 added lines. **Code content is clean:**

- Credential patterns (Alibaba Cloud `LTAI` / `AKID` AK, `access_key_secret`, PEM private key header, JWT, GitHub / Slack token, `sk-` prefixed key): **zero hits**.
- Internal domains (`*-inc.com`), private network ranges beyond RFC 1918, internal system codenames (aone / cstar / netframe / DingTalk / Yuque, etc.): **zero hits** in the diff.
- Real instance IDs, ARNs, 16-digit account UIDs: **zero hits**.
- Chinese characters, `TODO` / `FIXME`, external URLs: **zero hits** in code.

The three IPs in the diff (`192.168.0.0/16`, `192.168.0.0/24`, `192.168.0.100`) are RFC 1918 private addresses used in VPC / endpoint acceptance tests — standard practice in community providers. `IpSetConfig.AccessMode` (UserDefine / Anycast), `Bandwidth` (200–5000), `vpc_id`, `vswitch_ids` are all already-public OpenAPI fields per official documentation — no pre-GA capability is disclosed.

## Known metadata items (not code defects) for reviewer awareness

1. **Author email exposes an employee-ID-form account** — the commit is authored by `xuxudong <wb-xxd918355@alibaba-inc.com>`. The `wb-` prefix plus digits is an outsourced-employee ID format. Consistent with project convention (212/300 and 1523/2000 recent commits use `@alibaba-inc.com`). If desensitization is desired, a one-shot `git rebase` to `users.noreply.github.com` is recommended rather than leaving two versions in history.
2. **Cherry-pick trace carries the internal commit SHA** — the commit message ends with `(cherry picked from commit 311d68a94ae8807b912f6f20c7c96528339deea0)`. The SHA is not resolvable from the public repo, but does leave a trace of the internal source. Can be dropped via `git commit --amend` if full scrubbing is preferred.

## Test plan

- [ ] `go build ./...` succeeds in the provider root.
- [ ] `go vet ./alicloud/...` reports no issues on the touched files.
- [ ] `TestAccAliCloudGaAccelerator_withAnycast`, `TestAccAlicloudGaAcceleratorsDataSource_withAnycast`, `TestAccAliCloudGaEndpointGroupsDataSource_withIpTarget` pass against a live GA-enabled Alibaba Cloud account.
- [ ] Existing `alicloud_ga_accelerator` and `alicloud_ga_endpoint_group` acceptance tests remain green.
- [ ] Reviewer confirms the 2 metadata items above are acceptable or wants them addressed before merge.