### PR TITLE
docs: clarify VPC DNS hostname status

### DIFF
--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 * `classic_link_enabled` - (Optional, Deprecated since v1.286.0) The status of ClassicLink function. Field 'classic_link_enabled' has been deprecated from provider version 1.286.0. The underlying ClassicLink feature has been deprecated by Alibaba Cloud and this field will be removed in a future version. For more information, see the deprecated API references [EnableVpcClassicLink](https://www.alibabacloud.com/help/en/vpc/developer-reference/api-vpc-2016-04-28-enablevpcclassiclink) and [DisableVpcClassicLink](https://www.alibabacloud.com/help/en/vpc/developer-reference/api-vpc-2016-04-28-disablevpcclassiclink).
 * `description` - (Optional) The new description of the VPC.
 The description must be 1 to 256 characters in length, and cannot start with `http://` or `https://`.
-* `dns_hostname_status` - (Optional, Computed, Available since v1.240.0) The status of VPC DNS Hostname. Valid values: `ENABLED`, `DISABLED`.
+* `dns_hostname_status` - (Optional, Computed, Available since v1.240.0) Whether to enable the DNS hostname feature. Valid values: `ENABLED`, `DISABLED`.
 * `dry_run` - (Optional, Available since v1.119.0) Whether to PreCheck only this request. Value:
   - `true`: The check request is sent without creating a VPC. Check items include whether required parameters, request format, and business restrictions are filled in. If the check does not pass, the corresponding error is returned. If the check passes, the error code 'DryRunOperation' is returned '.
   - `false` (default): Sends a normal request, returns an HTTP 2xx status code and directly creates a VPC.


### PR DESCRIPTION
## Summary
- clarify that dns_hostname_status controls the DNS hostname feature
- retain the existing supported values: ENABLED, DISABLED

## Validation
- git diff --check

Related Aone workitem: 65850168