### PR TITLE
feat(dts): support source_endpoint_ssl for subscription job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.293.0 (Unreleased)
+
+ENHANCEMENTS:
+
+- resource/alicloud_dts_subscription_job: support source_endpoint_ssl.
 ## 1.292.0 (September 8, 2026)
 
 - **New Resource:** `alicloud_threat_detection_rd_default_sync_list` ([#10207](https://github.com/aliyun/terraform-provider-alicloud/issues/10207))

--- a/alicloud/resource_alicloud_dts_subscription_job.go
+++ b/alicloud/resource_alicloud_dts_subscription_job.go
@@ -155,6 +155,12 @@ func resourceAliCloudDtsSubscriptionJob() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"source_endpoint_ssl": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"0", "1"}, false),
+			},
 			"status": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -292,6 +298,9 @@ func resourceAliCloudDtsSubscriptionJobRead(d *schema.ResourceData, meta interfa
 	d.Set("source_endpoint_region", object["SourceEndpoint"].(map[string]interface{})["Region"])
 	d.Set("source_endpoint_role", object["SourceEndpoint"].(map[string]interface{})["RoleName"])
 	d.Set("source_endpoint_user_name", object["SourceEndpoint"].(map[string]interface{})["UserName"])
+	if ssl := convertDtsEndpointSslResponse(object["SourceEndpoint"].(map[string]interface{})["SslSolutionEnum"]); ssl != nil {
+		d.Set("source_endpoint_ssl", ssl)
+	}
 	d.Set("status", object["Status"])
 	d.Set("subscription_data_type_ddl", object["SubscriptionDataType"].(map[string]interface{})["Ddl"])
 	d.Set("subscription_data_type_dml", object["SubscriptionDataType"].(map[string]interface{})["Dml"])
@@ -508,6 +517,9 @@ func resourceAliCloudDtsSubscriptionJobUpdate(d *schema.ResourceData, meta inter
 	if v, ok := d.GetOk("source_endpoint_user_name"); ok {
 		configureSubscriptionReq["SourceEndpointUserName"] = v
 	}
+	if d.HasChange("source_endpoint_ssl") {
+		update = true
+	}
 	if d.HasChange("subscription_data_type_ddl") || d.IsNewResource() {
 		update = true
 	}
@@ -552,6 +564,11 @@ func resourceAliCloudDtsSubscriptionJobUpdate(d *schema.ResourceData, meta inter
 		if v, ok := d.GetOk("reserve"); ok {
 			configureSubscriptionReq["Reserve"] = v
 		}
+		if d.HasChange("source_endpoint_ssl") {
+			if err := setDtsEndpointSSL(d, configureSubscriptionReq); err != nil {
+				return WrapError(err)
+			}
+		}
 		action := "ConfigureSubscription"
 		wait := incrementalWait(3*time.Second, 3*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
@@ -585,6 +602,7 @@ func resourceAliCloudDtsSubscriptionJobUpdate(d *schema.ResourceData, meta inter
 		d.SetPartial("source_endpoint_region")
 		d.SetPartial("source_endpoint_role")
 		d.SetPartial("source_endpoint_user_name")
+		d.SetPartial("source_endpoint_ssl")
 		d.SetPartial("subscription_data_type_ddl")
 		d.SetPartial("subscription_data_type_dml")
 		d.SetPartial("subscription_instance_vpc_id")

--- a/alicloud/resource_alicloud_dts_subscription_job_test.go
+++ b/alicloud/resource_alicloud_dts_subscription_job_test.go
@@ -135,6 +135,7 @@ func TestAccAliCloudDTSSubscriptionJob_basic0(t *testing.T) {
 					"source_endpoint_database_name":      "${alicloud_rds_account.source_account.account_password}",
 					"source_endpoint_user_name":          "${alicloud_rds_account.source_account.account_name}",
 					"source_endpoint_password":           "${alicloud_rds_account.source_account.account_password}",
+					"source_endpoint_ssl":                "1",
 					"db_list":                            "{\\\"test_database\\\":{\\\"name\\\":\\\"test_database\\\",\\\"all\\\":true,\\\"state\\\":\\\"normal\\\"}}",
 					"subscription_instance_network_type": "vpc",
 					"subscription_instance_vpc_id":       "${data.alicloud_vpcs.default.ids.0}",
@@ -150,8 +151,33 @@ func TestAccAliCloudDTSSubscriptionJob_basic0(t *testing.T) {
 						"source_endpoint_database_name":      "N1cetest",
 						"source_endpoint_user_name":          "test_mysql",
 						"source_endpoint_password":           "N1cetest",
+						"source_endpoint_ssl":                "1",
 						"db_list":                            "{\"test_database\":{\"name\":\"test_database\",\"all\":true,\"state\":\"normal\"}}",
 						"subscription_instance_network_type": "vpc",
+					}),
+				),
+			},
+			// Turn SSL off on the source endpoint in place. The field is not ForceNew, so this
+			// must go through ConfigureSubscription with the srcSSL reserve key rather than
+			// recreating the job.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"source_endpoint_ssl": "0",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"source_endpoint_ssl": "0",
+					}),
+				),
+			},
+			// Turn SSL back on, covering the enable-by-update direction as well as disable.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"source_endpoint_ssl": "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"source_endpoint_ssl": "1",
 					}),
 				),
 			},
@@ -525,6 +551,7 @@ var AliCloudDTSSubscriptionJobMap0 = map[string]string{
 	"subscription_data_type_ddl":       CHECKSET,
 	"destination_endpoint_engine_name": NOSET,
 	"used_time":                        NOSET,
+	"source_endpoint_ssl":              NOSET,
 	"status":                           CHECKSET,
 }
 

--- a/website/docs/r/dts_subscription_job.html.markdown
+++ b/website/docs/r/dts_subscription_job.html.markdown
@@ -152,6 +152,7 @@ The following arguments were support:
 * `source_endpoint_owner_id` - (Optional) The Alibaba Cloud account ID to which the source instance belongs. This parameter is only available when configuring data subscriptions across Alibaba Cloud accounts and must be passed in.
 * `source_endpoint_user_name` - (Optional) The username of source database instance account.
 * `source_endpoint_password` - (Optional) The password of source database instance account.
+* `source_endpoint_ssl` - (Optional, Computed) The connection method of the source instance. Valid values: `0` (an unencrypted connection), `1` (an SSL-secured connection). Only supported when the source endpoint is accessed as a cloud instance or as a self-managed database hosted on ECS.
 * `source_endpoint_port` - (Optional) The port of source database.
 * `source_endpoint_region` - (Required) The region of source database.
 * `source_endpoint_role` - (Optional) Both the authorization roles. When the source instance and configure subscriptions task of the Alibaba Cloud account is not the same as the need to pass the parameter, to specify the source of the authorization roles, to allow configuration subscription task of the Alibaba Cloud account to access the source of the source instance information.


### PR DESCRIPTION
## Summary

Add `source_endpoint_ssl` to `alicloud_dts_subscription_job` (DTS `SourceEndpoint.SslSolutionEnum`), matching the existing migration/synchronization job resources (v1.287.0 #10099).

## Changes

- Schema: `source_endpoint_ssl` Optional+Computed, ValidateFunc `["0","1"]`
- Create/Update: fold srcSSL into `ConfigureSubscription.Reserve` via `setDtsEndpointSSL` (merged with user reserve, not overwritten); Update adds SetPartial
- Read/Import: backfill via `convertDtsEndpointSslResponse`
- Docs: `website/docs/r/dts_subscription_job.html.markdown`
- CHANGELOG: 1.293.0 (Unreleased) ENHANCEMENTS entry
- Test: `TestAccAliCloudDTSSubscriptionJob_basic0` extended with 1→0→1 in-place update + ImportState verification

## Verification

- gofmt: clean
- go vet: no new warnings
- `go test -run '^$' ./alicloud`: pass (package compiles)
- check-public-diff scan: pass
- ACC `TestAccAliCloudDTSSubscriptionJob_basic0` (C1-C4/C6): pending QA execution

baseCommit: 57b19059ad55a38ccc632bde38ac11430f6dbf56
headCommit: 87fc3e2e8d03b1369806796850e6e25b5823197e