### PR TITLE
resource/alicloud_cr_storage_domain_routing_rule: fix perpetual diff on routes.storage_domain

### DIFF
--- a/alicloud/resource_alicloud_cr_storage_domain_routing_rule.go
+++ b/alicloud/resource_alicloud_cr_storage_domain_routing_rule.go
@@ -45,6 +45,9 @@ func resourceAliCloudCrStorageDomainRoutingRule() *schema.Resource {
 						"storage_domain": {
 							Type:     schema.TypeString,
 							Required: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return strings.TrimPrefix(old, "https://") == strings.TrimPrefix(new, "https://")
+							},
 						},
 						"endpoint_type": {
 							Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_cr_storage_domain_routing_rule_test.go
+++ b/alicloud/resource_alicloud_cr_storage_domain_routing_rule_test.go
@@ -162,6 +162,95 @@ func TestAccAliCloudCrStorageDomainRoutingRule_basic11834_twin(t *testing.T) {
 	})
 }
 
+// The API returns storage_domain with an https:// prefix while the configuration
+// may omit it. The plan must stay empty in both directions.
+func TestAccAliCloudCrStorageDomainRoutingRule_noHttpsPrefix(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cr_storage_domain_routing_rule.default"
+	ra := resourceAttrInit(resourceId, AliCloudCrStorageDomainRoutingRuleMap11834)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CrServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCrStorageDomainRoutingRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccr%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCrStorageDomainRoutingRuleBasicDependence11834)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"routes": []map[string]interface{}{
+						{
+							"instance_domain": "${alicloud_cr_ee_instance.default.instance_name}-registry-vpc.cn-hangzhou.cr.aliyuncs.com",
+							"storage_domain":  "${alicloud_cr_ee_instance.default.id}-registry.oss-cn-hangzhou-internal.aliyuncs.com",
+							"endpoint_type":   "Internet",
+						},
+					},
+					"instance_id": "${alicloud_cr_ee_instance.default.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"routes.#":    "1",
+						"instance_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				// Same configuration without the prefix: the plan must be empty.
+				Config: testAccConfig(map[string]interface{}{
+					"routes": []map[string]interface{}{
+						{
+							"instance_domain": "${alicloud_cr_ee_instance.default.instance_name}-registry-vpc.cn-hangzhou.cr.aliyuncs.com",
+							"storage_domain":  "${alicloud_cr_ee_instance.default.id}-registry.oss-cn-hangzhou-internal.aliyuncs.com",
+							"endpoint_type":   "Internet",
+						},
+					},
+					"instance_id": "${alicloud_cr_ee_instance.default.id}",
+				}),
+				PlanOnly: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"routes.#": "1",
+					}),
+				),
+			},
+			{
+				// The prefixed form documented by the API must not produce a diff either.
+				Config: testAccConfig(map[string]interface{}{
+					"routes": []map[string]interface{}{
+						{
+							"instance_domain": "${alicloud_cr_ee_instance.default.instance_name}-registry-vpc.cn-hangzhou.cr.aliyuncs.com",
+							"storage_domain":  "https://${alicloud_cr_ee_instance.default.id}-registry.oss-cn-hangzhou-internal.aliyuncs.com",
+							"endpoint_type":   "Internet",
+						},
+					},
+					"instance_id": "${alicloud_cr_ee_instance.default.id}",
+				}),
+				PlanOnly: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"routes.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
 var AliCloudCrStorageDomainRoutingRuleMap11834 = map[string]string{
 	"rule_id":     CHECKSET,
 	"create_time": CHECKSET,

--- a/website/docs/r/cr_storage_domain_routing_rule.html.markdown
+++ b/website/docs/r/cr_storage_domain_routing_rule.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 The routes supports the following:
 * `endpoint_type` - (Required) Endpoint Type.
 * `instance_domain` - (Required) Instance domain name.
-* `storage_domain` - (Required) Storage domain name.
+* `storage_domain` - (Required) Storage domain name. The API returns this value with an `https://` prefix; the prefix is optional in the configuration and is ignored when comparing the configured value with the returned one.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Summary
- The Get API returns `routes.storage_domain` with an `https://` prefix while the configuration may omit it, so every plan showed the same change after a successful apply.
- Compare the configured and reported values with the optional `https://` prefix removed via a `DiffSuppressFunc`, so both the prefixed and unprefixed forms converge.
- Document that the `https://` prefix of `storage_domain` is optional in the configuration.

## Test plan
- [x] `TestAccAliCloudCrStorageDomainRoutingRule_basic11834` PASS in cn-hangzhou (142.67s): create -> update routes -> import.
- [x] `TestAccAliCloudCrStorageDomainRoutingRule_basic11834_twin` PASS in cn-hangzhou (145.98s).
- [x] `TestAccAliCloudCrStorageDomainRoutingRule_noHttpsPrefix` PASS in cn-hangzhou (181.46s): apply with `storage_domain` omitting the `https://` prefix, plan stays empty, switching to the prefixed form also plans empty, import verifies.

=== RUN   TestAccAliCloudCrStorageDomainRoutingRule_basic11834
--- PASS: TestAccAliCloudCrStorageDomainRoutingRule_basic11834 (142.67s)

=== RUN   TestAccAliCloudCrStorageDomainRoutingRule_basic11834_twin
--- PASS: TestAccAliCloudCrStorageDomainRoutingRule_basic11834_twin (145.98s)

=== RUN   TestAccAliCloudCrStorageDomainRoutingRule_noHttpsPrefix
--- PASS: TestAccAliCloudCrStorageDomainRoutingRule_noHttpsPrefix (181.46s)