### PR TITLE
data-source/alicloud_slb_load_balancers: fix and expose creation time

### DIFF
--- a/alicloud/data_source_alicloud_slb_load_balancers.go
+++ b/alicloud/data_source_alicloud_slb_load_balancers.go
@@ -172,6 +172,10 @@ func dataSourceAlicloudSlbLoadBalancers() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"create_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"create_time_stamp": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -530,7 +534,7 @@ func dataSourceAlicloudSlbLoadBalancersRead(d *schema.ResourceData, meta interfa
 	}
 	ids := make([]string, 0)
 	names := make([]interface{}, 0)
-	s := make([]map[string]interface{}, 0)
+	balancers := make([]map[string]interface{}, 0)
 	slbs := make([]map[string]interface{}, 0)
 	for _, v := range objects {
 		object := v.(map[string]interface{})
@@ -538,6 +542,7 @@ func dataSourceAlicloudSlbLoadBalancersRead(d *schema.ResourceData, meta interfa
 			"address":                        object["Address"],
 			"address_ip_version":             object["AddressIPVersion"],
 			"address_type":                   object["AddressType"],
+			"create_time":                    object["CreateTime"],
 			"create_time_stamp":              formatInt(object["CreateTimeStamp"]),
 			"id":                             fmt.Sprint(object["LoadBalancerId"]),
 			"load_balancer_id":               fmt.Sprint(object["LoadBalancerId"]),
@@ -580,7 +585,7 @@ func dataSourceAlicloudSlbLoadBalancersRead(d *schema.ResourceData, meta interfa
 			"vswitch_id":               object["VSwitchId"],
 			"address":                  object["Address"],
 			"internet":                 fmt.Sprint(object["NetworkType"]) == strings.ToLower(string(Internet)),
-			"creation_time":            object["CreationTime"],
+			"creation_time":            object["CreateTime"],
 			"tags":                     tags,
 		}
 		slbs = append(slbs, slb)
@@ -588,7 +593,7 @@ func dataSourceAlicloudSlbLoadBalancersRead(d *schema.ResourceData, meta interfa
 		if detailedEnabled := d.Get("enable_details"); !detailedEnabled.(bool) {
 			ids = append(ids, fmt.Sprint(object["LoadBalancerId"]))
 			names = append(names, object["LoadBalancerName"])
-			s = append(s, mapping)
+			balancers = append(balancers, mapping)
 			continue
 		}
 
@@ -657,7 +662,7 @@ func dataSourceAlicloudSlbLoadBalancersRead(d *schema.ResourceData, meta interfa
 		mapping["renewal_status"] = getResp["RenewalStatus"]
 		ids = append(ids, fmt.Sprint(object["LoadBalancerId"]))
 		names = append(names, object["LoadBalancerName"])
-		s = append(s, mapping)
+		balancers = append(balancers, mapping)
 	}
 
 	d.SetId(dataResourceIdHash(ids))
@@ -669,7 +674,7 @@ func dataSourceAlicloudSlbLoadBalancersRead(d *schema.ResourceData, meta interfa
 		return WrapError(err)
 	}
 
-	if err := d.Set("balancers", s); err != nil {
+	if err := d.Set("balancers", balancers); err != nil {
 		return WrapError(err)
 	}
 	if err := d.Set("slbs", slbs); err != nil {
@@ -679,7 +684,7 @@ func dataSourceAlicloudSlbLoadBalancersRead(d *schema.ResourceData, meta interfa
 		return WrapError(err)
 	}
 	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
-		writeToFile(output.(string), s)
+		writeToFile(output.(string), balancers)
 	}
 
 	return nil

--- a/alicloud/data_source_alicloud_slb_load_balancers_test.go
+++ b/alicloud/data_source_alicloud_slb_load_balancers_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-func TestAccAlicloudSLBLoadBalancersDataSource(t *testing.T) {
+func TestAccAliCloudSLBLoadBalancersDataSource(t *testing.T) {
 	checkoutSupportedRegions(t, true, connectivity.TestSalveRegions)
 	rand := acctest.RandInt()
 	idsConf := dataSourceTestAccConfig{
@@ -150,6 +150,8 @@ func TestAccAlicloudSLBLoadBalancersDataSource(t *testing.T) {
 			"balancers.0.address_ip_version":             `ipv4`,
 			"balancers.0.address_type":                   `intranet`,
 			"balancers.0.bandwidth":                      CHECKSET,
+			"balancers.0.create_time":                    CHECKSET,
+			"balancers.0.create_time_stamp":              CHECKSET,
 			"balancers.0.internet_charge_type":           `PayByTraffic`,
 			"balancers.0.delete_protection":              `off`,
 			"balancers.0.load_balancer_name":             CHECKSET,
@@ -163,6 +165,7 @@ func TestAccAlicloudSLBLoadBalancersDataSource(t *testing.T) {
 			"balancers.0.status":                         `active`,
 			"balancers.0.tags.%":                         `1`,
 			"balancers.0.vswitch_id":                     CHECKSET,
+			"slbs.0.creation_time":                       CHECKSET,
 		}
 	}
 	var fakeAlicloudSlbLoadBalancersDataSourceNameMapFunc = func(rand int) map[string]string {

--- a/website/docs/d/slb_load_balancers.html.markdown
+++ b/website/docs/d/slb_load_balancers.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Classic Load Balancer (SLB)"
 layout: "alicloud"
-page_title: "Alicloud: alicloud_slbs_load_balancers"
+page_title: "Alicloud: alicloud_slb_load_balancers"
 sidebar_current: "docs-alicloud-datasource-slb-load-balancers"
 description: |-
     Provides a list of server load balancers to the user.
@@ -11,7 +11,7 @@ description: |-
 
 This data source provides the server load balancers of the current Alibaba Cloud user.
 
--> **NOTE:** Available in 1.123.1+
+-> **NOTE:** Available since v1.123.1
 
 ## Example Usage
 
@@ -51,6 +51,8 @@ The following arguments are supported:
 * `server_intranet_address` - (Optional, ForceNew) The server intranet address.
 * `master_zone_id` - (Optional, ForceNew) The master zone id of the SLB.
 * `slave_zone_id` - (Optional, ForceNew) The slave zone id of the SLB.
+* `status` - (Optional) The status of the SLB. Valid values: `active`, `inactive` and `locked`.
+* `enable_details` - (Optional) Whether to enable details of the SLB. Default to `false`.
 
 ## Attributes Reference
 
@@ -59,45 +61,61 @@ The following attributes are exported in addition to the arguments listed above:
 * `ids` - A list of slb IDs.
 * `names` - A list of slb names.
 * `balancers` - A list of SLBs. Each element contains the following attributes:
-    * `id` - ID of the SLB.
-    * `address` - The IP address that the SLB instance uses to provide services.
-    * `address_ip_version` - The address ip version.
-    * `address_type` - The address type.
-    * `auto_release_time` - The auto release time.
-    * `backend_servers` - The backend servers of the SLB.
-        * `description` - The description of servers.
-        * `server_id` - The ID of the Elastic Compute Service (ECS) instance that is specified as a backend server of the CLB instance.
-        * `type` - The type of servers.
-        * `weight` - The weight of servers.
-    * `bandwidth` - The bandwidth of the SLB.
-    * `create_time_stamp` - The create time stamp of the SLB.
-    * `delete_protection` - Whether the SLB should delete protection.
-    * `end_time` - The end time of the SLB.
-    * `end_time_stamp` - The end time stamp of the SLB.
-    * `internet_charge_type` - The billing method of the Internet-facing SLB instance.
-    * `listener_ports_and_protocal` - The listener ports and protocal of the SLB.
-        * `listener_port` - The listener port.
-        * `listener_protocal` - The listener protoal.
-    * `listener_ports_and_protocol` - The listener ports and protocol of the SLB.
-        * `description` - The description of protocol.
-        * `forward_port` - The forward port.
-        * `listener_forward` - The listener forward.
-        * `listener_port` - The listener port.
-        * `listener_protocol` - The listener protocol.
-    * `load_balancer_id` - Thd ID of the SLB.
-    * `load_balancer_name` - The name of the SLB.
-    * `master_zone_id` - Master availability zone of the SLBs.
-    * `modification_protection_reason` - The reason of modification protection.
-    * `modification_protection_status` - The status of modification protection.
-    * `network_type` -  Network type of the SLB. Possible values: `vpc` and `classic`.
-    * `region_id_alias` - Region ID the SLB belongs to.
-    * `renewal_cyc_unit` - The renewal cyc unit of the SLB.
-    * `renewal_duration` - The renewal duration of the SLB.
-    * `renewal_status` - The renewal status of the SLB.
-    * `resource_group_id` - The ID of the resource group.
-    * `slave_zone_id` - Slave availability zone of the SLBs.
-    * `load_balancer_spec` - The specification of the SLB.
-    * `status` - SLB current status. Possible values: `inactive`, `active` and `locked`.
-    * `tags` - The tags of the SLB.
-    * `vswitch_id` - ID of the vSwitch the SLB belongs to.
-    * `vpc_id` - ID of the VPC the SLB belongs to.
+  * `id` - ID of the SLB.
+  * `address` - The IP address that the SLB instance uses to provide services.
+  * `address_ip_version` - The address ip version.
+  * `address_type` - The address type.
+  * `auto_release_time` - The auto release time.
+  * `backend_servers` - The backend servers of the SLB.
+    * `description` - The description of servers.
+    * `server_id` - The ID of the Elastic Compute Service (ECS) instance that is specified as a backend server of the CLB instance.
+    * `type` - The type of servers.
+    * `weight` - The weight of servers.
+  * `bandwidth` - The bandwidth of the SLB.
+  * `create_time` - The creation time of the SLB, mapped from the API `CreateTime` field.
+  * `create_time_stamp` - The create time stamp of the SLB.
+  * `delete_protection` - Whether the SLB should delete protection.
+  * `end_time` - The end time of the SLB.
+  * `end_time_stamp` - The end time stamp of the SLB.
+  * `internet_charge_type` - The billing method of the Internet-facing SLB instance.
+  * `listener_ports_and_protocal` - The listener ports and protocal of the SLB.
+    * `listener_port` - The listener port.
+    * `listener_protocal` - The listener protoal.
+  * `listener_ports_and_protocol` - The listener ports and protocol of the SLB.
+    * `description` - The description of protocol.
+    * `forward_port` - The forward port.
+    * `listener_forward` - The listener forward.
+    * `listener_port` - The listener port.
+    * `listener_protocol` - The listener protocol.
+  * `load_balancer_id` - Thd ID of the SLB.
+  * `load_balancer_name` - The name of the SLB.
+  * `master_zone_id` - Master availability zone of the SLBs.
+  * `modification_protection_reason` - The reason of modification protection.
+  * `modification_protection_status` - The status of modification protection.
+  * `network_type` -  Network type of the SLB. Possible values: `vpc` and `classic`.
+  * `payment_type` - The payment type of the SLB.
+  * `region_id_alias` - Region ID the SLB belongs to.
+  * `renewal_cyc_unit` - The renewal cyc unit of the SLB.
+  * `renewal_duration` - The renewal duration of the SLB.
+  * `renewal_status` - The renewal status of the SLB.
+  * `resource_group_id` - The ID of the resource group.
+  * `slave_zone_id` - Slave availability zone of the SLBs.
+  * `load_balancer_spec` - The specification of the SLB.
+  * `status` - SLB current status. Possible values: `inactive`, `active` and `locked`.
+  * `tags` - The tags of the SLB.
+  * `vswitch_id` - ID of the vSwitch the SLB belongs to.
+  * `vpc_id` - ID of the VPC the SLB belongs to.
+* `slbs` - **Deprecated** It has been deprecated from v1.123.1 and replaced by `balancers`. Each element contains the following attributes:
+  * `id` - ID of the SLB.
+  * `region_id` - Region ID the SLB belongs to.
+  * `master_availability_zone` - Master availability zone of the SLB.
+  * `slave_availability_zone` - Slave availability zone of the SLB.
+  * `status` - SLB current status. Possible values: `inactive`, `active` and `locked`.
+  * `name` - The name of the SLB.
+  * `network_type` - Network type of the SLB. Possible values: `vpc` and `classic`.
+  * `vpc_id` - ID of the VPC the SLB belongs to.
+  * `vswitch_id` - ID of the vSwitch the SLB belongs to.
+  * `address` - The IP address that the SLB instance uses to provide services.
+  * `internet` - Whether the SLB is internet-facing.
+  * `creation_time` - The creation time of the SLB.
+  * `tags` - The tags of the SLB.


### PR DESCRIPTION
The legacy `slbs.creation_time` output was empty because it read `CreationTime` instead of the `CreateTime` returned by `DescribeLoadBalancers`.

This change fixes that mapping and exposes the same string as `balancers.create_time`, alongside the existing `balancers.create_time_stamp`. It also renames the result slice from `s` to `balancers` and documents the new output.

The acceptance test now checks `slbs.0.creation_time`, `balancers.0.create_time_stamp`, and `balancers.0.create_time` together.

Validation:
- Provider schema validation tests passed.
- Go formatting and documentation lint passed.
- `TestAccAliCloudSLBLoadBalancersDataSource` passed in 293.93 seconds with `TF_ACC=1` (PASS=1, FAIL=0, SKIP=0).
