### PR TITLE
resource/alicloud_ecs_invocation: mark timed as deprecated and update docs

### DIFF
--- a/alicloud/data_source_alicloud_ecs_invocations_test.go
+++ b/alicloud/data_source_alicloud_ecs_invocations_test.go
@@ -115,7 +115,7 @@ variable "name" {
 }
 
 	data "alicloud_zones" "default" {
-  		available_disk_category     = "cloud_efficiency"
+  		available_disk_category     = "cloud_essd"
   		available_resource_creation = "VSwitch"
 	}
 
@@ -126,8 +126,9 @@ variable "name" {
 	}
 
 	data "alicloud_instance_types" "default" {
-  		availability_zone = data.alicloud_zones.default.zones.0.id
-  		image_id          = data.alicloud_images.default.images.0.id
+  		availability_zone    = data.alicloud_zones.default.zones.0.id
+  		instance_type_family = "ecs.u1"
+  		image_id             = data.alicloud_images.default.images.0.id
 	}
 
 	resource "alicloud_vpc" "default" {
@@ -155,7 +156,7 @@ variable "name" {
   		internet_max_bandwidth_out = "10"
   		availability_zone          = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
   		instance_charge_type       = "PostPaid"
-  		system_disk_category       = "cloud_efficiency"
+  		system_disk_category       = "cloud_essd"
   		vswitch_id                 = alicloud_vswitch.default.id
   		instance_name              = var.name
 	}

--- a/alicloud/resource_alicloud_ecs_invocation.go
+++ b/alicloud/resource_alicloud_ecs_invocation.go
@@ -44,10 +44,11 @@ func resourceAlicloudEcsInvocation() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"Once", "Period", "NextRebootOnly", "EveryReboot"}, false),
 			},
 			"timed": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeBool,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "Field `timed` has been deprecated because it is deprecated in the ECS API and takes no effect. To run a command periodically, set `repeat_mode` to `Period` and specify `frequency`.",
 			},
 			"frequency": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_ecs_invocation_test.go
+++ b/alicloud/resource_alicloud_ecs_invocation_test.go
@@ -131,7 +131,7 @@ func AliCloudECSInvocationBasicDependence0(name string) string {
 	}
 
 	data "alicloud_zones" "default" {
-  		available_disk_category     = "cloud_efficiency"
+  		available_disk_category     = "cloud_essd"
   		available_resource_creation = "VSwitch"
 	}
 
@@ -142,8 +142,9 @@ func AliCloudECSInvocationBasicDependence0(name string) string {
 	}
 
 	data "alicloud_instance_types" "default" {
-  		availability_zone = data.alicloud_zones.default.zones.0.id
-  		image_id          = data.alicloud_images.default.images.0.id
+  		availability_zone    = data.alicloud_zones.default.zones.0.id
+  		instance_type_family = "ecs.u1"
+  		image_id             = data.alicloud_images.default.images.0.id
 	}
 
 	resource "alicloud_vpc" "default" {
@@ -171,7 +172,7 @@ func AliCloudECSInvocationBasicDependence0(name string) string {
   		internet_max_bandwidth_out = "10"
   		availability_zone          = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
   		instance_charge_type       = "PostPaid"
-  		system_disk_category       = "cloud_efficiency"
+  		system_disk_category       = "cloud_essd"
   		vswitch_id                 = alicloud_vswitch.default.id
   		instance_name              = var.name
 	}
@@ -197,7 +198,7 @@ func AliCloudECSInvocationBasicDependence1(name string) string {
 	}
 
 	data "alicloud_zones" "default" {
-  		available_disk_category     = "cloud_efficiency"
+  		available_disk_category     = "cloud_essd"
   		available_resource_creation = "VSwitch"
 	}
 
@@ -208,8 +209,9 @@ func AliCloudECSInvocationBasicDependence1(name string) string {
 	}
 
 	data "alicloud_instance_types" "default" {
-  		availability_zone = data.alicloud_zones.default.zones.0.id
-  		image_id          = data.alicloud_images.default.images.0.id
+  		availability_zone    = data.alicloud_zones.default.zones.0.id
+  		instance_type_family = "ecs.u1"
+  		image_id             = data.alicloud_images.default.images.0.id
 	}
 
 	resource "alicloud_vpc" "default" {
@@ -237,7 +239,7 @@ func AliCloudECSInvocationBasicDependence1(name string) string {
   		internet_max_bandwidth_out = "10"
   		availability_zone          = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
   		instance_charge_type       = "PostPaid"
-  		system_disk_category       = "cloud_efficiency"
+  		system_disk_category       = "cloud_essd"
   		vswitch_id                 = alicloud_vswitch.default.id
   		instance_name              = var.name
 	}

--- a/website/docs/r/ecs_invocation.html.markdown
+++ b/website/docs/r/ecs_invocation.html.markdown
@@ -104,11 +104,11 @@ The following arguments are supported:
 
 * `command_id` - (Required, ForceNew) The ID of the command.
 * `instance_id` - (Required, ForceNew) The list of instances to execute the command. You can specify up to 50 instance IDs.
-* `repeat_mode` - (Optional, ForceNew, Computed) Specifies how to run the command. Valid values: `Once`, `Period`, `NextRebootOnly`, `EveryReboot`. Default value: When `timed` is set to false and Frequency is not specified, the default value of `repeat_mode` is `Once`. When `Timed` is set to true and Frequency is specified, `period` is used as the value of RepeatMode regardless of whether `repeat_mode` is specified.
-* `timed` - (Optional, ForceNew, Computed) Specifies whether to periodically run the command. Default value: `false`.
+* `repeat_mode` - (Optional, ForceNew, Computed) Specifies how to run the command. Valid values: `Once`, `Period`, `NextRebootOnly`, `EveryReboot`. Default value: When `frequency` is not specified, the default value of `repeat_mode` is `Once`. When `frequency` is specified, `Period` is used as the value of `repeat_mode` regardless of whether `repeat_mode` is specified.
+* `timed` - (Optional, ForceNew, Computed, Deprecated) Specifies whether to periodically run the command. Default value: `false`. **NOTE:** This parameter has been deprecated by the ECS API and no longer takes effect. To run a command periodically, set `repeat_mode` to `Period` and specify `frequency` instead. Existing configurations in which `timed` is set to `true` together with `frequency` are not affected because the command runs periodically as long as `frequency` is specified.
 * `frequency` - (Optional, ForceNew) The schedule on which the recurring execution of the command takes place. Take note of the following items:
   * The interval between two consecutive executions must be 10 seconds or longer. The minimum interval cannot be less than the timeout period of the execution.
-  * When you set Timed to true, you must specify Frequency.
+  * When you set `repeat_mode` to `Period`, you must specify `frequency`.
   * The value of the Frequency parameter is a cron expression. For more information, see [Cron expression](https://www.alibabacloud.com/help/en/elastic-compute-service/latest/cron-expression).
 * `parameters` - (Optional, ForceNew) The key-value pairs of custom parameters to be passed in when the custom parameter feature is enabled.  Number of custom parameters: 0 to 10.
 * `username` - (Optional, ForceNew, Computed) The username that is used to run the command on the ECS instance. 


### PR DESCRIPTION
### Description

The `timed` parameter of `alicloud_ecs_invocation` has been deprecated by the ECS InvokeCommand API and no longer takes effect on the API side. Periodic execution is now determined solely by `frequency`: when `frequency` is specified, the command runs periodically (RepeatMode is treated as `Period`) regardless of `timed`.

This PR:

- marks `timed` as `Deprecated` in the resource schema, with migration guidance (`repeat_mode` = `Period` + `frequency`) while keeping the field accepted for backward compatibility
- updates the resource documentation: `timed` is flagged deprecated with a NOTE explaining the impact on existing configurations (configs that set `timed` together with `frequency` keep working as before); the `repeat_mode` default-value description and the `frequency` requirement are aligned with the latest API semantics
- stabilizes the acceptance test dependencies: the instance-type data source now pins `instance_type_family = "ecs.u1"` and the test blocks use `cloud_essd` system disks, because the test account enforces native snapshot encryption which is not supported by the previously resolved instance family / `cloud_efficiency` combination

### Test result

```
=== RUN TestAccAliCloudECSInvocation_basic0
--- PASS: TestAccAliCloudECSInvocation_basic0 (93.98s)

=== RUN TestAccAliCloudECSInvocation_basic1
--- PASS: TestAccAliCloudECSInvocation_basic1 (93.39s)
```