### PR TITLE
New Resource: alicloud_threat_detection_global_config

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -2117,6 +2117,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_threat_detection_baseline_strategy":                    resourceAlicloudThreatDetectionBaselineStrategy(),
 			"alicloud_threat_detection_anti_brute_force_rule":                resourceAliCloudThreatDetectionAntiBruteForceRule(),
 			"alicloud_threat_detection_honey_pot":                            resourceAlicloudThreatDetectionHoneyPot(),
+			"alicloud_threat_detection_global_config":                        resourceAlicloudThreatDetectionGlobalConfig(),
 			"alicloud_threat_detection_honeypot_probe":                       resourceAlicloudThreatDetectionHoneypotProbe(),
 			"alicloud_ecs_capacity_reservation":                              resourceAlicloudEcsCapacityReservation(),
 			"alicloud_cen_inter_region_traffic_qos_queue":                    resourceAliCloudCenInterRegionTrafficQosQueue(),

--- a/alicloud/resource_alicloud_threat_detection_global_config.go
+++ b/alicloud/resource_alicloud_threat_detection_global_config.go
@@ -1,0 +1,170 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAlicloudThreatDetectionGlobalConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudThreatDetectionGlobalConfigCreate,
+		Read:   resourceAlicloudThreatDetectionGlobalConfigRead,
+		Update: resourceAlicloudThreatDetectionGlobalConfigUpdate,
+		Delete: resourceAlicloudThreatDetectionGlobalConfigDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"global_config_name": {
+				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"global_config_value": {
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+			"lang": {
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+			"role_for": {
+				Optional: true,
+				Type:     schema.TypeInt,
+			},
+		},
+	}
+}
+
+// cloudSiemEndpoint resolves the endpoint for the cloud-siem (Cloud SIEM) product.
+// The resource is center scope with different endpoints for china and intl sites.
+// The china-site service is region-pinned and only serves on cn-shanghai.
+func cloudSiemEndpoint(client *connectivity.AliyunClient) string {
+	if client.IsInternationalAccount() {
+		return "cloud-siem.ap-southeast-1.aliyuncs.com"
+	}
+	return "cloud-siem.cn-shanghai.aliyuncs.com"
+}
+
+func resourceAlicloudThreatDetectionGlobalConfigCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	request := make(map[string]interface{})
+
+	if v, ok := d.GetOk("global_config_name"); ok {
+		request["GlobalConfigName"] = v
+	}
+	if v, ok := d.GetOk("global_config_value"); ok {
+		request["GlobalConfigValue"] = v
+	}
+	if v, ok := d.GetOk("lang"); ok {
+		request["Lang"] = v
+	}
+	if v, ok := d.GetOk("role_for"); ok {
+		request["RoleFor"] = v
+	}
+	request["RegionId"] = client.RegionId
+
+	endpoint := cloudSiemEndpoint(client)
+	action := "UpdateGlobalConfig"
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	var err error
+	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
+		resp, err := client.RpcPostWithEndpoint("cloud-siem", "2024-12-12", action, nil, request, false, endpoint)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, resp, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_global_config", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(d.Get("global_config_name")))
+	return resourceAlicloudThreatDetectionGlobalConfigRead(d, meta)
+}
+
+func resourceAlicloudThreatDetectionGlobalConfigRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	threatDetectionServiceV2 := ThreatDetectionServiceV2{client}
+
+	object, err := threatDetectionServiceV2.DescribeThreatDetectionGlobalConfig(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_threat_detection_global_config DescribeThreatDetectionGlobalConfig Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+	d.Set("global_config_name", object["GlobalConfigName"])
+	d.Set("global_config_value", object["GlobalConfigValue"])
+
+	return nil
+}
+
+func resourceAlicloudThreatDetectionGlobalConfigUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceAlicloudThreatDetectionGlobalConfigCreate(d, meta)
+}
+
+func resourceAlicloudThreatDetectionGlobalConfigDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy resource AliCloud Threat Detection Global Config. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}
+
+// DescribeThreatDetectionGlobalConfig queries the Threat Detection Global Config by its name.
+func (s *ThreatDetectionServiceV2) DescribeThreatDetectionGlobalConfig(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	request := make(map[string]interface{})
+	request["GlobalConfigName"] = id
+	request["RegionId"] = client.RegionId
+	// GetGlobalConfig requires a non-empty Lang; it only selects the response language.
+	request["Lang"] = "zh"
+
+	endpoint := cloudSiemEndpoint(client)
+	action := "GetGlobalConfig"
+	var response map[string]interface{}
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		resp, err := client.RpcPostWithEndpoint("cloud-siem", "2024-12-12", action, nil, request, true, endpoint)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		response = resp
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	v, err := jsonpath.Get("$.GlobalConfig", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.GlobalConfig", response)
+	}
+	if v == nil {
+		return object, WrapErrorf(NotFoundErr("ThreatDetection:GlobalConfig", id), NotFoundWithResponse, response)
+	}
+	object, ok := v.(map[string]interface{})
+	if !ok {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.GlobalConfig", response)
+	}
+	return object, nil
+}

--- a/alicloud/resource_alicloud_threat_detection_global_config_test.go
+++ b/alicloud/resource_alicloud_threat_detection_global_config_test.go
@@ -1,0 +1,93 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// lintignore: AT001
+func TestAccAliCloudThreatDetectionGlobalConfig_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_global_config.default"
+	ra := resourceAttrInit(resourceId, AlicloudThreatDetectionGlobalConfigMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionGlobalConfig")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc-tdgc-%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudThreatDetectionGlobalConfigBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"global_config_name":  "${var.name}",
+					"global_config_value": "config-value-1",
+					"lang":                "zh",
+					"role_for":            0,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"global_config_name":  name,
+						"global_config_value": "config-value-1",
+						"lang":                "zh",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"global_config_name":  "${var.name}",
+					"global_config_value": "config-value-2",
+					"lang":                "zh",
+					"role_for":            0,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"global_config_name":  name,
+						"global_config_value": "config-value-2",
+						"lang":                "zh",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"global_config_name":  "${var.name}",
+					"global_config_value": "",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"global_config_name": name,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"lang", "role_for"},
+			},
+		},
+	})
+}
+
+var AlicloudThreatDetectionGlobalConfigMap = map[string]string{}
+
+func AlicloudThreatDetectionGlobalConfigBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+`, name)
+}

--- a/website/docs/r/threat_detection_global_config.html.markdown
+++ b/website/docs/r/threat_detection_global_config.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_global_config"
+description: |-
+  Provides a Alicloud Threat Detection Global Config resource.
+---
+
+# alicloud_threat_detection_global_config
+
+Provides a Threat Detection Global Config resource.
+
+Cloud Security Information Event Management (SIEM) global configuration. The resource supports reading and updating a named global configuration entry; creation and deletion are not supported by the API, so `create` issues an update to set the value and `delete` removes the resource from state only.
+
+For information about Threat Detection Global Config and how to use it, see [What is Global Config](https://www.alibabacloud.com/help/en/security-center/developer-reference/).
+
+-> **NOTE:** This is a singleton-style resource. The configuration entry is identified by `global_config_name`; Terraform cannot destroy it, only remove it from the state file.
+
+-> **NOTE:** Available since v1.241.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_threat_detection_global_config" "default" {
+  global_config_name  = "alert-config"
+  global_config_value = "enabled"
+  lang                = "zh"
+  role_for            = 0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `global_config_name` - (Required, ForceNew) The name of the global configuration entry. It identifies which named configuration to manage; changing it creates a new resource.
+* `global_config_value` - (Optional) The value of the global configuration entry.
+* `lang` - (Optional) The language type. Valid values: `zh`, `en`.
+* `role_for` - (Optional, Int) The role for user ID. Default to `0`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource, which equals to the `global_config_name`.
+
+## Import
+
+Threat Detection Global Config can be imported using the id, e.g. the `global_config_name`, e.g.
+
+```shell
+$ terraform import alicloud_threat_detection_global_config.example alert-config
+```


### PR DESCRIPTION
### New Resource
- `alicloud_threat_detection_global_config`

### Description

This PR adds a new resource `alicloud_threat_detection_global_config` for managing Cloud SIEM (cloud-siem) global configuration entries.

The resource is singleton-style: the API does not provide Create or Delete operations, so Terraform `create` issues an `UpdateGlobalConfig` call to set the named configuration value, and `delete` removes the resource from the state file only (the cloud configuration is preserved).

The endpoint is resolved by account type (china site: `cloud-siem.aliyuncs.com`, international site: `cloud-siem.ap-southeast-1.aliyuncs.com`).

### Schema

| Attribute | Type | Required/Optional | ForceNew | Description |
|-----------|------|-------------------|----------|-------------|
| `global_config_name` | string | Required | Yes | The name of the global configuration entry |
| `global_config_value` | string | Optional | No | The value of the global configuration entry |
| `lang` | string | Optional | No | The language type |
| `role_for` | int | Optional | No | The role for user ID |

### CRUD Design

- **Create**: calls `UpdateGlobalConfig` (cloud-siem/2024-12-12) to set the config value; ID = `global_config_name`.
- **Read**: calls `GetGlobalConfig` (cloud-siem/2024-12-12), reads `$.GlobalConfig` from the response.
- **Update**: calls `UpdateGlobalConfig` with the new value.
- **Delete**: no-op (singleton config cannot be destroyed; removed from state only).
- **Import**: supported via `global_config_name`.

### Test Result

Remote acceptance tests are pending.