### PR TITLE
resource/alicloud_alikafka_instance_allowed_ip_attachment: support the description attribute

### DIFF
--- a/alicloud/resource_alicloud_alikafka_instance_allowed_ip_attachment.go
+++ b/alicloud/resource_alicloud_alikafka_instance_allowed_ip_attachment.go
@@ -45,6 +45,11 @@ func resourceAliCloudAliKafkaInstanceAllowedIpAttachment() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -62,6 +67,9 @@ func resourceAliCloudAliKafkaInstanceAllowedIpAttachmentCreate(d *schema.Resourc
 	request["AllowedListType"] = d.Get("allowed_type")
 	request["PortRange"] = d.Get("port_range")
 	request["AllowedListIp"] = d.Get("allowed_ip")
+	if v, ok := d.GetOk("description"); ok {
+		request["Description"] = v
+	}
 
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {

--- a/alicloud/resource_alicloud_alikafka_instance_allowed_ip_attachment_test.go
+++ b/alicloud/resource_alicloud_alikafka_instance_allowed_ip_attachment_test.go
@@ -44,6 +44,7 @@ func TestAccAliCloudAliKafkaInstanceAllowedIpAttachment_basic0(t *testing.T) {
 					"allowed_type": "vpc",
 					"port_range":   "9092/9092",
 					"allowed_ip":   "172.168.4.0/24",
+					"description":  "${var.name}-description",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -51,13 +52,15 @@ func TestAccAliCloudAliKafkaInstanceAllowedIpAttachment_basic0(t *testing.T) {
 						"allowed_type": "vpc",
 						"port_range":   "9092/9092",
 						"allowed_ip":   "172.168.4.0/24",
+						"description":  fmt.Sprintf("%s-description", name),
 					}),
 				),
 			},
 			{
-				ResourceName:      resourceId,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"description"},
 			},
 		},
 	})
@@ -244,6 +247,7 @@ func TestUnitAliCloudAliKafkaInstanceAllowedIpAttachment(t *testing.T) {
 		"port_range":   "9092/9092",
 		"instance_id":  "instance_id",
 		"allowed_type": "vpc",
+		"description":  "tf-testacc-description",
 	}
 	for key, value := range attributes {
 		err := dInit.Set(key, value)

--- a/website/docs/r/alikafka_instance_allowed_ip_attachment.html.markdown
+++ b/website/docs/r/alikafka_instance_allowed_ip_attachment.html.markdown
@@ -90,6 +90,7 @@ The following arguments are supported:
   - `9094/9094`: The port range for access from VPCs by using the Simple Authentication and Security Layer (SASL) endpoint.
   - `9095/9095`: The port range for access from VPCs by using the Secure Sockets Layer (SSL) endpoint.
 * `allowed_ip` - (Required, ForceNew) The IP address whitelist. It can be a CIDR block.
+* `description` - (Optional, ForceNew) The description of the whitelist.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### Summary

Expose the optional `Description` parameter of `UpdateAllowedIp` on `alicloud_alikafka_instance_allowed_ip_attachment`.

- **Schema**: new `description` attribute, `Optional` + `ForceNew` (consistent with the existing attributes of this attachment resource; a whitelist entry is managed via add/delete only).
- **Create**: sends `Description` when it is set.
- **Read**: `GetAllowedIpList` does not return the description of a whitelist entry, so the configured value is kept in state and not refreshed; the import step ignores this attribute.
- **Docs**: argument reference updated.
- **Tests**: `TestAccAliCloudAliKafkaInstanceAllowedIpAttachment_basic0` covers the new attribute (inline `testAccConfig(map)`); unit test updated accordingly.

### Test Result

Remote acceptance tests all passed (basic0 with the new `description` attribute, plus basic1/basic2/basic3 regression; the debug log confirms the `UpdateAllowedIp` request carries a non-empty `Description` and returns success, and the import step passes):

```
=== RUN   TestAccAliCloudAliKafkaInstanceAllowedIpAttachment_basic0
--- PASS: TestAccAliCloudAliKafkaInstanceAllowedIpAttachment_basic0 (583.40s)

=== RUN   TestAccAliCloudAliKafkaInstanceAllowedIpAttachment_basic1
--- PASS: TestAccAliCloudAliKafkaInstanceAllowedIpAttachment_basic1 (683.70s)

=== RUN   TestAccAliCloudAliKafkaInstanceAllowedIpAttachment_basic2
--- PASS: TestAccAliCloudAliKafkaInstanceAllowedIpAttachment_basic2 (583.14s)

=== RUN   TestAccAliCloudAliKafkaInstanceAllowedIpAttachment_basic3
--- PASS: TestAccAliCloudAliKafkaInstanceAllowedIpAttachment_basic3 (578.38s)
```
