### PR TITLE
data-source/alicloud_ess_scheduled_tasks: support scaling_group_id

### DIFF
--- a/alicloud/data_source_alicloud_ess_scheduled_tasks.go
+++ b/alicloud/data_source_alicloud_ess_scheduled_tasks.go
@@ -18,6 +18,10 @@ func dataSourceAlicloudEssScheduledTasks() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"scaling_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"scheduled_action": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -48,6 +52,10 @@ func dataSourceAlicloudEssScheduledTasks() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"scaling_group_id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -111,6 +119,9 @@ func dataSourceAlicloudEssScheduledTasksRead(d *schema.ResourceData, meta interf
 
 	if v, ok := d.GetOk("scheduled_task_id"); ok {
 		request.ScheduledTaskId = &[]string{v.(string)}
+	}
+	if v, ok := d.GetOk("scaling_group_id"); ok {
+		request.ScalingGroupId = v.(string)
 	}
 	if v, ok := d.GetOk("scheduled_action"); ok {
 		request.ScheduledAction = &[]string{v.(string)}
@@ -187,6 +198,7 @@ func scheduledTasksDescriptionAttribute(d *schema.ResourceData, tasks []ess.Sche
 	for _, t := range tasks {
 		mapping := map[string]interface{}{
 			"id":                     t.ScheduledTaskId,
+			"scaling_group_id":       t.ScalingGroupId,
 			"name":                   t.ScheduledTaskName,
 			"scheduled_action":       t.ScheduledAction,
 			"description":            t.Description,

--- a/alicloud/data_source_alicloud_ess_scheduled_tasks_test.go
+++ b/alicloud/data_source_alicloud_ess_scheduled_tasks_test.go
@@ -19,6 +19,14 @@ func TestAccAlicloudEssScheduledtasksDataSource(t *testing.T) {
 			"scheduled_task_id": `"${alicloud_ess_scheduled_task.default.id}_fake"`,
 		}),
 	}
+	scalingGroupIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEssScheduledTasksDataSourceConfig(rand, map[string]string{
+			"scaling_group_id": `"${alicloud_ess_scaling_group.default.id}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudEssScheduledTasksDataSourceConfig(rand, map[string]string{
+			"scaling_group_id": `"${alicloud_ess_scaling_group.default.id}_fake"`,
+		}),
+	}
 	actionConf := dataSourceTestAccConfig{
 		existConfig: testAccCheckAlicloudEssScheduledTasksDataSourceConfig(rand, map[string]string{
 			"scheduled_action": `"${alicloud_ess_scheduled_task.default.scheduled_action}"`,
@@ -51,12 +59,14 @@ func TestAccAlicloudEssScheduledtasksDataSource(t *testing.T) {
 			"ids":               `["${alicloud_ess_scheduled_task.default.id}"]`,
 			"name_regex":        `"${alicloud_ess_scheduled_task.default.scheduled_task_name}"`,
 			"scheduled_task_id": `"${alicloud_ess_scheduled_task.default.id}"`,
+			"scaling_group_id":  `"${alicloud_ess_scaling_group.default.id}"`,
 		}),
 		fakeConfig: testAccCheckAlicloudEssScheduledTasksDataSourceConfig(rand, map[string]string{
 			"scheduled_action":  `"${alicloud_ess_scheduled_task.default.scheduled_action}_fake"`,
 			"ids":               `["${alicloud_ess_scheduled_task.default.id}"]`,
 			"name_regex":        `"${alicloud_ess_scheduled_task.default.scheduled_task_name}"`,
 			"scheduled_task_id": `"${alicloud_ess_scheduled_task.default.id}"`,
+			"scaling_group_id":  `"${alicloud_ess_scaling_group.default.id}_fake"`,
 		}),
 	}
 
@@ -66,6 +76,7 @@ func TestAccAlicloudEssScheduledtasksDataSource(t *testing.T) {
 			"tasks.#":                        "1",
 			"tasks.0.name":                   fmt.Sprintf("tf-testAccDataSourceEssScheduledTasks-%d", rand),
 			"tasks.0.id":                     CHECKSET,
+			"tasks.0.scaling_group_id":       CHECKSET,
 			"tasks.0.scheduled_action":       CHECKSET,
 			"tasks.0.launch_expiration_time": CHECKSET,
 			"tasks.0.launch_time":            CHECKSET,
@@ -89,7 +100,7 @@ func TestAccAlicloudEssScheduledtasksDataSource(t *testing.T) {
 		fakeMapFunc:  fakeEssScheduledTasksMapFunc,
 	}
 
-	essScheduledTasksCheckInfo.dataSourceTestCheck(t, rand, idConf, actionConf, nameRegexConf, idsConf, allConf)
+	essScheduledTasksCheckInfo.dataSourceTestCheck(t, rand, idConf, scalingGroupIdConf, actionConf, nameRegexConf, idsConf, allConf)
 }
 
 func testAccCheckAlicloudEssScheduledTasksDataSourceConfig(rand int, attrMap map[string]string) string {

--- a/website/docs/d/ess_scheduled_tasks.html.markdown
+++ b/website/docs/d/ess_scheduled_tasks.html.markdown
@@ -11,14 +11,14 @@ description: |-
 
 This data source provides available scheduled task resources. 
 
--> **NOTE:** Available in 1.72.0+
+-> **NOTE:** Available since v1.72.0.
 
 ## Example Usage
 
-```
+```terraform
 data "alicloud_ess_scheduled_tasks" "ds" {
   scheduled_task_id = "scheduled_task_id"
-  name_regex       = "scheduled_task_name"
+  name_regex        = "scheduled_task_name"
 }
 
 output "first_scheduled_task" {
@@ -31,6 +31,7 @@ output "first_scheduled_task" {
 The following arguments are supported:
 
 * `scheduled_task_id` - (Optional) The id of the scheduled task.
+* `scaling_group_id` - (Optional, Available since v1.292.0) The id of the scaling group to which the scheduled task belongs.
 * `scheduled_action` - (Optional) The operation to be performed when a scheduled task is triggered.
 * `name_regex` - (Optional) A regex string to filter resulting scheduled tasks by name.
 * `ids` - (Optional) A list of scheduled task IDs.
@@ -44,11 +45,15 @@ The following attributes are exported in addition to the arguments listed above:
 * `names` - A list of scheduled task names.
 * `tasks` - A list of scheduled tasks. Each element contains the following attributes:
   * `id` - ID of the scheduled task id.
+  * `scaling_group_id` - The id of the scaling group to which the scheduled task belongs.
   * `name` - Name of the scheduled task name.
   * `scheduled_action` - The operation to be performed when a scheduled task is triggered.
   * `description` - Description of the scheduled task.
   * `launch_expiration_time` - The time period during which a failed scheduled task is retried.
   * `launch_time` - The time at which the scheduled task is triggered.
+  * `max_value` - The maximum number of instances in a scaling group when the scaling method of the scheduled task is to specify the number of instances in a scaling group.
+  * `min_value` - The minimum number of instances in a scaling group when the scaling method of the scheduled task is to specify the number of instances in a scaling group.
+  * `task_enabled` - Whether to start the scheduled task.
   * `recurrence_type` - Specifies the recurrence type of the scheduled task. 
   * `recurrence_value` - Specifies how often a scheduled task recurs. 
   * `recurrence_end_time` - Specifies the end time after which the scheduled task is no longer repeated.


### PR DESCRIPTION
## Summary
- Add the `scaling_group_id` optional argument to the `alicloud_ess_scheduled_tasks` data source, filtering scheduled tasks by scaling group via the `DescribeScheduledTasks` API.
- Export the `scaling_group_id` attribute in each element of the `tasks` list, so scheduled tasks can be correlated with scaling groups.

## Test plan
- [x] `TestAccAlicloudEssScheduledtasksDataSource` PASS (89.91s): id/scaling_group_id/scheduled_action/name_regex/ids/all filters, exist + fake configs.

```
=== RUN TestAccAlicloudEssScheduledtasksDataSource
--- PASS: TestAccAlicloudEssScheduledtasksDataSource (89.91s)
```