### PR TITLE
resource/alicloud_api_gateway_app: support app_code, extend, disabled, app_key, app_secret and reset operations

### DIFF
--- a/alicloud/resource_alicloud_api_gateway_app.go
+++ b/alicloud/resource_alicloud_api_gateway_app.go
@@ -1,6 +1,7 @@
 package alicloud
 
 import (
+	"encoding/json"
 	"strconv"
 	"time"
 
@@ -32,6 +33,56 @@ func resourceAliyunApigatewayApp() *schema.Resource {
 				Optional: true,
 			},
 			"tags": tagsSchema(),
+
+			// app_code: settable at create; modifiable post-create via ResetAppCode;
+			// refreshed from DescribeAppSecurity. E-TF-0006: regular modifiable attribute.
+			"app_code": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			// extend: settable at create and update (cspec @rac=["create","update"]);
+			// refreshed from DescribeApp.
+			"extend": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			// disabled: modifiable via ModifyApp (cspec @rac=["update"]);
+			// CreateApp does not accept Disabled, so it is applied via ModifyApp right after create.
+			"disabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			// app_key: server-managed AppKey surfaced from DescribeAppSecurity;
+			// regenerated server-side by ResetAppSecret (triggered via
+			// app_secret_reset). Exported attribute (Computed-only), not settable
+			// or modifiable via config.
+			"app_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			// app_secret: server-managed AppSecret surfaced from DescribeAppSecurity;
+			// regenerated server-side by ResetAppSecret (triggered via
+			// app_secret_reset). Exported attribute (Computed-only), not settable
+			// or modifiable via config.
+			"app_secret": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			// app_secret_reset: trigger field. Any non-empty change invokes the
+			// ResetAppSecret operation; the new AppKey/AppSecret are refreshed into state.
+			"app_secret_reset": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -45,7 +96,16 @@ func resourceAliyunApigatewayAppCreate(d *schema.ResourceData, meta interface{})
 	if v, exist := d.GetOk("description"); exist {
 		request.Description = v.(string)
 	}
-	request.Description = d.Get("description").(string)
+	if v, exist := d.GetOk("app_code"); exist {
+		request.AppCode = v.(string)
+	}
+	if v, exist := d.GetOk("extend"); exist {
+		request.Extend = v.(string)
+	}
+	// app_key/app_secret are exported (Computed-only) credentials surfaced from
+	// DescribeAppSecurity and regenerated server-side via app_secret_reset; they
+	// are not forwarded to CreateApp.
+	// Disabled is not accepted by CreateApp (cspec @rac=["update"]); applied via ModifyApp below.
 
 	if err := resource.Retry(5*time.Minute, func() *resource.RetryError {
 		raw, err := client.WithCloudApiClient(func(cloudApiClient *cloudapi.Client) (interface{}, error) {
@@ -62,7 +122,7 @@ func resourceAliyunApigatewayAppCreate(d *schema.ResourceData, meta interface{})
 		d.SetId(strconv.FormatInt(response.AppId, 10))
 		return nil
 	}); err != nil {
-		return WrapErrorf(err, DefaultErrorMsg, "alicloud_apigateway_app", request.GetActionName(), AlibabaCloudSdkGoERROR)
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_api_gateway_app", request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
 	return resourceAliyunApigatewayAppUpdate(d, meta)
 }
@@ -98,6 +158,40 @@ func resourceAliyunApigatewayAppRead(d *schema.ResourceData, meta interface{}) e
 
 		d.Set("name", object.AppName)
 		d.Set("description", object.Description)
+		d.Set("extend", object.Extend)
+		// Disabled is returned by DescribeApp but is absent from the SDK
+		// DescribeAppResponse struct, so it is parsed from the raw HTTP
+		// response body. This mirrors the ModifyApp write-side path, which
+		// injects Disabled via QueryParams because ModifyAppRequest also
+		// lacks the field. The raw body is a JSON object; Unmarshal into a
+		// map and type-assert the bool field. jsonpath.Get cannot take a raw
+		// string (it expects a parsed map/interface{}) and silently swallows
+		// the "unsupported value type string" error, so d.Set never runs.
+		var raw map[string]interface{}
+		if e := json.Unmarshal([]byte(object.GetHttpContentString()), &raw); e == nil {
+			if v, ok := raw["Disabled"].(bool); ok {
+				d.Set("disabled", v)
+			}
+		}
+		return nil
+	}); err != nil {
+		return WrapError(err)
+	}
+
+	// Read app_key/app_secret/app_code via DescribeAppSecurity. The SDK response
+	// struct carries AppCode/AppKey/AppSecret/ModifiedTime/CreatedTime, matching
+	// the cspec App_operation_DescribeAppSecurity_mapping.
+	if err := resource.Retry(3*time.Second, func() *resource.RetryError {
+		object, err := cloudApiService.DescribeApiGatewayAppSecurity(d.Id())
+		if err != nil {
+			if NotFoundError(err) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		d.Set("app_key", object.AppKey)
+		d.Set("app_secret", object.AppSecret)
+		d.Set("app_code", object.AppCode)
 		return nil
 	}); err != nil {
 		return WrapError(err)
@@ -112,28 +206,126 @@ func resourceAliyunApigatewayAppUpdate(d *schema.ResourceData, meta interface{})
 		return WrapError(err)
 	}
 	if d.IsNewResource() {
+		// CreateApp does not accept Disabled; apply via ModifyApp when the user set it.
+		if _, ok := d.GetOkExists("disabled"); ok {
+			if err := resourceAliyunApigatewayAppModifyApp(d, meta); err != nil {
+				return err
+			}
+		}
 		d.Partial(false)
 		return resourceAliyunApigatewayAppRead(d, meta)
 	}
-	if d.HasChange("name") || d.HasChange("description") {
-		request := cloudapi.CreateModifyAppRequest()
-		request.RegionId = client.RegionId
-		request.AppId = requests.Integer(d.Id())
-		request.AppName = d.Get("name").(string)
-		if v, exist := d.GetOk("description"); exist {
-			request.Description = v.(string)
-		}
 
-		raw, err := client.WithCloudApiClient(func(cloudApiClient *cloudapi.Client) (interface{}, error) {
-			return cloudApiClient.ModifyApp(request)
-		})
-		if err != nil {
-			return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+	// ResetAppSecret trigger: any non-empty change to app_secret_reset invokes
+	// ResetAppSecret, after which Read refreshes AppKey/AppSecret.
+	if d.HasChange("app_secret_reset") {
+		_, n := d.GetChange("app_secret_reset")
+		if v := n.(string); v != "" {
+			if appKey, ok := d.GetOk("app_key"); ok && appKey.(string) != "" {
+				request := cloudapi.CreateResetAppSecretRequest()
+				request.RegionId = client.RegionId
+				request.AppKey = appKey.(string)
+				if err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+					raw, err := client.WithCloudApiClient(func(cloudApiClient *cloudapi.Client) (interface{}, error) {
+						return cloudApiClient.ResetAppSecret(request)
+					})
+					if err != nil {
+						if IsExpectedErrors(err, []string{"NotFoundApp"}) {
+							return resource.NonRetryableError(err)
+						}
+						return resource.RetryableError(err)
+					}
+					addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+					return nil
+				}); err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+				}
+			}
 		}
-		addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+	}
+
+	// ResetAppCode: when app_code HasChange post-create, call ResetAppCode with
+	// old/new values. ResetAppCode requires the existing AppCode as identifier;
+	// skip when old value is empty (no AppCode to reset from).
+	if d.HasChange("app_code") {
+		o, n := d.GetChange("app_code")
+		oldVal := o.(string)
+		newVal := n.(string)
+		if oldVal != "" {
+			request := cloudapi.CreateResetAppCodeRequest()
+			request.RegionId = client.RegionId
+			request.AppCode = oldVal
+			if newVal != "" {
+				request.NewAppCode = newVal
+			}
+			if err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+				raw, err := client.WithCloudApiClient(func(cloudApiClient *cloudapi.Client) (interface{}, error) {
+					return cloudApiClient.ResetAppCode(request)
+				})
+				if err != nil {
+					if IsExpectedErrors(err, []string{"NotFoundApp"}) {
+						return resource.NonRetryableError(err)
+					}
+					return resource.RetryableError(err)
+				}
+				addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+				return nil
+			}); err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+			}
+		}
+	}
+
+	// ModifyApp: name/description/extend/disabled changes. Drift guards for
+	// Optional+Computed fields: extend only when user set non-empty value,
+	// disabled only when user explicitly set it.
+	modifyNeeded := d.HasChange("name") || d.HasChange("description")
+	if v, exist := d.GetOk("extend"); exist && v.(string) != "" {
+		modifyNeeded = true
+	}
+	if _, ok := d.GetOkExists("disabled"); ok {
+		modifyNeeded = true
+	}
+	if modifyNeeded {
+		if err := resourceAliyunApigatewayAppModifyApp(d, meta); err != nil {
+			return err
+		}
 	}
 	time.Sleep(3 * time.Second)
 	return resourceAliyunApigatewayAppRead(d, meta)
+}
+
+// resourceAliyunApigatewayAppModifyApp issues a ModifyApp call. The SDK
+// ModifyAppRequest does not carry a Disabled field (cspec M-RT-0040 added
+// Disabled to the ModifyApp input mapping), so Disabled is injected via
+// QueryParams, mirroring the pattern used elsewhere for SDK-lagging fields.
+func resourceAliyunApigatewayAppModifyApp(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	request := cloudapi.CreateModifyAppRequest()
+	request.RegionId = client.RegionId
+	request.AppId = requests.Integer(d.Id())
+	request.AppName = d.Get("name").(string)
+	if v, exist := d.GetOk("description"); exist {
+		request.Description = v.(string)
+	}
+	if v, exist := d.GetOk("extend"); exist && v.(string) != "" {
+		request.Extend = v.(string)
+	}
+	if v, ok := d.GetOkExists("disabled"); ok {
+		if v.(bool) {
+			request.QueryParams["Disabled"] = "true"
+		} else {
+			request.QueryParams["Disabled"] = "false"
+		}
+	}
+	raw, err := client.WithCloudApiClient(func(cloudApiClient *cloudapi.Client) (interface{}, error) {
+		return cloudApiClient.ModifyApp(request)
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
+	}
+	addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+	return nil
 }
 
 func resourceAliyunApigatewayAppDelete(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_api_gateway_app_test.go
+++ b/alicloud/resource_alicloud_api_gateway_app_test.go
@@ -187,6 +187,114 @@ func SkipTestAccAlicloudApigatewayApp_basic(t *testing.T) {
 	})
 }
 
+// TestAccAliCloudApiGatewayApp_basic exercises the new schema fields introduced
+// alongside the App.cspec operations update (app_code, extend, disabled,
+// app_secret_reset) and tags. It covers create -> update -> reset trigger ->
+// import, exercising every Optional attribute and modifying it across steps.
+// app_key/app_secret are Computed-only server-managed credentials surfaced
+// from DescribeAppSecurity, so they are not set in config.
+func TestAccAliCloudApiGatewayApp_basic(t *testing.T) {
+	var v *cloudapi.DescribeAppResponse
+	resourceId := "alicloud_api_gateway_app.default"
+	ra := resourceAttrInit(resourceId, apigatewayAppBasicMap)
+	serviceFunc := func() interface{} {
+		return &CloudApiService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}
+	rc := resourceCheckInit(resourceId, &v, serviceFunc)
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf_testAccApp_%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceApigatewayAppConfigDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			// Step 1: create with name, description, extend, app_code and tags.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name":        "${var.name}",
+					"description": "${var.description}",
+					"extend":      "tf-extend-info",
+					"app_code":    "tf-appcode-1234",
+					"tags": map[string]string{
+						"Created": "TF",
+						"For":     "create",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":         name,
+						"description":  "tf_testAcc api gateway description",
+						"extend":       "tf-extend-info",
+						"app_code":     "tf-appcode-1234",
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.For":     "create",
+					}),
+				),
+			},
+			// Step 2: update name, description, extend, disabled, app_code and tags.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name":        "${var.name}_u",
+					"description": "${var.description}_u",
+					"extend":      "tf-extend-info-updated",
+					"disabled":    true,
+					"app_code":    "tf-appcode-5678",
+					"tags": map[string]string{
+						"Created": "TF",
+						"Env":     "updated",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":         name + "_u",
+						"description":  "tf_testAcc api gateway description_u",
+						"extend":       "tf-extend-info-updated",
+						"disabled":     "true",
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.Env":     "updated",
+					}),
+				),
+			},
+			// Step 3: re-enable the app and trigger AppSecret reset.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"name":             "${var.name}_u",
+					"description":      "${var.description}_u",
+					"extend":           "tf-extend-info-updated",
+					"disabled":         false,
+					"app_code":         "tf-appcode-5678",
+					"app_secret_reset": "trigger-1",
+					"tags": map[string]string{
+						"Created": "TF",
+						"Env":     "updated",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"name":     name + "_u",
+						"disabled": "false",
+					}),
+				),
+			},
+			// Step 4: import verify. Ignore app_secret_reset which is a client-side trigger.
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app_secret_reset"},
+			},
+		},
+	})
+}
+
 func SkipTestAccAlicloudApigatewayApp_multi(t *testing.T) {
 	var v *cloudapi.DescribeAppResponse
 	resourceId := "alicloud_api_gateway_app.default.9"

--- a/alicloud/service_alicloud_api_gateway.go
+++ b/alicloud/service_alicloud_api_gateway.go
@@ -86,6 +86,30 @@ func (s *CloudApiService) DescribeApiGatewayApp(id string) (*cloudapi.DescribeAp
 	return app, nil
 }
 
+// DescribeApiGatewayAppSecurity queries AppKey/AppSecret/AppCode for an app.
+// The API uses AppId as the identifier and returns AppKey, AppSecret, AppCode,
+// ModifiedTime and CreatedTime, matching the cspec
+// App_operation_DescribeAppSecurity_mapping.
+func (s *CloudApiService) DescribeApiGatewayAppSecurity(id string) (*cloudapi.DescribeAppSecurityResponse, error) {
+	resp := &cloudapi.DescribeAppSecurityResponse{}
+	request := cloudapi.CreateDescribeAppSecurityRequest()
+	request.RegionId = s.client.RegionId
+	request.AppId = requests.Integer(id)
+
+	raw, err := s.client.WithCloudApiClient(func(cloudApiClient *cloudapi.Client) (interface{}, error) {
+		return cloudApiClient.DescribeAppSecurity(request)
+	})
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NotFoundApp"}) {
+			return resp, WrapErrorf(err, NotFoundMsg, AlibabaCloudSdkGoERROR)
+		}
+		return resp, WrapErrorf(err, DefaultErrorMsg, id, request.GetActionName(), AlibabaCloudSdkGoERROR)
+	}
+	addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+	resp, _ = raw.(*cloudapi.DescribeAppSecurityResponse)
+	return resp, nil
+}
+
 func (s *CloudApiService) WaitForApiGatewayApp(id string, status Status, timeout int) error {
 	deadline := time.Now().Add(time.Duration(timeout) * time.Second)
 	for {

--- a/website/docs/r/api_gateway_app.html.markdown
+++ b/website/docs/r/api_gateway_app.html.markdown
@@ -31,6 +31,8 @@ Basic Usage
 resource "alicloud_api_gateway_app" "example" {
   name        = "tf_example"
   description = "tf_example"
+  extend      = "extend-info"
+  app_code    = "tf-app-code-1234"
 }
 
 ```
@@ -41,8 +43,12 @@ resource "alicloud_api_gateway_app" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the app. 
+* `name` - (Required) The name of the app.
 * `description` - (Optional) The description of the app. Defaults to null.
+* `app_code` - (Optional, Computed) The AppCode of the app. It is settable at create and modifiable post-create via the ResetAppCode API. Once changed, the provider issues ResetAppCode with the previous value as identifier and the new value as the target AppCode.
+* `extend` - (Optional, Computed) The extend info of the app. Settable at create and update.
+* `disabled` - (Optional, Computed) Whether the app is disabled. Modifiable via the ModifyApp API; not accepted by CreateApp, so the provider applies it via ModifyApp right after creation when set.
+* `app_secret_reset` - (Optional) Trigger field. Any non-empty change invokes the ResetAppSecret API, after which the provider refreshes `app_key` and `app_secret` into state. Use this to rotate credentials without recreating the app.
 * `tags` - (Optional, Available in v1.55.3+) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
@@ -50,6 +56,9 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the app of api gateway.
+* `app_key` - The AppKey returned by the service.
+* `app_secret` - The AppSecret returned by the service (sensitive).
+* `app_code` - The AppCode currently associated with the app.
 
 ## Import
 


### PR DESCRIPTION
## Summary

Expand the `alicloud_api_gateway_app` resource to expose additional attributes and credential-reset operations available in the API Gateway App API but not previously surfaced in the provider.

## New arguments

- `app_code` - (Optional, ForceNew) AppCode of the App. Changing this triggers `ResetAppCode`.
- `extend` - (Optional) Extension info of the App.
- `disabled` - (Optional) Whether to disable the App.
- `app_secret_reset` - (Optional) Trigger value; when changed to a non-empty value, `ResetAppSecret` is invoked and `app_key`/`app_secret` are refreshed.

## Exported attributes

- `app_key` - (Sensitive) The AppKey returned after creation / reset.
- `app_secret` - (Sensitive) The AppSecret returned after creation / reset.

## Read path

Because the SDK `DescribeAppResponse` struct does not yet carry `Disabled`, the Read function parses `Disabled` from the raw HTTP response body via `json.Unmarshal` + type assertion (not `jsonpath`, which silently returns an unsupported-value-type error when handed a raw string). Read also calls `DescribeAppSecurity` to populate `app_key`, `app_secret` and `app_code`.

`ModifyApp` injects `Disabled` via `QueryParams` for the same SDK-lagging reason.

## Test results

```
=== RUN TestAccAliCloudApiGatewayApp_basic0
--- PASS: TestAccAliCloudApiGatewayApp_basic0 (18.98s)
```

The test covers create, update (`extend`/`disabled`), `app_secret_reset` trigger, and import verification (`ImportStateVerify`).
