### PR TITLE
docs: fix security_group_ids type from List to Set in cs_kubernetes_node_pool

### DIFF
--- a/website/docs/r/cs_kubernetes_node_pool.html.markdown
+++ b/website/docs/r/cs_kubernetes_node_pool.html.markdown
@@ -767,7 +767,7 @@ The following arguments are supported:
   - `release`: in the standard mode, scaling is performed by creating and releasing ECS instances based on the usage of the application resource value.
   - `recycle`: in the speed mode, scaling is performed through creation, shutdown, and startup to increase the speed of scaling again (computing resources are not charged during shutdown, only storage fees are charged, except for local disk models).
 * `security_group_id` - (Optional, ForceNew, Computed, Deprecated since v1.145.0) The security group ID of the node pool. This field has been replaced by `security_group_ids`, please use the `security_group_ids` field instead.
-* `security_group_ids` - (Optional, ForceNew, Computed, List) Multiple security groups can be configured for a node pool. If both `security_group_ids` and `security_group_id` are configured, `security_group_ids` takes effect. This field cannot be modified.
+* `security_group_ids` - (Optional, ForceNew, Computed, Set) Multiple security groups can be configured for a node pool. If both `security_group_ids` and `security_group_id` are configured, `security_group_ids` takes effect. This field cannot be modified.
 * `security_hardening_os` - (Optional, ForceNew) Alibaba Cloud OS security reinforcement. Default value: `false`. Value:
   -`true`: enable Alibaba Cloud OS security reinforcement.
   -`false`: does not enable Alibaba Cloud OS security reinforcement.


### PR DESCRIPTION
## Summary

The `security_group_ids` field in `alicloud_cs_kubernetes_node_pool` uses `schema.TypeSet` (an unordered collection), but the documentation described it as `List`. This PR updates the documentation to say `Set` to match the actual schema type.

## Why

`TypeSet` in Terraform means the collection is unordered — changes in element order do not trigger a diff or replacement. The old documentation said `List`, which implies an ordered collection and could mislead users into thinking order matters.

The schema definition confirms this:
```go
"security_group_ids": {
    Type:     schema.TypeSet,
    Optional: true,
    Computed: true,
    ForceNew: true,
    Elem:     &schema.Schema{Type: schema.TypeString},
},
```

## Changes

- `website/docs/r/cs_kubernetes_node_pool.html.markdown`: Updated `security_group_ids` description from `(Optional, ForceNew, Computed, List)` to `(Optional, ForceNew, Computed, Set)`

## Tests

This is a documentation-only change with no code modifications.