### PR TITLE
New Data Source: alicloud_cms_alert_metric_groups

### DIFF
--- a/alicloud/data_source_alicloud_cms_alert_metric_groups.go
+++ b/alicloud/data_source_alicloud_cms_alert_metric_groups.go
@@ -1,0 +1,356 @@
+package alicloud
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudCmsAlertMetricGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudCmsAlertMetricGroupsRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"datasource_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"include_details": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"alert_metric_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"datasource_types": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"display_name_cn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"display_name_en": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description_cn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description_en": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"order_index": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"filters": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dim": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"display_name_cn": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"display_name_en": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"hidden": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"opt": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"label_disabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"dim_disabled": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"supported_opts": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"display_name_cn": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"display_name_en": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"params": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"max_width": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"min_width": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"placeholder_cn": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"placeholder_en": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"values": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"label_cn": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"label_en": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"value": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudCmsAlertMetricGroupsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var response map[string]interface{}
+	var query map[string]*string
+	// ListAlertMetricGroups
+	action := "/alertMetricGroups"
+	var err error
+	query = make(map[string]*string)
+	if v, ok := d.GetOk("datasource_type"); ok {
+		query["datasourceType"] = StringPointer(v.(string))
+	}
+	if v, ok := d.GetOkExists("include_details"); ok {
+		query["includeDetails"] = StringPointer(fmt.Sprint(v.(bool)))
+	}
+	query["maxResults"] = StringPointer(strconv.Itoa(PageSizeLarge))
+
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+			response, err = client.RoaGet("Cms", "2024-03-30", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, nil)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.data[*]", response)
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["alertMetricGroupId"])]; !ok {
+					continue
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		if nextToken, ok := response["nextToken"].(string); ok && nextToken != "" {
+			query["nextToken"] = StringPointer(nextToken)
+		} else {
+			break
+		}
+	}
+
+	ids := make([]string, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		mapping["id"] = objectRaw["alertMetricGroupId"]
+		mapping["alert_metric_group_id"] = objectRaw["alertMetricGroupId"]
+		mapping["datasource_types"] = objectRaw["datasourceTypes"]
+		mapping["display_name_cn"] = objectRaw["displayNameCn"]
+		mapping["display_name_en"] = objectRaw["displayNameEn"]
+		mapping["description_cn"] = objectRaw["descriptionCn"]
+		mapping["description_en"] = objectRaw["descriptionEn"]
+		mapping["order_index"] = objectRaw["orderIndex"]
+
+		filtersMaps := make([]map[string]interface{}, 0)
+		if objectRaw["filters"] != nil {
+			for _, filtersChildRaw := range convertToInterfaceArray(objectRaw["filters"]) {
+				filtersMap := make(map[string]interface{})
+				filtersChildRaw := filtersChildRaw.(map[string]interface{})
+				filtersMap["dim"] = filtersChildRaw["dim"]
+				filtersMap["display_name_cn"] = filtersChildRaw["displayNameCn"]
+				filtersMap["display_name_en"] = filtersChildRaw["displayNameEn"]
+				filtersMap["hidden"] = filtersChildRaw["hidden"]
+				filtersMap["opt"] = filtersChildRaw["opt"]
+				filtersMap["label_disabled"] = filtersChildRaw["labelDisabled"]
+				filtersMap["dim_disabled"] = filtersChildRaw["dimDisabled"]
+
+				supportedOptsMaps := make([]map[string]interface{}, 0)
+				if filtersChildRaw["supportedOpts"] != nil {
+					for _, supportedOptsChildRaw := range convertToInterfaceArray(filtersChildRaw["supportedOpts"]) {
+						supportedOptsMap := make(map[string]interface{})
+						supportedOptsChildRaw := supportedOptsChildRaw.(map[string]interface{})
+						supportedOptsMap["display_name_cn"] = supportedOptsChildRaw["displayNameCn"]
+						supportedOptsMap["display_name_en"] = supportedOptsChildRaw["displayNameEn"]
+						supportedOptsMap["value"] = supportedOptsChildRaw["value"]
+
+						supportedOptsMaps = append(supportedOptsMaps, supportedOptsMap)
+					}
+				}
+				filtersMap["supported_opts"] = supportedOptsMaps
+
+				filtersMaps = append(filtersMaps, filtersMap)
+			}
+		}
+		mapping["filters"] = filtersMaps
+
+		paramsMaps := make([]map[string]interface{}, 0)
+		if objectRaw["params"] != nil {
+			for _, paramsChildRaw := range convertToInterfaceArray(objectRaw["params"]) {
+				paramsMap := make(map[string]interface{})
+				paramsChildRaw := paramsChildRaw.(map[string]interface{})
+				paramsMap["max_width"] = paramsChildRaw["maxWidth"]
+				paramsMap["min_width"] = paramsChildRaw["minWidth"]
+				paramsMap["name"] = paramsChildRaw["name"]
+				paramsMap["placeholder_cn"] = paramsChildRaw["placeholderCn"]
+				paramsMap["placeholder_en"] = paramsChildRaw["placeholderEn"]
+				paramsMap["type"] = paramsChildRaw["type"]
+				paramsMap["value"] = paramsChildRaw["value"]
+
+				valuesMaps := make([]map[string]interface{}, 0)
+				if paramsChildRaw["values"] != nil {
+					for _, valuesChildRaw := range convertToInterfaceArray(paramsChildRaw["values"]) {
+						valuesMap := make(map[string]interface{})
+						valuesChildRaw := valuesChildRaw.(map[string]interface{})
+						valuesMap["label_cn"] = valuesChildRaw["labelCn"]
+						valuesMap["label_en"] = valuesChildRaw["labelEn"]
+						valuesMap["value"] = valuesChildRaw["value"]
+
+						valuesMaps = append(valuesMaps, valuesMap)
+					}
+				}
+				paramsMap["values"] = valuesMaps
+
+				paramsMaps = append(paramsMaps, paramsMap)
+			}
+		}
+		mapping["params"] = paramsMaps
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("groups", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_cms_alert_metric_groups_test.go
+++ b/alicloud/data_source_alicloud_cms_alert_metric_groups_test.go
@@ -1,0 +1,114 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+// Test Cms AlertMetricGroups data source. >>> Data source test cases.
+
+// TestAccAliCloudCmsAlertMetricGroupsDataSource exercises every Optional filter
+// of the data source: ids, datasource_type, include_details and output_file.
+//
+// Alert metric groups are predefined, read-only system entries shared by all
+// accounts, so the test does not create any resource: an unfiltered companion
+// data source ("all") provides a real alert metric group id that each config
+// then filters on, keeping the exist assertions deterministic.
+func TestAccAliCloudCmsAlertMetricGroupsDataSource(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsAlertMetricGroupsSourceConfig(rand, map[string]string{
+			"ids": `[data.alicloud_cms_alert_metric_groups.all.groups.0.id]`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsAlertMetricGroupsSourceConfig(rand, map[string]string{
+			"ids": `["${data.alicloud_cms_alert_metric_groups.all.groups.0.id}_fake"]`,
+		}),
+	}
+
+	datasourceTypeConf := dataSourceTestAccConfig{
+		// datasource_type is a server-side filter; the value is derived from the
+		// first group's own datasource_types (a JSON array string such as
+		// ["arms_metrics"]) so the pinned id always matches the filter.
+		existConfig: testAccCheckAlicloudCmsAlertMetricGroupsSourceConfig(rand, map[string]string{
+			"ids":             `[data.alicloud_cms_alert_metric_groups.all.groups.0.id]`,
+			"datasource_type": `jsondecode(data.alicloud_cms_alert_metric_groups.all.groups.0.datasource_types)[0]`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsAlertMetricGroupsSourceConfig(rand, map[string]string{
+			"ids":             `["${data.alicloud_cms_alert_metric_groups.all.groups.0.id}_fake"]`,
+			"datasource_type": `"nonexistent_datasource_type"`,
+		}),
+	}
+
+	includeDetailsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsAlertMetricGroupsSourceConfig(rand, map[string]string{
+			"ids":             `[data.alicloud_cms_alert_metric_groups.all.groups.0.id]`,
+			"include_details": `true`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsAlertMetricGroupsSourceConfig(rand, map[string]string{
+			"ids":             `["${data.alicloud_cms_alert_metric_groups.all.groups.0.id}_fake"]`,
+			"include_details": `true`,
+		}),
+	}
+
+	outputFileConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudCmsAlertMetricGroupsSourceConfig(rand, map[string]string{
+			"ids":         `[data.alicloud_cms_alert_metric_groups.all.groups.0.id]`,
+			"output_file": `"/tmp/cms_alert_metric_groups_ds_output.txt"`,
+		}),
+		fakeConfig: testAccCheckAlicloudCmsAlertMetricGroupsSourceConfig(rand, map[string]string{
+			"ids":         `["${data.alicloud_cms_alert_metric_groups.all.groups.0.id}_fake"]`,
+			"output_file": `"/tmp/cms_alert_metric_groups_ds_output_fake.txt"`,
+		}),
+	}
+
+	CmsAlertMetricGroupsCheckInfo.dataSourceTestCheck(t, rand, idsConf, datasourceTypeConf, includeDetailsConf, outputFileConf)
+}
+
+var existCmsAlertMetricGroupsMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"groups.#":                       "1",
+		"ids.#":                          "1",
+		"groups.0.id":                    CHECKSET,
+		"groups.0.alert_metric_group_id": CHECKSET,
+		"groups.0.datasource_types":      CHECKSET,
+		"groups.0.display_name_cn":       CHECKSET,
+		"groups.0.display_name_en":       CHECKSET,
+		// filters/params/order_index/description_* are sparse predefined-system
+		// fields (only populated for some groups, or only when include_details is
+		// true), so they are intentionally not asserted.
+	}
+}
+
+var fakeCmsAlertMetricGroupsMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"groups.#": "0",
+		"ids.#":    "0",
+	}
+}
+
+var CmsAlertMetricGroupsCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_cms_alert_metric_groups.default",
+	existMapFunc: existCmsAlertMetricGroupsMapFunc,
+	fakeMapFunc:  fakeCmsAlertMetricGroupsMapFunc,
+}
+
+func testAccCheckAlicloudCmsAlertMetricGroupsSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	return fmt.Sprintf(`
+data "alicloud_cms_alert_metric_groups" "all" {
+}
+
+data "alicloud_cms_alert_metric_groups" "default" {
+  %s
+}
+`, strings.Join(pairs, "\n  "))
+}
+
+// Test Cms AlertMetricGroups data source. <<< Data source test cases.

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"alicloud_cms_alert_metric_groups":                        dataSourceAliCloudCmsAlertMetricGroups(),
 			"alicloud_threat_detection_attack_path_whitelists":        dataSourceAliCloudThreatDetectionAttackPathWhitelists(),
 			"alicloud_ehpc_users":                                     dataSourceAliCloudEhpcUsers(),
 			"alicloud_realtime_compute_members":                       dataSourceAliCloudRealtimeComputeMembers(),

--- a/website/docs/d/cms_alert_metric_groups.html.markdown
+++ b/website/docs/d/cms_alert_metric_groups.html.markdown
@@ -1,0 +1,98 @@
+---
+subcategory: "Cms"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_alert_metric_groups"
+sidebar_current: "docs-alicloud-datasource-cms-alert-metric-groups"
+description: |-
+  Provides a list of Cms Alert Metric Group available to the user.
+---
+
+# alicloud_cms_alert_metric_groups
+
+This data source provides the predefined alert metric groups of CloudMonitor 2.0. Alert metric groups are read-only, system-defined entries that group alert metrics and carry shared filters and parameters; they cannot be created, modified or deleted by the user.
+
+-> **NOTE:** Available since v1.292.0.
+
+## Example Usage
+
+```terraform
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+data "alicloud_cms_alert_metric_groups" "default" {
+  include_details = true
+}
+
+output "alicloud_cms_alert_metric_group_example_id" {
+  value = data.alicloud_cms_alert_metric_groups.default.groups.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ids` - (Optional, ForceNew, Computed) A list of Alert Metric Group IDs.
+* `datasource_type` - (Optional, ForceNew) The data source type, used to filter alert metric groups that support a certain data source type. Example: `arms_metrics`.
+* `include_details` - (Optional, ForceNew, Bool) Whether to include detail attributes such as `filters` and `params`. Default value: `false`.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `ids` - A list of Alert Metric Group IDs.
+* `groups` - A list of Alert Metric Group Entries.
+
+### `groups`
+
+The groups supports the following attributes:
+* `id` - The ID of the alert metric group.
+* `alert_metric_group_id` - The unique ID of the alert metric group. The `.` separator can be used to identify the hierarchy structure.
+* `datasource_types` - The data source types supported by the alert metric group, in JSON array string format. Example: `["arms_metrics"]`.
+* `display_name_cn` - The display name of the alert metric group in Chinese.
+* `display_name_en` - The display name of the alert metric group in English.
+* `description_cn` - The description of the alert metric group in Chinese.
+* `description_en` - The description of the alert metric group in English.
+* `order_index` - The ordering index of the alert metric group. A larger value indicates a higher priority within the same level.
+* `filters` - The shared filter conditions of the metrics in the group. Metrics inherit these filters automatically instead of defining them repeatedly at the metric level. **NOTE:** This field is only available when `include_details` is `true`.
+* `params` - The shared parameters of the metrics in the group. All metrics inherit them automatically. Only read-only text parameters can be defined at the group level. **NOTE:** This field is only available when `include_details` is `true`.
+
+### `groups.filters`
+
+The filters supports the following attributes:
+* `dim` - The filter dimension.
+* `display_name_cn` - The display name of the filter in Chinese.
+* `display_name_en` - The display name of the filter in English.
+* `hidden` - Indicates whether the filter is hidden. A hidden filter is not displayed in the frontend interaction, but its value can still be uploaded when rendering PromQL.
+* `opt` - The filter operator.
+* `label_disabled` - Indicates whether the filter is excluded from the label filter of PromQL.
+* `dim_disabled` - Indicates whether the filter is excluded from the group by clause of PromQL.
+* `supported_opts` - The supported operators of the filter.
+
+### `groups.filters.supported_opts`
+
+The supported_opts supports the following attributes:
+* `display_name_cn` - The display name of the operator in Chinese.
+* `display_name_en` - The display name of the operator in English.
+* `value` - The value of the operator.
+
+### `groups.params`
+
+The params supports the following attributes:
+* `max_width` - The maximum width of the input box. Only valid for `SELECT_PARAM` and `INPUT_PARAM`.
+* `min_width` - The minimum width of the input box. Only valid for `SELECT_PARAM` and `INPUT_PARAM`.
+* `name` - The name of the parameter.
+* `placeholder_cn` - The Chinese placeholder displayed in the frontend. Only valid for `INPUT_PARAM`.
+* `placeholder_en` - The English placeholder displayed in the frontend. Only valid for `INPUT_PARAM`.
+* `type` - The type of the parameter. Valid values: `TEXT_PARAM` (read-only text parameter defined by the backend, no user input control is displayed), `INPUT_PARAM` (input box parameter) and `SELECT_PARAM` (select box parameter).
+* `value` - The value of the parameter.
+* `values` - The optional value list of the dropdown. Only valid for `SELECT_PARAM`.
+
+### `groups.params.values`
+
+The values supports the following attributes:
+* `label_cn` - The Chinese display name of the option.
+* `label_en` - The English display name of the option.
+* `value` - The value of the option.


### PR DESCRIPTION
## Summary

- Add the `alicloud_cms_alert_metric_groups` data source, which exposes the predefined alert metric groups of CloudMonitor 2.0. Alert metric groups are read-only, system-defined entries (they group alert metrics and carry shared filters and parameters), so they are provided as a data source only.
- Supports filtering by `ids` (alert metric group IDs, matched client-side against the full list) and `datasource_type` (server-side filter), plus `include_details` to output the shared `filters` and `params` of each group, and `output_file`.

## Test plan

- [x] Local: `gofmt`, `go vet ./alicloud` and `go build ./alicloud` pass with no findings in the new files; website doc passes markdownlint with the repository CI config.
- [ ] `TestAccAliCloudCmsAlertMetricGroupsDataSource`: exercises every optional filter (`ids`, `datasource_type`, `include_details`, `output_file`) with exist/fake configs against the predefined system entries; to be executed via remote acceptance testing.
