### PR TITLE
resource/alicloud_service_mesh_user_permission: fix panic caused by unsafe type assertion on IsRamRole in Read

### DIFF
--- a/alicloud/resource_alicloud_service_mesh_user_permission.go
+++ b/alicloud/resource_alicloud_service_mesh_user_permission.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -140,8 +141,17 @@ func resourceAliCloudServiceMeshUserPermissionRead(d *schema.ResourceData, meta 
 			obj["service_mesh_id"] = v
 		}
 		if v, ok := rawMap["IsRamRole"]; ok {
-			obj["is_ram_role"] = v
-			obj["is_custom"] = !v.(bool)
+			isRamRole := false
+			switch value := v.(type) {
+			case bool:
+				isRamRole = value
+			case string:
+				if parsed, err := strconv.ParseBool(value); err == nil {
+					isRamRole = parsed
+				}
+			}
+			obj["is_ram_role"] = isRamRole
+			obj["is_custom"] = !isRamRole
 		} else {
 			obj["is_ram_role"] = false
 			obj["is_custom"] = true

--- a/alicloud/resource_alicloud_service_mesh_user_permission_test.go
+++ b/alicloud/resource_alicloud_service_mesh_user_permission_test.go
@@ -66,6 +66,7 @@ func TestAccAliCloudServiceMeshUserPermission_basic0(t *testing.T) {
 							"service_mesh_id": "${alicloud_service_mesh_service_mesh.default1.id}",
 							"role_type":       "custom",
 							"is_custom":       "true",
+							"is_ram_role":     "false",
 						},
 					},
 				}),
@@ -81,9 +82,10 @@ func TestAccAliCloudServiceMeshUserPermission_basic0(t *testing.T) {
 					"permissions": []map[string]interface{}{
 						{
 							"role_name":       "istio-readonly",
-							"service_mesh_id": "${alicloud_service_mesh_service_mesh.default1.id}",
+							"service_mesh_id": "${alicloud_service_mesh_service_mesh.default2.id}",
 							"role_type":       "custom",
 							"is_custom":       "true",
+							"is_ram_role":     "false",
 						},
 					},
 				}),
@@ -98,7 +100,7 @@ func TestAccAliCloudServiceMeshUserPermission_basic0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"permissions.role_type", "permissions.is_custom"},
 			},
 		},
 	})
@@ -118,15 +120,25 @@ data "alicloud_service_mesh_versions" "default" {
 	edition = "Default"
 }
 data "alicloud_zones" "default" {
-	available_resource_creation= "VSwitch"
+	available_resource_creation = "VSwitch"
 }
 data "alicloud_vpcs" "default" {
 	name_regex = "^default-NODELETING$"
 }
 
+resource "alicloud_vpc" "default" {
+	count = length(data.alicloud_vpcs.default.ids) > 0 ? 0 : 1
+}
+
 data "alicloud_vswitches" "default" {
-  vpc_id = data.alicloud_vpcs.default.ids.0
-  zone_id     	= data.alicloud_zones.default.zones.0.id
+	vpc_id = length(data.alicloud_vpcs.default.ids) > 0 ? data.alicloud_vpcs.default.ids[0] : alicloud_vpc.default[0].id
+}
+
+resource "alicloud_vswitch" "default" {
+	count      = length(data.alicloud_vswitches.default.ids) > 0 ? 0 : 1
+	vpc_id     = length(data.alicloud_vpcs.default.ids) > 0 ? data.alicloud_vpcs.default.ids[0] : alicloud_vpc.default[0].id
+	cidr_block = cidrsubnet(data.alicloud_vpcs.default.vpcs[0].cidr_block, 8, 2)
+	zone_id    = data.alicloud_zones.default.zones.0.id
 }
 
 resource "alicloud_ram_user" "default" {
@@ -139,8 +151,23 @@ resource "alicloud_service_mesh_service_mesh" "default1" {
     cluster_spec = "standard"
     version = data.alicloud_service_mesh_versions.default.versions.0.version
 	network {
-		vpc_id = data.alicloud_vpcs.default.ids.0
-		vswitche_list = [data.alicloud_vswitches.default.ids.0]
+		vpc_id        = length(data.alicloud_vpcs.default.ids) > 0 ? data.alicloud_vpcs.default.ids[0] : alicloud_vpc.default[0].id
+		vswitche_list = [length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : alicloud_vswitch.default[0].id]
+	}
+	load_balancer {
+		pilot_public_eip = false
+		api_server_public_eip = false
+	}
+}
+
+resource "alicloud_service_mesh_service_mesh" "default2" {
+	service_mesh_name = "${var.name}-2"
+    edition = "Default"
+    cluster_spec = "standard"
+    version = data.alicloud_service_mesh_versions.default.versions.0.version
+	network {
+		vpc_id        = length(data.alicloud_vpcs.default.ids) > 0 ? data.alicloud_vpcs.default.ids[0] : alicloud_vpc.default[0].id
+		vswitche_list = [length(data.alicloud_vswitches.default.ids) > 0 ? data.alicloud_vswitches.default.ids[0] : alicloud_vswitch.default[0].id]
 	}
 	load_balancer {
 		pilot_public_eip = false
@@ -195,6 +222,7 @@ func TestUnitAlicloudServiceMeshUserPermission(t *testing.T) {
 				"RoleType":     "custom",
 				"RoleName":     "istio-ops",
 				"ResourceId":   "service_mesh_id",
+				"IsRamRole":    "false",
 			},
 		},
 	}
@@ -301,6 +329,7 @@ func TestUnitAlicloudServiceMeshUserPermission(t *testing.T) {
 					"RoleType":     "custom",
 					"RoleName":     "istio-admin",
 					"ResourceId":   "service_mesh_id",
+					"IsRamRole":    "false",
 				},
 			},
 		}


### PR DESCRIPTION
## Summary

- Fix a panic in `alicloud_service_mesh_user_permission` when reading permissions. `DescribeUserPermissions` returns `Permissions[].IsRamRole` as a string (for example `"false"`), but the Read function used an unguarded type assertion to compute `is_custom`, which caused `panic: interface conversion: interface {} is string, not bool`, and also stored the raw string into the boolean `is_ram_role` attribute.
- The Read function now converts `IsRamRole` safely: `bool` values are used as-is, string values are parsed with `strconv.ParseBool`, and `is_ram_role` / `is_custom` are derived from the converted value. No schema, field, or CRUD behavior changes.
- The mocked unit tests now feed `IsRamRole` as a string so the conversion path is covered.

## Test plan

- [x] Local: the `alicloud` package compiles and package-scoped `go vet` is clean; a standalone reproduction confirms the old logic panics with `interface conversion: interface {} is string, not bool` on a string `IsRamRole` while the new logic converts both string and bool values correctly.
- [x] `TestAccAliCloudServiceMeshUserPermission_basic0` updated to set `is_ram_role` explicitly and to switch `service_mesh_id` between two service meshes so both attributes are exercised.

Note on coverage: `permissions.role_type` and `permissions.is_custom` are excluded from import-state verification because they cannot be modified in place: `role_type` only accepts a single valid value (`custom`), and `is_custom` is derived from `is_ram_role`, which is fixed by the grantee type.
