### PR TITLE
docs: fix missing external_port argument and duplicate status attribute in forward_entries

### DIFF
--- a/website/docs/d/forward_entries.html.markdown
+++ b/website/docs/d/forward_entries.html.markdown
@@ -74,13 +74,14 @@ The following arguments are supported:
 * `ids` - (Optional, ForceNew) A list of Forward Entries IDs.
 * `name_regex` - (Optional, ForceNew, Available since 1.44.0+) A regex string to filter results by forward entry name.
 * `external_ip` - (Optional, ForceNew) The public IP address.
+* `external_port` - (Optional, ForceNew) The public port.
 * `internal_ip` - (Optional, ForceNew) The private IP address.
 * `forward_table_id` - (Required, ForceNew) The ID of the Forward table.
 * `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
 * `forward_entry_name` - (Optional, ForceNew, Available since 1.119.1+) The name of forward entry.
 * `internal_port` - (Optional, ForceNew, Available since 1.119.1+) The internal port.
 * `ip_protocol` - (Optional, ForceNew, Available since 1.119.1+) The ip protocol. Valid values: `any`,`tcp` and `udp`. 
-* `status` - (Optional, ForceNew, Available since 1.119.1+) The status of farward entry. Valid value `Available`, `Deleting` and `Pending`.
+* `status` - (Optional, ForceNew, Available since 1.119.1+) The status of forward entry. Valid values: `Available`, `Deleting` and `Pending`.
 
 ## Attributes Reference
 
@@ -99,5 +100,4 @@ The following attributes are exported in addition to the arguments listed above:
   * `status` - The status of the Forward Entry.
   * `forward_entry_id` - The forward entry ID.
   * `forward_entry_name` - The name of forward entry.
-  * `status` - The status of forward entry.
 


### PR DESCRIPTION
## Summary

- Add missing `external_port` to the Argument Reference section of `alicloud_forward_entries` data source documentation
- Remove duplicate `status` attribute from the Attributes Reference section
- Fix typo: "farward" → "forward" and "Valid value" → "Valid values"

The `external_port` parameter exists in the data source schema as an Optional filter argument but was not documented. The `status` attribute was listed twice in the exported entries attributes.