### PR TITLE
resource/alicloud_alb_acl_entry_attachment: wait for acl Available; resource/alicloud_alb_listener_acl_attachment: wait for acl Available before associating

### DIFF
--- a/alicloud/resource_alicloud_alb_acl_entry_attachment.go
+++ b/alicloud/resource_alicloud_alb_acl_entry_attachment.go
@@ -89,6 +89,13 @@ func resourceAlicloudAlbAclEntryAttachmentCreate(d *schema.ResourceData, meta in
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
+	// The acl entry turns Available before the acl itself leaves Configuring status.
+	// Wait for the acl to become Available, so that dependent resources (e.g. alicloud_alb_listener_acl_attachment)
+	// will not be created while the server side still considers the acl Configuring.
+	stateConf = BuildStateConf([]string{"Creating", "Configuring"}, []string{"Available"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, albService.AlbAclStateRefreshFunc(fmt.Sprint(request["AclId"]), []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
 	return resourceAlicloudAlbAclEntryAttachmentRead(d, meta)
 }
 

--- a/alicloud/resource_alicloud_alb_acl_entry_attachment_test.go
+++ b/alicloud/resource_alicloud_alb_acl_entry_attachment_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccAlicloudAlbAclEntryAttachment_basic0(t *testing.T) {
+func TestAccAliCloudALBAclEntryAttachment_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_alb_acl_entry_attachment.default"
 	ra := resourceAttrInit(resourceId, nil)

--- a/alicloud/resource_alicloud_alb_listener_acl_attachment.go
+++ b/alicloud/resource_alicloud_alb_listener_acl_attachment.go
@@ -52,6 +52,7 @@ func resourceAliCloudAlbListenerAclAttachment() *schema.Resource {
 func resourceAliCloudAlbListenerAclAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
 
 	client := meta.(*connectivity.AliyunClient)
+	albService := AlbService{client}
 
 	action := "AssociateAclsWithListener"
 	var request map[string]interface{}
@@ -64,6 +65,13 @@ func resourceAliCloudAlbListenerAclAttachmentCreate(d *schema.ResourceData, meta
 	request["ClientToken"] = buildClientToken(action)
 
 	request["AclType"] = d.Get("acl_type")
+	// The acl can still be Creating or Configuring when this resource is created right after
+	// alicloud_alb_acl or alicloud_alb_acl_entry_attachment; AssociateAclsWithListener rejects
+	// such an acl with IncorrectStatus.Acl, so wait for it to become Available first.
+	stateConf := BuildStateConf([]string{"Creating", "Configuring"}, []string{"Available"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, albService.AlbAclStateRefreshFunc(fmt.Sprint(d.Get("acl_id")), []string{}))
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, IdMsg, fmt.Sprint(d.Get("acl_id")))
+	}
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("Alb", "2020-06-16", action, nil, request, true)
@@ -87,7 +95,7 @@ func resourceAliCloudAlbListenerAclAttachmentCreate(d *schema.ResourceData, meta
 	d.SetId(fmt.Sprintf("%v:%v", request["ListenerId"], request["AclIds.1"]))
 
 	albServiceV2 := AlbServiceV2{client}
-	stateConf := BuildStateConf([]string{}, []string{"Associated"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, albServiceV2.AlbListenerAclAttachmentStateRefreshFunc(d.Id(), "$.AclConfig.AclRelations[0].Status", []string{}))
+	stateConf = BuildStateConf([]string{}, []string{"Associated"}, d.Timeout(schema.TimeoutCreate), 5*time.Second, albServiceV2.AlbListenerAclAttachmentStateRefreshFunc(d.Id(), "$.AclConfig.AclRelations[0].Status", []string{}))
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}


### PR DESCRIPTION
### Description

An ACL entry reaches `Available` status before the ACL itself leaves `Configuring` (`AddEntriesToAcl` is asynchronous). As a result `alicloud_alb_acl_entry_attachment` finished creating while the server side still considered the ACL `Configuring`, and creating `alicloud_alb_listener_acl_attachment` right after failed with `IncorrectStatus.Acl` (`The status of acl-xxx [Configuring] is incorrect`) until the create timeout.

Changes:

- `resource/alicloud_alb_acl_entry_attachment`: after the entry reaches `Available`, additionally wait for the ACL itself to become `Available`, so dependent resources are not created while the ACL is still `Configuring`
- `resource/alicloud_alb_listener_acl_attachment`: wait for the ACL to become `Available` before calling `AssociateAclsWithListener`, so the association does not depend on the `IncorrectStatus.Acl` retry backoff alone
- rename `TestAccAlicloudAlbAclEntryAttachment_basic0` to `TestAccAliCloudALBAclEntryAttachment_basic0` to match the current test naming convention

Delete paths already retry `IncorrectStatus.Acl` in all three related resources (`DissociateAclsFromListener`, `RemoveEntriesFromAcl`, `DeleteAcl`), so no destroy-side change is needed.

### Acceptance Test

```
PASS: TestAccAliCloudALBAclEntryAttachment_basic0 (26.24s)
PASS: TestAccAliCloudALBListenerAclAttachment_basic0 (277.21s)
```
