### PR TITLE
New Resource: alicloud_threat_detection_attack_path_whitelist; New Data Source: alicloud_threat_detection_attack_path_whitelists

### DIFF
--- a/alicloud/data_source_alicloud_threat_detection_attack_path_whitelists.go
+++ b/alicloud/data_source_alicloud_threat_detection_attack_path_whitelists.go
@@ -1,0 +1,281 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudThreatDetectionAttackPathWhitelists() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudThreatDetectionAttackPathWhitelistRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"lang": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"path_name_desc": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"path_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"whitelist_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"whitelists": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"attack_path_asset_list": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"asset_type": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"instance_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"node_type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"region_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"vendor": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"asset_sub_type": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"attack_path_whitelist_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"path_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"path_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"remark": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"whitelist_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"whitelist_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"enable_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudThreatDetectionAttackPathWhitelistRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListAttackPathWhitelist"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if v, ok := d.GetOk("lang"); ok {
+		request["Lang"] = v
+	}
+	if v, ok := d.GetOk("path_name_desc"); ok {
+		request["PathNameDesc"] = v
+	}
+	if v, ok := d.GetOk("path_type"); ok {
+		request["PathType"] = v
+	}
+	if v, ok := d.GetOk("whitelist_name"); ok {
+		request["WhitelistName"] = v
+	}
+	request["PageSize"] = PageSizeLarge
+	request["CurrentPage"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.AttackPathWhitelistList[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["AttackPathWhitelistId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["CurrentPage"] = request["CurrentPage"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["AttackPathWhitelistId"]
+
+		mapping["path_name"] = objectRaw["PathName"]
+		mapping["path_type"] = objectRaw["PathType"]
+		mapping["remark"] = objectRaw["Remark"]
+		mapping["whitelist_name"] = objectRaw["WhitelistName"]
+		mapping["whitelist_type"] = objectRaw["WhitelistType"]
+		mapping["attack_path_whitelist_id"] = objectRaw["AttackPathWhitelistId"]
+
+		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
+			ids = append(ids, fmt.Sprint(mapping["id"]))
+			s = append(s, mapping)
+			continue
+		}
+
+		id := fmt.Sprint(objectRaw["AttackPathWhitelistId"])
+		mapping, err = dataSourceAliCloudThreatDetectionAttackPathWhitelistReadDescription(d, id, mapping, meta)
+		if err != nil {
+			return WrapError(err)
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("whitelists", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}
+
+func dataSourceAliCloudThreatDetectionAttackPathWhitelistReadDescription(d *schema.ResourceData, id string, object map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	client := meta.(*connectivity.AliyunClient)
+
+	threatDetectionServiceV2 := ThreatDetectionServiceV2{client}
+	getResp, err := threatDetectionServiceV2.DescribeThreatDetectionAttackPathWhitelist(id)
+	if err != nil {
+		return nil, WrapError(err)
+	}
+
+	// Merge additional fields from Get API response to mapping
+	// Reuse the response mapping template from Resource's read function
+	mapping := object
+	objectRaw := getResp
+
+	mapping["path_name"] = objectRaw["PathName"]
+	mapping["path_type"] = objectRaw["PathType"]
+	mapping["remark"] = objectRaw["Remark"]
+	mapping["whitelist_name"] = objectRaw["WhitelistName"]
+	mapping["whitelist_type"] = objectRaw["WhitelistType"]
+	mapping["attack_path_whitelist_id"] = objectRaw["AttackPathWhitelistId"]
+
+	attackPathAssetListRaw := objectRaw["AttackPathAssetList"]
+	attackPathAssetListMaps := make([]map[string]interface{}, 0)
+	if attackPathAssetListRaw != nil {
+		for _, attackPathAssetListChildRaw := range convertToInterfaceArray(attackPathAssetListRaw) {
+			attackPathAssetListMap := make(map[string]interface{})
+			attackPathAssetListChildRaw := attackPathAssetListChildRaw.(map[string]interface{})
+			attackPathAssetListMap["asset_sub_type"] = attackPathAssetListChildRaw["AssetSubType"]
+			attackPathAssetListMap["asset_type"] = attackPathAssetListChildRaw["AssetType"]
+			attackPathAssetListMap["instance_id"] = attackPathAssetListChildRaw["InstanceId"]
+			attackPathAssetListMap["node_type"] = attackPathAssetListChildRaw["NodeType"]
+			attackPathAssetListMap["region_id"] = attackPathAssetListChildRaw["RegionId"]
+			attackPathAssetListMap["vendor"] = attackPathAssetListChildRaw["Vendor"]
+
+			attackPathAssetListMaps = append(attackPathAssetListMaps, attackPathAssetListMap)
+		}
+	}
+	mapping["attack_path_asset_list"] = attackPathAssetListMaps
+
+	return mapping, nil
+}

--- a/alicloud/data_source_alicloud_threat_detection_attack_path_whitelists_test.go
+++ b/alicloud/data_source_alicloud_threat_detection_attack_path_whitelists_test.go
@@ -1,0 +1,121 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudThreatDetectionAttackPathWhitelistDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudThreatDetectionAttackPathWhitelistSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_threat_detection_attack_path_whitelist.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudThreatDetectionAttackPathWhitelistSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_threat_detection_attack_path_whitelist.default.id}_fake"]`,
+		}),
+	}
+
+	WhitelistNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudThreatDetectionAttackPathWhitelistSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_threat_detection_attack_path_whitelist.default.id}"]`,
+			"whitelist_name": `"${var.name}"`,
+		}),
+		fakeConfig: testAccCheckAlicloudThreatDetectionAttackPathWhitelistSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_threat_detection_attack_path_whitelist.default.id}_fake"]`,
+			"whitelist_name": `"${var.name}_fake"`,
+		}),
+	}
+	PathTypeConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudThreatDetectionAttackPathWhitelistSourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_threat_detection_attack_path_whitelist.default.id}"]`,
+			"path_type": `"role_escalation"`,
+		}),
+		fakeConfig: testAccCheckAlicloudThreatDetectionAttackPathWhitelistSourceConfig(rand, map[string]string{
+			"ids":       `["${alicloud_threat_detection_attack_path_whitelist.default.id}_fake"]`,
+			"path_type": `"role_escalation_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudThreatDetectionAttackPathWhitelistSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_threat_detection_attack_path_whitelist.default.id}"]`,
+			"whitelist_name": `"${var.name}"`,
+
+			"path_type": `"role_escalation"`,
+		}),
+		fakeConfig: testAccCheckAlicloudThreatDetectionAttackPathWhitelistSourceConfig(rand, map[string]string{
+			"ids":            `["${alicloud_threat_detection_attack_path_whitelist.default.id}_fake"]`,
+			"whitelist_name": `"${var.name}_fake"`,
+
+			"path_type": `"role_escalation_fake"`,
+		}),
+	}
+
+	ThreatDetectionAttackPathWhitelistCheckInfo.dataSourceTestCheck(t, rand, idsConf, WhitelistNameConf, PathTypeConf, allConf)
+}
+
+var existThreatDetectionAttackPathWhitelistMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"whitelists.#":                          "1",
+		"whitelists.0.whitelist_name":           CHECKSET,
+		"whitelists.0.attack_path_whitelist_id": CHECKSET,
+		"whitelists.0.remark":                   CHECKSET,
+		"whitelists.0.path_type":                CHECKSET,
+		"whitelists.0.whitelist_type":           CHECKSET,
+		"whitelists.0.path_name":                CHECKSET,
+	}
+}
+
+var fakeThreatDetectionAttackPathWhitelistMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"whitelists.#": "0",
+	}
+}
+
+var ThreatDetectionAttackPathWhitelistCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_threat_detection_attack_path_whitelists.default",
+	existMapFunc: existThreatDetectionAttackPathWhitelistMapFunc,
+	fakeMapFunc:  fakeThreatDetectionAttackPathWhitelistMapFunc,
+}
+
+func testAccCheckAlicloudThreatDetectionAttackPathWhitelistSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccThreatDetectionAttackPathWhitelist%d"
+}
+
+
+resource "alicloud_threat_detection_attack_path_whitelist" "default" {
+  path_type      = "role_escalation"
+  whitelist_type = "PART_ASSET"
+  whitelist_name = var.name
+  path_name      = "ecs_get_credential_by_create_login_profile"
+  remark         = var.name
+  attack_path_asset_list {
+    instance_id    = "AliyunYundunSASReadOnlyAccess::System"
+    region_id      = "cn-hangzhou"
+    vendor         = 0
+    asset_type     = 15
+    asset_sub_type = 2
+    node_type      = "end"
+  }
+}
+
+data "alicloud_threat_detection_attack_path_whitelists" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_threat_detection_attack_path_whitelists":        dataSourceAliCloudThreatDetectionAttackPathWhitelists(),
 			"alicloud_ehpc_users":                                     dataSourceAliCloudEhpcUsers(),
 			"alicloud_ens_load_balancer_udp_listeners":                dataSourceAliCloudEnsLoadBalancerUdpListeners(),
 			"alicloud_ecd_desktop_groups":                             dataSourceAliCloudEcdDesktopGroups(),
@@ -967,6 +968,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_sls_metric_stores":                                dataSourceAliCloudSlsMetricStores(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_threat_detection_attack_path_whitelist":               resourceAliCloudThreatDetectionAttackPathWhitelist(),
 			"alicloud_ehpc_user":                                            resourceAliCloudEhpcUser(),
 			"alicloud_realtime_compute_member":                              resourceAliCloudRealtimeComputeMember(),
 			"alicloud_ens_load_balancer_udp_listener":                       resourceAliCloudEnsLoadBalancerUdpListener(),

--- a/alicloud/resource_alicloud_threat_detection_attack_path_whitelist.go
+++ b/alicloud/resource_alicloud_threat_detection_attack_path_whitelist.go
@@ -1,0 +1,298 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudThreatDetectionAttackPathWhitelist() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudThreatDetectionAttackPathWhitelistCreate,
+		Read:   resourceAliCloudThreatDetectionAttackPathWhitelistRead,
+		Update: resourceAliCloudThreatDetectionAttackPathWhitelistUpdate,
+		Delete: resourceAliCloudThreatDetectionAttackPathWhitelistDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"attack_path_asset_list": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"asset_type": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"instance_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"node_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: StringInSlice([]string{"start", "end"}, false),
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"vendor": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: IntInSlice([]int{0, 1}),
+						},
+						"asset_sub_type": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"path_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"path_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"remark": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"whitelist_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"whitelist_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringInSlice([]string{"ALL_ASSET", "PART_ASSET"}, false),
+			},
+		},
+	}
+}
+
+func resourceAliCloudThreatDetectionAttackPathWhitelistCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateAttackPathWhitelist"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	if v, ok := d.GetOk("attack_path_asset_list"); ok {
+		attackPathAssetListMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(v) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := make(map[string]interface{})
+			dataLoopMap["RegionId"] = dataLoopTmp["region_id"]
+			dataLoopMap["AssetType"] = dataLoopTmp["asset_type"]
+			dataLoopMap["NodeType"] = dataLoopTmp["node_type"]
+			dataLoopMap["AssetSubType"] = dataLoopTmp["asset_sub_type"]
+			dataLoopMap["InstanceId"] = dataLoopTmp["instance_id"]
+			dataLoopMap["Vendor"] = dataLoopTmp["vendor"]
+			attackPathAssetListMapsArray = append(attackPathAssetListMapsArray, dataLoopMap)
+		}
+		request["AttackPathAssetList"] = attackPathAssetListMapsArray
+	}
+
+	request["WhitelistName"] = d.Get("whitelist_name")
+	request["WhitelistType"] = d.Get("whitelist_type")
+	request["PathType"] = d.Get("path_type")
+	request["PathName"] = d.Get("path_name")
+	if v, ok := d.GetOk("remark"); ok {
+		request["Remark"] = v
+	}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_attack_path_whitelist", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.AttackPathWhitelist.AttackPathWhitelistId", response)
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudThreatDetectionAttackPathWhitelistRead(d, meta)
+}
+
+func resourceAliCloudThreatDetectionAttackPathWhitelistRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	threatDetectionServiceV2 := ThreatDetectionServiceV2{client}
+
+	objectRaw, err := threatDetectionServiceV2.DescribeThreatDetectionAttackPathWhitelist(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_threat_detection_attack_path_whitelist DescribeThreatDetectionAttackPathWhitelist Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("path_name", objectRaw["PathName"])
+	d.Set("path_type", objectRaw["PathType"])
+	d.Set("remark", objectRaw["Remark"])
+	d.Set("whitelist_name", objectRaw["WhitelistName"])
+	d.Set("whitelist_type", objectRaw["WhitelistType"])
+
+	attackPathAssetListRaw := objectRaw["AttackPathAssetList"]
+	attackPathAssetListMaps := make([]map[string]interface{}, 0)
+	if attackPathAssetListRaw != nil {
+		for _, attackPathAssetListChildRaw := range convertToInterfaceArray(attackPathAssetListRaw) {
+			attackPathAssetListMap := make(map[string]interface{})
+			attackPathAssetListChildRaw := attackPathAssetListChildRaw.(map[string]interface{})
+			attackPathAssetListMap["asset_sub_type"] = attackPathAssetListChildRaw["AssetSubType"]
+			attackPathAssetListMap["asset_type"] = attackPathAssetListChildRaw["AssetType"]
+			attackPathAssetListMap["instance_id"] = attackPathAssetListChildRaw["InstanceId"]
+			attackPathAssetListMap["node_type"] = attackPathAssetListChildRaw["NodeType"]
+			attackPathAssetListMap["region_id"] = attackPathAssetListChildRaw["RegionId"]
+			attackPathAssetListMap["vendor"] = attackPathAssetListChildRaw["Vendor"]
+
+			attackPathAssetListMaps = append(attackPathAssetListMaps, attackPathAssetListMap)
+		}
+	}
+	if err := d.Set("attack_path_asset_list", attackPathAssetListMaps); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAliCloudThreatDetectionAttackPathWhitelistUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "UpdateAttackPathWhitelist"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["AttackPathWhitelistId"] = d.Id()
+
+	if d.HasChange("attack_path_asset_list") {
+		update = true
+		if v, ok := d.GetOk("attack_path_asset_list"); ok || d.HasChange("attack_path_asset_list") {
+			attackPathAssetListMapsArray := make([]interface{}, 0)
+			for _, dataLoop := range convertToInterfaceArray(v) {
+				dataLoopTmp := dataLoop.(map[string]interface{})
+				dataLoopMap := make(map[string]interface{})
+				dataLoopMap["RegionId"] = dataLoopTmp["region_id"]
+				dataLoopMap["AssetType"] = dataLoopTmp["asset_type"]
+				dataLoopMap["NodeType"] = dataLoopTmp["node_type"]
+				dataLoopMap["AssetSubType"] = dataLoopTmp["asset_sub_type"]
+				dataLoopMap["InstanceId"] = dataLoopTmp["instance_id"]
+				dataLoopMap["Vendor"] = dataLoopTmp["vendor"]
+				attackPathAssetListMapsArray = append(attackPathAssetListMapsArray, dataLoopMap)
+			}
+			request["AttackPathAssetList"] = attackPathAssetListMapsArray
+		}
+	}
+
+	if d.HasChange("whitelist_name") {
+		update = true
+	}
+	request["WhitelistName"] = d.Get("whitelist_name")
+	if d.HasChange("whitelist_type") {
+		update = true
+	}
+	request["WhitelistType"] = d.Get("whitelist_type")
+	if d.HasChange("path_type") {
+		update = true
+	}
+	request["PathType"] = d.Get("path_type")
+	if d.HasChange("path_name") {
+		update = true
+	}
+	request["PathName"] = d.Get("path_name")
+	if d.HasChange("remark") {
+		update = true
+		request["Remark"] = d.Get("remark")
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudThreatDetectionAttackPathWhitelistRead(d, meta)
+}
+
+func resourceAliCloudThreatDetectionAttackPathWhitelistDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteAttackPathWhitelist"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["AttackPathWhitelistId"] = d.Id()
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"DataNotExists"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_threat_detection_attack_path_whitelist_test.go
+++ b/alicloud/resource_alicloud_threat_detection_attack_path_whitelist_test.go
@@ -1,0 +1,285 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test ThreatDetection AttackPathWhitelist. >>> Resource test cases, automatically generated.
+func TestAccAliCloudThreatDetectionAttackPathWhitelist_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_attack_path_whitelist.default"
+	ra := resourceAttrInit(resourceId, AliCloudThreatDetectionAttackPathWhitelistMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionAttackPathWhitelist")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetection%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudThreatDetectionAttackPathWhitelistBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"path_type":      "role_escalation",
+					"whitelist_type": "ALL_ASSET",
+					"whitelist_name": name,
+					"path_name":      "ecs_get_credential_by_create_login_profile",
+					"remark":         name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"path_type":                "role_escalation",
+						"whitelist_type":           "ALL_ASSET",
+						"whitelist_name":           name,
+						"path_name":                "ecs_get_credential_by_create_login_profile",
+						"remark":                   name,
+						"attack_path_asset_list.#": "0",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"path_type":      "role_escalation",
+					"whitelist_type": "PART_ASSET",
+					"whitelist_name": name + "_update",
+					"path_name":      "ecs_get_credential_by_create_login_profile",
+					"remark":         name + "_update",
+					"attack_path_asset_list": []map[string]interface{}{
+						{
+							"instance_id":    "AliyunYundunSASReadOnlyAccess::System",
+							"vendor":         "0",
+							"asset_type":     "15",
+							"asset_sub_type": "2",
+							"region_id":      "cn-hangzhou",
+							"node_type":      "end",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"whitelist_type":           "PART_ASSET",
+						"whitelist_name":           name + "_update",
+						"remark":                   name + "_update",
+						"attack_path_asset_list.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"path_type":      "role_escalation",
+					"whitelist_type": "PART_ASSET",
+					"whitelist_name": name + "_update",
+					"path_name":      "ecs_get_credential_by_create_login_profile",
+					"remark":         name + "_update",
+					"attack_path_asset_list": []map[string]interface{}{
+						{
+							"instance_id":    "AliyunYundunSASReadOnlyAccess::System",
+							"vendor":         "0",
+							"asset_type":     "15",
+							"asset_sub_type": "2",
+							"region_id":      "cn-hangzhou",
+							"node_type":      "start",
+						},
+						{
+							"instance_id":    "${data.alicloud_ddoscoo_instances.default.instances.0.id}",
+							"vendor":         "0",
+							"asset_type":     "16",
+							"asset_sub_type": "0",
+							"region_id":      "${data.alicloud_regions.default.regions.0.id}",
+							"node_type":      "end",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"attack_path_asset_list.#": "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"path_type":      "sensitive_asset",
+					"whitelist_type": "PART_ASSET",
+					"whitelist_name": name + "_update",
+					"path_name":      "ram_user_has_access_to_sensitive_asset",
+					"remark":         name + "_update",
+					"attack_path_asset_list": []map[string]interface{}{
+						{
+							"instance_id":    "AliyunYundunSASReadOnlyAccess::System",
+							"vendor":         "0",
+							"asset_type":     "15",
+							"asset_sub_type": "2",
+							"region_id":      "cn-hangzhou",
+							"node_type":      "start",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"path_type":                "sensitive_asset",
+						"path_name":                "ram_user_has_access_to_sensitive_asset",
+						"attack_path_asset_list.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudThreatDetectionAttackPathWhitelist_basic_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_attack_path_whitelist.default"
+	ra := resourceAttrInit(resourceId, AliCloudThreatDetectionAttackPathWhitelistMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionAttackPathWhitelist")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetection%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudThreatDetectionAttackPathWhitelistBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"path_type":      "role_escalation",
+					"whitelist_type": "PART_ASSET",
+					"whitelist_name": name,
+					"path_name":      "ecs_get_credential_by_create_login_profile",
+					"remark":         name,
+					"attack_path_asset_list": []map[string]interface{}{
+						{
+							"instance_id":    "AliyunYundunSASReadOnlyAccess::System",
+							"vendor":         "0",
+							"asset_type":     "15",
+							"asset_sub_type": "2",
+							"region_id":      "cn-hangzhou",
+							"node_type":      "end",
+						},
+						{
+							"instance_id":    "AliyunYundunSASReadOnlyAccess::System",
+							"vendor":         "0",
+							"asset_type":     "15",
+							"asset_sub_type": "2",
+							"region_id":      "cn-hangzhou",
+							"node_type":      "start",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"path_type":                "role_escalation",
+						"whitelist_type":           "PART_ASSET",
+						"whitelist_name":           name,
+						"path_name":                "ecs_get_credential_by_create_login_profile",
+						"remark":                   name,
+						"attack_path_asset_list.#": "2",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudThreatDetectionAttackPathWhitelist_allasset(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_attack_path_whitelist.default"
+	ra := resourceAttrInit(resourceId, AliCloudThreatDetectionAttackPathWhitelistMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionAttackPathWhitelist")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetection%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudThreatDetectionAttackPathWhitelistBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"path_type":      "role_escalation",
+					"whitelist_type": "ALL_ASSET",
+					"whitelist_name": name,
+					"path_name":      "ecs_get_credential_by_create_login_profile",
+					"remark":         name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"path_type":                "role_escalation",
+						"whitelist_type":           "ALL_ASSET",
+						"whitelist_name":           name,
+						"path_name":                "ecs_get_credential_by_create_login_profile",
+						"remark":                   name,
+						"attack_path_asset_list.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AliCloudThreatDetectionAttackPathWhitelistMap = map[string]string{}
+
+func AliCloudThreatDetectionAttackPathWhitelistBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_regions" "default" {
+  current = true
+}
+
+data "alicloud_ddoscoo_instances" "default" {
+}
+
+`, name)
+}
+
+// Test ThreatDetection AttackPathWhitelist. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_threat_detection_v2.go
+++ b/alicloud/service_alicloud_threat_detection_v2.go
@@ -1580,3 +1580,79 @@ func (s *ThreatDetectionServiceV2) ThreatDetectionMonitorAccountStateRefreshFunc
 }
 
 // DescribeThreatDetectionMonitorAccount >>> Encapsulated.
+
+// DescribeThreatDetectionAttackPathWhitelist <<< Encapsulated get interface for ThreatDetection AttackPathWhitelist.
+
+func (s *ThreatDetectionServiceV2) DescribeThreatDetectionAttackPathWhitelist(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["AttackPathWhitelistId"] = id
+
+	action := "GetAttackPathWhitelist"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"DataNotExists"}) {
+			return object, WrapErrorf(NotFoundErr("AttackPathWhitelist", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.AttackPathWhitelist", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.AttackPathWhitelist", response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *ThreatDetectionServiceV2) ThreatDetectionAttackPathWhitelistStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ThreatDetectionAttackPathWhitelistStateRefreshFuncWithApi(id, field, failStates, s.DescribeThreatDetectionAttackPathWhitelist)
+}
+
+func (s *ThreatDetectionServiceV2) ThreatDetectionAttackPathWhitelistStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeThreatDetectionAttackPathWhitelist >>> Encapsulated.

--- a/website/docs/d/threat_detection_attack_path_whitelists.html.markdown
+++ b/website/docs/d/threat_detection_attack_path_whitelists.html.markdown
@@ -1,0 +1,85 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_attack_path_whitelists"
+sidebar_current: "docs-alicloud-datasource-threat-detection-attack-path-whitelists"
+description: |-
+  Provides a list of Threat Detection Attack Path Whitelist owned by an Alibaba Cloud account.
+---
+
+# alicloud_threat_detection_attack_path_whitelists
+
+This data source provides Threat Detection Attack Path Whitelist available to the user.[What is Attack Path Whitelist](https://next.api.alibabacloud.com/document/Sas/2018-12-03/CreateAttackPathWhitelist)
+
+-> **NOTE:** Available since v1.292.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_threat_detection_attack_path_whitelist" "default" {
+  path_type      = "role_escalation"
+  whitelist_type = "PART_ASSET"
+  whitelist_name = var.name
+  path_name      = "ecs_get_credential_by_create_login_profile"
+  remark         = var.name
+  attack_path_asset_list {
+    instance_id    = "AliyunYundunSASReadOnlyAccess::System"
+    region_id      = "cn-hangzhou"
+    vendor         = 0
+    asset_type     = 15
+    asset_sub_type = 2
+    node_type      = "end"
+  }
+}
+
+data "alicloud_threat_detection_attack_path_whitelists" "default" {
+  ids            = ["${alicloud_threat_detection_attack_path_whitelist.default.id}"]
+  path_type      = "role_escalation"
+  whitelist_name = var.name
+}
+
+output "alicloud_threat_detection_attack_path_whitelist_example_id" {
+  value = data.alicloud_threat_detection_attack_path_whitelists.default.whitelists.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `lang` - (Optional) The language of the request and response. Valid values: `zh` (Chinese, default), `en` (English).
+* `path_name_desc` - (Optional) The description of the path name. You can call [ListAvailableAttackPath](https://next.api.alibabacloud.com/document/Sas/2018-12-03/ListAvailableAttackPath) to query the path name descriptions.
+* `path_type` - (Optional) The path type of the whitelist. You can call [ListAvailableAttackPath](https://next.api.alibabacloud.com/document/Sas/2018-12-03/ListAvailableAttackPath) to query the available path types.
+* `whitelist_name` - (Optional) The name of the whitelist.
+* `ids` - (Optional, Computed) A list of Attack Path Whitelist IDs.
+* `enable_details` - (Optional) Default to `false`. Set it to `true` can output more details about resource attributes.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Attack Path Whitelist IDs.
+* `whitelists` - A list of Attack Path Whitelist Entries. Each element contains the following attributes:
+  * `attack_path_asset_list` - **NOTE:** This field is only available when `enable_details` is `true`. The list of attack path cloud product assets.
+    * `asset_sub_type` - The subtype of the cloud product asset.
+    * `asset_type` - The type of the cloud product asset.
+    * `instance_id` - The instance ID of the cloud product asset.
+    * `node_type` - The type of the whitelist node.
+    * `region_id` - The region ID of the cloud product asset instance.
+    * `vendor` - The vendor of the cloud product asset.
+  * `attack_path_whitelist_id` - The ID of the attack path whitelist.
+  * `path_name` - The path name of the whitelist.
+  * `path_type` - The path type of the whitelist.
+  * `remark` - The remarks of the whitelist.
+  * `whitelist_name` - The name of the whitelist.
+  * `whitelist_type` - The type of the whitelist.
+  * `id` - The ID of the resource supplied above.

--- a/website/docs/r/threat_detection_attack_path_whitelist.html.markdown
+++ b/website/docs/r/threat_detection_attack_path_whitelist.html.markdown
@@ -1,0 +1,88 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_attack_path_whitelist"
+description: |-
+  Provides a Alicloud Threat Detection Attack Path Whitelist resource.
+---
+
+# alicloud_threat_detection_attack_path_whitelist
+
+Provides a Threat Detection Attack Path Whitelist resource.
+
+Attack Path Whitelist.
+
+For information about Threat Detection Attack Path Whitelist and how to use it, see [What is Attack Path Whitelist](https://next.api.alibabacloud.com/document/Sas/2018-12-03/CreateAttackPathWhitelist).
+
+-> **NOTE:** Available since v1.292.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+
+resource "alicloud_threat_detection_attack_path_whitelist" "default" {
+  path_type      = "role_escalation"
+  whitelist_type = "PART_ASSET"
+  whitelist_name = "example-1"
+  path_name      = "ecs_get_credential_by_create_login_profile"
+  remark         = "example-1"
+  attack_path_asset_list {
+    instance_id    = "AliyunYundunSASReadOnlyAccess::System"
+    region_id      = "cn-hangzhou"
+    vendor         = 0
+    asset_type     = 15
+    asset_sub_type = 2
+    node_type      = "end"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `attack_path_asset_list` - (Optional, List) The list of attack path cloud product assets. See [`attack_path_asset_list`](#attack_path_asset_list) below.
+* `path_name` - (Required) The path name of the whitelist. You can call [ListAvailableAttackPath](https://next.api.alibabacloud.com/document/Sas/2018-12-03/ListAvailableAttackPath) to query the available path names.
+* `path_type` - (Required) The path type of the whitelist. You can call [ListAvailableAttackPath](https://next.api.alibabacloud.com/document/Sas/2018-12-03/ListAvailableAttackPath) to query the available path types.
+* `remark` - (Optional) The remarks of the whitelist.
+* `whitelist_name` - (Required) The name of the whitelist.
+* `whitelist_type` - (Required) The type of the whitelist. Valid values: `ALL_ASSET` (all assets), `PART_ASSET` (partial assets).
+
+### `attack_path_asset_list`
+
+The attack_path_asset_list supports the following:
+* `asset_sub_type` - (Optional, Int) The subtype of the cloud product asset. You can call [ListCloudAssetInstances](https://next.api.alibabacloud.com/document/Sas/2018-12-03/ListCloudAssetInstances) to query the asset subtypes.
+* `asset_type` - (Optional, Int) The type of the cloud product asset. You can call [ListCloudAssetInstances](https://next.api.alibabacloud.com/document/Sas/2018-12-03/ListCloudAssetInstances) to query the asset types.
+* `instance_id` - (Optional) The instance ID of the cloud product asset. You can call [ListCloudAssetInstances](https://next.api.alibabacloud.com/document/Sas/2018-12-03/ListCloudAssetInstances) to query the instance IDs.
+* `node_type` - (Optional) The type of the whitelist node. Valid values: `start` (starting point), `end` (end point).
+* `region_id` - (Optional) The region ID of the cloud product asset instance.
+* `vendor` - (Required, Int) The vendor of the cloud product asset. You can call [ListCloudAssetInstances](https://next.api.alibabacloud.com/document/Sas/2018-12-03/ListCloudAssetInstances) to query the vendors.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Attack Path Whitelist.
+* `delete` - (Defaults to 5 mins) Used when delete the Attack Path Whitelist.
+* `update` - (Defaults to 5 mins) Used when update the Attack Path Whitelist.
+
+## Import
+
+Threat Detection Attack Path Whitelist can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_threat_detection_attack_path_whitelist.example <attack_path_whitelist_id>
+```


### PR DESCRIPTION
## Summary
- New Resource: `alicloud_threat_detection_attack_path_whitelist` — manages Threat Detection attack path whitelists (create / read / update / delete / import), backed by the Sas 2018-12-03 APIs `CreateAttackPathWhitelist`, `GetAttackPathWhitelist`, `UpdateAttackPathWhitelist`, `DeleteAttackPathWhitelist`.
- New Data Source: `alicloud_threat_detection_attack_path_whitelists` — lists attack path whitelists with `ids` / `whitelist_name` / `path_type` / `path_name_desc` / `lang` filters and `enable_details` for full attribute output, backed by `ListAttackPathWhitelist`.

## Test plan
- [x] `TestAccAliCloudThreatDetectionAttackPathWhitelist_basic` PASS in cn-hangzhou (29.04s): create with `whitelist_type = "ALL_ASSET"` -> update to `PART_ASSET` with `attack_path_asset_list` -> modify asset entries -> update `path_type`/`path_name` -> import -> destroy.
- [x] `TestAccAliCloudThreatDetectionAttackPathWhitelist_basic_twin` PASS (8.35s): create with two asset entries -> import -> destroy.
- [x] `TestAccAliCloudThreatDetectionAttackPathWhitelist_allasset` PASS (8.50s): create with `whitelist_type = "ALL_ASSET"` -> import -> destroy.
- [x] `TestAccAliCloudThreatDetectionAttackPathWhitelistDataSource` PASS (17.20s): ids exist/fake filter, `whitelist_name`/`path_type` filters, combined filters.

```
=== RUN TestAccAliCloudThreatDetectionAttackPathWhitelist_basic
--- PASS: TestAccAliCloudThreatDetectionAttackPathWhitelist_basic (29.04s)

=== RUN TestAccAliCloudThreatDetectionAttackPathWhitelist_basic_twin
--- PASS: TestAccAliCloudThreatDetectionAttackPathWhitelist_basic_twin (8.35s)

=== RUN TestAccAliCloudThreatDetectionAttackPathWhitelist_allasset
--- PASS: TestAccAliCloudThreatDetectionAttackPathWhitelist_allasset (8.50s)

=== RUN TestAccAliCloudThreatDetectionAttackPathWhitelistDataSource
--- PASS: TestAccAliCloudThreatDetectionAttackPathWhitelistDataSource (17.20s)
```