### PR TITLE
New Resource: alicloud_threat_detection_data_source_template

### DIFF
--- a/alicloud/connectivity/endpoint.go
+++ b/alicloud/connectivity/endpoint.go
@@ -348,6 +348,7 @@ var irregularProductEndpoint = map[string]string{
 	"alidns":                  "alidns.aliyuncs.com",
 	"openapiexplorer":         "openapi-mcp.cn-hangzhou.aliyuncs.com",
 	"computenestsupplier":     "computenestsupplier.cn-hangzhou.aliyuncs.com",
+	"cloud-siem":              "cloud-siem.aliyuncs.com",
 }
 
 // irregularProductEndpointForIntlRegion specially records those product codes that
@@ -357,7 +358,8 @@ var irregularProductEndpoint = map[string]string{
 // Value: product endpoint
 // The priority of this configuration is higher than location service, lower than user environment variable configuration
 var irregularProductEndpointForIntlRegion = map[string]string{
-	"sas": SaSOpenAPIEndpointInternational,
+	"sas":        SaSOpenAPIEndpointInternational,
+	"cloud-siem": "cloud-siem.ap-southeast-1.aliyuncs.com",
 }
 
 // irregularProductEndpointForIntlAccount specially records those product codes that

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1154,6 +1154,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_nlb_load_balancer_zone_shifted_attachment":            resourceAliCloudNlbLoadBalancerZoneShiftedAttachment(),
 			"alicloud_threat_detection_log_meta":                            resourceAliCloudThreatDetectionLogMeta(),
 			"alicloud_threat_detection_asset_selection_config":              resourceAliCloudThreatDetectionAssetSelectionConfig(),
+			"alicloud_threat_detection_data_source_template":                resourceAlicloudThreatDetectionDataSourceTemplate(),
 			"alicloud_ram_user_group_attachment":                            resourceAliCloudRamUserGroupAttachment(),
 			"alicloud_esa_kv_namespace":                                     resourceAliCloudEsaKvNamespace(),
 			"alicloud_esa_client_ca_certificate":                            resourceAliCloudEsaClientCaCertificate(),

--- a/alicloud/resource_alicloud_threat_detection_data_source_template.go
+++ b/alicloud/resource_alicloud_threat_detection_data_source_template.go
@@ -1,0 +1,228 @@
+package alicloud
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAlicloudThreatDetectionDataSourceTemplate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudThreatDetectionDataSourceTemplateCreate,
+		Read:   resourceAlicloudThreatDetectionDataSourceTemplateRead,
+		Update: resourceAlicloudThreatDetectionDataSourceTemplateUpdate,
+		Delete: resourceAlicloudThreatDetectionDataSourceTemplateDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"data_source_template_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"data_source_recognize_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"auto_scan_new": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"enabled", "disabled"}, false),
+			},
+			"data_source_template_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"log_project_pattern": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"log_store_pattern": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"log_user_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"log_region_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"lang": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"role_for": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"create_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"data_source_from": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_source_recognizer": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAlicloudThreatDetectionDataSourceTemplateCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	threatDetectionServiceV2 := ThreatDetectionServiceV2{client}
+
+	id := d.Get("data_source_template_id").(string)
+	// Verify the template exists before adopting it
+	_, err := threatDetectionServiceV2.DescribeThreatDetectionDataSourceTemplate(id)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_data_source_template", "ListDataSourceTemplates", AlibabaCloudSdkGoERROR)
+	}
+
+	// Apply the desired configuration via UpdateDataSourceTemplate
+	if err := updateThreatDetectionDataSourceTemplate(d, client); err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_data_source_template", "UpdateDataSourceTemplate", AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(id)
+	return resourceAlicloudThreatDetectionDataSourceTemplateRead(d, meta)
+}
+
+func resourceAlicloudThreatDetectionDataSourceTemplateRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	threatDetectionServiceV2 := ThreatDetectionServiceV2{client}
+
+	object, err := threatDetectionServiceV2.DescribeThreatDetectionDataSourceTemplate(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_threat_detection_data_source_template DescribeThreatDetectionDataSourceTemplate Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("data_source_template_id", object["dataSourceTemplateId"])
+	d.Set("data_source_recognize_enabled", object["dataSourceRecognizeEnabled"])
+	d.Set("auto_scan_new", object["autoScanNew"])
+	d.Set("data_source_template_name", object["dataSourceTemplateName"])
+	d.Set("log_project_pattern", object["logProjectPattern"])
+	d.Set("log_store_pattern", object["logStorePattern"])
+	d.Set("create_time", object["createTime"])
+	d.Set("update_time", object["updateTime"])
+	d.Set("data_source_from", object["dataSourceFrom"])
+	d.Set("data_source_recognizer", object["dataSourceRecognizer"])
+	d.Set("region_id", client.RegionId)
+
+	if v, ok := object["logUserIds"].([]interface{}); ok {
+		d.Set("log_user_ids", v)
+	}
+	if v, ok := object["logRegionIds"].([]interface{}); ok {
+		d.Set("log_region_ids", v)
+	}
+	return nil
+}
+
+func resourceAlicloudThreatDetectionDataSourceTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	if err := updateThreatDetectionDataSourceTemplate(d, client); err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), "UpdateDataSourceTemplate", AlibabaCloudSdkGoERROR)
+	}
+	return resourceAlicloudThreatDetectionDataSourceTemplateRead(d, meta)
+}
+
+func resourceAlicloudThreatDetectionDataSourceTemplateDelete(d *schema.ResourceData, meta interface{}) error {
+	// No DeleteDataSourceTemplate API exists; the template is preserved.
+	log.Printf("[DEBUG] Resource alicloud_threat_detection_data_source_template %s is preserved (no delete API).", d.Id())
+	return nil
+}
+
+func updateThreatDetectionDataSourceTemplate(d *schema.ResourceData, client *connectivity.AliyunClient) error {
+	action := "UpdateDataSourceTemplate"
+	request := make(map[string]interface{})
+	query := make(map[string]interface{})
+	request["DataSourceTemplateId"] = d.Get("data_source_template_id")
+
+	if v, ok := d.GetOk("data_source_template_name"); ok {
+		request["DataSourceTemplateName"] = v
+	}
+	if v, ok := d.GetOk("log_project_pattern"); ok {
+		request["LogProjectPattern"] = v
+	}
+	if v, ok := d.GetOk("log_store_pattern"); ok {
+		request["LogStorePattern"] = v
+	}
+	if v, ok := d.GetOk("lang"); ok {
+		request["Lang"] = v
+	}
+	if v, ok := d.GetOkExists("role_for"); ok {
+		request["RoleFor"] = v
+	}
+	if v, ok := d.GetOk("auto_scan_new"); ok {
+		request["AutoScanNew"] = v
+	}
+	// DataSourceRecognizeEnabled is accepted via query per the API definition
+	if v, ok := d.GetOkExists("data_source_recognize_enabled"); ok {
+		query["DataSourceRecognizeEnabled"] = v
+	}
+	if v, ok := d.GetOk("log_user_ids"); ok && len(v.([]interface{})) > 0 {
+		request["LogUserIds"] = convertToInterfaceArray(v)
+	}
+	if v, ok := d.GetOk("log_region_ids"); ok && len(v.([]interface{})) > 0 {
+		request["LogRegionIds"] = strings.Join(toStringArray(v), ",")
+	}
+
+	var response map[string]interface{}
+	var err error
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
+		resp, err := client.RpcPost("cloud-siem", "2024-12-12", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		response = resp
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+	return nil
+}

--- a/alicloud/resource_alicloud_threat_detection_data_source_template_test.go
+++ b/alicloud/resource_alicloud_threat_detection_data_source_template_test.go
@@ -1,0 +1,108 @@
+package alicloud
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudThreatDetectionDataSourceTemplate_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_data_source_template.default"
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionDataSourceTemplate")
+	rac := resourceAttrCheckInit(rc, nil)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+
+	templateID := os.Getenv("ALICLOUD_THREAT_DETECTION_DATA_SOURCE_TEMPLATE_ID")
+	if templateID == "" {
+		t.Skip("ALICLOUD_THREAT_DETECTION_DATA_SOURCE_TEMPLATE_ID is not set; skipping because DataSourceTemplate has no Create API and a pre-existing template ID is required")
+	}
+
+	name := templateID
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, testAccThreatDetectionDataSourceTemplateBasicDependence)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"data_source_template_id":       "${var.name}",
+					"data_source_recognize_enabled": true,
+					"auto_scan_new":                 "enabled",
+					"data_source_template_name":     "tf-testacc-dst-name-initial",
+					"log_project_pattern":           "tf-testacc-log-project-initial",
+					"log_store_pattern":             "tf-testacc-log-store-initial",
+					"log_user_ids":                  []string{"tf-testacc-user-1"},
+					"log_region_ids":                []string{"cn-hangzhou"},
+					"lang":                          "zh",
+					"role_for":                      0,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"data_source_template_id":       templateID,
+						"data_source_recognize_enabled": "true",
+						"auto_scan_new":                 "enabled",
+						"data_source_template_name":     CHECKSET,
+						"log_project_pattern":           CHECKSET,
+						"log_store_pattern":             CHECKSET,
+						"create_time":                   CHECKSET,
+						"update_time":                   CHECKSET,
+						"data_source_from":              CHECKSET,
+						"data_source_recognizer":        CHECKSET,
+						"region_id":                     CHECKSET,
+						"log_user_ids.#":                "1",
+						"log_region_ids.#":              "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"data_source_template_id":       "${var.name}",
+					"data_source_recognize_enabled": false,
+					"auto_scan_new":                 "disabled",
+					"data_source_template_name":     "tf-testacc-dst-name-updated",
+					"log_project_pattern":           "tf-testacc-log-project-updated",
+					"log_store_pattern":             "tf-testacc-log-store-updated",
+					"log_user_ids":                  []string{"tf-testacc-user-2"},
+					"log_region_ids":                []string{"cn-shanghai"},
+					"lang":                          "en",
+					"role_for":                      1,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"data_source_recognize_enabled": "false",
+						"auto_scan_new":                 "disabled",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func testAccThreatDetectionDataSourceTemplateBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+`, name)
+}

--- a/alicloud/service_alicloud_threat_detection_v2.go
+++ b/alicloud/service_alicloud_threat_detection_v2.go
@@ -1656,3 +1656,59 @@ func (s *ThreatDetectionServiceV2) ThreatDetectionAttackPathWhitelistStateRefres
 }
 
 // DescribeThreatDetectionAttackPathWhitelist >>> Encapsulated.
+
+// DescribeThreatDetectionDataSourceTemplate <<< Encapsulated get interface for ThreatDetection DataSourceTemplate.
+// DataSourceTemplate has no dedicated Get API; this method calls ListDataSourceTemplates
+// and returns the entry whose dataSourceTemplateId matches the given id.
+func (s *ThreatDetectionServiceV2) DescribeThreatDetectionDataSourceTemplate(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	action := "ListDataSourceTemplates"
+	request := make(map[string]interface{})
+	query := make(map[string]interface{})
+	request["DataSourceTemplateIds"] = []interface{}{id}
+	request["PageNumber"] = "1"
+	request["PageSize"] = "20"
+	if region := client.RegionId; region != "" {
+		request["RegionId"] = region
+	}
+
+	var response map[string]interface{}
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		resp, e := client.RpcPost("cloud-siem", "2024-12-12", action, query, request, true)
+		if e != nil {
+			if NeedRetry(e) {
+				wait()
+				return resource.RetryableError(e)
+			}
+			return resource.NonRetryableError(e)
+		}
+		response = resp
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, e := jsonpath.Get("$.data", response)
+	if e != nil || v == nil {
+		return object, WrapErrorf(NotFoundErr("ThreatDetection:DataSourceTemplate", id), NotFoundMsg, response)
+	}
+	templates, ok := v.([]interface{})
+	if !ok {
+		return object, WrapErrorf(NotFoundErr("ThreatDetection:DataSourceTemplate", id), NotFoundMsg, response)
+	}
+	for _, raw := range templates {
+		tmpl, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if fmt.Sprint(tmpl["dataSourceTemplateId"]) == id {
+			return tmpl, nil
+		}
+	}
+	return object, WrapErrorf(NotFoundErr("ThreatDetection:DataSourceTemplate", id), NotFoundMsg, response)
+}
+
+// DescribeThreatDetectionDataSourceTemplate >>> Encapsulated.

--- a/website/docs/r/threat_detection_data_source_template.html.markdown
+++ b/website/docs/r/threat_detection_data_source_template.html.markdown
@@ -1,0 +1,86 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_data_source_template"
+description: |-
+  Provides a Alicloud Threat Detection Data Source Template resource.
+---
+
+# alicloud_threat_detection_data_source_template
+
+Provides a Threat Detection Data Source Template resource.
+
+Data Source Template.
+
+For information about Threat Detection Data Source Template and how to use it, see [What is Data Source Template](https://next.api.alibabacloud.com/document/cloud-siem/2024-12-12/ListDataSourceTemplates).
+
+-> **NOTE:** Available since v1.246.0.
+
+-> **NOTE:** The `alicloud_threat_detection_data_source_template` resource does not support create or delete operations because the corresponding API is not available. You must first create a data source template in the console, then use Terraform to manage (adopt and update) its configuration by specifying `data_source_template_id`.
+
+## Example Usage
+
+Basic Usage
+
+<div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
+  <a href="https://api.aliyun.com/terraform?resource=alicloud_threat_detection_data_source_template&activeTab=example&intl_lang=EN_US" target="_blank">
+    <img alt="Open in AliCloud" src="https://img.alicdn.com/imgextra/i1/O1CN01hjjqXv1uYUlY56FyX_!!6000000006049-55-tps-254-36.svg" style="max-height: 44px; max-width: 100%;">
+  </a>
+</div></div>
+
+```terraform
+variable "data_source_template_id" {
+  type    = string
+  default = "your-existing-data-source-template-id"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_threat_detection_data_source_template" "default" {
+  data_source_template_id       = var.data_source_template_id
+  data_source_recognize_enabled = true
+  auto_scan_new                 = "enabled"
+  lang                          = "zh"
+  log_user_ids                  = ["user1"]
+  log_region_ids                = ["cn-hangzhou"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `data_source_template_id` - (Required, ForceNew) The ID of the data source template. This field identifies an existing template to adopt and manage.
+* `data_source_recognize_enabled` - (Optional) Whether to automatically discover new data sources.
+* `auto_scan_new` - (Optional) Whether to automatically discover new users. Valid values: `enabled`, `disabled`.
+* `data_source_template_name` - (Optional) The data source template name.
+* `log_project_pattern` - (Optional) Log Service project name matching rules.
+* `log_store_pattern` - (Optional) Log service LogStore name matching rules.
+* `log_user_ids` - (Optional) The data batch access user ID list.
+* `log_region_ids` - (Optional) List of log storage region IDs.
+* `lang` - (Optional) Language.
+* `role_for` - (Optional) The user ID that the administrator switches to another member's perspective.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `create_time` - Creation time.
+* `update_time` - Update time.
+* `data_source_from` - Data sources. Value: `center`, `custom`.
+* `data_source_recognizer` - Data source recognizer.
+* `region_id` - Region ID.
+
+### Deleting `alicloud_threat_detection_data_source_template` or removing it from your configuration
+
+Terraform cannot destroy resource `alicloud_threat_detection_data_source_template`. Terraform will remove this resource from the state file, however resources may remain.
+
+## Import
+
+Threat Detection Data Source Template can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_threat_detection_data_source_template.example <data_source_template_id>
+```


### PR DESCRIPTION
## New Resource: alicloud_threat_detection_data_source_template

This PR adds a new resource `alicloud_threat_detection_data_source_template` for managing Threat Detection Data Source Templates via the cloud-siem API.

### Overview

The `alicloud_threat_detection_data_source_template` resource manages the configuration of a Threat Detection data source template. Since there is no Create or Delete API for data source templates, this resource adopts an existing template (created in the console) by its `data_source_template_id` and manages its updateable configuration.

### CRUD Design

- **Create**: Adopts an existing template by verifying its existence via `ListDataSourceTemplates`, then applies the desired configuration via `UpdateDataSourceTemplate`.
- **Read**: Calls `ListDataSourceTemplates` filtered by `DataSourceTemplateId`.
- **Update**: Calls `UpdateDataSourceTemplate` with the changed fields.
- **Delete**: No-op (the template is preserved; no `DeleteDataSourceTemplate` API exists).

### Schema

The resource exposes the following arguments and attributes:

**Arguments:**
- `data_source_template_id` (Required, ForceNew) - The ID of the data source template to adopt and manage.
- `data_source_recognize_enabled` (Optional) - Whether to automatically discover new data sources.
- `auto_scan_new` (Optional) - Whether to automatically discover new users (`enabled`/`disabled`).
- `data_source_template_name` (Optional) - The data source template name.
- `log_project_pattern` (Optional) - Log Service project name matching rules.
- `log_store_pattern` (Optional) - Log service LogStore name matching rules.
- `log_user_ids` (Optional) - The data batch access user ID list.
- `log_region_ids` (Optional) - List of log storage region IDs.
- `lang` (Optional) - Language.
- `role_for` (Optional) - The user ID for admin perspective switching.

**Attributes (computed):**
- `create_time`, `update_time`, `data_source_from`, `data_source_recognizer`, `region_id`

### Endpoint

Adds `cloud-siem` product endpoint (`cloud-siem.aliyuncs.com` domestic, `cloud-siem.ap-southeast-1.aliyuncs.com` international) to the connectivity endpoint map.

### Test Cases

```
=== RUN TestAccAliCloudThreatDetectionDataSourceTemplate_basic
--- PASS: TestAccAliCloudThreatDetectionDataSourceTemplate_basic (pending remote ACC verification)
```

> Note: Since there is no Create API, the ACC test requires a pre-existing data source template ID provided via the `ALICLOUD_THREAT_DETECTION_DATA_SOURCE_TEMPLATE_ID` environment variable. Remote ACC verification will be performed separately.

### Import

```shell
terraform import alicloud_threat_detection_data_source_template.example <data_source_template_id>
```
