### PR TITLE
resource/alicloud_ram_user: support tags managed via the IMS tagging API

### DIFF
--- a/alicloud/resource_alicloud_ram_user.go
+++ b/alicloud/resource_alicloud_ram_user.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"time"
 
+	"github.com/PaesslerAG/jsonpath"
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/alibabacloud-go/tea/tea"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ram"
@@ -51,6 +52,7 @@ func resourceAlicloudRamUser() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"tags": tagsSchema(),
 		},
 	}
 }
@@ -108,6 +110,16 @@ func resourceAlicloudRamUserCreate(d *schema.ResourceData, meta interface{}) err
 	err = ramService.WaitForRamUser(d.Id(), Normal, DefaultTimeout)
 	if err != nil {
 		return WrapError(err)
+	}
+
+	// Tags on a RAM user are managed via the IMS (2019-08-15) tagging API
+	// (ResourceType=user), because the legacy RAM (2015-05-01) TagResources
+	// API does not enumerate "user" as a taggable resource type.
+	if _, ok := d.GetOk("tags"); ok {
+		imsService := ImsServiceV2{client}
+		if err := imsService.SetImsUserTags(d); err != nil {
+			return WrapError(err)
+		}
 	}
 
 	return resourceAlicloudRamUserRead(d, meta)
@@ -191,6 +203,13 @@ func resourceAlicloudRamUserUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
+	if d.HasChange("tags") {
+		imsService := ImsServiceV2{client}
+		if err := imsService.SetImsUserTags(d); err != nil {
+			return WrapError(err)
+		}
+	}
+
 	return resourceAlicloudRamUserRead(d, meta)
 }
 
@@ -214,6 +233,23 @@ func resourceAlicloudRamUserRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("email", object.Email)
 	d.Set("comments", object.Comments)
 
+	// Tags on a RAM user are read via the IMS (2019-08-15) ListTagResources
+	// API with ResourceType=user and the RAM user id as the resource id.
+	imsService := ImsServiceV2{client}
+	tagsRaw, err := imsService.DescribeImsUserTags(d.Id())
+	if err != nil && !NotFoundError(err) {
+		return WrapError(err)
+	}
+	if tagsRaw != nil {
+		// IMS (2019-08-15) ListTagResources nests the tag list under
+		// TagResources.TagResource, unlike the legacy RAM (2015-05-01)
+		// API where TagResources is the list directly. Align with the
+		// canonical ims tag parse used by cdn_domain_new,
+		// common_bandwidth_package and ddoscoo_instance.
+		tagsMaps, _ := jsonpath.Get("$.TagResources.TagResource", tagsRaw)
+		d.Set("tags", tagsToMap(tagsMaps))
+	}
+
 	return nil
 }
 
@@ -233,6 +269,7 @@ func resourceAlicloudRamUserDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	userName := object.UserName
+
 	request := ram.CreateListAccessKeysRequest()
 	request.RegionId = client.RegionId
 	request.UserName = userName

--- a/alicloud/resource_alicloud_ram_user_test.go
+++ b/alicloud/resource_alicloud_ram_user_test.go
@@ -406,3 +406,117 @@ func testAccRamUserConfig(rand int) string {
 	}
 `, defaultRegionToTest, rand)
 }
+
+// TestAccAliCloudRAMUser_tags covers the tags attribute, whose CRUD is
+// managed via the IMS (2019-08-15) tagging API with ResourceType=user,
+// because the legacy RAM (2015-05-01) TagResources API does not enumerate
+// "user" as a taggable resource type.
+func TestAccAliCloudRAMUser_tags(t *testing.T) {
+	var v *ram.User
+	randInt := acctest.RandIntRange(1000000, 99999999)
+
+	resourceId := "alicloud_ram_user.default"
+	name := fmt.Sprintf("tf-testAcc%sRamUserTags-%d", defaultRegionToTest, randInt)
+	ra := resourceAttrInit(resourceId, nil)
+	rc := resourceCheckInit(resourceId, &v, func() interface{} {
+		return &RamService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	})
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, func(string) string { return "" })
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckRamUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name":  name,
+					"force": true,
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "Test",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":         name,
+						"force":        "true",
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.For":     "Test",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF-update",
+						"For":     "Test-update",
+						"New":     "Tag",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "3",
+						"tags.Created": "TF-update",
+						"tags.For":     "Test-update",
+						"tags.New":     "Tag",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "1",
+						"tags.Created": "TF",
+						"tags.For":     REMOVEKEY,
+						"tags.New":     REMOVEKEY,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "Test",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.For":     "Test",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force"},
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "0",
+						"tags.Created": REMOVEKEY,
+						"tags.For":     REMOVEKEY,
+					}),
+				),
+			},
+		},
+	})
+}

--- a/alicloud/service_alicloud_ims_v2.go
+++ b/alicloud/service_alicloud_ims_v2.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/blues/jsonata-go"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 type ImsServiceV2 struct {
@@ -97,3 +98,120 @@ func (s *ImsServiceV2) ImsOidcProviderStateRefreshFunc(id string, field string, 
 }
 
 // DescribeImsOidcProvider >>> Encapsulated.
+
+// DescribeImsUserTags <<< Encapsulated get tags for Ims RAM user.
+// Tags on a RAM user are managed by the IMS (2019-08-15) tagging API with
+// ResourceType=user and the resource id being the RAM user id, because the
+// legacy RAM (2015-05-01) TagResources API does not enumerate "user" as a
+// taggable resource type.
+func (s *ImsServiceV2) DescribeImsUserTags(userId string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	request["ResourceType"] = "user"
+	request["ResourceId.1"] = userId
+
+	action := "ListTagResources"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcPost("Ims", "2019-08-15", action, query, request, true)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"EntityNotExist.User"}) {
+			return object, WrapErrorf(NotFoundErr("RamUser", userId), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, userId, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+// SetImsUserTags <<< Encapsulated tag function for Ims RAM user.
+func (s *ImsServiceV2) SetImsUserTags(d *schema.ResourceData) error {
+	if d.HasChange("tags") {
+		client := s.client
+		var response map[string]interface{}
+		var err error
+
+		added, removed := parsingTags(d)
+		removedTagKeys := make([]string, 0)
+		for _, v := range removed {
+			if !ignoredTags(v, "") {
+				removedTagKeys = append(removedTagKeys, v)
+			}
+		}
+		if len(removedTagKeys) > 0 {
+			action := "UntagResources"
+			request := map[string]interface{}{
+				"ResourceType": "user",
+				"ResourceId.1": d.Id(),
+			}
+			query := make(map[string]interface{})
+			for i, key := range removedTagKeys {
+				request[fmt.Sprintf("TagKey.%d", i+1)] = key
+			}
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Ims", "2019-08-15", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+		}
+
+		if len(added) > 0 {
+			action := "TagResources"
+			request := map[string]interface{}{
+				"ResourceType": "user",
+				"ResourceId.1": d.Id(),
+			}
+			query := make(map[string]interface{})
+			count := 1
+			for key, value := range added {
+				request[fmt.Sprintf("Tag.%d.Key", count)] = key
+				request[fmt.Sprintf("Tag.%d.Value", count)] = value
+				count++
+			}
+			wait := incrementalWait(3*time.Second, 5*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RpcPost("Ims", "2019-08-15", action, query, request, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+		}
+	}
+	return nil
+}

--- a/website/docs/r/ram_user.html.markdown
+++ b/website/docs/r/ram_user.html.markdown
@@ -55,6 +55,7 @@ The following arguments are supported:
 * `email` - (Optional) Email of the RAM user.
 * `comments` - (Optional) Comment of the RAM user. This parameter can have a string of 1 to 128 characters.
 * `force` - (Optional, Bool) This parameter is used for resource destroy. Default value: `false`.
+* `tags` - (Optional, Map, Available since v1.292.0) A mapping of tags to assign to the RAM user.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### What this PR does

Adds a `tags` argument to the `alicloud_ram_user` resource so that RAM users can be tagged through Terraform.

### Why

The RAM (2015-05-01) `TagResources` API does not enumerate `user` as a taggable resource type, so `alicloud_ram_user` could not manage tags. The IMS (2019-08-15) tagging API (`TagResources` / `UntagResources` / `ListTagResources`) supports `ResourceType=user` with the RAM user id as the resource id, which is used here to provide tag CRUD without changing the existing user CRUD (CreateUser/GetUser/UpdateUser/DeleteUser/ListUsers).

### How

- An optional `tags` map argument is added (same convention as other alicloud resources).
- Create: after the user reaches the normal state, tags are applied via `TagResources`.
- Read: tags are listed via `ListTagResources` and set into state.
- Update: the tags diff is split into `UntagResources` (removed keys) and `TagResources` (added keys).
- Delete: the user is removed; tags are not separately cleared beforehand.
- The RAM user id (already the resource id) is reused as the IMS `ResourceId`, so no id-assembly change is needed and import keeps working.

### Tests

- `TestAccAliCloudRAMUser_tags` covers create with tags, update (add/modify/remove), partial removal, re-add, import (tags read back), and full clear.
- Existing `TestAccAliCloudRAMUser` continues to cover the non-tags attributes and the no-tags path. Existing configurations that do not set `tags` are unaffected.

Remote acceptance tests are pending.
