### PR TITLE
resource/alicloud_threat_detection_check_config: support config_standard_ids/config_requirement_ids/resource_directory_account_id

### DIFF
--- a/alicloud/resource_alicloud_threat_detection_check_config.go
+++ b/alicloud/resource_alicloud_threat_detection_check_config.go
@@ -74,6 +74,48 @@ func resourceAliCloudThreatDetectionCheckConfig() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"config_standard_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"add_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+						},
+						"remove_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+						},
+					},
+				},
+			},
+			"config_requirement_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"add_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+						},
+						"remove_ids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+						},
+					},
+				},
+			},
+			"resource_directory_account_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -120,6 +162,60 @@ func resourceAliCloudThreatDetectionCheckConfigCreate(d *schema.ResourceData, me
 	}
 	if v, ok := d.GetOk("end_time"); ok {
 		request["EndTime"] = v
+	}
+
+	if v, ok := d.GetOk("config_standard_ids"); ok {
+		if configStandardIdsList, ok := v.([]interface{}); ok && len(configStandardIdsList) > 0 {
+			if configStandardIdsMap, ok := configStandardIdsList[0].(map[string]interface{}); ok {
+				configStandardIdsReq := make(map[string]interface{})
+				if addIds, ok := configStandardIdsMap["add_ids"].([]interface{}); ok && len(addIds) > 0 {
+					addIdsList := make([]interface{}, 0, len(addIds))
+					for _, id := range addIds {
+						addIdsList = append(addIdsList, id)
+					}
+					configStandardIdsReq["AddIds"] = addIdsList
+				}
+				if removeIds, ok := configStandardIdsMap["remove_ids"].([]interface{}); ok && len(removeIds) > 0 {
+					removeIdsList := make([]interface{}, 0, len(removeIds))
+					for _, id := range removeIds {
+						removeIdsList = append(removeIdsList, id)
+					}
+					configStandardIdsReq["RemoveIds"] = removeIdsList
+				}
+				if len(configStandardIdsReq) > 0 {
+					request["ConfigStandardIds"] = configStandardIdsReq
+				}
+			}
+		}
+	}
+
+	if v, ok := d.GetOk("config_requirement_ids"); ok {
+		if configRequirementIdsList, ok := v.([]interface{}); ok && len(configRequirementIdsList) > 0 {
+			if configRequirementIdsMap, ok := configRequirementIdsList[0].(map[string]interface{}); ok {
+				configRequirementIdsReq := make(map[string]interface{})
+				if addIds, ok := configRequirementIdsMap["add_ids"].([]interface{}); ok && len(addIds) > 0 {
+					addIdsList := make([]interface{}, 0, len(addIds))
+					for _, id := range addIds {
+						addIdsList = append(addIdsList, id)
+					}
+					configRequirementIdsReq["AddIds"] = addIdsList
+				}
+				if removeIds, ok := configRequirementIdsMap["remove_ids"].([]interface{}); ok && len(removeIds) > 0 {
+					removeIdsList := make([]interface{}, 0, len(removeIds))
+					for _, id := range removeIds {
+						removeIdsList = append(removeIdsList, id)
+					}
+					configRequirementIdsReq["RemoveIds"] = removeIdsList
+				}
+				if len(configRequirementIdsReq) > 0 {
+					request["ConfigRequirementIds"] = configRequirementIdsReq
+				}
+			}
+		}
+	}
+
+	if v, ok := d.GetOk("resource_directory_account_id"); ok {
+		request["ResourceDirectoryAccountId"] = v
 	}
 
 	if _, ok := d.GetOk("selected_checks"); ok {

--- a/alicloud/resource_alicloud_threat_detection_check_config_test.go
+++ b/alicloud/resource_alicloud_threat_detection_check_config_test.go
@@ -69,6 +69,19 @@ func TestAccAliCloudThreatDetectionCheckConfig_basic12031(t *testing.T) {
 					"enable_auto_check": "false",
 					"enable_add_check":  "false",
 					"start_time":        "6",
+					"config_standard_ids": []map[string]interface{}{
+						{
+							"add_ids":    []interface{}{},
+							"remove_ids": []interface{}{},
+						},
+					},
+					"config_requirement_ids": []map[string]interface{}{
+						{
+							"add_ids":    []interface{}{},
+							"remove_ids": []interface{}{},
+						},
+					},
+					"resource_directory_account_id": 0,
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -106,7 +119,7 @@ func TestAccAliCloudThreatDetectionCheckConfig_basic12031(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"configure", "system_config", "vendors"},
+				ImportStateVerifyIgnore: []string{"configure", "system_config", "vendors", "config_standard_ids", "config_requirement_ids", "resource_directory_account_id"},
 			},
 		},
 	})

--- a/website/docs/r/threat_detection_check_config.html.markdown
+++ b/website/docs/r/threat_detection_check_config.html.markdown
@@ -81,7 +81,31 @@ The following arguments are supported:
 
 -> **NOTE:** This parameter only applies during resource creation, update. If modified in isolation without other property changes, Terraform will not trigger any action.
 
+* `config_standard_ids` - (Optional) The standard IDs configuration for the check config. See [`config_standard_ids`](#config_standard_ids) below.
+
+-> **NOTE:** This parameter only applies during resource creation, update. If modified in isolation without other property changes, Terraform will not trigger any action.
+
+* `config_requirement_ids` - (Optional) The requirement IDs configuration for the check config. See [`config_requirement_ids`](#config_requirement_ids) below.
+
+-> **NOTE:** This parameter only applies during resource creation, update. If modified in isolation without other property changes, Terraform will not trigger any action.
+
+* `resource_directory_account_id` - (Optional, Int) The resource directory account ID.
+
+-> **NOTE:** This parameter only applies during resource creation, update. If modified in isolation without other property changes, Terraform will not trigger any action.
+
 * `selected_checks` - (Optional) The check items selected in the policy. See [`selected_checks`](#selected_checks) below.
+
+### `config_standard_ids`
+
+The config_standard_ids supports the following:
+* `add_ids` - (Optional, List) The list of standard IDs to add.
+* `remove_ids` - (Optional, List) The list of standard IDs to remove.
+
+### `config_requirement_ids`
+
+The config_requirement_ids supports the following:
+* `add_ids` - (Optional, List) The list of requirement IDs to add.
+* `remove_ids` - (Optional, List) The list of requirement IDs to remove.
 
 ### `selected_checks`
 


### PR DESCRIPTION
Add three optional fields to the `alicloud_threat_detection_check_config` resource, backed by the `ChangeCheckConfig` (Sas) API:

- `config_standard_ids` — nested block with `add_ids` and `remove_ids` integer lists
- `config_requirement_ids` — nested block with `add_ids` and `remove_ids` integer lists
- `resource_directory_account_id` — optional integer field

On create/update these are passed to `ChangeCheckConfig`. They are write-only: the read API (`GetCheckConfig`) does not return them, so they are not backfilled on read and retain their configured values (ignored during import state verification).

Test case:
- `TestAccAliCloudThreatDetectionCheckConfig_basic12031` covers create/update/import with the new fields present.

Remote ACC validation is pending.