### PR TITLE
resource/alicloud_alb_acl_entry_attachment: wait for ACL Available status after entry add/remove

### DIFF
--- a/alicloud/resource_alicloud_alb_acl_entry_attachment.go
+++ b/alicloud/resource_alicloud_alb_acl_entry_attachment.go
@@ -89,6 +89,15 @@ func resourceAlicloudAlbAclEntryAttachmentCreate(d *schema.ResourceData, meta in
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
+	// Wait for the ACL itself to settle to Available before returning. The
+	// entry-level status may flip to Available while the ACL is still
+	// Configuring, which breaks downstream operations such as associating the
+	// ACL with a listener (IncorrectStatus.Acl). Aligns with the deprecated
+	// acl_entries path in resourceAlicloudAlbAclUpdate.
+	aclStateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, albService.AlbAclStateRefreshFunc(d.Get("acl_id").(string), []string{}))
+	if _, err := aclStateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
 	return resourceAlicloudAlbAclEntryAttachmentRead(d, meta)
 }
 
@@ -158,6 +167,13 @@ func resourceAlicloudAlbAclEntryAttachmentDelete(d *schema.ResourceData, meta in
 	}
 	stateConf := BuildStateConf([]string{}, []string{}, d.Timeout(schema.TimeoutDelete), 5*time.Second, albService.AlbAclEntryAttachmentStateRefreshFunc(d.Id(), []string{}))
 	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+	// Wait for the ACL itself to settle to Available before returning. The
+	// entry is gone once the remove call succeeds, but the ACL may still be
+	// Configuring, which breaks downstream operations on the same ACL.
+	aclStateConf := BuildStateConf([]string{}, []string{"Available"}, d.Timeout(schema.TimeoutDelete), 5*time.Second, albService.AlbAclStateRefreshFunc(parts[0], []string{}))
+	if _, err := aclStateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
 	return nil

--- a/alicloud/resource_alicloud_alb_acl_entry_attachment_test.go
+++ b/alicloud/resource_alicloud_alb_acl_entry_attachment_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAlicloudAlbAclEntryAttachment_basic0(t *testing.T) {
+func TestAccAliCloudAlbAclEntryAttachment_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_alb_acl_entry_attachment.default"
 	ra := resourceAttrInit(resourceId, nil)


### PR DESCRIPTION
## What

`alicloud_alb_acl_entry_attachment` Create and Delete only waited for the **entry-level** `Status` (returned by `ListAclEntries`) to reach `Available`. An entry can flip to `Available` while the parent ACL is still in `Configuring`, so the resource returned success too early. Downstream operations such as `alicloud_alb_listener_acl_attachment` (which calls `AssociateAclsWithListener`) then failed with `IncorrectStatus.Acl` because the ACL had not settled yet.

## Fix

After the existing entry-level `stateConf.WaitForState()` in both `resourceAlicloudAlbAclEntryAttachmentCreate` and `resourceAlicloudAlbAclEntryAttachmentDelete`, add a second `WaitForState()` on the **ACL-level** `AclStatus` using `AlbAclStateRefreshFunc`, targeting `Available`.

This aligns the entry-attachment resource with the deprecated `acl_entries` path in `resourceAlicloudAlbAclUpdate`, which already waits on `AclStatus` after `AddEntriesToAcl` / `RemoveEntriesFromAcl`.

- Create uses `schema.TimeoutCreate`; Delete uses `schema.TimeoutDelete` (no hardcoded timeout).
- The existing entry-level wait is preserved; the ACL wait is appended so both conditions are satisfied before returning.
- Error handling follows the existing style (`WrapErrorf(err, IdMsg, d.Id())`).

## Root cause

Two independent status fields:

- `ListAclEntries` returns each entry's `Status` (entry-level).
- `ListAcls` returns `AclStatus` (ACL-level).

The entry can reach `Available` before the ACL exits `Configuring`, so waiting only on the entry left a window where the ACL was not yet usable.

## Testing

Existing acceptance test `TestAccAlicloudAlbAclEntryAttachment_basic0` covers create -> import. Remote acceptance tests will be run to validate the fix end-to-end (create entry attachment, then associate ACL with a listener without the `IncorrectStatus.Acl` race).