### PR TITLE
New Resource: alicloud_threat_detection_monitor_account

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1327,6 +1327,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_quotas_template_applications":                         resourceAliCloudQuotasTemplateApplications(),
 			"alicloud_threat_detection_oss_scan_config":                     resourceAliCloudThreatDetectionOssScanConfig(),
 			"alicloud_threat_detection_malicious_file_whitelist_config":     resourceAliCloudThreatDetectionMaliciousFileWhitelistConfig(),
+			"alicloud_threat_detection_monitor_account":                     resourceAliCloudThreatDetectionMonitorAccount(),
 			"alicloud_adb_lake_account":                                     resourceAliCloudAdbLakeAccount(),
 			"alicloud_ens_security_group":                                   resourceAliCloudEnsSecurityGroup(),
 			"alicloud_ens_vswitch":                                          resourceAliCloudEnsVswitch(),

--- a/alicloud/resource_alicloud_threat_detection_monitor_account.go
+++ b/alicloud/resource_alicloud_threat_detection_monitor_account.go
@@ -1,0 +1,176 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudThreatDetectionMonitorAccount() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudThreatDetectionMonitorAccountCreate,
+		Read:   resourceAliCloudThreatDetectionMonitorAccountRead,
+		Update: resourceAliCloudThreatDetectionMonitorAccountUpdate,
+		Delete: resourceAliCloudThreatDetectionMonitorAccountDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"account_ids": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				DiffSuppressFunc: monitorAccountIdsDiffSuppressFunc,
+			},
+		},
+	}
+}
+
+// monitorAccountIdsDiffSuppressFunc compares two comma-separated account id lists as sets,
+// because the backend returns the member account ids in its own order.
+func monitorAccountIdsDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	oldSet := make(map[string]struct{})
+	for _, v := range strings.Split(old, ",") {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			oldSet[v] = struct{}{}
+		}
+	}
+	newSet := make(map[string]struct{})
+	for _, v := range strings.Split(new, ",") {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			newSet[v] = struct{}{}
+		}
+	}
+	if len(oldSet) != len(newSet) {
+		return false
+	}
+	for v := range oldSet {
+		if _, ok := newSet[v]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func resourceAliCloudThreatDetectionMonitorAccountCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateMonitorAccount"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	if v, ok := d.GetOk("account_ids"); ok {
+		request["AccountIds"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_monitor_account", action, AlibabaCloudSdkGoERROR)
+	}
+
+	accountId, err := client.AccountId()
+	if err != nil {
+		return WrapError(err)
+	}
+	d.SetId(accountId)
+
+	return resourceAliCloudThreatDetectionMonitorAccountRead(d, meta)
+}
+
+func resourceAliCloudThreatDetectionMonitorAccountRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	threatDetectionServiceV2 := ThreatDetectionServiceV2{client}
+
+	objectRaw, err := threatDetectionServiceV2.DescribeThreatDetectionMonitorAccount(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_threat_detection_monitor_account DescribeThreatDetectionMonitorAccount Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	accountIds := make([]string, 0)
+	if v, ok := objectRaw["AccountIds"]; ok && v != nil {
+		for _, item := range v.([]interface{}) {
+			accountIds = append(accountIds, fmt.Sprint(item))
+		}
+	}
+	sort.Strings(accountIds)
+	d.Set("account_ids", strings.Join(accountIds, ","))
+
+	return nil
+}
+
+func resourceAliCloudThreatDetectionMonitorAccountUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "CreateMonitorAccount"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if d.HasChange("account_ids") {
+		update = true
+		request["AccountIds"] = d.Get("account_ids")
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudThreatDetectionMonitorAccountRead(d, meta)
+}
+
+func resourceAliCloudThreatDetectionMonitorAccountDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource AliCloud Resource Monitor Account. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/alicloud/resource_alicloud_threat_detection_monitor_account_test.go
+++ b/alicloud/resource_alicloud_threat_detection_monitor_account_test.go
@@ -1,0 +1,87 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// lintignore: AT001
+func TestAccAliCloudThreatDetectionMonitorAccount_basic0(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_monitor_account.default"
+	ra := resourceAttrInit(resourceId, AlicloudThreatDetectionMonitorAccountMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionMonitorAccount")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetection%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudThreatDetectionMonitorAccountBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"account_ids": "${join(\",\", data.alicloud_resource_manager_accounts.default.accounts[*].account_id)}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"account_ids": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"account_ids": "",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"account_ids": "",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"account_ids": "${join(\",\", data.alicloud_resource_manager_accounts.default.accounts[*].account_id)}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"account_ids": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudThreatDetectionMonitorAccountMap0 = map[string]string{}
+
+func AlicloudThreatDetectionMonitorAccountBasicDependence0(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_resource_manager_accounts" "default" {
+  status = "CreateSuccess"
+}
+
+
+`, name)
+}

--- a/alicloud/service_alicloud_threat_detection_v2.go
+++ b/alicloud/service_alicloud_threat_detection_v2.go
@@ -1509,3 +1509,74 @@ func (s *ThreatDetectionServiceV2) DescribeAsyncDescribeServiceLinkedRoleStatus(
 }
 
 // DescribeAsyncDescribeServiceLinkedRoleStatus >>> Encapsulated.
+// DescribeThreatDetectionMonitorAccount <<< Encapsulated get interface for ThreatDetection MonitorAccount.
+
+func (s *ThreatDetectionServiceV2) DescribeThreatDetectionMonitorAccount(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	action := "DescribeMonitorAccounts"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *ThreatDetectionServiceV2) ThreatDetectionMonitorAccountStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ThreatDetectionMonitorAccountStateRefreshFuncWithApi(id, field, failStates, s.DescribeThreatDetectionMonitorAccount)
+}
+
+func (s *ThreatDetectionServiceV2) ThreatDetectionMonitorAccountStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeThreatDetectionMonitorAccount >>> Encapsulated.

--- a/website/docs/r/threat_detection_monitor_account.html.markdown
+++ b/website/docs/r/threat_detection_monitor_account.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_monitor_account"
+description: |-
+  Provides a Alicloud Threat Detection Monitor Account resource.
+---
+
+# alicloud_threat_detection_monitor_account
+
+Provides a Threat Detection Monitor Account resource.
+
+Multi-account management account. The member accounts in the resource directory are added to the monitor account list of Threat Detection (Security Center), so that the security administrator account can manage the security of these member accounts in a unified manner.
+
+For information about Threat Detection Monitor Account and how to use it, see [What is Monitor Account](https://next.api.alibabacloud.com/document/Sas/2018-12-03/CreateMonitorAccount).
+
+-> **NOTE:** Available since v1.292.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+variable "member_account_ids" {
+  description = "The IDs of the member accounts in the resource directory. Multiple IDs must be separated by commas (,)."
+  type        = string
+}
+
+resource "alicloud_threat_detection_monitor_account" "default" {
+  account_ids = var.member_account_ids
+}
+```
+
+### Deleting `alicloud_threat_detection_monitor_account` or removing it from your configuration
+
+Terraform cannot destroy resource `alicloud_threat_detection_monitor_account`. Terraform will remove this resource from the state file, however resources may remain.
+
+## Argument Reference
+
+The following arguments are supported:
+* `account_ids` - (Optional) The list of member account IDs in the resource directory. You can call [ListAccountsInResourceDirectory](https://next.api.alibabacloud.com/document/Sas/2018-12-03/ListAccountsInResourceDirectory) to obtain the member account IDs. Multiple member account IDs must be separated by commas (,). The monitor account list is fully replaced by the incoming list. If this parameter is not specified, the existing monitor account list is cleared.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<Alibaba Cloud Account ID>`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Monitor Account.
+* `update` - (Defaults to 5 mins) Used when update the Monitor Account.
+* `delete` - (Defaults to 5 mins) Used when delete the Monitor Account.
+
+## Import
+
+Threat Detection Monitor Account can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_threat_detection_monitor_account.example <Alibaba Cloud Account ID>
+```


### PR DESCRIPTION
## Summary
- Add a new resource `alicloud_threat_detection_monitor_account` to manage the multi-account management (monitor account) list of Threat Detection (Security Center). The resource adds the member accounts of a resource directory to the monitor account list so that the security administrator can manage them in a unified manner.
- The resource is a singleton with full-replace semantics: `account_ids` is a comma-separated list of member account IDs backed by `CreateMonitorAccount` (create/update) and `DescribeMonitorAccounts` (read). Destroy only removes the resource from the state file, following the existing convention of singleton config resources such as `alicloud_threat_detection_log_meta`.

## Test plan
- [x] `TestAccAliCloudThreatDetectionMonitorAccount_basic0` PASS in cn-hangzhou (25.98s): create with member account ids -> update (clear list) -> update (restore list) -> import.

=== RUN   TestAccAliCloudThreatDetectionMonitorAccount_basic0
--- PASS: TestAccAliCloudThreatDetectionMonitorAccount_basic0 (25.98s)