### PR TITLE
data-source/alicloud_cloud_firewall_nat_firewalls: expose status and region_no output fields

### DIFF
--- a/alicloud/data_source_alicloud_cloud_firewall_nat_firewalls.go
+++ b/alicloud/data_source_alicloud_cloud_firewall_nat_firewalls.go
@@ -115,8 +115,16 @@ func dataSourceAliCloudCloudFirewallNatFirewalls() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"region_no": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"strict_mode": {
 							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"vpc_id": {
@@ -222,7 +230,6 @@ func dataSourceAliCloudCloudFirewallNatFirewallRead(d *schema.ResourceData, meta
 	}
 
 	ids := make([]string, 0)
-	names := make([]interface{}, 0)
 	s := make([]map[string]interface{}, 0)
 	for _, objectRaw := range objects {
 		mapping := map[string]interface{}{}
@@ -234,7 +241,9 @@ func dataSourceAliCloudCloudFirewallNatFirewallRead(d *schema.ResourceData, meta
 		mapping["nat_gateway_id"] = objectRaw["NatGatewayId"]
 		mapping["nat_gateway_name"] = objectRaw["NatGatewayName"]
 		mapping["proxy_name"] = objectRaw["ProxyName"]
+		mapping["region_no"] = objectRaw["RegionId"]
 		mapping["strict_mode"] = objectRaw["StrictMode"]
+		mapping["status"] = objectRaw["ProxyStatus"]
 		mapping["vpc_id"] = objectRaw["VpcId"]
 		mapping["proxy_id"] = objectRaw["ProxyId"]
 
@@ -255,7 +264,6 @@ func dataSourceAliCloudCloudFirewallNatFirewallRead(d *schema.ResourceData, meta
 		mapping["nat_route_entry_list"] = natRouteEntryListMaps
 
 		ids = append(ids, fmt.Sprint(mapping["id"]))
-		names = append(names, objectRaw[""])
 		s = append(s, mapping)
 	}
 

--- a/alicloud/data_source_alicloud_cloud_firewall_nat_firewalls_test.go
+++ b/alicloud/data_source_alicloud_cloud_firewall_nat_firewalls_test.go
@@ -129,6 +129,8 @@ var existCloudFirewallNatFirewallMapFunc = func(rand int) map[string]string {
 		"firewalls.0.nat_route_entry_list.#": CHECKSET,
 		"firewalls.0.nat_gateway_id":         CHECKSET,
 		"firewalls.0.ali_uid":                CHECKSET,
+		"firewalls.0.region_no":              CHECKSET,
+		"firewalls.0.status":                 CHECKSET,
 	}
 }
 

--- a/website/docs/d/cloud_firewall_nat_firewalls.html.markdown
+++ b/website/docs/d/cloud_firewall_nat_firewalls.html.markdown
@@ -133,6 +133,8 @@ The following attributes are exported in addition to the arguments listed above:
     * `route_table_id` - The route table where the default route of the NAT gateway is located.
   * `proxy_id` - NAT firewall ID
   * `proxy_name` - NAT firewall name
+  * `region_no` - The region ID of the NAT firewall.
   * `strict_mode` - Whether strict mode is enabled1-Enable strict mode0-Disable strict mode
+  * `status` - The status of the NAT firewall.
   * `vpc_id` - The ID of the VPC instance.
   * `id` - The ID of the resource supplied above.


### PR DESCRIPTION
## Summary
The `alicloud_cloud_firewall_nat_firewalls` data source exposes the list of NAT firewalls but did not include each firewall status or region in the `firewalls` output block. As a result, users could not read a firewall status to locate NAT gateways without a firewall created, and could not pass the data source output into `alicloud_cloud_firewall_nat_firewall` resources, which require `region_no`.

This change adds two computed output attributes to the `firewalls` block:
- `status` - mapped from the `ProxyStatus` response field
- `region_no` - mapped from the `RegionId` response field

The existing `status` and `region_no` input filters, pagination, and ids matching logic are unchanged. A latent reference to an empty object key and its unused accumulator are also removed.

## Test plan
- [x] `gofmt` on the changed Go files (clean)
- [x] `go vet ./alicloud` - the package builds; no vet issues in the changed files
- [x] Added `firewalls.0.status` and `firewalls.0.region_no` CHECKSET assertions to the existing exist-case checks in `data_source_alicloud_cloud_firewall_nat_firewalls_test.go`; existing assertions unchanged
- [ ] GitHub CI on the final head SHA
- [ ] Independent QA verification of the datasource contract