### PR TITLE
resource/alicloud_nlb_listener: reject empty strings in certificate_ids and ca_certificate_ids

### DIFF
--- a/alicloud/resource_alicloud_nlb_listener.go
+++ b/alicloud/resource_alicloud_nlb_listener.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceAliCloudNlbListener() *schema.Resource {
@@ -40,7 +41,10 @@ func resourceAliCloudNlbListener() *schema.Resource {
 			"ca_certificate_ids": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
 			},
 			"ca_enabled": {
 				Type:     schema.TypeBool,
@@ -50,7 +54,10 @@ func resourceAliCloudNlbListener() *schema.Resource {
 			"certificate_ids": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
 			},
 			"cps": {
 				Type:         schema.TypeInt,

--- a/alicloud/resource_alicloud_nlb_listener_test.go
+++ b/alicloud/resource_alicloud_nlb_listener_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
@@ -2432,6 +2433,36 @@ func TestAccAliCloudNlbListener_basic4683_twin(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+// An empty string inside certificate list parameters is decoded as a nil
+// element by the SDK, which crashes the request serializer. It must be
+// rejected at validation time instead of reaching the SDK.
+func TestAccAliCloudNlbListener_emptyStringInList(t *testing.T) {
+	resourceId := "alicloud_nlb_listener.default"
+	rand := acctest.RandIntRange(1000, 9999)
+	name := fmt.Sprintf("tf-testacc%snlblistener%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudNlbListenerBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, connectivity.NLBSupportRegions)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"listener_protocol":  "TCP",
+					"listener_port":      "80",
+					"load_balancer_id":   "${alicloud_nlb_load_balancer.default.id}",
+					"server_group_id":    "${alicloud_nlb_server_group.default.id}",
+					"ca_certificate_ids": []string{"", "cert-not-exist"},
+				}),
+				ExpectError: regexp.MustCompile(`ca_certificate_ids\.0.*to not be an empty string`),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

`alicloud_nlb_listener` crashed the whole provider process when `certificate_ids` or `ca_certificate_ids` contained an empty string:

```
panic: reflect: call of reflect.Value.Interface on zero Value
github.com/alibabacloud-go/tea-rpc-utils/service.handleRepeatedParams
```

Root cause: terraform-plugin-sdk decodes an empty-string element inside a list attribute as a `nil` element; the tea-rpc-utils request serializer reflects over slice elements and panics on the nil entry before any HTTP request is sent.

## Changes

- Add element-level `ValidateFunc: validation.StringIsNotEmpty` to `certificate_ids` and `ca_certificate_ids`, so an empty string is rejected at plan/validation time with a clear message instead of crashing the provider at apply time:

```
Error: expected "ca_certificate_ids.0" to not be an empty string, got
```

- Add regression test `TestAccAliCloudNlbListener_emptyStringInList`.

## Notes

- Validation was chosen over runtime filtering: silently dropping the empty element would desynchronize config vs state and produce a permanent diff/update loop.
- This guards the resource side; the serializer side (returning a clean error for nil list elements instead of panicking) is being handled upstream in tea-rpc.

## ACC test evidence (remote, full Nlb/Listener sweep on this branch)

```
PASS: TestAccAliCloudNlbListener_basic0 (149.5s)
PASS: TestAccAliCloudNlbListener_TCPSSL (169.07s)
FAIL: TestAccAliCloudNlbListener_basic1 (212.29s)
PASS: TestAccAliCloudNlbListener_basic4673 (359.39s)
PASS: TestAccAliCloudNlbListener_basic4673_twin (148.69s)
PASS: TestAccAliCloudNlbListener_basic4675 (663s)
PASS: TestAccAliCloudNlbListener_basic4675_twin (149.31s)
PASS: TestAccAliCloudNlbListener_basic4683 (750.23s)
PASS: TestAccAliCloudNlbListener_basic4683_twin (169.07s)
PASS: TestAccAliCloudNlbListener_emptyStringInList (0.33s)
```

- `basic1` failed at Step 3 (`UpdateListenerAttribute`) with `IncorrectStatus.loadbalancer` — the NLB was still in `Configuring` status from the previous step's async change, a known status-race flake; the same test passed on an earlier run of the same suite on identical base code.
- `TestAccAliCloudNlbListener_emptyStringInList` (new): the config with `ca_certificate_ids = ["", "cert-not-exist"]` is rejected at validation time, no resources are created (`Skipping destroy test since there is no state`), no provider crash.
- The sweep pattern also matched `TestAccAliCloudNlbListenerAdditionalCertificateAttachment_basic5384` (a different resource); it failed at teardown with `DependencyViolation.SecurityGroup` (leftover security group blocking VPC deletion) — environmental, unrelated to this change.

## CI note

`TestingCoverageRate` fails on this PR, but it flags pre-existing coverage debt of the resource — `ca_enabled` and `proxy_protocol_config.proxy_protocol_config_private_link_ep_id_enabled` / `proxy_protocol_config_private_link_eps_id_enabled` — none of which are touched by this diff (it only adds `ValidateFunc` to `certificate_ids` / `ca_certificate_ids`, both already covered). The other open `nlb_listener` PRs hit the exact same failure with the identical attribute list.
