### PR TITLE
resource/alicloud_polardb_cluster: fix TDE automatic rotation not taking effect on already-enabled clusters

### DIFF
--- a/alicloud/resource_alicloud_polardb_cluster.go
+++ b/alicloud/resource_alicloud_polardb_cluster.go
@@ -1015,7 +1015,40 @@ func resourceAlicloudPolarDBClusterUpdate(d *schema.ResourceData, meta interface
 				return nil
 			})
 			if err != nil {
-				if !IsExpectedErrors(err, []string{"InvalidTDEStatus.AlreadyEnabled"}) {
+				if IsExpectedErrors(err, []string{"InvalidTDEStatus.AlreadyEnabled"}) {
+					// TDE is already enabled, so sending TDEStatus=Enable was rejected with
+					// InvalidTDEStatus.AlreadyEnabled and the whole request (including
+					// EnableAutomaticRotation/EncryptNewTables/EncryptionKey/RoleArn) was
+					// discarded. When the request carried other TDE parameters, retry once
+					// without TDEStatus so the server applies them instead of silently
+					// dropping the change. A pure re-enable with no other parameters is
+					// treated as idempotent (AlreadyEnabled tolerated).
+					if len(request) > 2 {
+						retryRequest := map[string]interface{}{"DBClusterId": d.Id()}
+						for k, val := range request {
+							if k == "TDEStatus" {
+								continue
+							}
+							retryRequest[k] = val
+						}
+						waitRetry := incrementalWait(3*time.Second, 3*time.Second)
+						err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+							resp, e := client.RpcPost("polardb", "2017-08-01", action, nil, retryRequest, false)
+							if e != nil {
+								if NeedRetry(e) {
+									waitRetry()
+									return resource.RetryableError(e)
+								}
+								return resource.NonRetryableError(e)
+							}
+							addDebug(action, resp, retryRequest)
+							return nil
+						})
+						if err != nil {
+							return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+						}
+					}
+				} else {
 					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 				}
 			}

--- a/alicloud/resource_alicloud_polardb_cluster_test.go
+++ b/alicloud/resource_alicloud_polardb_cluster_test.go
@@ -215,6 +215,43 @@ func TestAccAliCloudPolarDBCluster_Update(t *testing.T) {
 					}),
 				),
 			},
+			// Verify incremental modification of enable_automatic_rotation on an
+			// already-TDE-enabled cluster. Before the fix, ModifyDBClusterTDE re-sends
+			// TDEStatus=Enable on an enabled cluster and the server rejects the whole
+			// request with InvalidTDEStatus.AlreadyEnabled; the error was swallowed and
+			// SetPartial marked the rotation as applied, so the rotation never took
+			// effect (automatic_rotation stayed unchanged). The fix retries the request
+			// without TDEStatus so the server applies the remaining parameters.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tde_status":                "Enabled",
+					"encrypt_new_tables":        "ON",
+					"encryption_key":            "${alicloud_kms_key.default.id}",
+					"role_arn":                  "acs:ram::${data.alicloud_account.current.id}:role/aliyunrdsinstanceencryptiondefaultrole",
+					"enable_automatic_rotation": false,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tde_status":         "Enabled",
+						"automatic_rotation": "Disabled",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tde_status":                "Enabled",
+					"encrypt_new_tables":        "ON",
+					"encryption_key":            "${alicloud_kms_key.default.id}",
+					"role_arn":                  "acs:ram::${data.alicloud_account.current.id}:role/aliyunrdsinstanceencryptiondefaultrole",
+					"enable_automatic_rotation": true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tde_status":         "Enabled",
+						"automatic_rotation": "Enabled",
+					}),
+				),
+			},
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"db_node_count": "3",


### PR DESCRIPTION
## Problem

`alicloud_polardb_cluster` `enable_automatic_rotation` was silently ignored when toggled on a cluster that already had TDE enabled.

The Update handler always re-sends `TDEStatus=Enable` in the `ModifyDBClusterTDE` request whenever any TDE-related attribute changes. On a cluster whose TDE is already enabled, the server rejects the whole request with `InvalidTDEStatus.AlreadyEnabled`. The handler swallowed that error and called `SetPartial("enable_automatic_rotation")`, so Terraform reported a successful apply while the automatic rotation was never applied (the same silent-drop also affected incremental changes to `encrypt_new_tables`, `encryption_key` and `role_arn`).

## Fix

When `InvalidTDEStatus.AlreadyEnabled` is returned and the original request carried other TDE parameters (rotation / encrypt_new_tables / encryption_key / role_arn), retry the `ModifyDBClusterTDE` request without `TDEStatus` so the server applies the remaining parameters instead of discarding them. A pure re-enable that carries no other parameters keeps treating `AlreadyEnabled` as idempotent. If the retry still fails, the error is surfaced rather than swallowed.

## Tests

Added two steps to `TestAccAliCloudPolarDBCluster_Update` that toggle `enable_automatic_rotation` off then on against an already-TDE-enabled cluster and assert `automatic_rotation` reflects the change (`Disabled` / `Enabled`). Before the fix these steps fail because the rotation never takes effect.

Remote acceptance test verification is pending (the rotation path requires an engine that supports automatic key rotation together with a custom KMS key).
