### PR TITLE
resource/alicloud_cms_agg_task_group: support from_time and tags; New Data Source: alicloud_cms_agg_task_groups

### DIFF
--- a/alicloud/data_source_alicloud_cms_agg_task_groups.go
+++ b/alicloud/data_source_alicloud_cms_agg_task_groups.go
@@ -1,0 +1,279 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceAliCloudCmsAggTaskGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudCmsAggTaskGroupsRead,
+		Schema: map[string]*schema.Schema{
+			"source_prometheus_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"name_regex": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"agg_task_group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"agg_task_group_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_prometheus_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"target_prometheus_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"cron_expr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"delay": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"from_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"interval": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"max_retries": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"max_run_time_in_seconds": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"schedule_mode": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"schedule_time_expr": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"to_time": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tags": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudCmsAggTaskGroupsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	var objects []map[string]interface{}
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	sourcePrometheusId := d.Get("source_prometheus_id").(string)
+	action := fmt.Sprintf("/prometheus-instances/%s/agg-task-groups", sourcePrometheusId)
+	var response map[string]interface{}
+	var err error
+	query := make(map[string]*string)
+	query["maxResults"] = StringPointer("100")
+
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			response, err = client.RoaGet("Cms", "2024-03-30", action, query, nil, nil)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, query)
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, "alicloud_cms_agg_task_groups", action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, _ := jsonpath.Get("$.aggTaskGroups[*]", response)
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if nameRegex != nil && !nameRegex.MatchString(fmt.Sprint(item["aggTaskGroupName"])) {
+				continue
+			}
+			if len(idsMap) > 0 {
+				id := fmt.Sprintf("%v:%v", sourcePrometheusId, item["aggTaskGroupId"])
+				if _, ok := idsMap[fmt.Sprint(item["aggTaskGroupId"])]; !ok {
+					if _, ok := idsMap[id]; !ok {
+						continue
+					}
+				}
+			}
+			objects = append(objects, item)
+		}
+
+		nextToken, _ := response["nextToken"].(string)
+		if nextToken == "" {
+			break
+		}
+		query["nextToken"] = StringPointer(nextToken)
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, objectRaw := range objects {
+		mapping := map[string]interface{}{}
+
+		id := fmt.Sprintf("%v:%v", sourcePrometheusId, objectRaw["aggTaskGroupId"])
+		mapping["id"] = id
+		mapping["agg_task_group_id"] = objectRaw["aggTaskGroupId"]
+		mapping["agg_task_group_name"] = objectRaw["aggTaskGroupName"]
+		mapping["source_prometheus_id"] = objectRaw["sourcePrometheusId"]
+		mapping["target_prometheus_id"] = objectRaw["targetPrometheusId"]
+		mapping["cron_expr"] = objectRaw["cronExpr"]
+		mapping["delay"] = objectRaw["delay"]
+		mapping["description"] = objectRaw["description"]
+		mapping["from_time"] = objectRaw["fromTime"]
+		mapping["interval"] = objectRaw["interval"]
+		mapping["max_retries"] = objectRaw["maxRetries"]
+		mapping["max_run_time_in_seconds"] = objectRaw["maxRunTimeInSeconds"]
+		mapping["region_id"] = objectRaw["regionId"]
+		mapping["schedule_mode"] = objectRaw["scheduleMode"]
+		mapping["schedule_time_expr"] = objectRaw["scheduleTimeExpr"]
+		mapping["status"] = objectRaw["status"]
+		mapping["to_time"] = objectRaw["toTime"]
+		mapping["update_time"] = objectRaw["updateTime"]
+
+		tagsMaps := make(map[string]interface{})
+		if tagsRaw, ok := objectRaw["tags"]; ok && tagsRaw != nil {
+			for _, tagRaw := range convertToInterfaceArray(tagsRaw) {
+				tagMap, ok := tagRaw.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				key := tagMap["key"]
+				if key == nil {
+					key = tagMap["Key"]
+				}
+				value := tagMap["value"]
+				if value == nil {
+					value = tagMap["Value"]
+				}
+				if key != nil && value != nil {
+					keyStr := fmt.Sprint(key)
+					if strings.HasPrefix(keyStr, "acs:") {
+						continue
+					}
+					tagsMaps[keyStr] = fmt.Sprint(value)
+				}
+			}
+		}
+		mapping["tags"] = tagsMaps
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, objectRaw["aggTaskGroupName"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+	if err := d.Set("groups", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+	return nil
+}

--- a/alicloud/data_source_alicloud_cms_agg_task_groups_test.go
+++ b/alicloud/data_source_alicloud_cms_agg_task_groups_test.go
@@ -1,0 +1,128 @@
+package alicloud
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+)
+
+func TestAccAliCloudCmsAggTaskGroupsDataSource_basic(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudCmsAggTaskGroupsDataSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_cms_agg_task_group.default.agg_task_group_id}"]`,
+		}),
+		fakeConfig: testAccCheckAliCloudCmsAggTaskGroupsDataSourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_cms_agg_task_group.default.agg_task_group_id}_fake"]`,
+		}),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudCmsAggTaskGroupsDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_cms_agg_task_group.default.agg_task_group_name}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudCmsAggTaskGroupsDataSourceConfig(rand, map[string]string{
+			"name_regex": `"${alicloud_cms_agg_task_group.default.agg_task_group_name}_fake"`,
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAliCloudCmsAggTaskGroupsDataSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_cms_agg_task_group.default.agg_task_group_id}"]`,
+			"name_regex": `"${alicloud_cms_agg_task_group.default.agg_task_group_name}"`,
+		}),
+		fakeConfig: testAccCheckAliCloudCmsAggTaskGroupsDataSourceConfig(rand, map[string]string{
+			"ids":        `["${alicloud_cms_agg_task_group.default.agg_task_group_id}_fake"]`,
+			"name_regex": `"${alicloud_cms_agg_task_group.default.agg_task_group_name}_fake"`,
+		}),
+	}
+
+	var existCmsAggTaskGroupsMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":                         "1",
+			"names.#":                       "1",
+			"groups.#":                      "1",
+			"groups.0.id":                   CHECKSET,
+			"groups.0.agg_task_group_id":    CHECKSET,
+			"groups.0.agg_task_group_name":  CHECKSET,
+			"groups.0.source_prometheus_id": CHECKSET,
+			"groups.0.target_prometheus_id": CHECKSET,
+			"groups.0.status":               CHECKSET,
+		}
+	}
+
+	var fakeCmsAggTaskGroupsMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":    "0",
+			"names.#":  "0",
+			"groups.#": "0",
+		}
+	}
+
+	var cmsAggTaskGroupsCheckInfo = dataSourceAttr{
+		resourceId:   "data.alicloud_cms_agg_task_groups.default",
+		existMapFunc: existCmsAggTaskGroupsMapFunc,
+		fakeMapFunc:  fakeCmsAggTaskGroupsMapFunc,
+	}
+
+	cmsAggTaskGroupsCheckInfo.dataSourceTestCheckWithPreCheck(t, rand, func() {
+		testAccPreCheck(t)
+		testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	}, idsConf, nameRegexConf, allConf)
+}
+
+func testAccCheckAliCloudCmsAggTaskGroupsDataSourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+
+	config := fmt.Sprintf(`
+variable "name" {
+  default = "tfacccms%d"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+
+resource "alicloud_cms_prometheus_instance" "default" {
+  count                    = 2
+  prometheus_instance_name = "${var.name}_${count.index}"
+  workspace                = alicloud_cms_workspace.default.id
+}
+
+resource "alicloud_cms_agg_task_group" "default" {
+  source_prometheus_id  = alicloud_cms_prometheus_instance.default.0.id
+  target_prometheus_id  = alicloud_cms_prometheus_instance.default.1.id
+  agg_task_group_name   = var.name
+  agg_task_group_config = <<EOF
+groups:
+- name: "node.rules"
+  interval: "60s"
+  rules:
+  - record: "node_namespace_pod:kube_pod_info:"
+    expr: "max(label_replace(kube_pod_info{job=\"kubernetes-pods-kube-state-metrics\" }, \"pod\", \"$1\", \"pod\", \"(.*)\")) by (node, namespace, pod, cluster)"
+EOF
+}
+
+data "alicloud_cms_agg_task_groups" "default" {
+  source_prometheus_id = alicloud_cms_agg_task_group.default.source_prometheus_id
+  %s
+}
+`, rand, strings.Join(pairs, "\n  "))
+	return config
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -823,6 +823,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_ecd_desktop_types":                                dataSourceAlicloudEcdDesktopTypes(),
 			"alicloud_config_deliveries":                                dataSourceAlicloudConfigDeliveries(),
 			"alicloud_cms_namespaces":                                   dataSourceAlicloudCmsNamespaces(),
+			"alicloud_cms_agg_task_groups":                              dataSourceAliCloudCmsAggTaskGroups(),
 			"alicloud_cms_datasets":                                     dataSourceAliCloudCmsDatasets(),
 			"alicloud_cms_sls_groups":                                   dataSourceAlicloudCmsSlsGroups(),
 			"alicloud_config_aggregate_deliveries":                      dataSourceAlicloudConfigAggregateDeliveries(),

--- a/alicloud/resource_alicloud_cms_agg_task_group.go
+++ b/alicloud/resource_alicloud_cms_agg_task_group.go
@@ -69,6 +69,17 @@ func resourceAliCloudCmsAggTaskGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"from_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if newTs, err := strconv.Atoi(new); err == nil && int64(newTs) <= time.Now().Unix() {
+						return true
+					}
+					return false
+				},
+			},
 			"max_retries": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -117,6 +128,12 @@ func resourceAliCloudCmsAggTaskGroup() *schema.Resource {
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: StringInSlice([]string{"Running", "Stopped"}, false),
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"target_prometheus_id": {
 				Type:     schema.TypeString,
@@ -174,8 +191,21 @@ func resourceAliCloudCmsAggTaskGroupCreate(d *schema.ResourceData, meta interfac
 		request["maxRunTimeInSeconds"] = v
 	}
 	request["targetPrometheusId"] = d.Get("target_prometheus_id")
+	if v, ok := d.GetOkExists("from_time"); ok {
+		request["fromTime"] = v
+	}
 	if v, ok := d.GetOkExists("to_time"); ok {
 		request["toTime"] = v
+	}
+	if v, ok := d.GetOk("tags"); ok {
+		tagsMaps := make([]map[string]interface{}, 0)
+		for key, value := range v.(map[string]interface{}) {
+			tagsMaps = append(tagsMaps, map[string]interface{}{
+				"key":   key,
+				"value": value,
+			})
+		}
+		request["tags"] = tagsMaps
 	}
 	if v, ok := d.GetOkExists("max_retries"); ok {
 		request["maxRetries"] = v
@@ -243,7 +273,34 @@ func resourceAliCloudCmsAggTaskGroupRead(d *schema.ResourceData, meta interface{
 	d.Set("schedule_time_expr", objectRaw["scheduleTimeExpr"])
 	d.Set("status", objectRaw["status"])
 	d.Set("target_prometheus_id", objectRaw["targetPrometheusId"])
+	d.Set("from_time", objectRaw["fromTime"])
 	d.Set("to_time", objectRaw["toTime"])
+
+	tagsMaps := make(map[string]interface{})
+	if tagsRaw, ok := objectRaw["tags"]; ok && tagsRaw != nil {
+		for _, tagRaw := range convertToInterfaceArray(tagsRaw) {
+			tagMap, ok := tagRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			key := tagMap["key"]
+			if key == nil {
+				key = tagMap["Key"]
+			}
+			value := tagMap["value"]
+			if value == nil {
+				value = tagMap["Value"]
+			}
+			if key != nil && value != nil {
+				keyStr := fmt.Sprint(key)
+				if strings.HasPrefix(keyStr, "acs:") {
+					continue
+				}
+				tagsMaps[keyStr] = fmt.Sprint(value)
+			}
+		}
+	}
+	d.Set("tags", tagsMaps)
 	d.Set("agg_task_group_id", objectRaw["aggTaskGroupId"])
 	d.Set("source_prometheus_id", objectRaw["sourcePrometheusId"])
 
@@ -323,6 +380,12 @@ func resourceAliCloudCmsAggTaskGroupUpdate(d *schema.ResourceData, meta interfac
 		update = true
 	}
 	request["targetPrometheusId"] = d.Get("target_prometheus_id")
+	if d.HasChange("from_time") {
+		update = true
+	}
+	if v, ok := d.GetOkExists("from_time"); ok || d.HasChange("from_time") {
+		request["fromTime"] = v
+	}
 	if d.HasChange("to_time") {
 		update = true
 	}

--- a/alicloud/resource_alicloud_cms_agg_task_group_test.go
+++ b/alicloud/resource_alicloud_cms_agg_task_group_test.go
@@ -23,11 +23,13 @@ func TestAccAliCloudCmsAggTaskGroup_basic8019(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tfacccms%d", rand)
+	fromTime := time.Now().Unix()
 	toTime := time.Now().AddDate(0, 0, 2).Unix()
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCmsAggTaskGroupBasicDependence8019)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
@@ -190,6 +192,31 @@ func TestAccAliCloudCmsAggTaskGroup_basic8019(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccConfig(map[string]interface{}{
+					"from_time": fromTime,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"from_time": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]interface{}{
+						"Created": "TF",
+						"For":     "agg-task-group",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.%":       "2",
+						"tags.Created": "TF",
+						"tags.For":     "agg-task-group",
+					}),
+				),
+			},
+			{
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -210,11 +237,13 @@ func TestAccAliCloudCmsAggTaskGroup_basic8019_twin(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
 	name := fmt.Sprintf("tfacccms%d", rand)
+	fromTime := time.Now().Unix()
 	toTime := time.Now().AddDate(0, 0, 2).Unix()
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudCmsAggTaskGroupBasicDependence8019)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
 		},
 		IDRefreshName: resourceId,
 		Providers:     testAccProviders,
@@ -230,14 +259,19 @@ func TestAccAliCloudCmsAggTaskGroup_basic8019_twin(t *testing.T) {
 					"cron_expr":                  "0/1 * * * *",
 					"delay":                      "60",
 					"description":                name,
+					"from_time":                  fromTime,
 					"max_retries":                "18",
 					"max_run_time_in_seconds":    "200",
 					"precheck_string":            `{\"policy\":\"skip\",\"prometheusId\":\"` + "${alicloud_cms_prometheus_instance.default.0.id}" + `\",\"query\":\"noPrecheck\",\"threshold\":0.5,\"timeout\":20,\"type\":\"none\"}`,
 					"schedule_mode":              "Cron",
 					"schedule_time_expr":         "@s",
 					"status":                     "Running",
-					"to_time":                    toTime,
-					"override_if_exists":         "true",
+					"tags": map[string]interface{}{
+						"Created": "TF",
+						"For":     "agg-task-group",
+					},
+					"to_time":            toTime,
+					"override_if_exists": "true",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -248,12 +282,16 @@ func TestAccAliCloudCmsAggTaskGroup_basic8019_twin(t *testing.T) {
 						"cron_expr":               "0/1 * * * *",
 						"delay":                   "60",
 						"description":             name,
+						"from_time":               CHECKSET,
 						"max_retries":             "18",
 						"max_run_time_in_seconds": "200",
 						"precheck_string":         CHECKSET,
 						"schedule_mode":           "Cron",
 						"schedule_time_expr":      "@s",
 						"status":                  "Running",
+						"tags.%":                  "2",
+						"tags.Created":            "TF",
+						"tags.For":                "agg-task-group",
 						"to_time":                 CHECKSET,
 					}),
 				),
@@ -284,6 +322,10 @@ func AliCloudCmsAggTaskGroupBasicDependence8019(name string) string {
 	return fmt.Sprintf(`
 variable "name" {
     default = "%s"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
 }
 
 resource "alicloud_log_project" "default" {

--- a/website/docs/d/cms_agg_task_groups.html.markdown
+++ b/website/docs/d/cms_agg_task_groups.html.markdown
@@ -1,0 +1,96 @@
+---
+subcategory: "Cms"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_cms_agg_task_groups"
+description: |-
+  Provides a list of Cms Agg Task Groups to the user.
+---
+
+# alicloud_cms_agg_task_groups
+
+This data source provides the Cms Agg Task Groups of the current Alibaba Cloud user.
+
+-> **NOTE:** Available since v1.289.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+resource "alicloud_log_project" "default" {
+  project_name = var.name
+}
+
+resource "alicloud_cms_workspace" "default" {
+  workspace_name = var.name
+  sls_project    = alicloud_log_project.default.project_name
+}
+
+resource "alicloud_cms_prometheus_instance" "default" {
+  count                    = 2
+  prometheus_instance_name = "${var.name}_${count.index}"
+  workspace                = alicloud_cms_workspace.default.id
+}
+
+resource "alicloud_cms_agg_task_group" "default" {
+  source_prometheus_id  = alicloud_cms_prometheus_instance.default.0.id
+  target_prometheus_id  = alicloud_cms_prometheus_instance.default.1.id
+  agg_task_group_name   = var.name
+  agg_task_group_config = <<EOF
+groups:
+- name: "node.rules"
+  interval: "60s"
+  rules:
+  - record: "node_namespace_pod:kube_pod_info:"
+    expr: "max(label_replace(kube_pod_info{job=\"kubernetes-pods-kube-state-metrics\" }, \"pod\", \"$1\", \"pod\", \"(.*)\")) by (node, namespace, pod, cluster)"
+EOF
+}
+
+data "alicloud_cms_agg_task_groups" "default" {
+  source_prometheus_id = alicloud_cms_agg_task_group.default.source_prometheus_id
+  ids                  = [alicloud_cms_agg_task_group.default.agg_task_group_id]
+}
+
+output "first_agg_task_group_name" {
+  value = data.alicloud_cms_agg_task_groups.default.groups.0.agg_task_group_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `source_prometheus_id` - (Required) The ID of the source Prometheus instance of the aggregation task groups.
+* `ids` - (Optional) A list of aggregation task group IDs. Both the plain `<agg_task_group_id>` and the resource ID format `<source_prometheus_id>:<agg_task_group_id>` are supported.
+* `name_regex` - (Optional) A regex string to filter results by aggregation task group name.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `names` - A list of aggregation task group names.
+* `groups` - A list of aggregation task groups. Each element contains the following attributes:
+  * `id` - The resource ID in terraform of the aggregation task group. It formats as `<source_prometheus_id>:<agg_task_group_id>`.
+  * `agg_task_group_id` - The ID of the aggregation task group.
+  * `agg_task_group_name` - The name of the aggregation task group.
+  * `source_prometheus_id` - The ID of the source Prometheus instance.
+  * `target_prometheus_id` - The ID of the target Prometheus instance.
+  * `cron_expr` - The cron expression for scheduling when `schedule_mode` is set to `Cron`.
+  * `delay` - The fixed delay for scheduling.
+  * `description` - The description of the aggregation task group.
+  * `from_time` - The UNIX timestamp for the scheduling start time.
+  * `interval` - The scheduling interval of the aggregation task group.
+  * `max_retries` - The maximum number of retries for an aggregation task.
+  * `max_run_time_in_seconds` - The maximum run time of an aggregation task.
+  * `region_id` - The region ID.
+  * `schedule_mode` - The scheduling mode.
+  * `schedule_time_expr` - The scheduling time expression.
+  * `status` - The status of the aggregation task group.
+  * `to_time` - The UNIX timestamp for the scheduling end time.
+  * `update_time` - The last update time of the aggregation task group.
+  * `tags` - The tags of the aggregation task group.

--- a/website/docs/r/cms_agg_task_group.html.markdown
+++ b/website/docs/r/cms_agg_task_group.html.markdown
@@ -81,6 +81,7 @@ The following arguments are supported:
 * `cron_expr` - (Optional) The cron expression for scheduling when `schedule_mode` is set to `Cron`.
 * `delay` - (Optional, Int) The fixed delay for scheduling.
 * `description` - (Optional) The description of the aggregation task group.
+* `from_time` - (Optional, Int, Available since v1.289.0) The UNIX timestamp for the scheduling start time. If the specified value is in the past, the server resets it to the current time, and the provider suppresses the resulting diff.
 * `max_retries` - (Optional, Int) The maximum number of retries for an aggregation task.
 * `max_run_time_in_seconds` - (Optional, Int) The maximum retry time for an aggregation task.
 * `override_if_exists` - (Optional, Bool) Specifies whether to overwrite an existing resource with the same name.
@@ -89,6 +90,7 @@ The following arguments are supported:
 * `schedule_time_expr` - (Optional) The scheduling time expression.
 * `source_prometheus_id` - (Required, ForceNew) The ID of the source Prometheus instance for the aggregation task group.
 * `status` - (Optional) The status of the aggregation task group. Valid values: `Running` and `Stopped`.
+* `tags` - (Optional, Map, ForceNew, Available since v1.289.0) A mapping of tags to assign to the aggregation task group. Tags can only be set at creation; changing tags forces a new resource because the update API does not persist tags.
 * `target_prometheus_id` - (Required, ForceNew) The ID of the target Prometheus instance for the aggregation task group.
 * `to_time` - (Optional, Int) The UNIX timestamp for the scheduling end time.
 


### PR DESCRIPTION
## What

- `resource/alicloud_cms_agg_task_group`: support the `from_time` and `tags` arguments.
  - `from_time`: the UNIX timestamp for the scheduling start time. If the specified value is in the past, the server resets it to the current time, and the provider suppresses the resulting diff.
  - `tags`: a mapping of tags assigned to the aggregation task group. Tags are persisted only at creation (the update API does not persist tags), so `tags` is ForceNew.
  - Server-added system tags (keys prefixed with `acs:`, e.g. the resource-group tag `acs:rm:rgId`) are filtered out when reading to avoid perpetual diffs.
- `data-source/alicloud_cms_agg_task_groups`: new data source that lists aggregation task groups of a source Prometheus instance, with `ids` / `name_regex` filters.

## Test results (remote acceptance tests)

=== RUN TestAccAliCloudCmsAggTaskGroup_basic8019
--- PASS: TestAccAliCloudCmsAggTaskGroup_basic8019 (265.82s)

=== RUN TestAccAliCloudCmsAggTaskGroup_basic8019_twin
--- PASS: TestAccAliCloudCmsAggTaskGroup_basic8019_twin (58.36s)

=== RUN TestAccAliCloudCmsAggTaskGroupsDataSource_basic
--- PASS: TestAccAliCloudCmsAggTaskGroupsDataSource_basic (82.57s)