### PR TITLE
New Data Source: alicloud_ros_template_estimate_cost

### DIFF
--- a/alicloud/data_source_alicloud_ros_template_estimate_cost.go
+++ b/alicloud/data_source_alicloud_ros_template_estimate_cost.go
@@ -1,0 +1,361 @@
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/helper"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAlicloudRosTemplateEstimateCost() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudRosTemplateEstimateCostRead,
+		Schema: map[string]*schema.Schema{
+			"template_body": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"template_body", "template_url", "template_id", "template_scratch_id"},
+			},
+			"template_url": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"template_body", "template_url", "template_id", "template_scratch_id"},
+			},
+			"template_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"template_body", "template_url", "template_id", "template_scratch_id"},
+			},
+			"template_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"template_scratch_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"template_body", "template_url", "template_id", "template_scratch_id"},
+			},
+			"template_scratch_region_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"stack_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"client_token": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"parameters": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 200,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"parameter_key": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"parameter_value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resources": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"resource_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alias_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"success": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"result": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"inquiry_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"order": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"currency": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"original_amount": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+												"discount_amount": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+												"trade_amount": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+												"tax_amount": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+												"total_cost_amount": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+												"stand_price": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+												"rule_ids": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"order_details": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"module_code": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"module_name": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"currency": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"original_amount": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+												"discount_amount": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+												"trade_amount": {
+													Type:     schema.TypeFloat,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"order_supplement": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"charge_type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"period": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"period_unit": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"price_type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"price_unit": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"quantity": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"auto_renew": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudRosTemplateEstimateCostRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "GetTemplateEstimateCost"
+	request := make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	if v, ok := d.GetOk("template_body"); ok {
+		request["TemplateBody"] = v
+	}
+	if v, ok := d.GetOk("template_url"); ok {
+		request["TemplateURL"] = v
+	}
+	if v, ok := d.GetOk("template_id"); ok {
+		request["TemplateId"] = v
+	}
+	if v, ok := d.GetOk("template_version"); ok {
+		request["TemplateVersion"] = v
+	}
+	if v, ok := d.GetOk("template_scratch_id"); ok {
+		request["TemplateScratchId"] = v
+	}
+	if v, ok := d.GetOk("template_scratch_region_id"); ok {
+		request["TemplateScratchRegionId"] = v
+	}
+	if v, ok := d.GetOk("stack_id"); ok {
+		request["StackId"] = v
+	}
+	if v, ok := d.GetOk("client_token"); ok {
+		request["ClientToken"] = v
+	}
+	if v, ok := d.GetOk("parameters"); ok {
+		parameters := make([]map[string]interface{}, 0)
+		for _, item := range v.([]interface{}) {
+			parameter := item.(map[string]interface{})
+			parameters = append(parameters, map[string]interface{}{
+				"ParameterKey":   parameter["parameter_key"],
+				"ParameterValue": parameter["parameter_value"],
+			})
+		}
+		request["Parameters"] = parameters
+	}
+
+	response, err := client.RpcPost("ROS", "2019-09-10", action, nil, request, true)
+	if err != nil {
+		return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_ros_template_estimate_cost", action, AlibabaCloudSdkGoERROR)
+	}
+	addDebug(action, response, request)
+
+	resp, err := jsonpath.Get("$.Resources", response)
+	if err != nil {
+		return WrapErrorf(err, FailedGetAttributeMsg, action, "$.Resources", response)
+	}
+
+	s := make([]map[string]interface{}, 0)
+	if resourcesMap, ok := resp.(map[string]interface{}); ok {
+		for resourceName, item := range resourcesMap {
+			resource := item.(map[string]interface{})
+			mapping := map[string]interface{}{
+				"resource_name": resourceName,
+				"resource_type": resource["Type"],
+				"alias_type":    resource["AliasType"],
+				"success":       resource["Success"],
+			}
+			result := make([]map[string]interface{}, 0)
+			if resultRaw, ok := resource["Result"].(map[string]interface{}); ok {
+				resultMapping := map[string]interface{}{
+					"inquiry_type": resultRaw["InquiryType"],
+				}
+				order := make([]map[string]interface{}, 0)
+				if orderRaw, ok := resultRaw["Order"].(map[string]interface{}); ok {
+					ruleIds := make([]string, 0)
+					if ruleIdsRaw, ok := orderRaw["RuleIds"].([]interface{}); ok {
+						for _, ruleId := range ruleIdsRaw {
+							ruleIds = append(ruleIds, fmt.Sprint(ruleId))
+						}
+					}
+					order = append(order, map[string]interface{}{
+						"currency":          orderRaw["Currency"],
+						"original_amount":   orderRaw["OriginalAmount"],
+						"discount_amount":   orderRaw["DiscountAmount"],
+						"trade_amount":      orderRaw["TradeAmount"],
+						"tax_amount":        orderRaw["TaxAmount"],
+						"total_cost_amount": orderRaw["TotalCostAmount"],
+						"stand_price":       orderRaw["StandPrice"],
+						"rule_ids":          ruleIds,
+					})
+				}
+				resultMapping["order"] = order
+
+				orderDetails := make([]map[string]interface{}, 0)
+				if orderDetailsRaw, ok := resultRaw["OrderDetails"].([]interface{}); ok {
+					for _, detail := range orderDetailsRaw {
+						detailMap := detail.(map[string]interface{})
+						orderDetails = append(orderDetails, map[string]interface{}{
+							"module_code":     detailMap["ModuleCode"],
+							"module_name":     detailMap["ModuleName"],
+							"currency":        detailMap["Currency"],
+							"original_amount": detailMap["OriginalAmount"],
+							"discount_amount": detailMap["DiscountAmount"],
+							"trade_amount":    detailMap["TradeAmount"],
+						})
+					}
+				}
+				resultMapping["order_details"] = orderDetails
+
+				orderSupplement := make([]map[string]interface{}, 0)
+				if supplementRaw, ok := resultRaw["OrderSupplement"].(map[string]interface{}); ok {
+					orderSupplement = append(orderSupplement, map[string]interface{}{
+						"charge_type": supplementRaw["ChargeType"],
+						"period":      supplementRaw["Period"],
+						"period_unit": supplementRaw["PeriodUnit"],
+						"price_type":  supplementRaw["PriceType"],
+						"price_unit":  supplementRaw["PriceUnit"],
+						"quantity":    supplementRaw["Quantity"],
+						"auto_renew":  supplementRaw["AutoRenew"],
+					})
+				}
+				resultMapping["order_supplement"] = orderSupplement
+				result = append(result, resultMapping)
+			}
+			mapping["result"] = result
+			s = append(s, mapping)
+		}
+	}
+
+	requestJson, err := json.Marshal(request)
+	if err != nil {
+		return WrapError(err)
+	}
+	d.SetId(fmt.Sprintf("%d", helper.Hashcode(string(requestJson))))
+	if err := d.Set("resources", s); err != nil {
+		return WrapError(err)
+	}
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+
+	return nil
+}

--- a/alicloud/data_source_alicloud_ros_template_estimate_cost_test.go
+++ b/alicloud/data_source_alicloud_ros_template_estimate_cost_test.go
@@ -1,0 +1,250 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudRosTemplateEstimateCostDataSource_rosTemplate(t *testing.T) {
+	checkoutSupportedRegions(t, true, connectivity.ROSSupportRegions)
+	rand := acctest.RandIntRange(100000, 999999)
+	resourceId := "data.alicloud_ros_template_estimate_cost.default"
+	name := fmt.Sprintf("tf-testacc-roscost-%d", rand)
+	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceRosTemplateEstimateCostDependence)
+
+	templateBodyConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"template_body": "${local.estimate_template}",
+			"client_token":  name,
+			"parameters": []map[string]interface{}{
+				{
+					"parameter_key":   "Bandwidth",
+					"parameter_value": "5",
+				},
+			},
+			"output_file": "./tf-testacc-ros-template-estimate-cost.txt",
+		}),
+	}
+	templateIdConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"template_id":      "${alicloud_ros_template.default.id}",
+			"template_version": "v1",
+		}),
+	}
+	stackConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"template_body": "${local.estimate_template}",
+			"stack_id":      "${alicloud_ros_stack.default.id}",
+			"parameters": []map[string]interface{}{
+				{
+					"parameter_key":   "Bandwidth",
+					"parameter_value": "10",
+				},
+			},
+		}),
+	}
+
+	var existRosTemplateEstimateCostMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"resources.#":                               "1",
+			"resources.0.resource_name":                 "NewEip",
+			"resources.0.resource_type":                 "ALIYUN::VPC::EIP",
+			"resources.0.success":                       "true",
+			"resources.0.result.#":                      "1",
+			"resources.0.result.0.inquiry_type":         "Buy",
+			"resources.0.result.0.order.#":              "1",
+			"resources.0.result.0.order.0.currency":     CHECKSET,
+			"resources.0.result.0.order.0.trade_amount": CHECKSET,
+			"resources.0.result.0.order_details.#":      CHECKSET,
+			"resources.0.result.0.order_supplement.#":   "1",
+		}
+	}
+
+	var fakeRosTemplateEstimateCostMapFunc = func(rand int) map[string]string {
+		return map[string]string{}
+	}
+
+	var RosTemplateEstimateCostCheckInfo = dataSourceAttr{
+		resourceId:   resourceId,
+		existMapFunc: existRosTemplateEstimateCostMapFunc,
+		fakeMapFunc:  fakeRosTemplateEstimateCostMapFunc,
+	}
+
+	RosTemplateEstimateCostCheckInfo.dataSourceTestCheck(t, rand, templateBodyConf, templateIdConf, stackConf)
+}
+
+func TestAccAlicloudRosTemplateEstimateCostDataSource_terraformTemplate(t *testing.T) {
+	checkoutSupportedRegions(t, true, connectivity.ROSSupportRegions)
+	rand := acctest.RandIntRange(100000, 999999)
+	resourceId := "data.alicloud_ros_template_estimate_cost.default"
+	name := fmt.Sprintf("tf-testacc-roscosttf-%d", rand)
+	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceRosTemplateEstimateCostTerraformDependence)
+
+	terraformTemplateConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"template_body": "${local.tf_estimate_template}",
+		}),
+	}
+
+	var existRosTemplateEstimateCostTerraformMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"resources.#":                               "1",
+			"resources.0.resource_name":                 "example",
+			"resources.0.resource_type":                 "alicloud_eip_address",
+			"resources.0.alias_type":                    "ALIYUN::VPC::EIP",
+			"resources.0.success":                       "true",
+			"resources.0.result.#":                      "1",
+			"resources.0.result.0.inquiry_type":         "Buy",
+			"resources.0.result.0.order.#":              "1",
+			"resources.0.result.0.order.0.currency":     CHECKSET,
+			"resources.0.result.0.order.0.trade_amount": CHECKSET,
+			"resources.0.result.0.order_details.#":      CHECKSET,
+			"resources.0.result.0.order_supplement.#":   "1",
+		}
+	}
+
+	var fakeRosTemplateEstimateCostTerraformMapFunc = func(rand int) map[string]string {
+		return map[string]string{}
+	}
+
+	var RosTemplateEstimateCostTerraformCheckInfo = dataSourceAttr{
+		resourceId:   resourceId,
+		existMapFunc: existRosTemplateEstimateCostTerraformMapFunc,
+		fakeMapFunc:  fakeRosTemplateEstimateCostTerraformMapFunc,
+	}
+
+	RosTemplateEstimateCostTerraformCheckInfo.dataSourceTestCheck(t, rand, terraformTemplateConf)
+}
+
+func TestAccAlicloudRosTemplateEstimateCostDataSource_templateScratch(t *testing.T) {
+	checkoutSupportedRegions(t, true, connectivity.ROSSupportRegions)
+	rand := acctest.RandIntRange(100000, 999999)
+	resourceId := "data.alicloud_ros_template_estimate_cost.default"
+	name := fmt.Sprintf("tf-testacc-roscostts-%d", rand)
+	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceRosTemplateEstimateCostScratchDependence)
+
+	templateScratchConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"template_scratch_id":        "${alicloud_ros_template_scratch.default.id}",
+			"template_scratch_region_id": "${data.alicloud_regions.default.regions.0.id}",
+		}),
+	}
+
+	var existRosTemplateEstimateCostScratchMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"resources.#": "0",
+		}
+	}
+
+	var fakeRosTemplateEstimateCostScratchMapFunc = func(rand int) map[string]string {
+		return map[string]string{}
+	}
+
+	var RosTemplateEstimateCostScratchCheckInfo = dataSourceAttr{
+		resourceId:   resourceId,
+		existMapFunc: existRosTemplateEstimateCostScratchMapFunc,
+		fakeMapFunc:  fakeRosTemplateEstimateCostScratchMapFunc,
+	}
+
+	RosTemplateEstimateCostScratchCheckInfo.dataSourceTestCheck(t, rand, templateScratchConf)
+}
+
+func dataSourceRosTemplateEstimateCostDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+locals {
+  estimate_template = jsonencode({
+    ROSTemplateFormatVersion = "2015-09-01"
+    Parameters = {
+      Bandwidth = {
+        Type    = "Number"
+        Default = 5
+      }
+    }
+    Resources = {
+      NewEip = {
+        Type = "ALIYUN::VPC::EIP"
+        Properties = {
+          InstanceChargeType = "Postpaid"
+          InternetChargeType = "PayByTraffic"
+          Bandwidth = {
+            Ref = "Bandwidth"
+          }
+        }
+      }
+    }
+  })
+}
+
+resource "alicloud_ros_template" "default" {
+  template_name = var.name
+  template_body = local.estimate_template
+}
+
+resource "alicloud_ros_stack" "default" {
+  stack_name    = var.name
+  template_body = local.estimate_template
+  parameters {
+    parameter_key   = "Bandwidth"
+    parameter_value = "5"
+  }
+}
+`, name)
+}
+
+func dataSourceRosTemplateEstimateCostTerraformDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+locals {
+  tf_estimate_template = jsonencode({
+    ROSTemplateFormatVersion = "2015-09-01"
+    Transform                = "Aliyun::Terraform-v1.2"
+    Workspace = {
+      "main.tf" = <<-EOT
+        provider "alicloud" {
+          region = "cn-hangzhou"
+        }
+        resource "alicloud_eip_address" "example" {
+          bandwidth            = 5
+          internet_charge_type = "PayByTraffic"
+          payment_type         = "Subscription"
+        }
+      EOT
+    }
+  })
+}
+`, name)
+}
+
+func dataSourceRosTemplateEstimateCostScratchDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_regions" "default" {
+  current = true
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {
+}
+
+resource "alicloud_ros_template_scratch" "default" {
+  description           = var.name
+  template_scratch_type = "ArchitectureReplication"
+  source_resource_group {
+    resource_group_id    = data.alicloud_resource_manager_resource_groups.default.ids.0
+    resource_type_filter = ["ALIYUN::ECS::VPC"]
+  }
+}
+`, name)
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -509,6 +509,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ros_stacks":                                       dataSourceAlicloudRosStacks(),
 			"alicloud_ros_stack_groups":                                 dataSourceAlicloudRosStackGroups(),
 			"alicloud_ros_templates":                                    dataSourceAlicloudRosTemplates(),
+			"alicloud_ros_template_estimate_cost":                       dataSourceAlicloudRosTemplateEstimateCost(),
 			"alicloud_privatelink_vpc_endpoint_services":                dataSourceAliCloudPrivateLinkVpcEndpointServices(),
 			"alicloud_privatelink_vpc_endpoints":                        dataSourceAlicloudPrivatelinkVpcEndpoints(),
 			"alicloud_privatelink_vpc_endpoint_connections":             dataSourceAlicloudPrivatelinkVpcEndpointConnections(),

--- a/website/docs/d/ros_template_estimate_cost.html.markdown
+++ b/website/docs/d/ros_template_estimate_cost.html.markdown
@@ -1,0 +1,116 @@
+---
+subcategory: "ROS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ros_template_estimate_cost"
+sidebar_current: "docs-alicloud-datasource-ros-template-estimate-cost"
+description: |-
+  Queries the estimated prices of the resources created in a ROS or Terraform template.
+---
+
+# alicloud\_ros\_template\_estimate\_cost
+
+This data source provides the estimated prices of the resources that are created in a ROS or Terraform template, which helps you evaluate resource costs before deployment.
+
+For information about the resources that support price estimation, see [Estimated resource prices](https://www.alibabacloud.com/help/en/ros/user-guide/estimate-resource-prices).
+
+-> **NOTE:** Available since v1.292.0.
+
+## Example Usage
+
+Estimate the cost of a Terraform template:
+
+```terraform
+data "alicloud_ros_template_estimate_cost" "example" {
+  template_body = jsonencode({
+    "ROSTemplateFormatVersion" = "2015-09-01"
+    "Transform"                = "Aliyun::Terraform-v1.2"
+    "Workspace" = {
+      "main.tf" = <<-EOT
+        provider "alicloud" {
+          region = "cn-hangzhou"
+        }
+        resource "alicloud_eip_address" "example" {
+          bandwidth            = 5
+          internet_charge_type = "PayByTraffic"
+          payment_type         = "Subscription"
+        }
+      EOT
+    }
+  })
+}
+
+output "estimated_resources" {
+  value = data.alicloud_ros_template_estimate_cost.example.resources
+}
+```
+
+Estimate the cost of a template that is stored in ROS:
+
+```terraform
+data "alicloud_ros_template_estimate_cost" "example" {
+  template_id      = "5ecd1e10-b0e9-4389-a565-e4c15efc****"
+  template_version = "v1"
+  parameters {
+    parameter_key   = "InstanceType"
+    parameter_value = "ecs.s6-c1m2.large"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `template_body` - (Optional) The structure that contains the template body. The template body must be 1 to 524,288 bytes in length. To estimate the cost of a Terraform template, wrap the `.tf` files in a ROS structure with `Transform` set to `Aliyun::Terraform-v1.2` and the files under `Workspace`. You must specify exactly one of `template_body`, `template_url`, `template_id`, and `template_scratch_id`.
+* `template_url` - (Optional) The URL of the file that contains the template body. The URL must point to a template that is located on an HTTP or HTTPS web server or in an Object Storage Service (OSS) bucket, such as `oss://ros/stack-policy/demo`. The template can be up to 524,288 bytes in length. You must specify exactly one of `template_body`, `template_url`, `template_id`, and `template_scratch_id`.
+* `template_id` - (Optional) The ID of the template. Shared templates and private templates are supported. You must specify exactly one of `template_body`, `template_url`, `template_id`, and `template_scratch_id`.
+* `template_version` - (Optional) The version of the template. This parameter takes effect only when `template_id` is specified.
+* `template_scratch_id` - (Optional) The ID of the resource scenario. You must specify exactly one of `template_body`, `template_url`, `template_id`, and `template_scratch_id`. **NOTE:** Resource scenarios of the `ResourceImport` type are not supported for cost estimation.
+* `template_scratch_region_id` - (Optional) The region ID of the resource scenario. Default value: the region ID of the current request.
+* `stack_id` - (Optional) The ID of the stack. When this parameter is specified, the estimated prices for a stack change (modification) scenario are queried. **NOTE:** If the new template has no priceable changes compared with the stack, an empty `resources` list is returned.
+* `client_token` - (Optional) The client token that is used to ensure the idempotence of the request. It can be up to 64 characters in length and can contain letters, digits, hyphens (-), and underscores (_).
+* `parameters` - (Optional) The parameters of the template. A maximum of 200 parameters can be specified. If you do not specify the names and values of the parameters that are defined in the template, the default values of the parameters are used. See [`parameters`](#parameters) below.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+### `parameters`
+
+The parameters supports the following:
+
+* `parameter_key` - (Required) The name of the parameter defined in the template.
+* `parameter_value` - (Required) The value of the parameter.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `resources` - The estimation details of the resources in the template. Each element contains the following attributes:
+  * `resource_name` - The logical name of the resource in the template.
+  * `resource_type` - The type of the resource. For Terraform templates, it is the Terraform resource type, such as `alicloud_eip_address`. For ROS templates, it is the ROS resource type, such as `ALIYUN::VPC::EIP`.
+  * `alias_type` - The ROS resource type that the Terraform resource type maps to, such as `ALIYUN::VPC::EIP`. It is returned only for Terraform templates.
+  * `success` - Indicates whether the price estimation of the resource succeeds.
+  * `result` - The estimation result of the resource. Each element contains the following attributes:
+    * `inquiry_type` - The type of the price estimation. Valid values: `Buy` (estimation for new purchase), `ModificationBuy` (estimation for specification change).
+    * `order` - The order information. Each element contains the following attributes:
+      * `currency` - The currency unit. `CNY` applies to the China site (aliyun.com), and `USD` applies to the international site (alibabacloud.com).
+      * `original_amount` - The original price.
+      * `discount_amount` - The discount amount.
+      * `trade_amount` - The final price, which equals the original price minus the discount.
+      * `tax_amount` - The tax amount.
+      * `total_cost_amount` - The total cost amount.
+      * `stand_price` - The list price of the resource.
+      * `rule_ids` - The IDs of the promotion rules that are applied.
+    * `order_details` - The billing module details of the order. Each element contains the following attributes:
+      * `module_code` - The code of the billing module.
+      * `module_name` - The name of the billing module.
+      * `currency` - The currency unit.
+      * `original_amount` - The original price of the module.
+      * `discount_amount` - The discount amount of the module.
+      * `trade_amount` - The final price of the module.
+    * `order_supplement` - The supplementary information of the order. Each element contains the following attributes:
+      * `charge_type` - The billing method, such as `PrePaid` (subscription) or `PostPaid` (pay-as-you-go).
+      * `period` - The billing duration.
+      * `period_unit` - The unit of the billing duration for the subscription billing method. Valid values: `Year`, `Month`.
+      * `price_type` - The type of the price.
+      * `price_unit` - The unit of the price for the pay-as-you-go billing method, such as `/Hour` or `/GB`.
+      * `quantity` - The quantity.
+      * `auto_renew` - Indicates whether auto-renewal is enabled.


### PR DESCRIPTION
## Summary
- Adds a new data source `alicloud_ros_template_estimate_cost` that queries the estimated prices of the resources in a ROS or Terraform template before deployment, backed by the ROS `GetTemplateEstimateCost` API.
- Supports four template sources (exactly one required): `template_body`, `template_url`, `template_id` (with `template_version`), and `template_scratch_id` (with `template_scratch_region_id`); plus `parameters` (template parameters), `stack_id` (stack modification scenario), `client_token`, and `output_file`.
- Exports per-resource estimation details: `resource_name`, `resource_type`, `alias_type`, `success`, and `result` (including `inquiry_type`, `order` amounts/currency/rule ids, `order_details` billing modules, and `order_supplement` billing terms).

## Test plan
- [x] `TestAccAlicloudRosTemplateEstimateCostDataSource_rosTemplate` PASS (43.16s): estimate via `template_body` with `parameters`/`client_token`/`output_file`, via `template_id` + `template_version`, and via `stack_id` modification scenario.
- [x] `TestAccAlicloudRosTemplateEstimateCostDataSource_terraformTemplate` PASS (14.24s): estimate for a Terraform template wrapped in the ROS `Aliyun::Terraform-v1.2` transform structure.
- [x] `TestAccAlicloudRosTemplateEstimateCostDataSource_templateScratch` PASS (59.58s): estimate via `template_scratch_id` + `template_scratch_region_id` with an `ArchitectureReplication` scenario.

```
=== RUN TestAccAlicloudRosTemplateEstimateCostDataSource_rosTemplate
--- PASS: TestAccAlicloudRosTemplateEstimateCostDataSource_rosTemplate (43.16s)

=== RUN TestAccAlicloudRosTemplateEstimateCostDataSource_terraformTemplate
--- PASS: TestAccAlicloudRosTemplateEstimateCostDataSource_terraformTemplate (14.24s)

=== RUN TestAccAlicloudRosTemplateEstimateCostDataSource_templateScratch
--- PASS: TestAccAlicloudRosTemplateEstimateCostDataSource_templateScratch (59.58s)
```