### PR TITLE
resource/alicloud_ram_role_policy_attachment: support resource group scope

### DIFF
--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -1587,10 +1587,7 @@ func compareCmsHybridMonitorFcTaskYamlConfigAreEquivalent(tem1, tem2 string) (bo
 	}
 
 	var P1 Products
-	err := yaml.Unmarshal([]byte(tem1), &P1)
-	if err != nil {
-		fmt.Sprintln(false)
-	}
+	_ = yaml.Unmarshal([]byte(tem1), &P1)
 
 	y1 := make([]string, 0)
 	for _, product := range P1.Products {
@@ -1599,10 +1596,7 @@ func compareCmsHybridMonitorFcTaskYamlConfigAreEquivalent(tem1, tem2 string) (bo
 	}
 
 	var P2 Products
-	err = yaml.Unmarshal([]byte(tem2), &P2)
-	if err != nil {
-		fmt.Sprintln(false)
-	}
+	_ = yaml.Unmarshal([]byte(tem2), &P2)
 
 	y2 := make([]string, 0)
 	for _, product := range P2.Products {

--- a/alicloud/resource_alicloud_ram_role_policy_attachment.go
+++ b/alicloud/resource_alicloud_ram_role_policy_attachment.go
@@ -3,14 +3,17 @@ package alicloud
 
 import (
 	"fmt"
-	"log"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
+
+var ramRolePolicyAttachmentScopePattern = regexp.MustCompile(`^rg-[A-Za-z0-9]+$`)
 
 func resourceAliCloudRamRolePolicyAttachment() *schema.Resource {
 	return &schema.Resource{
@@ -41,30 +44,91 @@ func resourceAliCloudRamRolePolicyAttachment() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"resource_group_id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^$|^rg-[A-Za-z0-9]+$`), "must be empty for account scope or a resource group ID"),
+			},
 		},
 	}
 }
 
+type ramRolePolicyAttachmentIdentity struct {
+	policyName, policyType, roleName, scope string
+}
+
+func parseRamRolePolicyAttachmentID(id string) (ramRolePolicyAttachmentIdentity, error) {
+	parts := strings.Split(id, ":")
+	identity := ramRolePolicyAttachmentIdentity{}
+	if (len(parts) != 4 && len(parts) != 5) || parts[0] != "role" {
+		return identity, fmt.Errorf("invalid RAM role policy attachment ID %q: expected role:<policy_name>:<policy_type>:<role_name>[:<resource_group_id>]", id)
+	}
+	if parts[1] == "" || parts[3] == "" || (parts[2] != "Custom" && parts[2] != "System") {
+		return identity, fmt.Errorf("invalid RAM role policy attachment identity in %q", id)
+	}
+	identity.policyName, identity.policyType, identity.roleName = parts[1], parts[2], parts[3]
+	if len(parts) == 5 {
+		if !ramRolePolicyAttachmentScopePattern.MatchString(parts[4]) {
+			return identity, fmt.Errorf("invalid resource group scope in RAM role policy attachment ID %q", id)
+		}
+		identity.scope = parts[4]
+	}
+	return identity, nil
+}
+
+func (identity ramRolePolicyAttachmentIdentity) request() map[string]interface{} {
+	request := map[string]interface{}{"PolicyName": identity.policyName, "PolicyType": identity.policyType, "RoleName": identity.roleName}
+	if identity.scope != "" {
+		request["ResourceGroupId"] = identity.scope
+	}
+	return request
+}
+
+// Only the scoped query's explicit absence result may clear state, not an arbitrary HTTP 404.
+func ramRolePolicyAttachmentNotFound(err error) bool {
+	wrapped, ok := err.(*ComplexError)
+	return ok && wrapped.Err != nil && strings.HasPrefix(wrapped.Err.Error(), ResourceNotfound)
+}
+
+func setRamRolePolicyAttachmentData(d *schema.ResourceData, identity ramRolePolicyAttachmentIdentity) error {
+	if err := d.Set("policy_name", identity.policyName); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("policy_type", identity.policyType); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("role_name", identity.roleName); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("resource_group_id", identity.scope); err != nil {
+		return WrapError(err)
+	}
+	return nil
+}
+
 func resourceAliCloudRamRolePolicyAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
 
+	id := strings.Join([]string{"role", d.Get("policy_name").(string), d.Get("policy_type").(string), d.Get("role_name").(string)}, ":")
+	if scope := d.Get("resource_group_id").(string); scope != "" {
+		id += ":" + scope
+	}
+	identity, err := parseRamRolePolicyAttachmentID(id)
+	if err != nil {
+		return WrapError(err)
+	}
 	client := meta.(*connectivity.AliyunClient)
+	ramServiceV2 := RamServiceV2{client}
 
+	request := identity.request()
 	action := "AttachPolicyToRole"
-	var request map[string]interface{}
-	var response map[string]interface{}
-	query := make(map[string]interface{})
-	var err error
-	request = make(map[string]interface{})
-
-	request["PolicyType"] = d.Get("policy_type")
-	request["PolicyName"] = d.Get("policy_name")
-	request["RoleName"] = d.Get("role_name")
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		response, err = client.RpcPost("Ram", "2015-05-01", action, query, request, true)
+		response, err := client.RpcPost("Ram", "2015-05-01", action, nil, request, true)
+		addDebug(action, response, request)
 		if err != nil {
-			if NeedRetry(err) {
+			if NeedRetry(err) || IsExpectedErrors(err, []string{"EntityNotExist.Role", "EntityNotExist.Policy", "EntityNotExists.ResourceGroup"}) {
 				wait()
 				return resource.RetryableError(err)
 			}
@@ -72,78 +136,69 @@ func resourceAliCloudRamRolePolicyAttachmentCreate(d *schema.ResourceData, meta 
 		}
 		return nil
 	})
-	addDebug(action, response, request)
 
 	if err != nil {
 		return WrapErrorf(err, DefaultErrorMsg, "alicloud_ram_role_policy_attachment", action, AlibabaCloudSdkGoERROR)
 	}
 
-	// In order to be compatible with previous Id (before 1.9.6) which format to role:<policy_name>:<policy_type>:<role_name>
-	d.SetId(fmt.Sprintf("%v:%v:%v:%v", "role", request["PolicyName"], request["PolicyType"], request["RoleName"]))
+	// Preserve the legacy four-part account ID and retain the identity if read-back fails.
+	d.SetId(id)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		_, err := ramServiceV2.DescribeRamRolePolicyAttachment(id)
+		if ramRolePolicyAttachmentNotFound(err) {
+			return resource.RetryableError(err)
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return WrapError(err)
+	}
 
-	return resourceAliCloudRamRolePolicyAttachmentRead(d, meta)
+	return setRamRolePolicyAttachmentData(d, identity)
 }
 
 func resourceAliCloudRamRolePolicyAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	identity, err := parseRamRolePolicyAttachmentID(d.Id())
+	if err != nil {
+		return WrapError(err)
+	}
 	client := meta.(*connectivity.AliyunClient)
 	ramServiceV2 := RamServiceV2{client}
-
-	if split := strings.Split(d.Id(), ":"); len(split) != 4 {
-		id := strings.Join([]string{"role", d.Get("policy_name").(string), d.Get("policy_type").(string), d.Get("role_name").(string)}, COLON_SEPARATED)
-		d.SetId(id)
-	}
-	objectRaw, err := ramServiceV2.DescribeRamRolePolicyAttachment(d.Id())
+	_, err = ramServiceV2.DescribeRamRolePolicyAttachment(d.Id())
 	if err != nil {
-		if !d.IsNewResource() && NotFoundError(err) {
-			log.Printf("[DEBUG] Resource alicloud_ram_role_policy_attachment DescribeRamRolePolicyAttachment Failed!!! %s", err)
+		if !d.IsNewResource() && ramRolePolicyAttachmentNotFound(err) {
 			d.SetId("")
 			return nil
 		}
 		return WrapError(err)
 	}
 
-	parts, err := ParseResourceId(d.Id(), 4)
-	if err != nil {
-		return WrapError(err)
-	}
-
-	d.Set("policy_name", objectRaw["PolicyName"])
-	d.Set("policy_type", objectRaw["PolicyType"])
-	d.Set("role_name", parts[3])
-
-	return nil
+	return setRamRolePolicyAttachmentData(d, identity)
 }
 
 func resourceAliCloudRamRolePolicyAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
 
-	client := meta.(*connectivity.AliyunClient)
-	action := "DetachPolicyFromRole"
-	var request map[string]interface{}
-	var response map[string]interface{}
-	query := make(map[string]interface{})
-	var err error
-	request = make(map[string]interface{})
-
-	id := strings.Join([]string{"role", d.Get("policy_name").(string), d.Get("policy_type").(string), d.Get("role_name").(string)}, COLON_SEPARATED)
-
-	if d.Id() != id {
-		d.SetId(id)
-	}
-
-	parts, err := ParseResourceId(id, 4)
+	identity, err := parseRamRolePolicyAttachmentID(d.Id())
 	if err != nil {
 		return WrapError(err)
 	}
-
-	request["PolicyType"] = parts[2]
-	request["PolicyName"] = parts[1]
-	request["RoleName"] = parts[3]
+	client := meta.(*connectivity.AliyunClient)
+	ramServiceV2 := RamServiceV2{client}
+	request := identity.request()
+	action := "DetachPolicyFromRole"
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
-		response, err = client.RpcPost("Ram", "2015-05-01", action, query, request, true)
+		response, err := client.RpcPost("Ram", "2015-05-01", action, nil, request, true)
+		addDebug(action, response, request)
 
 		if err != nil {
+			if IsExpectedErrors(err, []string{"EntityNotExist.Role", "EntityNotExist.Role.Policy", "EntityNotExists.ResourceGroup"}) {
+				return nil
+			}
 			if NeedRetry(err) {
 				wait()
 				return resource.RetryableError(err)
@@ -152,14 +207,19 @@ func resourceAliCloudRamRolePolicyAttachmentDelete(d *schema.ResourceData, meta 
 		}
 		return nil
 	})
-	addDebug(action, response, request)
 
 	if err != nil {
-		if IsExpectedErrors(err, []string{"EntityNotExist.Role", "EntityNotExist.Role.Policy"}) || NotFoundError(err) {
-			return nil
-		}
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 
-	return nil
+	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		_, err := ramServiceV2.DescribeRamRolePolicyAttachment(d.Id())
+		if ramRolePolicyAttachmentNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return resource.RetryableError(fmt.Errorf("RAM role policy attachment %s is still visible", d.Id()))
+	})
 }

--- a/alicloud/resource_alicloud_ram_role_policy_attachment_test.go
+++ b/alicloud/resource_alicloud_ram_role_policy_attachment_test.go
@@ -2,11 +2,15 @@ package alicloud
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 // Test Ram RolePolicyAttachment. >>> Resource test cases, automatically generated.
@@ -78,13 +82,13 @@ func TestAccAliCloudRamRolePolicyAttachment_basic9051(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"role_name":   "${alicloud_ram_role.default.id}",
-					"policy_name": "AliyunECSFullAccess",
+					"policy_name": "AliyunECSReadOnlyAccess",
 					"policy_type": "System",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"role_name":   CHECKSET,
-						"policy_name": "AliyunECSFullAccess",
+						"policy_name": "AliyunECSReadOnlyAccess",
 						"policy_type": "System",
 					}),
 				),
@@ -157,3 +161,255 @@ func AliCloudRamRolePolicyAttachmentBasicDependence9050(name string) string {
 }
 
 // Test Ram RolePolicyAttachment. <<< Resource test cases, automatically generated.
+
+func TestAccAliCloudRamRolePolicyAttachment_resourceGroupScopes(t *testing.T) {
+	resourceId := "alicloud_ram_role_policy_attachment.default"
+	accountResourceId := "alicloud_ram_role_policy_attachment.account"
+	scopeAResourceId := "alicloud_ram_role_policy_attachment.scope_a"
+	name := fmt.Sprintf("tf-testacc-ram-scope-%d", acctest.RandIntRange(1000000, 9999999))
+	accountID, accountAlias := "", ""
+	if os.Getenv("TF_ACC") != "" {
+		testAccPreCheck(t)
+		rawClient, err := sharedClientForRegion(os.Getenv("ALICLOUD_REGION"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		client := rawClient.(*connectivity.AliyunClient)
+		accountID, err = client.AccountId()
+		if err != nil {
+			t.Fatal(err)
+		}
+		response, err := client.RpcPost("ims", "2019-08-15", "GetDefaultDomain", nil, map[string]interface{}{}, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		domain, ok := response["DefaultDomainName"].(string)
+		if !ok || !strings.HasSuffix(domain, ".onaliyun.com") {
+			t.Fatal("invalid RAM default domain")
+		}
+		accountAlias = strings.TrimSuffix(domain, ".onaliyun.com")
+		if accountAlias == "" {
+			t.Fatal("empty RAM account alias")
+		}
+	}
+	allScopes := resourceTestAccConfigFunc(resourceId, name, func(name string) string {
+		return RamRolePolicyAttachmentScopeDependence(name, true, true)
+	})
+	withoutA := resourceTestAccConfigFunc(resourceId, name, func(name string) string {
+		return RamRolePolicyAttachmentScopeDependence(name, false, true)
+	})
+	singleAttachment := resourceTestAccConfigFunc(resourceId, name, func(name string) string {
+		return RamRolePolicyAttachmentScopeDependence(name, false, false)
+	})
+	var accountIDInitial, scopeAID, scopeBID, movedID, accountIDFinal string
+	ids := map[string]bool{}
+	check := func(resourceName string, saved *string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			rs, ok := s.RootModule().Resources[resourceName]
+			if !ok || rs.Primary.ID == "" {
+				return fmt.Errorf("attachment %s missing from state", resourceName)
+			}
+			if *saved != "" && *saved != rs.Primary.ID {
+				return fmt.Errorf("attachment %s unexpectedly changed ID", resourceName)
+			}
+			*saved = rs.Primary.ID
+			ids[*saved] = true
+			return testAccRamRolePolicyAttachmentRawScope(*saved, accountID, accountAlias, true)
+		}
+	}
+	absent := func(id *string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			if *id == "" {
+				return fmt.Errorf("missing saved attachment ID")
+			}
+			return testAccRamRolePolicyAttachmentRawScope(*id, accountID, accountAlias, false)
+		}
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) }, Providers: testAccProviders, IDRefreshName: resourceId,
+		CheckDestroy: func(s *terraform.State) error {
+			for _, rs := range s.RootModule().Resources {
+				if rs.Type == "alicloud_ram_role_policy_attachment" {
+					ids[rs.Primary.ID] = true
+				}
+			}
+			for id := range ids {
+				if id != "" {
+					if err := testAccRamRolePolicyAttachmentRawScope(id, accountID, accountAlias, false); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: allScopes(map[string]interface{}{
+					"policy_name": "${alicloud_ram_policy.scope.policy_name}", "policy_type": "Custom",
+					"role_name":         "${alicloud_ram_role.scope.role_name}",
+					"resource_group_id": "${alicloud_resource_manager_resource_group.scope_b.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(check(accountResourceId, &accountIDInitial), check(scopeAResourceId, &scopeAID), check(resourceId, &scopeBID),
+					resource.TestCheckResourceAttr(accountResourceId, "resource_group_id", ""),
+					resource.TestCheckResourceAttrPair(scopeAResourceId, "resource_group_id", "alicloud_resource_manager_resource_group.scope_a", "id"),
+					resource.TestCheckResourceAttrPair(resourceId, "resource_group_id", "alicloud_resource_manager_resource_group.scope_b", "id"),
+					func(s *terraform.State) error {
+						if len(strings.Split(accountIDInitial, ":")) != 4 || len(strings.Split(scopeAID, ":")) != 5 || len(strings.Split(scopeBID, ":")) != 5 || scopeAID == scopeBID {
+							return fmt.Errorf("account/resource-group IDs are not distinct and importable")
+						}
+						return nil
+					}),
+			},
+			{ResourceName: accountResourceId, ImportState: true, ImportStateVerify: true},
+			{ResourceName: scopeAResourceId, ImportState: true, ImportStateVerify: true},
+			{ResourceName: resourceId, ImportState: true, ImportStateVerify: true},
+			{
+				Config: withoutA(map[string]interface{}{
+					"policy_name": "${alicloud_ram_policy.scope.policy_name}", "policy_type": "Custom",
+					"role_name":         "${alicloud_ram_role.scope.role_name}",
+					"resource_group_id": "${alicloud_resource_manager_resource_group.scope_b.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(absent(&scopeAID), check(accountResourceId, &accountIDInitial), check(resourceId, &scopeBID)),
+			},
+			{
+				Config: withoutA(map[string]interface{}{
+					"policy_name": "${alicloud_ram_policy.scope.policy_name}", "policy_type": "Custom",
+					"role_name":         "${alicloud_ram_role.scope.role_name}",
+					"resource_group_id": "${alicloud_resource_manager_resource_group.scope_a.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(absent(&scopeBID), check(accountResourceId, &accountIDInitial), check(resourceId, &movedID),
+					resource.TestCheckResourceAttrPair(resourceId, "resource_group_id", "alicloud_resource_manager_resource_group.scope_a", "id")),
+			},
+			{
+				Config: singleAttachment(map[string]interface{}{
+					"policy_name": "${alicloud_ram_policy.scope.policy_name}", "policy_type": "Custom",
+					"role_name":         "${alicloud_ram_role.scope.role_name}",
+					"resource_group_id": "${alicloud_resource_manager_resource_group.scope_a.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(absent(&accountIDInitial), check(resourceId, &movedID)),
+			},
+			{
+				Config: singleAttachment(map[string]interface{}{
+					"policy_name": "${alicloud_ram_policy.scope.policy_name}", "policy_type": "Custom",
+					"role_name": "${alicloud_ram_role.scope.role_name}", "resource_group_id": "",
+				}),
+				Check: resource.ComposeTestCheckFunc(absent(&movedID), check(resourceId, &accountIDFinal),
+					resource.TestCheckResourceAttr(resourceId, "resource_group_id", ""),
+					func(s *terraform.State) error {
+						if accountIDFinal != accountIDInitial {
+							return fmt.Errorf("clearing scope did not restore the legacy account ID")
+						}
+						return nil
+					}),
+			},
+			{
+				Config: singleAttachment(map[string]interface{}{
+					"policy_name": "${alicloud_ram_policy.scope.policy_name}", "policy_type": "Custom",
+					"role_name": "${alicloud_ram_role.scope.role_name}",
+				}),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccRamRolePolicyAttachmentRawScope(id, accountID, accountAlias string, present bool) error {
+	parts := strings.Split(id, ":")
+	if len(parts) != 4 && len(parts) != 5 {
+		return fmt.Errorf("invalid saved attachment ID")
+	}
+	scope := accountID
+	if len(parts) == 5 {
+		scope = parts[4]
+	}
+	request := map[string]interface{}{
+		"PolicyName": parts[1], "PolicyType": parts[2], "PrincipalType": "ServiceRole",
+		"PrincipalName": parts[3] + "@role." + accountAlias + ".onaliyunservice.com", "ResourceGroupId": scope,
+	}
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+	return resource.Retry(2*time.Minute, func() *resource.RetryError {
+		response, err := client.RpcPost("ResourceManager", "2020-03-31", "ListPolicyAttachments", nil, request, true)
+		if err != nil {
+			if !present && IsExpectedErrors(err, []string{"EntityNotExists.ResourceGroup", "EntityNotExist.Policy"}) {
+				return nil
+			}
+			return resource.NonRetryableError(err)
+		}
+		container, ok := response["PolicyAttachments"].(map[string]interface{})
+		if !ok {
+			return resource.NonRetryableError(fmt.Errorf("missing policy attachments response"))
+		}
+		items, ok := container["PolicyAttachment"].([]interface{})
+		if !ok {
+			return resource.NonRetryableError(fmt.Errorf("invalid policy attachments list"))
+		}
+		if !present {
+			if len(items) == 0 {
+				return nil
+			}
+			return resource.RetryableError(fmt.Errorf("detached scope still has an attachment"))
+		}
+		if len(items) != 1 {
+			return resource.RetryableError(fmt.Errorf("expected one attachment, got %d", len(items)))
+		}
+		item, ok := items[0].(map[string]interface{})
+		if !ok {
+			return resource.NonRetryableError(fmt.Errorf("invalid policy attachment"))
+		}
+		for field, expected := range request {
+			if actual, ok := item[field].(string); !ok || actual != expected {
+				return resource.NonRetryableError(fmt.Errorf("attachment returned a different %s", field))
+			}
+		}
+		return nil
+	})
+}
+
+func RamRolePolicyAttachmentScopeDependence(name string, includeA, includeAccount bool) string {
+	config := fmt.Sprintf(`
+variable "name" { default = %q }
+data "alicloud_account" "scope" {}
+resource "alicloud_ram_role" "scope" {
+  role_name = var.name
+  assume_role_policy_document = jsonencode({
+    Version = "1"
+    Statement = [{ Action = "sts:AssumeRole", Effect = "Allow", Principal = { RAM = [format("acs:ram::%%s:root", data.alicloud_account.scope.id)] } }]
+  })
+}
+resource "alicloud_ram_policy" "scope" {
+  policy_name = var.name
+  policy_document = jsonencode({
+    Version = "1"
+    Statement = [{ Action = ["ecs:DescribeInstances"], Effect = "Allow", Resource = ["*"] }]
+  })
+}
+resource "alicloud_resource_manager_resource_group" "scope_a" {
+  resource_group_name = "${var.name}-a"
+  display_name = "${var.name}-a"
+}
+resource "alicloud_resource_manager_resource_group" "scope_b" {
+  resource_group_name = "${var.name}-b"
+  display_name = "${var.name}-b"
+}
+`, name)
+	if includeA {
+		config += `
+resource "alicloud_ram_role_policy_attachment" "scope_a" {
+  policy_name = alicloud_ram_policy.scope.policy_name
+  policy_type = "Custom"
+  role_name = alicloud_ram_role.scope.role_name
+  resource_group_id = alicloud_resource_manager_resource_group.scope_a.id
+}
+`
+	}
+	if includeAccount {
+		config += `
+resource "alicloud_ram_role_policy_attachment" "account" {
+  policy_name = alicloud_ram_policy.scope.policy_name
+  policy_type = "Custom"
+  role_name = alicloud_ram_role.scope.role_name
+}
+`
+	}
+	return config
+}

--- a/alicloud/service_alicloud_ram_v2.go
+++ b/alicloud/service_alicloud_ram_v2.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -337,63 +338,92 @@ func (s *RamServiceV2) RamSamlProviderStateRefreshFunc(id string, field string, 
 
 // DescribeRamRolePolicyAttachment <<< Encapsulated get interface for Ram RolePolicyAttachment.
 
-func (s *RamServiceV2) DescribeRamRolePolicyAttachment(id string) (object map[string]interface{}, err error) {
+func (s *RamServiceV2) DescribeRamRolePolicyAttachment(id string) (map[string]interface{}, error) {
 	client := s.client
-	var request map[string]interface{}
-	var response map[string]interface{}
-	var query map[string]interface{}
-	parts := strings.Split(id, ":")
-	if len(parts) != 4 {
-		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 3, len(parts)))
+	identity, err := parseRamRolePolicyAttachmentID(id)
+	if err != nil {
+		return nil, WrapError(err)
 	}
-	request = make(map[string]interface{})
-	query = make(map[string]interface{})
-	request["RoleName"] = parts[3]
-
-	action := "ListPoliciesForRole"
-
-	wait := incrementalWait(3*time.Second, 5*time.Second)
-	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
-		response, err = client.RpcPost("Ram", "2015-05-01", action, query, request, true)
-
+	scope := identity.scope
+	if scope == "" {
+		scope, err = client.AccountId()
 		if err != nil {
-			if NeedRetry(err) {
-				wait()
-				return resource.RetryableError(err)
+			return nil, WrapError(err)
+		}
+		if scope == "" {
+			return nil, fmt.Errorf("cannot resolve account scope for RAM role policy attachment")
+		}
+	}
+	request := map[string]interface{}{
+		"PolicyName": identity.policyName, "PolicyType": identity.policyType,
+		"PrincipalType": "ServiceRole", "ResourceGroupId": scope, "PageSize": 100,
+	}
+	action := "ListPolicyAttachments"
+	seen := 0
+	for page := 1; ; page++ {
+		request["PageNumber"] = page
+		var response map[string]interface{}
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(time.Minute, func() *resource.RetryError {
+			var err error
+			response, err = client.RpcPost("ResourceManager", "2020-03-31", action, nil, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
 			}
-			return resource.NonRetryableError(err)
+			return nil
+		})
+		addDebug(action, response, request)
+		if err != nil {
+			if IsExpectedErrors(err, []string{"EntityNotExists.ResourceGroup", "EntityNotExist.Policy"}) {
+				return nil, WrapErrorf(NotFoundErr("RolePolicyAttachment", id), NotFoundMsg, response)
+			}
+			return nil, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
 		}
-		return nil
-	})
-	addDebug(action, response, request)
-	if err != nil {
-		if IsExpectedErrors(err, []string{"EntityNotExist.Role"}) {
-			return object, WrapErrorf(NotFoundErr("RolePolicyAttachment", id), NotFoundMsg, response)
+		container, ok := response["PolicyAttachments"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("%s returned an invalid PolicyAttachments object", action)
 		}
-		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
-	}
-
-	v, err := jsonpath.Get("$.Policies.Policy[*]", response)
-	if err != nil {
-		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.Policies.Policy[*]", response)
-	}
-
-	if len(v.([]interface{})) == 0 {
-		return object, WrapErrorf(NotFoundErr("RolePolicyAttachment", id), NotFoundMsg, response)
-	}
-
-	result, _ := v.([]interface{})
-	for _, v := range result {
-		item := v.(map[string]interface{})
-		if fmt.Sprint(item["PolicyName"]) != parts[1] {
-			continue
+		items, ok := container["PolicyAttachment"].([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("%s returned an invalid PolicyAttachment list", action)
 		}
-		if fmt.Sprint(item["PolicyType"]) != parts[2] {
-			continue
+		total, err := strconv.Atoi(fmt.Sprint(response["TotalCount"]))
+		if err != nil || total < 0 || total < seen+len(items) || (len(items) == 0 && seen < total) {
+			return nil, fmt.Errorf("%s returned inconsistent pagination metadata", action)
 		}
-		return item, nil
+		for _, value := range items {
+			item, ok := value.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("%s returned an invalid attachment", action)
+			}
+			fields := make(map[string]string, 5)
+			for _, field := range []string{"PolicyName", "PolicyType", "PrincipalType", "PrincipalName", "ResourceGroupId"} {
+				text, ok := item[field].(string)
+				if !ok || text == "" {
+					return nil, fmt.Errorf("%s returned an invalid attachment %s", action, field)
+				}
+				fields[field] = text
+			}
+			if fields["PrincipalType"] != "ServiceRole" {
+				continue
+			}
+			principal := strings.Split(fields["PrincipalName"], "@role.")
+			if len(principal) != 2 || principal[0] == "" || !strings.HasSuffix(principal[1], ".onaliyunservice.com") || strings.TrimSuffix(principal[1], ".onaliyunservice.com") == "" {
+				return nil, fmt.Errorf("%s returned an invalid ServiceRole principal", action)
+			}
+			if fields["PolicyName"] == identity.policyName && fields["PolicyType"] == identity.policyType && principal[0] == identity.roleName && fields["ResourceGroupId"] == scope {
+				return item, nil
+			}
+		}
+		seen += len(items)
+		if seen >= total {
+			return nil, WrapErrorf(NotFoundErr("RolePolicyAttachment", id), NotFoundMsg, response)
+		}
 	}
-	return object, WrapErrorf(NotFoundErr("RolePolicyAttachment", id), NotFoundMsg, response)
 }
 
 func (s *RamServiceV2) RamRolePolicyAttachmentStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {

--- a/website/docs/r/ram_role_policy_attachment.html.markdown
+++ b/website/docs/r/ram_role_policy_attachment.html.markdown
@@ -16,6 +16,10 @@ For information about RAM Role Policy Attachment and how to use it, see [What is
 
 -> **NOTE:** Available since v1.0.0.
 
+Set `resource_group_id` to grant permissions within a resource group. Omitting it or setting it to an empty string grants permissions at the account level.
+
+-> **NOTE:** Reading this resource uses ResourceManager `ListPolicyAttachments`. The credentials running Terraform must allow `ram:ListPolicyAttachments`, including when managing existing account-level attachments.
+
 ## Example Usage
 
 Basic Usage
@@ -85,6 +89,27 @@ resource "alicloud_ram_role_policy_attachment" "attach" {
 }
 ```
 
+
+Resource Group Scope
+
+The following attachment grants the same role and policy access within one resource group:
+
+```terraform
+resource "alicloud_resource_manager_resource_group" "group" {
+  resource_group_name = "example-group"
+  display_name        = "Example group"
+}
+
+resource "alicloud_ram_role_policy_attachment" "group" {
+  policy_name       = alicloud_ram_policy.policy.policy_name
+  policy_type       = alicloud_ram_policy.policy.type
+  role_name         = alicloud_ram_role.role.role_name
+  resource_group_id = alicloud_resource_manager_resource_group.group.id
+}
+```
+
+Account-level and resource-group attachments can coexist. Adding a resource-group attachment does not narrow an existing account-level attachment. To remove an unneeded account-level grant, remove that attachment from the configuration and review the Terraform plan before applying it.
+
 📚 Need more examples? [VIEW MORE EXAMPLES](https://api.aliyun.com/terraform?activeTab=sample&source=Sample&sourcePath=OfficialSample:alicloud_ram_role_policy_attachment&spm=docs.r.ram_role_policy_attachment.example&intl_lang=EN_US)
 
 ## Argument Reference
@@ -95,11 +120,12 @@ The following arguments are supported:
   - Custom: Custom policy.
   - System: System policy.
 * `role_name` - (Required, ForceNew) The RAM role name.
+* `resource_group_id` - (Optional, ForceNew) The resource group in which the policy is attached. Omit this argument or use an empty string for account-level authorization. Changing the scope replaces the attachment.
 
 ## Attributes Reference
 
 The following attributes are exported:
-* `id` - The ID of the resource supplied above. The value is formulated as `role:<policy_name>:<policy_type>:<role_name>`.
+* `id` - Account-level attachments use `role:<policy_name>:<policy_type>:<role_name>`. Resource-group attachments use `role:<policy_name>:<policy_type>:<role_name>:<resource_group_id>`. Existing account-level IDs remain valid.
 
 ## Timeouts
 
@@ -113,4 +139,10 @@ RAM Role Policy Attachment can be imported using the id, e.g.
 
 ```shell
 $ terraform import alicloud_ram_role_policy_attachment.example role:<policy_name>:<policy_type>:<role_name>
+```
+
+For a resource-group attachment, append the resource group ID:
+
+```shell
+$ terraform import alicloud_ram_role_policy_attachment.example role:<policy_name>:<policy_type>:<role_name>:<resource_group_id>
 ```


### PR DESCRIPTION
Add optional `resource_group_id` support to `alicloud_ram_role_policy_attachment`.

- Send the selected scope in RAM attach/detach requests. Read through `RamServiceV2` using ResourceManager `ListPolicyAttachments`, explicit scope, and exact attachment matching.
- Preserve existing four-part account IDs and add five-part resource-group IDs for imports. Read and delete use the stored identity; pagination, visibility delays, and error handling preserve scope and state.
- Document the additional `ram:ListPolicyAttachments` read permission and account/resource-group coexistence. Add a scoped acceptance case and retain the Custom-policy and read-only System-policy cases.

Validation: Go 1.25.0 acceptance-test compilation and `go vet -p=1 ./alicloud` passed for the service-call cleanup. The three acceptance tests passed at `99bab17e4fc9fc5fd7b8b3e17a56561fc06552a9` (39.91s, 6.10s, 6.07s), covering account/A/B coexistence, all three imports, independent deletion, scope replacement and clearing, and omitted/empty scope equivalence. The acceptance-test source is unchanged; the later service-call cleanup preserves the validated query and lifecycle behavior.

Also removes two no-op `fmt.Sprintln` calls that block package vet, preserving the existing YAML comparison behavior.
