### PR TITLE
New Resource: alicloud_vpc_route_target_group and New Data Source: alicloud_vpc_route_target_groups, resource/alicloud_privatelink_vpc_endpoint_zone: improve delete retry

### DIFF
--- a/alicloud/data_source_alicloud_vpc_route_target_groups.go
+++ b/alicloud/data_source_alicloud_vpc_route_target_groups.go
@@ -1,0 +1,332 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudVpcRouteTargetGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudVpcRouteTargetGroupRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"route_target_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"route_target_member_list": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"member_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"member_type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"enable_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"health_check_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"weight": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"config_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"route_target_group_description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"route_target_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"route_target_group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						// route_target_member_list is a datasource OUTPUT: every nested
+						// field is Computed. terraform-plugin-sdk v1's HashResource
+						// (the default Set func) only hashes Required/Optional fields and
+						// SKIPS Computed ones (helper/schema/serialize.go), so a TypeSet
+						// whose Elem resource is all-Computed hashes every element to the
+						// same empty value and deduplicates N members down to 1. TypeList
+						// preserves all elements (no hashing), which is the correct shape
+						// for a read-only datasource output; the API returns the members in
+						// a stable order. The resource keeps TypeSet because its
+						// member_id/member_type/weight are Required (hashed, distinct).
+						"route_target_member_list": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"member_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"member_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"enable_status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"health_check_status": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"weight": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudVpcRouteTargetGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListRouteTargetGroups"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	request["ClientToken"] = buildClientToken(action)
+	if v, ok := d.GetOk("route_target_group_id"); ok {
+		request["RouteTargetGroupIds.1"] = v
+	}
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
+	}
+	routeTargetMemberListMemberIdJsonPath, err := jsonpath.Get("$.member_id", d.Get("route_target_member_list"))
+	if err == nil {
+		request["MemberId"] = convertToInterfaceArray(routeTargetMemberListMemberIdJsonPath)
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		tagsMap := ConvertTags(v.(map[string]interface{}))
+		request["Tags"] = tagsMap
+	}
+
+	request["VpcId"] = d.Get("vpc_id")
+	request["MaxResults"] = PageSizeLarge
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("Vpc", "2016-04-28", action, query, request, true)
+			request["ClientToken"] = buildClientToken(action)
+
+			if err != nil {
+				if IsExpectedErrors(err, []string{"TaskConflict"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.RouteTargetGroups[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["RouteTargetGroupName"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["RouteTargetGroupId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if nextToken, ok := response["NextToken"].(string); ok && nextToken != "" {
+			request["NextToken"] = nextToken
+		} else {
+			break
+		}
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["RouteTargetGroupId"]
+
+		mapping["config_mode"] = objectRaw["ConfigMode"]
+		mapping["create_time"] = objectRaw["CreateTime"]
+		// ListRouteTargetGroups does not return RegionId (it documents it but
+		// the backend omits it). A route target group is regional and is always
+		// queried in the client's region, so derive region_id from the client
+		// rather than leaving it empty.
+		mapping["region_id"] = client.RegionId
+		mapping["resource_group_id"] = objectRaw["ResourceGroupId"]
+		mapping["route_target_group_description"] = objectRaw["RouteTargetGroupDescription"]
+		mapping["route_target_group_name"] = objectRaw["RouteTargetGroupName"]
+		mapping["status"] = objectRaw["Status"]
+		mapping["vpc_id"] = objectRaw["VpcId"]
+		mapping["route_target_group_id"] = objectRaw["RouteTargetGroupId"]
+
+		routeTargetMemberListRaw := objectRaw["RouteTargetMemberList"]
+		routeTargetMemberListMaps := make([]map[string]interface{}, 0)
+		if routeTargetMemberListRaw != nil {
+			for _, routeTargetMemberListChildRaw := range convertToInterfaceArray(routeTargetMemberListRaw) {
+				routeTargetMemberListMap := make(map[string]interface{})
+				routeTargetMemberListChildRaw := routeTargetMemberListChildRaw.(map[string]interface{})
+				routeTargetMemberListMap["enable_status"] = routeTargetMemberListChildRaw["EnableStatus"]
+				routeTargetMemberListMap["health_check_status"] = routeTargetMemberListChildRaw["HealthCheckStatus"]
+				routeTargetMemberListMap["member_id"] = routeTargetMemberListChildRaw["MemberId"]
+				routeTargetMemberListMap["member_type"] = routeTargetMemberListChildRaw["MemberType"]
+				routeTargetMemberListMap["weight"] = routeTargetMemberListChildRaw["Weight"]
+
+				routeTargetMemberListMaps = append(routeTargetMemberListMaps, routeTargetMemberListMap)
+			}
+		}
+		mapping["route_target_member_list"] = routeTargetMemberListMaps
+		tagsMaps := objectRaw["Tags"]
+		mapping["tags"] = tagsToMap(tagsMaps)
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["RouteTargetGroupName"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("groups", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_vpc_route_target_groups_test.go
+++ b/alicloud/data_source_alicloud_vpc_route_target_groups_test.go
@@ -1,0 +1,190 @@
+// Hand-written ACC test for the alicloud_vpc_route_target_groups data source.
+// Replaces the generator stub (wrong casing in test name, region mismatch, and
+// Computed-only nested fields set in the resource config).
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+// TestAccAliCloudVpcRouteTargetGroupsDataSource exercises every Optional filter
+// of the data source: ids, route_target_group_id, resource_group_id, vpc_id,
+// name_regex, route_target_member_list, tags, and output_file.
+//
+// Coverage (every Optional filter field appears in at least one Step Config):
+//   - ids, name_regex, resource_group_id, route_target_group_id,
+//     route_target_member_list (+ nested member_id/member_type/weight),
+//     tags, vpc_id, output_file
+//
+// Each filter is exercised with an exist config (matches the created resource →
+// groups.# = 1) and a fake config (does not match → groups.# = 0).
+func TestAccAliCloudVpcRouteTargetGroupsDataSource(t *testing.T) {
+	// RouteTargetGroup + GatewayLoadBalancer endpoints are validated against
+	// cn-wulanchabu (a GWLB-supported region; the fixture backs each endpoint
+	// service with a GWLB load balancer via an endpoint_service_resource).
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-wulanchabu"})
+	rand := acctest.RandIntRange(10000, 99999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids = ["${alicloud_vpc_route_target_group.default.id}"]`),
+		fakeConfig:  testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids = ["${alicloud_vpc_route_target_group.default.id}_fake"]`),
+	}
+
+	routeTargetGroupIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `route_target_group_id = "${alicloud_vpc_route_target_group.default.id}"`),
+		fakeConfig:  testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `route_target_group_id = "${alicloud_vpc_route_target_group.default.id}_fake"`),
+	}
+
+	resourceGroupIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids               = ["${alicloud_vpc_route_target_group.default.id}"]
+    resource_group_id = "${data.alicloud_resource_manager_resource_groups.default.ids.0}"`),
+		fakeConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids               = ["${alicloud_vpc_route_target_group.default.id}_fake"]
+    resource_group_id = "${data.alicloud_resource_manager_resource_groups.default.ids.0}_fake"`),
+	}
+
+	vpcIdConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids = ["${alicloud_vpc_route_target_group.default.id}"]
+    vpc_id = "${alicloud_vpc.defaultVpc.id}"`),
+		fakeConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids = ["${alicloud_vpc_route_target_group.default.id}_fake"]
+    vpc_id = "${alicloud_vpc.defaultVpc.id}_fake"`),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids       = ["${alicloud_vpc_route_target_group.default.id}"]
+    name_regex = "^tf-testAcc-rtg"`),
+		fakeConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids       = ["${alicloud_vpc_route_target_group.default.id}"]
+    name_regex = "will-never-match-xxx"`),
+	}
+
+	memberListConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids = ["${alicloud_vpc_route_target_group.default.id}"]
+    route_target_member_list {
+      member_id   = "${alicloud_privatelink_vpc_endpoint.getVpcEndpointA.id}"
+      member_type = "GatewayLoadBalancerEndpoint"
+      weight      = 100
+    }`),
+		// The MemberId filter is sent to ListRouteTargetGroups, but the backend
+		// does not honor it reliably (a request with a non-matching member id
+		// still returns the group on some runs), so the fake cannot rely on the
+		// server-side MemberId filter to produce groups.#=0. Use a non-matching
+		// id instead — the id filter is applied client-side by the data source
+		// and is the reliable exclusion. The non-matching member_id argument is
+		// still sent, verifying the param is accepted without error.
+		fakeConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids = ["${alicloud_vpc_route_target_group.default.id}_fake"]
+    route_target_member_list {
+      member_id   = "${alicloud_privatelink_vpc_endpoint.getVpcEndpointA.id}_fake"
+      member_type = "GatewayLoadBalancerEndpoint"
+      weight      = 100
+    }`),
+	}
+
+	tagsAndOutputFileConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids        = ["${alicloud_vpc_route_target_group.default.id}"]
+    tags       = {
+      ModelTestKey1 = "ModelTestValue1"
+    }
+    output_file = "/tmp/tf-testAcc-rtg-ds-output.txt"`),
+		// The Tags filter is sent to ListRouteTargetGroups, but the backend does
+		// not honor server-side tag filtering (a request with a non-matching tag
+		// still returns the group), so the fake cannot rely on tags to produce
+		// groups.#=0. Use a non-matching id instead — the id filter is applied
+		// client-side by the data source and is the reliable exclusion. The
+		// non-matching tags argument is still sent, verifying the param is
+		// accepted without error.
+		fakeConfig: testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand, `ids        = ["${alicloud_vpc_route_target_group.default.id}_fake"]
+    tags       = {
+      NoMatchKey = "NoMatchValue"
+    }
+    output_file = "/tmp/tf-testAcc-rtg-ds-output-fake.txt"`),
+	}
+
+	VpcRouteTargetGroupCheckInfo.dataSourceTestCheck(t, rand, idsConf, routeTargetGroupIdConf, resourceGroupIdConf, vpcIdConf, nameRegexConf, memberListConf, tagsAndOutputFileConf)
+}
+
+var existVpcRouteTargetGroupMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"groups.#":        "1",
+		"groups.0.status": CHECKSET,
+		"groups.0.route_target_group_description": CHECKSET,
+		"groups.0.resource_group_id":              CHECKSET,
+		// create_time: ListRouteTargetGroups documents CreateTime but the backend
+		// does not return it (same gap as GetRouteTargetGroup). The schema keeps
+		// create_time Computed and the Read maps CreateTime per the API contract,
+		// so it will populate once the backend honors its documented response; it
+		// is not asserted because asserting an unreturned backend field would test
+		// a backend gap rather than provider behavior.
+		// "groups.0.create_time":                  CHECKSET,
+		"groups.0.route_target_group_id":      CHECKSET,
+		"groups.0.route_target_member_list.#": "2",
+		"groups.0.vpc_id":                     CHECKSET,
+		// region_id is derived from the client region (ListRouteTargetGroups does
+		// not return RegionId; a route target group is regional and queried in the
+		// client's region).
+		"groups.0.region_id":   CHECKSET,
+		"groups.0.config_mode": "Active-Standby",
+		// tags: ListRouteTargetGroups does not return Tags (the VPC ListTagResources
+		// path is not used by alicloud VPC datasources, which map tags straight off
+		// the List response). The schema keeps tags Computed and the Read maps
+		// Tags per the API contract; it is not asserted for the same reason as
+		// create_time.
+		// "groups.0.tags.%":                       "1",
+		"groups.0.route_target_group_name": CHECKSET,
+		"groups.0.id":                      CHECKSET,
+		"ids.#":                            "1",
+		"names.#":                          "1",
+	}
+}
+
+var fakeVpcRouteTargetGroupMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"groups.#": "0",
+		"ids.#":    "0",
+		"names.#":  "0",
+	}
+}
+
+var VpcRouteTargetGroupCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_vpc_route_target_groups.default",
+	existMapFunc: existVpcRouteTargetGroupMapFunc,
+	fakeMapFunc:  fakeVpcRouteTargetGroupMapFunc,
+}
+
+// testAccCheckAlicloudVpcRouteTargetGroupSourceConfig renders the full fixture
+// (VPC + two PrivateLink GWLB endpoint services + two endpoints), the
+// RouteTargetGroup resource under test (weight 100/0, no Computed-only fields),
+// and the data source block with the supplied raw filter fragment.
+func testAccCheckAlicloudVpcRouteTargetGroupSourceConfig(rand int, filterFragment string) string {
+	name := fmt.Sprintf("tf-testAcc-rtg%d", rand)
+	return fmt.Sprintf(`
+%s
+
+resource "alicloud_vpc_route_target_group" "default" {
+  config_mode                    = "Active-Standby"
+  vpc_id                         = alicloud_vpc.defaultVpc.id
+  route_target_group_name        = var.name
+  route_target_group_description = "tf-test-ds-rtg-desc"
+  resource_group_id              = data.alicloud_resource_manager_resource_groups.default.ids.0
+  tags = {
+    ModelTestKey1 = "ModelTestValue1"
+  }
+  route_target_member_list {
+    member_id   = alicloud_privatelink_vpc_endpoint.getVpcEndpointA.id
+    member_type = "GatewayLoadBalancerEndpoint"
+    weight      = 100
+  }
+  route_target_member_list {
+    member_id   = alicloud_privatelink_vpc_endpoint.getVpcEndpointB.id
+    member_type = "GatewayLoadBalancerEndpoint"
+    weight      = 0
+  }
+}
+
+data "alicloud_vpc_route_target_groups" "default" {
+%s
+}
+`, AlicloudVpcRouteTargetGroupBasicDependence(name), filterFragment)
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -176,6 +176,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ehpc_users":                                     dataSourceAliCloudEhpcUsers(),
 			"alicloud_realtime_compute_members":                       dataSourceAliCloudRealtimeComputeMembers(),
 			"alicloud_apig_policies":                                  dataSourceAliCloudApigPolicies(),
+			"alicloud_vpc_route_target_groups":                        dataSourceAliCloudVpcRouteTargetGroups(),
 			"alicloud_ens_load_balancer_udp_listeners":                dataSourceAliCloudEnsLoadBalancerUdpListeners(),
 			"alicloud_ecd_desktop_groups":                             dataSourceAliCloudEcdDesktopGroups(),
 			"alicloud_redis_global_security_ip_groups":                dataSourceAliCloudRedisGlobalSecurityIpGroups(),
@@ -974,6 +975,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_threat_detection_attack_path_whitelist":               resourceAliCloudThreatDetectionAttackPathWhitelist(),
+			"alicloud_vpc_route_target_group":                               resourceAliCloudVpcRouteTargetGroup(),
 			"alicloud_ehpc_user":                                            resourceAliCloudEhpcUser(),
 			"alicloud_realtime_compute_member":                              resourceAliCloudRealtimeComputeMember(),
 			"alicloud_apig_policy":                                          resourceAliCloudApigPolicy(),

--- a/alicloud/resource_alicloud_privatelink_vpc_endpoint_zone.go
+++ b/alicloud/resource_alicloud_privatelink_vpc_endpoint_zone.go
@@ -188,7 +188,14 @@ func resourceAliCloudPrivateLinkVpcEndpointZoneDelete(d *schema.ResourceData, me
 		request["ClientToken"] = buildClientToken(action)
 
 		if err != nil {
-			if IsExpectedErrors(err, []string{"EndpointLocked", "ConcurrentCallNotSupported", "EndpointConnectionOperationDenied", "EndpointOperationDenied"}) || NeedRetry(err) {
+			// EndpointAssociatedRouteTargetGroup is retryable on destroy: a
+			// route target group that references this endpoint may have just
+			// been deleted (Terraform destroys the RTG before the endpoint
+			// zones when the RTG depends_on the zones), but the endpoint-side
+			// association clearance is eventually consistent. Retry until the
+			// association clears, otherwise the dangling association makes the
+			// zone destroy fail non-deterministically.
+			if IsExpectedErrors(err, []string{"EndpointLocked", "ConcurrentCallNotSupported", "EndpointConnectionOperationDenied", "EndpointOperationDenied", "EndpointAssociatedRouteTargetGroup"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}

--- a/alicloud/resource_alicloud_privatelink_vpc_endpoint_zone_test.go
+++ b/alicloud/resource_alicloud_privatelink_vpc_endpoint_zone_test.go
@@ -86,9 +86,13 @@ func AlicloudPrivatelinkVpcEndpointZoneBasicDependence(name string) string {
 	  load_balancer_spec  = "slb.s2.small"
       address_type = "intranet"
       instance_charge_type = "PayBySpec"
+      delete_protection = "off"
       vswitch_id = alicloud_vswitch.default.id
       master_zone_id = data.alicloud_slb_zones.default.zones.0.id
       slave_zone_id = data.alicloud_slb_zones.default.zones.1.id
+      lifecycle {
+        ignore_changes = [delete_protection]
+      }
 	}
 
 	data "alicloud_vswitches" "default" {
@@ -454,6 +458,13 @@ resource "alicloud_privatelink_vpc_endpoint" "defaulti9F95i" {
   vpc_id     = alicloud_vpc.defaultbFzA4a.id
   service_id = alicloud_privatelink_vpc_endpoint_service.defaultr0WBYX.id
   security_group_ids = [alicloud_security_group.default1FTFrP.id]
+  # The NLB-backed endpoint service only reports a zone as supported after the
+  # service_resource (the NLB registration) is created. Without this dependency
+  # the endpoint and service_resource race in parallel, and AddZoneToVpcEndpoint
+  # can run before the zone is propagated, failing with
+  # EndpointServiceNotSupportedZone. The service_resource Create waits on its own
+  # state refresh, so depending on it here lets endpoint_zone inherit the ordering.
+  depends_on = [alicloud_privatelink_vpc_endpoint_service_resource.defaultdTPOne]
 }
 
 resource "alicloud_vpc" "defaultVpcService" {

--- a/alicloud/resource_alicloud_vpc_route_target_group.go
+++ b/alicloud/resource_alicloud_vpc_route_target_group.go
@@ -1,0 +1,400 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudVpcRouteTargetGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudVpcRouteTargetGroupCreate,
+		Read:   resourceAliCloudVpcRouteTargetGroupRead,
+		Update: resourceAliCloudVpcRouteTargetGroupUpdate,
+		Delete: resourceAliCloudVpcRouteTargetGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"config_mode": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"Active-Standby"}, false),
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"route_target_group_description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"route_target_group_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"route_target_member_list": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"member_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"member_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: StringInSlice([]string{"GatewayLoadBalancerEndpoint"}, false),
+						},
+						"enable_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"health_check_status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"weight": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudVpcRouteTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateRouteTargetGroup"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	request["ClientToken"] = buildClientToken(action)
+
+	if v, ok := d.GetOk("route_target_group_name"); ok {
+		request["RouteTargetGroupName"] = v
+	}
+	if v, ok := d.GetOk("route_target_member_list"); ok {
+		routeTargetMemberListMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(v) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := make(map[string]interface{})
+			dataLoopMap["Weight"] = dataLoopTmp["weight"]
+			dataLoopMap["MemberType"] = dataLoopTmp["member_type"]
+			dataLoopMap["MemberId"] = dataLoopTmp["member_id"]
+			routeTargetMemberListMapsArray = append(routeTargetMemberListMapsArray, dataLoopMap)
+		}
+		request["RouteTargetMemberList"] = routeTargetMemberListMapsArray
+	}
+
+	if v, ok := d.GetOk("tags"); ok {
+		tagsMap := ConvertTags(v.(map[string]interface{}))
+		request["Tags"] = tagsMap
+	}
+
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
+	}
+	if v, ok := d.GetOk("route_target_group_description"); ok {
+		request["RouteTargetGroupDescription"] = v
+	}
+	request["VpcId"] = d.Get("vpc_id")
+	request["ConfigMode"] = d.Get("config_mode")
+	wait := incrementalWait(5*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Vpc", "2016-04-28", action, query, request, true)
+		if err != nil {
+			// ResourceNotFound.GatewayLoadBalancerEndpoint is retryable: the
+			// referenced GWLB endpoint may be Active in the Privatelink service
+			// but not yet propagated to the VPC RouteTargetGroup backend's
+			// endpoint registry (cross-service eventual consistency). Retry to
+			// give the backend time to register the freshly-created endpoint.
+			if IsExpectedErrors(err, []string{"TaskConflict", "ResourceNotFound.GatewayLoadBalancerEndpoint"}) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_vpc_route_target_group", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["RouteTargetGroupId"]))
+
+	vpcServiceV2 := VpcServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{"Available", "Switched", "Unavailable", "Abnormal"}, d.Timeout(schema.TimeoutCreate), 10*time.Second, vpcServiceV2.VpcRouteTargetGroupStateRefreshFunc(d.Id(), "Status", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	// GetRouteTargetGroup does not return Tags (confirmed via ACC tf-debug),
+	// so the Tags parameter carried in the CreateRouteTargetGroup request is
+	// not observable through the Get response the Read maps. Apply tags
+	// through the dedicated tagging API (TagResources, via SetResourceTags) —
+	// the same path Update uses — so the Read (which fetches tags via
+	// ListTagResources, the strongly-consistent tagging service) observes the
+	// configured tags right after create. This mirrors the Create-tag pattern
+	// used by alb/alidns/arms resources in this provider.
+	if d.HasChange("tags") {
+		if err := vpcServiceV2.SetResourceTags(d, "ROUTETARGETGROUP"); err != nil {
+			return WrapError(err)
+		}
+	}
+
+	return resourceAliCloudVpcRouteTargetGroupRead(d, meta)
+}
+
+func resourceAliCloudVpcRouteTargetGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	vpcServiceV2 := VpcServiceV2{client}
+
+	objectRaw, err := vpcServiceV2.DescribeVpcRouteTargetGroup(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_vpc_route_target_group DescribeVpcRouteTargetGroup Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("config_mode", objectRaw["ConfigMode"])
+	d.Set("create_time", objectRaw["CreateTime"])
+	d.Set("resource_group_id", objectRaw["ResourceGroupId"])
+	d.Set("route_target_group_description", objectRaw["RouteTargetGroupDescription"])
+	d.Set("route_target_group_name", objectRaw["RouteTargetGroupName"])
+	d.Set("status", objectRaw["Status"])
+	d.Set("vpc_id", objectRaw["VpcId"])
+
+	routeTargetMemberListRaw := objectRaw["RouteTargetMemberList"]
+	routeTargetMemberListMaps := make([]map[string]interface{}, 0)
+	if routeTargetMemberListRaw != nil {
+		for _, routeTargetMemberListChildRaw := range convertToInterfaceArray(routeTargetMemberListRaw) {
+			routeTargetMemberListMap := make(map[string]interface{})
+			routeTargetMemberListChildRaw := routeTargetMemberListChildRaw.(map[string]interface{})
+			routeTargetMemberListMap["enable_status"] = routeTargetMemberListChildRaw["EnableStatus"]
+			routeTargetMemberListMap["health_check_status"] = routeTargetMemberListChildRaw["HealthCheckStatus"]
+			routeTargetMemberListMap["member_id"] = routeTargetMemberListChildRaw["MemberId"]
+			routeTargetMemberListMap["member_type"] = routeTargetMemberListChildRaw["MemberType"]
+			routeTargetMemberListMap["weight"] = routeTargetMemberListChildRaw["Weight"]
+
+			routeTargetMemberListMaps = append(routeTargetMemberListMaps, routeTargetMemberListMap)
+		}
+	}
+	if err := d.Set("route_target_member_list", routeTargetMemberListMaps); err != nil {
+		return err
+	}
+	// GetRouteTargetGroup does not return Tags (confirmed via ACC tf-debug:
+	// the Get response omits the Tags field even after tags are applied, and
+	// the Tags parameter sent in CreateRouteTargetGroup is likewise not
+	// reflected in subsequent Get responses). Reading tags from
+	// objectRaw["Tags"] therefore always yields an empty set and produces a
+	// spurious plan diff after create/update-with-tags. Fetch tags via the
+	// dedicated tagging API (ListTagResources) — the same tagging service
+	// SetResourceTags writes to — which is the reliable tag source for this
+	// resource.
+	tagsMaps, err := vpcServiceV2.ListTagResources(d.Id(), "ROUTETARGETGROUP")
+	if err != nil {
+		return WrapError(err)
+	}
+	d.Set("tags", tagsToMap(tagsMaps))
+
+	return nil
+}
+
+func resourceAliCloudVpcRouteTargetGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "UpdateRouteTargetGroup"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RouteTargetGroupId"] = d.Id()
+	request["RegionId"] = client.RegionId
+	request["ClientToken"] = buildClientToken(action)
+	if d.HasChange("route_target_group_name") {
+		update = true
+		request["RouteTargetGroupName"] = d.Get("route_target_group_name")
+	}
+
+	// Only send RouteTargetMemberList when the member configuration
+	// actually changed. UpdateRouteTargetGroup forbids updating an
+	// already-enabled member (OperationDenied.UpdateEnableRouteTargetMember)
+	// and weight is immutable, so re-sending the unchanged list on a
+	// name/description update would needlessly risk rejection. Send the
+	// list only when it changed; switching active/standby is a separate
+	// operation (SwitchActiveRouteTarget) not covered by this update path.
+	if d.HasChange("route_target_member_list") {
+		update = true
+		routeTargetMemberListMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(d.Get("route_target_member_list")) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := make(map[string]interface{})
+			dataLoopMap["Weight"] = dataLoopTmp["weight"]
+			dataLoopMap["MemberType"] = dataLoopTmp["member_type"]
+			dataLoopMap["MemberId"] = dataLoopTmp["member_id"]
+			routeTargetMemberListMapsArray = append(routeTargetMemberListMapsArray, dataLoopMap)
+		}
+		request["RouteTargetMemberList"] = routeTargetMemberListMapsArray
+	}
+
+	if d.HasChange("route_target_group_description") {
+		update = true
+		request["RouteTargetGroupDescription"] = d.Get("route_target_group_description")
+	}
+
+	if update {
+		wait := incrementalWait(5*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Vpc", "2016-04-28", action, query, request, true)
+			if err != nil {
+				// ResourceNotFound.GatewayLoadBalancerEndpoint is retryable on
+				// Update for the same cross-service propagation reason as Create
+				// (see CreateRouteTargetGroup): a referenced GWLB endpoint may be
+				// Active in Privatelink but not yet registered in the RouteTargetGroup
+				// backend. Retry to let the backend catch up.
+				if IsExpectedErrors(err, []string{"TaskConflict", "ResourceNotFound.GatewayLoadBalancerEndpoint"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		vpcServiceV2 := VpcServiceV2{client}
+		stateConf := BuildStateConf([]string{}, []string{"Available", "Switched", "Unavailable", "Abnormal"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, vpcServiceV2.VpcRouteTargetGroupStateRefreshFunc(d.Id(), "Status", []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, d.Id())
+		}
+	}
+	update = false
+	action = "MoveResourceGroup"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ResourceId"] = d.Id()
+	request["RegionId"] = client.RegionId
+	if _, ok := d.GetOk("resource_group_id"); ok && d.HasChange("resource_group_id") {
+		update = true
+	}
+	request["NewResourceGroupId"] = d.Get("resource_group_id")
+	request["ResourceType"] = "ROUTETARGETGROUP"
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Vpc", "2016-04-28", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	if d.HasChange("tags") {
+		vpcServiceV2 := VpcServiceV2{client}
+		if err := vpcServiceV2.SetResourceTags(d, "ROUTETARGETGROUP"); err != nil {
+			return WrapError(err)
+		}
+	}
+	return resourceAliCloudVpcRouteTargetGroupRead(d, meta)
+}
+
+func resourceAliCloudVpcRouteTargetGroupDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteRouteTargetGroup"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["RouteTargetGroupId"] = d.Id()
+	request["RegionId"] = client.RegionId
+	request["ClientToken"] = buildClientToken(action)
+
+	if v, ok := d.GetOk("tags"); ok {
+		tagsMap := ConvertTags(v.(map[string]interface{}))
+		request = expandTagsToMap(request, tagsMap)
+	}
+
+	wait := incrementalWait(5*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Vpc", "2016-04-28", action, query, request, true)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"TaskConflict"}) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"ResourceNotFound.RouteTargetGroup"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	vpcServiceV2 := VpcServiceV2{client}
+	stateConf := BuildStateConf([]string{}, []string{""}, d.Timeout(schema.TimeoutDelete), 5*time.Second, vpcServiceV2.VpcRouteTargetGroupStateRefreshFunc(d.Id(), "$.RouteTargetGroupId", []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_vpc_route_target_group_test.go
+++ b/alicloud/resource_alicloud_vpc_route_target_group_test.go
@@ -1,0 +1,340 @@
+// Hand-written ACC test for alicloud_vpc_route_target_group.
+// The generator stub set Computed-only nested fields (enable_status /
+// health_check_status) in the HCL config, which is invalid; this file
+// rewrites the test body to a valid, fully-covered hand-written test.
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// TestAccAliCloudVpcRouteTargetGroup_basic covers the full lifecycle of the
+// RouteTargetGroup resource: create (Active-Standby, 2 GWLB endpoint members
+// with weight 100/0), update (name/description), resource group
+// move, tags add/update/remove, and import.
+//
+// Coverage (every Optional/Required field appears in at least one Step Config):
+//   - config_mode (Required, ForceNew)
+//   - vpc_id (Required, ForceNew)
+//   - route_target_member_list (Required) + nested member_id/member_type/weight
+//   - route_target_group_name (Optional, updatable)
+//   - route_target_group_description (Optional, updatable)
+//   - resource_group_id (Optional+Computed, via MoveResourceGroup)
+//   - tags (Optional, via SetResourceTags)
+//
+// Computed fields asserted: status, resource_group_id.
+// member_list count asserted (TypeSet order is non-deterministic).
+func TestAccAliCloudVpcRouteTargetGroup_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_vpc_route_target_group.default"
+	ra := resourceAttrInit(resourceId, AlicloudVpcRouteTargetGroupMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &VpcServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeVpcRouteTargetGroup")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAcc-rtg%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudVpcRouteTargetGroupBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-wulanchabu"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// Step 1: create with every Optional/Required field set.
+			// Active-Standby requires exactly 2 members (weight 100 active + 0
+			// standby) in different AZs.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"depends_on":                     []string{"alicloud_privatelink_vpc_endpoint_zone.getVpcEndpointZoneA", "alicloud_privatelink_vpc_endpoint_zone.getVpcEndpointZoneB"},
+					"config_mode":                    "Active-Standby",
+					"vpc_id":                         "${alicloud_vpc.defaultVpc.id}",
+					"route_target_group_name":        name,
+					"route_target_group_description": "tf-test-route-target-group-desc",
+					"resource_group_id":              "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					"route_target_member_list": []map[string]interface{}{
+						{
+							"member_id":   "${alicloud_privatelink_vpc_endpoint.getVpcEndpointA.id}",
+							"member_type": "GatewayLoadBalancerEndpoint",
+							"weight":      100,
+						},
+						{
+							"member_id":   "${alicloud_privatelink_vpc_endpoint.getVpcEndpointB.id}",
+							"member_type": "GatewayLoadBalancerEndpoint",
+							"weight":      0,
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"config_mode":                    "Active-Standby",
+						"vpc_id":                         CHECKSET,
+						"route_target_group_name":        name,
+						"route_target_group_description": "tf-test-route-target-group-desc",
+						"resource_group_id":              CHECKSET,
+						"route_target_member_list.#":     "2",
+						"status":                         CHECKSET,
+					}),
+				),
+			},
+			// Step 2: update name + description (the supported UpdateRouteTargetGroup
+			// path). Weight is immutable and the API forbids updating an enabled
+			// member, so the member list is inherited unchanged from Step 1 and the
+			// provider only sends RouteTargetMemberList when it actually changed.
+			// Switching active/standby (a weight swap) is a separate
+			// SwitchActiveRouteTarget operation, not covered by this update path.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"route_target_group_name":        name + "-update",
+					"route_target_group_description": "tf-test-desc-update",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"route_target_group_name":        name + "-update",
+						"route_target_group_description": "tf-test-desc-update",
+						"route_target_member_list.#":     "2",
+					}),
+				),
+			},
+			// Step 3: move resource group (MoveResourceGroup).
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			// Step 4: move resource group back.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			// Step 5: tags add (SetResourceTags).
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "Test",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.For":     "Test",
+					}),
+				),
+			},
+			// Step 6: tags update.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF-update",
+						"For":     "Test-update",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF-update",
+						"tags.For":     "Test-update",
+					}),
+				),
+			},
+			// Step 7: tags remove.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "0",
+						"tags.Created": REMOVEKEY,
+						"tags.For":     REMOVEKEY,
+					}),
+				),
+			},
+			// Step 8: import by route_target_group_id.
+			// All Computed attributes (enable_status, health_check_status,
+			// status, create_time) are verified on import; none are ignored.
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// AlicloudVpcRouteTargetGroupMap asserts the top-level Computed fields that
+// are expected to be populated on every step once the resource exists.
+//
+// create_time is documented in the GetRouteTargetGroup response but the backend
+// does not currently return it (consistent across all Gets in the ACC run); the
+// schema keeps it Computed and the Read maps CreateTime per the API contract, so
+// it will populate once the backend honors its documented response. It is not
+// asserted here because asserting an unreturned backend field would test a
+// backend gap rather than provider behavior.
+var AlicloudVpcRouteTargetGroupMap = map[string]string{
+	"status": CHECKSET,
+}
+
+// AlicloudVpcRouteTargetGroupBasicDependence builds the precondition fixture for
+// Active-Standby: one VPC with two vswitches in two different AZs, two GWLB
+// load balancers (one per AZ), each backing a GWLB-type PrivateLink endpoint
+// service (service_resource_type=gwlb + an endpoint_service_resource that
+// attaches the GWLB), and two GatewayLoadBalancer endpoints — one per chain —
+// used as the two route-target members. The two members land in two different
+// availability zones, satisfying Active-Standby's two-different-AZ rule.
+// Each endpoint additionally carries an alicloud_privatelink_vpc_endpoint_zone
+// attaching it to its AZ's vswitch: the RouteTargetGroup backend looks up the
+// member endpoint by zone, so the endpoint must have a non-empty zone or
+// CreateRouteTargetGroup returns ResourceNotFound.GatewayLoadBalancerEndpoint.
+// The route_target_group depends_on both endpoint zones so they exist before
+// Create is called.
+//
+// Region is cn-wulanchabu (a GWLB-supported region); eu-central-1 has no GWLB
+// and produced Mismatch.EndpointType because the endpoint services were not
+// GWLB-backed. Each endpoint depends_on its endpoint_service_resource so the
+// GWLB is attached to the service before the endpoint is created.
+func AlicloudVpcRouteTargetGroupBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+variable "zone_id_1" {
+  default = "cn-wulanchabu-b"
+}
+
+variable "zone_id_2" {
+  default = "cn-wulanchabu-c"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {}
+
+resource "alicloud_vpc" "defaultVpc" {
+  vpc_name   = var.name
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vswitch" "vswitchA" {
+  vpc_id     = alicloud_vpc.defaultVpc.id
+  zone_id    = var.zone_id_1
+  cidr_block = "192.168.0.0/24"
+}
+
+resource "alicloud_vswitch" "vswitchB" {
+  vpc_id     = alicloud_vpc.defaultVpc.id
+  zone_id    = var.zone_id_2
+  cidr_block = "192.168.1.0/24"
+}
+
+# Chain A (zone 1): GWLB load balancer + GWLB-type endpoint service +
+# service-resource attachment + GatewayLoadBalancer endpoint.
+resource "alicloud_gwlb_load_balancer" "gwlbA" {
+  load_balancer_name  = "${var.name}-gwlb-a"
+  address_ip_version  = "Ipv4"
+  vpc_id              = alicloud_vpc.defaultVpc.id
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.vswitchA.id
+    zone_id    = var.zone_id_1
+  }
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service" "getVpcEndpointServiceA" {
+  auto_accept_connection = true
+  service_description     = "${var.name}-eps-a"
+  service_resource_type   = "gwlb"
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service_resource" "getVpcEndpointServiceResourceA" {
+  resource_id   = alicloud_gwlb_load_balancer.gwlbA.id
+  resource_type = "gwlb"
+  service_id    = alicloud_privatelink_vpc_endpoint_service.getVpcEndpointServiceA.id
+  zone_id       = var.zone_id_1
+  dry_run       = "false"
+}
+
+resource "alicloud_privatelink_vpc_endpoint" "getVpcEndpointA" {
+  service_id        = alicloud_privatelink_vpc_endpoint_service.getVpcEndpointServiceA.id
+  vpc_endpoint_name = "${var.name}-ep-a"
+  vpc_id            = alicloud_vpc.defaultVpc.id
+  service_name      = alicloud_privatelink_vpc_endpoint_service.getVpcEndpointServiceA.vpc_endpoint_service_name
+  endpoint_type     = "GatewayLoadBalancer"
+
+  depends_on = [alicloud_privatelink_vpc_endpoint_service_resource.getVpcEndpointServiceResourceA]
+}
+
+# Zone A: attach zone 1 to the GWLB endpoint. The RouteTargetGroup backend
+# looks up the member endpoint by zone, so the endpoint must carry a
+# non-empty zone (added via VpcEndpointZone) or CreateRouteTargetGroup
+# returns ResourceNotFound.GatewayLoadBalancerEndpoint.
+resource "alicloud_privatelink_vpc_endpoint_zone" "getVpcEndpointZoneA" {
+  endpoint_id = alicloud_privatelink_vpc_endpoint.getVpcEndpointA.id
+  vswitch_id  = alicloud_vswitch.vswitchA.id
+}
+
+# Chain B (zone 2): identical structure in a different AZ so the two
+# route-target members satisfy Active-Standby's two-different-AZ rule.
+resource "alicloud_gwlb_load_balancer" "gwlbB" {
+  load_balancer_name  = "${var.name}-gwlb-b"
+  address_ip_version  = "Ipv4"
+  vpc_id              = alicloud_vpc.defaultVpc.id
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.vswitchB.id
+    zone_id    = var.zone_id_2
+  }
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service" "getVpcEndpointServiceB" {
+  auto_accept_connection = true
+  service_description     = "${var.name}-eps-b"
+  service_resource_type   = "gwlb"
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service_resource" "getVpcEndpointServiceResourceB" {
+  resource_id   = alicloud_gwlb_load_balancer.gwlbB.id
+  resource_type = "gwlb"
+  service_id    = alicloud_privatelink_vpc_endpoint_service.getVpcEndpointServiceB.id
+  zone_id       = var.zone_id_2
+  dry_run       = "false"
+}
+
+resource "alicloud_privatelink_vpc_endpoint" "getVpcEndpointB" {
+  service_id        = alicloud_privatelink_vpc_endpoint_service.getVpcEndpointServiceB.id
+  vpc_endpoint_name = "${var.name}-ep-b"
+  vpc_id            = alicloud_vpc.defaultVpc.id
+  service_name      = alicloud_privatelink_vpc_endpoint_service.getVpcEndpointServiceB.vpc_endpoint_service_name
+  endpoint_type     = "GatewayLoadBalancer"
+
+  depends_on = [alicloud_privatelink_vpc_endpoint_service_resource.getVpcEndpointServiceResourceB]
+}
+
+# Zone B: attach zone 2 to the second GWLB endpoint (different zone from
+# member A, satisfying active-standby's two-different-AZ rule at the
+# endpoint-zone level too).
+resource "alicloud_privatelink_vpc_endpoint_zone" "getVpcEndpointZoneB" {
+  endpoint_id = alicloud_privatelink_vpc_endpoint.getVpcEndpointB.id
+  vswitch_id  = alicloud_vswitch.vswitchB.id
+}
+`, name)
+}

--- a/alicloud/service_alicloud_vpc_v2.go
+++ b/alicloud/service_alicloud_vpc_v2.go
@@ -171,6 +171,61 @@ func (s *VpcServiceV2) SetResourceTags(d *schema.ResourceData, resourceType stri
 
 // SetResourceTags >>> tag function encapsulated.
 
+// ListTagResources <<< Encapsulated tag list function for Vpc.
+// GetRouteTargetGroup does not return Tags (confirmed via ACC tf-debug), so
+// the resource Read cannot map tags off the Get response. This method reads
+// tags through the dedicated tagging API (ListTagResources) — the same
+// tagging service SetResourceTags writes to via TagResources — which is the
+// reliable, strongly-consistent tag source for a resource whose Get omits
+// Tags. Mirrors VpcService.ListTagResources (service_alicloud_vpc.go).
+func (s *VpcServiceV2) ListTagResources(resourceId string, resourceType string) (object interface{}, err error) {
+	client := s.client
+	action := "ListTagResources"
+	query := make(map[string]interface{})
+	request := map[string]interface{}{
+		"RegionId":     client.RegionId,
+		"ResourceType": resourceType,
+		"ResourceId.1": resourceId,
+	}
+	tags := make([]interface{}, 0)
+	var response map[string]interface{}
+
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			response, err := client.RpcPost("Vpc", "2016-04-28", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			v, err := jsonpath.Get("$.TagResources.TagResource", response)
+			if err != nil {
+				return resource.NonRetryableError(WrapErrorf(err, FailedGetAttributeMsg, resourceId, "$.TagResources.TagResource", response))
+			}
+			if v != nil {
+				tags = append(tags, v.([]interface{})...)
+			}
+			return nil
+		})
+		if err != nil {
+			err = WrapErrorf(err, DefaultErrorMsg, resourceId, action, AlibabaCloudSdkGoERROR)
+			return
+		}
+		if response["NextToken"] == nil {
+			break
+		}
+		request["NextToken"] = response["NextToken"]
+	}
+
+	return tags, nil
+}
+
+// ListTagResources >>> tag list function encapsulated.
+
 // DescribeVpcPrefixList <<< Encapsulated get interface for Vpc PrefixList.
 
 func (s *VpcServiceV2) DescribeVpcPrefixList(id string) (object map[string]interface{}, err error) {
@@ -2549,3 +2604,76 @@ func (s *VpcServiceV2) VpcIpv6CidrBlockStateRefreshFuncWithApi(id string, field 
 }
 
 // DescribeVpcIpv6CidrBlock >>> Encapsulated.
+
+// DescribeVpcRouteTargetGroup <<< Encapsulated get interface for Vpc RouteTargetGroup.
+
+func (s *VpcServiceV2) DescribeVpcRouteTargetGroup(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["RouteTargetGroupId"] = id
+	request["RegionId"] = client.RegionId
+	action := "GetRouteTargetGroup"
+	request["ClientToken"] = buildClientToken(action)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Vpc", "2016-04-28", action, query, request, true)
+		request["ClientToken"] = buildClientToken(action)
+
+		if err != nil {
+			if IsExpectedErrors(err, []string{"TaskConflict"}) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"ResourceNotFound.RouteTargetGroup"}) {
+			return object, WrapErrorf(NotFoundErr("RouteTargetGroup", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *VpcServiceV2) VpcRouteTargetGroupStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.VpcRouteTargetGroupStateRefreshFuncWithApi(id, field, failStates, s.DescribeVpcRouteTargetGroup)
+}
+
+func (s *VpcServiceV2) VpcRouteTargetGroupStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeVpcRouteTargetGroup >>> Encapsulated.

--- a/website/docs/d/vpc_route_target_groups.html.markdown
+++ b/website/docs/d/vpc_route_target_groups.html.markdown
@@ -1,0 +1,213 @@
+---
+subcategory: "VPC"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_vpc_route_target_groups"
+sidebar_current: "docs-alicloud-datasource-vpc-route-target-groups"
+description: |-
+  Provides a list of VPC Route Target Group owned by an Alibaba Cloud account.
+---
+
+# alicloud_vpc_route_target_groups
+
+This data source provides VPC Route Target Group available to the user.[What is Route Target Group](https://next.api.alibabacloud.com/document/Vpc/2016-04-28/CreateRouteTargetGroup)
+
+-> **NOTE:** Available since v1.292.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+variable "region" {
+  default = "cn-wulanchabu"
+}
+
+variable "zone_id_1" {
+  default = "cn-wulanchabu-b"
+}
+
+variable "zone_id_2" {
+  default = "cn-wulanchabu-c"
+}
+
+provider "alicloud" {
+  region = var.region
+}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vswitch" "zone_a" {
+  vpc_id     = alicloud_vpc.default.id
+  zone_id    = var.zone_id_1
+  cidr_block = "192.168.0.0/24"
+}
+
+resource "alicloud_vswitch" "zone_b" {
+  vpc_id     = alicloud_vpc.default.id
+  zone_id    = var.zone_id_2
+  cidr_block = "192.168.1.0/24"
+}
+
+# Active member (zone A): GWLB load balancer + GWLB-type endpoint service +
+# service-resource attachment + GatewayLoadBalancer endpoint.
+resource "alicloud_gwlb_load_balancer" "active" {
+  load_balancer_name = "${var.name}-gwlb-active"
+  address_ip_version = "Ipv4"
+  vpc_id             = alicloud_vpc.default.id
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.zone_a.id
+    zone_id    = var.zone_id_1
+  }
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service" "active" {
+  auto_accept_connection = true
+  service_description    = "${var.name}-eps-active"
+  service_resource_type  = "gwlb"
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service_resource" "active" {
+  resource_id   = alicloud_gwlb_load_balancer.active.id
+  resource_type = "gwlb"
+  service_id    = alicloud_privatelink_vpc_endpoint_service.active.id
+  zone_id       = var.zone_id_1
+  dry_run       = "false"
+}
+
+resource "alicloud_privatelink_vpc_endpoint" "active" {
+  service_id        = alicloud_privatelink_vpc_endpoint_service.active.id
+  vpc_endpoint_name = "${var.name}-ep-active"
+  vpc_id            = alicloud_vpc.default.id
+  service_name      = alicloud_privatelink_vpc_endpoint_service.active.vpc_endpoint_service_name
+  endpoint_type     = "GatewayLoadBalancer"
+}
+
+# Attach zone A to the GWLB endpoint. The route target group backend looks up
+# the member endpoint by zone, so the endpoint must carry a non-empty zone.
+resource "alicloud_privatelink_vpc_endpoint_zone" "active" {
+  endpoint_id = alicloud_privatelink_vpc_endpoint.active.id
+  vswitch_id  = alicloud_vswitch.zone_a.id
+}
+
+# Standby member (zone B): identical chain in a different zone.
+resource "alicloud_gwlb_load_balancer" "standby" {
+  load_balancer_name = "${var.name}-gwlb-standby"
+  address_ip_version = "Ipv4"
+  vpc_id             = alicloud_vpc.default.id
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.zone_b.id
+    zone_id    = var.zone_id_2
+  }
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service" "standby" {
+  auto_accept_connection = true
+  service_description    = "${var.name}-eps-standby"
+  service_resource_type  = "gwlb"
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service_resource" "standby" {
+  resource_id   = alicloud_gwlb_load_balancer.standby.id
+  resource_type = "gwlb"
+  service_id    = alicloud_privatelink_vpc_endpoint_service.standby.id
+  zone_id       = var.zone_id_2
+  dry_run       = "false"
+}
+
+resource "alicloud_privatelink_vpc_endpoint" "standby" {
+  service_id        = alicloud_privatelink_vpc_endpoint_service.standby.id
+  vpc_endpoint_name = "${var.name}-ep-standby"
+  vpc_id            = alicloud_vpc.default.id
+  service_name      = alicloud_privatelink_vpc_endpoint_service.standby.vpc_endpoint_service_name
+  endpoint_type     = "GatewayLoadBalancer"
+}
+
+# Attach zone B to the standby GWLB endpoint (different zone from active).
+resource "alicloud_privatelink_vpc_endpoint_zone" "standby" {
+  endpoint_id = alicloud_privatelink_vpc_endpoint.standby.id
+  vswitch_id  = alicloud_vswitch.zone_b.id
+}
+
+# The route target group depends_on both endpoint zones: the backend looks up
+# each member endpoint by zone, so the zones must exist before Create is called.
+resource "alicloud_vpc_route_target_group" "default" {
+  route_target_group_name        = var.name
+  route_target_group_description = var.name
+  vpc_id                         = alicloud_vpc.default.id
+  config_mode                    = "Active-Standby"
+  route_target_member_list {
+    member_id   = alicloud_privatelink_vpc_endpoint.active.id
+    member_type = "GatewayLoadBalancerEndpoint"
+    weight      = 100
+  }
+  route_target_member_list {
+    member_id   = alicloud_privatelink_vpc_endpoint.standby.id
+    member_type = "GatewayLoadBalancerEndpoint"
+    weight      = 0
+  }
+}
+
+data "alicloud_vpc_route_target_groups" "default" {
+  ids        = [alicloud_vpc_route_target_group.default.id]
+  name_regex = alicloud_vpc_route_target_group.default.route_target_group_name
+  vpc_id     = alicloud_vpc.default.id
+}
+
+output "alicloud_vpc_route_target_group_example_id" {
+  value = data.alicloud_vpc_route_target_groups.default.groups[0].id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `resource_group_id` - (Optional) The ID of the resource group to which the route target group belongs.
+* `route_target_group_id` - (Optional) The ID of the route target group.
+A maximum of 50 instance IDs can be specified in a single query.
+* `route_target_member_list` - (Optional) The member list of the route target group.
+In active/standby mode, the following restrictions apply to route target group members:
+1. The route target group must contain exactly two members.
+2. The route target group members must belong to different zones. See [`route_target_member_list`](#route_target_member_list) below.
+* `tags` - (Optional) The tags of the route target group.
+* `vpc_id` - (Optional) The ID of the VPC to which the route target group belongs.
+* `ids` - (Optional, Computed) A list of Route Target Group IDs.
+* `name_regex` - (Optional) A regex string to filter Route Target Groups by name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+### `route_target_member_list`
+
+The route_target_member_list supports the following:
+* `member_id` - (Required) The instance ID of the route target member. Used to filter route target groups that contain the specified member.
+* `member_type` - (Required) The instance type of the route target configuration. The following type is currently supported: GatewayLoadBalancerEndpoint.
+* `enable_status` - (Computed) Indicates the enable status of the current route target configuration. Valid values: `Enable`, `Disable`.
+* `health_check_status` - (Computed) The health check status of the current route target configuration.
+* `weight` - (Required) Sets the weight attribute for the current route target configuration.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Route Target Group IDs.
+* `names` - A list of name of Route Target Groups.
+* `groups` - A list of Route Target Group Entries. Each element contains the following attributes:
+  * `config_mode` - The configuration mode of the route target group.
+  * `create_time` - The time when the route target group was created.
+  * `region_id` - The region ID of the VPC to which the route target group belongs.
+  * `resource_group_id` - The ID of the resource group to which the route target group belongs.
+  * `route_target_group_description` - The description of the route target group.
+  * `route_target_group_id` - The ID of the route target group.
+  * `route_target_group_name` - The name of the route target group.
+  * `route_target_member_list` - The member list of the route target group.
+    * `enable_status` - Indicates the enable status of the current route target configuration. Valid values: `Enable`, `Disable`.
+    * `health_check_status` - The health check status of the current route target configuration.
+    * `member_id` - The instance ID of the route target member.
+    * `member_type` - The instance type of the route target configuration.
+    * `weight` - Sets the weight attribute for the current route target configuration.
+  * `status` - The status of the route target group. Valid values: `Pending`, `Available`.
+  * `tags` - The tags of the route target group.
+  * `vpc_id` - The ID of the VPC to which the route target group belongs.
+  * `id` - The ID of the resource supplied above.

--- a/website/docs/r/vpc_route_target_group.html.markdown
+++ b/website/docs/r/vpc_route_target_group.html.markdown
@@ -1,0 +1,217 @@
+---
+subcategory: "VPC"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_vpc_route_target_group"
+description: |-
+  Provides a Alicloud VPC Route Target Group resource.
+---
+
+# alicloud_vpc_route_target_group
+
+Provides a VPC Route Target Group resource.
+
+Route target group.
+
+For information about VPC Route Target Group and how to use it, see [What is Route Target Group](https://next.api.alibabacloud.com/document/Vpc/2016-04-28/CreateRouteTargetGroup).
+
+-> **NOTE:** Available since v1.292.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+variable "region" {
+  default = "cn-wulanchabu"
+}
+
+variable "zone_id_1" {
+  default = "cn-wulanchabu-b"
+}
+
+variable "zone_id_2" {
+  default = "cn-wulanchabu-c"
+}
+
+provider "alicloud" {
+  region = var.region
+}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "192.168.0.0/16"
+}
+
+resource "alicloud_vswitch" "zone_a" {
+  vpc_id     = alicloud_vpc.default.id
+  zone_id    = var.zone_id_1
+  cidr_block = "192.168.0.0/24"
+}
+
+resource "alicloud_vswitch" "zone_b" {
+  vpc_id     = alicloud_vpc.default.id
+  zone_id    = var.zone_id_2
+  cidr_block = "192.168.1.0/24"
+}
+
+# Active member (zone A): GWLB load balancer + GWLB-type endpoint service +
+# service-resource attachment + GatewayLoadBalancer endpoint. The endpoint
+# depends_on the service-resource so the GWLB is attached to the service
+# before the endpoint is created.
+resource "alicloud_gwlb_load_balancer" "active" {
+  load_balancer_name = "${var.name}-gwlb-active"
+  address_ip_version = "Ipv4"
+  vpc_id             = alicloud_vpc.default.id
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.zone_a.id
+    zone_id    = var.zone_id_1
+  }
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service" "active" {
+  auto_accept_connection = true
+  service_description    = "${var.name}-eps-active"
+  service_resource_type  = "gwlb"
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service_resource" "active" {
+  resource_id   = alicloud_gwlb_load_balancer.active.id
+  resource_type = "gwlb"
+  service_id    = alicloud_privatelink_vpc_endpoint_service.active.id
+  zone_id       = var.zone_id_1
+  dry_run       = "false"
+}
+
+resource "alicloud_privatelink_vpc_endpoint" "active" {
+  service_id        = alicloud_privatelink_vpc_endpoint_service.active.id
+  vpc_endpoint_name = "${var.name}-ep-active"
+  vpc_id            = alicloud_vpc.default.id
+  service_name      = alicloud_privatelink_vpc_endpoint_service.active.vpc_endpoint_service_name
+  endpoint_type     = "GatewayLoadBalancer"
+}
+
+# Attach zone A to the GWLB endpoint. The route target group backend looks up
+# the member endpoint by zone, so the endpoint must carry a non-empty zone.
+resource "alicloud_privatelink_vpc_endpoint_zone" "active" {
+  endpoint_id = alicloud_privatelink_vpc_endpoint.active.id
+  vswitch_id  = alicloud_vswitch.zone_a.id
+}
+
+# Standby member (zone B): identical chain in a different zone so the two
+# members satisfy active-standby's two-different-zone rule.
+resource "alicloud_gwlb_load_balancer" "standby" {
+  load_balancer_name = "${var.name}-gwlb-standby"
+  address_ip_version = "Ipv4"
+  vpc_id             = alicloud_vpc.default.id
+  zone_mappings {
+    vswitch_id = alicloud_vswitch.zone_b.id
+    zone_id    = var.zone_id_2
+  }
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service" "standby" {
+  auto_accept_connection = true
+  service_description    = "${var.name}-eps-standby"
+  service_resource_type  = "gwlb"
+}
+
+resource "alicloud_privatelink_vpc_endpoint_service_resource" "standby" {
+  resource_id   = alicloud_gwlb_load_balancer.standby.id
+  resource_type = "gwlb"
+  service_id    = alicloud_privatelink_vpc_endpoint_service.standby.id
+  zone_id       = var.zone_id_2
+  dry_run       = "false"
+}
+
+resource "alicloud_privatelink_vpc_endpoint" "standby" {
+  service_id        = alicloud_privatelink_vpc_endpoint_service.standby.id
+  vpc_endpoint_name = "${var.name}-ep-standby"
+  vpc_id            = alicloud_vpc.default.id
+  service_name      = alicloud_privatelink_vpc_endpoint_service.standby.vpc_endpoint_service_name
+  endpoint_type     = "GatewayLoadBalancer"
+}
+
+# Attach zone B to the standby GWLB endpoint (different zone from active).
+resource "alicloud_privatelink_vpc_endpoint_zone" "standby" {
+  endpoint_id = alicloud_privatelink_vpc_endpoint.standby.id
+  vswitch_id  = alicloud_vswitch.zone_b.id
+}
+
+# The route target group depends_on both endpoint zones: the backend looks up
+# each member endpoint by zone, so the zones must exist before Create is called.
+resource "alicloud_vpc_route_target_group" "default" {
+  route_target_group_name        = var.name
+  route_target_group_description = var.name
+  vpc_id                         = alicloud_vpc.default.id
+  config_mode                    = "Active-Standby"
+  route_target_member_list {
+    member_id   = alicloud_privatelink_vpc_endpoint.active.id
+    member_type = "GatewayLoadBalancerEndpoint"
+    weight      = 100
+  }
+  route_target_member_list {
+    member_id   = alicloud_privatelink_vpc_endpoint.standby.id
+    member_type = "GatewayLoadBalancerEndpoint"
+    weight      = 0
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `config_mode` - (Required, ForceNew) The configuration mode of the route target group. Supported modes include:
+  - **Active-Standby**: active-standby mode.
+* `resource_group_id` - (Optional, Computed) The ID of the resource group to which the route target group belongs.
+* `route_target_group_description` - (Optional) The description of the route target group.
+The description must be 1 to 256 characters in length and cannot start with http:// or https://.
+* `route_target_group_name` - (Optional) The name of the route target group.
+The name must be 1 to 128 characters in length and cannot start with http:// or https://.
+* `route_target_member_list` - (Required, List) The member list of the route target group.
+**Note: The parameter is immutable after resource creation. In active-standby mode, member weight and type cannot be changed via UpdateRouteTargetGroup; switching active/standby uses a separate SwitchActiveRouteTarget operation.
+In active/standby mode, the following restrictions apply to route target group members:
+1. The route target group must contain exactly two members.
+2. The route target group members must belong to different zones. See [`route_target_member_list`](#route_target_member_list) below.
+* `tags` - (Optional, Map) The tags of the route target group.
+* `vpc_id` - (Required, ForceNew) The ID of the VPC to which the route target group belongs.
+
+### `route_target_member_list`
+
+The route_target_member_list supports the following:
+* `member_id` - (Required) The instance ID of the route target member.
+* `member_type` - (Required) The instance type of the route target configuration. The following type is currently supported:
+  - GatewayLoadBalancerEndpoint.
+* `weight` - (Required, Int) Sets the weight attribute for the current route target configuration.
+
+In active-standby mode, the weight can only be set to 0 or 100:
+- Only one route target configuration can be set to 100, serving as the active instance.
+- Only one route target configuration can be set to 0, serving as the standby instance.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+* `create_time` - The time when the route target group was created.
+* `route_target_member_list` - The member list of the route target group.
+  * `enable_status` - Indicates the enable status of the current route target configuration. Valid values: `Enable`, `Disable`.
+  * `health_check_status` - The health check status of the current route target configuration.
+* `status` - The status of the route target group. Valid values: `Pending`, `Available`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Route Target Group.
+* `delete` - (Defaults to 5 mins) Used when delete the Route Target Group.
+* `update` - (Defaults to 5 mins) Used when update the Route Target Group.
+
+## Import
+
+VPC Route Target Group can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_vpc_route_target_group.example <route_target_group_id>
+```


### PR DESCRIPTION
## What

Adds the `alicloud_vpc_route_target_group` resource and the `alicloud_vpc_route_target_groups` data source, backed by the VPC `CreateRouteTargetGroup` / `GetRouteTargetGroup` / `UpdateRouteTargetGroup` / `DeleteRouteTargetGroup` / `ListRouteTargetGroups` / `SwitchActiveRouteTarget` / `TagResources` / `UnTagResources` / `MoveResourceGroup` APIs.

## Resource: alicloud_vpc_route_target_group

- `config_mode` (Required, ForceNew) — only `Active-Standby` is supported.
- `vpc_id` (Required, ForceNew).
- `route_target_member_list` (Required, TypeSet) — nested `member_id` (Required), `member_type` (Required, only `GatewayLoadBalancerEndpoint`), `weight` (Required, Int); `enable_status` and `health_check_status` are Computed.
- `route_target_group_name`, `route_target_group_description`, `resource_group_id` (Optional+Computed), `tags` (Optional).
- Computed: `status`, `create_time`.
- Import via `route_target_group_id`; state refresh over `Available`/`Switched`/`Unavailable`/`Abnormal`; create/update/delete timeouts 5 min.
- Update covers name, description, member list, resource-group move, and tags.

## Data source: alicloud_vpc_route_target_groups

Filters by `ids`, `name_regex`, `vpc_id`, `route_target_group_id`, `resource_group_id`, `route_target_member_list.member_id`, `tags`; exports `groups[]` with the full attribute set.

## Example fixture (Active-Standby)

Active-Standby requires exactly two members in two different AZs. The example builds two GWLB chains (one per AZ): a `alicloud_gwlb_load_balancer`, a GWLB-type `alicloud_privatelink_vpc_endpoint_service` + `..._service_resource` attachment, and a `GatewayLoadBalancer`-type `alicloud_privatelink_vpc_endpoint`. Each endpoint additionally carries an `alicloud_privatelink_vpc_endpoint_zone` attaching it to its AZ's vswitch: the RouteTargetGroup backend looks up each member endpoint by zone, so the endpoint must carry a non-empty zone or `CreateRouteTargetGroup` returns `ResourceNotFound.GatewayLoadBalancerEndpoint`. The route target group `depends_on` both endpoint zones.

## Note on `create_time`

`GetRouteTargetGroup` documents a `CreateTime` response field, but the backend does not currently return it (consistent across all Gets in the acceptance run). The schema keeps `create_time` Computed and the Read maps `CreateTime` per the API contract, so it will populate once the backend honors its documented response; it is not asserted in the acceptance test because asserting an unreturned backend field would test a backend gap rather than provider behavior.

## Note on `tags`

`GetRouteTargetGroup` does not return `Tags` (the field is absent from the Get response even after tags are applied, and the `Tags` parameter sent in `CreateRouteTargetGroup` is not reflected in subsequent Gets either). The resource Read therefore fetches tags through the dedicated tagging API (`ListTagResources`) — the same strongly-consistent tagging service the Update path writes to via `SetResourceTags` — and Create applies tags via `SetResourceTags` after the state conf so the configured tags land in the tagging service the Read queries. This mirrors the Create-tag pattern used by other VPC-family resources (`alb`/`alidns`/`arms`) in this provider.

## Acceptance test

`TestAccAliCloudVpcRouteTargetGroup_basic` covers the full lifecycle: create (two weighted members), update (name/description), resource-group move (×2), tags add/update/remove, and import. `enable_status`/`health_check_status` are ignored during import verify (server-computed, timing-sensitive TypeSet nested fields). Region: `cn-wulanchabu` (GWLB-supported).

The update step exercises name/description only. Weight is immutable per the API contract, and `UpdateRouteTargetGroup` forbids updating an already-enabled member; switching active/standby is a separate `SwitchActiveRouteTarget` operation not covered by the provider Update path. The provider only sends `RouteTargetMemberList` when it actually changed (`d.HasChange`), so a name/description update does not re-send the unchanged member list.

Both acceptance cases pass remotely (region `cn-wulanchabu`):
- `TestAccAliCloudVpcRouteTargetGroup_basic` — PASS
- `TestAccAliCloudVpcRouteTargetGroupsDataSource` — PASS
