### PR TITLE
resource/alicloud_threat_detection_malicious_file_whitelist_config: support remark parameter

### DIFF
--- a/alicloud/resource_alicloud_threat_detection_malicious_file_whitelist_config.go
+++ b/alicloud/resource_alicloud_threat_detection_malicious_file_whitelist_config.go
@@ -60,6 +60,10 @@ func resourceAliCloudThreatDetectionMaliciousFileWhitelistConfig() *schema.Resou
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"remark": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -95,6 +99,9 @@ func resourceAliCloudThreatDetectionMaliciousFileWhitelistConfigCreate(d *schema
 	}
 	if v, ok := d.GetOk("source"); ok {
 		request["Source"] = v
+	}
+	if v, ok := d.GetOk("remark"); ok {
+		request["Remark"] = v
 	}
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
@@ -142,6 +149,7 @@ func resourceAliCloudThreatDetectionMaliciousFileWhitelistConfigRead(d *schema.R
 	d.Set("source", objectRaw["Source"])
 	d.Set("target_type", objectRaw["TargetType"])
 	d.Set("target_value", objectRaw["TargetValue"])
+	d.Set("remark", objectRaw["Remark"])
 
 	return nil
 }
@@ -186,6 +194,11 @@ func resourceAliCloudThreatDetectionMaliciousFileWhitelistConfigUpdate(d *schema
 		update = true
 	}
 	request["FieldValue"] = d.Get("field_value")
+
+	if d.HasChange("remark") {
+		update = true
+	}
+	request["Remark"] = d.Get("remark")
 
 	if update {
 		wait := incrementalWait(3*time.Second, 5*time.Second)

--- a/alicloud/resource_alicloud_threat_detection_malicious_file_whitelist_config_test.go
+++ b/alicloud/resource_alicloud_threat_detection_malicious_file_whitelist_config_test.go
@@ -40,6 +40,7 @@ func TestAccAliCloudThreatDetectionMaliciousFileWhitelistConfig_basic4979(t *tes
 					"event_name":   "ALL",
 					"source":       "agentless",
 					"field_value":  "714",
+					"remark":       "test remark",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -50,6 +51,7 @@ func TestAccAliCloudThreatDetectionMaliciousFileWhitelistConfig_basic4979(t *tes
 						"event_name":   "ALL",
 						"source":       "agentless",
 						"field_value":  "714",
+						"remark":       "test remark",
 					}),
 				),
 			},
@@ -309,7 +311,7 @@ func TestAccAliCloudThreatDetectionMaliciousFileWhitelistConfig_basic4979(t *tes
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"remark"},
 			},
 		},
 	})
@@ -357,6 +359,7 @@ func TestAccAliCloudThreatDetectionMaliciousFileWhitelistConfig_basic4979_twin(t
 					"event_name":   "123",
 					"source":       "agentless",
 					"field_value":  "sadfas",
+					"remark":       "twin remark",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -367,6 +370,7 @@ func TestAccAliCloudThreatDetectionMaliciousFileWhitelistConfig_basic4979_twin(t
 						"event_name":   "123",
 						"source":       "agentless",
 						"field_value":  "sadfas",
+						"remark":       "twin remark",
 					}),
 				),
 			},
@@ -374,7 +378,7 @@ func TestAccAliCloudThreatDetectionMaliciousFileWhitelistConfig_basic4979_twin(t
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"remark"},
 			},
 		},
 	})

--- a/website/docs/r/threat_detection_malicious_file_whitelist_config.html.markdown
+++ b/website/docs/r/threat_detection_malicious_file_whitelist_config.html.markdown
@@ -37,6 +37,7 @@ resource "alicloud_threat_detection_malicious_file_whitelist_config" "default" {
   event_name   = "123"
   source       = "agentless"
   field_value  = "sadfas"
+  remark       = "example remark"
 }
 ```
 
@@ -53,6 +54,7 @@ The following arguments are supported:
   - agentless: agentless detection.
 * `target_type` - (Optional) The type of target in effect on behalf of the resource.
 * `target_value` - (Optional) Represents the specific value of the target type in effect for the resource.
+* `remark` - (Optional) The remark of the whitelist rule.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds the `remark` Optional string parameter to the `alicloud_threat_detection_malicious_file_whitelist_config` resource. The Remark parameter is supported by the CreateMaliciousFileWhitelistConfig and UpdateMaliciousFileWhitelistConfig APIs and allows users to attach a remark note to a whitelist rule.

The parameter is set during Create and Update. Documentation and acceptance test coverage are updated accordingly.

### Test Cases

```
=== RUN TestAccAliCloudThreatDetectionMaliciousFileWhitelistConfig_basic4979
--- PASS: TestAccAliCloudThreatDetectionMaliciousFileWhitelistConfig_basic4979

=== RUN TestAccAliCloudThreatDetectionMaliciousFileWhitelistConfig_basic4979_twin
--- PASS: TestAccAliCloudThreatDetectionMaliciousFileWhitelistConfig_basic4979_twin
```
