### PR TITLE
resource/alicloud_mse_gateway: support resource_group_id and tags

### DIFF
--- a/alicloud/resource_alicloud_mse_gateway.go
+++ b/alicloud/resource_alicloud_mse_gateway.go
@@ -1,6 +1,7 @@
 package alicloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -72,6 +73,12 @@ func resourceAlicloudMseGateway() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
 			"delete_slb": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -147,6 +154,13 @@ func resourceAlicloudMseGatewayCreate(d *schema.ResourceData, meta interface{}) 
 
 	request["VSwitchId"] = d.Get("vswitch_id")
 	request["Vpc"] = d.Get("vpc_id")
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		tagsMap := ConvertTags(v.(map[string]interface{}))
+		request = expandTagsToMap(request, tagsMap)
+	}
 
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
@@ -196,6 +210,17 @@ func resourceAlicloudMseGatewayRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("status", fmt.Sprint(formatInt(object["Status"])))
 	d.Set("vswitch_id", object["Vswitch"])
 	d.Set("vpc_id", object["Vpc"])
+	d.Set("resource_group_id", object["ResourceGroupId"])
+	// GetGateway returns the gateway tags as a JSON string in the "MseTag" field
+	// (e.g. {"For":"Test","acs:rm:rgId":"rg-xxx","Created":"TF"}); there is no
+	// "Tags" array on this API. tagIgnored filters the acs: system tags.
+	var tagMap map[string]interface{}
+	if mseTagStr, ok := object["MseTag"].(string); ok && mseTagStr != "" {
+		if err := json.Unmarshal([]byte(mseTagStr), &tagMap); err != nil {
+			log.Printf("[DEBUG] Resource alicloud_mse_gateway unmarshal MseTag failed: %s", err)
+		}
+	}
+	d.Set("tags", tagsToMap(tagMap))
 
 	slbListObject, err := mseService.ListGatewaySlb(d.Id())
 	if err != nil {
@@ -230,36 +255,81 @@ func resourceAlicloudMseGatewayRead(d *schema.ResourceData, meta interface{}) er
 }
 func resourceAlicloudMseGatewayUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
-	request := map[string]interface{}{
-		"GatewayUniqueId": d.Id(),
+	mseService := MseService{client}
+	d.Partial(true)
+
+	if !d.IsNewResource() && d.HasChange("resource_group_id") {
+		action := "ChangeResourceGroup"
+		request := map[string]interface{}{
+			"ResourceId":       d.Id(),
+			"ResourceRegionId": client.RegionId,
+			"ResourceGroupId":  d.Get("resource_group_id"),
+			"ResourceType":     "Gateway",
+		}
+		var response map[string]interface{}
+		var err error
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("mse", "2019-05-31", action, nil, request, false)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		if fmt.Sprint(response["Success"]) == "false" {
+			return WrapError(fmt.Errorf("%s failed, response: %v", action, response))
+		}
+		d.SetPartial("resource_group_id")
 	}
-	var response map[string]interface{}
+
 	if d.HasChange("gateway_name") {
+		action := "UpdateGatewayName"
+		request := map[string]interface{}{
+			"GatewayUniqueId": d.Id(),
+		}
 		if v, ok := d.GetOk("gateway_name"); ok {
 			request["Name"] = v
 		}
-	}
-	action := "UpdateGatewayName"
-	var err error
-	wait := incrementalWait(3*time.Second, 3*time.Second)
-	err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
-		response, err = client.RpcGet("mse", "2019-05-31", action, request, nil)
-		if err != nil {
-			if NeedRetry(err) {
-				wait()
-				return resource.RetryableError(err)
+		var response map[string]interface{}
+		var err error
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcGet("mse", "2019-05-31", action, request, nil)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
 			}
-			return resource.NonRetryableError(err)
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
-		return nil
-	})
-	addDebug(action, response, request)
-	if err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		if fmt.Sprint(response["Success"]) == "false" {
+			return WrapError(fmt.Errorf("%s failed, response: %v", action, response))
+		}
+		d.SetPartial("gateway_name")
 	}
-	if fmt.Sprint(response["Success"]) == "false" {
-		return WrapError(fmt.Errorf("%s failed, response: %v", action, response))
+
+	if d.HasChange("tags") {
+		if err := mseService.SetResourceTags(d, "GATEWAY"); err != nil {
+			return WrapError(err)
+		}
+		d.SetPartial("tags")
 	}
+
+	d.Partial(false)
 	return resourceAlicloudMseGatewayRead(d, meta)
 }
 func resourceAlicloudMseGatewayDelete(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_mse_gateway_test.go
+++ b/alicloud/resource_alicloud_mse_gateway_test.go
@@ -112,7 +112,7 @@ func testSweepMseGateway(region string) error {
 	return nil
 }
 
-func TestAccAlicloudMSEGateway_basic0(t *testing.T) {
+func TestAccAliCloudMSEGateway_basic0(t *testing.T) {
 	var v map[string]interface{}
 	checkoutSupportedRegions(t, true, connectivity.MSEGatewaySupportRegions)
 	resourceId := "alicloud_mse_gateway.default"
@@ -135,29 +135,45 @@ func TestAccAlicloudMSEGateway_basic0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"spec":         "MSE_GTW_2_4_200_c",
-					"replica":      "2",
-					"vpc_id":       "${data.alicloud_vpcs.default.ids.0}",
-					"vswitch_id":   "${data.alicloud_vswitches.default.ids.0}",
-					"gateway_name": "${var.name}",
+					"spec":              "MSE_GTW_2_4_200_c",
+					"replica":           "2",
+					"vpc_id":            "${data.alicloud_vpcs.default.ids.0}",
+					"vswitch_id":        "${data.alicloud_vswitches.default.ids.0}",
+					"gateway_name":      "${var.name}",
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.groups.1.id}",
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "Test",
+					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"spec":         "MSE_GTW_2_4_200_c",
-						"replica":      "2",
-						"vpc_id":       CHECKSET,
-						"vswitch_id":   CHECKSET,
-						"gateway_name": name,
+						"spec":              "MSE_GTW_2_4_200_c",
+						"replica":           "2",
+						"vpc_id":            CHECKSET,
+						"vswitch_id":        CHECKSET,
+						"gateway_name":      name,
+						"resource_group_id": CHECKSET,
+						"tags.%":            "2",
+						"tags.Created":      "TF",
+						"tags.For":          "Test",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"gateway_name": "${var.name}_update",
+					"tags": map[string]string{
+						"Created": "TF-update",
+						"For":     "Test-update",
+					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"gateway_name": name + "_update",
+						"tags.%":       "2",
+						"tags.Created": "TF-update",
+						"tags.For":     "Test-update",
 					}),
 				),
 			},
@@ -165,12 +181,12 @@ func TestAccAlicloudMSEGateway_basic0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enterprise_security_group", "slb_spec", "delete_slb"},
+				ImportStateVerifyIgnore: []string{"enterprise_security_group", "slb_spec", "delete_slb", "resource_group_id"},
 			},
 		},
 	})
 }
-func TestAccAlicloudMSEGateway_basic1(t *testing.T) {
+func TestAccAliCloudMSEGateway_basic1(t *testing.T) {
 	checkoutSupportedRegions(t, true, connectivity.MSEGatewaySupportRegions)
 	var v map[string]interface{}
 	resourceId := "alicloud_mse_gateway.default"
@@ -244,6 +260,8 @@ data "alicloud_vswitches" "default" {
 	vpc_id  = data.alicloud_vpcs.default.ids.0
 	zone_id = data.alicloud_zones.default.zones.0.id
 }
+data "alicloud_resource_manager_resource_groups" "default" {
+}
 
 `, name)
 }
@@ -265,6 +283,11 @@ func TestUnitAlicloudMSEGateway(t *testing.T) {
 		"slb_spec":                  "slb_spec",
 		"internet_slb_spec":         "internet_slb_spec",
 		"delete_slb":                true,
+		"resource_group_id":         "resource_group_id",
+		"tags": map[string]interface{}{
+			"Created": "TF",
+			"For":     "Test",
+		},
 	} {
 		err := dCreate.Set(key, value)
 		assert.Nil(t, err)
@@ -282,13 +305,15 @@ func TestUnitAlicloudMSEGateway(t *testing.T) {
 		"Success": "true",
 		"Code":    "200",
 		"Data": map[string]interface{}{
-			"Spec":     "spec",
-			"Replica":  2,
-			"Vpc":      "vpc_id",
-			"Vswitch":  "vswitch_id",
-			"Vswitch2": "backup_vswitch_id",
-			"Name":     "gateway_name",
-			"Status":   "2",
+			"Spec":            "spec",
+			"Replica":         2,
+			"Vpc":             "vpc_id",
+			"Vswitch":         "vswitch_id",
+			"Vswitch2":        "backup_vswitch_id",
+			"Name":            "gateway_name",
+			"Status":          "2",
+			"ResourceGroupId": "resource_group_id",
+			"Tags":            map[string]interface{}{"Created": "TF", "For": "Test"},
 		},
 	}
 

--- a/website/docs/r/mse_gateway.html.markdown
+++ b/website/docs/r/mse_gateway.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Provides a Microservice Engine (MSE) Gateway resource.
 
-For information about Microservice Engine (MSE) Gateway and how to use it, see [What is Gateway](https://help.aliyun.com/document_detail/347638.html).
+For information about Microservice Engine (MSE) Gateway and how to use it, see [What is Gateway](https://www.alibabacloud.com/help/en/mse/developer-reference/api-mse-2019-05-31-addgateway).
 
 -> **NOTE:** Available since v1.157.0.
 
@@ -73,6 +73,8 @@ The following arguments are supported:
 * `vswitch_id` - (Required, ForceNew) The ID of the vswitch.
 * `vpc_id` - (Required, ForceNew) The ID of the vpc.
 * `delete_slb` - (Optional) Whether to delete the SLB purchased on behalf of the gateway at the same time.
+* `resource_group_id` - (Optional, Computed) The ID of the resource group which the gateway belongs.
+* `tags` - (Optional, Computed) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Description

Add `resource_group_id` and `tags` support for the `alicloud_mse_gateway` resource.

- `resource_group_id` - (Optional, Computed) The ID of the resource group which the gateway belongs.
- `tags` - (Optional, Computed) A mapping of tags to assign to the resource.

The MSE AddGateway API already accepts `ResourceGroupId` and `Tag` parameters. The gateway Read path now populates both fields from the GetGateway response, and Update uses the generic ChangeResourceGroup and TagResources/UnTagResources APIs to keep them in sync.

### Related Issue
Fixes #8757