### PR TITLE
New Resource: alicloud_threat_detection_file_protect_client_rule; New Data Source: alicloud_threat_detection_file_protect_client_rules

### DIFF
--- a/alicloud/data_source_alicloud_threat_detection_file_protect_client_rules.go
+++ b/alicloud/data_source_alicloud_threat_detection_file_protect_client_rules.go
@@ -1,0 +1,245 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"time"
+)
+
+func dataSourceAliCloudThreatDetectionFileProtectClientRules() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudThreatDetectionFileProtectClientRuleRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"alert_level": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"platform": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rule_action": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rule_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"alert_level": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"exclude_users": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"file_ops": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"file_paths": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"file_types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"platform": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"proc_paths": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"rule_action": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"rule_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"switch_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudThreatDetectionFileProtectClientRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	action := "ListFileProtectClientRule"
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+
+	if v, ok := d.GetOkExists("alert_level"); ok {
+		request["AlertLevel"] = v
+	}
+	if v, ok := d.GetOk("platform"); ok {
+		request["Platform"] = v
+	}
+	if v, ok := d.GetOk("rule_action"); ok {
+		request["RuleAction"] = v
+	}
+	if v, ok := d.GetOk("rule_name"); ok {
+		request["RuleName"] = v
+	}
+	request["PageSize"] = PageSizeLarge
+	request["CurrentPage"] = 1
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.FileProtectList[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["Id"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+		request["CurrentPage"] = request["CurrentPage"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["Id"]
+
+		mapping["alert_level"] = objectRaw["AlertLevel"]
+		mapping["platform"] = objectRaw["Platform"]
+		mapping["rule_action"] = objectRaw["RuleAction"]
+		mapping["rule_name"] = objectRaw["RuleName"]
+		mapping["status"] = objectRaw["Status"]
+		mapping["switch_id"] = objectRaw["SwitchId"]
+
+		excludeUsersRaw := make([]interface{}, 0)
+		if objectRaw["ExcludeUsers"] != nil {
+			excludeUsersRaw = convertToInterfaceArray(objectRaw["ExcludeUsers"])
+		}
+
+		mapping["exclude_users"] = excludeUsersRaw
+		fileOpsRaw := make([]interface{}, 0)
+		if objectRaw["FileOps"] != nil {
+			fileOpsRaw = convertToInterfaceArray(objectRaw["FileOps"])
+		}
+
+		mapping["file_ops"] = fileOpsRaw
+		filePathsRaw := make([]interface{}, 0)
+		if objectRaw["FilePaths"] != nil {
+			filePathsRaw = convertToInterfaceArray(objectRaw["FilePaths"])
+		}
+
+		mapping["file_paths"] = filePathsRaw
+		fileTypesRaw := make([]interface{}, 0)
+		if objectRaw["FileTypes"] != nil {
+			fileTypesRaw = convertToInterfaceArray(objectRaw["FileTypes"])
+		}
+
+		mapping["file_types"] = fileTypesRaw
+		procPathsRaw := make([]interface{}, 0)
+		if objectRaw["ProcPaths"] != nil {
+			procPathsRaw = convertToInterfaceArray(objectRaw["ProcPaths"])
+		}
+
+		mapping["proc_paths"] = procPathsRaw
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("rules", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_threat_detection_file_protect_client_rules_test.go
+++ b/alicloud/data_source_alicloud_threat_detection_file_protect_client_rules_test.go
@@ -1,0 +1,154 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudThreatDetectionFileProtectClientRulesDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetection%d", rand)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids": `["${alicloud_threat_detection_file_protect_client_rule.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids": `["${alicloud_threat_detection_file_protect_client_rule.default.id}_fake"]`,
+		}),
+	}
+
+	ruleNameConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids":       `["${alicloud_threat_detection_file_protect_client_rule.default.id}"]`,
+			"rule_name": `"${alicloud_threat_detection_file_protect_client_rule.default.rule_name}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids":       `["${alicloud_threat_detection_file_protect_client_rule.default.id}"]`,
+			"rule_name": `"${alicloud_threat_detection_file_protect_client_rule.default.rule_name}_fake"`,
+		}),
+	}
+
+	ruleActionConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids":         `["${alicloud_threat_detection_file_protect_client_rule.default.id}"]`,
+			"rule_action": `"pass"`,
+		}),
+		fakeConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids":         `["${alicloud_threat_detection_file_protect_client_rule.default.id}"]`,
+			"rule_action": `"block"`,
+		}),
+	}
+
+	platformConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids":      `["${alicloud_threat_detection_file_protect_client_rule.default.id}"]`,
+			"platform": `"linux"`,
+		}),
+		fakeConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids":      `["${alicloud_threat_detection_file_protect_client_rule.default.id}"]`,
+			"platform": `"windows"`,
+		}),
+	}
+
+	alertLevelConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids":         `["${alicloud_threat_detection_file_protect_client_rule.default.id}"]`,
+			"alert_level": `"1"`,
+		}),
+		fakeConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids":         `["${alicloud_threat_detection_file_protect_client_rule.default.id}"]`,
+			"alert_level": `"3"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids":         `["${alicloud_threat_detection_file_protect_client_rule.default.id}"]`,
+			"rule_name":   `"${alicloud_threat_detection_file_protect_client_rule.default.rule_name}"`,
+			"rule_action": `"pass"`,
+			"platform":    `"linux"`,
+			"alert_level": `"1"`,
+		}),
+		fakeConfig: testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name, map[string]string{
+			"ids":         `["${alicloud_threat_detection_file_protect_client_rule.default.id}_fake"]`,
+			"rule_name":   `"${alicloud_threat_detection_file_protect_client_rule.default.rule_name}_fake"`,
+			"rule_action": `"block"`,
+			"platform":    `"windows"`,
+			"alert_level": `"3"`,
+		}),
+	}
+
+	var existDataMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":                   "1",
+			"rules.#":                 "1",
+			"rules.0.id":              CHECKSET,
+			"rules.0.rule_name":       name,
+			"rules.0.rule_action":     "pass",
+			"rules.0.status":          "0",
+			"rules.0.platform":        "linux",
+			"rules.0.alert_level":     "1",
+			"rules.0.file_paths.#":    "2",
+			"rules.0.file_ops.#":      "1",
+			"rules.0.proc_paths.#":    "1",
+			"rules.0.file_types.#":    "1",
+			"rules.0.exclude_users.#": "1",
+		}
+	}
+
+	var fakeDataMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":   "0",
+			"rules.#": "0",
+		}
+	}
+
+	var fileProtectClientRulesCheckInfo = dataSourceAttr{
+		resourceId:   "data.alicloud_threat_detection_file_protect_client_rules.default",
+		existMapFunc: existDataMapFunc,
+		fakeMapFunc:  fakeDataMapFunc,
+	}
+
+	preCheck := func() {
+		testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		testAccPreCheck(t)
+	}
+
+	fileProtectClientRulesCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, idsConf, ruleNameConf, ruleActionConf, platformConf, alertLevelConf, allConf)
+}
+
+func testAccCheckAliCloudThreatDetectionFileProtectClientRulesDataSourceName(name string, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+
+	config := fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+resource "alicloud_threat_detection_file_protect_client_rule" "default" {
+  rule_name     = var.name
+  rule_action   = "pass"
+  status        = 0
+  platform      = "linux"
+  alert_level   = 1
+  file_paths    = ["/opt/a", "/tmp/d"]
+  file_ops      = ["READ"]
+  proc_paths    = ["/usr/bin/java"]
+  file_types    = ["sh"]
+  exclude_users = ["root"]
+}
+
+data "alicloud_threat_detection_file_protect_client_rules" "default" {
+  %s
+}
+`, name, strings.Join(pairs, "\n  "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_threat_detection_file_protect_client_rules":     dataSourceAliCloudThreatDetectionFileProtectClientRules(),
 			"alicloud_threat_detection_attack_path_whitelists":        dataSourceAliCloudThreatDetectionAttackPathWhitelists(),
 			"alicloud_ehpc_users":                                     dataSourceAliCloudEhpcUsers(),
 			"alicloud_realtime_compute_members":                       dataSourceAliCloudRealtimeComputeMembers(),
@@ -973,7 +974,8 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_sls_metric_stores":                                dataSourceAliCloudSlsMetricStores(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"alicloud_threat_detection_attack_path_whitelist":               resourceAliCloudThreatDetectionAttackPathWhitelist(),
+			"alicloud_threat_detection_file_protect_client_rule": resourceAliCloudThreatDetectionFileProtectClientRule(),
+			"alicloud_threat_detection_attack_path_whitelist":    resourceAliCloudThreatDetectionAttackPathWhitelist(),
 			"alicloud_ehpc_user":                                            resourceAliCloudEhpcUser(),
 			"alicloud_realtime_compute_member":                              resourceAliCloudRealtimeComputeMember(),
 			"alicloud_apig_policy":                                          resourceAliCloudApigPolicy(),

--- a/alicloud/resource_alicloud_threat_detection_file_protect_client_rule.go
+++ b/alicloud/resource_alicloud_threat_detection_file_protect_client_rule.go
@@ -1,0 +1,391 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudThreatDetectionFileProtectClientRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudThreatDetectionFileProtectClientRuleCreate,
+		Read:   resourceAliCloudThreatDetectionFileProtectClientRuleRead,
+		Update: resourceAliCloudThreatDetectionFileProtectClientRuleUpdate,
+		Delete: resourceAliCloudThreatDetectionFileProtectClientRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"alert_level": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: IntInSlice([]int{0, 1, 2, 3}),
+			},
+			"exclude_users": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"file_ops": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"file_paths": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"file_types": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"platform": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"windows", "linux"}, false),
+			},
+			"proc_paths": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"rule_action": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: StringInSlice([]string{"pass", "monitor", "block"}, false),
+			},
+			"rule_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"status": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: IntInSlice([]int{0, 1}),
+			},
+			"switch_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudThreatDetectionFileProtectClientRuleCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateFileProtectClientRule"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["ClientToken"] = buildClientToken(action)
+
+	if v, ok := d.GetOk("proc_paths"); ok {
+		procPathsMapsArray := convertToInterfaceArray(v)
+
+		request["ProcPaths"] = procPathsMapsArray
+	}
+
+	if v, ok := d.GetOk("file_types"); ok {
+		fileTypesMapsArray := convertToInterfaceArray(v)
+
+		request["FileTypes"] = fileTypesMapsArray
+	}
+
+	if v, ok := d.GetOk("file_paths"); ok {
+		filePathsMapsArray := convertToInterfaceArray(v)
+
+		request["FilePaths"] = filePathsMapsArray
+	}
+
+	request["RuleAction"] = d.Get("rule_action")
+	if v, ok := d.GetOkExists("alert_level"); ok {
+		request["AlertLevel"] = v
+	}
+	request["Status"] = d.Get("status")
+	request["RuleName"] = d.Get("rule_name")
+	if v, ok := d.GetOk("platform"); ok {
+		request["Platform"] = v
+	}
+	if v, ok := d.GetOk("exclude_users"); ok {
+		excludeUsersMapsArray := convertToInterfaceArray(v)
+
+		request["ExcludeUsers"] = excludeUsersMapsArray
+	}
+	if v, ok := d.GetOk("file_ops"); ok {
+		fileOpsMapsArray := convertToInterfaceArray(v)
+
+		request["FileOps"] = fileOpsMapsArray
+	}
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_threat_detection_file_protect_client_rule", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["Id"]))
+
+	return resourceAliCloudThreatDetectionFileProtectClientRuleRead(d, meta)
+}
+
+func resourceAliCloudThreatDetectionFileProtectClientRuleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	threatDetectionServiceV2 := ThreatDetectionServiceV2{client}
+
+	objectRaw, err := threatDetectionServiceV2.DescribeThreatDetectionFileProtectClientRule(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_threat_detection_file_protect_client_rule DescribeThreatDetectionFileProtectClientRule Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("alert_level", objectRaw["AlertLevel"])
+	d.Set("platform", objectRaw["Platform"])
+	d.Set("rule_action", objectRaw["RuleAction"])
+	d.Set("rule_name", objectRaw["RuleName"])
+	d.Set("status", objectRaw["Status"])
+	d.Set("switch_id", objectRaw["SwitchId"])
+
+	excludeUsersRaw := make([]interface{}, 0)
+	if objectRaw["ExcludeUsers"] != nil {
+		excludeUsersRaw = convertToInterfaceArray(objectRaw["ExcludeUsers"])
+	}
+
+	d.Set("exclude_users", excludeUsersRaw)
+	fileOpsRaw := make([]interface{}, 0)
+	if objectRaw["FileOps"] != nil {
+		fileOpsRaw = convertToInterfaceArray(objectRaw["FileOps"])
+	}
+
+	d.Set("file_ops", fileOpsRaw)
+	filePathsRaw := make([]interface{}, 0)
+	if objectRaw["FilePaths"] != nil {
+		filePathsRaw = convertToInterfaceArray(objectRaw["FilePaths"])
+	}
+
+	d.Set("file_paths", filePathsRaw)
+	fileTypesRaw := make([]interface{}, 0)
+	if objectRaw["FileTypes"] != nil {
+		fileTypesRaw = convertToInterfaceArray(objectRaw["FileTypes"])
+	}
+
+	d.Set("file_types", fileTypesRaw)
+	procPathsRaw := make([]interface{}, 0)
+	if objectRaw["ProcPaths"] != nil {
+		procPathsRaw = convertToInterfaceArray(objectRaw["ProcPaths"])
+	}
+
+	d.Set("proc_paths", procPathsRaw)
+
+	return nil
+}
+
+func resourceAliCloudThreatDetectionFileProtectClientRuleUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	update := false
+
+	var err error
+	action := "UpdateFileProtectClientRule"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["Id"] = d.Id()
+
+	if d.HasChange("proc_paths") {
+		update = true
+	}
+	if v, ok := d.GetOk("proc_paths"); ok || d.HasChange("proc_paths") {
+		procPathsMapsArray := convertToInterfaceArray(v)
+
+		request["ProcPaths"] = procPathsMapsArray
+	}
+
+	if d.HasChange("file_types") {
+		update = true
+		if v, ok := d.GetOk("file_types"); ok || d.HasChange("file_types") {
+			fileTypesMapsArray := convertToInterfaceArray(v)
+
+			request["FileTypes"] = fileTypesMapsArray
+		}
+	}
+
+	if d.HasChange("file_paths") {
+		update = true
+	}
+	if v, ok := d.GetOk("file_paths"); ok || d.HasChange("file_paths") {
+		filePathsMapsArray := convertToInterfaceArray(v)
+
+		request["FilePaths"] = filePathsMapsArray
+	}
+
+	if d.HasChange("rule_action") {
+		update = true
+	}
+	request["RuleAction"] = d.Get("rule_action")
+	if d.HasChange("alert_level") {
+		update = true
+		request["AlertLevel"] = d.Get("alert_level")
+	}
+
+	if d.HasChange("rule_name") {
+		update = true
+	}
+	request["RuleName"] = d.Get("rule_name")
+	request["Status"] = d.Get("status")
+	if d.HasChange("exclude_users") {
+		update = true
+		if v, ok := d.GetOk("exclude_users"); ok || d.HasChange("exclude_users") {
+			excludeUsersMapsArray := convertToInterfaceArray(v)
+
+			request["ExcludeUsers"] = excludeUsersMapsArray
+		}
+	}
+
+	if d.HasChange("file_ops") {
+		update = true
+	}
+	if v, ok := d.GetOk("file_ops"); ok || d.HasChange("file_ops") {
+		fileOpsMapsArray := convertToInterfaceArray(v)
+
+		request["FileOps"] = fileOpsMapsArray
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+	update = false
+	action = "UpdateFileProtectClientRuleStatus"
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["IdList.1"] = d.Id()
+	request["SelectAll"] = false
+
+	if d.HasChange("rule_action") {
+		update = true
+	}
+	request["RuleAction"] = d.Get("rule_action")
+	if d.HasChange("alert_level") {
+		update = true
+		request["AlertLevel"] = d.Get("alert_level")
+	}
+
+	if d.HasChange("status") {
+		update = true
+	}
+	request["Status"] = d.Get("status")
+	if d.HasChange("rule_name") {
+		update = true
+	}
+	request["RuleName"] = d.Get("rule_name")
+	if d.HasChange("platform") {
+		update = true
+		request["Platform"] = d.Get("platform")
+	}
+
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudThreatDetectionFileProtectClientRuleRead(d, meta)
+}
+
+func resourceAliCloudThreatDetectionFileProtectClientRuleDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteFileProtectClientRule"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["IdList.1"] = d.Id()
+	request["SelectAll"] = false
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_threat_detection_file_protect_client_rule_test.go
+++ b/alicloud/resource_alicloud_threat_detection_file_protect_client_rule_test.go
@@ -1,0 +1,162 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test ThreatDetection FileProtectClientRule. >>> Resource test cases.
+func TestAccAliCloudThreatDetectionFileProtectClientRule_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_file_protect_client_rule.default"
+	ra := resourceAttrInit(resourceId, AliCloudThreatDetectionFileProtectClientRuleMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionFileProtectClientRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetection%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudThreatDetectionFileProtectClientRuleBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rule_name":     name,
+					"rule_action":   "pass",
+					"status":        "0",
+					"platform":      "linux",
+					"alert_level":   "1",
+					"file_paths":    []string{"/opt/a", "/tmp/d"},
+					"file_ops":      []string{"READ"},
+					"proc_paths":    []string{"/usr/bin/java"},
+					"file_types":    []string{"sh"},
+					"exclude_users": []string{"root"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rule_name":       name,
+						"rule_action":     "pass",
+						"status":          "0",
+						"platform":        "linux",
+						"alert_level":     "1",
+						"file_paths.#":    "2",
+						"file_ops.#":      "1",
+						"proc_paths.#":    "1",
+						"file_types.#":    "1",
+						"exclude_users.#": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rule_name":     name + "_update",
+					"rule_action":   "monitor",
+					"status":        "1",
+					"platform":      "linux",
+					"alert_level":   "3",
+					"file_paths":    []string{"/opt/b"},
+					"file_ops":      []string{"READ", "WRITE", "DELETE"},
+					"proc_paths":    []string{"/usr/bin/java", "/usr/bin/python"},
+					"file_types":    []string{"sh", "py"},
+					"exclude_users": []string{},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rule_name":       name + "_update",
+						"rule_action":     "monitor",
+						"status":          "1",
+						"alert_level":     "3",
+						"file_paths.#":    "1",
+						"file_ops.#":      "3",
+						"proc_paths.#":    "2",
+						"file_types.#":    "2",
+						"exclude_users.#": "0",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudThreatDetectionFileProtectClientRule_basic_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_threat_detection_file_protect_client_rule.default"
+	ra := resourceAttrInit(resourceId, AliCloudThreatDetectionFileProtectClientRuleMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ThreatDetectionServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeThreatDetectionFileProtectClientRule")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccthreatdetection%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudThreatDetectionFileProtectClientRuleBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"rule_name":   name,
+					"rule_action": "block",
+					"status":      "1",
+					"platform":    "windows",
+					"file_paths":  []string{"C:\\\\inetpub"},
+					"file_ops":    []string{"WRITE", "CHMOD", "RENAME"},
+					"proc_paths":  []string{"C:\\\\Windows\\\\System32"},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"rule_name":    name,
+						"rule_action":  "block",
+						"status":       "1",
+						"platform":     "windows",
+						"file_paths.#": "1",
+						"file_ops.#":   "3",
+						"proc_paths.#": "1",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AliCloudThreatDetectionFileProtectClientRuleMap = map[string]string{}
+
+func AliCloudThreatDetectionFileProtectClientRuleBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+`, name)
+}
+
+// Test ThreatDetection FileProtectClientRule. <<< Resource test cases.

--- a/alicloud/service_alicloud_threat_detection_v2.go
+++ b/alicloud/service_alicloud_threat_detection_v2.go
@@ -1656,3 +1656,79 @@ func (s *ThreatDetectionServiceV2) ThreatDetectionAttackPathWhitelistStateRefres
 }
 
 // DescribeThreatDetectionAttackPathWhitelist >>> Encapsulated.
+
+// DescribeThreatDetectionFileProtectClientRule <<< Encapsulated get interface for ThreatDetection FileProtectClientRule.
+
+func (s *ThreatDetectionServiceV2) DescribeThreatDetectionFileProtectClientRule(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["Id"] = id
+
+	action := "GetFileProtectClientRule"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Sas", "2018-12-03", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"ServerError"}) {
+			return object, WrapErrorf(NotFoundErr("FileProtectClientRule", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	v, err := jsonpath.Get("$.Data", response)
+	if err != nil {
+		return object, WrapErrorf(NotFoundErr("FileProtectClientRule", id), NotFoundMsg, response)
+	}
+
+	return v.(map[string]interface{}), nil
+}
+
+func (s *ThreatDetectionServiceV2) ThreatDetectionFileProtectClientRuleStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ThreatDetectionFileProtectClientRuleStateRefreshFuncWithApi(id, field, failStates, s.DescribeThreatDetectionFileProtectClientRule)
+}
+
+func (s *ThreatDetectionServiceV2) ThreatDetectionFileProtectClientRuleStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeThreatDetectionFileProtectClientRule >>> Encapsulated.

--- a/website/docs/d/threat_detection_file_protect_client_rules.html.markdown
+++ b/website/docs/d/threat_detection_file_protect_client_rules.html.markdown
@@ -1,0 +1,74 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_file_protect_client_rules"
+sidebar_current: "docs-alicloud-datasource-threat-detection-file-protect-client-rules"
+description: |-
+  Provides a list of Threat Detection File Protect Client Rule owned by an Alibaba Cloud account.
+---
+
+# alicloud_threat_detection_file_protect_client_rules
+
+This data source provides Threat Detection File Protect Client Rule available to the user.[What is File Protect Client Rule](https://next.api.alibabacloud.com/document/Sas/2018-12-03/CreateFileProtectClientRule)
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_threat_detection_file_protect_client_rule" "default" {
+  rule_name   = var.name
+  rule_action = "pass"
+  status      = 0
+  alert_level = 1
+  platform    = "linux"
+  file_paths  = ["/opt/a", "/tmp/d"]
+  file_ops    = ["READ", "WRITE"]
+  proc_paths  = ["/usr/bin/java"]
+}
+
+data "alicloud_threat_detection_file_protect_client_rules" "default" {
+  ids = [alicloud_threat_detection_file_protect_client_rule.default.id]
+}
+
+output "file_protect_client_rule_id" {
+  value = data.alicloud_threat_detection_file_protect_client_rules.default.rules.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `alert_level` - (Optional, Int) Filter rules by alert level. Valid values: `0` (no alert), `1` (info), `2` (suspicious), `3` (critical).
+* `platform` - (Optional) Filter rules by operating system type. Valid values: `windows`, `linux`.
+* `rule_action` - (Optional) Filter rules by action. Valid values: `pass`, `monitor`, `block`.
+* `rule_name` - (Optional) Filter rules by rule name.
+* `ids` - (Optional, Computed) A list of File Protect Client Rule IDs.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `ids` - A list of File Protect Client Rule IDs.
+* `rules` - A list of File Protect Client Rule Entries. Each element contains the following attributes:
+  * `id` - The ID of the rule.
+  * `alert_level` - The alert level of the rule. `0`: no alert, `1`: info, `2`: suspicious, `3`: critical.
+  * `exclude_users` - The list of users to exclude.
+  * `file_ops` - The operations that are performed on the files.
+  * `file_paths` - The paths to the files that are monitored.
+  * `file_types` - The list of file types to monitor.
+  * `platform` - The type of the operating system.
+  * `proc_paths` - The paths to the processes that are monitored.
+  * `rule_action` - The action of the rule.
+  * `rule_name` - The name of the rule.
+  * `status` - The status of the rule. `0`: disabled, `1`: enabled.
+  * `switch_id` - The switch ID of the rule.

--- a/website/docs/r/threat_detection_file_protect_client_rule.html.markdown
+++ b/website/docs/r/threat_detection_file_protect_client_rule.html.markdown
@@ -1,0 +1,83 @@
+---
+subcategory: "Threat Detection"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_threat_detection_file_protect_client_rule"
+description: |-
+  Provides a Alicloud Threat Detection File Protect Client Rule resource.
+---
+
+# alicloud_threat_detection_file_protect_client_rule
+
+Provides a Threat Detection File Protect Client Rule resource.
+
+Client file protection event monitoring rules, including file read/write, delete, rename, and permission change.
+
+For information about Threat Detection File Protect Client Rule and how to use it, see [What is File Protect Client Rule](https://next.api.alibabacloud.com/document/Sas/2018-12-03/CreateFileProtectClientRule).
+
+-> **NOTE:** Available since v1.287.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_threat_detection_file_protect_client_rule" "default" {
+  rule_name   = var.name
+  rule_action = "pass"
+  status      = 0
+  alert_level = 1
+  platform    = "linux"
+  file_paths  = ["/opt/a", "/tmp/d"]
+  file_ops    = ["READ", "WRITE"]
+  proc_paths  = ["/usr/bin/java"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `alert_level` - (Optional, Int) 0 no alert 1 info 2 suspicious 3 critical
+* `exclude_users` - (Optional, List) The list of users to exclude.
+* `file_ops` - (Required, List) The operations that you want to perform on the files.
+* `file_paths` - (Required, List) The paths to the files that you want to monitor. Wildcard characters are supported.
+* `file_types` - (Optional, List) The list of file types to monitor.
+* `platform` - (Optional, ForceNew) The type of the operating system. Valid values:
+
+  - `windows`: Windows
+  - `linux`: Linux
+* `proc_paths` - (Required, List) The paths to the processes that you want to monitor. Wildcard characters are supported.
+* `rule_action` - (Required) The action of the rule. Valid values: `pass`, `monitor`, `block`.
+* `rule_name` - (Required) The name of the rule.
+* `status` - (Required, Int) Specifies whether to enable the rule. Valid values:
+
+  - `1`: yes
+  - `0`: no
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+* `switch_id` - The switch ID of the rule, assigned by the server.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the File Protect Client Rule.
+* `delete` - (Defaults to 5 mins) Used when delete the File Protect Client Rule.
+* `update` - (Defaults to 5 mins) Used when update the File Protect Client Rule.
+
+## Import
+
+Threat Detection File Protect Client Rule can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_threat_detection_file_protect_client_rule.example <id>
+```


### PR DESCRIPTION
## Summary
- New Resource: alicloud_threat_detection_file_protect_client_rule
- New Data Source: alicloud_threat_detection_file_protect_client_rules

## Test plan
- [x] `TestAccAliCloudThreatDetectionFileProtectClientRule_basic` PASS in cn-hangzhou (6.05s): create → update → import → destroy.
- [x] `TestAccAliCloudThreatDetectionFileProtectClientRule_basic_twin` PASS (3.66s): windows platform create → import → destroy.
- [x] `TestAccAliCloudThreatDetectionFileProtectClientRulesDataSource` PASS (28.60s): ids/rule_name/rule_action/platform/alert_level filters.

```
=== RUN TestAccAliCloudThreatDetectionFileProtectClientRule_basic
--- PASS: TestAccAliCloudThreatDetectionFileProtectClientRule_basic (6.05s)

=== RUN TestAccAliCloudThreatDetectionFileProtectClientRule_basic_twin
--- PASS: TestAccAliCloudThreatDetectionFileProtectClientRule_basic_twin (3.66s)

=== RUN TestAccAliCloudThreatDetectionFileProtectClientRulesDataSource
--- PASS: TestAccAliCloudThreatDetectionFileProtectClientRulesDataSource (28.60s)
```