### PR TITLE
resource/alicloud_fcv3_function: add registry_config support in custom_container_config; data-source/alicloud_fcv3_functions: add registry_config in custom_container_config

### DIFF
--- a/alicloud/data_source_alicloud_fcv3_functions.go
+++ b/alicloud/data_source_alicloud_fcv3_functions.go
@@ -138,6 +138,67 @@ func dataSourceAliCloudFcv3Functions() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"registry_config": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"auth_config": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"user_name": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"password": {
+																Type:      schema.TypeString,
+																Computed:  true,
+																Sensitive: true,
+															},
+														},
+													},
+												},
+												"cert_config": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"insecure": {
+																Type:     schema.TypeBool,
+																Computed: true,
+															},
+															"root_ca_cert_base64": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"network_config": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"vpc_id": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"vswitch_id": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"security_group_id": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -758,6 +819,50 @@ func dataSourceAliCloudFcv3FunctionRead(d *schema.ResourceData, meta interface{}
 				healthCheckConfigMaps = append(healthCheckConfigMaps, healthCheckConfigMap)
 			}
 			customContainerConfigMap["health_check_config"] = healthCheckConfigMaps
+			registryConfigMaps := make([]map[string]interface{}, 0)
+			registryConfigRaw := make(map[string]interface{})
+			if customContainerConfigRaw["registryConfig"] != nil {
+				registryConfigRaw = customContainerConfigRaw["registryConfig"].(map[string]interface{})
+			}
+			if len(registryConfigRaw) > 0 {
+				registryConfigMap := make(map[string]interface{})
+				authConfigMaps := make([]map[string]interface{}, 0)
+				if registryConfigRaw["authConfig"] != nil {
+					authConfigRaw := registryConfigRaw["authConfig"].(map[string]interface{})
+					if len(authConfigRaw) > 0 {
+						authConfigMap := make(map[string]interface{})
+						authConfigMap["user_name"] = authConfigRaw["userName"]
+						authConfigMap["password"] = authConfigRaw["password"]
+						authConfigMaps = append(authConfigMaps, authConfigMap)
+					}
+				}
+				registryConfigMap["auth_config"] = authConfigMaps
+				certConfigMaps := make([]map[string]interface{}, 0)
+				if registryConfigRaw["certConfig"] != nil {
+					certConfigRaw := registryConfigRaw["certConfig"].(map[string]interface{})
+					if len(certConfigRaw) > 0 {
+						certConfigMap := make(map[string]interface{})
+						certConfigMap["insecure"] = certConfigRaw["insecure"]
+						certConfigMap["root_ca_cert_base64"] = certConfigRaw["rootCaCertBase64"]
+						certConfigMaps = append(certConfigMaps, certConfigMap)
+					}
+				}
+				registryConfigMap["cert_config"] = certConfigMaps
+				networkConfigMaps := make([]map[string]interface{}, 0)
+				if registryConfigRaw["networkConfig"] != nil {
+					networkConfigRaw := registryConfigRaw["networkConfig"].(map[string]interface{})
+					if len(networkConfigRaw) > 0 {
+						networkConfigMap := make(map[string]interface{})
+						networkConfigMap["vpc_id"] = networkConfigRaw["vpcId"]
+						networkConfigMap["vswitch_id"] = networkConfigRaw["vSwitchId"]
+						networkConfigMap["security_group_id"] = networkConfigRaw["securityGroupId"]
+						networkConfigMaps = append(networkConfigMaps, networkConfigMap)
+					}
+				}
+				registryConfigMap["network_config"] = networkConfigMaps
+				registryConfigMaps = append(registryConfigMaps, registryConfigMap)
+			}
+			customContainerConfigMap["registry_config"] = registryConfigMaps
 			customContainerConfigMaps = append(customContainerConfigMaps, customContainerConfigMap)
 		}
 		mapping["custom_container_config"] = customContainerConfigMaps

--- a/alicloud/resource_alicloud_fcv3_function.go
+++ b/alicloud/resource_alicloud_fcv3_function.go
@@ -165,6 +165,71 @@ func resourceAliCloudFcv3Function() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"registry_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"auth_config": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"user_name": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"password": {
+													Type:      schema.TypeString,
+													Optional:  true,
+													Sensitive: true,
+												},
+											},
+										},
+									},
+									"cert_config": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"insecure": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"root_ca_cert_base64": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"network_config": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"vpc_id": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"vswitch_id": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"security_group_id": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -810,6 +875,50 @@ func resourceAliCloudFcv3FunctionCreate(d *schema.ResourceData, meta interface{}
 		if acrInstanceId1 != nil && acrInstanceId1 != "" {
 			customContainerConfig["acrInstanceId"] = acrInstanceId1
 		}
+		registryConfig1 := make(map[string]interface{})
+		authConfig1 := make(map[string]interface{})
+		userName1, _ := jsonpath.Get("$[0].registry_config[0].auth_config[0].user_name", d.Get("custom_container_config"))
+		if userName1 != nil && userName1 != "" {
+			authConfig1["userName"] = userName1
+		}
+		password1, _ := jsonpath.Get("$[0].registry_config[0].auth_config[0].password", d.Get("custom_container_config"))
+		if password1 != nil && password1 != "" {
+			authConfig1["password"] = password1
+		}
+		if len(authConfig1) > 0 {
+			registryConfig1["authConfig"] = authConfig1
+		}
+		certConfig1 := make(map[string]interface{})
+		insecure1, _ := jsonpath.Get("$[0].registry_config[0].cert_config[0].insecure", d.Get("custom_container_config"))
+		if insecure1 != nil {
+			certConfig1["insecure"] = insecure1
+		}
+		rootCaCertBase641, _ := jsonpath.Get("$[0].registry_config[0].cert_config[0].root_ca_cert_base64", d.Get("custom_container_config"))
+		if rootCaCertBase641 != nil && rootCaCertBase641 != "" {
+			certConfig1["rootCaCertBase64"] = rootCaCertBase641
+		}
+		if len(certConfig1) > 0 {
+			registryConfig1["certConfig"] = certConfig1
+		}
+		networkConfig1 := make(map[string]interface{})
+		vpcId1, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].vpc_id", d.Get("custom_container_config"))
+		if vpcId1 != nil && vpcId1 != "" {
+			networkConfig1["vpcId"] = vpcId1
+		}
+		vSwitchId1, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].vswitch_id", d.Get("custom_container_config"))
+		if vSwitchId1 != nil && vSwitchId1 != "" {
+			networkConfig1["vSwitchId"] = vSwitchId1
+		}
+		securityGroupId1, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].security_group_id", d.Get("custom_container_config"))
+		if securityGroupId1 != nil && securityGroupId1 != "" {
+			networkConfig1["securityGroupId"] = securityGroupId1
+		}
+		if len(networkConfig1) > 0 {
+			registryConfig1["networkConfig"] = networkConfig1
+		}
+		if len(registryConfig1) > 0 {
+			customContainerConfig["registryConfig"] = registryConfig1
+		}
 
 		request["customContainerConfig"] = customContainerConfig
 	}
@@ -1090,6 +1199,61 @@ func resourceAliCloudFcv3FunctionRead(d *schema.ResourceData, meta interface{}) 
 			healthCheckConfigMaps = append(healthCheckConfigMaps, healthCheckConfigMap)
 		}
 		customContainerConfigMap["health_check_config"] = healthCheckConfigMaps
+		registryConfigMaps := make([]map[string]interface{}, 0)
+		registryConfigRaw := make(map[string]interface{})
+		if customContainerConfigRaw["registryConfig"] != nil {
+			registryConfigRaw = customContainerConfigRaw["registryConfig"].(map[string]interface{})
+		}
+		if len(registryConfigRaw) > 0 {
+			registryConfigMap := make(map[string]interface{})
+			authConfigMaps := make([]map[string]interface{}, 0)
+			authConfigRaw := make(map[string]interface{})
+			if registryConfigRaw["authConfig"] != nil {
+				authConfigRaw = registryConfigRaw["authConfig"].(map[string]interface{})
+			}
+			if len(authConfigRaw) > 0 {
+				authConfigMap := make(map[string]interface{})
+				authConfigMap["user_name"] = authConfigRaw["userName"]
+				if authConfigRaw["password"] != nil && authConfigRaw["password"] != "" {
+					authConfigMap["password"] = authConfigRaw["password"]
+				} else if v, ok := d.GetOk("custom_container_config.0.registry_config.0.auth_config.0.password"); ok {
+					authConfigMap["password"] = v
+				}
+				authConfigMaps = append(authConfigMaps, authConfigMap)
+			} else if v, ok := d.GetOk("custom_container_config.0.registry_config.0.auth_config"); ok {
+				for _, item := range v.([]interface{}) {
+					if m, ok := item.(map[string]interface{}); ok {
+						authConfigMaps = append(authConfigMaps, m)
+					}
+				}
+			}
+			registryConfigMap["auth_config"] = authConfigMaps
+			certConfigMaps := make([]map[string]interface{}, 0)
+			if registryConfigRaw["certConfig"] != nil {
+				certConfigRaw := registryConfigRaw["certConfig"].(map[string]interface{})
+				if len(certConfigRaw) > 0 {
+					certConfigMap := make(map[string]interface{})
+					certConfigMap["insecure"] = certConfigRaw["insecure"]
+					certConfigMap["root_ca_cert_base64"] = certConfigRaw["rootCaCertBase64"]
+					certConfigMaps = append(certConfigMaps, certConfigMap)
+				}
+			}
+			registryConfigMap["cert_config"] = certConfigMaps
+			networkConfigMaps := make([]map[string]interface{}, 0)
+			if registryConfigRaw["networkConfig"] != nil {
+				networkConfigRaw := registryConfigRaw["networkConfig"].(map[string]interface{})
+				if len(networkConfigRaw) > 0 {
+					networkConfigMap := make(map[string]interface{})
+					networkConfigMap["vpc_id"] = networkConfigRaw["vpcId"]
+					networkConfigMap["vswitch_id"] = networkConfigRaw["vSwitchId"]
+					networkConfigMap["security_group_id"] = networkConfigRaw["securityGroupId"]
+					networkConfigMaps = append(networkConfigMaps, networkConfigMap)
+				}
+			}
+			registryConfigMap["network_config"] = networkConfigMaps
+			registryConfigMaps = append(registryConfigMaps, registryConfigMap)
+		}
+		customContainerConfigMap["registry_config"] = registryConfigMaps
 		customContainerConfigMaps = append(customContainerConfigMaps, customContainerConfigMap)
 	}
 	if err := d.Set("custom_container_config", customContainerConfigMaps); err != nil {
@@ -1662,6 +1826,50 @@ func resourceAliCloudFcv3FunctionUpdate(d *schema.ResourceData, meta interface{}
 			acrInstanceId1, _ := jsonpath.Get("$[0].acr_instance_id", v)
 			if acrInstanceId1 != nil && acrInstanceId1 != "" {
 				customContainerConfig["acrInstanceId"] = acrInstanceId1
+			}
+			registryConfig1 := make(map[string]interface{})
+			authConfig1 := make(map[string]interface{})
+			userName1, _ := jsonpath.Get("$[0].registry_config[0].auth_config[0].user_name", d.Get("custom_container_config"))
+			if userName1 != nil && userName1 != "" {
+				authConfig1["userName"] = userName1
+			}
+			password1, _ := jsonpath.Get("$[0].registry_config[0].auth_config[0].password", d.Get("custom_container_config"))
+			if password1 != nil && password1 != "" {
+				authConfig1["password"] = password1
+			}
+			if len(authConfig1) > 0 {
+				registryConfig1["authConfig"] = authConfig1
+			}
+			certConfig1 := make(map[string]interface{})
+			insecure1, _ := jsonpath.Get("$[0].registry_config[0].cert_config[0].insecure", d.Get("custom_container_config"))
+			if insecure1 != nil {
+				certConfig1["insecure"] = insecure1
+			}
+			rootCaCertBase641, _ := jsonpath.Get("$[0].registry_config[0].cert_config[0].root_ca_cert_base64", d.Get("custom_container_config"))
+			if rootCaCertBase641 != nil && rootCaCertBase641 != "" {
+				certConfig1["rootCaCertBase64"] = rootCaCertBase641
+			}
+			if len(certConfig1) > 0 {
+				registryConfig1["certConfig"] = certConfig1
+			}
+			networkConfig1 := make(map[string]interface{})
+			vpcId1, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].vpc_id", d.Get("custom_container_config"))
+			if vpcId1 != nil && vpcId1 != "" {
+				networkConfig1["vpcId"] = vpcId1
+			}
+			vSwitchId1, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].vswitch_id", d.Get("custom_container_config"))
+			if vSwitchId1 != nil && vSwitchId1 != "" {
+				networkConfig1["vSwitchId"] = vSwitchId1
+			}
+			securityGroupId1, _ := jsonpath.Get("$[0].registry_config[0].network_config[0].security_group_id", d.Get("custom_container_config"))
+			if securityGroupId1 != nil && securityGroupId1 != "" {
+				networkConfig1["securityGroupId"] = securityGroupId1
+			}
+			if len(networkConfig1) > 0 {
+				registryConfig1["networkConfig"] = networkConfig1
+			}
+			if len(registryConfig1) > 0 {
+				customContainerConfig["registryConfig"] = registryConfig1
 			}
 
 			request["customContainerConfig"] = customContainerConfig

--- a/alicloud/resource_alicloud_fcv3_function_test.go
+++ b/alicloud/resource_alicloud_fcv3_function_test.go
@@ -2063,4 +2063,178 @@ data "alicloud_resource_manager_resource_groups" "default" {
 `, name)
 }
 
+var AliCloudFc3FunctionMapRegistryConfig = map[string]string{
+	"cpu":                  "0.5",
+	"function_name":        CHECKSET,
+	"disk_size":            "512",
+	"instance_concurrency": CHECKSET,
+	"memory_size":          "512",
+	"create_time":          CHECKSET,
+	"internet_access":      "true",
+}
+
+func AliCloudFc3FunctionRegistryConfigDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+variable "registry_image" {
+  default = "registry-vpc.cn-hangzhou.aliyuncs.com/eci_open/nginx:alpine"
+}
+
+data "alicloud_vpcs" "default" {
+  is_default = true
+}
+
+data "alicloud_vswitches" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+
+data "alicloud_security_groups" "default" {
+  vpc_id = data.alicloud_vpcs.default.ids.0
+}
+`, name)
+}
+
+func TestAccAliCloudFcv3Function_registryConfig(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_fcv3_function.default"
+	ra := resourceAttrInit(resourceId, AliCloudFc3FunctionMapRegistryConfig)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &Fcv3ServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeFcv3Function")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sfc3reg%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudFc3FunctionRegistryConfigDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"function_name": name,
+					"memory_size":   "512",
+					"runtime":       "custom-container",
+					"timeout":       "3",
+					"handler":       "index.handler",
+					"description":   "registry_config create",
+					"cpu":           "0.5",
+					"disk_size":     "512",
+					"log_config": []map[string]interface{}{
+						{
+							"log_begin_rule": "None",
+						},
+					},
+					"custom_container_config": []map[string]interface{}{
+						{
+							"image": "${var.registry_image}",
+							"port":  "9000",
+							"registry_config": []map[string]interface{}{
+								{
+									"auth_config": []map[string]interface{}{
+										{
+											"user_name": "tf-acc-user",
+											"password":  "tf-acc-password1",
+										},
+									},
+									"cert_config": []map[string]interface{}{
+										{
+											"insecure":            "true",
+											"root_ca_cert_base64": "dGVzdC1jYS1jZXJ0",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"function_name":                                                                 name,
+						"custom_container_config.#":                                                     "1",
+						"custom_container_config.0.registry_config.#":                                   "1",
+						"custom_container_config.0.registry_config.0.auth_config.#":                     "1",
+						"custom_container_config.0.registry_config.0.auth_config.0.user_name":           "tf-acc-user",
+						"custom_container_config.0.registry_config.0.auth_config.0.password":            "tf-acc-password1",
+						"custom_container_config.0.registry_config.0.cert_config.#":                     "1",
+						"custom_container_config.0.registry_config.0.cert_config.0.insecure":            "true",
+						"custom_container_config.0.registry_config.0.cert_config.0.root_ca_cert_base64": "dGVzdC1jYS1jZXJ0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"function_name": name,
+					"memory_size":   "512",
+					"runtime":       "custom-container",
+					"timeout":       "3",
+					"handler":       "index.handler",
+					"description":   "registry_config update",
+					"cpu":           "0.5",
+					"disk_size":     "512",
+					"log_config": []map[string]interface{}{
+						{
+							"log_begin_rule": "None",
+						},
+					},
+					"custom_container_config": []map[string]interface{}{
+						{
+							"image": "${var.registry_image}",
+							"port":  "9000",
+							"registry_config": []map[string]interface{}{
+								{
+									"auth_config": []map[string]interface{}{
+										{
+											"user_name": "tf-acc-user2",
+											"password":  "tf-acc-password2",
+										},
+									},
+									"cert_config": []map[string]interface{}{
+										{
+											"insecure":            "false",
+											"root_ca_cert_base64": "dGVzdC1jYS1jZXJ0LXVwZGF0ZQ==",
+										},
+									},
+									"network_config": []map[string]interface{}{
+										{
+											"vpc_id":            "${data.alicloud_vpcs.default.ids.0}",
+											"vswitch_id":        "${data.alicloud_vswitches.default.ids.0}",
+											"security_group_id": "${data.alicloud_security_groups.default.ids.0}",
+										},
+									},
+								},
+							},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"custom_container_config.0.registry_config.0.auth_config.0.user_name":            "tf-acc-user2",
+						"custom_container_config.0.registry_config.0.auth_config.0.password":             "tf-acc-password2",
+						"custom_container_config.0.registry_config.0.cert_config.0.insecure":             "false",
+						"custom_container_config.0.registry_config.0.cert_config.0.root_ca_cert_base64":  "dGVzdC1jYS1jZXJ0LXVwZGF0ZQ==",
+						"custom_container_config.0.registry_config.0.network_config.#":                   "1",
+						"custom_container_config.0.registry_config.0.network_config.0.vpc_id":            CHECKSET,
+						"custom_container_config.0.registry_config.0.network_config.0.vswitch_id":        CHECKSET,
+						"custom_container_config.0.registry_config.0.network_config.0.security_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
 // Test Fcv3 Function. <<< Resource test cases, automatically generated.

--- a/website/docs/d/fcv3_functions.html.markdown
+++ b/website/docs/d/fcv3_functions.html.markdown
@@ -69,6 +69,17 @@ The following attributes are exported in addition to the arguments listed above:
     * `image` - The container Image address.
     * `port` - The listening port of the HTTP Server when the custom container runs.
     * `resolved_image_uri` - The actual digest version of the deployed Image. The code version specified by this digest is used when the function starts.
+    * `registry_config` - The configuration of the custom image registry.
+      * `auth_config` - The authentication configuration of the image registry.
+        * `user_name` - The username of the image registry.
+        * `password` - The password of the image registry.
+      * `cert_config` - The certificate configuration of the image registry.
+        * `insecure` - Whether to skip certificate verification when pulling images from the registry.
+        * `root_ca_cert_base64` - The Base64-encoded CA certificate of the image registry.
+      * `network_config` - The network configuration used to access the image registry.
+        * `vpc_id` - The ID of the VPC that can connect to the image registry.
+        * `vswitch_id` - The ID of the vSwitch that can connect to the image registry.
+        * `security_group_id` - The ID of the security group that can connect to the image registry.
   * `custom_dns` - Function custom DNS configuration
     * `dns_options` - List of configuration items in the resolv.conf file. Each item corresponds to a key-value pair in the format of key:value, where the key is required.
       * `name` - Configuration Item Name.

--- a/website/docs/r/fcv3_function.html.markdown
+++ b/website/docs/r/fcv3_function.html.markdown
@@ -171,6 +171,7 @@ The custom_container_config supports the following:
 * `health_check_config` - (Optional, List) Function custom health check configuration See [`health_check_config`](#custom_container_config-health_check_config) below.
 * `image` - (Optional) The container Image address.
 * `port` - (Optional, Int) The listening port of the HTTP Server when the custom container runs.
+* `registry_config` - (Optional, List, Available since v1.259.0) The configuration of the custom image registry. Used when the container image is stored in a self-managed image registry instead of ACR. See [`registry_config`](#custom_container_config-registry_config) below.
 
 ### `custom_container_config-health_check_config`
 
@@ -181,6 +182,32 @@ The custom_container_config-health_check_config supports the following:
 * `period_seconds` - (Optional, Int) Health check cycle. The value range is 1~120. The default value is 3.
 * `success_threshold` - (Optional, Int) The threshold for the number of successful health checks. When the threshold is reached, the system considers that the health check is successful. The value range is 1~120. The default value is 1.
 * `timeout_seconds` - (Optional, Int) Health check timeout. Value range 1~3. The default value is 1.
+
+### `custom_container_config-registry_config`
+
+The registry_config supports the following:
+* `auth_config` - (Optional, List) The authentication configuration of the image registry. See [`auth_config`](#custom_container_config-registry_config-auth_config) below.
+* `cert_config` - (Optional, List) The certificate configuration of the image registry. See [`cert_config`](#custom_container_config-registry_config-cert_config) below.
+* `network_config` - (Optional, List) The network configuration used to access the image registry. See [`network_config`](#custom_container_config-registry_config-network_config) below.
+
+### `custom_container_config-registry_config-auth_config`
+
+The auth_config supports the following:
+* `user_name` - (Optional) The username of the image registry.
+* `password` - (Optional) The password of the image registry.
+
+### `custom_container_config-registry_config-cert_config`
+
+The cert_config supports the following:
+* `insecure` - (Optional, Bool) Whether to skip certificate verification when pulling images from the registry.
+* `root_ca_cert_base64` - (Optional) The Base64-encoded CA certificate of the image registry.
+
+### `custom_container_config-registry_config-network_config`
+
+The network_config supports the following:
+* `vpc_id` - (Optional) The ID of the VPC that can connect to the image registry.
+* `vswitch_id` - (Optional) The ID of the vSwitch that can connect to the image registry.
+* `security_group_id` - (Optional) The ID of the security group that can connect to the image registry.
 
 ### `custom_dns`
 


### PR DESCRIPTION
## What

Add `registry_config` support to `custom_container_config` in `alicloud_fcv3_function`, so that functions using custom container images can pull from self-managed image registries with authentication.

`custom_container_config.registry_config` now supports:

- `auth_config` - registry authentication (`user_name`, `password` (sensitive))
- `cert_config` - registry certificate settings (`insecure`, `root_ca_cert_base64`)
- `network_config` - network used to reach the registry (`vpc_id`, `vswitch_id`, `security_group_id`)

The data source `alicloud_fcv3_functions` exposes the same computed structure.

Note: the FC API does not return the plaintext `authConfig` on read (it is stored encrypted). The resource preserves the configured `auth_config` values from state to avoid perpetual diffs.

## Test

=== RUN TestAccAliCloudFcv3Function_registryConfig
--- PASS: TestAccAliCloudFcv3Function_registryConfig (24.76s)

Regression run over all existing fcv3 function test cases:

=== RUN TestAccAliCloudFcv3Function_basic6916_raw
--- PASS: TestAccAliCloudFcv3Function_basic6916_raw (48.07s)

=== RUN TestAccAliCloudFcv3Function_basic6917_raw
--- PASS: TestAccAliCloudFcv3Function_basic6917_raw (19.10s)

=== RUN TestAccAliCloudFcv3Function_basic6936_raw
--- PASS: TestAccAliCloudFcv3Function_basic6936_raw (11.32s)

=== RUN TestAccAliCloudFcv3Function_basic6938_raw
--- PASS: TestAccAliCloudFcv3Function_basic6938_raw (56.30s)

=== RUN TestAccAlicloudFcv3FunctionDataSource
--- PASS: TestAccAlicloudFcv3FunctionDataSource (36.25s)