### PR TITLE
New Data Source: alicloud_threat_detection_incident_investigations

### DIFF
--- a/alicloud/data_source_alicloud_threat_detection_incident_investigations.go
+++ b/alicloud/data_source_alicloud_threat_detection_incident_investigations.go
@@ -1,0 +1,217 @@
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAlicloudThreatDetectionIncidentInvestigations() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAlicloudThreatDetectionIncidentInvestigationsRead,
+		Schema: map[string]*schema.Schema{
+			"incident_uuid": {
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+			"lang": {
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+			"role_for": {
+				Optional: true,
+				Type:     schema.TypeInt,
+			},
+			"ids": {
+				Optional: true,
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"output_file": {
+				Optional: true,
+				Type:     schema.TypeString,
+			},
+			"page_number": {
+				Optional: true,
+				Type:     schema.TypeInt,
+			},
+			"page_size": {
+				Optional: true,
+				Type:     schema.TypeInt,
+				Default:  100,
+			},
+			"investigations": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"incident_investigation_id": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"incident_investigation_start_time": {
+							Computed: true,
+							Type:     schema.TypeInt,
+						},
+						"incident_investigation_end_time": {
+							Computed: true,
+							Type:     schema.TypeInt,
+						},
+						"incident_investigation_status": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"incident_investigation_summary": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"incident_investigation_display_id": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"incident_investigation_alert_name": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"incident_investigation_conclusion": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+						"incident_uuid": {
+							Computed: true,
+							Type:     schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAlicloudThreatDetectionIncidentInvestigationsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	request := map[string]interface{}{
+		"RegionId": client.RegionId,
+	}
+
+	if v, ok := d.GetOk("lang"); ok {
+		request["Lang"] = v
+	}
+	if v, ok := d.GetOkExists("role_for"); ok {
+		request["RoleFor"] = v
+	}
+	if v, ok := d.GetOk("incident_uuid"); ok {
+		request["IncidentUuid"] = v
+	}
+	if v, ok := d.GetOk("page_number"); ok && v.(int) > 0 {
+		request["PageNumber"] = v.(int)
+	} else {
+		request["PageNumber"] = 1
+	}
+	if v, ok := d.GetOk("page_size"); ok && v.(int) > 0 {
+		request["PageSize"] = v.(int)
+	} else {
+		request["PageSize"] = PageSizeLarge
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var err error
+	var objects []interface{}
+	var response map[string]interface{}
+
+	for {
+		action := "ListIncidentInvestigations"
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			resp, err := client.RpcPost("cloud-siem", "2024-12-12", action, nil, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			response = resp
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_threat_detection_incident_investigations", action, AlibabaCloudSdkGoERROR)
+		}
+		resp, err := jsonpath.Get("$.IncidentInvestigations", response)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.IncidentInvestigations", response)
+		}
+		result, _ := resp.([]interface{})
+		if isPagingRequest(d) {
+			objects = result
+			break
+		}
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["IncidentInvestigationId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+		if len(result) < request["PageSize"].(int) {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, v := range objects {
+		object := v.(map[string]interface{})
+		mapping := map[string]interface{}{
+			"incident_investigation_id":         fmt.Sprint(object["IncidentInvestigationId"]),
+			"incident_investigation_start_time": object["IncidentInvestigationStartTime"],
+			"incident_investigation_end_time":   object["IncidentInvestigationEndTime"],
+			"incident_investigation_status":     object["IncidentInvestigationStatus"],
+			"incident_investigation_summary":    object["IncidentInvestigationSummary"],
+			"incident_investigation_display_id": object["IncidentInvestigationDisplayId"],
+			"incident_investigation_alert_name": object["IncidentInvestigationAlertName"],
+			"incident_investigation_conclusion": object["IncidentInvestigationConclusion"],
+			"incident_uuid":                     fmt.Sprint(object["IncidentUuid"]),
+		}
+
+		ids = append(ids, fmt.Sprint(object["IncidentInvestigationId"]))
+
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("investigations", s); err != nil {
+		return WrapError(err)
+	}
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		if err := writeToFile(output.(string), s); err != nil {
+			return WrapError(err)
+		}
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_threat_detection_incident_investigations_test.go
+++ b/alicloud/data_source_alicloud_threat_detection_incident_investigations_test.go
@@ -1,0 +1,62 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudThreatDetectionIncidentInvestigationsDataSource(t *testing.T) {
+	rand := acctest.RandInt()
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudThreatDetectionIncidentInvestigationsDataSourceName(rand, map[string]string{
+			"output_file": `"out.txt"`,
+		}),
+		fakeConfig: testAccCheckAlicloudThreatDetectionIncidentInvestigationsDataSourceName(rand, map[string]string{
+			"incident_uuid": `"fake-incident-uuid-not-exist"`,
+		}),
+	}
+
+	var existAlicloudThreatDetectionIncidentInvestigationsDataSourceNameMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":            CHECKSET,
+			"investigations.#": CHECKSET,
+		}
+	}
+	var fakeAlicloudThreatDetectionIncidentInvestigationsDataSourceNameMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":            "0",
+			"investigations.#": "0",
+		}
+	}
+	var alicloudThreatDetectionIncidentInvestigationsCheckInfo = dataSourceAttr{
+		resourceId:   "data.alicloud_threat_detection_incident_investigations.default",
+		existMapFunc: existAlicloudThreatDetectionIncidentInvestigationsDataSourceNameMapFunc,
+		fakeMapFunc:  fakeAlicloudThreatDetectionIncidentInvestigationsDataSourceNameMapFunc,
+	}
+	preCheck := func() {
+		testAccPreCheck(t)
+	}
+	alicloudThreatDetectionIncidentInvestigationsCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, allConf)
+}
+
+func testAccCheckAlicloudThreatDetectionIncidentInvestigationsDataSourceName(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+
+	config := fmt.Sprintf(`
+	variable "name" {
+		default = "tf-testAccThreatDetectionIncidentInvestigation-%d"
+	}
+
+	data "alicloud_threat_detection_incident_investigations" "default" {
+		%s
+	}
+`, rand, strings.Join(pairs, " \n "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -916,6 +916,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cen_child_instance_route_entry_to_attachments":    dataSourceAlicloudCenChildInstanceRouteEntryToAttachments(),
 			"alicloud_cen_transit_router_multicast_domain_associations": dataSourceAlicloudCenTransitRouterMulticastDomainAssociations(),
 			"alicloud_threat_detection_honeypot_presets":                dataSourceAlicloudThreatDetectionHoneypotPresets(),
+			"alicloud_threat_detection_incident_investigations":         dataSourceAlicloudThreatDetectionIncidentInvestigations(),
 			"alicloud_cen_transit_router_multicast_domain_sources":      dataSourceAlicloudCenTransitRouterMulticastDomainSources(),
 			"alicloud_bss_open_api_products":                            dataSourceAlicloudBssOpenApiProducts(),
 			"alicloud_bss_open_api_pricing_modules":                     dataSourceAlicloudBssOpenApiPricingModules(),

--- a/website/docs/d/threat_detection_incident_investigations.html.markdown
+++ b/website/docs/d/threat_detection_incident_investigations.html.markdown
@@ -1,0 +1,52 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_incident_investigations"
+sidebar_current: "docs-alicloud-datasource-threat_detection-incident-investigations"
+description: |-
+  Provides a list of Threat Detection Incident Investigations owned by an Alibaba Cloud account.
+---
+
+# alicloud_threat_detection_incident_investigations
+
+This data source provides Threat Detection Incident Investigation available to the user.
+
+-> **NOTE:** Available since v1.245.0.
+
+## Example Usage
+
+```terraform
+data "alicloud_threat_detection_incident_investigations" "default" {
+  incident_uuid = "xxxxx-xxxxx-xxxxx-xxxxx"
+}
+
+output "first_investigation_id" {
+  value = data.alicloud_threat_detection_incident_investigations.default.investigations.0.incident_investigation_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `incident_uuid` - (Optional, ForceNew) The UUID of the incident to which the investigations belong.
+* `lang` - (Optional, ForceNew) The language type. Valid values: `zh`, `en`.
+* `role_for` - (Optional, ForceNew) The ID of the other role user.
+* `ids` - (Optional, ForceNew, Computed) A list of Incident Investigation IDs.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+* `page_number` - (Optional, ForceNew) The page number of the list. Default value: `1`.
+* `page_size` - (Optional, ForceNew) The number of items per page. Maximum value: `100`. Default value: `100`.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of Incident Investigation IDs.
+* `investigations` - A list of Incident Investigation Entries. Each element contains the following attributes:
+  * `incident_investigation_id` - The ID of the incident investigation.
+  * `incident_investigation_start_time` - The start time of the incident investigation.
+  * `incident_investigation_end_time` - The end time of the incident investigation.
+  * `incident_investigation_status` - The status of the incident investigation.
+  * `incident_investigation_summary` - The summary of the incident investigation.
+  * `incident_investigation_display_id` - The display ID of the incident investigation.
+  * `incident_investigation_alert_name` - The name of the alert that triggers the investigation.
+  * `incident_investigation_conclusion` - The conclusion of the incident investigation.
+  * `incident_uuid` - The UUID of the incident.


### PR DESCRIPTION
## Description

Add a new data source `alicloud_threat_detection_incident_investigations` that queries the list of incident investigations from Threat Detection (cloud-siem).

The data source supports filtering by `incident_uuid`, `lang`, `role_for`, and `ids`, with pagination via `page_number` and `page_size`.

## Schema

### Argument Reference
* `incident_uuid` - (Optional) The UUID of the incident to which the investigations belong.
* `lang` - (Optional) The language type.
* `role_for` - (Optional) The ID of the other role user.
* `ids` - (Optional, Computed) A list of Incident Investigation IDs.
* `output_file` - (Optional) File name to save data source results.
* `page_number` - (Optional) The page number. Default: 1.
* `page_size` - (Optional) The number of items per page. Max: 100. Default: 100.

### Attributes Reference
* `ids` - A list of Incident Investigation IDs.
* `investigations` - A list of entries, each containing:
  * `incident_investigation_id`
  * `incident_investigation_start_time`
  * `incident_investigation_end_time`
  * `incident_investigation_status`
  * `incident_investigation_summary`
  * `incident_investigation_display_id`
  * `incident_investigation_alert_name`
  * `incident_investigation_conclusion`
  * `incident_uuid`

## Test

```
=== RUN TestAccAliCloudThreatDetectionIncidentInvestigationsDataSource
```

Remote acceptance test verification is pending.