### PR TITLE
resource/alicloud_polardb_cluster: fix TDE auto-rotation not applying on enabled clusters

### DIFF
--- a/alicloud/resource_alicloud_polardb_cluster.go
+++ b/alicloud/resource_alicloud_polardb_cluster.go
@@ -986,19 +986,34 @@ func resourceAlicloudPolarDBClusterUpdate(d *schema.ResourceData, meta interface
 			action := "ModifyDBClusterTDE"
 			request := map[string]interface{}{
 				"DBClusterId": d.Id(),
-				"TDEStatus":   convertPolarDBTdeStatusUpdateRequest(v.(string)),
 			}
+			// Distinguish a first-time TDE enable from an incremental update on an
+			// already-enabled cluster. Sending TDEStatus=Enable when TDE is already
+			// enabled makes the server reject the whole ModifyDBClusterTDE call with
+			// InvalidTDEStatus.AlreadyEnabled, which previously was swallowed and left
+			// EnableAutomaticRotation (and the other incremental fields) silently
+			// un-applied. Only carry TDEStatus when this is the Disable->Enable turn.
+			tdeOld, _ := d.GetChange("tde_status")
+			firstTimeEnable := tdeOld.(string) == "" || tdeOld.(string) == "Disabled"
+			if firstTimeEnable {
+				request["TDEStatus"] = convertPolarDBTdeStatusUpdateRequest(v.(string))
+			}
+			hasIncrementalFields := false
 			if s, ok := d.GetOk("encrypt_new_tables"); ok && s.(string) != "" {
 				request["EncryptNewTables"] = s.(string)
+				hasIncrementalFields = true
 			}
 			if v, ok := d.GetOk("encryption_key"); ok && v.(string) != "" {
 				request["EncryptionKey"] = v.(string)
+				hasIncrementalFields = true
 			}
 			if v, ok := d.GetOk("role_arn"); ok && v.(string) != "" {
 				request["RoleArn"] = v.(string)
+				hasIncrementalFields = true
 			}
 			if v, ok := d.GetOkExists("enable_automatic_rotation"); ok {
 				request["EnableAutomaticRotation"] = v
+				hasIncrementalFields = true
 			}
 			//retry
 			wait := incrementalWait(3*time.Second, 3*time.Second)
@@ -1015,7 +1030,13 @@ func resourceAlicloudPolarDBClusterUpdate(d *schema.ResourceData, meta interface
 				return nil
 			})
 			if err != nil {
-				if !IsExpectedErrors(err, []string{"InvalidTDEStatus.AlreadyEnabled"}) {
+				// InvalidTDEStatus.AlreadyEnabled means TDE is already enabled and the
+				// server rejected the whole call. Only tolerate it for a pure first-time
+				// enable no-op; when the request also carries EnableAutomaticRotation
+				// (or another incremental field) the rejection means the update did NOT
+				// take effect, so it must surface as a real failure instead of being
+				// swallowed as a silent success.
+				if !(IsExpectedErrors(err, []string{"InvalidTDEStatus.AlreadyEnabled"}) && !hasIncrementalFields) {
 					return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 				}
 			}

--- a/alicloud/resource_alicloud_polardb_cluster_test.go
+++ b/alicloud/resource_alicloud_polardb_cluster_test.go
@@ -412,6 +412,127 @@ func TestAccAliCloudPolarDBCluster_Update(t *testing.T) {
 
 }
 
+func TestAccAliCloudPolarDBCluster_TDEAutomaticRotationIncremental(t *testing.T) {
+	// This case reproduces the incremental TDE auto-rotation bug: when TDE is
+	// already Enabled and the user adds enable_automatic_rotation=true, the
+	// provider used to resend TDEStatus=Enable, hit
+	// InvalidTDEStatus.AlreadyEnabled and swallow it, so the rotation fields
+	// never applied and automatic_rotation/rotation_interval drifted empty.
+	// PostgreSQL is used because EnableAutomaticRotation is only supported on
+	// PostgreSQL/Oracle engines (MySQL produces a false negative).
+	var v *polardb.DescribeDBClusterAttributeResponse
+	name := "tf-testAccPolarDBClusterTDEAutoRot"
+	resourceId := "alicloud_polardb_cluster.default"
+	var basicMap = map[string]string{
+		"description":   CHECKSET,
+		"db_node_class": CHECKSET,
+		"vswitch_id":    CHECKSET,
+		"db_type":       "PostgreSQL",
+		"db_version":    "14",
+		"tde_status":    "Disabled",
+		"status":        CHECKSET,
+		"create_time":   CHECKSET,
+	}
+	ra := resourceAttrInit(resourceId, basicMap)
+	serviceFunc := func() interface{} {
+		return &PolarDBService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, serviceFunc, "DescribePolarDBClusterAttribute")
+	rac := resourceAttrCheckInit(rc, ra)
+
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourcePolarDBClusterTDEPostgreSQLConfigDependence)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+
+		// module name
+		IDRefreshName: resourceId,
+
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// Create a PostgreSQL cluster with TDE disabled.
+				Config: testAccConfig(map[string]interface{}{
+					"db_type":           "PostgreSQL",
+					"db_version":        "14",
+					"pay_type":          "PostPaid",
+					"db_node_count":     "2",
+					"db_node_class":     "polar.pg.x4.medium",
+					"vswitch_id":        "${local.vswitch_id}",
+					"description":       "${var.name}",
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+					// Align with the API default for a TDE-disabled cluster:
+					// DescribeDBClusterTDE returns EncryptNewTables="OFF", but the
+					// schema field is Optional (not Computed), so an unset config
+					// (value="") would produce a perpetual diff OFF=>"" at step0.
+					"encrypt_new_tables": "OFF",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id": CHECKSET,
+						"zone_id":           CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"modify_type", "imci_switch", "sub_category"},
+			},
+			{
+				// stepA: first-enable TDE without automatic rotation. This
+				// exercises the first-enable path (tde_status Disabled→Enabled
+				// sends TDEStatus=Enable) and must not regress. Auto-rotation
+				// is not requested, so automatic_rotation stays unset.
+				// encrypt_new_tables is intentionally not set here (it inherits
+				// "OFF" from step0): ModifyDBClusterTDE silently ignores
+				// EncryptNewTables during the first TDE enable, so asserting ON
+				// here would flap. The encrypt_new_tables incremental behavior is
+				// out of scope for this PR and tracked separately.
+				Config: testAccConfig(map[string]interface{}{
+					"tde_status":     "Enabled",
+					"encryption_key": "${alicloud_kms_key.default.id}",
+					"role_arn":       "acs:ram::${data.alicloud_account.current.id}:role/aliyunrdsinstanceencryptiondefaultrole",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tde_status":     "Enabled",
+						"encryption_key": CHECKSET,
+						"role_arn":       CHECKSET,
+					}),
+				),
+			},
+			{
+				// stepB: incremental TDE update — tde_status is already
+				// Enabled, now add enable_automatic_rotation=true. Before the
+				// fix the provider resent TDEStatus=Enable, received
+				// InvalidTDEStatus.AlreadyEnabled and swallowed it, so the
+				// rotation settings never applied and Read returned empty
+				// automatic_rotation/rotation_interval. After the fix the
+				// provider skips TDEStatus on the incremental path, the server
+				// accepts the rotation settings, and Read backfills non-empty
+				// values.
+				Config: testAccConfig(map[string]interface{}{
+					"enable_automatic_rotation": true,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tde_status":         "Enabled",
+						"automatic_rotation": CHECKSET,
+						"rotation_interval":  CHECKSET,
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAliCloudPolarDBCluster_UpdatePrePaid(t *testing.T) {
 	var v *polardb.DescribeDBClusterAttributeResponse
 	name := "tf-testAccPolarDBClusterUpdatePrePaid"
@@ -2406,6 +2527,14 @@ func resourcePolarDBClusterPrePaidConfigDependence(name string) string {
 }
 
 func resourcePolarDBClusterTDEConfigDependence(name string) string {
+	// PolarDB TDE references the system preset role
+	// AliyunRDSInstanceEncryptionDefaultRole through role_arn in the test
+	// step config; the service auto-associates that role, so no custom RAM
+	// role or ResourceManager policy attachment is provisioned here. A
+	// previous version built a self-built role plus a policy attachment whose
+	// principal_name domain (derived from the numeric account id) did not
+	// match the account default domain, causing a deterministic
+	// EntityNotExist.Role (404) that aborted Step 0 before TDE was exercised.
 	return fmt.Sprintf(`
 	variable "name" {
 		default = "%s"
@@ -2454,37 +2583,26 @@ func resourcePolarDBClusterTDEConfigDependence(name string) string {
         description             =  var.name
         pending_window_in_days =  7
         status                  = "Enabled"
-    }
-    resource "alicloud_ram_role" "default" {
-      role_name   = "AliyunRDSInstanceEncryptionDefaultRole"
-	  document    = <<DEFINITION
-		{
-			"Statement": [
-				{
-					"Action": "sts:AssumeRole",
-					"Effect": "Allow",
-					"Principal": {
-						"Service": [
-							"rds.aliyuncs.com"
-						]
-					}
-				}
-			],
-			"Version": "1"
-		}
-		DEFINITION
-	  description = "RDS使用此角色来访问您在其他云产品中的资源"
-    }
-	
-	// principal_name = "<roleName>@role.<userDefaultDomainName>"
-    resource "alicloud_resource_manager_policy_attachment" "default" {
-	    policy_name       = "AliyunRDSInstanceEncryptionRolePolicy"
-	    policy_type       = "System"
-	    principal_name    = "${alicloud_ram_role.default.name}@role.${data.alicloud_account.current.id}.onaliyunservice.com"
-	    principal_type    = "ServiceRole"
-	    resource_group_id = "${data.alicloud_account.current.id}"
-		depends_on = [alicloud_ram_role.default]
     }`, name)
+}
+
+func resourcePolarDBClusterTDEPostgreSQLConfigDependence(name string) string {
+	// Reuse the MySQL TDE dependence for shared infrastructure (KMS key, RAM
+	// role, policy attachment, VPC, vswitch, security groups). The node-class
+	// data source is intentionally left querying MySQL rather than switched to
+	// PostgreSQL: data_source_alicloud_polardb_node_classes filters with
+	// strings.Contains(Engine, db_type), but the DescribeDBClusterAvailableResources
+	// API returns abbreviated Engine names like "pg14", so a PostgreSQL query
+	// returns an empty class list and classes.0.zone_id fails with Invalid index.
+	// The vswitch zone is hardcoded to cn-hangzhou-k, confirmed via
+	// DescribeDBClusterAvailableResources to offer polar.pg.x4.medium
+	// (Category=Normal) for pg14. The PostgreSQL
+	// cluster identity (db_type, db_version, db_node_class) is supplied by the
+	// test step config, mirroring TestAccAliCloudPolarDBCluster_EnableDynamoDB
+	// which also hardcodes the PG node class while keeping the MySQL data source.
+	mysql := resourcePolarDBClusterTDEConfigDependence(name)
+	pg := strings.Replace(mysql, `zone_id = data.alicloud_polardb_node_classes.this.classes.0.zone_id`, `zone_id = "cn-hangzhou-k"`, 1)
+	return pg
 }
 
 func resourcePolarDBClusterConfigDependence(name string) string {


### PR DESCRIPTION
## What

`alicloud_polardb_cluster` TDE automatic key rotation was silently not applied when the cluster TDE was already enabled.

## Why

The `ModifyDBClusterTDE` update path always sent `TDEStatus=Enable` on every TDE-related update. When the cluster TDE was already `Enabled`, the server rejected the whole call with `InvalidTDEStatus.AlreadyEnabled`. The provider treated that error as ignorable and reported the apply as successful, so `enable_automatic_rotation` (and the other incremental TDE fields) never reached the server.

## How

- Distinguish a first-time `Disable -> Enable` turn from an incremental update on an already-enabled cluster using `d.GetChange("tde_status")`. `TDEStatus` is only sent on the first-time turn, which is the only case where the OpenAPI requires it.
- Stop swallowing `InvalidTDEStatus.AlreadyEnabled` when the request also carries `enable_automatic_rotation` or another incremental field (`encrypt_new_tables`, `encryption_key`, `role_arn`); the rejection means the update did not take effect, so apply now surfaces a real failure instead of silently succeeding.
- First-time enable behavior is unchanged.
