### PR TITLE
resource/alicloud_lindorm_instance: allow log_num to update independently

### DIFF
--- a/alicloud/resource_alicloud_lindorm_instance.go
+++ b/alicloud/resource_alicloud_lindorm_instance.go
@@ -825,12 +825,12 @@ func resourceAliCloudLindormInstanceUpdate(d *schema.ResourceData, meta interfac
 		d.SetPartial("search_engine_node_count")
 	}
 
-	if (d.HasChange("table_engine_node_count") || d.HasChange("table_engine_specification")) && !d.IsNewResource() {
+	if (d.HasChange("table_engine_node_count") || d.HasChange("table_engine_specification") || d.HasChange("log_num")) && !d.IsNewResource() {
 		newLindormSpec := d.Get("table_engine_specification")
 		newLindormNum := d.Get("table_engine_node_count")
 		enabled := d.Get("enabled_table_engine").(bool)
 		currentInstanceStorage := formatInt(d.Get("instance_storage"))
-		if !enabled {
+		if !enabled && (d.HasChange("table_engine_node_count") || d.HasChange("table_engine_specification")) {
 			upgradeLindormInstanceTableReq := map[string]interface{}{}
 			upgradeLindormInstanceTableReq["UpgradeType"] = "open-lindorm-engine"
 			upgradeLindormInstanceTableReq["LindormSpec"] = newLindormSpec
@@ -853,8 +853,8 @@ func resourceAliCloudLindormInstanceUpdate(d *schema.ResourceData, meta interfac
 			}
 		}
 
-		if enabled && d.HasChange("table_engine_node_count") {
-			if !d.IsNewResource() && d.HasChange("log_num") && d.HasChange("table_engine_node_count") {
+		if enabled && (d.HasChange("table_engine_node_count") || d.HasChange("log_num")) {
+			if !d.IsNewResource() && d.HasChange("log_num") {
 				upgradeLindormLogNumReq := map[string]interface{}{}
 				upgradeLindormLogNumReq["UpgradeType"] = "upgrade-lindorm-core-num"
 				upgradeLindormLogNumReq["LogNum"] = d.Get("log_num")
@@ -877,6 +877,7 @@ func resourceAliCloudLindormInstanceUpdate(d *schema.ResourceData, meta interfac
 
 		d.SetPartial("table_engine_specification")
 		d.SetPartial("table_engine_node_count")
+		d.SetPartial("log_num")
 	}
 
 	if (d.HasChange("time_series_engine_node_count") || d.HasChange("time_serires_engine_specification") || d.HasChange("time_series_engine_specification")) && !d.IsNewResource() {

--- a/alicloud/resource_alicloud_lindorm_instance_test.go
+++ b/alicloud/resource_alicloud_lindorm_instance_test.go
@@ -108,6 +108,7 @@ func testSweepLindormInstances(region string) error {
 
 func TestAccAliCloudLindormInstance_basic0(t *testing.T) {
 	var v map[string]interface{}
+	checkoutSupportedRegions(t, true, connectivity.LindormInstanceRegions)
 	resourceId := "alicloud_lindorm_instance.default_0"
 	ra := resourceAttrInit(resourceId, AliCloudLindormInstanceMap0)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
@@ -446,6 +447,7 @@ func TestAccAliCloudLindormInstance_basic0(t *testing.T) {
 
 func TestAccAliCloudLindormInstance_basic1(t *testing.T) {
 	var v map[string]interface{}
+	checkoutSupportedRegions(t, true, connectivity.LindormInstanceRegions)
 	resourceId := "alicloud_lindorm_instance.default_1"
 	ra := resourceAttrInit(resourceId, AliCloudLindormInstanceMap0)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
@@ -636,6 +638,17 @@ func TestAccAliCloudLindormInstance_basic2(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"log_num": "12",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"table_engine_node_count": "8",
+						"log_num":                 "12",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"log_spec": "lindorm.sn1.2xlarge",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -656,6 +669,7 @@ func TestAccAliCloudLindormInstance_basic2(t *testing.T) {
 
 func TestAccAliCloudLindormInstance_basic3(t *testing.T) {
 	var v map[string]interface{}
+	checkoutSupportedRegions(t, true, connectivity.LindormInstanceRegions)
 	resourceId := "alicloud_lindorm_instance.default_0"
 	ra := resourceAttrInit(resourceId, AliCloudLindormInstanceMap0)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
@@ -758,6 +772,7 @@ func TestAccAliCloudLindormInstance_basic3(t *testing.T) {
 
 func TestAccAliCloudLindormInstance_twin(t *testing.T) {
 	var v map[string]interface{}
+	checkoutSupportedRegions(t, true, connectivity.LindormInstanceRegions)
 	resourceId := "alicloud_lindorm_instance.default_1"
 	ra := resourceAttrInit(resourceId, AliCloudLindormInstanceMap0)
 	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {


### PR DESCRIPTION
## What

`alicloud_lindorm_instance.log_num` is `Optional` with no `ForceNew`, so it is intended to be updatable in place. However, changing `log_num` alone (without also changing `table_engine_node_count`) was silently dropped: the Update function's table-engine gate excluded `log_num`, and the `LogNum` upgrade branch additionally required `table_engine_node_count` to change via `&&`.

## Fix

- Add `log_num` to the table-engine upgrade gate so a `log_num`-only change enters the block.
- Drop the redundant `&& d.HasChange("table_engine_node_count")` in the `LogNum` branch so `log_num` alone reaches the `upgrade-lindorm-core-num` request (`LogNum` + `LindormNum`, where `LindormNum` is the current `table_engine_node_count` value).
- Gate the `open-lindorm-engine` branch on actual table-engine param changes, so a `log_num`-only change does not re-open the engine with unchanged spec/num.
- Add `d.SetPartial("log_num")`.

`UpgradeLindormInstance` (product `hitsdb`, version `2020-06-15`) accepts `LogNum` together with `UpgradeType=upgrade-lindorm-core-num`, so a `log_num`-only upgrade is API-supported.

## Behavior matrix

| Change | enabled_table_engine | UpgradeLindormInstance call |
|---|---|---|
| log_num only | true | upgrade-lindorm-core-num (LogNum + LindormNum=current) — NEW |
| table_engine_node_count only | true | upgrade-lindorm-core-num (LindormNum + ClusterStorage) — unchanged |
| log_num + table_engine_node_count | true | upgrade-lindorm-core-num (LogNum + LindormNum=new) — unchanged |
| table_engine_specification only | true | upgrade-lindorm-engine — unchanged |
| log_num only | false | none (engine must be opened first) — acceptable, matches existing behavior |

## Test

Extended `TestAccAliCloudLindormInstance_basic2` with a `log_num`-only update step (combined `table_engine_node_count=8, log_num=8`, then `log_num=12` alone) reusing the already-provisioned instance.
