### PR TITLE
docs: fix doc/source inconsistencies in cms_integration_policy, cms_prometheus_instance, oss_bucket

### DIFF
--- a/website/docs/r/cms_integration_policy.html.markdown
+++ b/website/docs/r/cms_integration_policy.html.markdown
@@ -59,7 +59,7 @@ resource "alicloud_cms_integration_policy" "default" {
 ## Argument Reference
 
 The following arguments are supported:
-* `entity_group` - (Optional, ForceNew, Set) The entity group used to create the policy. See [`entity_group`](#entity_group) below.
+* `entity_group` - (Optional, ForceNew, List) The entity group used to create the policy. See [`entity_group`](#entity_group) below.
 * `force` - (Optional, Bool) Specifies whether to force delete the cloud native appliance. Valid values:
   - `true`: Enable.
   - `false`: Disable.

--- a/website/docs/r/cms_prometheus_instance.html.markdown
+++ b/website/docs/r/cms_prometheus_instance.html.markdown
@@ -58,13 +58,13 @@ resource "alicloud_cms_prometheus_instance" "default" {
 ## Argument Reference
 
 The following arguments are supported:
-* `archive_duration` - (Optional, Int) The number of days that data is automatically archived after the storage duration expires. Valid values: `60` to `3650`.
+* `archive_duration` - (Optional, Int) The number of days that data is automatically archived after the storage duration expires. A value of `0` indicates that data is not archived. V1: `60` to `365` days. V2: `60` to `3650` days (`3650` indicates permanent retention).
 * `auth_free_read_policy` - (Optional) The policy for password-free read access.
 * `auth_free_write_policy` - (Optional) The policy for password-free write access.
 * `enable_auth_free_read` - (Optional, Bool) Specifies whether to enable password-free read access. Valid values: `true`, `false`.
 * `enable_auth_free_write` - (Optional, Bool) Specifies whether to enable password-free write access. Valid values: `true`, `false`.
 * `prometheus_instance_name` - (Required) The name of the instance.
-* `storage_duration` - (Optional, Int) The storage duration of the instance in days.
+* `storage_duration` - (Optional, Int) The storage duration of the instance in days. By write volume: `90` or `180`. By metric reporting volume: `15`, `30`, `60`, `90`, or `180`.
 * `workspace` - (Required, ForceNew) The workspace to which the instance belongs.
 
 ## Attributes Reference

--- a/website/docs/r/oss_bucket.html.markdown
+++ b/website/docs/r/oss_bucket.html.markdown
@@ -768,7 +768,7 @@ The tag configuration block supports the following:
 
 The server_side_encryption_rule configuration block supports the following:
 
-* `sse_algorithm` - (Required) The server-side encryption algorithm to use. Possible values: `AES256` and `KMS`.
+* `sse_algorithm` - (Required) The server-side encryption algorithm to use. Possible values: `AES256`, `KMS` and `SM4`.
 * `kms_master_key_id` - (Optional, Available since 1.92.0) The alibaba cloud KMS master key ID used for the SSE-KMS encryption.
 * `kms_data_encryption` - (Optional, Available since 1.246.0) The algorithm used to encrypt objects. If this element is not specified, objects are encrypted with AES256. This element is valid only when the value of SSEAlgorithm is set to KMS. Valid values: `SM4`.
 

--- a/website/docs/r/oss_bucket_server_side_encryption.html.markdown
+++ b/website/docs/r/oss_bucket_server_side_encryption.html.markdown
@@ -78,7 +78,7 @@ The following arguments are supported:
 * `bucket` - (Required, ForceNew) The name of the bucket.
 * `kms_data_encryption` - (Optional) The algorithm used to encrypt objects. If this element is not specified, objects are encrypted by using AES256. This element is valid only when the value of SSEAlgorithm is set to KMS.
 * `kms_master_key_id` - (Optional) The CMK ID that must be specified when SSEAlgorithm is set to KMS and a specified CMK is used for encryption. In other cases, this element must be set to null.
-* `sse_algorithm` - (Required) The server-side encryption method. Valid Values: KMS, AES256.
+* `sse_algorithm` - (Required) The server-side encryption method. Valid Values: KMS, AES256, SM4.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### What this PR does

Fixes documentation inconsistencies between the provider source code and the generated docs for three resources:

- **alicloud_cms_integration_policy**: `entity_group` is backed by `TypeList` with `MaxItems=1` in the schema, but the doc labeled it `Set`. Corrected to `List` to match the source.
- **alicloud_cms_prometheus_instance**:
  - `archive_duration`: the schema allows `0` (data not archived) and distinguishes V1 (60–365) from V2 (60–3650, where 3650 = permanent retention). The doc only stated "60 to 3650". Documented the full semantics aligned with the OpenAPI.
  - `storage_duration`: the OpenAPI defines discrete enum values by instance type — write volume: 90 or 180; metric reporting volume: 15, 30, 60, 90, or 180. The doc gave no valid values. Added the enum to the doc.
- **alicloud_oss_bucket** / **alicloud_oss_bucket_server_side_encryption**: `sse_algorithm` accepts `SM4` (server-side encryption with SM4, already supported in the schema and covered by acceptance tests), but the docs only listed `AES256` and `KMS`. Added `SM4` to both docs.

### Verification

- `git diff --check` clean (no trailing whitespace)
- `markdownlint-cli@0.47.0 --config .github/markdownlint/website-docs.json` passes on all four files
- No source (.go) changes — docs-only
