### PR TITLE
New Resource: alicloud_threat_detection_web_lock_bind

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -2103,6 +2103,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ga_basic_accelerate_ip_endpoint_relation":              resourceAlicloudGaBasicAccelerateIpEndpointRelation(),
 			"alicloud_vpc_gateway_route_table_attachment":                    resourceAliCloudVpcGatewayRouteTableAttachment(),
 			"alicloud_threat_detection_web_lock_config":                      resourceAlicloudThreatDetectionWebLockConfig(),
+			"alicloud_threat_detection_web_lock_bind":                        resourceAlicloudThreatDetectionWebLockBind(),
 			"alicloud_threat_detection_backup_policy":                        resourceAlicloudThreatDetectionBackupPolicy(),
 			"alicloud_dms_enterprise_proxy_access":                           resourceAlicloudDmsEnterpriseProxyAccess(),
 			"alicloud_threat_detection_vul_whitelist":                        resourceAlicloudThreatDetectionVulWhitelist(),

--- a/alicloud/resource_alicloud_threat_detection_web_lock_bind.go
+++ b/alicloud/resource_alicloud_threat_detection_web_lock_bind.go
@@ -1,0 +1,372 @@
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAlicloudThreatDetectionWebLockBind() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudThreatDetectionWebLockBindCreate,
+		Read:   resourceAlicloudThreatDetectionWebLockBindRead,
+		Update: resourceAlicloudThreatDetectionWebLockBindUpdate,
+		Delete: resourceAlicloudThreatDetectionWebLockBindDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"defence_mode": {
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"block", "audit"}, false),
+				Type:         schema.TypeString,
+			},
+			"dir": {
+				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"exclusive_dir": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"exclusive_file": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"exclusive_file_type": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"inclusive_file_type": {
+				Optional: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"lang": {
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"zh", "en"}, false),
+				Type:         schema.TypeString,
+			},
+			"local_backup_dir": {
+				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+			"mode": {
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"whitelist", "blacklist"}, false),
+				Type:         schema.TypeString,
+			},
+			"status": {
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"on", "off"}, false),
+				Type:         schema.TypeString,
+			},
+			"uuid": {
+				Required: true,
+				ForceNew: true,
+				Type:     schema.TypeString,
+			},
+		},
+	}
+}
+
+func resourceAlicloudThreatDetectionWebLockBindCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	request := make(map[string]interface{})
+
+	request["DefenceMode"] = d.Get("defence_mode")
+	request["Dir"] = d.Get("dir")
+	// ExclusiveDir and ExclusiveFile are rejected with IllegalParam unless sent
+	// as JSON array strings (verified against the live API).
+	if v, ok := d.GetOk("exclusive_dir"); ok {
+		request["ExclusiveDir"] = webLockBindToJsonArray(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("exclusive_file"); ok {
+		request["ExclusiveFile"] = webLockBindToJsonArray(v.([]interface{}))
+	}
+	if v, ok := d.GetOk("exclusive_file_type"); ok {
+		request["ExclusiveFileType"] = v
+	}
+	if v, ok := d.GetOk("inclusive_file_type"); ok {
+		request["InclusiveFileType"] = v
+	}
+	request["LocalBackupDir"] = d.Get("local_backup_dir")
+	request["Mode"] = d.Get("mode")
+	request["Uuid"] = d.Get("uuid")
+
+	var response map[string]interface{}
+	action := "ModifyWebLockStart"
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err := resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
+		resp, err := client.RpcPost("Sas", "2018-12-03", action, nil, request, false)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"BindDataExist"}) {
+				return nil
+			}
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		response = resp
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_web_lock_bind", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(request["Uuid"]))
+
+	// status and lang are update-only fields (ModifyWebLockStatus); apply them
+	// after the bind is started so the desired state is reached in one apply.
+	if v, ok := d.GetOk("status"); ok {
+		if err := webLockBindUpdateStatus(client, d.Id(), fmt.Sprint(v), d.Get("lang")); err != nil {
+			return err
+		}
+	} else if v, ok := d.GetOk("lang"); ok {
+		if err := webLockBindUpdateStatus(client, d.Id(), "", fmt.Sprint(v)); err != nil {
+			return err
+		}
+	}
+
+	return resourceAlicloudThreatDetectionWebLockBindRead(d, meta)
+}
+
+func resourceAlicloudThreatDetectionWebLockBindRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	sasService := SasService{client}
+
+	object, err := sasService.DescribeThreatDetectionWebLockBind(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_threat_detection_web_lock_bind sasService.DescribeThreatDetectionWebLockBind Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+	d.Set("uuid", object["Uuid"])
+	d.Set("status", object["Status"])
+
+	// DescribeWebLockBindList only returns the bind status; the protection
+	// config (dir, mode, backup dir, file types, ...) is served by
+	// DescribeWebLockConfigList.
+	config, err := sasService.DescribeThreatDetectionWebLockConfig(d.Id())
+	if err != nil {
+		if NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_threat_detection_web_lock_bind sasService.DescribeThreatDetectionWebLockConfig Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+	d.Set("defence_mode", config["DefenceMode"])
+	d.Set("dir", config["Dir"])
+	d.Set("exclusive_dir", webLockBindFromJsonArray(config["ExclusiveDir"]))
+	d.Set("exclusive_file", webLockBindFromJsonArray(config["ExclusiveFile"]))
+	d.Set("exclusive_file_type", config["ExclusiveFileType"])
+	d.Set("inclusive_file_type", config["InclusiveFileType"])
+	d.Set("local_backup_dir", config["LocalBackupDir"])
+	d.Set("mode", config["Mode"])
+
+	return nil
+}
+
+func resourceAlicloudThreatDetectionWebLockBindUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	// ModifyWebLockStatus only updates status and lang; all other fields are
+	// ForceNew and trigger recreation.
+	if d.HasChange("status") || d.HasChange("lang") {
+		if err := webLockBindUpdateStatus(client, d.Id(), d.Get("status"), d.Get("lang")); err != nil {
+			return err
+		}
+	}
+
+	return resourceAlicloudThreatDetectionWebLockBindRead(d, meta)
+}
+
+func resourceAlicloudThreatDetectionWebLockBindDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	sasService := SasService{client}
+
+	if _, err := sasService.DescribeThreatDetectionWebLockBind(d.Id()); err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	// ModifyWebLockUnbind rejects the request with "StillOn" while the
+	// protection is still switched on; turn it off first and wait for the
+	// bind entry to report status=off.
+	if err := webLockBindUpdateStatus(client, d.Id(), "off", nil); err != nil {
+		if NotFoundError(err) || IsExpectedErrors(err, []string{"Asset not bind.", "AssetNotBind"}) {
+			return nil
+		}
+		return WrapError(err)
+	}
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"on"},
+		Target:     []string{"off"},
+		Refresh:    webLockBindStatusRefreshFunc(sasService, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	request := map[string]interface{}{
+		"Uuid": d.Id(),
+	}
+
+	action := "ModifyWebLockUnbind"
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err := resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutDelete)), func() *resource.RetryError {
+		resp, err := client.RpcPost("Sas", "2018-12-03", action, nil, request, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, resp, request)
+		return nil
+	})
+	if err != nil {
+		if NotFoundError(err) || IsExpectedErrors(err, []string{"Asset not bind.", "AssetNotBind"}) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	// Unbind is asynchronous: the bind entry keeps showing up in
+	// DescribeWebLockBindList for a while. Wait until it is really gone so an
+	// immediate re-create of the same server does not hit a stale entry.
+	removeConf := &resource.StateChangeConf{
+		Pending:    []string{"on", "off"},
+		Target:     []string{"removed"},
+		Refresh:    webLockBindRemovedRefreshFunc(sasService, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+	if _, err := removeConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+	return nil
+}
+
+// webLockBindRemovedRefreshFunc reports "removed" once the bind entry no
+// longer appears in DescribeWebLockBindList.
+func webLockBindRemovedRefreshFunc(sasService SasService, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := sasService.DescribeThreatDetectionWebLockBind(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "removed", nil
+			}
+			return nil, "", err
+		}
+		return object, fmt.Sprint(object["Status"]), nil
+	}
+}
+
+// webLockBindStatusRefreshFunc polls DescribeWebLockBindList for the bind
+// entry status; a missing entry is reported as "off" so deletion can proceed.
+func webLockBindStatusRefreshFunc(sasService SasService, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := sasService.DescribeThreatDetectionWebLockBind(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "off", nil
+			}
+			return nil, "", err
+		}
+		return object, fmt.Sprint(object["Status"]), nil
+	}
+}
+
+// webLockBindToJsonArray marshals a schema list into the JSON array string
+// form that ExclusiveDir/ExclusiveFile require.
+func webLockBindToJsonArray(list []interface{}) string {
+	items := make([]string, 0, len(list))
+	for _, item := range list {
+		items = append(items, fmt.Sprint(item))
+	}
+	out, _ := json.Marshal(items)
+	return string(out)
+}
+
+// webLockBindFromJsonArray decodes the JSON array string returned for
+// ExclusiveDir/ExclusiveFile back into a list; a non-empty plain string is
+// returned as a single-element list for robustness.
+func webLockBindFromJsonArray(v interface{}) []interface{} {
+	s := fmt.Sprint(v)
+	if s == "" || s == "<nil>" {
+		return nil
+	}
+	var items []interface{}
+	if err := json.Unmarshal([]byte(s), &items); err == nil {
+		return items
+	}
+	return []interface{}{s}
+}
+
+// webLockBindUpdateStatus calls ModifyWebLockStatus to update the protection
+// status and/or language of a web lock bind entry.
+func webLockBindUpdateStatus(client *connectivity.AliyunClient, id, status, lang interface{}) error {
+	request := map[string]interface{}{
+		"Uuid": id,
+	}
+	if status != nil && fmt.Sprint(status) != "" {
+		request["Status"] = status
+	}
+	if lang != nil && fmt.Sprint(lang) != "" {
+		request["Lang"] = lang
+	}
+
+	action := "ModifyWebLockStatus"
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		resp, err := client.RpcPost("Sas", "2018-12-03", action, nil, request, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, resp, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	return nil
+}

--- a/alicloud/resource_alicloud_threat_detection_web_lock_bind_test.go
+++ b/alicloud/resource_alicloud_threat_detection_web_lock_bind_test.go
@@ -1,0 +1,133 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudThreatDetectionWebLockBind_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_web_lock_bind.default"
+	ra := resourceAttrInit(resourceId, AlicloudThreatDetectionWebLockBindMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &SasService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionWebLockBind")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sThreatDetectionWebLockBind%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudThreatDetectionWebLockBindBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"inclusive_file_type": "php;jsp;asp;aspx;js;cgi;html;htm;xml;shtml;shtm;jpg",
+					"uuid":                "${data.alicloud_threat_detection_assets.default.ids.0}",
+					"mode":                "whitelist",
+					"local_backup_dir":    "/usr/local/aegis/bak",
+					"dir":                 "/tmp/",
+					"defence_mode":        "audit",
+					"status":              "on",
+					"lang":                "zh",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"inclusive_file_type": "php;jsp;asp;aspx;js;cgi;html;htm;xml;shtml;shtm;jpg",
+						"uuid":                CHECKSET,
+						"mode":                "whitelist",
+						"local_backup_dir":    "/usr/local/aegis/bak",
+						"dir":                 "/tmp/",
+						"defence_mode":        "audit",
+						"status":              "on",
+						"lang":                "zh",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"inclusive_file_type": "php;jsp;asp;aspx;js;cgi;html;htm;xml;shtml;shtm;jpg",
+					"uuid":                "${data.alicloud_threat_detection_assets.default.ids.0}",
+					"mode":                "whitelist",
+					"local_backup_dir":    "/usr/local/aegis/bak",
+					"dir":                 "/tmp/",
+					"defence_mode":        "audit",
+					"status":              "off",
+					"lang":                "en",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"inclusive_file_type": "php;jsp;asp;aspx;js;cgi;html;htm;xml;shtml;shtm;jpg",
+						"uuid":                CHECKSET,
+						"mode":                "whitelist",
+						"local_backup_dir":    "/usr/local/aegis/bak",
+						"dir":                 "/tmp/",
+						"defence_mode":        "audit",
+						"status":              "off",
+						"lang":                "en",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"uuid":                "${data.alicloud_threat_detection_assets.default.ids.0}",
+					"dir":                 "/tmp/",
+					"local_backup_dir":    "/usr/local/aegis/bak",
+					"defence_mode":        "audit",
+					"mode":                "blacklist",
+					"exclusive_dir":       []interface{}{"/tmp/logs"},
+					"exclusive_file_type": "jpg;gif;png",
+					"exclusive_file":      []interface{}{"/tmp/protected.db"},
+					"status":              "on",
+					"lang":                "zh",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"uuid":                CHECKSET,
+						"dir":                 "/tmp/",
+						"local_backup_dir":    "/usr/local/aegis/bak",
+						"defence_mode":        "audit",
+						"mode":                "blacklist",
+						"exclusive_dir.#":     "1",
+						"exclusive_dir.0":     "/tmp/logs",
+						"exclusive_file_type": "jpg;gif;png",
+						"exclusive_file.#":    "1",
+						"exclusive_file.0":    "/tmp/protected.db",
+						"status":              "on",
+						"lang":                "zh",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"lang"},
+			},
+		},
+	})
+}
+
+var AlicloudThreatDetectionWebLockBindMap = map[string]string{}
+
+func AlicloudThreatDetectionWebLockBindBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_threat_detection_assets" "default" {
+  machine_types = "ecs"
+}
+
+`, name)
+}

--- a/alicloud/service_alicloud_sas.go
+++ b/alicloud/service_alicloud_sas.go
@@ -143,6 +143,54 @@ func (s *SasService) DescribeThreatDetectionWebLockConfig(id string) (object map
 	return object, nil
 }
 
+func (s *SasService) DescribeThreatDetectionWebLockBind(id string) (object map[string]interface{}, err error) {
+	client := s.client
+
+	request := map[string]interface{}{
+		"Uuid": id,
+	}
+	request["CurrentPage"] = 1
+	request["PageSize"] = PageSizeLarge
+
+	var response map[string]interface{}
+	action := "DescribeWebLockBindList"
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		resp, err := client.RpcPost("Sas", "2018-12-03", action, nil, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		response = resp
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	v, err := jsonpath.Get("$.BindList", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.BindList", response)
+	}
+	result, _ := v.([]interface{})
+	if len(result) < 1 {
+		return object, WrapErrorf(NotFoundErr("WebLockBind", id), NotFoundWithResponse, response)
+	}
+	for _, item := range result {
+		if entry, ok := item.(map[string]interface{}); ok && fmt.Sprint(entry["Uuid"]) == id {
+			object = entry
+			break
+		}
+	}
+	if object == nil {
+		return object, WrapErrorf(NotFoundErr("WebLockBind", id), NotFoundWithResponse, response)
+	}
+	return object, nil
+}
+
 func (s *SasService) DescribeThreatDetectionBaselineStrategy(id string) (object map[string]interface{}, err error) {
 	client := s.client
 

--- a/website/docs/r/threat_detection_web_lock_bind.html.markdown
+++ b/website/docs/r/threat_detection_web_lock_bind.html.markdown
@@ -1,0 +1,77 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_web_lock_bind"
+sidebar_current: "docs-alicloud-resource-threat-detection-web-lock-bind"
+description: |-
+  Provides a Alicloud Threat Detection Web Lock Bind resource.
+---
+
+# alicloud_threat_detection_web_lock_bind
+
+Provides a Threat Detection Web Lock Bind resource.
+
+Bind a server to the web tamper proofing feature, configure the protected directories and file types, and manage the protection status.
+
+For information about Threat Detection Web Lock Bind and how to use it, see [ModifyWebLockStart](https://www.alibabacloud.com/help/en/security-center/developer-reference/api-sas-2018-12-03-modifyweblockstart).
+
+-> **NOTE:** Available since v1.248.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+data "alicloud_threat_detection_assets" "default" {
+  machine_types = "ecs"
+}
+
+resource "alicloud_threat_detection_web_lock_bind" "default" {
+  uuid                = data.alicloud_threat_detection_assets.default.ids.0
+  dir                 = "/tmp/"
+  mode                = "whitelist"
+  local_backup_dir    = "/usr/local/aegis/bak"
+  defence_mode        = "audit"
+  inclusive_file_type = "php;jsp;asp;aspx;js;cgi;html;htm;xml;shtml;shtm;jpg"
+  status              = "on"
+  lang                = "zh"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `uuid` - (Required, ForceNew) The UUID of the server to which the web tamper proofing feature is bound. You can call the [DescribeWebLockBindList](https://www.alibabacloud.com/help/en/security-center/developer-reference/api-sas-2018-12-03-describeweblockbindlist) operation to query the bound servers.
+* `dir` - (Required, ForceNew) The protected directory. Separate multiple directories with commas (,).
+* `local_backup_dir` - (Required, ForceNew) The local backup path used to safely back up the protected directory.
+* `mode` - (Required, ForceNew) The protected directory mode. Valid values: `whitelist`, `blacklist`.
+* `defence_mode` - (Required, ForceNew) The protection mode. Valid values: `block`, `audit`.
+* `exclusive_dir` - (Optional, ForceNew, List) The excluded directories that do not require web tamper protection. Required when `mode` is `blacklist`.
+* `exclusive_file_type` - (Optional, ForceNew) The excluded file types that do not require web tamper protection. Separate multiple file types with semicolons (;). Required when `mode` is `blacklist`.
+* `inclusive_file_type` - (Optional, ForceNew) The file types that require tamper protection. Separate multiple file types with semicolons (;). Required when `mode` is `whitelist`.
+* `exclusive_file` - (Optional, ForceNew, List) The excluded files that do not require web tamper protection. Required when `mode` is `blacklist`.
+* `status` - (Optional) The protection status of the server. Valid values: `on`, `off`.
+* `lang` - (Optional) The language type of the request and response. Valid values: `zh`, `en`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource, which is the `uuid` of the bound server.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 5 mins) Used when creating the Web Lock Bind.
+* `update` - (Defaults to 5 mins) Used when updating the Web Lock Bind.
+* `delete` - (Defaults to 5 mins) Used when deleting the Web Lock Bind.
+
+## Import
+
+Threat Detection Web Lock Bind can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_threat_detection_web_lock_bind.example <uuid>
+```


### PR DESCRIPTION
This PR adds a new resource `alicloud_threat_detection_web_lock_bind` to bind servers to the web tamper proofing feature of Alibaba Cloud Security Center (Sas).

## What

The new resource manages the full lifecycle of a web lock bind entry:

- **Create** — `ModifyWebLockStart`: bind a server to web tamper proofing with the specified protected directory, mode (`whitelist`/`blacklist`), defence mode (`block`/`audit`), backup directory, and inclusive/exclusive file types and files.
- **Read** — `DescribeWebLockBindList` (filtered by `Uuid`): refresh the bound server state.
- **Update** — `ModifyWebLockStatus`: update the protection status (`on`/`off`) and language (`zh`/`en`) in place.
- **Delete** — `ModifyWebLockUnbind`: unbind the server.

## Schema

| Argument | Type | Required | ForceNew | Notes |
|----------|------|----------|----------|-------|
| `uuid` | string | yes | yes | Server UUID to bind |
| `dir` | string | yes | yes | Protected directory |
| `local_backup_dir` | string | yes | yes | Local backup path |
| `mode` | string | yes | yes | `whitelist` / `blacklist` |
| `defence_mode` | string | yes | yes | `block` / `audit` |
| `exclusive_dir` | string | no | yes | Excluded directory (blacklist) |
| `exclusive_file_type` | string | no | yes | Excluded file types (blacklist) |
| `inclusive_file_type` | string | no | yes | Protected file types (whitelist) |
| `exclusive_file` | string | no | yes | Excluded files (blacklist) |
| `status` | string | no | no | Protection status: `on` / `off` |
| `lang` | string | no | no | Language: `zh` / `en` |

## Test

`TestAccAliCloudThreatDetectionWebLockBind_basic` covers create with all arguments (whitelist mode), in-place update of `status` and `lang`, ForceNew recreation in blacklist mode with exclusive dir/file lists, and import verify.

Acceptance test result (remote):

```
=== RUN   TestAccAliCloudThreatDetectionWebLockBind_basic
--- PASS: TestAccAliCloudThreatDetectionWebLockBind_basic (55.55s)
```

## Documentation

- Resource doc added at `website/docs/r/threat_detection_web_lock_bind.html.markdown`.
- Imported using `terraform import alicloud_threat_detection_web_lock_bind.example <uuid>`.
