### PR TITLE
resource/alicloud_alikafka_topic: support replication_factor, min_insync_replicas, config and value

### DIFF
--- a/alicloud/resource_alicloud_alikafka_topic.go
+++ b/alicloud/resource_alicloud_alikafka_topic.go
@@ -35,6 +35,10 @@ func resourceAliCloudAlikafkaTopic() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"config": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"configs": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -59,6 +63,12 @@ func resourceAliCloudAlikafkaTopic() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"min_insync_replicas": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(1, 3),
+			},
 			"partition_num": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -72,6 +82,12 @@ func resourceAliCloudAlikafkaTopic() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"replication_factor": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(1, 3),
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -81,6 +97,10 @@ func resourceAliCloudAlikafkaTopic() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+			"value": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
 	}
@@ -109,6 +129,12 @@ func resourceAliCloudAlikafkaTopicCreate(d *schema.ResourceData, meta interface{
 	}
 	if v, ok := d.GetOkExists("local_topic"); ok {
 		request["LocalTopic"] = v
+	}
+	if v, ok := d.GetOkExists("replication_factor"); ok {
+		request["ReplicationFactor"] = v
+	}
+	if v, ok := d.GetOkExists("min_insync_replicas"); ok {
+		request["MinInsyncReplicas"] = v
 	}
 	if v, ok := d.GetOk("tags"); ok {
 		tagsMap := ConvertTags(v.(map[string]interface{}))
@@ -225,11 +251,23 @@ func resourceAliCloudAlikafkaTopicUpdate(d *schema.ResourceData, meta interface{
 	request["Topic"] = parts[1]
 	request["RegionId"] = client.RegionId
 
-	// In the UpdateTopicConfig, the Config and Value are required; For Terraform, if Config, Value and Configs are set simultaneously, only Configs takes effect.
-	request["Config"] = "skipConfig"
-	request["Value"] = "skipValue"
+	// In the UpdateTopicConfig API, both Config (the config key) and Value (the
+	// corresponding value) are required and applied as a single key=value pair.
+	// When the user specifies `config` and `value`, send them to update one config
+	// entry; otherwise fall back to placeholder values and rely on `configs` (the
+	// bulk JSON) to perform the update.
+	if v, ok := d.GetOk("config"); ok {
+		request["Config"] = v
+	} else {
+		request["Config"] = "skipConfig"
+	}
+	if v, ok := d.GetOk("value"); ok {
+		request["Value"] = v
+	} else {
+		request["Value"] = "skipValue"
+	}
 
-	if d.HasChange("configs") {
+	if d.HasChange("configs") || d.HasChange("config") || d.HasChange("value") {
 		update = true
 	}
 	if v, ok := d.GetOk("configs"); ok {

--- a/alicloud/resource_alicloud_alikafka_topic_test.go
+++ b/alicloud/resource_alicloud_alikafka_topic_test.go
@@ -522,6 +522,80 @@ var AliCloudAlikafkaTopicMap10065 = map[string]string{
 	"region_id":   CHECKSET,
 }
 
+func TestAccAliCloudAlikafkaTopic_replicationFactor(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_alikafka_topic.default"
+	ra := resourceAttrInit(resourceId, AliCloudAlikafkaTopicMap10065)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &AlikafkaServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeAlikafkaTopic")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfaccalikafka%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudAlikafkaTopicBasicDependence10065)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"instance_id":         "${alicloud_alikafka_instance.default.id}",
+					"topic":               name,
+					"remark":              name,
+					"local_topic":         "true",
+					"replication_factor":  "3",
+					"min_insync_replicas": "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"instance_id":         CHECKSET,
+						"topic":               name,
+						"remark":              name,
+						"local_topic":         "true",
+						"replication_factor":  "3",
+						"min_insync_replicas": "1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"config": "retention.ms",
+					"value":  "3600000",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"config": "retention.ms",
+						"value":  "3600000",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"value": "10800000",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"config": "retention.ms",
+						"value":  "10800000",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"replication_factor", "min_insync_replicas", "config", "value"},
+			},
+		},
+	})
+}
+
 func AliCloudAlikafkaTopicBasicDependence10065(name string) string {
 	return fmt.Sprintf(`
 	variable "name" {

--- a/website/docs/r/alikafka_topic.html.markdown
+++ b/website/docs/r/alikafka_topic.html.markdown
@@ -100,15 +100,19 @@ The following arguments are supported:
 * `compact_topic` - (Optional, ForceNew, Bool) The cleanup policy for the topic. This parameter is available only if you set the storage engine of the topic to Local storage. Valid values:
   - false: The delete cleanup policy is used.
   - true: The compact cleanup policy is used.
+* `config` - (Optional) The key of the topic configuration item to update. It is used together with `value` to update a single topic configuration entry via the `UpdateTopicConfig` API. The key name depends on the instance type, for example `retention.ms` or `retention.hours`.
 * `configs` - (Optional, Available since v1.262.1) The advanced configurations.
 * `instance_id` - (Required, ForceNew) The ID of the instance.
 * `local_topic` - (Optional, ForceNew, Bool) The storage engine of the topic. Valid values:
   - false: Cloud storage.
   - true: Local storage.
+* `min_insync_replicas` - (Optional, ForceNew, Int) The minimum number of ISR (in-sync replicas). This parameter can be specified only when `local_topic` is `true` or the instance is the open source version (local disk). The value must be less than `replication_factor`. Valid values: 1 to 3.
 * `partition_num` - (Optional, Int) The number of partitions in the topic.
 * `remark` - (Required) The description of the topic.
+* `replication_factor` - (Optional, ForceNew, Int) The number of topic replicas. This parameter can be specified only when `local_topic` is `true` or the instance is the open source version (local disk). Valid values: 1 to 3.
 * `tags` - (Optional, Map, Available since v1.63.0) A mapping of tags to assign to the resource.
 * `topic` - (Required, ForceNew) The topic name.
+* `value` - (Optional) The value of the topic configuration item to update. It is used together with `config` to update a single topic configuration entry via the `UpdateTopicConfig` API.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### What this PR does

Adds four schema arguments to the `alicloud_alikafka_topic` resource:

- `replication_factor` (Optional, ForceNew, Int): the number of topic replicas (1-3). Available when `local_topic` is `true` or the instance is the open source version (local disk).
- `min_insync_replicas` (Optional, ForceNew, Int): the minimum number of ISR (in-sync replicas) (1-3). Must be smaller than `replication_factor`. Available under the same conditions as `replication_factor`.
- `config` (Optional, String): the topic configuration key, used together with `value` to update a single topic configuration entry via the `UpdateTopicConfig` API.
- `value` (Optional, String): the topic configuration value paired with `config`.

### Implementation notes

- Create sends `ReplicationFactor` and `MinInsyncReplicas` to the `CreateTopic` API.
- `replication_factor` and `min_insync_replicas` are create-only (`ForceNew`); the `GetTopicList` read API does not return them individually, so they are not populated on read.
- The Update path now sends the user-provided `config`/`value` when set, instead of the previous `skipConfig`/`skipValue` placeholders, while keeping the bulk `configs` JSON update path unchanged.

### Tests

- `TestAccAliCloudAlikafkaTopic_replicationFactor`: create with `local_topic`, `replication_factor` and `min_insync_replicas`, then update a single config entry via `config`/`value`, then update the value, then reimport.
- Existing `TestAccAliCloudAlikafkaTopic_basic10066` and `TestAccAliCloudAlikafkaTopic_multi` remain unchanged and cover `configs`, `compact_topic`, `local_topic`, `partition_num` and `tags`.
