### PR TITLE
New Resource: alicloud_modelstudio_workspace

### DIFF
--- a/alicloud/connectivity/endpoint.go
+++ b/alicloud/connectivity/endpoint.go
@@ -348,6 +348,7 @@ var irregularProductEndpoint = map[string]string{
 	"alidns":                  "alidns.aliyuncs.com",
 	"openapiexplorer":         "openapi-mcp.cn-hangzhou.aliyuncs.com",
 	"computenestsupplier":     "computenestsupplier.cn-hangzhou.aliyuncs.com",
+	"modelstudio":             "modelstudio.%s.aliyuncs.com",
 }
 
 // irregularProductEndpointForIntlRegion specially records those product codes that

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1064,6 +1064,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_eflo_vpd_grant_rule":                                  resourceAliCloudEfloVpdGrantRule(),
 			"alicloud_wafv3_defense_resource_group":                         resourceAliCloudWafv3DefenseResourceGroup(),
 			"alicloud_milvus_instance":                                      resourceAliCloudMilvusInstance(),
+			"alicloud_modelstudio_workspace":                                resourceAliCloudModelstudioWorkspace(),
 			"alicloud_resource_manager_delivery_channel":                    resourceAliCloudResourceManagerDeliveryChannel(),
 			"alicloud_esa_load_balancer":                                    resourceAliCloudEsaLoadBalancer(),
 			"alicloud_resource_manager_multi_account_delivery_channel":      resourceAliCloudResourceManagerMultiAccountDeliveryChannel(),

--- a/alicloud/resource_alicloud_modelstudio_workspace.go
+++ b/alicloud/resource_alicloud_modelstudio_workspace.go
@@ -1,0 +1,290 @@
+// Package alicloud
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudModelstudioWorkspace() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudModelstudioWorkspaceCreate,
+		Read:   resourceAliCloudModelstudioWorkspaceRead,
+		Update: resourceAliCloudModelstudioWorkspaceUpdate,
+		Delete: resourceAliCloudModelstudioWorkspaceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"api_host": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_site": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"workspace_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"workspace_name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringLenBetween(1, 30),
+			},
+		},
+	}
+}
+
+func resourceAliCloudModelstudioWorkspaceCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := "/modelstudio/workspaces"
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+
+	query["workspaceName"] = StringPointer(d.Get("workspace_name").(string))
+	if v, ok := d.GetOk("service_site"); ok {
+		query["serviceSite"] = StringPointer(v.(string))
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("modelstudio", "2026-02-10", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, query)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_modelstudio_workspace", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, idErr := extractModelstudioWorkspaceId(response)
+	if idErr != nil {
+		return WrapError(idErr)
+	}
+	d.SetId(id)
+
+	return resourceAliCloudModelstudioWorkspaceRead(d, meta)
+}
+
+func resourceAliCloudModelstudioWorkspaceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	modelstudioService := ModelstudioService{client}
+
+	object, err := modelstudioService.DescribeModelstudioWorkspace(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_modelstudio_workspace DescribeModelstudioWorkspace Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("workspace_id", object["workspaceId"])
+	d.Set("workspace_name", object["workspaceName"])
+	d.Set("region_id", object["region"])
+	d.Set("api_host", object["apiHost"])
+	d.Set("service_site", object["serviceSite"])
+	d.Set("create_time", object["gmtCreate"])
+
+	return nil
+}
+
+func resourceAliCloudModelstudioWorkspaceUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := fmt.Sprintf("/modelstudio/workspaces/%s", d.Id())
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+
+	d.Partial(true)
+
+	if d.HasChange("workspace_name") {
+		query["workspaceName"] = StringPointer(d.Get("workspace_name").(string))
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RoaPut("modelstudio", "2026-02-10", action, query, nil, nil, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, query)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		d.SetPartial("workspace_name")
+	}
+
+	d.Partial(false)
+	return resourceAliCloudModelstudioWorkspaceRead(d, meta)
+}
+
+func resourceAliCloudModelstudioWorkspaceDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := fmt.Sprintf("/modelstudio/workspaces/%s", d.Id())
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("modelstudio", "2026-02-10", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, query)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}
+
+// extractModelstudioWorkspaceId extracts the workspace ID from the create-workspace
+// response. The gateway response may expose the workspace object under a top-level
+// "workspace" key (per the CloudSpec mapping rootMapping) or via the backend nested
+// path data.DataV2.data.data. Both paths are tried defensively.
+func extractModelstudioWorkspaceId(response map[string]interface{}) (string, error) {
+	if response == nil {
+		return "", fmt.Errorf("empty response from create-workspace")
+	}
+
+	// Primary: top-level "workspace" key (CloudSpec mapping rootMapping $.workspace).
+	if raw, ok := response["workspace"]; ok && raw != nil {
+		if m, ok := raw.(map[string]interface{}); ok {
+			if id := fmt.Sprint(m["workspaceId"]); id != "" && id != "<nil>" {
+				return id, nil
+			}
+		}
+	}
+
+	// Fallback: backend nested path data.DataV2.data.data.
+	if v, perr := jsonpath.Get("$.data.DataV2.data.data", response); perr == nil && v != nil {
+		if m, ok := v.(map[string]interface{}); ok {
+			if id := fmt.Sprint(m["workspaceId"]); id != "" && id != "<nil>" {
+				return id, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("failed to extract workspaceId from create-workspace response: %#v", response)
+}
+
+type ModelstudioService struct {
+	client *connectivity.AliyunClient
+}
+
+// DescribeModelstudioWorkspace fetches a single workspace by ID via the public
+// list-workspaces API (get-workspace is not published). The response workspaces
+// array is searched for a matching workspaceId; an empty result is treated as
+// NotFound.
+func (s *ModelstudioService) DescribeModelstudioWorkspace(id string) (map[string]interface{}, error) {
+	action := "/modelstudio/workspaces"
+	query := make(map[string]*string)
+	query["workspaceId"] = StringPointer(id)
+
+	var response map[string]interface{}
+	var err error
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(10*time.Minute, func() *resource.RetryError {
+		response, err = s.client.RoaGet("modelstudio", "2026-02-10", action, query, nil, nil)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, query)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	workspaces := extractModelstudioWorkspacesList(response)
+	for _, ws := range workspaces {
+		if m, ok := ws.(map[string]interface{}); ok {
+			if fmt.Sprint(m["workspaceId"]) == id {
+				return m, nil
+			}
+		}
+	}
+
+	return nil, WrapErrorf(NotFoundErr("ModelstudioWorkspace", id), NotFoundMsg, response)
+}
+
+// extractModelstudioWorkspacesList extracts the workspaces array from the
+// list-workspaces response, trying the top-level "workspaces" key (CloudSpec
+// mapping rootMapping $.workspaces) and the backend nested path defensively.
+func extractModelstudioWorkspacesList(response map[string]interface{}) []interface{} {
+	if response == nil {
+		return nil
+	}
+
+	// Primary: top-level "workspaces" key.
+	if raw, ok := response["workspaces"]; ok && raw != nil {
+		if arr, ok := raw.([]interface{}); ok {
+			return arr
+		}
+	}
+
+	// Fallback: backend nested path data.DataV2.data.data.
+	if v, perr := jsonpath.Get("$.data.DataV2.data.data", response); perr == nil && v != nil {
+		if arr, ok := v.([]interface{}); ok {
+			return arr
+		}
+		// The backend may return a single object instead of an array when filtered.
+		if m, ok := v.(map[string]interface{}); ok {
+			return []interface{}{m}
+		}
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_modelstudio_workspace_test.go
+++ b/alicloud/resource_alicloud_modelstudio_workspace_test.go
@@ -1,0 +1,105 @@
+// Package alicloud
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAliCloudModelstudioWorkspace_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_modelstudio_workspace.default"
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-acc-ms-%d", rand)
+	updatedName := fmt.Sprintf("tf-acc-ms-upd-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, func(name string) string { return "" })
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckModelstudioWorkspaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"workspace_name": name,
+					"service_site":   "global",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckModelstudioWorkspaceExists(resourceId, &v),
+					resource.TestCheckResourceAttr(resourceId, "workspace_name", name),
+					resource.TestCheckResourceAttr(resourceId, "service_site", "global"),
+					resource.TestCheckResourceAttrSet(resourceId, "workspace_id"),
+					resource.TestCheckResourceAttrSet(resourceId, "api_host"),
+					resource.TestCheckResourceAttrSet(resourceId, "region_id"),
+					resource.TestCheckResourceAttrSet(resourceId, "create_time"),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"workspace_name": updatedName,
+					"service_site":   "global",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckModelstudioWorkspaceExists(resourceId, &v),
+					resource.TestCheckResourceAttr(resourceId, "workspace_name", updatedName),
+					resource.TestCheckResourceAttr(resourceId, "service_site", "global"),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckModelstudioWorkspaceExists(n string, v *map[string]interface{}) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set for resource %s", n)
+		}
+		client := testAccProvider.Meta().(*connectivity.AliyunClient)
+		modelstudioService := ModelstudioService{client}
+		obj, err := modelstudioService.DescribeModelstudioWorkspace(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("DescribeModelstudioWorkspace failed: %v", err)
+		}
+		*v = obj
+		return nil
+	}
+}
+
+func testAccCheckModelstudioWorkspaceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+	modelstudioService := ModelstudioService{client}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_modelstudio_workspace" {
+			continue
+		}
+		if rs.Primary.ID == "" {
+			continue
+		}
+		_, err := modelstudioService.DescribeModelstudioWorkspace(rs.Primary.ID)
+		if err != nil && NotFoundError(err) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("unexpected error checking destroy for modelstudio workspace %s: %v", rs.Primary.ID, err)
+		}
+		return fmt.Errorf("modelstudio workspace %s still exists", rs.Primary.ID)
+	}
+	return nil
+}

--- a/website/docs/r/modelstudio_workspace.html.markdown
+++ b/website/docs/r/modelstudio_workspace.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "Model Studio"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_modelstudio_workspace"
+description: |-
+  Provides a Alicloud Model Studio workspace resource.
+---
+
+# alicloud_modelstudio_workspace
+
+Provides a Model Studio workspace resource.
+
+For information about Model Studio workspace and how to use it, see [Create a workspace](https://www.alibabacloud.com/help/en/model-studio/developer-reference/create-workspace).
+
+-> **NOTE:** Available since v1.244.0.
+
+## Example Usage
+
+```terraform
+resource "alicloud_modelstudio_workspace" "default" {
+  workspace_name = "tf-example"
+  service_site   = "global"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `workspace_name` - (Required) The name of the business workspace. The name must be 1 to 30 characters in length.
+* `service_site` - (Optional, ForceNew, Computed) The service deployment scope. Services that rely on GPU resources (such as inference, training, and deployment) are deployed in this scope.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the workspace.
+* `workspace_id` - The ID of the workspace.
+* `create_time` - The creation time of the workspace.
+* `region_id` - The region ID of the workspace.
+* `api_host` - The access endpoint of the workspace, which is a dedicated isolated access point for the workspace.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration-0-11/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 5 mins) Used when creating the workspace.
+* `update` - (Defaults to 5 mins) Used when updating the workspace.
+* `delete` - (Defaults to 5 mins) Used when deleting the workspace.
+
+## Import
+
+Model Studio workspace can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_modelstudio_workspace.example <workspace-id>
+```


### PR DESCRIPTION
## New Resource: alicloud_modelstudio_workspace

This PR adds a new resource `alicloud_modelstudio_workspace` for managing Alibaba Cloud Model Studio (Bailian) workspaces.

### Schema

| Argument | Type | Required/Optional | Description |
|---|---|---|---|
| `workspace_name` | string | Required | The name of the business workspace (1-30 chars). |
| `service_site` | string | Optional, ForceNew | The service deployment scope (e.g. inference, training, deployment relying on GPU resources). |
| `workspace_id` | string | Computed | The workspace ID. |
| `create_time` | int | Computed | The creation time. |
| `region_id` | string | Computed | The region ID. |
| `api_host` | string | Computed | The access endpoint (dedicated isolated access point for the workspace). |

### CRUD Mapping

| Operation | HTTP Method | Path |
|---|---|---|
| Create | POST | `/modelstudio/workspaces` |
| Read | GET | `/modelstudio/workspaces` (list filtered by workspaceId) |
| Update | PUT | `/modelstudio/workspaces/{workspaceId}` |
| Delete | DELETE | `/modelstudio/workspaces/{workspaceId}` |

### Tests

Remote acceptance tests will be run to verify the resource lifecycle (create → read → update → import → destroy).

```
TestAccAliCloudModelstudioWorkspace_basic
```