### PR TITLE
resource/alicloud_threat_detection_client_file_protect: add platform attribute

### DIFF
--- a/alicloud/resource_alicloud_threat_detection_client_file_protect.go
+++ b/alicloud/resource_alicloud_threat_detection_client_file_protect.go
@@ -41,6 +41,13 @@ func resourceAliCloudThreatDetectionClientFileProtect() *schema.Resource {
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"platform": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"windows", "linux"}, false),
+			},
 			"proc_paths": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -105,6 +112,9 @@ func resourceAliCloudThreatDetectionClientFileProtectCreate(d *schema.ResourceDa
 	if v, ok := d.GetOk("switch_id"); ok {
 		request["SwitchId"] = v
 	}
+	if v, ok := d.GetOk("platform"); ok {
+		request["Platform"] = v
+	}
 	if v, ok := d.GetOk("status"); ok {
 		request["Status"] = v
 	} else {
@@ -153,6 +163,7 @@ func resourceAliCloudThreatDetectionClientFileProtectRead(d *schema.ResourceData
 	d.Set("rule_name", objectRaw["RuleName"])
 	d.Set("status", objectRaw["Status"])
 	d.Set("switch_id", objectRaw["SwitchId"])
+	d.Set("platform", objectRaw["Platform"])
 	fileOps1Raw := make([]interface{}, 0)
 	if objectRaw["FileOps"] != nil {
 		fileOps1Raw = objectRaw["FileOps"].([]interface{})

--- a/alicloud/resource_alicloud_threat_detection_client_file_protect_test.go
+++ b/alicloud/resource_alicloud_threat_detection_client_file_protect_test.go
@@ -44,6 +44,7 @@ func TestAccAliCloudThreatDetectionClientFileProtect_basic4514(t *testing.T) {
 					"rule_name": "ruleTest2_843",
 					"status":    "0",
 					"switch_id": "FILE_PROTECT_RULE_SWITCH_TYPE_1693474122929",
+					"platform":  "linux",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -55,6 +56,7 @@ func TestAccAliCloudThreatDetectionClientFileProtect_basic4514(t *testing.T) {
 						"rule_name":    CHECKSET,
 						"status":       "0",
 						"switch_id":    "FILE_PROTECT_RULE_SWITCH_TYPE_1693474122929",
+						"platform":     "linux",
 					}),
 				),
 			},
@@ -343,6 +345,7 @@ func TestAccAliCloudThreatDetectionClientFileProtect_basic4514_twin(t *testing.T
 					"alert_level": "1",
 					"switch_id":   "FILE_PROTECT_RULE_SWITCH_TYPE_1693474122929",
 					"rule_name":   "ruleTest_772",
+					"platform":    "windows",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -354,6 +357,7 @@ func TestAccAliCloudThreatDetectionClientFileProtect_basic4514_twin(t *testing.T
 						"alert_level":  "1",
 						"switch_id":    "FILE_PROTECT_RULE_SWITCH_TYPE_1693474122929",
 						"rule_name":    CHECKSET,
+						"platform":     "windows",
 					}),
 				),
 			},

--- a/website/docs/r/threat_detection_client_file_protect.html.markdown
+++ b/website/docs/r/threat_detection_client_file_protect.html.markdown
@@ -37,6 +37,7 @@ provider "alicloud" {
 resource "alicloud_threat_detection_client_file_protect" "default" {
   status      = "0"
   file_paths  = ["/usr/local"]
+  platform    = "linux"
   file_ops    = ["CREATE"]
   rule_action = "pass"
   proc_paths  = ["/usr/local"]
@@ -54,6 +55,7 @@ The following arguments are supported:
 * `alert_level` - (Optional) 0 no alert 1 info 2 suspicious 3 critical.
 * `file_ops` - (Required) file operation.
 * `file_paths` - (Required) file path.
+* `platform` - (Optional, ForceNew) The platform type. Valid values: `windows`, `linux`.
 * `proc_paths` - (Required) process path.
 * `rule_action` - (Required) rule action, pass or alert.
 * `rule_name` - (Required) ruleName.


### PR DESCRIPTION
This PR adds the `platform` attribute to the `alicloud_threat_detection_client_file_protect` resource.

## Changes

- Add `platform` field to the resource schema: `Optional + Computed + ForceNew`, accepts `windows` or `linux` (validated via `StringInSlice`)
- Send `Platform` in the `CreateFileProtectRule` request
- Read `platform` back from the `GetFileProtectRule` response (`$.Data.Platform`)
- The `UpdateFileProtectRule` API does not include `Platform`, so changing the value forces resource recreation
- Update acceptance tests to cover the new attribute across both enum values (`linux` in the basic case, `windows` in the twin case)

## API Reference

- **CreateFileProtectRule** (Sas, 2018-12-03): `Platform` is an optional string parameter accepting `windows` or `linux`
- **GetFileProtectRule**: returns `Platform` in the response body
- **UpdateFileProtectRule**: does not accept `Platform` — the field is read-only after creation

## Notes

- Acceptance test cases are updated to include `platform` in both the basic and twin scenarios. Remote ACC verification will follow.