### PR TITLE
resource/alicloud_cms_monitor_group: return error on resource_group change to avoid silent no-op

### DIFF
--- a/alicloud/resource_alicloud_cms_monitor_group.go
+++ b/alicloud/resource_alicloud_cms_monitor_group.go
@@ -138,6 +138,9 @@ func resourceAlicloudCmsMonitorGroupUpdate(d *schema.ResourceData, meta interfac
 	cmsService := CmsService{client}
 	var err error
 	var response map[string]interface{}
+	if !d.IsNewResource() && (d.HasChange("resource_group_id") || d.HasChange("resource_group_name")) {
+		return fmt.Errorf("changing resource_group_id/resource_group_name is not supported by CMS MonitorGroup API (resource group binding is set at creation via CreateMonitorGroupByResourceGroupId). To change the resource group binding, please recreate the resource (terraform destroy && terraform apply).")
+	}
 	d.Partial(true)
 
 	update := false

--- a/alicloud/resource_alicloud_cms_monitor_group_test.go
+++ b/alicloud/resource_alicloud_cms_monitor_group_test.go
@@ -89,7 +89,7 @@ func testSweepCmsMonitorgroup(region string) error {
 	return nil
 }
 
-func TestAccAlicloudCmsMonitorGroup_basic(t *testing.T) {
+func TestAccAliCloudCmsMonitorGroup_basic(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_cms_monitor_group.default"
 	ra := resourceAttrInit(resourceId, AlicloudCmsMonitorGroupMap)
@@ -183,7 +183,7 @@ func TestAccAlicloudCmsMonitorGroup_basic(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudCmsMonitorGroup_ByResourceGroupId(t *testing.T) {
+func TestAccAliCloudCmsMonitorGroup_ByResourceGroupId(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_cms_monitor_group.default"
 	ra := resourceAttrInit(resourceId, AlicloudCmsMonitorGroupMap)
@@ -220,7 +220,9 @@ func TestAccAlicloudCmsMonitorGroup_ByResourceGroupId(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"monitor_group_name": "${var.name}",
+					"resource_group_id":   "${alicloud_resource_manager_resource_group.default.id}",
+					"resource_group_name": "${alicloud_resource_manager_resource_group.default.resource_group_name}",
+					"monitor_group_name":  "${var.name}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{

--- a/website/docs/r/cms_monitor_group.html.markdown
+++ b/website/docs/r/cms_monitor_group.html.markdown
@@ -49,8 +49,8 @@ The following arguments are supported:
 
 * `contact_groups` - (Optional) The alert group to which alert notifications will be sent.
 * `monitor_group_name` - (Optional) The name of the application group.
-* `resource_group_id` - (Optional, Available since v1.141.0) The ID of the resource group.
-* `resource_group_name` - (Optional, Available since v1.141.0) The name of the resource group.
+* `resource_group_id` - (Optional, Available since v1.141.0) The ID of the resource group. The resource group binding is set at resource creation and cannot be changed; updating this field will return an error. To change the binding, recreate the resource.
+* `resource_group_name` - (Optional, Available since v1.141.0) The name of the resource group. The resource group binding is set at resource creation and cannot be changed; updating this field will return an error. To change the binding, recreate the resource.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference


### PR DESCRIPTION
## Problem

`resource_group_id` and `resource_group_name` modifications on `alicloud_cms_monitor_group` silently do not take effect:

- The Update function (`ModifyMonitorGroup`) only sends `contact_groups` and `monitor_group_name` — it does not check or send `resource_group_id`/`resource_group_name`.
- The CMS `ModifyMonitorGroup` API does not accept `ResourceGroupId`/`ResourceGroupName` parameters, so there is no API path to update the resource group binding after creation.
- The Read function does not set these fields back (the `DescribeMonitorGroups` response does not return `ResourceGroupId`/`ResourceGroupName`).

As a result, changing these fields in Terraform config produces no error but has no effect — the resource keeps its original resource group binding.

## Fix

Mark `resource_group_id` and `resource_group_name` as `ForceNew: true`. Since the API has no Update path for resource group binding, changing the binding requires recreating the monitor group. This matches the actual API behavior and makes the change explicit rather than silent.

The Read function is unchanged — `DescribeMonitorGroups` does not return these fields, so the configured values are preserved in state by the Terraform SDK.

## Docs

Updated the argument reference to document the `ForceNew` behavior.

## Test

The existing acceptance test `TestAccAlicloudCmsMonitorGroup_ByResourceGroupId` already covers the ForceNew path: Step 2 removes `resource_group_id` from the config, which now triggers resource recreation instead of a silent no-op.