### PR TITLE
New Resource: alicloud_cms_context_store_api_key

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -974,6 +974,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_sls_metric_stores":                                dataSourceAliCloudSlsMetricStores(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"alicloud_cms_context_store_api_key":                            resourceAliCloudCmsContextStoreApiKey(),
 			"alicloud_threat_detection_attack_path_whitelist":               resourceAliCloudThreatDetectionAttackPathWhitelist(),
 			"alicloud_vpc_route_target_group":                               resourceAliCloudVpcRouteTargetGroup(),
 			"alicloud_ehpc_user":                                            resourceAliCloudEhpcUser(),

--- a/alicloud/resource_alicloud_cms_context_store_api_key.go
+++ b/alicloud/resource_alicloud_cms_context_store_api_key.go
@@ -1,0 +1,173 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudCmsContextStoreApiKey() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCmsContextStoreApiKeyCreate,
+		Read:   resourceAliCloudCmsContextStoreApiKeyRead,
+		Delete: resourceAliCloudCmsContextStoreApiKeyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"workspace": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"context_store_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"api_key": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCmsContextStoreApiKeyCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := fmt.Sprintf("/workspace/%v/contextstore/%v/apikey", d.Get("workspace"), d.Get("context_store_name"))
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	request["name"] = d.Get("name")
+	body = request
+	wait := incrementalWait(3*time.Second, 0*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("Cms", "2024-03-30", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cms_context_store_api_key", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v:%v", d.Get("workspace"), d.Get("context_store_name"), d.Get("name")))
+
+	if v, ok := response["apiKey"]; ok && fmt.Sprint(v) != "" {
+		d.Set("api_key", v)
+	}
+
+	return resourceAliCloudCmsContextStoreApiKeyRead(d, meta)
+}
+
+func resourceAliCloudCmsContextStoreApiKeyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cmsServiceV2 := CmsServiceV2{client}
+
+	objectRaw, err := cmsServiceV2.DescribeCmsContextStoreApiKey(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cms_context_store_api_key DescribeCmsContextStoreApiKey Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	parts := strings.SplitN(d.Id(), ":", 3)
+	if v, ok := objectRaw["apiKey"]; ok && fmt.Sprint(v) != "" {
+		d.Set("api_key", v)
+	}
+	d.Set("create_time", objectRaw["createTime"])
+	d.Set("region_id", client.RegionId)
+	if v, ok := objectRaw["name"]; ok && fmt.Sprint(v) != "" {
+		d.Set("name", v)
+	} else {
+		d.Set("name", parts[2])
+	}
+	if v, ok := objectRaw["workspace"]; ok && fmt.Sprint(v) != "" {
+		d.Set("workspace", v)
+	} else {
+		d.Set("workspace", parts[0])
+	}
+	if v, ok := objectRaw["contextStoreName"]; ok && fmt.Sprint(v) != "" {
+		d.Set("context_store_name", v)
+	} else {
+		d.Set("context_store_name", parts[1])
+	}
+
+	return nil
+}
+
+func resourceAliCloudCmsContextStoreApiKeyDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	parts := strings.SplitN(d.Id(), ":", 3)
+	action := fmt.Sprintf("/workspace/%v/contextstore/%v/apikey/%v", parts[0], parts[1], parts[2])
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+
+	wait := incrementalWait(3*time.Second, 0*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("Cms", "2024-03-30", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"WorkspaceNotExist", "ContextStoreNotExist", "NotFound", "EntityNotExist"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_cms_context_store_api_key_test.go
+++ b/alicloud/resource_alicloud_cms_context_store_api_key_test.go
@@ -1,0 +1,210 @@
+package alicloud
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Cms ContextStoreApiKey. >>> Resource test cases.
+func TestAccAliCloudCmsContextStoreApiKey_basic0(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_context_store_api_key.default"
+	ra := resourceAttrInit(resourceId, AliCloudCmsContextStoreApiKeyMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsContextStoreApiKey")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccsak%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCmsContextStoreApiKeyBasicDependence0)
+	if os.Getenv("TF_ACC") != "" {
+		testAccCmsContextStorePrepare(t, name)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"workspace":          name,
+					"context_store_name": name,
+					"name":               name,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"workspace":          name,
+						"context_store_name": name,
+						"name":               name,
+						"api_key":            CHECKSET,
+						"create_time":        CHECKSET,
+						"region_id":          CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func TestAccAliCloudCmsContextStoreApiKey_basic0_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_context_store_api_key.default"
+	ra := resourceAttrInit(resourceId, AliCloudCmsContextStoreApiKeyMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsContextStoreApiKey")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccsak%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCmsContextStoreApiKeyBasicDependence0)
+	if os.Getenv("TF_ACC") != "" {
+		testAccCmsContextStorePrepare(t, name)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"workspace":          name,
+					"context_store_name": name,
+					"name":               fmt.Sprintf("%s-key", name),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"workspace":          name,
+						"context_store_name": name,
+						"name":               fmt.Sprintf("%s-key", name),
+						"api_key":            CHECKSET,
+						"create_time":        CHECKSET,
+						"region_id":          CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AliCloudCmsContextStoreApiKeyMap0 = map[string]string{
+	"api_key":     CHECKSET,
+	"create_time": CHECKSET,
+	"region_id":   CHECKSET,
+}
+
+func AliCloudCmsContextStoreApiKeyBasicDependence0(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+`, name)
+}
+
+// testAccCmsContextStorePrepare pre-creates the parent resources (an SLS project, a Cms
+// workspace binding it and a context store) through raw API calls, because the parent
+// context store is not managed by the provider yet. All of them are removed on cleanup.
+func testAccCmsContextStorePrepare(t *testing.T, name string) {
+	region := os.Getenv("ALICLOUD_REGION")
+	if region == "" {
+		region = "cn-hangzhou"
+	}
+	rawClient, err := sharedClientForRegion(region)
+	if err != nil {
+		t.Fatalf("Error getting Alicloud client: %s", err)
+	}
+	client := rawClient.(*connectivity.AliyunClient)
+
+	retryAll := func(timeout time.Duration, call func() error) error {
+		var lastErr error
+		e := resource.Retry(timeout, func() *resource.RetryError {
+			lastErr = call()
+			if lastErr != nil {
+				time.Sleep(5 * time.Second)
+				return resource.RetryableError(lastErr)
+			}
+			return nil
+		})
+		if e != nil && lastErr != nil {
+			return lastErr
+		}
+		return e
+	}
+
+	query := make(map[string]*string)
+	hostMap := make(map[string]*string)
+	slsBody := map[string]interface{}{
+		"projectName": name,
+		"description": name,
+	}
+	err = retryAll(3*time.Minute, func() error {
+		_, e := client.Do("Sls", roaParam("POST", "2020-12-30", "CreateProject", "/"), query, slsBody, nil, hostMap, false)
+		return e
+	})
+	if err != nil {
+		t.Fatalf("Error creating SLS project %s: %s", name, err)
+	}
+
+	wsAction := fmt.Sprintf("/workspace/%s", name)
+	wsBody := map[string]interface{}{
+		"slsProject":  name,
+		"description": name,
+	}
+	err = retryAll(3*time.Minute, func() error {
+		_, e := client.RoaPost("Cms", "2024-03-30", wsAction, make(map[string]*string), nil, wsBody, true)
+		return e
+	})
+	if err != nil {
+		t.Fatalf("Error creating Cms workspace %s: %s", name, err)
+	}
+
+	csAction := fmt.Sprintf("/workspace/%s/contextstore", name)
+	csBody := map[string]interface{}{
+		"contextStoreName": name,
+		"contextType":      "memory",
+		"description":      name,
+	}
+	err = retryAll(3*time.Minute, func() error {
+		_, e := client.RoaPost("Cms", "2024-03-30", csAction, make(map[string]*string), nil, csBody, true)
+		return e
+	})
+	if err != nil {
+		t.Fatalf("Error creating Cms context store %s: %s", name, err)
+	}
+
+	t.Cleanup(func() {
+		csDelAction := fmt.Sprintf("/workspace/%s/contextstore/%s", name, name)
+		_, _ = client.RoaDelete("Cms", "2024-03-30", csDelAction, make(map[string]*string), nil, nil, true)
+		_, _ = client.RoaDelete("Cms", "2024-03-30", wsAction, make(map[string]*string), nil, nil, true)
+		delHostMap := make(map[string]*string)
+		delHostMap["project"] = StringPointer(name)
+		_, _ = client.Do("Sls", roaParam("DELETE", "2020-12-30", "DeleteProject", "/"), query, nil, nil, delHostMap, false)
+	})
+}
+
+// Test Cms ContextStoreApiKey. <<< Resource test cases.

--- a/alicloud/service_alicloud_cms_v2.go
+++ b/alicloud/service_alicloud_cms_v2.go
@@ -638,3 +638,99 @@ func (s *CmsServiceV2) CmsEventNotifyPolicyStateRefreshFuncWithApi(id string, fi
 }
 
 // DescribeCmsEventNotifyPolicy >>> Encapsulated.
+
+// DescribeCmsContextStoreApiKey <<< Encapsulated get interface for Cms ContextStoreAPIKey.
+
+func (s *CmsServiceV2) DescribeCmsContextStoreApiKey(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	parts := strings.SplitN(id, ":", 3)
+	if len(parts) != 3 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 3, len(parts)))
+		return nil, err
+	}
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	query["maxResults"] = StringPointer("100")
+	action := fmt.Sprintf("/workspace/%s/contextstore/%s/apikey", parts[0], parts[1])
+
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+			response, err = client.RoaGet("Cms", "2024-03-30", action, query, nil, nil)
+
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"WorkspaceNotExist", "ContextStoreNotExist", "NotFound", "EntityNotExist"}) || NotFoundError(err) {
+				return object, WrapErrorf(NotFoundErr("ContextStoreAPIKey", id), NotFoundMsg, response)
+			}
+			return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+		}
+
+		v, err := jsonpath.Get("$.results", response)
+		if err == nil && v != nil {
+			for _, item := range v.([]interface{}) {
+				itemRaw, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if fmt.Sprint(itemRaw["name"]) == parts[2] {
+					return itemRaw, nil
+				}
+			}
+		}
+
+		if nextToken, ok := response["nextToken"].(string); ok && nextToken != "" {
+			query["nextToken"] = StringPointer(nextToken)
+			continue
+		}
+		break
+	}
+
+	return object, WrapErrorf(NotFoundErr("ContextStoreAPIKey", id), NotFoundMsg, response)
+}
+
+func (s *CmsServiceV2) CmsContextStoreApiKeyStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.CmsContextStoreApiKeyStateRefreshFuncWithApi(id, field, failStates, s.DescribeCmsContextStoreApiKey)
+}
+
+func (s *CmsServiceV2) CmsContextStoreApiKeyStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeCmsContextStoreApiKey >>> Encapsulated.

--- a/website/docs/r/cms_context_store_api_key.html.markdown
+++ b/website/docs/r/cms_context_store_api_key.html.markdown
@@ -1,0 +1,71 @@
+---
+subcategory: "Cms"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_context_store_api_key"
+description: |-
+  Provides a Alicloud Cms Context Store API Key resource.
+---
+
+# alicloud_cms_context_store_api_key
+
+Provides a Cms Context Store API Key resource.
+
+An API key of a context store in a Cloud Monitor 2.0 workspace.
+
+For information about Cms Context Store API Key and how to use it, see [What is Context Store API Key](https://next.api.alibabacloud.com/document/Cms/2024-03-30/CreateContextStoreAPIKey).
+
+-> **NOTE:** Available since v1.292.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+
+resource "alicloud_cms_context_store_api_key" "default" {
+  workspace          = alicloud_cms_workspace.default.workspace_name
+  context_store_name = "example-context-store"
+  name               = var.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `workspace` - (Required, ForceNew) The name of the workspace to which the context store belongs.
+* `context_store_name` - (Required, ForceNew) The name of the context store.
+* `name` - (Required, ForceNew) The display name of the API key, which is used to identify the purpose of the key.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<workspace>:<context_store_name>:<name>`.
+* `api_key` - The value of the API key.
+* `create_time` - The creation time of the API key.
+* `region_id` - The region ID of the API key.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Context Store API Key.
+* `delete` - (Defaults to 5 mins) Used when delete the Context Store API Key.
+
+## Import
+
+Cms Context Store API Key can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cms_context_store_api_key.example <workspace>:<context_store_name>:<name>
+```


### PR DESCRIPTION
#### New Resource

- `alicloud_cms_context_store_api_key`

#### Description

Adds a resource to manage the API key of a context store in a CloudMonitor (Cms, API version 2024-03-30) workspace.

- Create: `POST /workspace/{workspace}/contextstore/{contextStoreName}/apikey`
- Read: `GET /workspace/{workspace}/contextstore/{contextStoreName}/apikey` (list with `nextToken` pagination, filtered by key name)
- Delete: `DELETE /workspace/{workspace}/contextstore/{contextStoreName}/apikey/{name}`

The API does not provide an update operation, so all arguments are `ForceNew`. The key value is exported as the sensitive computed attribute `api_key`. Import is supported with the `<workspace>:<context_store_name>:<name>` ID format.

#### Acceptance Tests

- `TestAccAliCloudCmsContextStoreApiKey_basic0`
- `TestAccAliCloudCmsContextStoreApiKey_basic0_twin`

Both cases cover create, attribute checks (including the sensitive `api_key`, `create_time` and `region_id`) and import state verification. Since the parent context store is not yet managed by the provider, the tests pre-create the parent chain (SLS project, Cms workspace, context store) through raw API calls and remove it during test cleanup. Remote acceptance run results will be attached as a PR comment.
