### PR TITLE
resource/alicloud_ecs_snapshot: add configurable wait_until policy

### DIFF
--- a/alicloud/resource_alicloud_ecs_snapshot.go
+++ b/alicloud/resource_alicloud_ecs_snapshot.go
@@ -1,4 +1,3 @@
-// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
@@ -27,6 +26,10 @@ func resourceAliCloudEcsSnapshot() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
+			"available": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"category": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -84,6 +87,11 @@ func resourceAliCloudEcsSnapshot() *schema.Resource {
 				Computed: true,
 			},
 			"tags": tagsSchema(),
+			"wait_until": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"accomplished", "available"}, false),
+			},
 			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -152,12 +160,20 @@ func resourceAliCloudEcsSnapshotCreate(d *schema.ResourceData, meta interface{})
 	d.SetId(fmt.Sprint(response["SnapshotId"]))
 
 	ecsServiceV2 := EcsServiceV2{client}
-	stateConf := BuildStateConf([]string{}, []string{"accomplished"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, ecsServiceV2.EcsSnapshotStateRefreshFunc(d.Id(), "Status", []string{}))
+	stateField, target := ecsSnapshotWaitCondition(d)
+	stateConf := BuildStateConf([]string{}, []string{target}, d.Timeout(schema.TimeoutCreate), 5*time.Second, ecsServiceV2.EcsSnapshotStateRefreshFunc(d.Id(), stateField, []string{}))
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
 
 	return resourceAliCloudEcsSnapshotRead(d, meta)
+}
+
+func ecsSnapshotWaitCondition(d *schema.ResourceData) (string, string) {
+	if v, ok := d.GetOk("wait_until"); ok && v == "available" {
+		return "Available", "true"
+	}
+	return "Status", "accomplished"
 }
 
 func resourceAliCloudEcsSnapshotRead(d *schema.ResourceData, meta interface{}) error {
@@ -174,6 +190,13 @@ func resourceAliCloudEcsSnapshotRead(d *schema.ResourceData, meta interface{}) e
 		return WrapError(err)
 	}
 
+	available := objectRaw["Available"]
+	if available == nil {
+		available = false
+	}
+	if err := d.Set("available", available); err != nil {
+		return WrapError(err)
+	}
 	if objectRaw["Category"] != nil {
 		d.Set("category", objectRaw["Category"])
 	}
@@ -211,10 +234,12 @@ func resourceAliCloudEcsSnapshotRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceAliCloudEcsSnapshotUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
+	ecsServiceV2 := EcsServiceV2{client}
 	var request map[string]interface{}
 	var response map[string]interface{}
 	var query map[string]interface{}
 	update := false
+	retentionDaysChanged := false
 	d.Partial(true)
 
 	action := "ModifySnapshotAttribute"
@@ -235,6 +260,7 @@ func resourceAliCloudEcsSnapshotUpdate(d *schema.ResourceData, meta interface{})
 
 	if d.HasChange("retention_days") {
 		update = true
+		retentionDaysChanged = true
 
 		if v, ok := d.GetOkExists("retention_days"); ok {
 			request["RetentionDays"] = v
@@ -250,6 +276,14 @@ func resourceAliCloudEcsSnapshotUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	if update {
+		if retentionDaysChanged {
+			// ECS only accepts retention-day changes after the snapshot upload is complete.
+			stateConf := BuildStateConf([]string{}, []string{"accomplished"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ecsServiceV2.EcsSnapshotStateRefreshFunc(d.Id(), "Status", []string{}))
+			if _, err := stateConf.WaitForState(); err != nil {
+				return WrapErrorf(err, IdMsg, d.Id())
+			}
+		}
+
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 			response, err = client.RpcPost("Ecs", "2014-05-26", action, query, request, true)
@@ -265,11 +299,6 @@ func resourceAliCloudEcsSnapshotUpdate(d *schema.ResourceData, meta interface{})
 		addDebug(action, response, request)
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
-		}
-		ecsServiceV2 := EcsServiceV2{client}
-		stateConf := BuildStateConf([]string{}, []string{"accomplished"}, d.Timeout(schema.TimeoutUpdate), 5*time.Second, ecsServiceV2.EcsSnapshotStateRefreshFunc(d.Id(), "Status", []string{}))
-		if _, err := stateConf.WaitForState(); err != nil {
-			return WrapErrorf(err, IdMsg, d.Id())
 		}
 	}
 	update = false

--- a/alicloud/resource_alicloud_ecs_snapshot_test.go
+++ b/alicloud/resource_alicloud_ecs_snapshot_test.go
@@ -1,19 +1,26 @@
 package alicloud
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/PaesslerAG/jsonpath"
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/alibabacloud-go/tea-rpc/client"
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/alibabacloud-go/tea/tea"
+	credentials "github.com/aliyun/credentials-go/credentials"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -129,7 +136,14 @@ func TestAccAliCloudECSSnapshot_basic0(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"disk_id": CHECKSET,
+						"status":  "accomplished",
 					}),
+					func(s *terraform.State) error {
+						if value := s.RootModule().Resources[resourceId].Primary.Attributes["wait_until"]; value != "" {
+							return fmt.Errorf("omitted wait_until must remain unset, got %q", value)
+						}
+						return nil
+					},
 				),
 			},
 			{
@@ -181,7 +195,7 @@ func TestAccAliCloudECSSnapshot_basic0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force"},
+				ImportStateVerifyIgnore: []string{"force", "wait_until"},
 			},
 		},
 	})
@@ -210,7 +224,8 @@ func TestAccAliCloudECSSnapshot_basic0_twin(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"disk_id":           "${alicloud_ecs_disk_attachment.default.disk_id}",
-					"category":          "flash",
+					"category":          "standard",
+					"wait_until":        "accomplished",
 					"retention_days":    "50",
 					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.groups.1.id}",
 					"snapshot_name":     name,
@@ -224,7 +239,9 @@ func TestAccAliCloudECSSnapshot_basic0_twin(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"disk_id":           CHECKSET,
-						"category":          "flash",
+						"category":          "standard",
+						"wait_until":        "accomplished",
+						"status":            "accomplished",
 						"retention_days":    "50",
 						"resource_group_id": CHECKSET,
 						"snapshot_name":     name,
@@ -239,7 +256,7 @@ func TestAccAliCloudECSSnapshot_basic0_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force"},
+				ImportStateVerifyIgnore: []string{"force", "wait_until"},
 			},
 		},
 	})
@@ -336,7 +353,7 @@ func TestAccAliCloudECSSnapshot_basic1(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force"},
+				ImportStateVerifyIgnore: []string{"force", "wait_until"},
 			},
 		},
 	})
@@ -394,13 +411,14 @@ func TestAccAliCloudECSSnapshot_basic1_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force"},
+				ImportStateVerifyIgnore: []string{"force", "wait_until"},
 			},
 		},
 	})
 }
 
 var AliCloudEcsSnapshotMap0 = map[string]string{
+	"available":   "true",
 	"create_time": CHECKSET,
 	"region_id":   CHECKSET,
 	"category":    CHECKSET,
@@ -419,16 +437,20 @@ func AliCloudEcsSnapshotBasicDependence0(name string) string {
 
 	data "alicloud_zones" "default" {
   		available_disk_category     = "cloud_essd"
-  		available_resource_creation = "VSwitch"
+		available_instance_type     = data.alicloud_instance_types.default.instance_types.0.id
+		available_resource_creation = "Instance"
 	}
 	
 	data "alicloud_images" "default" {
   		most_recent = true
   		owners      = "system"
+		architecture = "x86_64"
+		os_type      = "linux"
 	}
 	
 	data "alicloud_instance_types" "default" {
-  		availability_zone    = data.alicloud_zones.default.zones.0.id
+		instance_type_family = "ecs.g7"
+		sorted_by            = "CPU"
   		image_id             = data.alicloud_images.default.images.0.id
   		system_disk_category = "cloud_essd"
 	}
@@ -456,22 +478,25 @@ func AliCloudEcsSnapshotBasicDependence0(name string) string {
   		security_groups            = alicloud_security_group.default.*.id
   		internet_charge_type       = "PayByTraffic"
   		internet_max_bandwidth_out = "10"
-  		availability_zone          = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
+		availability_zone          = data.alicloud_zones.default.zones.0.id
   		instance_charge_type       = "PostPaid"
   		system_disk_category       = "cloud_essd"
+		system_disk_encrypted      = true
   		vswitch_id                 = alicloud_vswitch.default.id
   		instance_name              = var.name
 		data_disks {
 			category = "cloud_essd"
+			encrypted = true
 			size     = 20
   		}
 	}
 	
 	resource "alicloud_ecs_disk" "default" {
   		disk_name = var.name
-  		zone_id   = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
+		zone_id   = data.alicloud_zones.default.zones.0.id
   		category  = "cloud_essd"
-  		size      = 500
+		encrypted = true
+		size      = 20
 	}
 	
 	resource "alicloud_ecs_disk_attachment" "default" {
@@ -482,72 +507,7 @@ func AliCloudEcsSnapshotBasicDependence0(name string) string {
 }
 
 func AliCloudEcsSnapshotBasicDependence1(name string) string {
-	return fmt.Sprintf(`
-	variable "name" {
- 		default = "%s"
-	}
-
-	data "alicloud_resource_manager_resource_groups" "default" {
- 		status = "OK"
-	}
-
-	data "alicloud_zones" "default" {
- 		available_disk_category     = "cloud_efficiency"
- 		available_resource_creation = "VSwitch"
-	}
-
-	data "alicloud_images" "default" {
- 		most_recent = true
- 		owners      = "system"
-	}
-
-	data "alicloud_instance_types" "default" {
- 		availability_zone = data.alicloud_zones.default.zones.0.id
- 		image_id          = data.alicloud_images.default.images.0.id
-	}
-
-	resource "alicloud_vpc" "default" {
- 		vpc_name   = var.name
- 		cidr_block = "192.168.0.0/16"
-	}
-
-	resource "alicloud_vswitch" "default" {
-		vswitch_name = var.name
- 		vpc_id       = alicloud_vpc.default.id
- 		cidr_block   = "192.168.192.0/24"
- 		zone_id      = data.alicloud_zones.default.zones.0.id
-	}
-
-	resource "alicloud_security_group" "default" {
- 		name   = var.name
- 		vpc_id = alicloud_vpc.default.id
-	}
-
-	resource "alicloud_instance" "default" {
- 		image_id                   = data.alicloud_images.default.images.0.id
- 		instance_type              = data.alicloud_instance_types.default.instance_types.0.id
- 		security_groups            = alicloud_security_group.default.*.id
- 		internet_charge_type       = "PayByTraffic"
- 		internet_max_bandwidth_out = "10"
- 		availability_zone          = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
- 		instance_charge_type       = "PostPaid"
- 		system_disk_category       = "cloud_efficiency"
- 		vswitch_id                 = alicloud_vswitch.default.id
- 		instance_name              = var.name
-	}
-
-	resource "alicloud_ecs_disk" "default" {
- 		disk_name = var.name
- 		zone_id   = data.alicloud_instance_types.default.instance_types.0.availability_zones.0
- 		category  = "cloud_efficiency"
- 		size      = 500
-	}
-
-	resource "alicloud_ecs_disk_attachment" "default" {
- 		instance_id = alicloud_instance.default.id
- 		disk_id     = alicloud_ecs_disk.default.id
-	}
-`, name)
+	return AliCloudEcsSnapshotBasicDependence0(name)
 }
 
 // lintignore: R001
@@ -593,6 +553,7 @@ func TestUnitAliCloudEcsSnapshot(t *testing.T) {
 					"SnapshotName":               "snapshot_name",
 					"Name":                       "snapshot_name",
 					"Status":                     "accomplished",
+					"Available":                  true,
 					"SnapshotId":                 "MockSnapshotId",
 				},
 			},
@@ -926,4 +887,808 @@ func TestUnitAliCloudEcsSnapshot(t *testing.T) {
 		patcheDorequest.Reset()
 		assert.NotNil(t, err)
 	})
+}
+
+func TestAccAliCloudECSSnapshot_availableDisk(t *testing.T) {
+	var snapshot, disk map[string]interface{}
+	snapshotID := "alicloud_ecs_snapshot.default"
+	diskID := "alicloud_ecs_disk.restored"
+	snapshotCheck := resourceCheckInitWithDescribeMethod(snapshotID, &snapshot, func() interface{} {
+		return &EcsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEcsSnapshot")
+	diskCheck := resourceCheckInitWithDescribeMethod(diskID, &disk, func() interface{} {
+		return &EcsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEcsDisk")
+	name := fmt.Sprintf("tf-testacc-snapshot-%d", acctest.RandIntRange(10000, 99999))
+	config := AliCloudEcsSnapshotBasicDependence0(name) + `
+resource "alicloud_ecs_snapshot" "default" {
+  disk_id       = alicloud_ecs_disk_attachment.default.disk_id
+  snapshot_name = var.name
+  force         = true
+  wait_until    = "available"
+}
+
+resource "alicloud_ecs_disk" "restored" {
+  disk_name   = "${var.name}-restored"
+  zone_id     = alicloud_ecs_disk.default.zone_id
+  category    = "cloud_essd"
+  snapshot_id = alicloud_ecs_snapshot.default.id
+  encrypted   = true
+  size        = 20
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			snapshotCheck.checkResourceDestroy(), diskCheck.checkResourceDestroy(),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					snapshotCheck.checkResourceExists(),
+					resource.TestCheckResourceAttr(snapshotID, "wait_until", "available"),
+					resource.TestCheckResourceAttr(snapshotID, "available", "true"),
+					diskCheck.checkResourceExists(),
+					resource.TestCheckResourceAttrPair(diskID, "snapshot_id", snapshotID, "id"),
+					func(s *terraform.State) error {
+						service := EcsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+						restored, err := service.DescribeEcsDisk(s.RootModule().Resources[diskID].Primary.ID)
+						if err != nil {
+							return err
+						}
+						if fmt.Sprint(restored["SourceSnapshotId"]) != s.RootModule().Resources[snapshotID].Primary.ID {
+							return fmt.Errorf("restored disk must use the created snapshot")
+						}
+						return nil
+					},
+				),
+			},
+			{
+				ResourceName: snapshotID, ImportState: true, ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"force", "wait_until"},
+			},
+		},
+	})
+}
+
+func ecsSnapshotTestClient(t *testing.T, handler http.HandlerFunc) *connectivity.AliyunClient {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Error(err)
+		}
+		for key := range r.Form {
+			if strings.EqualFold(strings.ReplaceAll(key, "_", ""), "WaitUntil") {
+				t.Errorf("local wait_until must not be sent to ECS: %s", key)
+			}
+			if strings.EqualFold(key, "Available") {
+				t.Errorf("computed available must not be sent to ECS: %s", key)
+			}
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+	credential, err := credentials.NewCredential(new(credentials.Config).
+		SetType("access_key").SetAccessKeyId("test-key").SetAccessKeySecret("test-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoints := new(sync.Map)
+	endpoint := strings.TrimPrefix(server.URL, "http://")
+	t.Setenv("NO_PROXY", endpoint)
+	config := &connectivity.Config{
+		AccessKey: "test-key", SecretKey: "test-secret", Credential: credential,
+		RegionId: "cn-hangzhou", AccountType: "test", Protocol: "http",
+		Endpoints: endpoints, SignVersion: new(sync.Map), SkipRegionValidation: true,
+	}
+	client, err := config.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoints.Store("ecs", endpoint)
+	return client
+}
+
+func TestUnitEcsSnapshotCreateAvailable(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		available   interface{}
+		status      string
+		progress    string
+		pending     bool
+		notFound    bool
+		apiError    bool
+		wantError   string
+		wantQueries int32
+	}{
+		{name: "uploading_available", available: true, status: "progressing", progress: "40%", wantQueries: 2},
+		{name: "becomes_available", available: true, status: "progressing", progress: "40%", pending: true, wantQueries: 3},
+		{name: "not_yet_available", available: false, status: "accomplished", progress: "100%", wantError: "timeout while waiting"},
+		{name: "missing_available", status: "accomplished", progress: "100%", wantError: "timeout while waiting"},
+		{name: "eventually_visible", available: true, status: "progressing", progress: "40%", notFound: true, wantQueries: 3},
+		{name: "query_error", apiError: true, wantError: "Forbidden", wantQueries: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var describes int32
+			client := ecsSnapshotTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if err := r.ParseForm(); err != nil {
+					t.Error(err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				var response interface{}
+				switch r.Form.Get("Action") {
+				case "CreateSnapshot":
+					response = map[string]interface{}{"SnapshotId": "snapshot-test"}
+				case "DescribeSnapshots":
+					count := atomic.AddInt32(&describes, 1)
+					if r.Form.Get("Status") != "" || r.Form.Get("SnapshotIds") != `["snapshot-test"]` {
+						t.Error("DescribeSnapshots must query the snapshot ID without filtering status")
+					}
+					if tc.apiError {
+						w.WriteHeader(http.StatusForbidden)
+						response = map[string]interface{}{"Code": "Forbidden", "Message": "test query failure"}
+						break
+					}
+					snapshot := map[string]interface{}{"SnapshotId": "snapshot-test", "Status": tc.status, "Progress": tc.progress}
+					if tc.available != nil {
+						snapshot["Available"] = tc.available
+					}
+					if tc.pending && count == 1 {
+						snapshot["Available"] = false
+					}
+					snapshots := []interface{}{snapshot}
+					if tc.notFound && count == 1 {
+						snapshots = []interface{}{}
+					}
+					response = map[string]interface{}{"Snapshots": map[string]interface{}{"Snapshot": snapshots}}
+				default:
+					t.Errorf("unexpected action: %s", r.Form.Get("Action"))
+					w.WriteHeader(http.StatusBadRequest)
+					response = map[string]interface{}{"Code": "UnexpectedAction"}
+				}
+				if err := json.NewEncoder(w).Encode(response); err != nil {
+					t.Error(err)
+				}
+			})
+			r := resourceAliCloudEcsSnapshot()
+			timeout := 6 * time.Second
+			if tc.pending || tc.notFound {
+				timeout = 10 * time.Second
+			}
+			r.Timeouts = &schema.ResourceTimeout{Create: schema.DefaultTimeout(timeout)}
+			d := r.Data(nil)
+			d.MarkNewResource()
+			if err := d.Set("disk_id", "disk-test"); err != nil {
+				t.Fatal(err)
+			}
+			if err := d.Set("wait_until", "available"); err != nil {
+				t.Fatal(err)
+			}
+			err := r.Create(d, client)
+			if tc.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("expected %q, got %v", tc.wantError, err)
+				}
+			} else if err != nil {
+				t.Fatalf("available snapshot must finish creation while uploading: %v", err)
+			}
+			if d.Id() != "snapshot-test" {
+				t.Fatalf("snapshot ID must be retained: %q", d.Id())
+			}
+			if tc.wantError == "" && d.Get("status") != tc.status {
+				t.Fatalf("Read must preserve the actual status: %v", d.Get("status"))
+			}
+			if got := atomic.LoadInt32(&describes); tc.wantQueries > 0 && got != tc.wantQueries {
+				t.Fatalf("expected %d DescribeSnapshots calls including the final Read, got %d", tc.wantQueries, got)
+			}
+		})
+	}
+}
+
+func TestUnitEcsSnapshotCategory(t *testing.T) {
+	for _, category := range []string{"standard", "flash"} {
+		t.Run(category, func(t *testing.T) {
+			var creates int32
+			client := ecsSnapshotTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if err := r.ParseForm(); err != nil {
+					t.Error(err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				response := map[string]interface{}{}
+				switch r.Form.Get("Action") {
+				case "CreateSnapshot":
+					atomic.AddInt32(&creates, 1)
+					if got := r.Form.Get("Category"); got != category {
+						t.Errorf("expected CreateSnapshot category %q, got %q", category, got)
+					}
+					response["SnapshotId"] = "snapshot-test"
+				case "DescribeSnapshots":
+					response = ecsSnapshotTestDescribeResponse("accomplished", true, map[string]interface{}{
+						"Category": category,
+					})
+				default:
+					t.Errorf("unexpected action: %s", r.Form.Get("Action"))
+					w.WriteHeader(http.StatusBadRequest)
+					response["Code"] = "UnexpectedAction"
+				}
+				if err := json.NewEncoder(w).Encode(response); err != nil {
+					t.Error(err)
+				}
+			})
+
+			r := resourceAliCloudEcsSnapshot()
+			r.Timeouts = &schema.ResourceTimeout{Create: schema.DefaultTimeout(10 * time.Second)}
+			d := r.Data(nil)
+			if err := d.Set("disk_id", "disk-test"); err != nil {
+				t.Fatal(err)
+			}
+			if err := d.Set("category", category); err != nil {
+				t.Fatal(err)
+			}
+			d.MarkNewResource()
+			if got := d.Timeout(schema.TimeoutCreate); got != 10*time.Second {
+				t.Fatalf("expected a 10s create timeout, got %s", got)
+			}
+			if err := r.Create(d, client); err != nil {
+				t.Fatal(err)
+			}
+			if got := atomic.LoadInt32(&creates); got != 1 {
+				t.Fatalf("expected one CreateSnapshot call, got %d", got)
+			}
+			if err := d.Set("category", ""); err != nil {
+				t.Fatal(err)
+			}
+			if err := r.Read(d, client); err != nil {
+				t.Fatal(err)
+			}
+			if got := d.Get("category"); got != category {
+				t.Fatalf("Read must restore category %q, got %v", category, got)
+			}
+		})
+	}
+}
+
+func TestUnitEcsSnapshotUpdateAvailable(t *testing.T) {
+	t.Run("description while uploading", func(t *testing.T) {
+		var describes int32
+		var modifies int32
+		var firstAction atomic.Value
+		client := ecsSnapshotTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Error(err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			response := map[string]interface{}{}
+			if firstAction.Load() == nil {
+				firstAction.Store(r.Form.Get("Action"))
+			}
+			switch r.Form.Get("Action") {
+			case "DescribeSnapshots":
+				atomic.AddInt32(&describes, 1)
+				response = ecsSnapshotTestDescribeResponse("progressing", true, map[string]interface{}{
+					"Description": "updated description",
+				})
+			case "ModifySnapshotAttribute":
+				if r.Form.Get("Description") != "updated description" {
+					t.Errorf("unexpected description: %q", r.Form.Get("Description"))
+				}
+				atomic.AddInt32(&modifies, 1)
+			default:
+				t.Errorf("unexpected action: %s", r.Form.Get("Action"))
+				w.WriteHeader(http.StatusBadRequest)
+				response = map[string]interface{}{"Code": "UnexpectedAction"}
+			}
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				t.Error(err)
+			}
+		})
+
+		d := schema.TestResourceDataRaw(t, resourceAliCloudEcsSnapshot().Schema, map[string]interface{}{
+			"disk_id":     "disk-test",
+			"description": "updated description",
+			"wait_until":  "available",
+		})
+		d.SetId("snapshot-test")
+		if err := resourceAliCloudEcsSnapshotUpdate(d, client); err != nil {
+			t.Fatalf("description update must finish while the snapshot is uploading: %v", err)
+		}
+		if got := atomic.LoadInt32(&modifies); got != 1 {
+			t.Fatalf("expected one ModifySnapshotAttribute call, got %d", got)
+		}
+		if got := atomic.LoadInt32(&describes); got != 1 {
+			t.Fatalf("expected only the final Read after the description update, got %d queries", got)
+		}
+		if got, _ := firstAction.Load().(string); got != "ModifySnapshotAttribute" {
+			t.Fatalf("ordinary metadata updates must not wait for upload completion before the API call, first action was %q", got)
+		}
+	})
+
+	t.Run("retention waits until accomplished", func(t *testing.T) {
+		var describes int32
+		var lastStatus atomic.Value
+		var modifies int32
+		client := ecsSnapshotTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Error(err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			response := map[string]interface{}{}
+			switch r.Form.Get("Action") {
+			case "DescribeSnapshots":
+				count := atomic.AddInt32(&describes, 1)
+				status := "accomplished"
+				if count == 1 {
+					status = "progressing"
+				}
+				lastStatus.Store(status)
+				response = ecsSnapshotTestDescribeResponse(status, true, map[string]interface{}{
+					"RetentionDays": 30,
+				})
+			case "ModifySnapshotAttribute":
+				if status, _ := lastStatus.Load().(string); status != "accomplished" {
+					w.WriteHeader(http.StatusForbidden)
+					response = map[string]interface{}{"Code": "InvalidSnapshotId.NotReady", "Message": "snapshot is not ready"}
+					break
+				}
+				if r.Form.Get("RetentionDays") != "30" {
+					t.Errorf("unexpected retention days: %q", r.Form.Get("RetentionDays"))
+				}
+				atomic.AddInt32(&modifies, 1)
+			default:
+				t.Errorf("unexpected action: %s", r.Form.Get("Action"))
+				w.WriteHeader(http.StatusBadRequest)
+				response = map[string]interface{}{"Code": "UnexpectedAction"}
+			}
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				t.Error(err)
+			}
+		})
+
+		d := schema.TestResourceDataRaw(t, resourceAliCloudEcsSnapshot().Schema, map[string]interface{}{
+			"disk_id":        "disk-test",
+			"retention_days": 30,
+		})
+		d.SetId("snapshot-test")
+		if err := resourceAliCloudEcsSnapshotUpdate(d, client); err != nil {
+			t.Fatalf("retention update must wait for upload completion: %v", err)
+		}
+		if got := atomic.LoadInt32(&modifies); got != 1 {
+			t.Fatalf("expected one successful ModifySnapshotAttribute call, got %d", got)
+		}
+		if got := atomic.LoadInt32(&describes); got < 2 {
+			t.Fatalf("expected the retention update to observe progressing then accomplished, got %d queries", got)
+		}
+	})
+
+	t.Run("resource group while uploading", func(t *testing.T) {
+		var describes int32
+		var joins int32
+		client := ecsSnapshotTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Error(err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			response := map[string]interface{}{}
+			switch r.Form.Get("Action") {
+			case "DescribeSnapshots":
+				atomic.AddInt32(&describes, 1)
+				if atomic.LoadInt32(&joins) != 1 {
+					t.Error("resource-group updates must call JoinResourceGroup before the final Read")
+				}
+				response = ecsSnapshotTestDescribeResponse("progressing", true, map[string]interface{}{
+					"ResourceGroupId": "rg-test",
+				})
+			case "JoinResourceGroup":
+				if atomic.LoadInt32(&describes) != 0 {
+					t.Error("resource-group updates must not wait before JoinResourceGroup")
+				}
+				if r.Form.Get("ResourceGroupId") != "rg-test" {
+					t.Errorf("unexpected resource group: %q", r.Form.Get("ResourceGroupId"))
+				}
+				atomic.AddInt32(&joins, 1)
+			default:
+				t.Errorf("unexpected action: %s", r.Form.Get("Action"))
+				w.WriteHeader(http.StatusBadRequest)
+				response = map[string]interface{}{"Code": "UnexpectedAction"}
+			}
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				t.Error(err)
+			}
+		})
+
+		d := schema.TestResourceDataRaw(t, resourceAliCloudEcsSnapshot().Schema, map[string]interface{}{
+			"disk_id":           "disk-test",
+			"resource_group_id": "rg-test",
+		})
+		d.SetId("snapshot-test")
+		if err := resourceAliCloudEcsSnapshotUpdate(d, client); err != nil {
+			t.Fatalf("resource group update must finish while the snapshot is uploading: %v", err)
+		}
+		if got := atomic.LoadInt32(&joins); got != 1 {
+			t.Fatalf("expected one JoinResourceGroup call, got %d", got)
+		}
+		if got := atomic.LoadInt32(&describes); got != 1 {
+			t.Fatalf("expected only the final Read, got %d DescribeSnapshots calls", got)
+		}
+		if d.Get("resource_group_id") != "rg-test" || d.Get("status") != "progressing" {
+			t.Fatal("Read must retain the resource group and actual snapshot status")
+		}
+	})
+}
+
+func ecsSnapshotTestDescribeResponse(status string, available bool, fields map[string]interface{}) map[string]interface{} {
+	snapshot := map[string]interface{}{
+		"SnapshotId":   "snapshot-test",
+		"SourceDiskId": "disk-test",
+		"Status":       status,
+		"Available":    available,
+	}
+	for key, value := range fields {
+		snapshot[key] = value
+	}
+	return map[string]interface{}{
+		"Snapshots": map[string]interface{}{
+			"Snapshot": []interface{}{snapshot},
+		},
+	}
+}
+
+func TestUnitEcsSnapshotWaitUntilSchema(t *testing.T) {
+	r := resourceAliCloudEcsSnapshot()
+	s := r.Schema["wait_until"]
+	if s == nil {
+		t.Fatal("wait_until must be an operation-local argument")
+	}
+	if s.Type != schema.TypeString || !s.Optional || s.Computed || s.ForceNew || s.Default != nil || s.DefaultFunc != nil {
+		t.Fatalf("unexpected wait_until schema: %#v", s)
+	}
+	available := r.Schema["available"]
+	if available == nil || available.Type != schema.TypeBool || !available.Computed || available.Optional || available.Required || available.ForceNew {
+		t.Fatalf("available must be a computed-only boolean, got %#v", available)
+	}
+	if _, errs := r.Validate(terraform.NewResourceConfigRaw(map[string]interface{}{"disk_id": "disk-test"})); len(errs) != 0 {
+		t.Fatalf("omitted wait_until must be valid: %v", errs)
+	}
+	for _, value := range []string{"accomplished", "available", "progressing", "AVAILABLE", ""} {
+		_, errs := r.Validate(terraform.NewResourceConfigRaw(map[string]interface{}{"disk_id": "disk-test", "wait_until": value}))
+		valid := value == "accomplished" || value == "available"
+		if valid != (len(errs) == 0) {
+			t.Errorf("wait_until %q validation errors: %v", value, errs)
+		}
+	}
+}
+
+func TestUnitEcsSnapshotCreateWaitUntil(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		policy     string
+		inProgress bool
+		wantError  bool
+	}{
+		{name: "default_does_not_return_available", inProgress: true, wantError: true},
+		{name: "accomplished_does_not_return_available", policy: "accomplished", inProgress: true, wantError: true},
+		{name: "default_reaches_accomplished"},
+		{name: "explicit_reaches_accomplished", policy: "accomplished"},
+		{name: "available_returns_while_progressing", policy: "available", inProgress: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var describes int32
+			client := ecsSnapshotTestClient(t, func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				response := map[string]interface{}{}
+				switch req.Form.Get("Action") {
+				case "CreateSnapshot":
+					response["SnapshotId"] = "snapshot-test"
+				case "DescribeSnapshots":
+					count := atomic.AddInt32(&describes, 1)
+					status := "progressing"
+					if !tc.inProgress && count > 1 {
+						status = "accomplished"
+					}
+					response = ecsSnapshotTestDescribeResponse(status, true, nil)
+				default:
+					t.Errorf("unexpected action: %s", req.Form.Get("Action"))
+				}
+				if err := json.NewEncoder(w).Encode(response); err != nil {
+					t.Error(err)
+				}
+			})
+			r := resourceAliCloudEcsSnapshot()
+			timeout := 10 * time.Second
+			if tc.wantError {
+				timeout = 6 * time.Second
+			}
+			r.Timeouts = &schema.ResourceTimeout{Create: schema.DefaultTimeout(timeout)}
+			config := map[string]interface{}{"disk_id": "disk-test"}
+			if tc.policy != "" {
+				config["wait_until"] = tc.policy
+			}
+			diff, err := r.Diff(nil, terraform.NewResourceConfigRaw(config), client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			state, err := r.Apply(nil, diff, client)
+			if tc.wantError {
+				if err == nil || !strings.Contains(err.Error(), "timeout while waiting") {
+					t.Fatalf("must keep waiting while Available=true and Status=progressing, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantPolicy, wantStatus, wantQueries := tc.policy, "accomplished", int32(3)
+			if tc.policy == "available" {
+				wantPolicy, wantStatus, wantQueries = "available", "progressing", 2
+			}
+			if state.ID != "snapshot-test" || state.Attributes["wait_until"] != wantPolicy || state.Attributes["status"] != wantStatus {
+				t.Fatalf("unexpected state: %#v", state)
+			}
+			if state.Attributes["available"] != "true" {
+				t.Fatalf("Read must preserve actual available value, got %q", state.Attributes["available"])
+			}
+			if got := atomic.LoadInt32(&describes); got != wantQueries {
+				t.Fatalf("expected %d queries including Read, got %d", wantQueries, got)
+			}
+		})
+	}
+}
+
+func TestUnitEcsSnapshotUpdateWaitUntil(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		policy string
+		field  string
+	}{
+		{name: "default_name", field: "snapshot_name"},
+		{name: "accomplished_name", policy: "accomplished", field: "snapshot_name"},
+		{name: "available_name", policy: "available", field: "snapshot_name"},
+		{name: "default_legacy_name", field: "name"},
+		{name: "available_legacy_name", policy: "available", field: "name"},
+		{name: "default_description", field: "description"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var describes, modifies int32
+			client := ecsSnapshotTestClient(t, func(w http.ResponseWriter, req *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				response := map[string]interface{}{}
+				switch req.Form.Get("Action") {
+				case "ModifySnapshotAttribute":
+					if atomic.LoadInt32(&describes) != 0 {
+						t.Error("ordinary metadata must be modified without a readiness precheck")
+					}
+					key := "SnapshotName"
+					if tc.field == "description" {
+						key = "Description"
+					}
+					if req.Form.Get(key) != "after" {
+						t.Errorf("expected %s=after, got %q", key, req.Form.Get(key))
+					}
+					atomic.AddInt32(&modifies, 1)
+				case "DescribeSnapshots":
+					atomic.AddInt32(&describes, 1)
+					if atomic.LoadInt32(&modifies) != 1 {
+						t.Error("Read must follow the metadata update")
+					}
+					response = ecsSnapshotTestDescribeResponse("progressing", true, map[string]interface{}{
+						"SnapshotName": "after", "Description": "after",
+					})
+				default:
+					t.Errorf("unexpected action: %s", req.Form.Get("Action"))
+				}
+				if err := json.NewEncoder(w).Encode(response); err != nil {
+					t.Error(err)
+				}
+			})
+			r := resourceAliCloudEcsSnapshot()
+			r.Timeouts = &schema.ResourceTimeout{Update: schema.DefaultTimeout(10 * time.Second)}
+			state := &terraform.InstanceState{ID: "snapshot-test", Attributes: map[string]string{
+				"disk_id": "disk-test", "snapshot_name": "before", "name": "before", "description": "before", "wait_until": "accomplished",
+			}}
+			config := map[string]interface{}{"disk_id": "disk-test", "description": "before"}
+			if tc.field != "name" {
+				config["snapshot_name"] = "before"
+			}
+			config[tc.field] = "after"
+			if tc.policy != "" {
+				config["wait_until"] = tc.policy
+			}
+			diff, err := r.Diff(state, terraform.NewResourceConfigRaw(config), client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			updated, err := r.Apply(state, diff, client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := atomic.LoadInt32(&describes); got != 1 || atomic.LoadInt32(&modifies) != 1 {
+				t.Fatalf("expected one modify and only the final Read, got modify=%d query=%d", modifies, got)
+			}
+			if updated.Attributes["status"] != "progressing" {
+				t.Fatalf("Read must preserve actual progressing status, got %q", updated.Attributes["status"])
+			}
+			if updated.Attributes[tc.field] != "after" {
+				t.Fatalf("Read must refresh %s, got %q", tc.field, updated.Attributes[tc.field])
+			}
+			if tc.field != "description" && (updated.Attributes["snapshot_name"] != "after" || updated.Attributes["name"] != "after") {
+				t.Fatalf("Read must refresh both name aliases, got %#v", updated.Attributes)
+			}
+		})
+	}
+}
+
+func TestUnitEcsSnapshotRetentionWaitUntil(t *testing.T) {
+	for _, policy := range []string{"accomplished", "available"} {
+		for _, mixed := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/mixed_%t", policy, mixed), func(t *testing.T) {
+				var describes, modifies int32
+				client := ecsSnapshotTestClient(t, func(w http.ResponseWriter, req *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					response := map[string]interface{}{}
+					switch req.Form.Get("Action") {
+					case "DescribeSnapshots":
+						count := atomic.AddInt32(&describes, 1)
+						status := "accomplished"
+						if count == 1 {
+							status = "progressing"
+						}
+						response = ecsSnapshotTestDescribeResponse(status, true, map[string]interface{}{"RetentionDays": 30})
+					case "ModifySnapshotAttribute":
+						if atomic.LoadInt32(&describes) < 2 {
+							t.Error("retention must observe accomplished before modification in every mode")
+						}
+						if req.Form.Get("RetentionDays") != "30" || mixed && req.Form.Get("Description") != "after" {
+							t.Error("missing retention or mixed metadata update")
+						}
+						atomic.AddInt32(&modifies, 1)
+					default:
+						t.Errorf("unexpected action: %s", req.Form.Get("Action"))
+					}
+					if err := json.NewEncoder(w).Encode(response); err != nil {
+						t.Error(err)
+					}
+				})
+				r := resourceAliCloudEcsSnapshot()
+				r.Timeouts = &schema.ResourceTimeout{Update: schema.DefaultTimeout(10 * time.Second)}
+				state := &terraform.InstanceState{ID: "snapshot-test", Attributes: map[string]string{
+					"disk_id": "disk-test", "retention_days": "20", "wait_until": policy,
+				}}
+				config := map[string]interface{}{"disk_id": "disk-test", "retention_days": 30, "wait_until": policy}
+				if mixed {
+					config["description"] = "after"
+				}
+				diff, err := r.Diff(state, terraform.NewResourceConfigRaw(config), client)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := r.Apply(state, diff, client); err != nil {
+					t.Fatal(err)
+				}
+				if atomic.LoadInt32(&modifies) != 1 || atomic.LoadInt32(&describes) != 3 {
+					t.Fatalf("expected progressing/accomplished pre-wait, one modify and final Read, got modify=%d queries=%d", modifies, describes)
+				}
+			})
+		}
+	}
+}
+
+func TestUnitEcsSnapshotWaitUntilOnly(t *testing.T) {
+	for _, tc := range []struct{ name, before, after string }{
+		{"to_available", "accomplished", "available"},
+		{"to_accomplished", "available", "accomplished"},
+		{"remove_override", "available", ""},
+		{"remove_accomplished", "accomplished", ""},
+		{"upgrade_legacy_state", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var describes int32
+			client := ecsSnapshotTestClient(t, func(w http.ResponseWriter, req *http.Request) {
+				if req.Form.Get("Action") != "DescribeSnapshots" {
+					t.Errorf("policy-only change must not mutate ECS: %s", req.Form.Get("Action"))
+				}
+				atomic.AddInt32(&describes, 1)
+				w.Header().Set("Content-Type", "application/json")
+				response := ecsSnapshotTestDescribeResponse("progressing", false, map[string]interface{}{
+					"SnapshotName": "unchanged", "Description": "unchanged", "WaitUntil": "cloud-value-must-be-ignored",
+				})
+				if err := json.NewEncoder(w).Encode(response); err != nil {
+					t.Error(err)
+				}
+			})
+			r := resourceAliCloudEcsSnapshot()
+			r.Timeouts = &schema.ResourceTimeout{Update: schema.DefaultTimeout(1 * time.Second)}
+			state := &terraform.InstanceState{ID: "snapshot-test", Attributes: map[string]string{
+				"disk_id": "disk-test", "snapshot_name": "unchanged", "name": "unchanged", "description": "unchanged", "status": "progressing",
+			}}
+			if tc.before != "" {
+				state.Attributes["wait_until"] = tc.before
+			}
+			state, err := r.Refresh(state, client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if state.Attributes["wait_until"] != tc.before {
+				t.Fatalf("Refresh must preserve the local policy, got %q", state.Attributes["wait_until"])
+			}
+			atomic.StoreInt32(&describes, 0)
+			config := map[string]interface{}{"disk_id": "disk-test", "snapshot_name": "unchanged", "description": "unchanged"}
+			if tc.after != "" {
+				config["wait_until"] = tc.after
+			}
+			diff, err := r.Diff(state, terraform.NewResourceConfigRaw(config), client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.before == "" && tc.after == "" {
+				if diff != nil && !diff.Empty() {
+					t.Fatalf("refreshing legacy state with no waiting policy must not create a resource diff: %#v", diff)
+				}
+				return
+			}
+			if diff == nil || diff.RequiresNew() || len(diff.Attributes) != 1 || diff.Attributes["wait_until"] == nil {
+				t.Fatalf("expected only a non-replacement wait_until diff, got %#v", diff)
+			}
+			updated, err := r.Apply(state, diff, client)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if updated.ID != state.ID || updated.Attributes["wait_until"] != tc.after || updated.Attributes["status"] != "progressing" || updated.Attributes["available"] != "false" {
+				t.Fatalf("Read must preserve the local policy and actual status without recreation: %#v", updated)
+			}
+			if got := atomic.LoadInt32(&describes); got != 1 {
+				t.Fatalf("policy-only changes must perform only the final Read, not a waiter, got %d queries", got)
+			}
+			diff, err = r.Diff(updated, terraform.NewResourceConfigRaw(config), client)
+			if err != nil || diff != nil && !diff.Empty() {
+				t.Fatalf("applied local policy must have no remaining diff: %#v, %v", diff, err)
+			}
+		})
+	}
+}
+
+func TestUnitEcsSnapshotReadAvailable(t *testing.T) {
+	values := []interface{}{true, false, true, "missing", true, nil}
+	var describes int32
+	client := ecsSnapshotTestClient(t, func(w http.ResponseWriter, req *http.Request) {
+		if req.Form.Get("Action") != "DescribeSnapshots" {
+			t.Errorf("unexpected action: %s", req.Form.Get("Action"))
+		}
+		count := atomic.AddInt32(&describes, 1)
+		response := ecsSnapshotTestDescribeResponse("progressing", false, map[string]interface{}{
+			"Available": values[count-1], "WaitUntil": "cloud-value-must-be-ignored",
+		})
+		if values[count-1] == "missing" {
+			snapshot := response["Snapshots"].(map[string]interface{})["Snapshot"].([]interface{})[0].(map[string]interface{})
+			delete(snapshot, "Available")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Error(err)
+		}
+	})
+	r := resourceAliCloudEcsSnapshot()
+	d := r.Data(nil)
+	d.SetId("snapshot-test")
+	imported, err := r.Importer.State(d, client)
+	if err != nil || len(imported) != 1 {
+		t.Fatalf("unexpected import result: %#v, %v", imported, err)
+	}
+	state := imported[0].State()
+	for _, value := range values {
+		state, err = r.Refresh(state, client)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if state.Attributes["available"] != strconv.FormatBool(value == true) || state.Attributes["status"] != "progressing" {
+			t.Fatalf("Read must replace availability with the reported boolean or false when absent, response=%v state=%#v", value, state.Attributes)
+		}
+		if got := r.Data(state).Get("available"); got != (value == true) {
+			t.Fatalf("available must remain a boolean in ResourceData, got %#v", got)
+		}
+		if state.Attributes["wait_until"] != "" {
+			t.Fatalf("import/Read must not invent a local policy: %q", state.Attributes["wait_until"])
+		}
+	}
 }

--- a/website/docs/r/ecs_snapshot.html.markdown
+++ b/website/docs/r/ecs_snapshot.html.markdown
@@ -16,6 +16,8 @@ For information about ECS Snapshot and how to use it, see [What is Snapshot](htt
 
 -> **NOTE:** Available since v1.120.0.
 
+-> **NOTE:** By default, creation waits for `status` to become `accomplished`. Set `wait_until = "available"` to finish when ECS reports `Available=true`. At this point, the snapshot can be used to create disks, roll back disks, or create images, and can be shared, even if background upload is still in progress and `status` remains `progressing`. Each operation's other requirements still apply. `wait_until` only controls when Terraform finishes waiting for snapshot creation; it does not change the snapshot's capabilities. Changing `retention_days` still requires `Status=accomplished`.
+
 ## Example Usage
 
 Basic Usage
@@ -119,12 +121,14 @@ The following arguments are supported:
 * `retention_days` - (Optional, Int) The retention period of the snapshot. Valid values: `1` to `65536`. **NOTE:** From version 1.231.0, `retention_days` can be modified.
 * `snapshot_name` - (Optional) The name of the snapshot.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+* `wait_until` - (Optional, Available since v1.293.0) Local waiting policy for creation only. Valid values: `accomplished`, which waits for `Status=accomplished`, and `available`, which waits for `Available=true`. When omitted, creation still waits for `Status=accomplished`, but no default waiting policy is inserted into state, avoiding a new `wait_until` default-value diff for existing configurations. This argument is not sent to ECS or read from ECS. Changing only `wait_until` neither recreates nor modifies the snapshot and is not a readiness barrier; it affects subsequent creation only. Metadata updates (`snapshot_name`, `name`, `description`) do not wait for background upload after ECS accepts the update; Read preserves the actual status. Resource-group and tag updates are also unaffected. **NOTE:** Independently of this policy, `retention_days` changes, including mixed attribute updates, must wait for `Status=accomplished` before sending the update, with no additional wait afterward.
 * `name` - (Optional, Deprecated since v1.120.0) Field `name` has been deprecated from provider version 1.120.0. New field `snapshot_name` instead.
 
 ## Attributes Reference
 
 The following attributes are exported:
 * `id` - The resource ID in terraform of Snapshot.
+* `available` - Whether ECS reports the snapshot as available. This read-only value can be `true` while `status` is still `progressing`, allowing the operations described in the availability note above. It reflects the most recent refresh, not the configured `wait_until` policy.
 * `create_time` - (Available since v1.239.0) The time when the snapshot was created.
 * `region_id` - (Available since v1.239.0) The region ID of the snapshot.
 * `status` - The status of the Snapshot.
@@ -141,6 +145,8 @@ The `timeouts` block allows you to specify [timeouts](https://developer.hashicor
 ## Import
 
 ECS Snapshot can be imported using the id, e.g.
+
+`available` is populated from ECS when the imported snapshot is refreshed. `wait_until` is a local setting and cannot be recovered from the imported snapshot. Keep any explicitly selected waiting policy in the Terraform configuration; omitting it continues to wait for `Status=accomplished` on subsequent creation without adding a default policy to state.
 
 ```shell
 $ terraform import alicloud_ecs_snapshot.example <id>


### PR DESCRIPTION
Add the provider-local `wait_until` argument to `alicloud_ecs_snapshot` to select the completion condition for **creation only**, and expose the ECS `available` value as a computed boolean.

- Omitting `wait_until` still waits for `Status=accomplished`. The schema has no default: the runtime `GetOk` fallback preserves existing creation behavior without inserting `wait_until=accomplished` into legacy state or creating a default-value configuration diff after refresh. Explicit `accomplished` and `available` are validated; an explicitly empty string is not a valid policy.
- Explicit `wait_until = "available"` waits for `Available=true`; background upload may still be in progress, and Read preserves the actual `status`. At `Available=true`, the snapshot supports disk creation, disk rollback, snapshot sharing, and image creation, subject to each operation's other requirements.
- `available` is read-only, populated on every Read, and independent of the waiting policy. A reported false replaces a previous true; an absent/null field clears it to false. Import refresh populates `available` but cannot recover `wait_until`.
- `wait_until` only controls when Terraform finishes waiting for snapshot creation; it does not change snapshot capabilities. Neither the local policy nor the computed availability is sent to ECS. Changing or removing only the policy neither recreates nor modifies the snapshot and is not a readiness barrier. Removing an explicitly stored policy remains a normal local configuration change and converges without a residual diff.
- Metadata updates (`snapshot_name`, legacy `name`, and `description`) no longer wait for snapshot upload after a successful `ModifySnapshotAttribute` call; they finish with the normal Read. Live probes showed these updates already persisted while the snapshot was still uploading. This intentionally removes the previous Update completion wait rather than treating upload status as an attribute-update result.
- Retention changes, including mixed metadata/retention requests, still wait for `Status=accomplished` **before** the API call in either mode. This precondition is backed by observed `InvalidSnapshotId.NotReady` responses followed by successful identical requests after upload completed. There is no extra post-update wait.
- Resource-group updates have no extra snapshot-readiness wait; tag handling is unchanged. `wait_until` does not govern Update operations.

Retain the five existing acceptance cases covering names, retention, resource groups, tags, import and destroy, including omitted/explicit accomplished creation and an available-mode snapshot consumed by a dependent disk. They now assert the computed availability, with omitted creation also asserting that no accomplished policy is written into state. Tests use compatible encrypted ESSD fixtures in matching zones. `AliCloudEcsSnapshotBasicDependence1` remains as a wrapper around the shared fixture; `basic1` and `basic1_twin` are retained, but their original `cloud_efficiency` disk-type coverage is no longer exercised. The generic category case uses `standard`; schema and RPC round-trip coverage retain legacy `flash` without claiming live cloud lifecycle coverage for it. The documented capabilities do not imply that this acceptance suite exercises all four downstream operations.

Validation for the latest schema/output revision:

- Tests-first regressions failed against the old implementation, exposing the legacy default-value diff, the swallowed removal of an accomplished policy, and the missing availability output. After the patch, all nine Snapshot-specific groups passed: 31 named subcases plus the schema check and the six-step import/Read sequence, with zero failures or skips (125.657s). Command: `GOMAXPROCS=2 go test -p=1 -vet=off ./alicloud -run '^TestUnitEcsSnapshot' -count=1 -v`.
- Coverage includes both creation policies, omitted-policy waiting and state, normal legacy Refresh→Diff compatibility, policy changes/removals and convergence, import, true→false/missing/null refreshes, metadata and legacy-name updates, retention-only/mixed preconditions, resource-group updates, and legacy category RPC round trips. No new test framework or cloud probe was added.
- Documentation content, Markdown lint, formatting and diff checks passed. The repository coverage checker was compiled against the updated schema and reported 100% attribute testing coverage and 100% modification coverage; this is schema/config coverage, not a live acceptance result.
- The single `go vet -p=1 ./alicloud` run reports only the two existing unused `fmt.Sprintln` results in unchanged `common.go` (lines 1592 and 1604); vet is not reported as clean.

Remote acceptance and all reported PR checks passed on commit `1d729f66a39b51b53deb45612b12858be2860b73`. The actual acceptance log confirms all five cases (`basic0`, `basic0_twin`, `basic1`, `basic1_twin`, and `availableDisk`) passed, with zero failures or skips. This run includes the schema-default removal and computed availability output, not an older implementation.

The latest revision only adds `Available since v1.293.0` to the `wait_until` documentation, matching the current unreleased development version (v1.292.0 is already released). Documentation content, Markdown lint and diff checks passed again. Provider and test code are unchanged from the acceptance-tested commit above; no new acceptance run was manually dispatched for this documentation-only revision. Checks on the new documentation-only head have not yet been verified.
