### PR TITLE
resource/alicloud_cloud_firewall_address_book: support ACK address book type

### DIFF
--- a/alicloud/resource_alicloud_cloud_firewall_address_book.go
+++ b/alicloud/resource_alicloud_cloud_firewall_address_book.go
@@ -29,7 +29,7 @@ func resourceAliCloudCloudFirewallAddressBook() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: StringInSlice([]string{"ip", "ipv6", "domain", "port", "tag", "asset", "assetIpv6"}, false),
+				ValidateFunc: StringInSlice([]string{"ip", "ipv6", "domain", "port", "tag", "asset", "assetIpv6", "ackLabel", "ackNamespace", "tagPrivate"}, false),
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -217,6 +217,38 @@ func resourceAliCloudCloudFirewallAddressBook() *schema.Resource {
 					},
 				},
 			},
+			"ack_cluster_connector_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"ack_labels": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 10,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"ack_namespaces": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 10,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"ack_cluster_connector_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"address_list_count": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -375,6 +407,30 @@ func flattenCloudFirewallAddressBookAssetRegionResourceTypes(src interface{}) []
 	return result
 }
 
+func expandCloudFirewallAddressBookAckLabels(configured []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	for _, item := range configured {
+		if item == nil {
+			continue
+		}
+
+		itemArg := item.(map[string]interface{})
+		itemMap := make(map[string]interface{})
+
+		if v, ok := itemArg["key"].(string); ok {
+			itemMap["Key"] = v
+		}
+
+		if v, ok := itemArg["value"].(string); ok {
+			itemMap["Value"] = v
+		}
+
+		result = append(result, itemMap)
+	}
+
+	return result
+}
+
 func resourceAliCloudCloudFirewallAddressBookCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	var response map[string]interface{}
@@ -427,6 +483,28 @@ func resourceAliCloudCloudFirewallAddressBookCreate(d *schema.ResourceData, meta
 		}
 
 		request["AssetRegionResourceTypes"] = assetRegionResourceTypesJson
+	}
+
+	if v, ok := d.GetOk("ack_cluster_connector_id"); ok {
+		request["AckClusterConnectorId"] = v
+	}
+
+	if v, ok := d.GetOk("ack_labels"); ok {
+		ackLabelsJson, err := convertArrayObjectToJsonString(expandCloudFirewallAddressBookAckLabels(v.([]interface{})))
+		if err != nil {
+			return WrapError(err)
+		}
+
+		request["AckLabels"] = ackLabelsJson
+	}
+
+	if v, ok := d.GetOk("ack_namespaces"); ok {
+		ackNamespacesJson, err := convertArrayObjectToJsonString(v.([]interface{}))
+		if err != nil {
+			return WrapError(err)
+		}
+
+		request["AckNamespaces"] = ackNamespacesJson
 	}
 
 	wait := incrementalWait(3*time.Second, 3*time.Second)
@@ -506,6 +584,41 @@ func resourceAliCloudCloudFirewallAddressBookRead(d *schema.ResourceData, meta i
 
 	if v, ok := object["AssetRegionResourceTypes"]; ok {
 		d.Set("asset_region_resource_types", flattenCloudFirewallAddressBookAssetRegionResourceTypes(v))
+	}
+
+	if v, ok := object["AckClusterConnectorId"]; ok {
+		d.Set("ack_cluster_connector_id", v)
+	}
+
+	if v, ok := object["AckClusterConnectorName"]; ok {
+		d.Set("ack_cluster_connector_name", v)
+	}
+
+	if v, ok := object["AckLabels"]; ok {
+		ackLabels := make([]map[string]interface{}, 0)
+		if labelList, ok := v.([]interface{}); ok {
+			for _, labelItem := range labelList {
+				labelArg, ok := labelItem.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				ackLabel := make(map[string]interface{})
+				ackLabel["key"] = labelArg["Key"]
+				ackLabel["value"] = labelArg["Value"]
+				ackLabels = append(ackLabels, ackLabel)
+			}
+		}
+		d.Set("ack_labels", ackLabels)
+	}
+
+	if v, ok := object["AckNamespaces"]; ok {
+		ackNamespaces := make([]string, 0)
+		if nsList, ok := v.([]interface{}); ok {
+			for _, ns := range nsList {
+				ackNamespaces = append(ackNamespaces, fmt.Sprint(ns))
+			}
+		}
+		d.Set("ack_namespaces", ackNamespaces)
 	}
 
 	if v, ok := object["AddressListCount"]; ok {
@@ -596,6 +709,32 @@ func resourceAliCloudCloudFirewallAddressBookUpdate(d *schema.ResourceData, meta
 			}
 
 			request["AssetRegionResourceTypes"] = assetRegionResourceTypesJson
+		}
+	}
+
+	if d.HasChange("ack_labels") {
+		update = true
+
+		if v, ok := d.GetOk("ack_labels"); ok {
+			ackLabelsJson, err := convertArrayObjectToJsonString(expandCloudFirewallAddressBookAckLabels(v.([]interface{})))
+			if err != nil {
+				return WrapError(err)
+			}
+
+			request["AckLabels"] = ackLabelsJson
+		}
+	}
+
+	if d.HasChange("ack_namespaces") {
+		update = true
+
+		if v, ok := d.GetOk("ack_namespaces"); ok {
+			ackNamespacesJson, err := convertArrayObjectToJsonString(v.([]interface{}))
+			if err != nil {
+				return WrapError(err)
+			}
+
+			request["AckNamespaces"] = ackNamespacesJson
 		}
 	}
 

--- a/alicloud/resource_alicloud_cloud_firewall_address_book_test.go
+++ b/alicloud/resource_alicloud_cloud_firewall_address_book_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -863,6 +864,140 @@ func TestAccAliCloudCloudFirewallAddressBook_basic7(t *testing.T) {
 						"asset_region_resource_types.0.resource_type.0.ipv6.0.ga_eipv6":          "false",
 						"asset_region_resource_types.0.resource_type.0.ipv6.0.api_gateway_eipv6": "true",
 						"asset_region_resource_types.0.resource_type.0.ipv6.0.ai_gateway_eipv6":  "true",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"lang"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudCloudFirewallAddressBook_ackLabel(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_firewall_address_book.default"
+	checkoutSupportedRegions(t, true, connectivity.CloudFirewallSupportRegions)
+	connectorId := os.Getenv("ALICLOUD_CLOUD_FIREWALL_ACK_CLUSTER_CONNECTOR_ID")
+	if connectorId == "" {
+		t.Skip("env ALICLOUD_CLOUD_FIREWALL_ACK_CLUSTER_CONNECTOR_ID is not set, skip ackLabel address book test")
+	}
+	ra := resourceAttrInit(resourceId, AliCloudCloudFirewallAddressBookMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudfwService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudFirewallAddressBook")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%scloudfirewalladdressbook%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudFirewallAddressBookBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group_name":               name,
+					"group_type":               "ackLabel",
+					"description":              name,
+					"ack_cluster_connector_id": connectorId,
+					"ack_labels": []map[string]interface{}{
+						{"key": "app", "value": "tf-test"},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group_name":               name,
+						"group_type":               "ackLabel",
+						"description":              name,
+						"ack_cluster_connector_id": connectorId,
+						"ack_labels.#":             "1",
+						"ack_labels.0.key":         "app",
+						"ack_labels.0.value":       "tf-test",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ack_labels": []map[string]interface{}{
+						{"key": "env", "value": "tf-test-update"},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ack_labels.0.key":   "env",
+						"ack_labels.0.value": "tf-test-update",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"lang"},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudCloudFirewallAddressBook_ackNamespace(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cloud_firewall_address_book.default"
+	checkoutSupportedRegions(t, true, connectivity.CloudFirewallSupportRegions)
+	connectorId := os.Getenv("ALICLOUD_CLOUD_FIREWALL_ACK_CLUSTER_CONNECTOR_ID")
+	if connectorId == "" {
+		t.Skip("env ALICLOUD_CLOUD_FIREWALL_ACK_CLUSTER_CONNECTOR_ID is not set, skip ackNamespace address book test")
+	}
+	ra := resourceAttrInit(resourceId, AliCloudCloudFirewallAddressBookMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CloudfwService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCloudFirewallAddressBook")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%scloudfirewalladdressbook%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCloudFirewallAddressBookBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"group_name":               name,
+					"group_type":               "ackNamespace",
+					"description":              name,
+					"ack_cluster_connector_id": connectorId,
+					"ack_namespaces":           []string{"kube-system"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"group_name":               name,
+						"group_type":               "ackNamespace",
+						"description":              name,
+						"ack_cluster_connector_id": connectorId,
+						"ack_namespaces.#":         "1",
+						"ack_namespaces.0":         "kube-system",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"ack_namespaces": []string{"kube-system", "default"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"ack_namespaces.#": "2",
 					}),
 				),
 			},

--- a/website/docs/r/cloud_firewall_address_book.html.markdown
+++ b/website/docs/r/cloud_firewall_address_book.html.markdown
@@ -45,7 +45,7 @@ resource "alicloud_cloud_firewall_address_book" "example" {
 
 The following arguments are supported:
 * `group_name` - (Required) The name of the Address Book.
-* `group_type` - (Required, ForceNew) The type of the Address Book. Valid values: `ip`, `ipv6`, `domain`, `port`, `tag`, `asset`, `assetIpv6`.
+* `group_type` - (Required, ForceNew) The type of the Address Book. Valid values: `ip`, `ipv6`, `domain`, `port`, `tag`, `asset`, `assetIpv6`, `ackLabel`, `ackNamespace`, `tagPrivate`.
 **NOTE:** From version 1.213.1, `group_type` can be set to `ipv6`, `domain`, `port`. From version 1.286.0, `group_type` can be set to `asset`, `assetIpv6`.
 * `description` - (Required) The description of the Address Book.
 * `auto_add_tag_ecs` - (Optional, Int) Whether you want to automatically add new matching tags of the ECS IP address to the Address Book. Valid values: `0`, `1`.
@@ -57,6 +57,9 @@ The following arguments are supported:
 * `ecs_tags` - (Optional, Set) A list of ECS tags. See [`ecs_tags`](#ecs_tags) below.
 * `asset_member_uids` - (Optional, List, Available since v1.286.0) The list of member account UIDs of the asset Address Book.
 * `asset_region_resource_types` - (Optional, List, Available since v1.286.0) The list of regions and asset types of the asset Address Book. See [`asset_region_resource_types`](#asset_region_resource_types) below.
+* `ack_cluster_connector_id` - (Optional, ForceNew) The ID of the ACK (Alibaba Cloud Kubernetes) cluster connector. Required when `group_type` is `ackLabel` or `ackNamespace`. The value is obtained from the `DescribeAckClusterConnectors` API.
+* `ack_labels` - (Optional, List) The list of ACK cluster pod labels. Required when `group_type` is `ackLabel`. Up to 10 labels. See [`ack_labels`](#ack_labels) below.
+* `ack_namespaces` - (Optional, List) The list of ACK cluster pod namespaces. Required when `group_type` is `ackNamespace`. Up to 10 namespaces.
 
 ### `ecs_tags`
 
@@ -64,6 +67,13 @@ The ecs_tags supports the following:
 
 * `tag_key` - (Optional) The key of ECS tag that to be matched.
 * `tag_value` - (Optional) The value of ECS tag that to be matched.
+
+### `ack_labels`
+
+The ack_labels supports the following:
+
+* `key` - (Optional) The key of the ACK cluster pod label.
+* `value` - (Optional) The value of the ACK cluster pod label.
 
 ### `asset_region_resource_types`
 
@@ -119,6 +129,7 @@ The ipv6 supports the following:
 The following attributes are exported:
 
 * `id` - The resource ID in terraform of Address Book.
+* `ack_cluster_connector_name` - The name of the ACK cluster connector.
 * `address_list_count` - (Available since v1.286.0) The number of addresses in the Address Book.
 * `reference_count` - (Available since v1.286.0) The number of times that the Address Book is referenced.
 


### PR DESCRIPTION
### What this PR does

Add support for ACK (Alibaba Cloud Kubernetes) address books to the `alicloud_cloud_firewall_address_book` resource.

### Changes

- Add `ack_cluster_connector_id` (Optional, ForceNew) — the ACK cluster connector ID, required when `group_type` is `ackLabel` or `ackNamespace`.
- Add `ack_labels` (Optional, List, max 10) — ACK cluster pod labels, required when `group_type` is `ackLabel`.
- Add `ack_namespaces` (Optional, List, max 10) — ACK cluster pod namespaces, required when `group_type` is `ackNamespace`.
- Add `ack_cluster_connector_name` (Computed) — sourced from `DescribeAddressBook`.
- Extend `group_type` valid values with `ackLabel`, `ackNamespace`, `tagPrivate`.

`ack_cluster_connector_id` is create-only (ForceNew) because `ModifyAddressBook` does not accept it; `ack_labels` and `ack_namespaces` are updatable. All three Ack fields are read back from `DescribeAddressBook` so state stays in sync.

### Tests

Remote acceptance tests are in progress for the ACK address book scenarios and will be reported here once complete.