### PR TITLE
resource/alicloud_alidns_instance: mark period as ForceNew and remove superfluous Update

### DIFF
--- a/alicloud/resource_alicloud_alidns_instance.go
+++ b/alicloud/resource_alicloud_alidns_instance.go
@@ -16,7 +16,6 @@ func resourceAlicloudAlidnsInstance() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAlicloudAlidnsInstanceCreate,
 		Read:   resourceAlicloudAlidnsInstanceRead,
-		Update: resourceAlicloudAlidnsInstanceUpdate,
 		Delete: resourceAlicloudAlidnsInstanceDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -43,6 +42,7 @@ func resourceAlicloudAlidnsInstance() *schema.Resource {
 			"period": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				ForceNew: true,
 			},
 			"renew_period": {
 				Type:     schema.TypeInt,
@@ -174,10 +174,6 @@ func resourceAlicloudAlidnsInstanceRead(d *schema.ResourceData, meta interface{}
 	}
 
 	return nil
-}
-func resourceAlicloudAlidnsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Println(fmt.Sprintf("[WARNING] The resouce has not update operation."))
-	return resourceAlicloudAlidnsInstanceRead(d, meta)
 }
 func resourceAlicloudAlidnsInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[WARN] Cannot destroy resourceAlicloudAlidnsInstance. Terraform will remove this resource from the state file, however resources may remain.")

--- a/alicloud/resource_alicloud_alidns_instance_test.go
+++ b/alicloud/resource_alicloud_alidns_instance_test.go
@@ -228,19 +228,6 @@ func TestUnitAlicloudAlidnsInstance(t *testing.T) {
 		}
 	}
 
-	// Update
-	patches = gomonkey.ApplyMethod(reflect.TypeOf(&connectivity.AliyunClient{}), "NewBssopenapiClient", func(_ *connectivity.AliyunClient) (*client.Client, error) {
-		return nil, &tea.SDKError{
-			Code:       String("loadEndpoint error"),
-			Data:       String("loadEndpoint error"),
-			Message:    String("loadEndpoint error"),
-			StatusCode: tea.Int(400),
-		}
-	})
-	err = resourceAlicloudAlidnsInstanceUpdate(dExisted, rawClient)
-	patches.Reset()
-	assert.NotNil(t, err)
-
 	// Read
 	errorCodes = []string{"NonRetryableError", "Throttling", "nil", "{}"}
 	for index, errorCode := range errorCodes {


### PR DESCRIPTION
### What this PR does

Marks the `period` attribute of the `alicloud_alidns_instance` resource as `ForceNew`.

### Why

`period` is the subscription duration ordered through BssOpenApi `CreateInstance`
when the DNS product instance is created. The alidns product exposes no
`ModifyInstance`/`UpdateInstance` API, so the resource `Update` path is a no-op
for `period`. As a result, changing `period` in configuration succeeded at
`apply` time (state recorded the new value and subsequent `plan` showed no
diff), while the actual cloud subscription period was left unchanged — a silent
state/cloud drift.

Marking `period` as `ForceNew` makes a change trigger replacement, so the
resource is recreated with the new subscription duration. This is consistent
with the sibling subscription parameters `renew_period` and `payment_type`,
which are already `ForceNew`.

### Verification

- `gofmt` clean.
- Existing acceptance test (`TestAccAlicloudAlidnsInstance_basic`) sets `period`
  once at create and then imports; it does not change `period` mid-flow, so
  `ForceNew` does not alter its behavior.
