### PR TITLE
testcase: upgrade tea-rpc to v1.3.4 and add nil list element regression test

### DIFF
--- a/alicloud/resource_alicloud_nlb_security_policy_test.go
+++ b/alicloud/resource_alicloud_nlb_security_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -873,6 +874,34 @@ func TestAccAliCloudNlbSecurityPolicy_basic5352_twin(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+// An empty string inside a list parameter is decoded as a nil element by
+// terraform-plugin-sdk, and the request serializer (tea-rpc-utils >= v1.1.3,
+// pulled in by tea-rpc >= v1.3.4) must fail with a clear serialization error
+// instead of crashing the provider process.
+func TestAccAliCloudNlbSecurityPolicy_emptyStringInList(t *testing.T) {
+	resourceId := "alicloud_nlb_security_policy.default"
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%snlbsecuritypolicy%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudNLBSecurityPolicyBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"security_policy_name": "${var.name}",
+					"ciphers":              []string{"", "ECDHE-RSA-AES128-SHA"},
+					"tls_versions":         []string{"TLSv1.2"},
+				}),
+				ExpectError: regexp.MustCompile(`cannot serialize repeated parameter element "Ciphers\.1": value is nil`),
 			},
 		},
 	})

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/alibabacloud-go/sts-20150401/v2 v2.0.2
 	github.com/alibabacloud-go/tea v1.5.2
 	github.com/alibabacloud-go/tea-roa v1.3.4
-	github.com/alibabacloud-go/tea-rpc v1.2.0
+	github.com/alibabacloud-go/tea-rpc v1.3.4
 	github.com/alibabacloud-go/tea-utils v1.4.5
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.9
 	github.com/aliyun/alibaba-cloud-sdk-go v1.63.107
@@ -81,7 +81,7 @@ require (
 	github.com/alibabacloud-go/openapi-util v0.1.1 // indirect
 	github.com/alibabacloud-go/tea-oss-utils v1.1.0 // indirect
 	github.com/alibabacloud-go/tea-roa-utils v1.1.5 // indirect
-	github.com/alibabacloud-go/tea-rpc-utils v1.1.2 // indirect
+	github.com/alibabacloud-go/tea-rpc-utils v1.1.3 // indirect
 	github.com/alibabacloud-go/tea-xml v1.1.3 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -280,10 +280,10 @@ github.com/alibabacloud-go/tea-roa v1.3.4 h1:afc1MrB9d5euBR5cxQTZ5Erswshguf1KSZm
 github.com/alibabacloud-go/tea-roa v1.3.4/go.mod h1:eja7Dg6m9p0X9XUL4LH3BeXjGf74gJGgecA8FUyzP70=
 github.com/alibabacloud-go/tea-roa-utils v1.1.5 h1:BkZAywim4piCeTA9qmRTq9gkcOI3Gltu3VobZwegnUE=
 github.com/alibabacloud-go/tea-roa-utils v1.1.5/go.mod h1:7mkMI3FZEm4LGKIR1322y0N6N9EC0R1G/oXvzQjf1fQ=
-github.com/alibabacloud-go/tea-rpc v1.2.0 h1:m3ohmuAT+IdXigKp7enB+lXuksqsor0OFNB5+QB7Isk=
-github.com/alibabacloud-go/tea-rpc v1.2.0/go.mod h1:zwKwxuf92liNsPcLOxPdrkvR5Dq6jtX2du6qx8FT094=
-github.com/alibabacloud-go/tea-rpc-utils v1.1.2 h1:ZTfFREnP2q9D49T2J/1jYYOndepGdrUOgm/JR8/bIQ0=
-github.com/alibabacloud-go/tea-rpc-utils v1.1.2/go.mod h1:V5HdNi6Xdn0JMpgVhQ19vsFAS51tydr7BqcJtuXH1Yw=
+github.com/alibabacloud-go/tea-rpc v1.3.4 h1:dJvduNWQbo1o8F10yD+6q5hekI22uz579CDps7mOF7E=
+github.com/alibabacloud-go/tea-rpc v1.3.4/go.mod h1:x/lsZZdbGNn2eZVWcdEddevALu2QqW+s9113zoc7Pl0=
+github.com/alibabacloud-go/tea-rpc-utils v1.1.3 h1:VtiVyNisThldCbc5xfZrXc4cRoR6Kz9ectsy8lgFqOY=
+github.com/alibabacloud-go/tea-rpc-utils v1.1.3/go.mod h1:V5HdNi6Xdn0JMpgVhQ19vsFAS51tydr7BqcJtuXH1Yw=
 github.com/alibabacloud-go/tea-utils v1.3.0/go.mod h1:EI/o33aBfj3hETm4RLiAxF/ThQdSngxrpF8rKUDJjPE=
 github.com/alibabacloud-go/tea-utils v1.3.1/go.mod h1:EI/o33aBfj3hETm4RLiAxF/ThQdSngxrpF8rKUDJjPE=
 github.com/alibabacloud-go/tea-utils v1.3.5/go.mod h1:EI/o33aBfj3hETm4RLiAxF/ThQdSngxrpF8rKUDJjPE=
@@ -313,8 +313,6 @@ github.com/aliyun/aliyun-mns-go-sdk v0.0.0-20210305050620-d1b5875bda58 h1:hX1oYy
 github.com/aliyun/aliyun-mns-go-sdk v0.0.0-20210305050620-d1b5875bda58/go.mod h1:eD/mEH7SwtLSwI9p8fP9VTH2cYM3wFSY1WNaxEdLIFU=
 github.com/aliyun/aliyun-oss-go-sdk v2.2.9+incompatible h1:Sg/2xHwDrioHpxTN6WMiwbXTpUEinBpHsN7mG21Rc2k=
 github.com/aliyun/aliyun-oss-go-sdk v2.2.9+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
-github.com/aliyun/aliyun-tablestore-go-sdk v1.7.16 h1:xfWOyeHyJsKXzE2P/uzwRy/WD8DFcJLEH1aF2GuRnN4=
-github.com/aliyun/aliyun-tablestore-go-sdk v1.7.16/go.mod h1:JzOJMpBPGN+4cuYnrGO5wdwphEyqbeGVY2vCaiAcNW8=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.9.3 h1:QWyWHXkmIvOK3g0azZyKNMTeohxylwDGOKDGfb/4F1c=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.9.3/go.mod h1:fy5w6iSSp3UTfuJZ0CzP5mKLEeZEl3xC977YOOwraXk=
 github.com/aliyun/credentials-go v1.1.2/go.mod h1:ozcZaMR5kLM7pwtCMEpVmQ242suV6qTJya2bDq4X1Tw=
@@ -410,6 +408,7 @@ github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS3
 github.com/denverdino/aliyungo v0.0.0-20220929054937-e3c8bf5ad947 h1:XSQNYTT3xgLDGbbDLUZMj98VhQBQcTxtyaMc3J1jiPo=
 github.com/denverdino/aliyungo v0.0.0-20220929054937-e3c8bf5ad947/go.mod h1:TK05uvk4XXfK2kdvRwfcZ1NaxjDxmm7H3aQLko0mJxA=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484 h1:pEtiCjIXx3RvGjlUJuCNxNOw0MNblyR9Wi+vJGBFh+8=
 github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
@@ -843,6 +842,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=


### PR DESCRIPTION
### What this PR does

- Upgrades `github.com/alibabacloud-go/tea-rpc` from v1.2.0 to v1.3.4 (pulling `github.com/alibabacloud-go/tea-rpc-utils` v1.1.2 → v1.1.3 as an indirect dependency).
- Adds a regression test for the crash scenario discussed in #10427.

### Why

When a list argument contains an empty string (e.g. `ciphers = ["", "ECDHE-RSA-AES128-SHA"]`), terraform-plugin-sdk v1.17.2 decodes the `""` element as `nil`. The repeated-parameter serializer in tea-rpc-utils v1.1.2 (`handleRepeatedParams`) then calls `reflect.Value.Interface()` on a zero `reflect.Value`, and the provider process panics — killing the whole Terraform run:

```
panic: reflect: call of reflect.Value.Interface on zero Value
```

tea-rpc v1.3.4 / tea-rpc-utils v1.1.3 fixes the serializer to fail cleanly instead, before the request goes out:

```
Resource alicloud_nlb_security_policy CreateSecurityPolicy Failed!!! [SDK alibaba-cloud-sdk-go ERROR]: cannot serialize repeated parameter element "Ciphers.1": value is nil
```

This is a crash fix, not a semantic change: the `""` → `nil` decoding lives in terraform-plugin-sdk and is unchanged, so users still need to remove empty elements from their configuration — but now they get a clear apply error instead of a dead provider. (On the provider side, `alicloud_nlb_listener` already rejects empty certificate ids at plan time since #10473; the new test deliberately uses `nlb_security_policy.ciphers`, which passes lists straight through to the serializer, to guard the SDK-level behavior itself.)

### Changes

- `go.mod` / `go.sum`: the two dependency bumps.
- `alicloud/resource_alicloud_nlb_security_policy_test.go`: new `TestAccAliCloudNlbSecurityPolicy_emptyStringInList` — config sets `ciphers = ["", "ECDHE-RSA-AES128-SHA"]` and expects `cannot serialize repeated parameter element "Ciphers.1": value is nil` from apply. The same nil-element path panics the provider on tea-rpc v1.2.0, so this test guards the fix.

### Acceptance tests

All run remotely against real resources on this branch (tea-rpc v1.3.4): 8 suites, 85 cases — **76 PASS / 9 FAIL**. None of the 9 failures involve request serialization: they are plan-time fixture issues (no API call made), an account-entitlement 400 from the server, or teardown-time server status races; one of them (`TestAccAliCloudVPCVSwitch_basic3078`) reproduces identically on a tea-rpc v1.2.0 control run of the same suite, i.e. version-independent.

#### Nlb / SecurityPolicy — 5/5

- PASS: TestAccAliCloudNlbSecurityPolicy_basic0 (15.23s)
- PASS: TestAccAliCloudNlbSecurityPolicy_basic1 (46.54s)
- PASS: TestAccAliCloudNlbSecurityPolicy_basic5352 (81.6s)
- PASS: TestAccAliCloudNlbSecurityPolicy_basic5352_twin (14.77s)
- PASS: TestAccAliCloudNlbSecurityPolicy_emptyStringInList (2.93s)

The new test fails at serialization with zero `CreateSecurityPolicy` HTTP calls and the provider process stays alive — the exact "clean error instead of panic" behavior.

#### Nlb / Listener — 9/11

- PASS: TestAccAliCloudNlbListener_basic0 (143.1s)
- PASS: TestAccAliCloudNlbListener_basic1 (377.24s)
- PASS: TestAccAliCloudNlbListener_basic4673 (361.5s)
- PASS: TestAccAliCloudNlbListener_basic4673_twin (149.61s)
- PASS: TestAccAliCloudNlbListener_basic4675 (662.53s)
- PASS: TestAccAliCloudNlbListener_basic4675_twin (149.1s)
- PASS: TestAccAliCloudNlbListener_basic4683 (748.08s)
- PASS: TestAccAliCloudNlbListener_basic4683_twin (188.15s)
- PASS: TestAccAliCloudNlbListener_emptyStringInList (0.33s)
- FAIL: TestAccAliCloudNlbListener_TCPSSL (144.41s) — destroy step: `DeleteLoadBalancer` hit `ResourceInConfiguring.loadbalancer` (HTTP 400, server-side status race).
- FAIL: TestAccAliCloudNlbListenerAdditionalCertificateAttachment_basic5384 (152.59s) — same `DeleteLoadBalancer` status race.

Both failures are teardown-time server races; the resources themselves were created and read back correctly.

#### Alb / HealthCheckTemplate — 6/6

- PASS: TestAccAliCloudAlbHealthCheckTemplate_basic0 (38.18s)
- PASS: TestAccAliCloudAlbHealthCheckTemplate_basic0_twin (4.75s)
- PASS: TestAccAliCloudAlbHealthCheckTemplate_basic1 (30.06s)
- PASS: TestAccAliCloudAlbHealthCheckTemplate_basic1_twin (4.81s)
- PASS: TestAccAliCloudAlbHealthCheckTemplate_basic9647 (16.65s)
- PASS: TestAccAliCloudAlbHealthCheckTemplate_basic9691 (16.99s)

#### ResourceManager / MessageContact — 1/1

- PASS: TestAccAliCloudResourceManagerMessageContact_basic11390 (10.86s)

#### EIP / Address — 10/11

- PASS: TestAccAliCloudEIPAddress_basic0 (63.63s)
- PASS: TestAccAliCloudEIPAddress_basic1 (75.98s)
- PASS: TestAccAliCloudEIPAddress_basic2 (52.69s)
- PASS: TestAccAliCloudEIPAddress_basic4 (0s)
- PASS: TestAccAliCloudEIPAddress_basic6 (17.39s)
- PASS: TestAccAliCloudEIPAddress_basic7 (0s)
- PASS: TestAccAliCloudEIPAddress_basic8 (34.95s)
- PASS: TestAccAliCloudEIPAddress_basic10 (0s)
- PASS: TestAccAliCloudEIPAddress_basic13 (0s)
- PASS: TestAccAliCloudEIPAddress_basic9_ip (0s)
- FAIL: TestAccAliCloudEIPAddress_basic9 (2.62s) — `OperationDenied.NotOpenDdosOriginProtectService`: the test account has not opened DDoS Origin Protection, required by `security_protection_types = ["AntiDDoS_Enhanced"]`. The server rejected on entitlement after parsing the list, which itself confirms list serialization is intact.

#### VPC / VSwitch — 19/20

- PASS: TestAccAliCloudVPCVSwitch_basic (37.19s)
- PASS: TestAccAliCloudVPCVSwitch_basic1 (23.44s)
- PASS: TestAccAliCloudVPCVSwitch_basic2 (26.55s)
- PASS: TestAccAliCloudVPCVSwitch_basic3 (23.74s)
- PASS: TestAccAliCloudVPCVSwitch_basic4 (36.4s)
- PASS: TestAccAliCloudVPCVSwitch_basic5 (46.35s)
- PASS: TestAccAliCloudVPCVSwitch_basic3078_twin (23.39s)
- PASS: TestAccAliCloudVPCVSwitch_isDefault (12.18s)
- PASS: TestAccAliCloudVPCVSwitch_isDefault_twin (11.78s)
- PASS: TestAccAliCloudVPCVSwitch_ipv6MaskRemoval (26.1s)
- PASS: TestAccAliCloudVPCVSwitch_ipv6MaskSetZero (30.45s)
- PASS: TestAccAliCloudVPCVSwitch_ipv6EnableNoMask (25.44s)
- PASS: TestAccAliCloudVPCVSwitch_ipv6EnableWithMask (30s)
- PASS: TestAccAliCloudVPCVSwitch_ipv6MaskWhileDisabled (26.23s)
- PASS: TestAccAliCloudVPCVSwitch_ipv6EnableZeroMaskFromDisabled (26.67s)
- PASS: TestAccAliCloudVPCVSwitch_enableIpv6FalseAfterComputedTrue (29.8s)
- PASS: TestAccAliCloudVPCVSwitch_ipv6ReenableSameMaskAfterDisable (32.43s)
- PASS: TestAccAliCloudVPCVSwitchesDataSourceBasic (110.15s)
- PASS: TestAccAliCloudVPCVSwitchesDataSourceCoverage (26.05s)
- FAIL: TestAccAliCloudVPCVSwitch_basic3078 (34.44s) — ipv6-enable path hits `ModifyVSwitchAttribute` 400 `MissingParam.Ipv6CidrBlockOrIpv6CidrMask`; reproduces identically on the tea-rpc v1.2.0 control run of the same suite (version-independent, pre-existing).

#### ECS / Disk — 10/14

- PASS: TestAccAliCloudECSDisk_basic8017 (367.7s)
- PASS: TestAccAliCloudECSDisk_basic8017_twin (197.24s)
- PASS: TestAccAliCloudECSDisk_basic8018 (66.83s)
- PASS: TestAccAliCloudECSDisk_basic8018_twin (71.87s)
- PASS: TestAccAliCloudECSDisk_basic8019 (63.66s)
- PASS: TestAccAliCloudECSDisk_basic8019_twin (71.48s)
- PASS: TestAccAliCloudECSDisk_basic8019_twin_excluding_kms_key_id (69.69s)
- PASS: TestAccAliCloudECSDisk_basic8019_essd_to_autopl_burst (247.69s)
- PASS: TestAccAliCloudECSDisk_basic8020 (164.87s)
- PASS: TestAccAliCloudECSDisk_basic8020_twin (97.54s)
- FAIL: TestAccAliCloudECSDisksDataSource (70.21s) — account-level default KMS key makes the `disks.0.kms_key_id` assertion drift from `""` to a real key id.
- FAIL: TestAccAliCloudECSDiskAttachmentBasic (10.85s), TestAccAliCloudECSDiskAttachmentBasic1 (11.07s), TestAccAliCloudECSDiskAttachmentMulti (11.56s) — plan-time `data.alicloud_vswitches.default.ids is empty list` fixture issue; no API calls involved.

All four failures are sibling resources swept in by the `-run` prefix; the 10 core disk cases all pass.

#### Nlb / ServerGroup — 16/17

- PASS: TestAccAliCloudNlbServerGroup_basic0 (229.45s)
- PASS: TestAccAliCloudNlbServerGroup_basic0_twin (23.95s)
- PASS: TestAccAliCloudNlbServerGroup_basic1 (119.96s)
- PASS: TestAccAliCloudNlbServerGroup_basic3734 (55.21s)
- PASS: TestAccAliCloudNlbServerGroup_basic3734_twin (26.63s)
- PASS: TestAccAliCloudNlbServerGroup_basic4668 (88.21s)
- PASS: TestAccAliCloudNlbServerGroup_basic4668_twin (26.66s)
- PASS: TestAccAliCloudNlbServerGroup_basic4639 (124.51s)
- PASS: TestAccAliCloudNlbServerGroup_basic4639_twin (26.84s)
- PASS: TestAccAliCloudNlbServerGroup_basic4662 (105.79s)
- PASS: TestAccAliCloudNlbServerGroup_basic4662_twin (27.49s)
- PASS: TestAccAliCloudNlbServerGroup_basic5353 (75.76s)
- PASS: TestAccAliCloudNlbServerGroup_basic5353_twin (34.76s)
- PASS: TestAccAliCloudNlbServerGroupServerAttachment_basic0_twin (86.82s)
- PASS: TestAccAliCloudNlbServerGroupServerAttachment_basic1 (104.49s)
- PASS: TestAccAliCloudNlbServerGroupServerAttachment_basic1_twin (34.71s)
- FAIL: TestAccAliCloudNlbServerGroupServerAttachment_basic0 (125.63s) — destroy step: `DeleteServerGroup` hit `ResourceInUse.ServerGroup` (HTTP 400, server-side status race); the twin case passed.

### Release note

`chore: upgrade tea-rpc to v1.3.4 — list parameters containing empty strings now fail with a clear serialization error instead of crashing the provider`
