### PR TITLE
resource/alicloud_nlb_listener: filter nil/empty elements in ca_certificate_ids and certificate_ids to avoid SDK panic

### DIFF
--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -414,6 +414,26 @@ func filterEmptyStrings(arr []interface{}) []interface{} {
 	return result
 }
 
+// filterNilAndEmptyStrings removes nil and empty-string elements from a
+// []interface{} before it is forwarded to the SDK request. The tea-rpc-utils
+// request serializer reflects over slice elements; a nil element triggers
+// "reflect: Value.Interface: cannot return zero Value" because the zero
+// Value has no concrete type to recover. Empty strings are dropped as well
+// to avoid sending placeholder entries that the server would reject.
+func filterNilAndEmptyStrings(arr []interface{}) []interface{} {
+	var result []interface{}
+	for _, str := range arr {
+		if str == nil {
+			continue
+		}
+		if fmt.Sprint(str) == "" {
+			continue
+		}
+		result = append(result, str)
+	}
+	return result
+}
+
 func convertBoolToString(configured bool) string {
 	return strconv.FormatBool(configured)
 }

--- a/alicloud/resource_alicloud_nlb_listener.go
+++ b/alicloud/resource_alicloud_nlb_listener.go
@@ -186,12 +186,12 @@ func resourceAliCloudNlbListenerCreate(d *schema.ResourceData, meta interface{})
 	}
 	if v, ok := d.GetOk("certificate_ids"); ok {
 		certificateIdsMapsArray := v.([]interface{})
-		request["CertificateIds"] = certificateIdsMapsArray
+		request["CertificateIds"] = filterNilAndEmptyStrings(certificateIdsMapsArray)
 	}
 
 	if v, ok := d.GetOk("ca_certificate_ids"); ok {
 		caCertificateIdsMapsArray := v.([]interface{})
-		request["CaCertificateIds"] = caCertificateIdsMapsArray
+		request["CaCertificateIds"] = filterNilAndEmptyStrings(caCertificateIdsMapsArray)
 	}
 
 	if v, ok := d.GetOk("alpn_policy"); ok {
@@ -487,7 +487,7 @@ func resourceAliCloudNlbListenerUpdate(d *schema.ResourceData, meta interface{})
 		update = true
 		if v, ok := d.GetOk("certificate_ids"); ok || d.HasChange("certificate_ids") {
 			certificateIdsMapsArray := v.([]interface{})
-			request["CertificateIds"] = certificateIdsMapsArray
+			request["CertificateIds"] = filterNilAndEmptyStrings(certificateIdsMapsArray)
 		}
 	}
 
@@ -495,7 +495,7 @@ func resourceAliCloudNlbListenerUpdate(d *schema.ResourceData, meta interface{})
 		update = true
 		if v, ok := d.GetOk("ca_certificate_ids"); ok || d.HasChange("ca_certificate_ids") {
 			caCertificateIdsMapsArray := v.([]interface{})
-			request["CaCertificateIds"] = caCertificateIdsMapsArray
+			request["CaCertificateIds"] = filterNilAndEmptyStrings(caCertificateIdsMapsArray)
 		}
 	}
 


### PR DESCRIPTION
## Summary

`alicloud_nlb_listener` Create and Update forwarded the raw `[]interface{}` for `certificate_ids` and `ca_certificate_ids` straight to the RPC request without filtering nil or empty-string elements. When a list contained a nil element, tea-rpc-utils panicked with `reflect: Value.Interface: cannot return zero Value` because it reflects over slice elements and the zero Value has no concrete type to recover.

## Changes

- Add `filterNilAndEmptyStrings` helper in `alicloud/common.go` (next to the existing `filterEmptyStrings`) that drops nil and empty-string entries from a `[]interface{}`.
- Wrap the `CertificateIds` and `CaCertificateIds` assignments in both `resourceAliCloudNlbListenerCreate` and `resourceAliCloudNlbListenerUpdate` with the new helper so the SDK serializer never receives a slice containing nil elements.

## Validation

- `go vet -p=1 ./alicloud` (package-scoped): clean for the changed code. Two pre-existing `fmt.Sprintln` warnings at `common.go:1612/1624` are unrelated master debt.
- Remote acceptance tests pending.
