### PR TITLE
New Data Source: alicloud_threat_detection_components

### DIFF
--- a/alicloud/connectivity/endpoint.go
+++ b/alicloud/connectivity/endpoint.go
@@ -343,6 +343,7 @@ var irregularProductEndpoint = map[string]string{
 	"esa":                     "esa.cn-hangzhou.aliyuncs.com",
 	"cas":                     "cas.aliyuncs.com",
 	"sas":                     "tds.aliyuncs.com",
+	"sophonsoar":              "sophonsoar.aliyuncs.com",
 	"ros":                     "ros.aliyuncs.com",
 	"eds_aic":                 "eds-aic.cn-shanghai.aliyuncs.com",
 	"alidns":                  "alidns.aliyuncs.com",

--- a/alicloud/data_source_alicloud_threat_detection_components.go
+++ b/alicloud/data_source_alicloud_threat_detection_components.go
@@ -1,0 +1,378 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAlicloudThreatDetectionComponents() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudThreatDetectionComponentsRead,
+		Schema: map[string]*schema.Schema{
+			"component_name": {
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+			"name_regex": {
+				Optional:     true,
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringIsValidRegExp,
+			},
+			"lang": {
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+			"role_for": {
+				Optional: true,
+				Type:     schema.TypeInt,
+			},
+			"ids": {
+				Optional: true,
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"output_file": {
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+			"components": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"component_name": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"component_alias": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"component_description": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"component_logo": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"component_extension": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"create_time": {
+							Computed: true,
+							Type:     schema.TypeInt,
+						},
+						"update_time": {
+							Computed: true,
+							Type:     schema.TypeInt,
+						},
+						"component_actions": {
+							Computed: true,
+							Type:     schema.TypeList,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"component_action_name": {
+										Computed: true,
+										Type:     schema.TypeString,
+									},
+									"component_action_description": {
+										Computed: true,
+										Type:     schema.TypeString,
+									},
+									"input_configs": {
+										Computed: true,
+										Type:     schema.TypeList,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"field_name": {
+													Computed: true,
+													Type:     schema.TypeString,
+												},
+												"field_type": {
+													Computed: true,
+													Type:     schema.TypeString,
+												},
+												"field_description": {
+													Computed: true,
+													Type:     schema.TypeString,
+												},
+												"field_display_config": {
+													Computed: true,
+													Type:     schema.TypeString,
+												},
+												"default_value": {
+													Computed: true,
+													Type:     schema.TypeString,
+												},
+												"required": {
+													Computed: true,
+													Type:     schema.TypeBool,
+												},
+											},
+										},
+									},
+									"output_configs": {
+										Computed: true,
+										Type:     schema.TypeList,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"field_name": {
+													Computed: true,
+													Type:     schema.TypeString,
+												},
+												"field_type": {
+													Computed: true,
+													Type:     schema.TypeString,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"component_asset_configs": {
+							Computed: true,
+							Type:     schema.TypeList,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"field_name": {
+										Computed: true,
+										Type:     schema.TypeString,
+									},
+									"field_type": {
+										Computed: true,
+										Type:     schema.TypeString,
+									},
+									"field_description": {
+										Computed: true,
+										Type:     schema.TypeString,
+									},
+									"required": {
+										Computed: true,
+										Type:     schema.TypeBool,
+									},
+									"encrypted": {
+										Computed: true,
+										Type:     schema.TypeBool,
+									},
+									"default_value": {
+										Computed: true,
+										Type:     schema.TypeString,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudThreatDetectionComponentsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := make(map[string]interface{})
+
+	var componentNameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		componentNameRegex = r
+	}
+	if v, ok := d.GetOk("component_name"); ok {
+		request["ComponentName"] = v
+	}
+	if v, ok := d.GetOk("lang"); ok {
+		request["Lang"] = v
+	}
+	if v, ok := d.GetOkExists("role_for"); ok {
+		request["RoleFor"] = v
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var err error
+	var objects []interface{}
+	var response map[string]interface{}
+
+	request["PageNumber"] = 1
+	request["PageSize"] = PageSizeMedium
+	for {
+		action := "ListComponents"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			resp, err := client.RpcPost("sophonsoar", "2025-09-03", action, nil, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			response = resp
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			// A data source filtering by component_name that matches no component
+			// receives Component.External.NotExist from the API. Return an empty
+			// result set instead of erroring out, matching the datasource contract
+			// that a filter with no match yields an empty list.
+			if IsExpectedErrors(err, []string{"Component.External.NotExist"}) {
+				objects = nil
+				break
+			}
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_threat_detection_components", action, AlibabaCloudSdkGoERROR)
+		}
+		resp, err := jsonpath.Get("$.Components", response)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.Components", response)
+		}
+		result, _ := resp.([]interface{})
+		if isPagingRequest(d) {
+			objects = result
+			break
+		}
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["ComponentName"])]; !ok {
+					continue
+				}
+			}
+			if componentNameRegex != nil && !componentNameRegex.MatchString(fmt.Sprint(item["ComponentName"])) {
+				continue
+			}
+			objects = append(objects, item)
+		}
+		if len(result) < request["PageSize"].(int) {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, v := range objects {
+		object := v.(map[string]interface{})
+		mapping := map[string]interface{}{
+			"id":                      fmt.Sprint(object["ComponentName"]),
+			"component_name":          object["ComponentName"],
+			"component_alias":         object["ComponentAlias"],
+			"component_description":   object["ComponentDescription"],
+			"component_logo":          object["ComponentLogo"],
+			"component_extension":     object["ComponentExtension"],
+			"create_time":             formatInt(object["CreateTime"]),
+			"update_time":             formatInt(object["UpdateTime"]),
+			"component_actions":       expandThreatDetectionComponentActions(object["ComponentActions"]),
+			"component_asset_configs": expandThreatDetectionComponentAssetConfigs(object["ComponentAssetConfigs"]),
+		}
+
+		ids = append(ids, fmt.Sprint(object["ComponentName"]))
+
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("components", s); err != nil {
+		return WrapError(err)
+	}
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		if err := writeToFile(output.(string), s); err != nil {
+			return WrapError(err)
+		}
+	}
+	return nil
+}
+
+func expandThreatDetectionComponentActions(raw interface{}) []map[string]interface{} {
+	items, _ := raw.([]interface{})
+	s := make([]map[string]interface{}, 0, len(items))
+	for _, v := range items {
+		item, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		s = append(s, map[string]interface{}{
+			"component_action_name":        item["ComponentActionName"],
+			"component_action_description": item["ComponentActionDescription"],
+			"input_configs":                expandThreatDetectionComponentFieldConfigs(item["InputConfigs"], true),
+			"output_configs":               expandThreatDetectionComponentFieldConfigs(item["OutputConfigs"], false),
+		})
+	}
+	return s
+}
+
+func expandThreatDetectionComponentFieldConfigs(raw interface{}, withDisplayAndDefault bool) []map[string]interface{} {
+	items, _ := raw.([]interface{})
+	s := make([]map[string]interface{}, 0, len(items))
+	for _, v := range items {
+		item, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		entry := map[string]interface{}{
+			"field_name": item["FieldName"],
+			"field_type": item["FieldType"],
+		}
+		if withDisplayAndDefault {
+			entry["field_description"] = item["FieldDescription"]
+			entry["field_display_config"] = item["FieldDisplayConfig"]
+			entry["default_value"] = item["DefaultValue"]
+			entry["required"] = item["Required"]
+		}
+		s = append(s, entry)
+	}
+	return s
+}
+
+func expandThreatDetectionComponentAssetConfigs(raw interface{}) []map[string]interface{} {
+	items, _ := raw.([]interface{})
+	s := make([]map[string]interface{}, 0, len(items))
+	for _, v := range items {
+		item, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		s = append(s, map[string]interface{}{
+			"field_name":        item["FieldName"],
+			"field_type":        item["FieldType"],
+			"field_description": item["FieldDescription"],
+			"required":          item["Required"],
+			"encrypted":         item["Encrypted"],
+			"default_value":     item["DefaultValue"],
+		})
+	}
+	return s
+}

--- a/alicloud/data_source_alicloud_threat_detection_components_test.go
+++ b/alicloud/data_source_alicloud_threat_detection_components_test.go
@@ -1,0 +1,81 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAlicloudThreatDetectionComponentsDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudThreatDetectionComponentsSourceConfig(rand, map[string]string{
+			"name_regex": `".*"`,
+		}),
+		fakeConfig: testAccCheckAlicloudThreatDetectionComponentsSourceConfig(rand, map[string]string{
+			"ids": fmt.Sprintf(`["tf-acc-fake-component-name-not-exist-%d"]`, rand),
+		}),
+	}
+
+	componentNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudThreatDetectionComponentsSourceConfig(rand, map[string]string{
+			"component_name": `"Http"`,
+		}),
+		fakeConfig: testAccCheckAlicloudThreatDetectionComponentsSourceConfig(rand, map[string]string{
+			"component_name": fmt.Sprintf(`"tf-acc-fake-component-name-not-exist-%d"`, rand),
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudThreatDetectionComponentsSourceConfig(rand, map[string]string{
+			"name_regex":  `".*"`,
+			"output_file": fmt.Sprintf(`"%d"`, rand),
+		}),
+		fakeConfig: testAccCheckAlicloudThreatDetectionComponentsSourceConfig(rand, map[string]string{
+			"name_regex": `"^tf-acc-fake-component-name-not-exist"`,
+		}),
+	}
+
+	ThreatDetectionComponentsCheckInfo.dataSourceTestCheck(t, rand, idsConf, componentNameConf, allConf)
+}
+
+var existThreatDetectionComponentsMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"components.#":                 CHECKSET,
+		"components.0.id":              CHECKSET,
+		"components.0.component_name":  CHECKSET,
+		"components.0.component_alias": CHECKSET,
+	}
+}
+
+var fakeThreatDetectionComponentsMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"components.#": "0",
+	}
+}
+
+var ThreatDetectionComponentsCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_threat_detection_components.default",
+	existMapFunc: existThreatDetectionComponentsMapFunc,
+	fakeMapFunc:  fakeThreatDetectionComponentsMapFunc,
+}
+
+func testAccCheckAlicloudThreatDetectionComponentsSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccThreatDetectionComponents%d"
+}
+
+data "alicloud_threat_detection_components" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -909,6 +909,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_threat_detection_honeypot_images":                 dataSourceAlicloudThreatDetectionHoneypotImages(),
 			"alicloud_threat_detection_honey_pots":                      dataSourceAlicloudThreatDetectionHoneyPots(),
 			"alicloud_threat_detection_honeypot_probes":                 dataSourceAlicloudThreatDetectionHoneypotProbes(),
+			"alicloud_threat_detection_components":                      dataSourceAlicloudThreatDetectionComponents(),
 			"alicloud_ecs_capacity_reservations":                        dataSourceAlicloudEcsCapacityReservations(),
 			"alicloud_cen_inter_region_traffic_qos_queues":              dataSourceAlicloudCenInterRegionTrafficQosQueues(),
 			"alicloud_cen_transit_router_multicast_domain_peer_members": dataSourceAlicloudCenTransitRouterMulticastDomainPeerMembers(),

--- a/website/docs/d/threat_detection_components.html.markdown
+++ b/website/docs/d/threat_detection_components.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_components"
+sidebar_current: "docs-alicloud-datasource-threat-detection-components"
+description: |-
+  Provides a list of Threat Detection Components owned by an Alibaba Cloud account.
+---
+
+# alicloud_threat_detection_components
+
+This data source provides the Threat Detection Components available to the user. A component is a reusable action unit that can be used to build security orchestration playbooks.
+
+-> **NOTE:** Available since v1.245.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+data "alicloud_threat_detection_components" "default" {
+  name_regex = "^my"
+  ids        = ["my-component"]
+}
+
+output "first_component_name" {
+  value = data.alicloud_threat_detection_components.default.components.0.component_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `component_name` - (Optional, ForceNew) The name of the component. The data source only returns the component that exactly matches this name.
+* `ids` - (Optional, ForceNew) A list of component names. The data source returns only the components whose names match the list.
+* `lang` - (Optional, ForceNew) The language type of the request and received messages. Valid values: `zh`, `en`.
+* `name_regex` - (Optional, ForceNew) A regex string to filter results by component name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `role_for` - (Optional, ForceNew) The account ID of the Resource Directory member.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `ids` - A list of component names.
+* `components` - A list of Component Entries. Each element contains the following attributes:
+  * `id` - The name of the component. The value is the same as `component_name`.
+  * `component_name` - The name of the component.
+  * `component_alias` - The alias of the component, used for display.
+  * `component_description` - The description of the component.
+  * `component_logo` - The logo URL of the component.
+  * `component_extension` - The extension information of the component.
+  * `create_time` - The creation time of the component.
+  * `update_time` - The update time of the component.
+  * `component_actions` - The list of actions supported by the component. Each element contains the following attributes:
+    * `component_action_name` - The name of the component action.
+    * `component_action_description` - The description of the component action.
+    * `input_configs` - The input configurations of the component action. Each element contains the following attributes:
+      * `field_name` - The field name.
+      * `field_type` - The field type.
+      * `field_description` - The field description.
+      * `field_display_config` - The field display configuration.
+      * `default_value` - The default value of the field.
+      * `required` - Whether the field is required.
+    * `output_configs` - The output configurations of the component action. Each element contains the following attributes:
+      * `field_name` - The field name.
+      * `field_type` - The field type.
+  * `component_asset_configs` - The asset configuration list of the component. Each element contains the following attributes:
+    * `field_name` - The field name.
+    * `field_type` - The field type.
+    * `field_description` - The field description.
+    * `required` - Whether the field is required.
+    * `encrypted` - Whether the field is stored encrypted.
+    * `default_value` - The default value of the field.


### PR DESCRIPTION
### What this PR does

Adds a new data source `alicloud_threat_detection_components` to the Alicloud provider.

This data source lists the available Threat Detection (SOAR) components via the `ListComponents` API. A component is a reusable action unit that can be used to build security orchestration playbooks. Each component exposes its action list (with input/output field configurations) and its asset configuration schema, allowing users to discover and reference available components in their configurations.

### Schema

Arguments:
- `component_name` - (Optional, ForceNew) Exact component name to match.
- `ids` - (Optional, ForceNew) A list of component names to filter by.
- `lang` - (Optional, ForceNew) Language type of the request and response.
- `name_regex` - (Optional, ForceNew) A regex string to filter results by component name.
- `output_file` - (Optional) File name to save results.
- `role_for` - (Optional, ForceNew) Resource Directory member account ID.

Attributes (in addition to arguments above):
- `ids` - A list of component names.
- `components` - A list of component entries, each containing `id`, `component_name`, `component_alias`, `component_description`, `component_logo`, `component_extension`, `create_time`, `update_time`, `component_actions` (with `input_configs`/`output_configs`) and `component_asset_configs`.

### Test

Acceptance test added: `TestAccAlicloudThreatDetectionComponentsDataSource` covering name_regex, ids filtering and output_file.
