### PR TITLE
docs: alicloud_oss_bucket_logging - fix example to put ignore_changes on the logging-enabled bucket and clarify enable/disable lifecycle

### DIFF
--- a/website/docs/r/oss_bucket_logging.html.markdown
+++ b/website/docs/r/oss_bucket_logging.html.markdown
@@ -16,6 +16,8 @@ For information about OSS Bucket Logging and how to use it, see [What is Bucket 
 
 -> **NOTE:** Available since v1.222.0.
 
+-> **NOTE:** This resource manages the full logging lifecycle of the bucket: creating or updating it enables logging (PutBucketLogging), and destroying it (or removing it from the configuration) disables logging (DeleteBucketLogging). If the same bucket is also managed by `alicloud_oss_bucket`, add `lifecycle { ignore_changes = [logging] }` to the bucket resource; otherwise `alicloud_oss_bucket` will keep disabling the logging configuration set by this resource on every apply.
+
 ## Example Usage
 
 Basic Usage
@@ -38,21 +40,22 @@ provider "alicloud" {
 resource "alicloud_oss_bucket" "CreateBucket" {
   storage_class = "Standard"
   bucket        = "resource-example-logging-806"
+  lifecycle {
+    # When you use `alicloud_oss_bucket_logging`, you must explicitly ignore the `logging` attribute on the `alicloud_oss_bucket` that logging is enabled for.
+    # Otherwise `alicloud_oss_bucket` detects the logging configuration set by this resource as drift and disables it on every apply.
+    ignore_changes = [logging]
+  }
 }
 
 resource "alicloud_oss_bucket" "CreateLoggingBucket" {
   storage_class = "Standard"
   bucket        = "resource-example-logging-153"
-  lifecycle {
-    # When you use `alicloud_oss_bucket_logging`, you must explicitly ignore the `logging` attribute on the `alicloud_oss_bucket`.
-    ignore_changes = [logging]
-  }
 }
 
 
 resource "alicloud_oss_bucket_logging" "default" {
   bucket        = alicloud_oss_bucket.CreateBucket.id
-  target_bucket = alicloud_oss_bucket.CreateBucket.id
+  target_bucket = alicloud_oss_bucket.CreateLoggingBucket.id
   target_prefix = "log/"
   logging_role  = "example-role"
 }


### PR DESCRIPTION
## What

Fix the `alicloud_oss_bucket_logging` documentation example and clarify the resource lifecycle.

## Why

The previous example placed `lifecycle { ignore_changes = [logging] }` on `CreateLoggingBucket`, while logging was actually enabled on `CreateBucket` (and `CreateLoggingBucket` was unused). When `alicloud_oss_bucket` manages a bucket whose logging is enabled by `alicloud_oss_bucket_logging` without `ignore_changes = [logging]`, the bucket resource reads the remote logging configuration into state, detects a diff against the absent inline `logging` block, and disables logging on every apply — causing logging to flap on/off across applies.

## Changes

- Move `ignore_changes = [logging]` onto the bucket where logging is enabled (`CreateBucket`), with an explanatory comment.
- Use `CreateLoggingBucket` as the `target_bucket` so the example is self-consistent.
- Add a NOTE documenting that this resource enables logging on create/update (`PutBucketLogging`) and disables logging on destroy (`DeleteBucketLogging`), and that `ignore_changes = [logging]` is required when the bucket is also managed by `alicloud_oss_bucket`.