### PR TITLE
New Resource: alicloud_threat_detection_cluster_scanner_yaml

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -2118,6 +2118,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_threat_detection_anti_brute_force_rule":                resourceAliCloudThreatDetectionAntiBruteForceRule(),
 			"alicloud_threat_detection_honey_pot":                            resourceAlicloudThreatDetectionHoneyPot(),
 			"alicloud_threat_detection_honeypot_probe":                       resourceAlicloudThreatDetectionHoneypotProbe(),
+			"alicloud_threat_detection_cluster_scanner_yaml":                 resourceAlicloudThreatDetectionClusterScannerYaml(),
 			"alicloud_ecs_capacity_reservation":                              resourceAlicloudEcsCapacityReservation(),
 			"alicloud_cen_inter_region_traffic_qos_queue":                    resourceAliCloudCenInterRegionTrafficQosQueue(),
 			"alicloud_cen_transit_router_multicast_domain_peer_member":       resourceAliCloudCenTransitRouterMulticastDomainPeerMember(),

--- a/alicloud/resource_alicloud_threat_detection_cluster_scanner_yaml.go
+++ b/alicloud/resource_alicloud_threat_detection_cluster_scanner_yaml.go
@@ -1,0 +1,132 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAlicloudThreatDetectionClusterScannerYaml() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudThreatDetectionClusterScannerYamlCreate,
+		Read:   resourceAlicloudThreatDetectionClusterScannerYamlRead,
+		Delete: resourceAlicloudThreatDetectionClusterScannerYamlDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"webhook_open": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"ca_cert_base64": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tls_key_base64": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tls_cert_base64": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_env_info": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAlicloudThreatDetectionClusterScannerYamlCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var err error
+	request := make(map[string]interface{})
+
+	if v, ok := d.GetOk("cluster_id"); ok {
+		request["ClusterId"] = v
+	}
+	if v, ok := d.GetOkExists("webhook_open"); ok {
+		request["WebhookOpen"] = v
+	}
+
+	var response map[string]interface{}
+	action := "GenerateClusterScannerWebhookYaml"
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
+		resp, err := client.RpcPost("Sas", "2018-12-03", action, nil, request, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		response = resp
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_cluster_scanner_yaml", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(request["ClusterId"]))
+
+	return resourceAlicloudThreatDetectionClusterScannerYamlRead(d, meta)
+}
+
+func resourceAlicloudThreatDetectionClusterScannerYamlRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	sasService := SasService{client}
+
+	object, err := sasService.DescribeThreatDetectionClusterScannerYaml(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_threat_detection_cluster_scanner_yaml sasService.DescribeThreatDetectionClusterScannerYaml Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+	d.Set("cluster_id", object["ClusterId"])
+	d.Set("webhook_open", formatInt(object["WebhookOpen"]))
+	d.Set("ca_cert_base64", object["CaCertBase64"])
+	d.Set("tls_key_base64", object["TlsKeyBase64"])
+	d.Set("tls_cert_base64", object["TlsCertBase64"])
+	d.Set("cluster_env_info", object["ClusterEnvInfo"])
+	d.Set("image", object["Image"])
+	d.Set("region_id", client.RegionId)
+	return nil
+}
+
+// resourceAlicloudThreatDetectionClusterScannerYamlDelete is a no-op because the
+// GenerateClusterScannerWebhookYaml API does not provide a corresponding delete
+// operation. Removing the resource from Terraform state does not modify the
+// cloud-side scanner configuration.
+func resourceAlicloudThreatDetectionClusterScannerYamlDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/alicloud/resource_alicloud_threat_detection_cluster_scanner_yaml_test.go
+++ b/alicloud/resource_alicloud_threat_detection_cluster_scanner_yaml_test.go
@@ -1,0 +1,126 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudThreatDetectionClusterScannerYaml_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_cluster_scanner_yaml.default"
+	ra := resourceAttrInit(resourceId, AlicloudThreatDetectionClusterScannerYamlMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &SasService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionClusterScannerYaml")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sThreatDetectionClusterScannerYaml%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudThreatDetectionClusterScannerYamlBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"cluster_id":   "${alicloud_cs_serverless_kubernetes.default.id}",
+					"webhook_open": 1,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cluster_id":       CHECKSET,
+						"webhook_open":     "1",
+						"region_id":        CHECKSET,
+						"ca_cert_base64":   CHECKSET,
+						"tls_key_base64":   CHECKSET,
+						"tls_cert_base64":  CHECKSET,
+						"cluster_env_info": CHECKSET,
+						"image":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"cluster_id":   "${alicloud_cs_serverless_kubernetes.default.id}",
+					"webhook_open": 0,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"cluster_id":   CHECKSET,
+						"webhook_open": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudThreatDetectionClusterScannerYamlMap = map[string]string{
+	"cluster_id":       CHECKSET,
+	"webhook_open":     CHECKSET,
+	"region_id":        CHECKSET,
+	"ca_cert_base64":   CHECKSET,
+	"tls_key_base64":   CHECKSET,
+	"tls_cert_base64":  CHECKSET,
+	"cluster_env_info": CHECKSET,
+	"image":            CHECKSET,
+}
+
+func AlicloudThreatDetectionClusterScannerYamlBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_enhanced_nat_available_zones" "enhanced" {
+}
+
+data "alicloud_cs_kubernetes_version" "version" {
+  cluster_type       = "Kubernetes"
+  kubernetes_version = "1.31"
+  profile            = "Serverless"
+}
+
+resource "alicloud_vpc" "default" {
+  vpc_name   = var.name
+  cidr_block = "172.16.0.0/12"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id       = alicloud_vpc.default.id
+  cidr_block   = cidrsubnet(alicloud_vpc.default.cidr_block, 8, 8)
+  zone_id      = data.alicloud_enhanced_nat_available_zones.enhanced.zones.0.zone_id
+  vswitch_name = var.name
+}
+
+resource "alicloud_security_group" "default" {
+  name   = var.name
+  vpc_id = alicloud_vpc.default.id
+}
+
+resource "alicloud_cs_serverless_kubernetes" "default" {
+  name                = var.name
+  vpc_id              = alicloud_vpc.default.id
+  vswitch_ids         = [alicloud_vswitch.default.id]
+  security_group_id   = alicloud_security_group.default.id
+  new_nat_gateway     = true
+  deletion_protection = false
+  version             = data.alicloud_cs_kubernetes_version.version.metadata.0.version
+  service_cidr        = "10.0.1.0/24"
+}
+`, name)
+}

--- a/alicloud/service_alicloud_sas.go
+++ b/alicloud/service_alicloud_sas.go
@@ -410,3 +410,51 @@ func (s *SasService) ThreatDetectionHoneypotProbeStateRefreshFunc(d *schema.Reso
 		return object, fmt.Sprint(object["Status"]), nil
 	}
 }
+
+func (s *SasService) DescribeThreatDetectionClusterScannerYaml(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	request := map[string]interface{}{
+		"ClusterId": id,
+	}
+
+	var response map[string]interface{}
+	action := "GetClusterScannerYaml"
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		resp, err := client.RpcPost("Sas", "2018-12-03", action, nil, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		response = resp
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	if response == nil {
+		return nil, WrapErrorf(NotFoundErr("ThreatDetection:ClusterScannerYaml", id), NotFoundWithResponse, response)
+	}
+	// The scanner yaml config fields are returned at the response root (PascalCase)
+	// by the gateway (outputParamVersion: 2). Fall back to a nested "Data" object
+	// in case the gateway wraps the payload.
+	object = response
+	if _, ok := object["ClusterId"]; !ok {
+		if dataRaw, ok2 := object["Data"]; ok2 && dataRaw != nil {
+			if dataMap, ok3 := dataRaw.(map[string]interface{}); ok3 {
+				if _, ok4 := dataMap["ClusterId"]; ok4 {
+					object = dataMap
+				}
+			}
+		}
+	}
+	v, jsonErr := jsonpath.Get("$.ClusterId", object)
+	if jsonErr != nil || v == nil || fmt.Sprint(v) == "" {
+		return nil, WrapErrorf(NotFoundErr("ThreatDetection:ClusterScannerYaml", id), NotFoundWithResponse, response)
+	}
+	return object, nil
+}

--- a/website/docs/r/threat_detection_cluster_scanner_yaml.html.markdown
+++ b/website/docs/r/threat_detection_cluster_scanner_yaml.html.markdown
@@ -1,0 +1,63 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_cluster_scanner_yaml"
+description: |-
+  Provides a Alicloud Threat Detection Cluster Scanner Yaml resource.
+---
+
+# alicloud_threat_detection_cluster_scanner_yaml
+
+Provides a Threat Detection Cluster Scanner Yaml resource.
+
+Generates the k8s cluster scanner webhook yaml configuration for a Security Center (Sas) managed cluster.
+
+For information about Threat Detection Cluster Scanner Yaml and how to use it, see [GenerateClusterScannerWebhookYaml](https://www.alibabacloud.com/help/en/security-center/developer-reference/api-sas-2018-12-03-generateclusterscannerwebhookyaml).
+
+-> **NOTE:** Available since v1.292.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_threat_detection_cluster_scanner_yaml" "default" {
+  cluster_id   = "cxxxxxxxxxxxxxxxxx"
+  webhook_open = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `cluster_id` - (Required, ForceNew) The ID of the k8s cluster to which the scan component needs to be deployed.
+* `webhook_open` - (Optional, ForceNew, Int) Specifies the webhook enabled state of the scan component. Valid values:
+  - `1`: webhook needs to be enabled.
+  - `0`: the webhook needs to be closed.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource. It is the cluster ID.
+* `ca_cert_base64` - The base64-encoded CA certificate of the cluster scan component.
+* `tls_key_base64` - The base64-encoded TLS private key of the cluster scan component.
+* `tls_cert_base64` - The base64-encoded TLS certificate corresponding to the cluster scan component.
+* `cluster_env_info` - The cluster environment information.
+* `image` - The image address corresponding to the cluster scan component.
+* `region_id` - The region ID of the resource.
+
+-> **NOTE:** This resource only supports create and read. The GenerateClusterScannerWebhookYaml API does not provide a delete operation, so removing the resource from Terraform state does not modify the cloud-side scanner configuration. Changes to `cluster_id` or `webhook_open` force a new resource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Cluster Scanner Yaml.
+* `delete` - (Defaults to 5 mins) Used when delete the Cluster Scanner Yaml.
+
+## Import
+
+Threat Detection Cluster Scanner Yaml can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_threat_detection_cluster_scanner_yaml.example <cluster_id>
+```


### PR DESCRIPTION
## New Resource: alicloud_threat_detection_cluster_scanner_yaml

This PR adds a new resource `alicloud_threat_detection_cluster_scanner_yaml` to the Threat Detection (Security Center / Sas) product.

### What it does

Generates and reads the k8s cluster scanner webhook YAML configuration for a Security Center managed cluster. The resource is backed by the following public APIs of `Sas 2018-12-03`:

- **Create**: `GenerateClusterScannerWebhookYaml` (`ClusterId` required, `WebhookOpen` optional int)
- **Read**: `GetClusterScannerYaml` (returns the scanner config: CA cert, TLS key/cert, image, cluster env info, webhook open state)

### Schema

| Attribute | Type | Description |
|-----------|------|-------------|
| `cluster_id` | string (Required, ForceNew) | The k8s cluster ID to deploy the scan component. |
| `webhook_open` | int (Optional, ForceNew) | Webhook enabled state: `1` enabled, `0` disabled. |
| `ca_cert_base64` | string (Computed) | Base64-encoded CA certificate. |
| `tls_key_base64` | string (Computed) | Base64-encoded TLS private key. |
| `tls_cert_base64` | string (Computed) | Base64-encoded TLS certificate. |
| `cluster_env_info` | string (Computed) | Cluster environment information. |
| `image` | string (Computed) | Scanner component image address. |
| `region_id` | string (Computed) | Region ID. |

### Notes

- This is a create-read resource: the backing API has no update or delete operation. Changes to `cluster_id` or `webhook_open` force a new resource. Removing the resource from Terraform state does not modify the cloud-side scanner configuration (delete is a no-op).
- `cluster_id` is used as the Terraform resource ID; the resource supports import via `terraform import alicloud_threat_detection_cluster_scanner_yaml.example <cluster_id>`.

### Tests

Acceptance test `TestAccAlicloudThreatDetectionClusterScannerYaml_basic` covers create, `webhook_open` ForceNew update, and import. Remote acceptance results will be appended once verified.
