### PR TITLE
New Resource: alicloud_threat_detection_vul_auto_config

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -2106,6 +2106,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_threat_detection_backup_policy":                        resourceAlicloudThreatDetectionBackupPolicy(),
 			"alicloud_dms_enterprise_proxy_access":                           resourceAlicloudDmsEnterpriseProxyAccess(),
 			"alicloud_threat_detection_vul_whitelist":                        resourceAlicloudThreatDetectionVulWhitelist(),
+			"alicloud_threat_detection_vul_auto_config":                      resourceAlicloudThreatDetectionVulAutoConfig(),
 			"alicloud_dms_enterprise_logic_database":                         resourceAlicloudDmsEnterpriseLogicDatabase(),
 			"alicloud_amqp_static_account":                                   resourceAliCloudAmqpStaticAccount(),
 			"alicloud_adb_resource_group":                                    resourceAliCloudAdbResourceGroup(),

--- a/alicloud/resource_alicloud_threat_detection_vul_auto_config.go
+++ b/alicloud/resource_alicloud_threat_detection_vul_auto_config.go
@@ -1,0 +1,275 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAlicloudThreatDetectionVulAutoConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudThreatDetectionVulAutoConfigCreate,
+		Read:   resourceAlicloudThreatDetectionVulAutoConfigRead,
+		Update: resourceAlicloudThreatDetectionVulAutoConfigUpdate,
+		Delete: resourceAlicloudThreatDetectionVulAutoConfigDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+			Update: schema.DefaultTimeout(3 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"config_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"start_time": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"period_unit": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"necessity": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"target_start_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"all_uuid": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"need_snapshot": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"snapshot_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"snapshot_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"target_end_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"enable": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"rules": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAlicloudThreatDetectionVulAutoConfigCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var response map[string]interface{}
+	action := "AddOrUpdateAutoFixConfig"
+	request := make(map[string]interface{})
+	var err error
+
+	request["Type"] = d.Get("type")
+	request["StartTime"] = d.Get("start_time")
+	request["AllUuid"] = d.Get("all_uuid")
+	request["NeedSnapshot"] = d.Get("need_snapshot")
+	request["Enable"] = d.Get("enable")
+
+	if v, ok := d.GetOk("period_unit"); ok {
+		request["PeriodUnit"] = v
+	}
+	if v, ok := d.GetOk("necessity"); ok {
+		request["Necessity"] = v
+	}
+	if v, ok := d.GetOk("target_start_time"); ok {
+		request["TargetStartTime"] = v
+	}
+	if v, ok := d.GetOk("snapshot_name"); ok {
+		request["SnapshotName"] = v
+	}
+	if v, ok := d.GetOk("snapshot_time"); ok {
+		request["SnapshotTime"] = v
+	}
+	if v, ok := d.GetOk("target_end_time"); ok {
+		request["TargetEndTime"] = v
+	}
+	if v, ok := d.GetOk("rules"); ok {
+		request["Rules"] = v
+	}
+
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, nil, request, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_vul_auto_config", action, AlibabaCloudSdkGoERROR)
+	}
+
+	if v, err := jsonpath.Get("$.ConfigId", response); err != nil || v == nil {
+		return WrapErrorf(err, IdMsg, "alicloud_threat_detection_vul_auto_config")
+	} else {
+		d.SetId(fmt.Sprint(v))
+	}
+
+	return resourceAlicloudThreatDetectionVulAutoConfigRead(d, meta)
+}
+
+func resourceAlicloudThreatDetectionVulAutoConfigRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	threatDetectionService := ThreatDetectionService{client}
+
+	object, err := threatDetectionService.DescribeThreatDetectionVulAutoConfig(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_threat_detection_vul_auto_config DescribeThreatDetectionVulAutoConfig Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("config_id", object["ConfigId"])
+	d.Set("type", object["Type"])
+	d.Set("start_time", object["StartTime"])
+	d.Set("period_unit", object["PeriodUnit"])
+	d.Set("necessity", object["Necessity"])
+	d.Set("target_start_time", object["TargetStartTime"])
+	d.Set("all_uuid", object["AllUuid"])
+	d.Set("need_snapshot", object["NeedSnapshot"])
+	d.Set("snapshot_name", object["SnapshotName"])
+	d.Set("snapshot_time", object["SnapshotTime"])
+	d.Set("target_end_time", object["TargetEndTime"])
+	d.Set("enable", object["Enable"])
+	d.Set("region_id", object["RegionId"])
+
+	return nil
+}
+
+func resourceAlicloudThreatDetectionVulAutoConfigUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var response map[string]interface{}
+	var err error
+
+	// If any field other than "enable" changed, perform a full upsert via AddOrUpdateAutoFixConfig.
+	fullUpdate := d.HasChange("type") || d.HasChange("start_time") || d.HasChange("period_unit") ||
+		d.HasChange("necessity") || d.HasChange("target_start_time") || d.HasChange("all_uuid") ||
+		d.HasChange("need_snapshot") || d.HasChange("snapshot_name") || d.HasChange("snapshot_time") ||
+		d.HasChange("target_end_time") || d.HasChange("rules")
+
+	if fullUpdate {
+		request := map[string]interface{}{
+			"ConfigId":     d.Id(),
+			"Type":         d.Get("type"),
+			"StartTime":    d.Get("start_time"),
+			"AllUuid":      d.Get("all_uuid"),
+			"NeedSnapshot": d.Get("need_snapshot"),
+			"Enable":       d.Get("enable"),
+		}
+		if v, ok := d.GetOk("period_unit"); ok {
+			request["PeriodUnit"] = v
+		}
+		if v, ok := d.GetOk("necessity"); ok {
+			request["Necessity"] = v
+		}
+		if v, ok := d.GetOk("target_start_time"); ok {
+			request["TargetStartTime"] = v
+		}
+		if v, ok := d.GetOk("snapshot_name"); ok {
+			request["SnapshotName"] = v
+		}
+		if v, ok := d.GetOk("snapshot_time"); ok {
+			request["SnapshotTime"] = v
+		}
+		if v, ok := d.GetOk("target_end_time"); ok {
+			request["TargetEndTime"] = v
+		}
+		if v, ok := d.GetOk("rules"); ok {
+			request["Rules"] = v
+		}
+		action := "AddOrUpdateAutoFixConfig"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
+			response, err = client.RpcPost("Sas", "2018-12-03", action, nil, request, false)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	} else if d.HasChange("enable") {
+		// Only the enable flag changed; use the lightweight status toggle API.
+		request := map[string]interface{}{
+			"ConfigId": d.Id(),
+			"Enable":   d.Get("enable"),
+		}
+		action := "UpdateAutoFixConfigStatus"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
+			response, err = client.RpcPost("Sas", "2018-12-03", action, nil, request, false)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAlicloudThreatDetectionVulAutoConfigRead(d, meta)
+}
+
+func resourceAlicloudThreatDetectionVulAutoConfigDelete(d *schema.ResourceData, meta interface{}) error {
+	// The ThreatDetection VulAutoConfig API does not provide a delete operation.
+	// AddOrUpdateAutoFixConfig is an upsert (add or update) and there is no
+	// DeleteAutoFixConfig API. Removing the resource from Terraform state only
+	// detaches management; the cloud-side configuration is preserved.
+	// Users can disable the rule by setting enable = 0 instead.
+	return nil
+}

--- a/alicloud/resource_alicloud_threat_detection_vul_auto_config_test.go
+++ b/alicloud/resource_alicloud_threat_detection_vul_auto_config_test.go
@@ -1,0 +1,177 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudThreatDetectionVulAutoConfig_basic0(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_vul_auto_config.default"
+	ra := resourceAttrInit(resourceId, resourceAlicloudThreatDetectionVulAutoConfigMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionVulAutoConfig")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccThreatDetectionVulAutoConfig-name%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceAlicloudThreatDetectionVulAutoConfigBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"type":              "vul",
+					"start_time":        1700000000,
+					"all_uuid":          1,
+					"need_snapshot":     0,
+					"enable":            1,
+					"period_unit":       "day",
+					"necessity":         "asap",
+					"target_start_time": 0,
+					"target_end_time":   23,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"type":              "vul",
+						"start_time":        "1700000000",
+						"all_uuid":          "1",
+						"need_snapshot":     "0",
+						"enable":            "1",
+						"period_unit":       "day",
+						"necessity":         "asap",
+						"target_start_time": "0",
+						"target_end_time":   "23",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"type":              "cve",
+					"start_time":        1800000000,
+					"all_uuid":          0,
+					"need_snapshot":     1,
+					"enable":            0,
+					"period_unit":       "week",
+					"necessity":         "serious",
+					"target_start_time": 6,
+					"target_end_time":   18,
+					"snapshot_name":     name,
+					"snapshot_time":     24,
+					"rules":             "[]",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"type":              "cve",
+						"start_time":        "1800000000",
+						"all_uuid":          "0",
+						"need_snapshot":     "1",
+						"enable":            "0",
+						"period_unit":       "week",
+						"necessity":         "serious",
+						"target_start_time": "6",
+						"target_end_time":   "18",
+						"snapshot_name":     name,
+						"snapshot_time":     "24",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"type":              "cve",
+					"start_time":        1800000000,
+					"all_uuid":          0,
+					"need_snapshot":     1,
+					"enable":            1,
+					"period_unit":       "week",
+					"necessity":         "serious",
+					"target_start_time": 6,
+					"target_end_time":   18,
+					"snapshot_name":     name,
+					"snapshot_time":     24,
+					"rules":             "[]",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAliCloudThreatDetectionVulAutoConfig_enableOnly(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_vul_auto_config.default"
+	ra := resourceAttrInit(resourceId, resourceAlicloudThreatDetectionVulAutoConfigMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionVulAutoConfig")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccThreatDetectionVulAutoConfigEnable-name%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceAlicloudThreatDetectionVulAutoConfigBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"type":          "vul",
+					"start_time":    1700000000,
+					"all_uuid":      1,
+					"need_snapshot": 0,
+					"enable":        1,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"type":          "vul",
+					"start_time":    1700000000,
+					"all_uuid":      1,
+					"need_snapshot": 0,
+					"enable":        0,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"enable": "0",
+					}),
+				),
+			},
+		},
+	})
+}
+
+var resourceAlicloudThreatDetectionVulAutoConfigMap = map[string]string{
+	"region_id": CHECKSET,
+}
+
+func resourceAlicloudThreatDetectionVulAutoConfigBasicDependence(name string) string {
+	return ""
+}

--- a/alicloud/service_alicloud_threat_detection.go
+++ b/alicloud/service_alicloud_threat_detection.go
@@ -249,3 +249,47 @@ func (s *ThreatDetectionService) DescribeThreatDetectionHoneypotPreset(id string
 	}
 	return v.(map[string]interface{}), nil
 }
+
+func (s *ThreatDetectionService) DescribeThreatDetectionVulAutoConfig(id string) (object map[string]interface{}, err error) {
+	var response map[string]interface{}
+	action := "DescribeAutoFixConfig"
+	client := s.client
+	request := map[string]interface{}{
+		"ConfigId": id,
+	}
+
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, nil, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"AutoFixConfigNotExist", "InvalidId", "ConfigId.NotFound"}) {
+			return nil, WrapErrorf(NotFoundErr("TDS:VulAutoConfig", id), NotFoundMsg, ProviderERROR)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Data", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Data", response)
+	}
+	if v == nil {
+		return nil, WrapErrorf(NotFoundErr("TDS:VulAutoConfig", id), NotFoundWithResponse, response)
+	}
+	object = v.(map[string]interface{})
+	// The resource is considered not found when the primary key ConfigId is absent or empty.
+	if fmt.Sprint(object["ConfigId"]) == "" || fmt.Sprint(object["ConfigId"]) == "<nil>" {
+		return nil, WrapErrorf(NotFoundErr("TDS:VulAutoConfig", id), NotFoundWithResponse, response)
+	}
+	return object, nil
+}

--- a/website/docs/r/threat_detection_vul_auto_config.html.markdown
+++ b/website/docs/r/threat_detection_vul_auto_config.html.markdown
@@ -1,0 +1,78 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_vul_auto_config"
+sidebar_current: "docs-alicloud-resource-threat-detection-vul-auto-config"
+description: |-
+  Provides a Alicloud Threat Detection Vul Auto Config resource.
+---
+
+# alicloud_threat_detection_vul_auto_config
+
+Provides a Threat Detection Vul Auto Config resource.
+
+Vulnerability automatic repair configuration. You can use this resource to manage the automatic fix configuration for vulnerabilities detected by Security Center (Sas).
+
+For information about Threat Detection Vul Auto Config and how to use it, see [AddOrUpdateAutoFixConfig](https://www.alibabacloud.com/help/en/security-center/developer-reference/api-sas-2018-12-03-addorupdateautofixconfig).
+
+-> **NOTE:** Available since v1.245.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_threat_detection_vul_auto_config" "default" {
+  type              = "vul"
+  start_time        = 1700000000
+  all_uuid          = 1
+  need_snapshot     = 0
+  enable            = 1
+  period_unit       = "day"
+  necessity         = "asap"
+  target_start_time = 0
+  target_end_time   = 23
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `type` - (Required) The task type of the automatic vulnerability repair configuration.
+* `start_time` - (Required) The task start time. Unix timestamp in seconds.
+* `all_uuid` - (Required) Whether to select all servers. Valid values: `0`, `1`.
+* `need_snapshot` - (Required) Whether to take a snapshot before the fix. Valid values: `0`, `1`.
+* `enable` - (Required) The status of the rule. Valid values: `0` (disabled), `1` (enabled).
+* `period_unit` - (Optional) The interval unit of the task.
+* `necessity` - (Optional) The vulnerability severity level to be automatically repaired.
+* `target_start_time` - (Optional) The start hour of the daily time range.
+* `target_end_time` - (Optional) The end hour of the daily time range.
+* `snapshot_name` - (Optional) The name of the snapshot.
+* `snapshot_time` - (Optional) The retention period of the snapshot.
+* `rules` - (Optional) The list of automatic repair rules.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The resource ID in terraform of Vul Auto Config. The value is the `config_id`.
+* `config_id` - The config ID of the automatic vulnerability repair configuration.
+* `region_id` - The region ID of the resource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 3 mins) Used when create the Vul Auto Config.
+* `update` - (Defaults to 3 mins) Used when update the Vul Auto Config.
+* `delete` - (Defaults to 3 mins) Used when delete the Vul Auto Config.
+
+## Import
+
+Threat Detection Vul Auto Config can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_threat_detection_vul_auto_config.example <config_id>
+```
+
+-> **NOTE:** The ThreatDetection VulAutoConfig API does not provide a delete operation. `AddOrUpdateAutoFixConfig` is an upsert and there is no `DeleteAutoFixConfig` API. Destroying the resource via Terraform removes it from state only; the cloud-side configuration is preserved. To disable the rule, set `enable = 0`.


### PR DESCRIPTION
New resource: alicloud_threat_detection_vul_auto_config

Adds the `alicloud_threat_detection_vul_auto_config` resource to manage the automatic vulnerability repair configuration for Security Center (Sas).

## Overview

This resource manages the VulAutoConfig (vulnerability automatic repair configuration) of Threat Detection / Security Center. It wraps the following Sas (2018-12-03) RPC APIs:

- **Create/Update**: `AddOrUpdateAutoFixConfig` (upsert — creates a new config or updates an existing one)
- **Read**: `DescribeAutoFixConfig`
- **Status toggle**: `UpdateAutoFixConfigStatus` (lightweight enable/disable)

There is no dedicated delete API for VulAutoConfig. `AddOrUpdateAutoFixConfig` is an upsert, so destroying the resource in Terraform removes it from state only; the cloud-side configuration is preserved. To disable the rule, set `enable = 0`.

## Schema

| Field | Type | Required/Optional | Notes |
|-------|------|-------------------|-------|
| `type` | string | Required | Task type |
| `start_time` | int | Required | Task start time (Unix timestamp in seconds) |
| `all_uuid` | int | Required | Whether to select all servers (0/1) |
| `need_snapshot` | int | Required | Whether to take a snapshot before fix (0/1) |
| `enable` | int | Required | Rule status (0=disabled, 1=enabled) |
| `period_unit` | string | Optional | Interval unit |
| `necessity` | string | Optional | Vulnerability severity level to auto-repair |
| `target_start_time` | int | Optional | Daily time range start hour |
| `target_end_time` | int | Optional | Daily time range end hour |
| `snapshot_name` | string | Optional | Snapshot name |
| `snapshot_time` | int | Optional | Snapshot retention period |
| `rules` | string | Optional | Automatic repair rules list |
| `config_id` | string | Computed | The config ID (resource primary key) |
| `region_id` | string | Computed | The region ID |

## Import

```terraform
terraform import alicloud_threat_detection_vul_auto_config.example <config_id>
```

## Tests

- `TestAccAlicloudThreatDetectionVulAutoConfig_basic0` — create → full update (AddOrUpdateAutoFixConfig) → enable-only toggle → import verify
- `TestAccAlicloudThreatDetectionVulAutoConfig_enableOnly` — verify the `UpdateAutoFixConfigStatus` lightweight status toggle path

Remote acceptance tests are pending validation.