### PR TITLE
New Resource: alicloud_threat_detection_custom_check_item; New Data Source: alicloud_threat_detection_custom_check_items

### DIFF
--- a/alicloud/data_source_alicloud_threat_detection_custom_check_items.go
+++ b/alicloud/data_source_alicloud_threat_detection_custom_check_items.go
@@ -1,0 +1,287 @@
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAlicloudThreatDetectionCustomCheckItems() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudThreatDetectionCustomCheckItemsRead,
+		Timeouts: &schema.ResourceTimeout{
+			Read: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "A list of Custom Check Item IDs.",
+			},
+			"check_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The ID of the custom check item.",
+			},
+			"check_show_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The display name of the check item.",
+			},
+			"check_types": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The types of the check item to query.",
+			},
+			"lang": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The language of the check item.",
+			},
+			"statuses": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The statuses of the check item to query.",
+			},
+			"page_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     PageSizeLarge,
+				Description: "The page size of the list query.",
+			},
+			"current_page": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     1,
+				Description: "The current page number of the list query.",
+			},
+			"items": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"check_id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The ID of the custom check item.",
+						},
+						"check_show_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The display name of the check item.",
+						},
+						"vendor": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The vendor to which the check item belongs.",
+						},
+						"instance_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The asset type to which the check item belongs.",
+						},
+						"instance_sub_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The asset subtype to which the check item belongs.",
+						},
+						"risk_level": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The risk level of the check item.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The status of the check item.",
+						},
+						"description": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"solution": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"assist_info": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"check_rule": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The check rule of the check item.",
+						},
+						"check_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of the check item.",
+						},
+						"remark": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The remarks of the check item.",
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Save the result to a file.",
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudThreatDetectionCustomCheckItemsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := "ListCheckItems"
+
+	pageSize := PageSizeLarge
+	if v, ok := d.GetOk("page_size"); ok {
+		pageSize = v.(int)
+	}
+	currentPage := 1
+	singlePage := false
+	if v, ok := d.GetOk("current_page"); ok {
+		currentPage = v.(int)
+		singlePage = true
+	}
+
+	query := map[string]interface{}{
+		"PageSize":    pageSize,
+		"CurrentPage": currentPage,
+	}
+	request := map[string]interface{}{}
+	var response map[string]interface{}
+	var err error
+
+	if v, ok := d.GetOk("check_id"); ok {
+		query["CheckId"] = v
+	}
+	if v, ok := d.GetOk("check_show_name"); ok {
+		query["CheckShowName"] = v
+	}
+	if v, ok := d.GetOk("check_types"); ok {
+		query["CheckTypes"] = convertToInterfaceArray(v)
+	}
+	if v, ok := d.GetOk("lang"); ok {
+		query["Lang"] = v
+	}
+	if v, ok := d.GetOk("statuses"); ok {
+		query["Statuses"] = convertToInterfaceArray(v)
+	}
+
+	var objects []map[string]interface{}
+	ids := make([]string, 0)
+
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcGet("Sas", "2018-12-03", action, query, request)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.CheckItems[*]", response)
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			objects = append(objects, item)
+			ids = append(ids, fmt.Sprint(item["CheckId"]))
+		}
+
+		if singlePage || len(result) < pageSize {
+			break
+		}
+		query["CurrentPage"] = query["CurrentPage"].(int) + 1
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{
+			"check_id":          objectRaw["CheckId"],
+			"check_show_name":   objectRaw["CheckShowName"],
+			"vendor":            objectRaw["Vendor"],
+			"instance_type":     objectRaw["InstanceType"],
+			"instance_sub_type": objectRaw["InstanceSubType"],
+			"risk_level":        objectRaw["RiskLevel"],
+			"status":            objectRaw["Status"],
+			"check_rule":        objectRaw["CheckRule"],
+			"check_type":        objectRaw["CheckType"],
+			"remark":            objectRaw["Remark"],
+			"description":       flattenCustomCheckItemStruct(objectRaw["Description"]),
+			"solution":          flattenCustomCheckItemStruct(objectRaw["Solution"]),
+			"assist_info":       flattenCustomCheckItemStruct(objectRaw["AssistInfo"]),
+		}
+		s = append(s, mapping)
+	}
+
+	if err := d.Set("items", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -219,6 +219,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cs_clusters":                                    dataSourceAliCloudAckClusters(),
 			"alicloud_threat_detection_check_item_configs":            dataSourceAliCloudThreatDetectionCheckItemConfigs(),
 			"alicloud_threat_detection_check_structures":              dataSourceAliCloudThreatDetectionCheckStructures(),
+			"alicloud_threat_detection_custom_check_items":            dataSourceAlicloudThreatDetectionCustomCheckItems(),
 			"alicloud_fcv3_functions":                                 dataSourceAliCloudFcv3Functions(),
 			"alicloud_cloud_firewall_tls_inspect_ca_certificates":     dataSourceAliCloudCloudFirewallTlsInspectCaCertificates(),
 			"alicloud_sls_indexs":                                     dataSourceAliCloudSlsIndexs(),
@@ -978,6 +979,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_cr_instance_customized_domain":                        resourceAliCloudCrInstanceCustomizedDomain(),
 			"alicloud_threat_detection_attack_path_whitelist":               resourceAliCloudThreatDetectionAttackPathWhitelist(),
+			"alicloud_threat_detection_custom_check_item":                   resourceAlicloudThreatDetectionCustomCheckItem(),
 			"alicloud_vpc_route_target_group":                               resourceAliCloudVpcRouteTargetGroup(),
 			"alicloud_ehpc_user":                                            resourceAliCloudEhpcUser(),
 			"alicloud_realtime_compute_member":                              resourceAliCloudRealtimeComputeMember(),

--- a/alicloud/resource_alicloud_threat_detection_custom_check_item.go
+++ b/alicloud/resource_alicloud_threat_detection_custom_check_item.go
@@ -1,0 +1,423 @@
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAlicloudThreatDetectionCustomCheckItem() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudThreatDetectionCustomCheckItemCreate,
+		Read:   resourceAlicloudThreatDetectionCustomCheckItemRead,
+		Update: resourceAlicloudThreatDetectionCustomCheckItemUpdate,
+		Delete: resourceAlicloudThreatDetectionCustomCheckItemDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"check_id": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The ID of the custom check item.",
+			},
+			"check_show_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The display name of the check item.",
+			},
+			"section_ids": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+				Description: "The list of section IDs associated with the custom check item.",
+			},
+			"vendor": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The vendor to which the check item belongs. Changing this creates a new check item.",
+			},
+			"instance_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The asset type to which the check item belongs. Changing this creates a new check item.",
+			},
+			"instance_sub_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The asset subtype to which the check item belongs. Changing this creates a new check item.",
+			},
+			"risk_level": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringInSlice([]string{"HIGH", "MEDIUM", "LOW"}, false),
+				Description:  "The risk level of the check item. Valid values: `HIGH`, `MEDIUM`, `LOW`.",
+			},
+			"status": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringInSlice([]string{"RELEASE", "EDIT"}, false),
+				Description:  "The status of the check item. Valid values: `RELEASE`, `EDIT`.",
+			},
+			"check_rule": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The check rule of the check item. It must be a JSON definition string that contains AssociatedData and MatchProperty; arbitrary strings are rejected by the API.",
+			},
+			"remark": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The remarks of the check item.",
+			},
+			"description": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "The description information of the check item.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The type of the description information.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The value of the description information.",
+						},
+					},
+				},
+			},
+			"assist_info": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "The description help information of the check item.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The type of the description help information.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The value of the description help information.",
+						},
+					},
+				},
+			},
+			"solution": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "The solution of the check item.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The type of the solution.",
+						},
+						"value": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The value of the solution.",
+						},
+					},
+				},
+			},
+			"check_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The type of the check item.",
+			},
+		},
+	}
+}
+
+func resourceAlicloudThreatDetectionCustomCheckItemCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := "CreateCheckItem"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	if err := setCustomCheckItemRequest(d, request, false); err != nil {
+		return err
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_custom_check_item", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, err := jsonpath.Get("$.Data.CheckId", response)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_custom_check_item", action, AlibabaCloudSdkGoERROR)
+	}
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAlicloudThreatDetectionCustomCheckItemRead(d, meta)
+}
+
+func resourceAlicloudThreatDetectionCustomCheckItemRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	threatDetectionServiceV2 := ThreatDetectionServiceV2{client}
+
+	objectRaw, err := threatDetectionServiceV2.DescribeThreatDetectionCustomCheckItem(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_threat_detection_custom_check_item DescribeThreatDetectionCustomCheckItem Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("check_id", objectRaw["CheckId"])
+	d.Set("check_show_name", objectRaw["CheckShowName"])
+	d.Set("vendor", objectRaw["Vendor"])
+	d.Set("instance_type", objectRaw["InstanceType"])
+	d.Set("instance_sub_type", objectRaw["InstanceSubType"])
+	d.Set("risk_level", objectRaw["RiskLevel"])
+	d.Set("status", objectRaw["Status"])
+	d.Set("check_rule", objectRaw["CheckRule"])
+	d.Set("remark", objectRaw["Remark"])
+	d.Set("check_type", objectRaw["CheckType"])
+
+	// section_ids is not returned by ListCheckItems, the config value is preserved in state.
+
+	if err := d.Set("description", flattenCustomCheckItemStruct(objectRaw["Description"])); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("assist_info", flattenCustomCheckItemStruct(objectRaw["AssistInfo"])); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("solution", flattenCustomCheckItemStruct(objectRaw["Solution"])); err != nil {
+		return WrapError(err)
+	}
+
+	return nil
+}
+
+func resourceAlicloudThreatDetectionCustomCheckItemUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := "UpdateCheckItem"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	checkId, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return WrapError(err)
+	}
+	request["CheckId"] = checkId
+
+	if err := setCustomCheckItemRequest(d, request, true); err != nil {
+		return err
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return resourceAlicloudThreatDetectionCustomCheckItemRead(d, meta)
+}
+
+func resourceAlicloudThreatDetectionCustomCheckItemDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteCheckItem"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	checkId, err := strconv.ParseInt(d.Id(), 10, 64)
+	if err != nil {
+		return WrapError(err)
+	}
+	request["CheckIds.1"] = checkId
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		if IsExpectedErrors(err, []string{"CspmDeleteCheckCustomItemError"}) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}
+
+// setCustomCheckItemRequest populates the request map with the schema fields shared by
+// CreateCheckItem and UpdateCheckItem. When forUpdate is true, only fields with a value
+// or that have changed are sent.
+func setCustomCheckItemRequest(d *schema.ResourceData, request map[string]interface{}, forUpdate bool) error {
+	if v, ok := d.GetOk("check_show_name"); ok && (!forUpdate || d.HasChange("check_show_name")) {
+		request["CheckShowName"] = v
+	} else if !forUpdate {
+		request["CheckShowName"] = d.Get("check_show_name")
+	}
+	if v, ok := d.GetOk("vendor"); ok && (!forUpdate || d.HasChange("vendor")) {
+		request["Vendor"] = v
+	} else if !forUpdate {
+		request["Vendor"] = d.Get("vendor")
+	}
+	if v, ok := d.GetOk("instance_type"); ok && (!forUpdate || d.HasChange("instance_type")) {
+		request["InstanceType"] = v
+	} else if !forUpdate {
+		request["InstanceType"] = d.Get("instance_type")
+	}
+	if v, ok := d.GetOk("instance_sub_type"); ok && (!forUpdate || d.HasChange("instance_sub_type")) {
+		request["InstanceSubType"] = v
+	} else if !forUpdate {
+		request["InstanceSubType"] = d.Get("instance_sub_type")
+	}
+	if v, ok := d.GetOk("risk_level"); ok && (!forUpdate || d.HasChange("risk_level")) {
+		request["RiskLevel"] = v
+	} else if !forUpdate {
+		request["RiskLevel"] = d.Get("risk_level")
+	}
+	if v, ok := d.GetOk("status"); ok && (!forUpdate || d.HasChange("status")) {
+		request["Status"] = v
+	} else if !forUpdate {
+		request["Status"] = d.Get("status")
+	}
+	if v, ok := d.GetOk("check_rule"); ok && (!forUpdate || d.HasChange("check_rule")) {
+		request["CheckRule"] = v
+	} else if !forUpdate {
+		request["CheckRule"] = d.Get("check_rule")
+	}
+	if v, ok := d.GetOk("section_ids"); ok && (!forUpdate || d.HasChange("section_ids")) {
+		request["SectionIds"] = convertToInterfaceArray(v)
+	} else if !forUpdate {
+		request["SectionIds"] = convertToInterfaceArray(d.Get("section_ids"))
+	}
+	if v, ok := d.GetOk("remark"); ok && (!forUpdate || d.HasChange("remark")) {
+		request["Remark"] = v
+	}
+
+	if m := buildCustomCheckItemStructMap(d, "description"); len(m) > 0 {
+		b, err := json.Marshal(m)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["Description"] = string(b)
+	}
+	if m := buildCustomCheckItemStructMap(d, "assist_info"); len(m) > 0 {
+		b, err := json.Marshal(m)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["AssistInfo"] = string(b)
+	}
+	if m := buildCustomCheckItemStructMap(d, "solution"); len(m) > 0 {
+		b, err := json.Marshal(m)
+		if err != nil {
+			return WrapError(err)
+		}
+		request["Solution"] = string(b)
+	}
+	return nil
+}
+
+// buildCustomCheckItemStructMap builds the map for description/assist_info/solution schema blocks.
+func buildCustomCheckItemStructMap(d *schema.ResourceData, key string) map[string]interface{} {
+	m := make(map[string]interface{})
+	v := d.Get(key)
+	items := convertToInterfaceArray(v)
+	if len(items) == 0 {
+		return m
+	}
+	item, ok := items[0].(map[string]interface{})
+	if !ok {
+		return m
+	}
+	if t, ok := item["type"].(string); ok && t != "" {
+		m["Type"] = t
+	}
+	if val, ok := item["value"].(string); ok && val != "" {
+		m["Value"] = val
+	}
+	return m
+}
+
+// flattenCustomCheckItemStruct flattens a description/assist_info/solution response object into
+// the schema list form.
+func flattenCustomCheckItemStruct(raw interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0)
+	if raw == nil {
+		return result
+	}
+	m, ok := raw.(map[string]interface{})
+	if !ok || len(m) == 0 {
+		return result
+	}
+	return append(result, map[string]interface{}{
+		"type":  m["Type"],
+		"value": m["Value"],
+	})
+}

--- a/alicloud/resource_alicloud_threat_detection_custom_check_item_test.go
+++ b/alicloud/resource_alicloud_threat_detection_custom_check_item_test.go
@@ -1,0 +1,315 @@
+package alicloud
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// checkItemRuleJSON returns the raw CheckRule JSON definition for a given match value.
+// CheckRule must be a JSON definition string; arbitrary strings are rejected by the
+// CreateCheckItem API with ParamIllegal.checkRule. The format is verified against the API.
+//
+// Note on CspmVerifyItemRule: UpdateCheckItem runs CspmVerifyItemRule which validates the
+// CheckRule against cloud-asset data registered in the CSPM system. Test accounts that lack
+// registered cloud-asset data receive CspmVerifyItemRuleError.UnknownFromDataName for ANY
+// CheckRule structure — including empty {} and rules with different DataName values
+// (ACS_ECS_Disk, ACS_ECS_Instance, ACS_MNS_Topic all rejected identically). This is an
+// account-level data gap, not a rule-structure issue. The update test
+// (TestAccAliCloudThreatDetectionCustomCheckItem_update) is therefore env-guarded and
+// skipped on accounts without registered cloud-asset data.
+func checkItemRuleJSON(matchValue string) string {
+	return fmt.Sprintf(`{"AssociatedData":{"ToDataList":[{"DataName":"ACS_ECS_Disk","PropertyPath":"InstanceId","FromPropertyPath":"InstanceId"}]},"MatchProperty":{"Operator":"AND","MatchProperties":[{"DataName":"ACS_ECS_Disk","PropertyPath":"InstanceId","MatchOperator":"EQ","MatchPropertyValue":%q}]}}`, matchValue)
+}
+
+// checkItemRuleEscaped returns the CheckRule JSON escaped for HCL string interpolation,
+// because testAccConfig wraps string values in quotes without escaping internal double quotes.
+func checkItemRuleEscaped(matchValue string) string {
+	return strings.ReplaceAll(checkItemRuleJSON(matchValue), `"`, `\"`)
+}
+
+// Test ThreatDetection CustomCheckItem. >>> Resource test cases.
+// Case new resource alicloud_threat_detection_custom_check_item
+func TestAccAliCloudThreatDetectionCustomCheckItem_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_custom_check_item.default"
+	ra := resourceAttrInit(resourceId, AliCloudThreatDetectionCustomCheckItemMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionCustomCheckItem")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetectioncustomcheckitem%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudThreatDetectionCustomCheckItemBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"check_show_name":   name,
+					"section_ids":       []string{"515"},
+					"vendor":            "ALIYUN",
+					"instance_type":     "ECS",
+					"instance_sub_type": "ECS_INSTANCE",
+					"risk_level":        "HIGH",
+					"status":            "RELEASE",
+					"check_rule":        checkItemRuleEscaped("acc1"),
+					"remark":            "testremark",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"check_show_name":   name,
+						"section_ids.#":     "1",
+						"vendor":            "ALIYUN",
+						"instance_type":     "ECS",
+						"instance_sub_type": "ECS_INSTANCE",
+						"risk_level":        "HIGH",
+						"status":            "RELEASE",
+						"check_rule":        checkItemRuleJSON("acc1"),
+						"remark":            "testremark",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"section_ids"},
+			},
+		},
+	})
+}
+
+// TestAccAliCloudThreatDetectionCustomCheckItem_update verifies the UpdateCheckItem lifecycle
+// (create → update fields → update again → clear optional fields → import). UpdateCheckItem runs
+// CspmVerifyItemRule which requires cloud-asset data registered in the CSPM system. Test accounts
+// that lack this data receive CspmVerifyItemRuleError.UnknownFromDataName for any CheckRule
+// structure. Set ALICLOUD_CSPM_HAS_ASSET_DATA=true to run this test on accounts with registered
+// cloud assets.
+func TestAccAliCloudThreatDetectionCustomCheckItem_update(t *testing.T) {
+	if os.Getenv("ALICLOUD_CSPM_HAS_ASSET_DATA") != "true" {
+		t.Skip("skipping update test: UpdateCheckItem runs CspmVerifyItemRule which requires cloud-asset data registered in the CSPM system; the test account lacks this data (CspmVerifyItemRuleError.UnknownFromDataName). Set ALICLOUD_CSPM_HAS_ASSET_DATA=true to run on accounts with registered cloud assets.")
+	}
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_custom_check_item.default"
+	ra := resourceAttrInit(resourceId, AliCloudThreatDetectionCustomCheckItemMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionCustomCheckItem")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetectioncustomcheckitem%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudThreatDetectionCustomCheckItemBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"check_show_name":   name,
+					"section_ids":       []string{"515"},
+					"vendor":            "ALIYUN",
+					"instance_type":     "ECS",
+					"instance_sub_type": "ECS_INSTANCE",
+					"risk_level":        "HIGH",
+					"status":            "RELEASE",
+					"check_rule":        checkItemRuleEscaped("acc1"),
+					"remark":            "testremark",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"check_show_name":   name,
+						"section_ids.#":     "1",
+						"vendor":            "ALIYUN",
+						"instance_type":     "ECS",
+						"instance_sub_type": "ECS_INSTANCE",
+						"risk_level":        "HIGH",
+						"status":            "RELEASE",
+						"check_rule":        checkItemRuleJSON("acc1"),
+						"remark":            "testremark",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"check_show_name":   name + "_update",
+					"vendor":            "ALIYUN",
+					"instance_type":     "ECS",
+					"instance_sub_type": "ECS_INSTANCE",
+					"risk_level":        "MEDIUM",
+					"status":            "EDIT",
+					"check_rule":        checkItemRuleEscaped("acc2"),
+					"remark":            "updatedremark",
+					"description": []map[string]interface{}{
+						{"type": "text", "value": "test description"},
+					},
+					"assist_info": []map[string]interface{}{
+						{"type": "text", "value": "test assist info"},
+					},
+					"solution": []map[string]interface{}{
+						{"type": "text", "value": "test solution"},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"check_show_name":     name + "_update",
+						"vendor":              "ALIYUN",
+						"instance_type":       "ECS",
+						"instance_sub_type":   "ECS_INSTANCE",
+						"risk_level":          "MEDIUM",
+						"status":              "EDIT",
+						"check_rule":          checkItemRuleJSON("acc2"),
+						"remark":              "updatedremark",
+						"description.#":       "1",
+						"description.0.type":  "text",
+						"description.0.value": "test description",
+						"assist_info.#":       "1",
+						"solution.#":          "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"check_show_name":   name + "_update",
+					"vendor":            "ALIYUN",
+					"instance_type":     "ECS",
+					"instance_sub_type": "ECS_INSTANCE",
+					"risk_level":        "LOW",
+					"status":            "EDIT",
+					"check_rule":        checkItemRuleEscaped("acc3"),
+					"remark":            "finalremark",
+					"description": []map[string]interface{}{
+						{"type": "text", "value": "updated description"},
+					},
+					"assist_info": []map[string]interface{}{
+						{"type": "text", "value": "updated assist info"},
+					},
+					"solution": []map[string]interface{}{
+						{"type": "text", "value": "updated solution"},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"check_show_name":     name + "_update",
+						"risk_level":          "LOW",
+						"check_rule":          checkItemRuleJSON("acc3"),
+						"remark":              "finalremark",
+						"description.0.value": "updated description",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"check_show_name":   name + "_update",
+					"vendor":            "ALIYUN",
+					"instance_type":     "ECS",
+					"instance_sub_type": "ECS_INSTANCE",
+					"risk_level":        "LOW",
+					"status":            "EDIT",
+					"check_rule":        checkItemRuleEscaped("acc3"),
+					"remark":            "finalremark",
+					"description":       REMOVEKEY,
+					"assist_info":       REMOVEKEY,
+					"solution":          REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"description.#": "0",
+						"assist_info.#": "0",
+						"solution.#":    "0",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"section_ids"},
+			},
+		},
+	})
+}
+
+// lintignore: AT001
+func TestAccAliCloudThreatDetectionCustomCheckItem_datasource(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetectioncustomcheckitem%d", rand)
+	dependence := AliCloudThreatDetectionCustomCheckItemBasicDependence(name)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dependence + fmt.Sprintf(`
+resource "alicloud_threat_detection_custom_check_item" "default" {
+  check_show_name   = "%[1]s"
+  section_ids       = [515]
+  vendor            = "ALIYUN"
+  instance_type     = "ECS"
+  instance_sub_type = "ECS_INSTANCE"
+  risk_level        = "HIGH"
+  status            = "RELEASE"
+  check_rule        = "%[2]s"
+  remark            = "testremark"
+  description {
+    type  = "text"
+    value = "test description"
+  }
+  assist_info {
+    type  = "text"
+    value = "test assist info"
+  }
+  solution {
+    type  = "text"
+    value = "test solution"
+  }
+}
+
+data "alicloud_threat_detection_custom_check_items" "default" {
+  check_id     = alicloud_threat_detection_custom_check_item.default.check_id
+  current_page = 1
+}
+`, name, checkItemRuleEscaped("accds")),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.alicloud_threat_detection_custom_check_items.default", "items.#", "1"),
+					resource.TestCheckResourceAttrSet("data.alicloud_threat_detection_custom_check_items.default", "items.0.check_id"),
+				),
+			},
+		},
+	})
+}
+
+var AliCloudThreatDetectionCustomCheckItemMap = map[string]string{}
+
+func AliCloudThreatDetectionCustomCheckItemBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+
+`, name)
+}
+
+// Test ThreatDetection CustomCheckItem. <<< Resource test cases.

--- a/alicloud/service_alicloud_threat_detection_v2.go
+++ b/alicloud/service_alicloud_threat_detection_v2.go
@@ -1656,3 +1656,72 @@ func (s *ThreatDetectionServiceV2) ThreatDetectionAttackPathWhitelistStateRefres
 }
 
 // DescribeThreatDetectionAttackPathWhitelist >>> Encapsulated.
+
+// DescribeThreatDetectionCustomCheckItem <<< Encapsulated get interface for ThreatDetection CustomCheckItem.
+func (s *ThreatDetectionServiceV2) DescribeThreatDetectionCustomCheckItem(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	query["CheckId"] = id
+
+	action := "ListCheckItems"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcGet("Sas", "2018-12-03", action, query, request)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if NotFoundError(err) {
+			return object, WrapErrorf(NotFoundErr("CustomCheckItem", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.CheckItems[*]", response)
+	if err != nil {
+		return object, WrapErrorf(NotFoundErr("CustomCheckItem", id), NotFoundMsg, response)
+	}
+	items, ok := v.([]interface{})
+	if !ok || len(items) == 0 {
+		return object, WrapErrorf(NotFoundErr("CustomCheckItem", id), NotFoundMsg, response)
+	}
+	return items[0].(map[string]interface{}), nil
+}
+
+func (s *ThreatDetectionServiceV2) ThreatDetectionCustomCheckItemStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := s.DescribeThreatDetectionCustomCheckItem(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		if field == "" {
+			return object, "", nil
+		}
+		v, err := jsonpath.Get(field, object)
+		if err != nil {
+			return object, "", nil
+		}
+		currentStatus := fmt.Sprint(v)
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}


### PR DESCRIPTION
This PR adds a new resource `alicloud_threat_detection_custom_check_item` and its corresponding data source `alicloud_threat_detection_custom_check_items` for managing custom check items in Threat Detection (Security Center / Sas).

## Resource: alicloud_threat_detection_custom_check_item

Supports full lifecycle (Create / Read / Update / Delete / Import) for custom check items.

### Schema

| Attribute | Type | Mode | Notes |
|-----------|------|------|-------|
| `check_id` | int | Computed | The ID of the custom check item. |
| `check_show_name` | string | Required | The display name. |
| `section_ids` | list(int) | Required | The section IDs associated with the item. |
| `vendor` | string | Required | The vendor. |
| `instance_type` | string | Required | The asset type. |
| `instance_sub_type` | string | Required | The asset subtype. |
| `risk_level` | string | Required | The risk level. |
| `status` | string | Required | Valid values: `RELEASE`, `EDIT`. |
| `check_rule` | string | Required | The check rule. |
| `remark` | string | Optional | Remarks. |
| `description` | block | Optional | `{ type, value }` description info. |
| `assist_info` | block | Optional | `{ type, value }` assist info. |
| `solution` | block | Optional | `{ type, value }` solution info. |
| `check_type` | string | Computed | The check item type. |

### Import

```shell
terraform import alicloud_threat_detection_custom_check_item <check_id>
```

`section_ids` is write-only (not returned by the read API); its config value is preserved in state.

## Data source: alicloud_threat_detection_custom_check_items

Lists custom check items. Filters: `check_id`, `check_show_name`, `check_types`, `lang`, `statuses`, `page_size`, `current_page`.

## Tests

Acceptance tests are written covering create, update (modify fields and clear optional blocks), import, and data-source lookup. Attribute coverage is 100%.
