### PR TITLE
resource/alicloud_dts_synchronization_job: resolve the valid job id before renaming when the instance carries deletion records; resource/alicloud_dts_subscription_job: resolve the valid job id before renaming when the instance carries deletion records

### DIFF
--- a/alicloud/resource_alicloud_dts_subscription_job.go
+++ b/alicloud/resource_alicloud_dts_subscription_job.go
@@ -350,6 +350,42 @@ func resourceAliCloudDtsSubscriptionJobUpdate(d *schema.ResourceData, meta inter
 			return nil
 		})
 		addDebug(action, response, request)
+		if isDtsJobNotFoundSignal(err, response) {
+			// An instance that carries historical deletion records can lose the server-side
+			// mapping between the job ID stored in state and the instance, so ModifyDtsJobName
+			// reports that the instance does not exist. Recover the currently valid job ID from
+			// the instance and retry the rename once before failing.
+			resolvedId, resolveErr := dtsSubscriptionJobResolveJobId(d, &dtsService)
+			if resolveErr != nil {
+				log.Printf("[WARN] Failed to resolve the valid DTS job ID under instance %s: %s", d.Get("dts_instance_id"), resolveErr)
+			}
+			if resolveErr == nil && resolvedId != "" && resolvedId != d.Id() {
+				log.Printf("[INFO] The DTS job ID %s of alicloud_dts_subscription_job is no longer valid, retrying %s with the resolved job ID %s.", d.Id(), action, resolvedId)
+				request["DtsJobId"] = resolvedId
+				var retryErr error
+				retryWait := incrementalWait(3*time.Second, 3*time.Second)
+				retryErr = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, retryErr = client.RpcPost("Dts", "2020-01-01", action, nil, request, false)
+					if retryErr != nil {
+						if NeedRetry(retryErr) {
+							retryWait()
+							return resource.RetryableError(retryErr)
+						}
+						return resource.NonRetryableError(retryErr)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if retryErr == nil && fmt.Sprint(response["Success"]) != "false" {
+					d.SetId(resolvedId)
+					err = nil
+				} else if retryErr != nil {
+					err = retryErr
+				} else {
+					err = fmt.Errorf("%s failed, response: %v", action, response)
+				}
+			}
+		}
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
@@ -743,6 +779,34 @@ func resourceAliCloudDtsSubscriptionJobStatusFlow(d *schema.ResourceData, meta i
 	}
 
 	return nil
+}
+
+// dtsSubscriptionJobResolveJobId recovers the currently valid DTS job ID from the DTS instance
+// backing this resource. The instance ID remains stable while the job attached to it can be
+// deleted and re-created, leaving the job ID stored in state stale.
+func dtsSubscriptionJobResolveJobId(d *schema.ResourceData, dtsService *DtsService) (string, error) {
+	instanceId := ""
+	if v, ok := d.GetOk("dts_instance_id"); ok {
+		instanceId = fmt.Sprint(v)
+	}
+	if instanceId == "" {
+		return "", fmt.Errorf("dts_instance_id is empty, cannot resolve the valid job ID of alicloud_dts_subscription_job %s", d.Id())
+	}
+	jobs, err := dtsService.DescribeDtsJobsByInstanceId(instanceId, "SUBSCRIBE")
+	if err != nil {
+		return "", WrapError(err)
+	}
+	if len(jobs) == 0 {
+		return "", fmt.Errorf("no DTS subscription job was found under instance %s", instanceId)
+	}
+	if len(jobs) == 1 {
+		return fmt.Sprint(jobs[0]["DtsJobId"]), nil
+	}
+	jobIds := make([]string, 0, len(jobs))
+	for _, job := range jobs {
+		jobIds = append(jobIds, fmt.Sprint(job["DtsJobId"]))
+	}
+	return "", fmt.Errorf("found multiple DTS subscription jobs (%s) under instance %s, cannot determine the valid job ID automatically", strings.Join(jobIds, ","), instanceId)
 }
 
 func convertDtsPaymentTypeResponse(source interface{}) interface{} {

--- a/alicloud/resource_alicloud_dts_subscription_job_test.go
+++ b/alicloud/resource_alicloud_dts_subscription_job_test.go
@@ -4,14 +4,22 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/PaesslerAG/jsonpath"
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/alibabacloud-go/tea-rpc/client"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/alibabacloud-go/tea/tea"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -609,4 +617,145 @@ resource "alicloud_rds_account" "target_account" {
 }
 
 `, name, os.Getenv("ALICLOUD_REGION"))
+}
+
+// lintignore: R001
+func TestUnitAlicloudDTSSubscriptionJob(t *testing.T) {
+	p := Provider().(*schema.Provider).ResourcesMap
+	d, _ := schema.InternalMap(p["alicloud_dts_subscription_job"].Schema).Data(nil, nil)
+	for key, value := range map[string]interface{}{
+		"dts_instance_id":               "dts_instance_id",
+		"dts_job_name":                  "dts_job_name",
+		"payment_type":                  "PayAsYouGo",
+		"source_endpoint_engine_name":   "MySQL",
+		"source_endpoint_instance_type": "RDS",
+		"source_endpoint_region":        "cn-hangzhou",
+		"status":                        "Normal",
+	} {
+		err := d.Set(key, value)
+		assert.Nil(t, err)
+	}
+	region := os.Getenv("ALICLOUD_REGION")
+	rawClient, err := sharedClientForRegion(region)
+	if err != nil {
+		t.Skipf("Skipping the test case with err: %s", err)
+		t.Skipped()
+	}
+	rawClient = rawClient.(*connectivity.AliyunClient)
+
+	readMockResponse := map[string]interface{}{
+		"Checkpoint":    0,
+		"DbObject":      "db_list",
+		"DtsInstanceID": "dts_instance_id",
+		"DtsJobName":    "dts_job_name_renamed",
+		"PayType":       "PostPaid",
+		"Reserved":      "",
+		"SourceEndpoint": map[string]interface{}{
+			"EngineName":   "MySQL",
+			"InstanceType": "RDS",
+			"Region":       "cn-hangzhou",
+		},
+		"Status": "Normal",
+		"SubscriptionDataType": map[string]interface{}{
+			"Ddl": true,
+			"Dml": true,
+		},
+	}
+
+	describeDtsJobsResponse := map[string]interface{}{
+		"Success": true,
+		"DtsJobList": []interface{}{
+			map[string]interface{}{
+				"DtsJobId":      "dts_job_id_resolved",
+				"DtsInstanceID": "dts_instance_id",
+				"Status":        "Normal",
+			},
+		},
+	}
+
+	responseMock := map[string]func(errorCode string) (map[string]interface{}, error){
+		"NoRetryError": func(errorCode string) (map[string]interface{}, error) {
+			return nil, &tea.SDKError{
+				Code:       String(errorCode),
+				Data:       String(errorCode),
+				Message:    String(errorCode),
+				StatusCode: tea.Int(400),
+			}
+		},
+		"ModifyJobNameNormal": func(errorCode string) (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"Success": true,
+			}, nil
+		},
+		"DescribeDtsJobsNormal": func(errorCode string) (map[string]interface{}, error) {
+			return describeDtsJobsResponse, nil
+		},
+		"DescribeDtsJobsEmpty": func(errorCode string) (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"Success":    true,
+				"DtsJobList": []interface{}{},
+			}, nil
+		},
+		"ReadNormal": func(errorCode string) (map[string]interface{}, error) {
+			return readMockResponse, nil
+		},
+	}
+
+	// The job ID stored in state no longer maps to the instance: the rename first fails with
+	// Forbidden.InstanceNotFound, then the valid job ID is resolved from the instance and the
+	// retry succeeds, refreshing the resource ID.
+	t.Run("UpdateModifyJobNameResolveNormal", func(t *testing.T) {
+		diff := terraform.NewInstanceDiff()
+		diff.SetAttribute("dts_job_name", &terraform.ResourceAttrDiff{Old: "dts_job_name", New: "dts_job_name_renamed"})
+		diff.SetAttribute("dts_instance_id", &terraform.ResourceAttrDiff{Old: "dts_instance_id", New: "dts_instance_id"})
+		resourceData, _ := schema.InternalMap(p["alicloud_dts_subscription_job"].Schema).Data(nil, diff)
+		resourceData.SetId("dts_job_id_old")
+		callIndex := 0
+		patcheRead := gomonkey.ApplyMethod(reflect.TypeOf(&DtsService{}), "DescribeDtsSubscriptionJob", func(*DtsService, string) (map[string]interface{}, error) {
+			return responseMock["ReadNormal"]("")
+		})
+		patcheTags := gomonkey.ApplyMethod(reflect.TypeOf(&DtsService{}), "ListTagResources", func(*DtsService, string, string) (interface{}, error) {
+			return map[string]interface{}{}, nil
+		})
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, _ *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			callIndex++
+			switch callIndex {
+			case 1:
+				return responseMock["NoRetryError"]("Forbidden.InstanceNotFound")
+			case 2:
+				return responseMock["DescribeDtsJobsNormal"]("")
+			default:
+				return responseMock["ModifyJobNameNormal"]("")
+			}
+		})
+		err := resourceAliCloudDtsSubscriptionJobUpdate(resourceData, rawClient)
+		patcheRead.Reset()
+		patcheTags.Reset()
+		patches.Reset()
+		assert.Nil(t, err)
+		assert.Equal(t, "dts_job_id_resolved", resourceData.Id())
+	})
+
+	// The rename fails and no valid job remains under the instance: the original failure is
+	// surfaced instead of being silently swallowed.
+	t.Run("UpdateModifyJobNameResolveNotFoundAbnormal", func(t *testing.T) {
+		diff := terraform.NewInstanceDiff()
+		diff.SetAttribute("dts_job_name", &terraform.ResourceAttrDiff{Old: "dts_job_name", New: "dts_job_name_renamed"})
+		diff.SetAttribute("dts_instance_id", &terraform.ResourceAttrDiff{Old: "dts_instance_id", New: "dts_instance_id"})
+		resourceData, _ := schema.InternalMap(p["alicloud_dts_subscription_job"].Schema).Data(nil, diff)
+		resourceData.SetId("dts_job_id_old")
+		callIndex := 0
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, _ *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			callIndex++
+			switch callIndex {
+			case 1:
+				return responseMock["NoRetryError"]("Forbidden.InstanceNotFound")
+			default:
+				return responseMock["DescribeDtsJobsEmpty"]("")
+			}
+		})
+		err := resourceAliCloudDtsSubscriptionJobUpdate(resourceData, rawClient)
+		patches.Reset()
+		assert.NotNil(t, err)
+	})
 }

--- a/alicloud/resource_alicloud_dts_synchronization_job.go
+++ b/alicloud/resource_alicloud_dts_synchronization_job.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -548,6 +549,43 @@ func resourceAlicloudDtsSynchronizationJobUpdate(d *schema.ResourceData, meta in
 			return nil
 		})
 		addDebug(action, response, request)
+		if isDtsJobNotFoundSignal(err, response) {
+			// An instance that carries historical deletion records can lose the server-side
+			// mapping between the job ID stored in state and the instance, so ModifyDtsJobName
+			// reports that the instance does not exist. Recover the currently valid job ID from
+			// the instance and retry the rename once before failing.
+			dtsService := DtsService{client}
+			resolvedId, resolveErr := dtsSynchronizationJobResolveJobId(d, &dtsService)
+			if resolveErr != nil {
+				log.Printf("[WARN] Failed to resolve the valid DTS job ID under instance %s: %s", d.Get("dts_instance_id"), resolveErr)
+			}
+			if resolveErr == nil && resolvedId != "" && resolvedId != d.Id() {
+				log.Printf("[INFO] The DTS job ID %s of alicloud_dts_synchronization_job is no longer valid, retrying %s with the resolved job ID %s.", d.Id(), action, resolvedId)
+				request["DtsJobId"] = resolvedId
+				var retryErr error
+				retryWait := incrementalWait(3*time.Second, 3*time.Second)
+				retryErr = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+					response, retryErr = client.RpcPost("Dts", "2020-01-01", action, nil, request, false)
+					if retryErr != nil {
+						if NeedRetry(retryErr) {
+							retryWait()
+							return resource.RetryableError(retryErr)
+						}
+						return resource.NonRetryableError(retryErr)
+					}
+					return nil
+				})
+				addDebug(action, response, request)
+				if retryErr == nil && fmt.Sprint(response["Success"]) != "false" {
+					d.SetId(resolvedId)
+					err = nil
+				} else if retryErr != nil {
+					err = retryErr
+				} else {
+					err = fmt.Errorf("%s failed, response: %v", action, response)
+				}
+			}
+		}
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
@@ -964,6 +1002,76 @@ func resourceAlicloudDtsSynchronizationJobStatusFlow(d *schema.ResourceData, met
 	}
 
 	return nil
+}
+
+// dtsSynchronizationJobResolveJobId recovers the currently valid DTS job ID from the DTS
+// instance backing this resource. The instance ID remains stable while the job attached to it
+// can be deleted and re-created, leaving the job ID stored in state stale.
+func dtsSynchronizationJobResolveJobId(d *schema.ResourceData, dtsService *DtsService) (string, error) {
+	instanceId := ""
+	if v, ok := d.GetOk("dts_instance_id"); ok {
+		instanceId = fmt.Sprint(v)
+	}
+	if instanceId == "" {
+		return "", fmt.Errorf("dts_instance_id is empty, cannot resolve the valid job ID of alicloud_dts_synchronization_job %s", d.Id())
+	}
+	jobs, err := dtsService.DescribeDtsJobsByInstanceId(instanceId, "SYNC")
+	if err != nil {
+		return "", WrapError(err)
+	}
+	// A bidirectional synchronization topology attaches a reverse job to the same instance, and
+	// DescribeDtsJobs may expose it either as a separate list entry or nested under ReverseJob.
+	candidates := make([]map[string]interface{}, 0, len(jobs))
+	seenJobIds := make(map[string]bool)
+	appendCandidate := func(item map[string]interface{}) {
+		jobId := fmt.Sprint(item["DtsJobId"])
+		if jobId == "" || jobId == "<nil>" || seenJobIds[jobId] {
+			return
+		}
+		seenJobIds[jobId] = true
+		candidates = append(candidates, item)
+	}
+	for _, job := range jobs {
+		appendCandidate(job)
+		if reverse, ok := job["ReverseJob"].(map[string]interface{}); ok {
+			appendCandidate(reverse)
+		}
+	}
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("no DTS synchronization job was found under instance %s", instanceId)
+	}
+	if len(candidates) == 1 {
+		return fmt.Sprint(candidates[0]["DtsJobId"]), nil
+	}
+	direction := ""
+	if v, ok := d.GetOk("synchronization_direction"); ok {
+		direction = fmt.Sprint(v)
+	}
+	if direction != "" {
+		matched := make([]string, 0, len(candidates))
+		for _, job := range candidates {
+			// DescribeDtsJobs returns the direction of each listed job as DtsJobDirection.
+			jobDirection := fmt.Sprint(job["DtsJobDirection"])
+			if jobDirection == "<nil>" || jobDirection == "" {
+				jobDirection = fmt.Sprint(job["SynchronizationDirection"])
+			}
+			if jobDirection == direction {
+				matched = append(matched, fmt.Sprint(job["DtsJobId"]))
+			}
+		}
+		if len(matched) == 1 {
+			return matched[0], nil
+		}
+		if len(matched) == 0 {
+			return "", fmt.Errorf("no DTS synchronization job with synchronization direction %s was found under instance %s", direction, instanceId)
+		}
+		return "", fmt.Errorf("found multiple DTS synchronization jobs (%s) with synchronization direction %s under instance %s, cannot determine the valid job ID automatically", strings.Join(matched, ","), direction, instanceId)
+	}
+	jobIds := make([]string, 0, len(candidates))
+	for _, job := range candidates {
+		jobIds = append(jobIds, fmt.Sprint(job["DtsJobId"]))
+	}
+	return "", fmt.Errorf("found multiple DTS synchronization jobs (%s) under instance %s, set synchronization_direction to determine the valid job ID", strings.Join(jobIds, ","), instanceId)
 }
 
 func convertSourceEndpointEngineNameUppercaseResponse(source interface{}) interface{} {

--- a/alicloud/resource_alicloud_dts_synchronization_job_test.go
+++ b/alicloud/resource_alicloud_dts_synchronization_job_test.go
@@ -2,11 +2,20 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
+	"reflect"
 	"testing"
 
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/alibabacloud-go/tea-rpc/client"
+	util "github.com/alibabacloud-go/tea-utils/service"
+	"github.com/alibabacloud-go/tea/tea"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccAliCloudDTSSynchronizationJob_basic0(t *testing.T) {
@@ -922,4 +931,250 @@ func AliCloudDTSSynchronizationJobBasicDependence1(name string) string {
   		sync_architecture                = "oneway"
 	}
 `, name)
+}
+
+// lintignore: R001
+func TestUnitAlicloudDTSSynchronizationJob(t *testing.T) {
+	p := Provider().(*schema.Provider).ResourcesMap
+	d, _ := schema.InternalMap(p["alicloud_dts_synchronization_job"].Schema).Data(nil, nil)
+	for key, value := range map[string]interface{}{
+		"dts_instance_id":                    "dts_instance_id",
+		"dts_job_name":                       "dts_job_name",
+		"source_endpoint_instance_type":      "RDS",
+		"source_endpoint_engine_name":        "MySQL",
+		"destination_endpoint_instance_type": "RDS",
+		"destination_endpoint_engine_name":   "MySQL",
+		"db_list":                            "db_list",
+		"structure_initialization":           true,
+		"data_initialization":                true,
+		"data_synchronization":               true,
+		"status":                             "Synchronizing",
+	} {
+		err := d.Set(key, value)
+		assert.Nil(t, err)
+	}
+	region := os.Getenv("ALICLOUD_REGION")
+	rawClient, err := sharedClientForRegion(region)
+	if err != nil {
+		t.Skipf("Skipping the test case with err: %s", err)
+		t.Skipped()
+	}
+	rawClient = rawClient.(*connectivity.AliyunClient)
+
+	readMockResponse := map[string]interface{}{
+		"Checkpoint": 0,
+		"MigrationMode": map[string]interface{}{
+			"DataInitialization":      true,
+			"DataSynchronization":     true,
+			"StructureInitialization": true,
+		},
+		"DbObject": "db_list",
+		"DestinationEndpoint": map[string]interface{}{
+			"EngineName":   "MySQL",
+			"InstanceType": "RDS",
+		},
+		"DtsInstanceID": "dts_instance_id",
+		"DtsJobName":    "dts_job_name_renamed",
+		"SourceEndpoint": map[string]interface{}{
+			"EngineName":   "MySQL",
+			"InstanceType": "RDS",
+		},
+		"Status":                   "Synchronizing",
+		"SynchronizationDirection": "Forward",
+	}
+
+	describeDtsJobsResponse := map[string]interface{}{
+		"Success": true,
+		"DtsJobList": []interface{}{
+			map[string]interface{}{
+				"DtsJobId":        "dts_job_id_resolved",
+				"DtsInstanceID":   "dts_instance_id",
+				"DtsJobDirection": "Forward",
+				"Status":          "Synchronizing",
+			},
+		},
+	}
+
+	describeDtsJobsBidirectionalResponse := map[string]interface{}{
+		"Success": true,
+		"DtsJobList": []interface{}{
+			map[string]interface{}{
+				"DtsJobId":        "dts_job_id_reverse",
+				"DtsInstanceID":   "dts_instance_id",
+				"DtsJobDirection": "Reverse",
+				"Status":          "Synchronizing",
+			},
+			map[string]interface{}{
+				"DtsJobId":        "dts_job_id_forward",
+				"DtsInstanceID":   "dts_instance_id",
+				"DtsJobDirection": "Forward",
+				"Status":          "Synchronizing",
+			},
+		},
+	}
+
+	responseMock := map[string]func(errorCode string) (map[string]interface{}, error){
+		"NoRetryError": func(errorCode string) (map[string]interface{}, error) {
+			return nil, &tea.SDKError{
+				Code:       String(errorCode),
+				Data:       String(errorCode),
+				Message:    String(errorCode),
+				StatusCode: tea.Int(400),
+			}
+		},
+		"ModifyJobNameNormal": func(errorCode string) (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"Success": true,
+			}, nil
+		},
+		"ModifyJobNameNotFoundResponse": func(errorCode string) (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"Success":    false,
+				"ErrCode":    errorCode,
+				"ErrMessage": errorCode,
+			}, nil
+		},
+		"DescribeDtsJobsNormal": func(errorCode string) (map[string]interface{}, error) {
+			return describeDtsJobsResponse, nil
+		},
+		"DescribeDtsJobsBidirectional": func(errorCode string) (map[string]interface{}, error) {
+			return describeDtsJobsBidirectionalResponse, nil
+		},
+		"DescribeDtsJobsEmpty": func(errorCode string) (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"Success":    true,
+				"DtsJobList": []interface{}{},
+			}, nil
+		},
+		"ReadNormal": func(errorCode string) (map[string]interface{}, error) {
+			return readMockResponse, nil
+		},
+	}
+
+	// The job ID stored in state no longer maps to the instance: the rename first fails with
+	// Forbidden.InstanceNotFound, then the valid job ID is resolved from the instance and the
+	// retry succeeds, refreshing the resource ID.
+	t.Run("UpdateModifyJobNameResolveNormal", func(t *testing.T) {
+		diff := terraform.NewInstanceDiff()
+		diff.SetAttribute("dts_job_name", &terraform.ResourceAttrDiff{Old: "dts_job_name", New: "dts_job_name_renamed"})
+		diff.SetAttribute("dts_instance_id", &terraform.ResourceAttrDiff{Old: "dts_instance_id", New: "dts_instance_id"})
+		resourceData, _ := schema.InternalMap(p["alicloud_dts_synchronization_job"].Schema).Data(nil, diff)
+		resourceData.SetId("dts_job_id_old")
+		callIndex := 0
+		patcheRead := gomonkey.ApplyMethod(reflect.TypeOf(&DtsService{}), "DescribeDtsSynchronizationJob", func(*DtsService, string) (map[string]interface{}, error) {
+			return responseMock["ReadNormal"]("")
+		})
+		patcheParameters := gomonkey.ApplyMethod(reflect.TypeOf(&DtsService{}), "QueryChangedJobParameters", func(*DtsService, string) (string, error) {
+			return "", nil
+		})
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, _ *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			callIndex++
+			switch callIndex {
+			case 1:
+				return responseMock["NoRetryError"]("Forbidden.InstanceNotFound")
+			case 2:
+				return responseMock["DescribeDtsJobsNormal"]("")
+			default:
+				return responseMock["ModifyJobNameNormal"]("")
+			}
+		})
+		err := resourceAlicloudDtsSynchronizationJobUpdate(resourceData, rawClient)
+		patcheRead.Reset()
+		patcheParameters.Reset()
+		patches.Reset()
+		assert.Nil(t, err)
+		assert.Equal(t, "dts_job_id_resolved", resourceData.Id())
+	})
+
+	// The rename fails with a business-level not-found response instead of an SDK error; the
+	// resolution fallback applies the same way.
+	t.Run("UpdateModifyJobNameResolveSuccessFalseNormal", func(t *testing.T) {
+		diff := terraform.NewInstanceDiff()
+		diff.SetAttribute("dts_job_name", &terraform.ResourceAttrDiff{Old: "dts_job_name", New: "dts_job_name_renamed"})
+		diff.SetAttribute("dts_instance_id", &terraform.ResourceAttrDiff{Old: "dts_instance_id", New: "dts_instance_id"})
+		resourceData, _ := schema.InternalMap(p["alicloud_dts_synchronization_job"].Schema).Data(nil, diff)
+		resourceData.SetId("dts_job_id_old")
+		callIndex := 0
+		patcheRead := gomonkey.ApplyMethod(reflect.TypeOf(&DtsService{}), "DescribeDtsSynchronizationJob", func(*DtsService, string) (map[string]interface{}, error) {
+			return responseMock["ReadNormal"]("")
+		})
+		patcheParameters := gomonkey.ApplyMethod(reflect.TypeOf(&DtsService{}), "QueryChangedJobParameters", func(*DtsService, string) (string, error) {
+			return "", nil
+		})
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, _ *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			callIndex++
+			switch callIndex {
+			case 1:
+				return responseMock["ModifyJobNameNotFoundResponse"]("Forbidden.InstanceNotFound")
+			case 2:
+				return responseMock["DescribeDtsJobsNormal"]("")
+			default:
+				return responseMock["ModifyJobNameNormal"]("")
+			}
+		})
+		err := resourceAlicloudDtsSynchronizationJobUpdate(resourceData, rawClient)
+		patcheRead.Reset()
+		patcheParameters.Reset()
+		patches.Reset()
+		assert.Nil(t, err)
+		assert.Equal(t, "dts_job_id_resolved", resourceData.Id())
+	})
+
+	// A bidirectional synchronization instance carries one job per direction under the same
+	// instance: the resolver must pick the job whose direction matches the resource state.
+	t.Run("UpdateModifyJobNameResolveBidirectionalNormal", func(t *testing.T) {
+		diff := terraform.NewInstanceDiff()
+		diff.SetAttribute("dts_job_name", &terraform.ResourceAttrDiff{Old: "dts_job_name", New: "dts_job_name_renamed"})
+		diff.SetAttribute("dts_instance_id", &terraform.ResourceAttrDiff{Old: "dts_instance_id", New: "dts_instance_id"})
+		diff.SetAttribute("synchronization_direction", &terraform.ResourceAttrDiff{Old: "Forward", New: "Forward"})
+		resourceData, _ := schema.InternalMap(p["alicloud_dts_synchronization_job"].Schema).Data(nil, diff)
+		resourceData.SetId("dts_job_id_old")
+		callIndex := 0
+		patcheRead := gomonkey.ApplyMethod(reflect.TypeOf(&DtsService{}), "DescribeDtsSynchronizationJob", func(*DtsService, string) (map[string]interface{}, error) {
+			return responseMock["ReadNormal"]("")
+		})
+		patcheParameters := gomonkey.ApplyMethod(reflect.TypeOf(&DtsService{}), "QueryChangedJobParameters", func(*DtsService, string) (string, error) {
+			return "", nil
+		})
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, _ *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			callIndex++
+			switch callIndex {
+			case 1:
+				return responseMock["NoRetryError"]("Forbidden.InstanceNotFound")
+			case 2:
+				return responseMock["DescribeDtsJobsBidirectional"]("")
+			default:
+				return responseMock["ModifyJobNameNormal"]("")
+			}
+		})
+		err := resourceAlicloudDtsSynchronizationJobUpdate(resourceData, rawClient)
+		patcheRead.Reset()
+		patcheParameters.Reset()
+		patches.Reset()
+		assert.Nil(t, err)
+		assert.Equal(t, "dts_job_id_forward", resourceData.Id())
+	})
+
+	// The rename fails and no valid job remains under the instance: the original failure is
+	// surfaced instead of being silently swallowed.
+	t.Run("UpdateModifyJobNameResolveNotFoundAbnormal", func(t *testing.T) {
+		diff := terraform.NewInstanceDiff()
+		diff.SetAttribute("dts_job_name", &terraform.ResourceAttrDiff{Old: "dts_job_name", New: "dts_job_name_renamed"})
+		diff.SetAttribute("dts_instance_id", &terraform.ResourceAttrDiff{Old: "dts_instance_id", New: "dts_instance_id"})
+		resourceData, _ := schema.InternalMap(p["alicloud_dts_synchronization_job"].Schema).Data(nil, diff)
+		resourceData.SetId("dts_job_id_old")
+		callIndex := 0
+		patches := gomonkey.ApplyMethod(reflect.TypeOf(&client.Client{}), "DoRequest", func(_ *client.Client, _ *string, _ *string, _ *string, _ *string, _ *string, _ map[string]interface{}, _ map[string]interface{}, _ *util.RuntimeOptions) (map[string]interface{}, error) {
+			callIndex++
+			switch callIndex {
+			case 1:
+				return responseMock["NoRetryError"]("Forbidden.InstanceNotFound")
+			default:
+				return responseMock["DescribeDtsJobsEmpty"]("")
+			}
+		})
+		err := resourceAlicloudDtsSynchronizationJobUpdate(resourceData, rawClient)
+		patches.Reset()
+		assert.NotNil(t, err)
+	})
 }

--- a/alicloud/service_alicloud_dts.go
+++ b/alicloud/service_alicloud_dts.go
@@ -736,6 +736,81 @@ func (s *DtsService) DescribeDtsInstance(id string) (object map[string]interface
 	return v.(map[string]interface{}), nil
 }
 
+// DescribeDtsJobsByInstanceId lists the DTS jobs currently attached to the given DTS instance.
+// An instance that carries historical deletion records can lose the server-side mapping between
+// the job ID stored in state and the instance, so listing the jobs by instance ID is the
+// reliable way to recover the currently valid job ID.
+func (s *DtsService) DescribeDtsJobsByInstanceId(instanceId, jobType string) (jobs []map[string]interface{}, err error) {
+	client := s.client
+	var response map[string]interface{}
+	action := "DescribeDtsJobs"
+	request := map[string]interface{}{
+		"RegionId":      client.RegionId,
+		"DtsInstanceId": instanceId,
+		"JobType":       jobType,
+		"PageSize":      PageSizeLarge,
+		"PageNumber":    1,
+	}
+	for {
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPost("Dts", "2020-01-01", action, nil, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"Forbidden.InstanceNotFound", "InvalidJobId"}) {
+				return jobs, WrapErrorf(NotFoundErr("DTS", instanceId), NotFoundWithResponse, response)
+			}
+			return jobs, WrapErrorf(err, DefaultErrorMsg, instanceId, action, AlibabaCloudSdkGoERROR)
+		}
+		v, err := jsonpath.Get("$.DtsJobList", response)
+		if err != nil {
+			return jobs, WrapErrorf(err, FailedGetAttributeMsg, instanceId, "$.DtsJobList", response)
+		}
+		list, ok := v.([]interface{})
+		if !ok {
+			return jobs, WrapErrorf(NotFoundErr("DTS", instanceId), NotFoundWithResponse, response)
+		}
+		for _, item := range list {
+			if job, ok := item.(map[string]interface{}); ok {
+				jobs = append(jobs, job)
+			}
+		}
+		if len(list) < request["PageSize"].(int) {
+			break
+		}
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+	return jobs, nil
+}
+
+// isDtsJobNotFoundSignal reports whether a failed DTS job modification means that the job ID
+// stored in state no longer maps to a valid DTS instance, for example when the instance carries
+// historical deletion records and the job ID and the instance ID no longer match.
+func isDtsJobNotFoundSignal(err error, response map[string]interface{}) bool {
+	notFoundCodes := []string{"Forbidden.InstanceNotFound", "InvalidJobId"}
+	if err != nil {
+		return IsExpectedErrors(err, notFoundCodes)
+	}
+	if fmt.Sprint(response["Success"]) == "false" {
+		errCode := fmt.Sprint(response["ErrCode"])
+		for _, code := range notFoundCodes {
+			if errCode == code {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // setDtsEndpointSSL folds source_endpoint_ssl and destination_endpoint_ssl into the DTS Reserve
 // parameter as its srcSSL and destSSL keys. ConfigureDtsJob has no dedicated SSL parameter, so
 // Reserve is the only place the connection mode can be sent. Values already present under those


### PR DESCRIPTION
## Summary

- `alicloud_dts_synchronization_job` / `alicloud_dts_subscription_job`: when a DTS instance carries historical deletion records, the mapping between the job id stored in the Terraform state and the instance can be lost on the server side, so renaming the job through `ModifyDtsJobName` fails with an instance-not-found style error even though the instance still exists. The Update path now detects that signal (both the SDK error and a business-level `Success=false` response with `Forbidden.InstanceNotFound` / `InvalidJobId`), lists the jobs attached to the instance via `DescribeDtsJobs` filtered by `DtsInstanceId`, and retries the rename once with the currently valid job id, refreshing the resource id on success.
- For bidirectional synchronization topologies (one forward job and one reverse job under the same instance), the resolver matches the direction reported by `DescribeDtsJobs` (`DtsJobDirection`, including the nested `ReverseJob` entry) against `synchronization_direction`, and fails with an explicit message instead of guessing when the direction cannot disambiguate.
- When no valid job remains under the instance, the original failure is surfaced instead of being silently swallowed.

## Test plan

- [x] `go build ./alicloud/` passes locally.
- [ ] Unit tests `TestUnitAlicloudDTSSynchronizationJob` / `TestUnitAlicloudDTSSubscriptionJob` cover: SDK-error not-found response then resolve-and-retry succeeds with the resource id refreshed; business-level `Success=false` not-found response taking the same fallback; a bidirectional instance where the forward job is selected by direction; and an empty job list under the instance returning the original error. Results will be posted once executed remotely.
- [ ] Remote acceptance runs of `TestAccAliCloudDTSSynchronizationJob_basic0` and `TestAccAliCloudDTSSubscriptionJob_basic0` to follow; PASS results with timings will be posted here once completed.
