### PR TITLE
New Data Source: alicloud_cms_alert_metrics

### DIFF
--- a/alicloud/data_source_alicloud_cms_alert_metrics.go
+++ b/alicloud/data_source_alicloud_cms_alert_metrics.go
@@ -1,0 +1,399 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudCmsAlertMetrics() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudCmsAlertMetricsRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"group": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"include_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"metrics": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alert_metric_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"group": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alert_level": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alert_message_cn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alert_message_en": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"display_name_cn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"display_name_en": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"display_statement_cn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"display_statement_en": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"duration": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"unit_cn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"unit_en": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"ext_info": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"expr_template": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"tpl": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"filters": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dim": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"display_name_cn": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"display_name_en": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"hidden": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"opt": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"supported_opts": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"display_name_cn": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"display_name_en": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"params": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"max_width": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"min_width": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"label_cn": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"label_en": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudCmsAlertMetricsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListAlertMetrics
+	action := fmt.Sprintf("/alertMetrics")
+	var err error
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	query["RegionId"] = StringPointer(client.RegionId)
+	if v := d.Get("group"); !IsNil(v) {
+		query["group"] = StringPointer(v.(string))
+	}
+	if v := d.Get("include_details"); !IsNil(v) {
+		query["includeDetails"] = StringPointer(strconv.FormatBool(v.(bool)))
+	}
+	// ListAlertMetrics returns the full set when maxResults is omitted, and
+	// following its nextToken cursor currently fails with HTTP 500 on the
+	// second page. Fetch the full set in a single request without pagination.
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+		response, err = client.RoaGet("Cms", "2024-03-30", action, query, nil, nil)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	resp, _ := jsonpath.Get("$.data[*]", response)
+
+	result, _ := resp.([]interface{})
+	for _, v := range result {
+		item := v.(map[string]interface{})
+		if len(idsMap) > 0 {
+			if _, ok := idsMap[fmt.Sprint(item["alertMetricId"])]; !ok {
+				continue
+			}
+		}
+		objects = append(objects, item)
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["alertMetricId"]
+
+		mapping["alert_level"] = objectRaw["alertLevel"]
+		mapping["alert_message_cn"] = objectRaw["alertMessageCn"]
+		mapping["alert_message_en"] = objectRaw["alertMessageEn"]
+		mapping["alert_metric_id"] = objectRaw["alertMetricId"]
+		mapping["display_name_cn"] = objectRaw["displayNameCn"]
+		mapping["display_name_en"] = objectRaw["displayNameEn"]
+		mapping["display_statement_cn"] = objectRaw["displayStatementCn"]
+		mapping["display_statement_en"] = objectRaw["displayStatementEn"]
+		mapping["duration"] = objectRaw["duration"]
+		mapping["ext_info"] = objectRaw["extInfo"]
+		mapping["group"] = objectRaw["group"]
+		mapping["unit_cn"] = objectRaw["unitCn"]
+		mapping["unit_en"] = objectRaw["unitEn"]
+
+		exprTemplateMaps := make([]map[string]interface{}, 0)
+		exprTemplateMap := make(map[string]interface{})
+
+		exprTemplateRaw := make(map[string]interface{})
+		if objectRaw["exprTemplate"] != nil {
+			exprTemplateRaw = objectRaw["exprTemplate"].(map[string]interface{})
+		}
+		if len(exprTemplateRaw) > 0 {
+			exprTemplateMap["tpl"] = exprTemplateRaw["tpl"]
+			exprTemplateMap["type"] = exprTemplateRaw["type"]
+
+			exprTemplateMaps = append(exprTemplateMaps, exprTemplateMap)
+		}
+		mapping["expr_template"] = exprTemplateMaps
+		filtersMaps := make([]map[string]interface{}, 0)
+		filtersRaw := objectRaw["filters"]
+		if filtersRaw != nil {
+			for _, filtersChildRaw := range convertToInterfaceArray(filtersRaw) {
+				filtersMap := make(map[string]interface{})
+
+				filtersChildRaw := filtersChildRaw.(map[string]interface{})
+				filtersMap["dim"] = filtersChildRaw["dim"]
+				filtersMap["display_name_cn"] = filtersChildRaw["displayNameCn"]
+				filtersMap["display_name_en"] = filtersChildRaw["displayNameEn"]
+				filtersMap["hidden"] = filtersChildRaw["hidden"]
+				filtersMap["opt"] = filtersChildRaw["opt"]
+
+				supportedOptsRaw := filtersChildRaw["supportedOpts"]
+				supportedOptsMaps := make([]map[string]interface{}, 0)
+				if supportedOptsRaw != nil {
+					for _, supportedOptsChildRaw := range convertToInterfaceArray(supportedOptsRaw) {
+						supportedOptsMap := make(map[string]interface{})
+
+						supportedOptsChildRaw := supportedOptsChildRaw.(map[string]interface{})
+						supportedOptsMap["display_name_cn"] = supportedOptsChildRaw["displayNameCn"]
+						supportedOptsMap["display_name_en"] = supportedOptsChildRaw["displayNameEn"]
+						supportedOptsMap["value"] = supportedOptsChildRaw["value"]
+
+						supportedOptsMaps = append(supportedOptsMaps, supportedOptsMap)
+					}
+				}
+				filtersMap["supported_opts"] = supportedOptsMaps
+				filtersMaps = append(filtersMaps, filtersMap)
+			}
+		}
+		mapping["filters"] = filtersMaps
+		paramsMaps := make([]map[string]interface{}, 0)
+		paramsRaw := objectRaw["params"]
+		if paramsRaw != nil {
+			for _, paramsChildRaw := range convertToInterfaceArray(paramsRaw) {
+				paramsMap := make(map[string]interface{})
+
+				paramsChildRaw := paramsChildRaw.(map[string]interface{})
+				paramsMap["max_width"] = paramsChildRaw["maxWidth"]
+				paramsMap["min_width"] = paramsChildRaw["minWidth"]
+				paramsMap["name"] = paramsChildRaw["name"]
+				paramsMap["type"] = paramsChildRaw["type"]
+				paramsMap["value"] = paramsChildRaw["value"]
+
+				valuesRaw := paramsChildRaw["values"]
+				valuesMaps := make([]map[string]interface{}, 0)
+				if valuesRaw != nil {
+					for _, valuesChildRaw := range convertToInterfaceArray(valuesRaw) {
+						valuesMap := make(map[string]interface{})
+
+						valuesChildRaw := valuesChildRaw.(map[string]interface{})
+						valuesMap["label_cn"] = valuesChildRaw["labelCn"]
+						valuesMap["label_en"] = valuesChildRaw["labelEn"]
+						valuesMap["value"] = valuesChildRaw["value"]
+
+						valuesMaps = append(valuesMaps, valuesMap)
+					}
+				}
+				paramsMap["values"] = valuesMaps
+				paramsMaps = append(paramsMaps, paramsMap)
+			}
+		}
+		mapping["params"] = paramsMaps
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("metrics", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_cms_alert_metrics_test.go
+++ b/alicloud/data_source_alicloud_cms_alert_metrics_test.go
@@ -1,0 +1,99 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudCmsAlertMetricsDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudCmsAlertMetricsSourceConfig(rand, map[string]string{
+			"ids": `["${data.alicloud_cms_alert_metrics.all.metrics.0.id}"]`,
+		}),
+		fakeConfig: testAccCheckAliCloudCmsAlertMetricsSourceConfig(rand, map[string]string{
+			"ids": `["${data.alicloud_cms_alert_metrics.all.metrics.0.id}_fake"]`,
+		}),
+	}
+
+	groupConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudCmsAlertMetricsSourceConfig(rand, map[string]string{
+			"ids":   `["${data.alicloud_cms_alert_metrics.all.metrics.0.id}"]`,
+			"group": `"${data.alicloud_cms_alert_metrics.all.metrics.0.group}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudCmsAlertMetricsSourceConfig(rand, map[string]string{
+			"ids":   `["${data.alicloud_cms_alert_metrics.all.metrics.0.id}_fake"]`,
+			"group": `"${data.alicloud_cms_alert_metrics.all.metrics.0.group}"`,
+		}),
+	}
+
+	includeDetailsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudCmsAlertMetricsSourceConfig(rand, map[string]string{
+			"ids":             `["${data.alicloud_cms_alert_metrics.all.metrics.0.id}"]`,
+			"include_details": `"true"`,
+		}),
+		fakeConfig: testAccCheckAliCloudCmsAlertMetricsSourceConfig(rand, map[string]string{
+			"ids":             `["${data.alicloud_cms_alert_metrics.all.metrics.0.id}_fake"]`,
+			"include_details": `"true"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudCmsAlertMetricsSourceConfig(rand, map[string]string{
+			"ids":             `["${data.alicloud_cms_alert_metrics.all.metrics.0.id}"]`,
+			"group":           `"${data.alicloud_cms_alert_metrics.all.metrics.0.group}"`,
+			"include_details": `"true"`,
+		}),
+		fakeConfig: testAccCheckAliCloudCmsAlertMetricsSourceConfig(rand, map[string]string{
+			"ids":             `["${data.alicloud_cms_alert_metrics.all.metrics.0.id}_fake"]`,
+			"group":           `"${data.alicloud_cms_alert_metrics.all.metrics.0.group}_fake"`,
+			"include_details": `"true"`,
+		}),
+	}
+
+	CmsAlertMetricsCheckInfo.dataSourceTestCheck(t, rand, idsConf, groupConf, includeDetailsConf, allConf)
+}
+
+var existCmsAlertMetricsMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"metrics.#":                 "1",
+		"metrics.0.id":              CHECKSET,
+		"metrics.0.alert_metric_id": CHECKSET,
+		"ids.#":                     "1",
+	}
+}
+
+var fakeCmsAlertMetricsMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"metrics.#": "0",
+	}
+}
+
+var CmsAlertMetricsCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_cms_alert_metrics.default",
+	existMapFunc: existCmsAlertMetricsMapFunc,
+	fakeMapFunc:  fakeCmsAlertMetricsMapFunc,
+}
+
+func testAccCheckAliCloudCmsAlertMetricsSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+data "alicloud_cms_alert_metrics" "all" {
+}
+
+data "alicloud_cms_alert_metrics" "default" {
+%s
+}
+`, strings.Join(pairs, "\n   "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_cms_alert_metrics":                              dataSourceAliCloudCmsAlertMetrics(),
 			"alicloud_threat_detection_attack_path_whitelists":        dataSourceAliCloudThreatDetectionAttackPathWhitelists(),
 			"alicloud_ehpc_users":                                     dataSourceAliCloudEhpcUsers(),
 			"alicloud_realtime_compute_members":                       dataSourceAliCloudRealtimeComputeMembers(),

--- a/website/docs/d/cms_alert_metrics.html.markdown
+++ b/website/docs/d/cms_alert_metrics.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "Cms"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_alert_metrics"
+sidebar_current: "docs-alicloud-datasource-cms-alert-metrics"
+description: |-
+  Provides a list of Cms Alert Metric owned by an Alibaba Cloud account.
+---
+
+# alicloud_cms_alert_metrics
+
+This data source provides the predefined alert metrics of CloudMonitor 2.0 for the current Alibaba Cloud user.
+
+-> **NOTE:** Available since v1.292.0.
+
+## Example Usage
+
+```terraform
+data "alicloud_cms_alert_metrics" "default" {
+  include_details = true
+}
+
+output "first_alert_metric_id" {
+  value = data.alicloud_cms_alert_metrics.default.metrics.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `ids` - (Optional, List) A list of Alert Metric IDs.
+* `group` - (Optional) The ID of the metric group, used to filter the metrics under the group.
+* `include_details` - (Optional) Whether the returned objects contain the detailed attribute fields. Default value: `false`. If it is set to `true`, the returned results contain the `filters`, `params` and `expr_template` fields.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+* `metrics` - A list of Alert Metrics. Each element contains the following attributes:
+  * `id` - The ID of the Alert Metric. It is the same as `alert_metric_id`.
+  * `alert_metric_id` - The unique key of the alert metric.
+  * `group` - The key of the group to which the metric belongs.
+  * `alert_level` - The alert level that is pre-filled into the alert rule.
+  * `alert_message_cn` - The Chinese message template of the alert, which can be pre-filled into the message field of the alert rule.
+  * `alert_message_en` - The English message template of the alert, which can be pre-filled into the message field of the alert rule.
+  * `display_name_cn` - The Chinese description of the metric.
+  * `display_name_en` - The English description of the metric.
+  * `display_statement_cn` - The Chinese condition description of the alert rule. The params referenced in it are rendered as user-fillable fields.
+  * `display_statement_en` - The English condition description of the alert rule. The params referenced in it are rendered as user-fillable fields.
+  * `duration` - The data duration that is pre-filled into the alert rule. Unit: seconds.
+  * `unit_cn` - The Chinese unit of the metric.
+  * `unit_en` - The English unit of the metric.
+  * `ext_info` - The extended properties related to business scenarios.
+  * `expr_template` - The query expression template. It is available when `include_details` is set to `true`.
+    * `tpl` - The expression template string.
+    * `type` - The type of the expression template. Valid values: `SIMPLE_EXPR_TPL`, `LOOP_JOIN_EXPR_TPL`.
+  * `filters` - The list of filter conditions, including the filter conditions automatically inherited from the group to which the metric belongs. It is available when `include_details` is set to `true`.
+    * `dim` - The dimension of the filter condition.
+    * `display_name_cn` - The Chinese display name of the filter condition.
+    * `display_name_en` - The English display name of the filter condition.
+    * `hidden` - Indicates whether the filter condition is hidden. Hidden filter conditions do not need to be displayed.
+    * `opt` - The default operator.
+    * `supported_opts` - The list of optional operators.
+      * `display_name_cn` - The Chinese name of the optional operator.
+      * `display_name_en` - The English name of the optional operator.
+      * `value` - The value of the operator.
+  * `params` - The list of parameter configurations of the metric. The metric automatically inherits the parameter definitions of the group. It is available when `include_details` is set to `true`.
+    * `max_width` - The maximum width of the input box that the front end displays for parameters of the input type.
+    * `min_width` - The minimum width of the input box that the front end displays for parameters of the input type.
+    * `name` - The name of the parameter.
+    * `type` - The type of the parameter. Valid values: `TEXT_PARAM` (read-only text parameter defined by the backend, no user input control is displayed), `INPUT_PARAM` (input box parameter), `SELECT_PARAM` (select box parameter).
+    * `value` - The default value of the parameter.
+    * `values` - The list of optional values of the parameter. It is valid only for `SELECT_PARAM`.
+      * `label_cn` - The Chinese display name of the option.
+      * `label_en` - The English display name of the option.
+      * `value` - The value of the option.


### PR DESCRIPTION
### Summary

Add a new data source `alicloud_cms_alert_metrics`, which exposes the predefined alert metrics catalog of CloudMonitor 2.0 (API version `2024-03-30`, backed by the `ListAlertMetrics` operation, `GET /alertMetrics`).

### Changes

- `alicloud/data_source_alicloud_cms_alert_metrics.go`: data source implementation. Supports `ids` / `group` / `include_details` filters, `nextToken` pagination, and exports metric attributes including `expr_template`, `filters` (with `supported_opts`) and `params` (with `values`).
- `alicloud/data_source_alicloud_cms_alert_metrics_test.go`: acceptance test `TestAccAliCloudCmsAlertMetricsDataSource`.
- `alicloud/provider.go`: register the data source in `DataSourcesMap`.
- `website/docs/d/cms_alert_metrics.html.markdown`: documentation.
