### PR TITLE
docs: clarify dkms_instance_id semantics and scenario-scoped attribute notes for alicloud_kms_key

### DIFF
--- a/website/docs/r/kms_key.html.markdown
+++ b/website/docs/r/kms_key.html.markdown
@@ -43,16 +43,26 @@ The following arguments are supported:
 * `deletion_protection` - (Optional, Available since v1.240.0) Specifies whether to enable deletion protection. Default value: `Disabled`. Valid values: `Enabled`, `Disabled`.
 * `deletion_protection_description` - (Optional, Available since v1.240.0) The description of deletion protection. **NOTE:** `deletion_protection_description` takes effect only if `deletion_protection` is set to `Enabled`.
 * `description` - (Optional) The description of the key.
-* `dkms_instance_id` - (Optional, ForceNew, Available since v1.183.0) The ID of the KMS instance.
+* `dkms_instance_id` - (Optional, ForceNew, Available since v1.183.0) The ID of the KMS instance. If specified, the key is created in the specified KMS instance; if omitted, a default key (master key) is created in the current region.
+
+  **NOTE:** The two types of keys differ in capability: only keys in KMS instances support key policies (`policy`), and the valid values of `key_spec` and `rotation_interval` are determined by the key management type. For more information, see [CreateKey](https://www.alibabacloud.com/help/en/kms/developer-reference/api-createkey).
 * `key_spec` - (Optional, ForceNew) The specification of the key. Default value: `Aliyun_AES_256`. Valid values: `Aliyun_AES_256`, `Aliyun_AES_128`, `Aliyun_AES_192`, `Aliyun_SM4`, `RSA_2048`, `RSA_3072`, `EC_P256`, `EC_P256K`, `EC_SM2`.
+
+  **NOTE:** The valid values vary based on the key management type. For keys in KMS instances, the supported specifications are determined by the instance type.
 * `key_usage` - (Optional, ForceNew) The usage of the key. Default value: `ENCRYPT/DECRYPT`. Valid values:
   - `ENCRYPT/DECRYPT`: Encrypts or decrypts data.
   - `SIGN/VERIFY`: Generates or verifies a digital signature.
 * `origin` - (Optional, ForceNew) The key material origin. Default value: `Aliyun_KMS`. Valid values: `Aliyun_KMS`, `EXTERNAL`.
 * `pending_window_in_days` - (Optional, Int) The number of days before the CMK is deleted. During this period, the CMK is in the PendingDeletion state. After this period ends, you cannot cancel the deletion. Unit: days. Valid values: `7` to `366`. **NOTE:** From version 1.184.0, `pending_window_in_days` can be set to `366`.
 * `policy` - (Optional, Available since v1.224.0) The content of the key policy. The value is in the JSON format. The value can be up to 32,768 bytes in length. For more information, see [How to use it](https://www.alibabacloud.com/help/en/kms/developer-reference/api-setkeypolicy).
+
+  **NOTE:** This parameter takes effect only on keys in KMS instances (`dkms_instance_id` specified). Default keys do not support key policies, and this parameter does not take effect on them.
 * `protection_level` - (Optional, ForceNew) The protection level of the key. Default value: `SOFTWARE`. Valid values: `SOFTWARE`, `HSM`.
-* `rotation_interval` - (Optional) The period of automatic key rotation. The following units are supported: d (day), h (hour), m (minute), and s (second). For example, you can use either 7d or 604800s to specify a seven-day interval. **NOTE**: If `automatic_rotation` is set to `Enabled`, `rotation_interval` is required.
+
+  **NOTE:** The default value does not take effect when `dkms_instance_id` is specified. In this case, this parameter is ignored and the instance type determines the protection level: keys in a software key management instance are `SOFTWARE`, and keys in a hardware key management instance are `HSM`. For keys whose actual protection level is `HSM` (such as hardware instance keys), explicitly set `protection_level` to `HSM`. Otherwise, the configuration (default `SOFTWARE`) never matches the actual level and Terraform forces key recreation on every apply.
+* `rotation_interval` - (Optional) The period of automatic key rotation. The following units are supported: d (day), h (hour), m (minute), and s (second). For example, you can use either 7d or 604800s to specify a seven-day interval.
+
+  **NOTE:** This parameter is required if `automatic_rotation` is set to `Enabled`, and takes effect only when the key management type supports automatic rotation: default keys support only a fixed period of 365 days, software-protected keys support 7 to 365 days, and hardware-protected keys do not support automatic rotation.
 * `status` - (Optional, Available since v1.123.1) The status of key. Default value: `Enabled`. Valid values: `Enabled`, `Disabled`, `PendingDeletion`.
 * `tags` - (Optional, Map, Available since v1.207.0) A mapping of tags to assign to the resource.
 * `deletion_window_in_days` - (Optional, Int, Deprecated since v1.85.0) Field `deletion_window_in_days` has been deprecated from provider version 1.85.0. New field `pending_window_in_days` instead.
@@ -61,7 +71,7 @@ The following arguments are supported:
 
 -> **NOTE:** If you set the origin parameter to EXTERNAL or the key_spec parameter to an asymmetric CMK type, automatic key rotation is unavailable.
 
--> **NOTE:** The default type of the CMK is `Aliyun_AES_256`. Only Dedicated KMS supports `Aliyun_AES_128` and `Aliyun_AES_192`.
+-> **NOTE:** The default type of the CMK is `Aliyun_AES_256`. Only keys in KMS instances support `Aliyun_AES_128` and `Aliyun_AES_192`.
 
 -> **NOTE:** When the pre-deletion days elapses, the key is permanently deleted and cannot be recovered.
 


### PR DESCRIPTION
### Description

The `dkms_instance_id` attribute of `alicloud_kms_key` was documented only as "The ID of the KMS instance", which does not reflect the actual API contract: when specified, the key is created in the specified KMS instance; when omitted, a default key (master key) is created in the current region. The two types of keys also differ in capability, which was undocumented and made the behavior of `dkms_instance_id` and related attributes unclear.

### Changes

Documentation-only change to `website/docs/r/kms_key.html.markdown` (no code changes):

- `dkms_instance_id`: describe the fork semantics (key in a KMS instance vs default key) and the capability differences between the two types of keys
- `key_spec`: note that valid values vary based on the key management type
- `policy`: note that key policies take effect only on keys in KMS instances; default keys do not support key policies
- `protection_level`: note that the default value does not take effect when `dkms_instance_id` is specified — the instance type determines the protection level (software key management instance: `SOFTWARE`, hardware key management instance: `HSM`); for keys whose actual protection level is `HSM`, explicitly set `protection_level` to `HSM`, otherwise the default (`SOFTWARE`) never matches the actual level and Terraform forces key recreation on every apply
- `rotation_interval`: note that the rotation period is determined by the key management type (default keys: fixed 365 days; software-protected keys: 7 to 365 days; hardware-protected keys: no automatic rotation)
- Replace the legacy "Dedicated KMS" terminology with "keys in KMS instances"

All statements match the CreateKey API reference (DKMSInstanceId, KeySpec, ProtectionLevel, RotationInterval, and Policy parameter descriptions) and the KMS documentation on key management types and key specifications.

### Acceptance tests

Documentation-only change; no Go code or test files modified.
