### PR TITLE
resource/alicloud_api_gateway_api: support app_code_auth_type

### DIFF
--- a/alicloud/resource_alicloud_api_gateway_api.go
+++ b/alicloud/resource_alicloud_api_gateway_api.go
@@ -48,6 +48,13 @@ func resourceAliyunApigatewayApi() *schema.Resource {
 				Required: true,
 			},
 
+			"app_code_auth_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"DISABLE", "HEADER", "HEADER_QUERY"}, false),
+			},
+
 			"request_config": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -431,6 +438,7 @@ func resourceAliyunApigatewayApiRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("name", objectRaw["ApiName"])
 	d.Set("description", objectRaw["Description"])
 	d.Set("auth_type", objectRaw["AuthType"])
+	d.Set("app_code_auth_type", objectRaw["AppCodeAuthType"])
 	d.Set("force_nonce_check", objectRaw["ForceNonceCheck"])
 
 	v := convertApiGatewayApiRequestConfigResponse(objectRaw["RequestConfig"])
@@ -499,12 +507,17 @@ func resourceAliyunApigatewayApiUpdate(d *schema.ResourceData, meta interface{})
 
 	d.Partial(true)
 
-	if d.HasChanges("name", "description", "auth_type") {
+	if d.HasChanges("name", "description", "auth_type", "app_code_auth_type") {
 		update = true
 	}
 	request.ApiName = d.Get("name").(string)
 	request.Description = d.Get("description").(string)
 	request.AuthType = d.Get("auth_type").(string)
+	if d.HasChange("app_code_auth_type") || d.Get("auth_type").(string) == "APP" {
+		if v, exist := d.GetOk("app_code_auth_type"); exist {
+			request.AppCodeAuthType = v.(string)
+		}
+	}
 
 	if d.HasChange("force_nonce_check") {
 		update = true
@@ -653,6 +666,9 @@ func buildAliyunApiArgs(d *schema.ResourceData, meta interface{}) (*cloudapi.Cre
 	request.Description = d.Get("description").(string)
 	request.ApiName = d.Get("name").(string)
 	request.AuthType = d.Get("auth_type").(string)
+	if v, exist := d.GetOk("app_code_auth_type"); exist {
+		request.AppCodeAuthType = v.(string)
+	}
 	if v, exist := d.GetOk("force_nonce_check"); exist {
 		request.ForceNonceCheck = requests.Boolean(strconv.FormatBool(v.(bool)))
 	}

--- a/alicloud/resource_alicloud_api_gateway_api_test.go
+++ b/alicloud/resource_alicloud_api_gateway_api_test.go
@@ -277,6 +277,97 @@ func TestAccAliCloudApigatewayApi_basic(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudApigatewayApi_appCodeAuthType(t *testing.T) {
+	var api *cloudapi.DescribeApiResponse
+	resourceId := "alicloud_api_gateway_api.default"
+	ra := resourceAttrInit(resourceId, apiGatewayApiMap)
+	serviceFunc := func() interface{} {
+		return &CloudApiService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &api, serviceFunc)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf_testAccApiGatewayApi_%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceApigatewayApiConfigDependence)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name":               "${alicloud_api_gateway_group.default.name}",
+					"group_id":           "${alicloud_api_gateway_group.default.id}",
+					"description":        "tf_testAcc_api description",
+					"auth_type":          "APP",
+					"app_code_auth_type": "HEADER",
+					"request_config": []map[string]string{{
+						"protocol": "HTTP",
+						"method":   "GET",
+						"path":     "/test/path",
+						"mode":     "MAPPING",
+					}},
+					"service_type": "HTTP",
+					"http_service_config": []map[string]string{{
+						"address":   "http://apigateway-backend.alicloudapi.com:8080",
+						"method":    "GET",
+						"path":      "/web/cloudapi",
+						"timeout":   "20",
+						"aone_name": "cloudapi-openapi",
+					}},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"app_code_auth_type": "HEADER",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"app_code_auth_type": "HEADER_QUERY",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"app_code_auth_type": "HEADER_QUERY",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"app_code_auth_type": "DISABLE",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"app_code_auth_type": "DISABLE",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"app_code_auth_type": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"app_code_auth_type": "DISABLE",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
 func TestAccAliCloudApigatewayApi_param(t *testing.T) {
 	var api *cloudapi.DescribeApiResponse
 	resourceId := "alicloud_api_gateway_api.default"
@@ -943,7 +1034,7 @@ func TestAccAliCloudApigatewayApi_fc2(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"fc_service_config": []map[string]string{{
-						"function_version":      "2.0",
+						"function_version":      "3.0",
 						"function_type":         "HttpTrigger",
 						"function_base_url":     "http://apigateway-update.alicloudapi.com/fcapp.run/",
 						"path":                  "/test/path/fc/update",
@@ -959,7 +1050,7 @@ func TestAccAliCloudApigatewayApi_fc2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"name":                                      name,
-						"fc_service_config.0.function_version":      "2.0",
+						"fc_service_config.0.function_version":      "3.0",
 						"fc_service_config.0.function_type":         "HttpTrigger",
 						"fc_service_config.0.function_base_url":     "http://apigateway-update.alicloudapi.com/fcapp.run/",
 						"fc_service_config.0.path":                  "/test/path/fc/update",

--- a/website/docs/r/api_gateway_api.html.markdown
+++ b/website/docs/r/api_gateway_api.html.markdown
@@ -138,6 +138,7 @@ The following arguments are supported:
 * `group_id` - (Required, ForceNew) The api gateway that the api belongs to. Defaults to null.
 * `description` - (Required) The description of the api. Defaults to null.
 * `auth_type` - (Required) The authorization Type including APP and ANONYMOUS. Defaults to null.
+* `app_code_auth_type` - (Optional, Available since v1.292.0) The App Code authentication type, only valid when `auth_type` is `APP`. Valid values: `DISABLE`, `HEADER` and `HEADER_QUERY`. If not set, the default value `DEFAULT` is used.
 * `request_config` - (Required, List) Request_config defines how users can send requests to your API. See [`request_config`](#request_config) below.
 * `service_type` - (Required) The type of backend service. Type including HTTP, VPC, FunctionCompute and MOCK. Defaults to null.
 * `http_service_config` - (Optional, List) http_service_config defines the config when service_type selected 'HTTP'. See [`http_service_config`](#http_service_config) below.
@@ -204,9 +205,9 @@ The fc_service_config mapping supports the following:
 * `arn_role` - (Required) RAM role arn attached to the Function Compute service. This governs both who / what can invoke your Function, as well as what resources our Function has access to. See [User Permissions](https://www.alibabacloud.com/help/doc-detail/52885.htm) for more details.
 * `timeout` - (Required) Backend service time-out time; unit: millisecond.
 * `content_type_category` - (Optional, Computed, Available since v1.281.0) The strategy for setting the Content-Type header when calling an HTTP backend service. Valid values:
- * `DEFAULT`: Use the default value provided by API Gateway.
- * `CUSTOM`: Use a custom value.
- * `CLIENT`: Use the Content-Type header from the client request.
+  * `DEFAULT`: Use the default value provided by API Gateway.
+  * `CUSTOM`: Use a custom value.
+  * `CLIENT`: Use the Content-Type header from the client request.
 * `content_type_value` - (Optional, Computed, Available since v1.281.0) The value of the Content-Type header when `content_type_category` is `DEFAULT` or `CUSTOM`. This field is ignored when `content_type_category` is set to `CLIENT`.
 
 ### `mock_service_config`


### PR DESCRIPTION
### Summary

`alicloud_api_gateway_api` exposes no way to configure the App Code authentication mode of an API. This PR adds the `app_code_auth_type` attribute (Optional, Computed) to control it. Valid values: `DISABLE`, `HEADER` and `HEADER_QUERY`; when unset, the server keeps the default value `DEFAULT`.

Fixes #1969

### Changes

- `alicloud/resource_alicloud_api_gateway_api.go`: add `app_code_auth_type` (Optional, Computed, `DISABLE`/`HEADER`/`HEADER_QUERY`), pass through on Create/Update and read back from `DescribeApi` in Read. The server rejects the `AppCodeAuthType` parameter whenever `AuthType` is not `APP` (`InvalidappCodeAuthType`), so Update only re-sends the computed state value when `auth_type` is `APP`; a value set in the configuration is always sent so invalid combinations fail fast.
- `alicloud/resource_alicloud_api_gateway_api_test.go`: add `TestAccAliCloudApigatewayApi_appCodeAuthType` (create with `HEADER` -> update to `HEADER_QUERY` -> update to `DISABLE` -> remove from config, value persists -> import). Also change `function_version` from `2.0` to `3.0` in `TestAccAliCloudApigatewayApi_fc2` step 2 to close a pre-existing gap of the testing coverage rate gate: the attribute never changed value between steps of a single test, so the gate failed on master as well.
- `website/docs/r/api_gateway_api.html.markdown`: document the new argument. Also fix the one-space list indentation under `content_type_category`, a pre-existing violation the markdown-lint gate reports since this PR touches the file.

### ACC Test

```
PASS: TestAccAliCloudApigatewayApi_appCodeAuthType (17.82s)
PASS: TestAccAliCloudApigatewayApi_backend (11.61s)
PASS: TestAccAliCloudApigatewayApi_basic (27.65s)
PASS: TestAccAliCloudApigatewayApi_convertBackend (101.42s)
PASS: TestAccAliCloudApigatewayApi_fc2 (8.64s)
PASS: TestAccAliCloudApigatewayApi_fc3 (11.64s)
PASS: TestAccAliCloudApigatewayApi_mock (8.94s)
PASS: TestAccAliCloudApigatewayApi_multi (7.56s)
PASS: TestAccAliCloudApigatewayApi_param (11.06s)
PASS: TestAccAliCloudApigatewayApi_post (12.10s)
FAIL: TestAccAliCloudApigatewayApi_convertFc (3.74s)  # InvalidFunctionComputeConfig at CreateApi - pre-existing, see below
FAIL: TestAccAliCloudApigatewayApi_fc (3.81s)         # InvalidFunctionComputeConfig at CreateApi - pre-existing, see below
FAIL: TestAccAliCloudApigatewayApi_vpc (25.61s)       # NotSupportSnapshotEncrypted.DiskCategory in alicloud_instance RunInstances - pre-existing, see below
```

The three failures also fail on the base master commit with identical error codes and are unrelated to this change: two `InvalidFunctionComputeConfig` errors are rejected by the server when creating the FunctionCompute backend itself, and one is an ECS disk-encryption limitation in a different resource.
