### PR TITLE
alicloud: deprecate tags schema helpers without Elem and add WithElements variants

### DIFF
--- a/alicloud/tags.go
+++ b/alicloud/tags.go
@@ -24,7 +24,41 @@ func String(v string) *string {
 	return &v
 }
 
+func tagsSchemaWithElements() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeMap,
+		Optional: true,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	}
+}
+
+func tagsSchemaForceNewWithElements() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeMap,
+		Optional: true,
+		ForceNew: true,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	}
+}
+
+func tagsSchemaComputedWithElements() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeMap,
+		Optional: true,
+		Computed: true,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	}
+}
+
 // lintignore: S006
+// Deprecated: Use tagsSchemaWithElements instead, which declares the string
+// element type explicitly.
 func tagsSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeMap,
@@ -33,6 +67,8 @@ func tagsSchema() *schema.Schema {
 }
 
 // lintignore: S006
+// Deprecated: Use tagsSchemaForceNewWithElements instead, which declares the
+// string element type explicitly.
 func tagsSchemaForceNew() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeMap,
@@ -42,6 +78,8 @@ func tagsSchemaForceNew() *schema.Schema {
 }
 
 // lintignore: S006
+// Deprecated: Use tagsSchemaComputedWithElements instead, which declares the
+// string element type explicitly.
 func tagsSchemaComputed() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeMap,


### PR DESCRIPTION
### Description

Marks the three legacy tags schema helpers that omit `Elem` as deprecated and introduces `Elem`-carrying replacements:

| Deprecated | Replacement |
|---|---|
| `tagsSchema()` | `tagsSchemaWithElements()` |
| `tagsSchemaForceNew()` | `tagsSchemaForceNewWithElements()` |
| `tagsSchemaComputed()` | `tagsSchemaComputedWithElements()` |

A `TypeMap` attribute without `Elem` leaves the element type implicit. Declaring `Elem: &schema.Schema{Type: schema.TypeString}` explicitly makes the schema self-describing and keeps it friendly to schema conversion tooling; `tagsSchemaWithElements` already exists on `release/v2` with the same shape, and this brings master in line with it.

`tagsSchemaWithIgnore` already declares `Elem` and is left unchanged.

No call sites are modified in this PR: existing resources keep working unchanged and can migrate to the new helpers incrementally.

### Test plan

Comment-only change plus additive (currently unused) helper functions — no behavior change, so no acceptance tests are required. `go build ./alicloud/` and `gofmt` pass.
