### PR TITLE
resource/alicloud_alb_acl_entry_attachment: adds batch entries attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 1.292.0 (Unreleased)
+
+- resource/alicloud_alb_acl_entry_attachment: adds `entries` to manage multiple ACL entries in one resource with batch API calls, and deprecates `entry`.
+
 ## 1.291.0 (September 1, 2026)
 
 - **New Resource:** `alicloud_ecd_desktop_group` ([#10230](https://github.com/aliyun/terraform-provider-alicloud/issues/10230))

--- a/alicloud/resource_alicloud_alb_acl_entry_attachment.go
+++ b/alicloud/resource_alicloud_alb_acl_entry_attachment.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -15,12 +16,14 @@ func resourceAlicloudAlbAclEntryAttachment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAlicloudAlbAclEntryAttachmentCreate,
 		Read:   resourceAlicloudAlbAclEntryAttachmentRead,
+		Update: resourceAlicloudAlbAclEntryAttachmentUpdate,
 		Delete: resourceAlicloudAlbAclEntryAttachmentDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
@@ -30,15 +33,40 @@ func resourceAlicloudAlbAclEntryAttachment() *schema.Resource {
 				ForceNew: true,
 			},
 			"entry": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringLenBetween(1, 256),
+				Deprecated:   "Field 'entry' has been deprecated from provider version 1.292.0 and it will be removed in the future version. Please use the new field 'entries'.",
+				ExactlyOneOf: []string{"entry", "entries"},
+			},
+			"description": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ValidateFunc:  validation.StringLenBetween(1, 256),
+				ConflictsWith: []string{"entries"},
+			},
+			"entries": {
+				Type:         schema.TypeSet,
+				Optional:     true,
+				ExactlyOneOf: []string{"entry", "entries"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"entry": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"description": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 256),
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"status": {
 				Type:     schema.TypeString,
@@ -50,6 +78,10 @@ func resourceAlicloudAlbAclEntryAttachment() *schema.Resource {
 
 func resourceAlicloudAlbAclEntryAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
+	// batch mode: the attachment owns all entries of the acl and its ID is the acl ID
+	if _, ok := d.GetOk("entries"); ok {
+		return resourceAlicloudAlbAclEntryAttachmentCreateBatch(d, meta)
+	}
 	albService := AlbService{client}
 	var response map[string]interface{}
 	var err error
@@ -99,9 +131,53 @@ func resourceAlicloudAlbAclEntryAttachmentCreate(d *schema.ResourceData, meta in
 	return resourceAlicloudAlbAclEntryAttachmentRead(d, meta)
 }
 
+func resourceAlicloudAlbAclEntryAttachmentCreateBatch(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	aclId := d.Get("acl_id").(string)
+	entries := d.Get("entries").(*schema.Set).List()
+	if len(entries) == 0 {
+		// the exactly-one-of constraint rejects zero entry blocks at plan time;
+		// keep an explicit error here in case an empty set reaches the apply path anyway
+		return WrapError(Error("at least one entry block is required, to remove all entries please remove the resource"))
+	}
+	if err := addAlbAclEntries(client, aclId, entries, d.Timeout(schema.TimeoutCreate)); err != nil {
+		return err
+	}
+	d.SetId(aclId)
+	return resourceAlicloudAlbAclEntryAttachmentRead(d, meta)
+}
+
 func resourceAlicloudAlbAclEntryAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	albService := AlbService{client}
+	// batch mode: the ID is the acl ID and the attachment owns all entries of the acl
+	if !strings.Contains(d.Id(), ":") {
+		entries, err := albService.ListAclEntries(d.Id())
+		if err != nil {
+			if NotFoundError(err) {
+				log.Printf("[DEBUG] Resource alicloud_alb_acl_entry_attachment AlbService.ListAclEntries Failed!!! %s", err)
+				d.SetId("")
+				return nil
+			}
+			return WrapError(err)
+		}
+		if len(entries) == 0 {
+			log.Printf("[DEBUG] Resource alicloud_alb_acl_entry_attachment batch attachment %s has no entries", d.Id())
+			d.SetId("")
+			return nil
+		}
+		entriesMaps := make([]interface{}, 0, len(entries))
+		for _, entry := range entries {
+			entriesMaps = append(entriesMaps, map[string]interface{}{
+				"description": entry["Description"],
+				"entry":       entry["Entry"],
+				"status":      entry["Status"],
+			})
+		}
+		d.Set("acl_id", d.Id())
+		d.Set("entries", entriesMaps)
+		return nil
+	}
 	object, err := albService.DescribeAlbAclEntryAttachment(d.Id())
 	if err != nil {
 		if NotFoundError(err) {
@@ -124,9 +200,54 @@ func resourceAlicloudAlbAclEntryAttachmentRead(d *schema.ResourceData, meta inte
 	return nil
 }
 
+func resourceAlicloudAlbAclEntryAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	// `acl_id`, `entry` and `description` are ForceNew: in-place update only applies to `entries` (batch mode)
+	if !d.HasChange("entries") {
+		return nil
+	}
+	oraw, nraw := d.GetChange("entries")
+	remove := oraw.(*schema.Set).Difference(nraw.(*schema.Set)).List()
+	create := nraw.(*schema.Set).Difference(oraw.(*schema.Set)).List()
+
+	if len(remove) > 0 {
+		entries := make([]interface{}, 0, len(remove))
+		for _, item := range remove {
+			entries = append(entries, item.(map[string]interface{})["entry"])
+		}
+		if err := removeAlbAclEntries(client, d.Id(), entries, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return err
+		}
+	}
+	if len(create) > 0 {
+		if err := addAlbAclEntries(client, d.Id(), create, d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return err
+		}
+	}
+	return resourceAlicloudAlbAclEntryAttachmentRead(d, meta)
+}
+
 func resourceAlicloudAlbAclEntryAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*connectivity.AliyunClient)
 	albService := AlbService{client}
+	// batch mode: remove all entries owned by this attachment from the acl
+	if !strings.Contains(d.Id(), ":") {
+		entries, err := albService.ListAclEntries(d.Id())
+		if err != nil {
+			if NotFoundError(err) {
+				return nil
+			}
+			return WrapError(err)
+		}
+		if len(entries) == 0 {
+			return nil
+		}
+		entryList := make([]interface{}, 0, len(entries))
+		for _, entry := range entries {
+			entryList = append(entryList, entry["Entry"])
+		}
+		return removeAlbAclEntries(client, d.Id(), entryList, d.Timeout(schema.TimeoutDelete))
+	}
 	action := "RemoveEntriesFromAcl"
 	var response map[string]interface{}
 	var err error
@@ -166,6 +287,104 @@ func resourceAlicloudAlbAclEntryAttachmentDelete(d *schema.ResourceData, meta in
 	stateConf := BuildStateConf([]string{}, []string{}, d.Timeout(schema.TimeoutDelete), 5*time.Second, albService.AlbAclEntryAttachmentStateRefreshFunc(d.Id(), []string{}))
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
+	}
+	return nil
+}
+
+// addAlbAclEntries adds the given acl entries in batches of at most 20 entries
+// per call, which is the limit of the AddEntriesToAcl API.
+func addAlbAclEntries(client *connectivity.AliyunClient, aclId string, entries []interface{}, timeout time.Duration) error {
+	albService := AlbService{client}
+	action := "AddEntriesToAcl"
+	for _, item := range SplitSlice(entries, 20) {
+		aclEntriesMaps := make([]map[string]interface{}, 0)
+		for _, aclEntry := range item {
+			aclEntryArg := aclEntry.(map[string]interface{})
+			aclEntriesMap := map[string]interface{}{
+				"Entry": aclEntryArg["entry"],
+			}
+			if v, ok := aclEntryArg["description"].(string); ok && v != "" {
+				aclEntriesMap["Description"] = v
+			}
+			aclEntriesMaps = append(aclEntriesMaps, aclEntriesMap)
+		}
+		request := map[string]interface{}{
+			"AclId":       aclId,
+			"AclEntries":  aclEntriesMaps,
+			"ClientToken": buildClientToken(action),
+		}
+		var response map[string]interface{}
+		var err error
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(timeout, func() *resource.RetryError {
+			response, err = client.RpcPost("Alb", "2020-06-16", action, nil, request, true)
+			if err != nil {
+				if IsExpectedErrors(err, []string{"OperationFailed.ResourceGroupStatusCheckFail", "IncorrectStatus.Acl", "ResourceInConfiguring"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			// an entry already on the acl is kept as it is: it either belongs to this
+			// full-set attachment or will converge on the next apply
+			if IsExpectedErrors(err, []string{"ResourceAlreadyExist.AclEntry"}) {
+				continue
+			}
+			return WrapErrorf(err, DefaultErrorMsg, aclId, action, AlibabaCloudSdkGoERROR)
+		}
+		stateConf := BuildStateConf([]string{}, []string{"Available"}, timeout, 5*time.Second, albService.AlbAclStateRefreshFunc(aclId, []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, aclId)
+		}
+	}
+	return nil
+}
+
+// removeAlbAclEntries removes the given acl entries in batches of at most 20
+// entries per call, which is the limit of the RemoveEntriesFromAcl API.
+func removeAlbAclEntries(client *connectivity.AliyunClient, aclId string, entries []interface{}, timeout time.Duration) error {
+	albService := AlbService{client}
+	action := "RemoveEntriesFromAcl"
+	for _, item := range SplitSlice(entries, 20) {
+		aclEntriesMaps := make([]string, 0)
+		for _, aclEntry := range item {
+			aclEntriesMaps = append(aclEntriesMaps, fmt.Sprint(aclEntry))
+		}
+		request := map[string]interface{}{
+			"AclId":       aclId,
+			"RegionId":    client.RegionId,
+			"Entries":     aclEntriesMaps,
+			"ClientToken": buildClientToken(action),
+		}
+		var response map[string]interface{}
+		var err error
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(timeout, func() *resource.RetryError {
+			response, err = client.RpcPost("Alb", "2020-06-16", action, nil, request, true)
+			if err != nil {
+				if IsExpectedErrors(err, []string{"IncorrectStatus.Acl", "OperationFailed.ResourceGroupStatusCheckFail", "ResourceInConfiguring"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"ResourceNotFound.AclEntry"}) {
+				continue
+			}
+			return WrapErrorf(err, DefaultErrorMsg, aclId, action, AlibabaCloudSdkGoERROR)
+		}
+		stateConf := BuildStateConf([]string{}, []string{"Available"}, timeout, 5*time.Second, albService.AlbAclStateRefreshFunc(aclId, []string{}))
+		if _, err := stateConf.WaitForState(); err != nil {
+			return WrapErrorf(err, IdMsg, aclId)
+		}
 	}
 	return nil
 }

--- a/alicloud/resource_alicloud_alb_acl_entry_attachment_test.go
+++ b/alicloud/resource_alicloud_alb_acl_entry_attachment_test.go
@@ -2,11 +2,14 @@ package alicloud
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccAliCloudALBAclEntryAttachment_basic0(t *testing.T) {
@@ -50,6 +53,262 @@ func TestAccAliCloudALBAclEntryAttachment_basic0(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccAliCloudALBAclEntryAttachment_entries(t *testing.T) {
+	var entries []map[string]interface{}
+	resourceId := "alicloud_alb_acl_entry_attachment.default"
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccAlbAclEntryAttachment%d", rand)
+	updatedName := fmt.Sprintf("%s-updated", name)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlbAclEntryAttachmentBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAlbAclEntryAttachmentBatchDestroy,
+		Steps: []resource.TestStep{
+			{
+				// exactly one of `entry` and `entries` must be specified: a config
+				// with zero entry blocks is rejected at plan time (the sdk reports
+				// the exactly-one-of keys in sorted order)
+				Config:      testAccConfig(map[string]interface{}{"acl_id": "${alicloud_alb_acl.default.id}"}),
+				ExpectError: regexp.MustCompile("one of `entries,entry` must be specified"),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"acl_id": "${alicloud_alb_acl.default.id}",
+					"entries": []map[string]interface{}{
+						{
+							"entry":       "10.10.10.0/24",
+							"description": name,
+						},
+						{
+							"entry":       "10.10.11.0/24",
+							"description": name,
+						},
+						{
+							"entry":       "10.10.12.0/24",
+							"description": name,
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlbAclEntryAttachmentBatchExists(resourceId, &entries),
+					resource.TestCheckResourceAttr(resourceId, "entries.#", "3"),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.10.10.0/24", name),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.10.11.0/24", name),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.10.12.0/24", name),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"acl_id": "${alicloud_alb_acl.default.id}",
+					"entries": []map[string]interface{}{
+						{
+							"entry":       "10.10.10.0/24",
+							"description": name,
+						},
+						{
+							"entry":       "10.10.11.0/24",
+							"description": updatedName,
+						},
+						{
+							"entry":       "10.10.13.0/24",
+							"description": name,
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlbAclEntryAttachmentBatchExists(resourceId, &entries),
+					resource.TestCheckResourceAttr(resourceId, "entries.#", "3"),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.10.10.0/24", name),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.10.11.0/24", updatedName),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.10.13.0/24", name),
+				),
+			},
+			{
+				// the order of the entry blocks is not significant: reordering
+				// them must not update the resource
+				Config: testAccConfig(map[string]interface{}{
+					"acl_id": "${alicloud_alb_acl.default.id}",
+					"entries": []map[string]interface{}{
+						{
+							"entry":       "10.10.13.0/24",
+							"description": name,
+						},
+						{
+							"entry":       "10.10.10.0/24",
+							"description": name,
+						},
+						{
+							"entry":       "10.10.11.0/24",
+							"description": updatedName,
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlbAclEntryAttachmentBatchExists(resourceId, &entries),
+					resource.TestCheckResourceAttr(resourceId, "entries.#", "3"),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.10.10.0/24", name),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.10.11.0/24", updatedName),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.10.13.0/24", name),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAliCloudALBAclEntryAttachment_entriesChunking(t *testing.T) {
+	var entries []map[string]interface{}
+	resourceId := "alicloud_alb_acl_entry_attachment.default"
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testAccAlbAclEntryAttachment%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudAlbAclEntryAttachmentBasicDependence0)
+	// the api accepts at most 20 entries per call: volumes above that are
+	// chunked, so the scenarios below cross the chunk boundary in every
+	// direction (create, add, remove and destroy)
+	entryBlocks := func(count, secondOctet int) []map[string]interface{} {
+		blocks := make([]map[string]interface{}, 0, count)
+		for i := 0; i < count; i++ {
+			blocks = append(blocks, map[string]interface{}{
+				"entry":       fmt.Sprintf("10.%d.%d.0/24", secondOctet, i),
+				"description": name,
+			})
+		}
+		return blocks
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAlbAclEntryAttachmentBatchDestroy,
+		Steps: []resource.TestStep{
+			{
+				// exactly 20 entries: the single-call boundary of the api
+				Config: testAccConfig(map[string]interface{}{
+					"acl_id":  "${alicloud_alb_acl.default.id}",
+					"entries": entryBlocks(20, 20),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlbAclEntryAttachmentBatchExists(resourceId, &entries),
+					resource.TestCheckResourceAttr(resourceId, "entries.#", "20"),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.20.0.0/24", name),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.20.19.0/24", name),
+				),
+			},
+			{
+				// grow to 43: 23 added entries are sent in 2 chunked calls (20+3)
+				Config: testAccConfig(map[string]interface{}{
+					"acl_id":  "${alicloud_alb_acl.default.id}",
+					"entries": entryBlocks(43, 20),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlbAclEntryAttachmentBatchExists(resourceId, &entries),
+					resource.TestCheckResourceAttr(resourceId, "entries.#", "43"),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.20.20.0/24", name),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.20.42.0/24", name),
+				),
+			},
+			{
+				// swap: 21 removed entries are sent in 2 chunked calls (20+1)
+				// and 22 added entries in 2 chunked calls (20+2)
+				Config: testAccConfig(map[string]interface{}{
+					"acl_id":  "${alicloud_alb_acl.default.id}",
+					"entries": append(entryBlocks(22, 20), entryBlocks(22, 21)...),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlbAclEntryAttachmentBatchExists(resourceId, &entries),
+					resource.TestCheckResourceAttr(resourceId, "entries.#", "44"),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.20.0.0/24", name),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.20.21.0/24", name),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.21.0.0/24", name),
+					testAccCheckAlbAclEntryAttachmentEntry(resourceId, "10.21.21.0/24", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAlbAclEntryAttachmentBatchExists(n string, entries *[]map[string]interface{}) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return WrapError(Error("Not found: %s", n))
+		}
+		if rs.Primary.ID == "" {
+			return WrapError(Error("No alicloud_alb_acl_entry_attachment ID is set"))
+		}
+		client := testAccProvider.Meta().(*connectivity.AliyunClient)
+		albService := AlbService{client}
+		list, err := albService.ListAclEntries(rs.Primary.ID)
+		if err != nil {
+			return WrapError(err)
+		}
+		if len(list) == 0 {
+			return WrapError(Error("the acl %s has no entries", rs.Primary.ID))
+		}
+		*entries = list
+		return nil
+	}
+}
+
+// testAccCheckAlbAclEntryAttachmentEntry asserts that one `entries` set element
+// with the given entry and description and the Available status exists in the
+// resource state.
+func testAccCheckAlbAclEntryAttachmentEntry(n, entry, description string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return WrapError(Error("Not found: %s", n))
+		}
+		for attributeName, attributeValue := range rs.Primary.Attributes {
+			if !strings.HasPrefix(attributeName, "entries.") || !strings.HasSuffix(attributeName, ".entry") || attributeValue != entry {
+				continue
+			}
+			hash := strings.TrimSuffix(strings.TrimPrefix(attributeName, "entries."), ".entry")
+			actual := rs.Primary.Attributes[fmt.Sprintf("entries.%s.description", hash)]
+			if actual != description {
+				return WrapError(Error("entry %s has description %q, expected %q", entry, actual, description))
+			}
+			status := rs.Primary.Attributes[fmt.Sprintf("entries.%s.status", hash)]
+			if status != "Available" {
+				return WrapError(Error("entry %s has status %q, expected %q", entry, status, "Available"))
+			}
+			return nil
+		}
+		return WrapError(Error("entry %s not found in resource %s", entry, n))
+	}
+}
+
+func testAccCheckAlbAclEntryAttachmentBatchDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_alb_acl_entry_attachment" {
+			continue
+		}
+		client := testAccProvider.Meta().(*connectivity.AliyunClient)
+		albService := AlbService{client}
+		entries, err := albService.ListAclEntries(rs.Primary.ID)
+		if err != nil {
+			if NotFoundError(err) {
+				continue
+			}
+			return WrapError(err)
+		}
+		if len(entries) > 0 {
+			return WrapError(Error("the acl %s still has %d entries", rs.Primary.ID, len(entries)))
+		}
+	}
+	return nil
 }
 
 func AlicloudAlbAclEntryAttachmentBasicDependence0(name string) string {

--- a/website/docs/r/alb_acl_entry_attachment.html.markdown
+++ b/website/docs/r/alb_acl_entry_attachment.html.markdown
@@ -13,6 +13,10 @@ For information about acl entry attachment and how to use it, see [Configure an 
 
 -> **NOTE:** Available since v1.166.0.
 
+-> **NOTE:** The `entries` attribute is available since v1.292.0. In batch mode, the attachment takes ownership of all entries of the ACL: entries added out of band or by other `alicloud_alb_acl_entry_attachment` resources attached to the same ACL are removed on the next apply. Do not manage the entries of the same ACL from multiple resources.
+
+-> **NOTE:** Exactly one of `entry` and `entries` must be specified. Switching between them replaces the resource. At least one entry block is required; to remove all the entries, remove the resource.
+
 ## Example Usage
 
 <div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
@@ -39,28 +43,58 @@ resource "alicloud_alb_acl_entry_attachment" "default" {
 }
 ```
 
+### Batch mode
+
+The `entries` attribute manages all entries of the ACL in one resource. The entries are added and removed in batches of at most `20` entries per API call.
+
+```terraform
+resource "alicloud_alb_acl_entry_attachment" "default" {
+  acl_id = alicloud_alb_acl.default.id
+
+  entries {
+    entry       = "168.10.10.0/24"
+    description = var.name
+  }
+
+  entries {
+    entry       = "168.10.11.0/24"
+    description = var.name
+  }
+}
+```
+
 📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_alb_acl_entry_attachment&spm=docs.r.alb_acl_entry_attachment.example&intl_lang=EN_US)
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `acl_id` - (Required, ForceNew) The ID of the Acl.
-* `entry` - (Required, ForceNew) The CIDR blocks.
-* `description` - (Optional, ForceNew) The description of the entry.
+* `acl_id` - (Required, ForceNew) The ID of the ACL.
+* `entry` - (Optional, ForceNew, Deprecated from v1.292.0+) The CIDR block of the ACL entry. Exactly one of `entry` and `entries` must be specified. Field `entry` has been deprecated from provider version 1.292.0 and it will be removed in the future version. Please use the new field `entries`.
+* `description` - (Optional, ForceNew) The description of the entry. Only valid when `entry` is set. The description must be `1` to `256` characters in length.
+* `entries` - (Optional, Available since v1.292.0) One or more entry blocks. Exactly one of `entry` and `entries` must be specified. The order of the blocks is not significant. See [`entries`](#entries) below for details.
+
+### `entries`
+
+The entries supports the following:
+
+* `entry` - (Required) The CIDR block of the ACL entry.
+* `description` - (Optional) The description of the ACL entry. The description must be `1` to `256` characters in length.
+* `status` - (Computed) The status of the ACL entry. Valid values: `Adding`, `Available` and `Removing`.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The ID of the resource. The value formats as `<acl_id>:<entry>`.
-* `status` - The Status of the resource.
+* `id` - The ID of the resource. The value formats as `<acl_id>:<entry>` when `entry` is set, or `<acl_id>` when `entries` is set.
+* `status` - The status of the resource. Only exported when `entry` is set. When `entries` is set, the status of each entry is exported in its `entries` block.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 5 mins) Used when create the resource.
+* `update` - (Defaults to 5 mins, Available since v1.292.0) Used when update the resource.
 * `delete` - (Defaults to 5 mins) Used when delete the resource.
 
 ## Import
@@ -69,4 +103,10 @@ Acl entry attachment can be imported using the id, which consists of acl_id and 
 
 ```shell
 $ terraform import alicloud_alb_acl_entry_attachment.example <acl_id>:<entry>
+```
+
+When `entries` is used, the id is the acl id, e.g.
+
+```shell
+$ terraform import alicloud_alb_acl_entry_attachment.example <acl_id>
 ```


### PR DESCRIPTION
### Description

`AddEntriesToAcl` / `RemoveEntriesFromAcl` accept up to 20 entries per call, but `alicloud_alb_acl_entry_attachment` manages exactly one entry per resource. Managing an ACL with many entries (e.g. hundreds of CIDRs) meant one resource and one API request per entry, plus a full `ListAclEntries` pagination scan per resource on every refresh, and concurrent attachments on the same ACL fighting `IncorrectStatus.Acl` / `ResourceInConfiguring` retry storms.

This PR adds an optional `entries` attribute (a set of `entry` + `description` blocks) that manages all entries of one ACL in a single resource:

- Entries are added and removed in chunks of at most 20 per call, matching the API limits.
- The set is diffed in place on update: remove-then-add, a description change is a remove + re-add (the API has no entry-update operation); reordering the entry blocks produces an empty plan.
- Each entry block exports its computed `status` (`Adding` / `Available` / `Removing`); at least one entry block is required — the plan is rejected when neither `entry` nor `entries` is set, and removing the resource removes all entries.
- In batch mode the resource ID is the ACL id and Read calls `ListAclEntries` once, so N entries collapse from O(N) API calls + O(N²/50) refresh reads to O(N/20) writes + O(N/50) reads.
- `entry` is deprecated in favor of `entries`; exactly one of `entry` / `entries` must be specified, so existing single-entry configurations keep working unchanged.

Note: in batch mode the attachment owns the entire entry set of the ACL — entries added out of band are removed on the next apply. This is documented in the resource docs.

### Changes

- `alicloud/resource_alicloud_alb_acl_entry_attachment.go`: `entries` TypeSet schema with per-entry computed `status`, batch-mode Create/Read/Update/Delete, chunked `addAlbAclEntries` / `removeAlbAclEntries` helpers, dual ID format (`acl_id:entry` legacy / `acl_id` batch).
- `alicloud/resource_alicloud_alb_acl_entry_attachment_test.go`: new `entries` acceptance test (plan-rejection step asserting the exactly-one-of error for a config with zero entry blocks, create 3 entries, update: drop + description-change + add, reorder-only step asserting no update, import verify, destroy); new `entriesChunking` acceptance test covering volumes above the 20-entries-per-call API limit across every direction (create exactly 20, grow to 43, update removing 21 and adding 22, destroy 44); test functions renamed to the `TestAccAliCloud` prefix required by the coverage gate.
- `website/docs/r/alb_acl_entry_attachment.html.markdown`: batch-mode example, `entries` block reference, ownership and exactly-one-of notes, dual import formats.
- `CHANGELOG.md`: 1.292.0 entry.

### Acceptance tests

```
PASS: TestAccAliCloudALBAclEntryAttachment_basic0 (26.86s)
PASS: TestAccAliCloudALBAclEntryAttachment_entries (38.49s)
PASS: TestAccAliCloudALBAclEntryAttachment_entriesChunking (71.10s)
```

3 passed, 0 failed, 0 skipped. The debug log confirms the batching at the API level: batch create of 3 entries is a single `AddEntriesToAcl` request; the update step is one `RemoveEntriesFromAcl` (dropped + changed entries) followed by one `AddEntriesToAcl` (changed + added entries); a reorder-only apply issues no API call at all; destroy is a single `RemoveEntriesFromAcl` with all entries. A config with zero entry blocks is rejected at plan time with `one of `entries,entry` must be specified`, before any API call. The chunking test confirms no call exceeds the 20-entry API limit: create of 20 entries is a single call, growing to 43 sends 2 calls (20+3), the swap update sends 2 remove calls (20+1) and 2 add calls (20+2), and destroy of 44 entries sends 3 calls (20+20+4). The legacy single-entry path is unchanged.

