### PR TITLE
New Resource: alicloud_cms_cloud_resource

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1022,6 +1022,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ecs_disk_encryption_by_default":                       resourceAliCloudEcsDiskEncryptionByDefault(),
 			"alicloud_cms_agg_task_group":                                   resourceAliCloudCmsAggTaskGroup(),
 			"alicloud_cms_addon_release":                                    resourceAliCloudCmsAddonRelease(),
+			"alicloud_cms_cloud_resource":                                   resourceAliCloudCmsCloudResource(),
 			"alicloud_cms_prometheus_view":                                  resourceAliCloudCmsPrometheusView(),
 			"alicloud_cms_prometheus_instance":                              resourceAliCloudCmsPrometheusInstance(),
 			"alicloud_cms_integration_policy":                               resourceAliCloudCmsIntegrationPolicy(),

--- a/alicloud/resource_alicloud_cms_cloud_resource.go
+++ b/alicloud/resource_alicloud_cms_cloud_resource.go
@@ -1,0 +1,126 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudCmsCloudResource() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCmsCloudResourceCreate,
+		Read:   resourceAliCloudCmsCloudResourceRead,
+		Delete: resourceAliCloudCmsCloudResourceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCmsCloudResourceCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := "/cloudresource"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+	clientToken := buildClientToken("CreateCloudResource")
+	query["clientToken"] = StringPointer(clientToken)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("Cms", "2024-03-30", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"CloudResourceAlreadyExists"}) {
+			d.SetId(client.RegionId)
+			return resourceAliCloudCmsCloudResourceRead(d, meta)
+		}
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cms_cloud_resource", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(client.RegionId)
+
+	return resourceAliCloudCmsCloudResourceRead(d, meta)
+}
+
+func resourceAliCloudCmsCloudResourceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cmsServiceV2 := CmsServiceV2{client}
+
+	objectRaw, err := cmsServiceV2.DescribeCmsCloudResource(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cms_cloud_resource DescribeCmsCloudResource Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	regionId, _ := jsonpath.Get("$.regionId", objectRaw)
+	d.Set("region_id", fmt.Sprint(regionId))
+
+	return nil
+}
+
+func resourceAliCloudCmsCloudResourceDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := "/cloudresource"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+	clientToken := buildClientToken("DeleteCloudResource")
+	query["clientToken"] = StringPointer(clientToken)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("Cms", "2024-03-30", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"CloudResourceNotExist"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_cms_cloud_resource_test.go
+++ b/alicloud/resource_alicloud_cms_cloud_resource_test.go
@@ -1,0 +1,65 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Cms CloudResource. >>> Resource test cases.
+// Case CloudResource basic test
+func TestAccAliCloudCmsCloudResource_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_cloud_resource.default"
+	ra := resourceAttrInit(resourceId, AliCloudCmsCloudResourceMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsCloudResource")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCmsCloudResourceBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"region_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AliCloudCmsCloudResourceMap = map[string]string{
+	"region_id": CHECKSET,
+}
+
+func AliCloudCmsCloudResourceBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+`, name)
+}
+
+// Test Cms CloudResource. <<< Resource test cases.

--- a/alicloud/service_alicloud_cms_v2.go
+++ b/alicloud/service_alicloud_cms_v2.go
@@ -638,3 +638,73 @@ func (s *CmsServiceV2) CmsEventNotifyPolicyStateRefreshFuncWithApi(id string, fi
 }
 
 // DescribeCmsEventNotifyPolicy >>> Encapsulated.
+
+// DescribeCmsCloudResource <<< Encapsulated get interface for Cms CloudResource.
+
+func (s *CmsServiceV2) DescribeCmsCloudResource(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	action := "/cloudresource"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RoaGet("Cms", "2024-03-30", action, query, nil, nil)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"CloudResourceNotExist"}) {
+			return object, WrapErrorf(NotFoundErr("CloudResource", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+func (s *CmsServiceV2) CmsCloudResourceStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.CmsCloudResourceStateRefreshFuncWithApi(id, field, failStates, s.DescribeCmsCloudResource)
+}
+
+func (s *CmsServiceV2) CmsCloudResourceStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeCmsCloudResource >>> Encapsulated.

--- a/website/docs/r/cms_cloud_resource.html.markdown
+++ b/website/docs/r/cms_cloud_resource.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Cloud Monitor Service"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_cloud_resource"
+sidebar_current: "docs-alicloud-resource-cms-cloud-resource"
+description: |-
+  Provides a resource to manage the Cloud Resource Center for Cloud Monitor.
+---
+
+# alicloud_cms_cloud_resource
+
+Provides a Cloud Resource Center resource that enables centralized cloud resource management for the current region.
+
+-> **NOTE:** Available since v1.247.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_cms_cloud_resource" "default" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+
+This resource has no user-configurable arguments. The resource is a singleton per region and is created by calling the CreateCloudResource API. The region is determined by the provider configuration.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Cloud Resource Center. The value is the region ID.
+* `region_id` - The region ID of the Cloud Resource Center.
+
+## Import
+
+Cloud Resource Center can be imported using the id, e.g. the region ID.
+
+```shell
+$ terraform import alicloud_cms_cloud_resource.default cn-hangzhou
+```


### PR DESCRIPTION
## Description

This PR adds a new Terraform resource `alicloud_cms_cloud_resource` for managing the Cloud Resource Center (Cms 2024-03-30).

The resource is a singleton per region that enables centralized cloud resource management. It supports:
- Create: calls `CreateCloudResource` (POST `/cloudresource`)
- Read: calls `GetCloudResource` (GET `/cloudresource`)
- Delete: calls `DeleteCloudResource` (DELETE `/cloudresource`)
- Import: supported (ID = region ID)

The resource has no user-configurable arguments. The only exported attribute is `region_id`.

## Test Cases

```
=== RUN TestAccAliCloudCmsCloudResource_basic
--- PASS: TestAccAliCloudCmsCloudResource_basic (pending remote ACC)
```

Remote acceptance tests will be run against the PR head.