### PR TITLE
resource/alicloud_nlb_listener: remove the upper limit of idle_timeout; resource/alicloud_nlb_load_balancer: retry delete on ResourceInConfiguring

### DIFF
--- a/alicloud/resource_alicloud_nlb_listener.go
+++ b/alicloud/resource_alicloud_nlb_listener.go
@@ -64,10 +64,9 @@ func resourceAliCloudNlbListener() *schema.Resource {
 				ValidateFunc: IntBetween(0, 65535),
 			},
 			"idle_timeout": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: IntBetween(0, 900),
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
 			},
 			"listener_description": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_nlb_load_balancer.go
+++ b/alicloud/resource_alicloud_nlb_load_balancer.go
@@ -876,7 +876,7 @@ func resourceAliCloudNlbLoadBalancerDelete(d *schema.ResourceData, meta interfac
 		request["ClientToken"] = buildClientToken(action)
 
 		if err != nil {
-			if NeedRetry(err) {
+			if IsExpectedErrors(err, []string{"ResourceInConfiguring.loadbalancer"}) || NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
 			}

--- a/website/docs/r/nlb_listener.html.markdown
+++ b/website/docs/r/nlb_listener.html.markdown
@@ -152,7 +152,7 @@ The following arguments are supported:
 
 -> **NOTE:**  This parameter is required when `ListenerPort` is set to `0`.
 
-* `idle_timeout` - (Optional, Computed, Int) The timeout period of idle connections. Unit: seconds. Valid values: `1` to `900`. Default value: `900`.
+* `idle_timeout` - (Optional, Computed, Int) The timeout period of idle connections. Unit: seconds. Valid values: `1` to `900`. Default value: `900`. Values greater than `900` can be used only after you contact the product team to add a whitelist for your account.
 * `listener_description` - (Optional) Enter a name for the listener.
 The description must be 2 to 256 characters in length, and can contain letters, digits, commas (,), periods (.), semicolons (;), forward slashes (/), at signs (@), underscores (\_), and hyphens (-).
 * `listener_port` - (Required, ForceNew, Int) The listener port. Valid values: `0` to `65535`.


### PR DESCRIPTION
## Summary
- Removed the `ValidateFunc: IntBetween(0, 900)` upper-bound constraint on the `idle_timeout` attribute of `alicloud_nlb_listener`, so the provider no longer rejects values greater than 900 at plan/validate time. The server-side API remains the source of truth for the effective range.
- Updated the `idle_timeout` documentation: values greater than `900` can be used only after the product team adds a whitelist for the account.
- Retry `ResourceInConfiguring.loadbalancer` in the NLB load balancer delete flow. The API can transiently return this error right after a listener deletion job reports success, which made `terraform destroy` fail intermittently (observed in the TCPSSL acceptance test teardown). This matches the retry handling already used by the ALB resources for the same error family.

## Test plan
- [x] `gofmt` on the changed Go files — clean.
- [x] `go vet` — no new warnings from the changed files.
- [x] Remote ACC for all 9 `alicloud_nlb_listener` acceptance tests — PASS (including `TestAccAliCloudNlbListener_TCPSSL`, which exercises the load balancer delete retry during teardown; it failed intermittently before the fix).
- [ ] Remote ACC with `idle_timeout > 900` on an account whose server-side whitelist allows it. On accounts without the whitelist the API rejects values > 900, which is expected server-side behavior, not a provider defect.

## Note on the TestingCoverageRate check
The `TestingCoverageRate` workflow reports `ca_enabled` as uncovered. This is a pre-existing gap on master for this resource: exercising `ca_enabled = true` requires uploading a real CA certificate, which the CI account does not provide. Covering that attribute is out of scope for this change.