### PR TITLE
New Resource: alicloud_cms_entity_store

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1027,6 +1027,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cms_prometheus_instance":                              resourceAliCloudCmsPrometheusInstance(),
 			"alicloud_cms_integration_policy":                               resourceAliCloudCmsIntegrationPolicy(),
 			"alicloud_cms_workspace":                                        resourceAliCloudCmsWorkspace(),
+			"alicloud_cms_entity_store":                                     resourceAliCloudCmsEntityStore(),
 			"alicloud_cms_dataset":                                          resourceAliCloudCmsDataset(),
 			"alicloud_cloud_firewall_vpc_firewall_control_policy_order":     resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrder(),
 			"alicloud_cloud_firewall_nat_firewall_control_policy_order":     resourceAliCloudCloudFirewallNatFirewallControlPolicyOrder(),

--- a/alicloud/resource_alicloud_cms_entity_store.go
+++ b/alicloud/resource_alicloud_cms_entity_store.go
@@ -1,0 +1,125 @@
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudCmsEntityStore() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudCmsEntityStoreCreate,
+		Read:   resourceAliCloudCmsEntityStoreRead,
+		Delete: resourceAliCloudCmsEntityStoreDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"workspace_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudCmsEntityStoreCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	workspaceName := d.Get("workspace_name").(string)
+	action := fmt.Sprintf("/workspace/%s/entitystore", workspaceName)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	wait := incrementalWait(3*time.Second, 0*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RoaPost("Cms", "2024-03-30", action, query, nil, body, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_cms_entity_store", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprint(response["workspaceName"]))
+
+	return resourceAliCloudCmsEntityStoreRead(d, meta)
+}
+
+func resourceAliCloudCmsEntityStoreRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	cmsServiceV2 := CmsServiceV2{client}
+
+	objectRaw, err := cmsServiceV2.DescribeCmsEntityStore(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_cms_entity_store DescribeCmsEntityStore Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("workspace_name", objectRaw["workspaceName"])
+	d.Set("region_id", objectRaw["regionId"])
+
+	return nil
+}
+
+func resourceAliCloudCmsEntityStoreDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	workspaceName := d.Id()
+	action := fmt.Sprintf("/workspace/%s/entitystore", workspaceName)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+
+	wait := incrementalWait(3*time.Second, 0*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RoaDelete("Cms", "2024-03-30", action, query, nil, nil, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"EntityStoreNotExist", "WorkspaceNotAvailable"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_cms_entity_store_test.go
+++ b/alicloud/resource_alicloud_cms_entity_store_test.go
@@ -1,0 +1,76 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccAliCloudCmsEntityStore_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_cms_entity_store.default"
+	ra := resourceAttrInit(resourceId, AliCloudCmsEntityStoreMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &CmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeCmsEntityStore")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tfacccms%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCmsEntityStoreBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"workspace_name": "${alicloud_cms_workspace.default.workspace_name}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"workspace_name": CHECKSET,
+						"region_id":      CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AliCloudCmsEntityStoreMap = map[string]string{
+	"region_id": CHECKSET,
+}
+
+func AliCloudCmsEntityStoreBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+    project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+    workspace_name = var.name
+    sls_project    = alicloud_log_project.default.project_name
+}
+`, name)
+}

--- a/alicloud/service_alicloud_cms_v2.go
+++ b/alicloud/service_alicloud_cms_v2.go
@@ -54,6 +54,43 @@ func (s *CmsServiceV2) DescribeCmsWorkspace(id string) (object map[string]interf
 	return response, nil
 }
 
+// DescribeCmsEntityStore <<< Encapsulated get interface for Cms EntityStore.
+
+func (s *CmsServiceV2) DescribeCmsEntityStore(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	workspaceName := id
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	action := fmt.Sprintf("/workspace/%s/entitystore", workspaceName)
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RoaGet("Cms", "2024-03-30", action, query, nil, nil)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"EntityStoreNotExist", "WorkspaceNotAvailable"}) {
+			return object, WrapErrorf(NotFoundErr("EntityStore", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
 func (s *CmsServiceV2) CmsWorkspaceStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
 	return s.CmsWorkspaceStateRefreshFuncWithApi(id, field, failStates, s.DescribeCmsWorkspace)
 }

--- a/website/docs/r/cms_entity_store.html.markdown
+++ b/website/docs/r/cms_entity_store.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "Cms"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_entity_store"
+description: |-
+  Provides a Alicloud Cms EntityStore resource.
+---
+
+# alicloud_cms_entity_store
+
+Provides a Cms EntityStore resource.
+
+EntityStore is a singleton sub-resource of a Cms Workspace. It is identified by
+the workspace name and does not support in-place updates; any change to the
+identity forces a new resource.
+
+For information about Cms EntityStore and how to use it, see [What is EntityStore](https://next.api.alibabacloud.com/document/Cms/2024-03-30/CreateEntityStore).
+
+-> **NOTE:** Available since v1.277.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+
+resource "alicloud_cms_entity_store" "default" {
+  workspace_name = alicloud_cms_workspace.default.workspace_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `workspace_name` - (Required, ForceNew) The name of the workspace that the EntityStore belongs to. EntityStore is a singleton resource identified by the workspace name.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. It is the workspace name.
+* `region_id` - The region ID of the resource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the EntityStore.
+* `delete` - (Defaults to 5 mins) Used when delete the EntityStore.
+
+## Import
+
+Cms EntityStore can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_cms_entity_store.example <workspace_name>
+```


### PR DESCRIPTION
### New Resource: alicloud_cms_entity_store

This PR adds the `alicloud_cms_entity_store` resource, which manages a Cms EntityStore. EntityStore is a singleton sub-resource of a Cms Workspace and is identified by the workspace name.

### Schema

- `workspace_name` - (Required, ForceNew) The name of the workspace that the EntityStore belongs to.
- `region_id` - (Computed) The region ID of the resource.

### CRUD mapping

- Create -> `CreateEntityStore` (POST `/workspace/{workspaceName}/entitystore`)
- Read -> `GetEntityStore` (GET `/workspace/{workspaceName}/entitystore`)
- Delete -> `DeleteEntityStore` (DELETE `/workspace/{workspaceName}/entitystore`)

EntityStore does not support an in-place update operation; changing the identity forces a new resource. `EntityStoreNotExist` is treated as a not-found condition on read and delete (idempotent delete).

### Import

The resource can be imported using the workspace name:

```
$ terraform import alicloud_cms_entity_store.example <workspace_name>
```

### Test

- `TestAccAliCloudCmsEntityStore_basic` (basic create + import state verify)

```
=== RUN TestAccAliCloudCmsEntityStore_basic
--- PASS: TestAccAliCloudCmsEntityStore_basic
```
