### PR TITLE
docs: document spec valid values and KMS 3.0 upgrade constraint for alicloud_kms_instance

### DIFF
--- a/website/docs/r/kms_instance.html.markdown
+++ b/website/docs/r/kms_instance.html.markdown
@@ -265,7 +265,7 @@ The following arguments are supported:
 -> **NOTE:** This parameter only applies during resource update. If modified in isolation without other property changes, Terraform will not trigger any action.
 
 * `secret_num` - (Optional, Int) Maximum number of Secrets. The attribute is valid when the attribute `payment_type` is `Subscription`.
-* `spec` - (Optional, Int) The computation performance level of the KMS instance. The attribute is valid when the attribute `payment_type` is `Subscription`.
+* `spec` - (Optional, Int) The computation performance level of the KMS instance. Valid values: `0`, `200`, `1000`, `2000` and `4000`. The attribute is valid when the attribute `payment_type` is `Subscription`. Valid values `1000` and above require a KMS 3.0 instance (`product_version` = `3`): a legacy instance with `spec` = `200` cannot be directly upgraded to a higher spec, and the instance must be upgraded to KMS 3.0 first. For more information, see [How to enable, view, upgrade, and renew KMS instances](https://www.alibabacloud.com/help/en/kms/key-management-service/user-guide/manage-kms-instances).
 * `tags` - (Optional, Map, Available since v1.259.0) The tag of the resource
 * `vpc_id` - (Required, ForceNew) The ID of the virtual private cloud (VPC) that is associated with the KMS instance.
 * `vpc_num` - (Optional, Int) The number of managed accesses. The maximum number of VPCs that can access this KMS instance. The attribute is valid when the attribute `payment_type` is `Subscription`.


### PR DESCRIPTION
### Description

The `spec` attribute of `alicloud_kms_instance` was documented only as "The computation performance level of the KMS instance" — the valid values and the upgrade constraint enforced by the cloud side were undocumented:

- Valid values: `0`, `200`, `1000`, `2000` and `4000`
- Values `1000` and above require a KMS 3.0 instance (`product_version` = `3`): a legacy instance with `spec` = `200` cannot be directly upgraded to a higher spec — the instance must be upgraded to KMS 3.0 first

### Changes

Documentation-only change to `website/docs/r/kms_instance.html.markdown` (no code changes):

- `spec`: list the valid values (matching the schema `ValidateFunc`) and document the upgrade constraint
- Link to the official "How to enable, view, upgrade, and renew KMS instances" documentation for the instance upgrade path

### Acceptance tests

Documentation-only change; no Go code or test files modified.
