### PR TITLE
resource/alicloud_threat_detection_web_lock_config: add lang and inclusive_file attributes, data-source/alicloud_threat_detection_web_lock_configs: add lang and inclusive_file attributes

### DIFF
--- a/alicloud/data_source_alicloud_threat_detection_web_lock_configs.go
+++ b/alicloud/data_source_alicloud_threat_detection_web_lock_configs.go
@@ -82,6 +82,10 @@ func dataSourceAlicloudThreatDetectionWebLockConfigs() *schema.Resource {
 							Computed: true,
 							Type:     schema.TypeString,
 						},
+						"inclusive_file": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
 						"inclusive_file_type": {
 							Computed: true,
 							Type:     schema.TypeString,
@@ -212,6 +216,7 @@ func dataSourceAlicloudThreatDetectionWebLockConfigsRead(d *schema.ResourceData,
 		mapping["exclusive_dir"] = object["ExclusiveDir"]
 		mapping["exclusive_file"] = object["ExclusiveFile"]
 		mapping["exclusive_file_type"] = object["ExclusiveFileType"]
+		mapping["inclusive_file"] = object["InclusiveFile"]
 		mapping["inclusive_file_type"] = object["InclusiveFileType"]
 		mapping["local_backup_dir"] = object["LocalBackupDir"]
 		mapping["mode"] = object["Mode"]

--- a/alicloud/data_source_alicloud_threat_detection_web_lock_configs_test.go
+++ b/alicloud/data_source_alicloud_threat_detection_web_lock_configs_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-func TestAccAlicloudThreatDetectionWebLockConfigDataSource(t *testing.T) {
+func TestAccAliCloudThreatDetectionWebLockConfigDataSource(t *testing.T) {
 	rand := acctest.RandIntRange(1000000, 9999999)
 
 	idsConf := dataSourceTestAccConfig{
@@ -64,6 +64,7 @@ var existThreatDetectionWebLockConfigMapFunc = func(rand int) map[string]string 
 		"configs.0.exclusive_dir":       "",
 		"configs.0.exclusive_file":      "",
 		"configs.0.exclusive_file_type": "",
+		"configs.0.inclusive_file":      "/tmp/include.txt",
 		"configs.0.inclusive_file_type": "php;jsp;asp;aspx;js;cgi;html;htm;xml;shtml;shtm;jpg",
 		"configs.0.local_backup_dir":    "/usr/local/aegis/bak",
 		"configs.0.mode":                "whitelist",
@@ -100,11 +101,16 @@ data "alicloud_threat_detection_assets" "default" {
 
 resource "alicloud_threat_detection_web_lock_config" "default" {
   inclusive_file_type = "php;jsp;asp;aspx;js;cgi;html;htm;xml;shtml;shtm;jpg"
+  inclusive_file      = "/tmp/include.txt"
+  lang                = "zh"
   uuid                = data.alicloud_threat_detection_assets.default.ids.0
   mode                = "whitelist"
   local_backup_dir    = "/usr/local/aegis/bak"
   dir                 = "/tmp/"
   defence_mode        = "audit"
+  exclusive_dir       = ""
+  exclusive_file      = ""
+  exclusive_file_type = ""
 }
 
 data "alicloud_threat_detection_web_lock_configs" "default" {

--- a/alicloud/resource_alicloud_threat_detection_web_lock_config.go
+++ b/alicloud/resource_alicloud_threat_detection_web_lock_config.go
@@ -46,6 +46,11 @@ func resourceAlicloudThreatDetectionWebLockConfig() *schema.Resource {
 				ForceNew: true,
 				Type:     schema.TypeString,
 			},
+			"inclusive_file": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
 			"inclusive_file_type": {
 				Optional: true,
 				ForceNew: true,
@@ -53,6 +58,12 @@ func resourceAlicloudThreatDetectionWebLockConfig() *schema.Resource {
 			},
 			"local_backup_dir": {
 				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"lang": {
+				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Type:     schema.TypeString,
 			},
@@ -88,15 +99,21 @@ func resourceAlicloudThreatDetectionWebLockConfigCreate(d *schema.ResourceData, 
 	if v, ok := d.GetOk("exclusive_file_type"); ok {
 		request["ExclusiveFileType"] = v
 	}
+	if v, ok := d.GetOk("inclusive_file"); ok {
+		request["InclusiveFile"] = v
+	}
 	if v, ok := d.GetOk("inclusive_file_type"); ok {
 		request["InclusiveFileType"] = v
+	}
+	if v, ok := d.GetOk("lang"); ok {
+		request["Lang"] = v
 	}
 	request["LocalBackupDir"] = d.Get("local_backup_dir")
 	request["Mode"] = d.Get("mode")
 	request["Uuid"] = d.Get("uuid")
 
 	var response map[string]interface{}
-	action := "ModifyWebLockStart"
+	action := "ModifyWebLockCreateConfig"
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
 		resp, err := client.RpcPost("Sas", "2018-12-03", action, nil, request, false)
@@ -139,6 +156,7 @@ func resourceAlicloudThreatDetectionWebLockConfigRead(d *schema.ResourceData, me
 	d.Set("exclusive_dir", object["ExclusiveDir"])
 	d.Set("exclusive_file", object["ExclusiveFile"])
 	d.Set("exclusive_file_type", object["ExclusiveFileType"])
+	d.Set("inclusive_file", object["InclusiveFile"])
 	d.Set("inclusive_file_type", object["InclusiveFileType"])
 	d.Set("local_backup_dir", object["LocalBackupDir"])
 	d.Set("mode", object["Mode"])

--- a/alicloud/resource_alicloud_threat_detection_web_lock_config_test.go
+++ b/alicloud/resource_alicloud_threat_detection_web_lock_config_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Case 1
-func TestAccAlicloudThreatDetectionWebLockConfig_basic1875(t *testing.T) {
+func TestAccAliCloudThreatDetectionWebLockConfig_basic1875(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_threat_detection_web_lock_config.default"
 	ra := resourceAttrInit(resourceId, AlicloudThreatDetectionWebLockConfigMap1875)
@@ -33,27 +33,36 @@ func TestAccAlicloudThreatDetectionWebLockConfig_basic1875(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"inclusive_file_type": "php;jsp;asp;aspx;js;cgi;html;htm;xml;shtml;shtm;jpg",
+					"inclusive_file":      "/tmp/include.txt",
+					"lang":                "zh",
 					"uuid":                "${data.alicloud_threat_detection_assets.default.ids.0}",
 					"mode":                "whitelist",
 					"local_backup_dir":    "/usr/local/aegis/bak",
 					"dir":                 "/tmp/",
 					"defence_mode":        "audit",
+					"exclusive_dir":       "",
+					"exclusive_file":      "",
+					"exclusive_file_type": "",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"inclusive_file_type": "php;jsp;asp;aspx;js;cgi;html;htm;xml;shtml;shtm;jpg",
+						"inclusive_file":      "/tmp/include.txt",
 						"uuid":                CHECKSET,
 						"mode":                "whitelist",
 						"local_backup_dir":    "/usr/local/aegis/bak",
 						"dir":                 "/tmp/",
 						"defence_mode":        "audit",
+						"exclusive_dir":       "",
+						"exclusive_file":      "",
+						"exclusive_file_type": "",
 					}),
 				),
 			}, {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"lang"},
 			},
 		},
 	})

--- a/website/docs/d/threat_detection_web_lock_configs.html.markdown
+++ b/website/docs/d/threat_detection_web_lock_configs.html.markdown
@@ -48,6 +48,7 @@ The following attributes are exported in addition to the arguments listed above:
   * `exclusive_dir` - The directory that has web tamper proofing disabled.
   * `exclusive_file` - The file that has web tamper proofing disabled. **Note:** If the value of `mode` is `blacklist`, this parameter is returned.
   * `exclusive_file_type` - The type of the file that has web tamper proofing disabled. **Note:** If the value of `mode` is `blacklist`, this parameter is returned.
+  * `inclusive_file` - The files that have web tamper proofing enabled. **Note:** If the value of `mode` is `whitelist`, this parameter is returned.
   * `inclusive_file_type` - The type of the file that has web tamper proofing enabled. **Note:** If the value of `mode` is `whitelist`, this parameter is returned.
   * `local_backup_dir` - The local path to the backup files of the protected directory.
   * `mode` - The protection mode of web tamper proofing. 

--- a/website/docs/r/threat_detection_web_lock_config.html.markdown
+++ b/website/docs/r/threat_detection_web_lock_config.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Provides a Threat Detection Web Lock Config resource.
 
-For information about Threat Detection Web Lock Config and how to use it, see [What is Web Lock Config](https://www.alibabacloud.com/help/en/security-center/developer-reference/api-sas-2018-12-03-modifyweblockstart).
+For information about Threat Detection Web Lock Config and how to use it, see [What is Web Lock Config](https://www.alibabacloud.com/help/en/security-center/developer-reference/api-sas-2018-12-03-modifyweblockcreateconfig).
 
 -> **NOTE:** Available since v1.195.0.
 
@@ -31,6 +31,8 @@ data "alicloud_threat_detection_assets" "default" {
 }
 resource "alicloud_threat_detection_web_lock_config" "default" {
   inclusive_file_type = "php;jsp;asp;aspx;js;cgi;html;htm;xml;shtml;shtm;jpg"
+  inclusive_file      = "/tmp/include.txt"
+  lang                = "zh"
   uuid                = data.alicloud_threat_detection_assets.default.ids.0
   mode                = "whitelist"
   local_backup_dir    = "/usr/local/aegis/bak"
@@ -44,15 +46,17 @@ resource "alicloud_threat_detection_web_lock_config" "default" {
 ## Argument Reference
 
 The following arguments are supported:
-* `defence_mode` - (Required,ForceNew) Protection mode. Value:-**block**: Intercept-**audit**: Alarm
-* `dir` - (Required,ForceNew) Specify the protection directory.
-* `exclusive_dir` - (ForceNew,Optional) Specify a directory address that does not require Web tamper protection (I. E. Excluded directories).> The protection Mode **Mode** is set to **blacklist**, you need to configure this parameter.
-* `exclusive_file` - (ForceNew,Optional) Specify files that do not need to enable tamper protection for web pages (that is, exclude files).> The protection Mode **Mode** is set to **blacklist**, you need to configure this parameter.
-* `exclusive_file_type` - (ForceNew,Optional) Specify the type of file that does not require Web tamper protection (that is, the type of excluded file). When there are multiple file types, use semicolons (;) separation. Value:-php-jsp-asp-aspx-js-cgi-html-htm-xml-shtml-shtm-jpg-gif-png > The protection Mode **Mode** is set to **blacklist**, you need to configure this parameter.
-* `inclusive_file_type` - (ForceNew,Optional) Specify the type of file that requires tamper protection. When there are multiple file types, use semicolons (;) separation. Value:-php-jsp-asp-aspx-js-cgi-html-htm-xml-shtml-shtm-jpg-gif-png> The protection Mode **Mode** is set to **whitelist**, you need to configure this parameter.
-* `local_backup_dir` - (Required,ForceNew) The local backup path is used to protect the safe backup of the Directory.
-* `mode` - (Required,ForceNew) Specify the protected directory mode. Value:-**whitelist**: whitelist mode, which protects the added protected directories and file types.-**blacklist**: blacklist mode, which protects all unexcluded subdirectories, file types, and specified files under the added protection directory.
-* `uuid` - (Required,ForceNew) Specify the UUID of the server to which you want to add a protection directory.> You can call the [DescribeCloudCenterInstances](~~ 141932 ~~) interface to obtain the UUID of the server.
+* `defence_mode` - (Required, ForceNew) Protection mode. Value:-**block**: Intercept-**audit**: Alarm
+* `dir` - (Required, ForceNew) Specify the protection directory.
+* `exclusive_dir` - (ForceNew, Optional) Specify a directory address that does not require Web tamper protection (I. E. Excluded directories).> The protection Mode **Mode** is set to **blacklist**, you need to configure this parameter.
+* `exclusive_file` - (ForceNew, Optional) Specify files that do not need to enable tamper protection for web pages (that is, exclude files).> The protection Mode **Mode** is set to **blacklist**, you need to configure this parameter.
+* `exclusive_file_type` - (ForceNew, Optional) Specify the type of file that does not require Web tamper protection (that is, the type of excluded file). When there are multiple file types, use semicolons (;) separation. Value:-php-jsp-asp-aspx-js-cgi-html-htm-xml-shtml-shtm-jpg-gif-png > The protection Mode **Mode** is set to **blacklist**, you need to configure this parameter.
+* `inclusive_file` - (ForceNew, Optional) The files that require tamper protection. When the protection mode **Mode** is set to **whitelist**, you need to configure this parameter.
+* `inclusive_file_type` - (ForceNew, Optional) Specify the type of file that requires tamper protection. When there are multiple file types, use semicolons (;) separation. Value:-php-jsp-asp-aspx-js-cgi-html-htm-xml-shtml-shtm-jpg-gif-png> The protection Mode **Mode** is set to **whitelist**, you need to configure this parameter.
+* `lang` - (ForceNew, Optional, Computed) The language of the content within the request and the response. Valid values: `zh`, `en`.
+* `local_backup_dir` - (Required, ForceNew) The local backup path is used to protect the safe backup of the Directory.
+* `mode` - (Required, ForceNew) Specify the protected directory mode. Value:-**whitelist**: whitelist mode, which protects the added protected directories and file types.-**blacklist**: blacklist mode, which protects all unexcluded subdirectories, file types, and specified files under the added protection directory.
+* `uuid` - (Required, ForceNew) Specify the UUID of the server to which you want to add a protection directory.> You can call the [DescribeCloudCenterInstances](~~ 141932 ~~) interface to obtain the UUID of the server.
 
 
 


### PR DESCRIPTION
## Summary

Add `lang` and `inclusive_file` attributes to the `alicloud_threat_detection_web_lock_config` resource and the `alicloud_threat_detection_web_lock_configs` data source.

The Create operation now calls `ModifyWebLockCreateConfig` (which accepts both `InclusiveFile` and `Lang` parameters) instead of `ModifyWebLockStart`. The Read operation reads back `inclusive_file` from the `DescribeWebLockConfigList` response.

## Changes

- Add `inclusive_file` (Optional, ForceNew) to the resource schema
- Add `lang` (Optional, Computed, ForceNew) to the resource schema
- Switch Create action from `ModifyWebLockStart` to `ModifyWebLockCreateConfig`
- Read back `inclusive_file` in the Read operation
- Add `inclusive_file` to the data source `configs` output
- Update resource and data source documentation
- Update test cases to cover the new attributes and fix `TestAccAliCloud` casing

## Test Cases

Remote acceptance test verification in progress.