### PR TITLE
resource/alicloud_threat_detection_honey_pot: support meta field

### DIFF
--- a/alicloud/resource_alicloud_threat_detection_honey_pot.go
+++ b/alicloud/resource_alicloud_threat_detection_honey_pot.go
@@ -47,6 +47,10 @@ func resourceAlicloudThreatDetectionHoneyPot() *schema.Resource {
 				ForceNew: true,
 				Type:     schema.TypeString,
 			},
+			"meta": {
+				Optional: true,
+				Type:     schema.TypeString,
+			},
 			"preset_id": {
 				Computed: true,
 				Type:     schema.TypeString,
@@ -82,6 +86,9 @@ func resourceAlicloudThreatDetectionHoneyPotCreate(d *schema.ResourceData, meta 
 	}
 	if v, ok := d.GetOk("node_id"); ok {
 		request["NodeId"] = v
+	}
+	if v, ok := d.GetOk("meta"); ok {
+		request["Meta"] = v
 	}
 
 	var response map[string]interface{}
@@ -151,6 +158,13 @@ func resourceAlicloudThreatDetectionHoneyPotUpdate(d *schema.ResourceData, meta 
 		update = true
 		if v, ok := d.GetOk("honeypot_name"); ok {
 			request["HoneypotName"] = v
+		}
+	}
+
+	if d.HasChange("meta") {
+		update = true
+		if v, ok := d.GetOk("meta"); ok {
+			request["Meta"] = v
 		}
 	}
 

--- a/alicloud/resource_alicloud_threat_detection_honey_pot_test.go
+++ b/alicloud/resource_alicloud_threat_detection_honey_pot_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 // Case 1
-func TestAccAlicloudThreatDetectionHoneyPot_basic1994(t *testing.T) {
+func TestAccAliCloudThreatDetectionHoneyPot_basic1994(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_threat_detection_honey_pot.default"
-	ra := resourceAttrInit(resourceId, AlicloudThreatDetectionHoneyPotMap1994)
+	ra := resourceAttrInit(resourceId, AliCloudThreatDetectionHoneyPotMap1994)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
 		return &SasService{testAccProvider.Meta().(*connectivity.AliyunClient)}
 	}, "DescribeThreatDetectionHoneyPot")
@@ -21,7 +21,7 @@ func TestAccAlicloudThreatDetectionHoneyPot_basic1994(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tf-testacc%sHoneyPot%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudThreatDetectionHoneyPotBasicDependence1994)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudThreatDetectionHoneyPotBasicDependence1994)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -36,6 +36,7 @@ func TestAccAlicloudThreatDetectionHoneyPot_basic1994(t *testing.T) {
 					"honeypot_image_id":   "${data.alicloud_threat_detection_honeypot_images.default.images.0.honeypot_image_id}",
 					"honeypot_name":       "${var.name}",
 					"node_id":             "${alicloud_threat_detection_honeypot_node.default.id}",
+					"meta":                "{\\\"trojan_git\\\":\\\"close\\\",\\\"burp\\\":\\\"close\\\",\\\"portrait_option\\\":\\\"false\\\"}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -49,6 +50,7 @@ func TestAccAlicloudThreatDetectionHoneyPot_basic1994(t *testing.T) {
 			}, {
 				Config: testAccConfig(map[string]interface{}{
 					"honeypot_name": "${var.name}-u",
+					"meta":          "{\\\"trojan_git\\\":\\\"close\\\",\\\"burp\\\":\\\"open\\\",\\\"portrait_option\\\":\\\"true\\\"}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -59,15 +61,15 @@ func TestAccAlicloudThreatDetectionHoneyPot_basic1994(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"meta"},
 			},
 		},
 	})
 }
 
-var AlicloudThreatDetectionHoneyPotMap1994 = map[string]string{}
+var AliCloudThreatDetectionHoneyPotMap1994 = map[string]string{}
 
-func AlicloudThreatDetectionHoneyPotBasicDependence1994(name string) string {
+func AliCloudThreatDetectionHoneyPotBasicDependence1994(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
     default = "%s"

--- a/website/docs/r/threat_detection_honey_pot.html.markdown
+++ b/website/docs/r/threat_detection_honey_pot.html.markdown
@@ -56,6 +56,7 @@ The following arguments are supported:
 * `honeypot_image_name` - (Required, ForceNew) Honeypot mirror name.
 * `honeypot_name` - (Required) Honeypot custom name.
 * `node_id` - (Required, ForceNew) The ID of the honeypot management node.
+* `meta` - (Optional) Honeypot custom configuration in JSON format. Contains fields: `trojan_git` (Git counterplan, valid values: `zip`, `web`, `close`), `trojan_git_addr` (Git counterplan connection address), `trojan_git.zip` (Git anti-Trojan package), `burp` (Burp counter, valid values: `open`, `close`), `portrait_option` (traceability configuration, valid values: `false`, `true`).
 
 
 ## Attributes Reference


### PR DESCRIPTION
Add `meta` field to `alicloud_threat_detection_honey_pot` resource.

The `meta` field is a honeypot custom configuration in JSON format, containing fields such as `trojan_git`, `burp`, and `portrait_option`. It is sent during CreateHoneypot and UpdateHoneypot API calls but is not returned by ListHoneypot.

Changes:
- Added `meta` (Optional, string) to the resource schema
- Send `Meta` in CreateHoneypot and UpdateHoneypot API calls
- Added `meta` to ImportStateVerifyIgnore (not returned by ListHoneypot)
- Updated test cases to cover the new field with different values in create and update steps
- Updated documentation
