### PR TITLE
New Data Source: alicloud_esa_lists

### DIFF
--- a/alicloud/data_source_alicloud_esa_lists.go
+++ b/alicloud/data_source_alicloud_esa_lists.go
@@ -1,0 +1,282 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAliCloudEsaLists() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudEsaListRead,
+		Schema: map[string]*schema.Schema{
+			"ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsValidRegExp,
+			},
+			"query_args": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id_like": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name_like": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"description_like": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name_item_like": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"item_like": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"kind": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"order_by": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"desc": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"lists": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"list_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"kind": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"length": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"update_time": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudEsaListRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "ListLists"
+	request := make(map[string]interface{})
+	request["RegionId"] = client.RegionId
+	request["PageSize"] = PageSizeLarge
+	request["PageNumber"] = 1
+
+	if v, ok := d.GetOk("query_args"); ok {
+		queryArgsMap := map[string]interface{}{}
+		for _, queryArgsList := range v.([]interface{}) {
+			queryArgsArg := queryArgsList.(map[string]interface{})
+
+			if idLike, ok := queryArgsArg["id_like"]; ok {
+				queryArgsMap["IdLike"] = idLike
+			}
+
+			if nameLike, ok := queryArgsArg["name_like"]; ok {
+				queryArgsMap["NameLike"] = nameLike
+			}
+
+			if descriptionLike, ok := queryArgsArg["description_like"]; ok {
+				queryArgsMap["DescriptionLike"] = descriptionLike
+			}
+
+			if nameItemLike, ok := queryArgsArg["name_item_like"]; ok {
+				queryArgsMap["NameItemLike"] = nameItemLike
+			}
+
+			if itemLike, ok := queryArgsArg["item_like"]; ok {
+				queryArgsMap["ItemLike"] = itemLike
+			}
+
+			if kind, ok := queryArgsArg["kind"]; ok {
+				queryArgsMap["Kind"] = kind
+			}
+
+			if orderBy, ok := queryArgsArg["order_by"]; ok {
+				queryArgsMap["OrderBy"] = orderBy
+			}
+
+			if desc, ok := d.GetOkExists("query_args.0.desc"); ok {
+				queryArgsMap["Desc"] = desc
+			}
+		}
+
+		request["QueryArgs"] = convertObjectToJsonString(queryArgsMap)
+	}
+
+	var objects []map[string]interface{}
+
+	idsMap := make(map[string]string)
+	if v, ok := d.GetOk("ids"); ok {
+		for _, vv := range v.([]interface{}) {
+			if vv == nil {
+				continue
+			}
+			idsMap[vv.(string)] = vv.(string)
+		}
+	}
+
+	var listNameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+
+		listNameRegex = r
+	}
+
+	var response map[string]interface{}
+	var err error
+
+	for {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			response, err = client.RpcPost("ESA", "2024-09-10", action, nil, request, true)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		})
+		addDebug(action, response, request)
+
+		if err != nil {
+			return WrapErrorf(err, DataDefaultErrorMsg, "alicloud_esa_lists", action, AlibabaCloudSdkGoERROR)
+		}
+
+		resp, err := jsonpath.Get("$.Lists", response)
+		if err != nil {
+			return WrapErrorf(err, FailedGetAttributeMsg, action, "$.Lists", response)
+		}
+
+		result, _ := resp.([]interface{})
+		for _, v := range result {
+			item := v.(map[string]interface{})
+			if len(idsMap) > 0 {
+				if _, ok := idsMap[fmt.Sprint(item["Id"])]; !ok {
+					continue
+				}
+			}
+
+			if listNameRegex != nil {
+				if !listNameRegex.MatchString(fmt.Sprint(item["Name"])) {
+					continue
+				}
+			}
+
+			objects = append(objects, item)
+		}
+
+		if len(result) < PageSizeLarge {
+			break
+		}
+
+		request["PageNumber"] = request["PageNumber"].(int) + 1
+	}
+
+	ids := make([]string, 0)
+	names := make([]interface{}, 0)
+	s := make([]map[string]interface{}, 0)
+	for _, object := range objects {
+		mapping := map[string]interface{}{
+			"id":          fmt.Sprint(object["Id"]),
+			"list_id":     fmt.Sprint(object["Id"]),
+			"name":        object["Name"],
+			"kind":        object["Kind"],
+			"description": object["Description"],
+			"length":      object["Length"],
+			"update_time": object["UpdateTime"],
+		}
+
+		ids = append(ids, fmt.Sprint(mapping["id"]))
+		names = append(names, object["Name"])
+		s = append(s, mapping)
+	}
+
+	d.SetId(dataResourceIdHash(ids))
+
+	if err := d.Set("ids", ids); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("names", names); err != nil {
+		return WrapError(err)
+	}
+
+	if err := d.Set("lists", s); err != nil {
+		return WrapError(err)
+	}
+
+	if output, ok := d.GetOk("output_file"); ok && output.(string) != "" {
+		writeToFile(output.(string), s)
+	}
+
+	return nil
+}

--- a/alicloud/data_source_alicloud_esa_lists_test.go
+++ b/alicloud/data_source_alicloud_esa_lists_test.go
@@ -1,0 +1,334 @@
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	credentials "github.com/aliyun/credentials-go/credentials"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func TestAccAliCloudEsaListsDataSource_basic0(t *testing.T) {
+	rand := acctest.RandIntRange(10000, 99999)
+	resourceId := "data.alicloud_esa_lists.default"
+	name := fmt.Sprintf("tf_testacc_esa_list_%d", rand)
+	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceEsaListsConfig)
+
+	idsConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"ids": []string{"${alicloud_esa_list.default.id}"},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"ids": []string{"${alicloud_esa_list.default.id}_fake"},
+		}),
+	}
+
+	nameRegexConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"name_regex": "${alicloud_esa_list.default.name}",
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"name_regex": "${alicloud_esa_list.default.name}_fake",
+		}),
+	}
+
+	nameSubstring := `${replace(alicloud_esa_list.default.name, "tf_testacc_", "")}`
+	itemSubstring := "${substr(alicloud_esa_list.default.items.0, 0, 6)}"
+	nameQueryArgsConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"query_args": []map[string]interface{}{
+				{
+					"name_like": nameSubstring,
+					"order_by":  "name",
+					"desc":      "true",
+				},
+			},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"query_args": []map[string]interface{}{
+				{
+					"name_like": nameSubstring + "_fake",
+					"order_by":  "name",
+					"desc":      "false",
+				},
+			},
+		}),
+	}
+
+	kindQueryArgsConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"ids": []string{"${alicloud_esa_list.default.id}"},
+			"query_args": []map[string]interface{}{
+				{
+					"kind": "ip",
+				},
+			},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"ids": []string{"${alicloud_esa_list.default.id}"},
+			"query_args": []map[string]interface{}{
+				{
+					"kind": "header",
+				},
+			},
+		}),
+	}
+
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccConfig(map[string]interface{}{
+			"ids":        []string{"${alicloud_esa_list.default.id}"},
+			"name_regex": "${alicloud_esa_list.default.name}",
+			"query_args": []map[string]interface{}{
+				{
+					"id_like":   "${alicloud_esa_list.default.id}",
+					"name_like": "${alicloud_esa_list.default.name}",
+					"kind":      "ip",
+					"order_by":  "id",
+					"desc":      "true",
+				},
+			},
+		}),
+		fakeConfig: testAccConfig(map[string]interface{}{
+			"ids":        []string{"${alicloud_esa_list.default.id}"},
+			"name_regex": "${alicloud_esa_list.default.name}",
+			"query_args": []map[string]interface{}{
+				{
+					"id_like":   "${alicloud_esa_list.default.id}",
+					"name_like": "${alicloud_esa_list.default.name}",
+					"kind":      "header",
+					"order_by":  "id",
+					"desc":      "false",
+				},
+			},
+		}),
+	}
+
+	configs := []dataSourceTestAccConfig{idsConf, nameRegexConf, nameQueryArgsConf, kindQueryArgsConf, allConf}
+	for _, tc := range []struct {
+		field string
+		match string
+		miss  string
+	}{
+		{"name_like", nameSubstring, nameSubstring + "_fake"},
+		{"description_like", "${alicloud_esa_list.default.name}", "${alicloud_esa_list.default.name}_fake"},
+		{"name_item_like", nameSubstring, nameSubstring + "_fake"},
+		{"name_item_like", itemSubstring, "192.0.2."},
+		{"id_like", "${substr(alicloud_esa_list.default.id, 1, -1)}", "${alicloud_esa_list.default.id}0"},
+	} {
+		// Isolate this fixture without masking the server-side filter with local filters.
+		match := map[string]interface{}{"name_like": "${alicloud_esa_list.default.name}"}
+		miss := map[string]interface{}{"name_like": "${alicloud_esa_list.default.name}"}
+		match[tc.field], miss[tc.field] = tc.match, tc.miss
+		configs = append(configs, dataSourceTestAccConfig{
+			existConfig: testAccConfig(map[string]interface{}{"query_args": []map[string]interface{}{match}}),
+			fakeConfig:  testAccConfig(map[string]interface{}{"query_args": []map[string]interface{}{miss}}),
+		})
+	}
+
+	var existAliCloudEsaListsMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":               "1",
+			"names.#":             "1",
+			"lists.#":             "1",
+			"lists.0.id":          CHECKSET,
+			"lists.0.list_id":     CHECKSET,
+			"lists.0.name":        name,
+			"lists.0.kind":        "ip",
+			"lists.0.description": "description_" + name + "_suffix",
+			"lists.0.length":      "2",
+			"lists.0.update_time": CHECKSET,
+		}
+	}
+
+	var fakeAliCloudEsaListsMapFunc = func(rand int) map[string]string {
+		return map[string]string{
+			"ids.#":   "0",
+			"names.#": "0",
+			"lists.#": "0",
+		}
+	}
+
+	var aliCloudEsaListsInfo = dataSourceAttr{
+		resourceId:   "data.alicloud_esa_lists.default",
+		existMapFunc: existAliCloudEsaListsMapFunc,
+		fakeMapFunc:  fakeAliCloudEsaListsMapFunc,
+	}
+
+	preCheck := func() {
+		testAccPreCheck(t)
+		testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	}
+
+	aliCloudEsaListsInfo.dataSourceTestCheckWithPreCheck(t, rand, preCheck, configs...)
+}
+
+func dataSourceEsaListsConfig(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+resource "alicloud_esa_list" "default" {
+  kind        = "ip"
+  name        = var.name
+  description = "description_${var.name}_suffix"
+  items       = ["10.1.1.1", "10.1.1.2"]
+}
+`, name)
+}
+
+func TestUnitEsaListsPagination(t *testing.T) {
+	records := make([]map[string]interface{}, 100)
+	for i := range records {
+		records[i] = map[string]interface{}{
+			"Id":          1000 + i,
+			"Name":        fmt.Sprintf("fixture-list-%03d", i),
+			"Kind":        "ip",
+			"Description": fmt.Sprintf("fixture-description-%03d", i),
+			"Length":      2,
+			"UpdateTime":  "2025-01-01T00:00:00Z",
+		}
+	}
+
+	for _, tc := range []struct {
+		name          string
+		total         int
+		filters       map[string]interface{}
+		wantStart     int
+		wantCount     int
+		wantPages     int
+		wantQueryArgs map[string]interface{}
+	}{
+		{
+			name: "item_like_passthrough", total: 51, wantCount: 51, wantPages: 2,
+			filters: map[string]interface{}{
+				"query_args": []interface{}{map[string]interface{}{"item_like": "192.0.2.", "desc": false}},
+			},
+			wantQueryArgs: map[string]interface{}{"ItemLike": "192.0.2.", "NameItemLike": "", "Desc": false},
+		},
+		{name: "50_plus_1", total: 51, wantCount: 51, wantPages: 2},
+		{name: "ids_second_page", total: 51, filters: map[string]interface{}{"ids": []interface{}{"1050"}}, wantStart: 50, wantCount: 1, wantPages: 2},
+		{name: "name_regex_second_page", total: 51, filters: map[string]interface{}{"name_regex": "^fixture-list-050$"}, wantStart: 50, wantCount: 1, wantPages: 2},
+		{name: "ids_no_match", total: 51, filters: map[string]interface{}{"ids": []interface{}{"9999"}}, wantPages: 2},
+		{name: "name_regex_no_match", total: 51, filters: map[string]interface{}{"name_regex": "^missing$"}, wantPages: 2},
+		{name: "50_plus_50_plus_0", total: 100, wantCount: 100, wantPages: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var requests int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestNumber := int(atomic.AddInt32(&requests, 1))
+				valid := true
+				if err := r.ParseForm(); err != nil {
+					t.Errorf("parse request: %v", err)
+					valid = false
+				}
+				for key, want := range map[string]string{"Action": "ListLists", "PageSize": "50"} {
+					if got := r.Form.Get(key); got != want {
+						t.Errorf("request %d: %s = %q, want %q", requestNumber, key, got, want)
+						valid = false
+					}
+				}
+				page, err := strconv.Atoi(r.Form.Get("PageNumber"))
+				if err != nil || page != requestNumber || page < 1 || page > tc.wantPages {
+					t.Errorf("request %d: PageNumber = %q, want %d within 1..%d", requestNumber, r.Form.Get("PageNumber"), requestNumber, tc.wantPages)
+					valid = false
+				}
+				if tc.wantQueryArgs != nil {
+					var queryArgs map[string]interface{}
+					if err := json.Unmarshal([]byte(r.Form.Get("QueryArgs")), &queryArgs); err != nil {
+						t.Errorf("request %d: parse QueryArgs: %v", requestNumber, err)
+						valid = false
+					} else {
+						for key, want := range tc.wantQueryArgs {
+							if got := queryArgs[key]; got != want {
+								t.Errorf("request %d: QueryArgs.%s = %#v, want %#v", requestNumber, key, got, want)
+								valid = false
+							}
+						}
+					}
+				}
+				// An invalid request gets an empty page so a pagination regression cannot loop forever.
+				items := make([]map[string]interface{}, 0)
+				if valid {
+					start, end := (page-1)*50, page*50
+					if end > tc.total {
+						end = tc.total
+					}
+					items = records[start:end]
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(map[string]interface{}{"Lists": items}); err != nil {
+					t.Errorf("encode response: %v", err)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			credential, err := credentials.NewCredential(new(credentials.Config).
+				SetType("access_key").SetAccessKeyId("test-key").SetAccessKeySecret("test-secret"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			endpoints := new(sync.Map)
+			endpoint := strings.TrimPrefix(server.URL, "http://")
+			t.Setenv("NO_PROXY", endpoint)
+			config := &connectivity.Config{
+				AccessKey: "test-key", SecretKey: "test-secret", Credential: credential,
+				RegionId: "cn-hangzhou", AccountType: "test", Protocol: "http",
+				Endpoints: endpoints, SignVersion: new(sync.Map), SkipRegionValidation: true,
+			}
+			client, err := config.Client()
+			if err != nil {
+				t.Fatal(err)
+			}
+			endpoints.Store("esa", endpoint)
+
+			ds := dataSourceAliCloudEsaLists()
+			d := schema.TestResourceDataRaw(t, ds.Schema, tc.filters)
+			if err := ds.Read(d, client); err != nil {
+				t.Fatal(err)
+			}
+			if got := atomic.LoadInt32(&requests); int(got) != tc.wantPages {
+				t.Fatalf("requests = %d, want %d", got, tc.wantPages)
+			}
+
+			wantIDs := make([]interface{}, tc.wantCount)
+			wantNames := make([]interface{}, tc.wantCount)
+			wantLists := make([]interface{}, tc.wantCount)
+			for i := 0; i < tc.wantCount; i++ {
+				record := records[tc.wantStart+i]
+				wantIDs[i] = fmt.Sprint(record["Id"])
+				wantNames[i] = record["Name"]
+				wantLists[i] = map[string]interface{}{
+					"id":          wantIDs[i],
+					"list_id":     wantIDs[i],
+					"name":        record["Name"],
+					"kind":        record["Kind"],
+					"description": record["Description"],
+					"length":      record["Length"],
+					"update_time": record["UpdateTime"],
+				}
+			}
+			for field, want := range map[string][]interface{}{"ids": wantIDs, "names": wantNames, "lists": wantLists} {
+				got := d.Get(field).([]interface{})
+				if len(got) != len(want) {
+					t.Fatalf("%s count = %d, want %d", field, len(got), len(want))
+				}
+				for i := range want {
+					if !reflect.DeepEqual(got[i], want[i]) {
+						t.Errorf("%s[%d] = %#v, want %#v", field, i, got[i], want[i])
+					}
+				}
+			}
+		})
+	}
+}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -215,6 +215,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_esa_https_basic_configurations":                 dataSourceAliCloudEsaHttpsBasicConfigurations(),
 			"alicloud_esa_cache_reserve_instances":                    dataSourceAliCloudEsaCacheReserveInstances(),
 			"alicloud_esa_waf_rulesets":                               dataSourceAliCloudEsaWafRuleSets(),
+			"alicloud_esa_lists":                                      dataSourceAliCloudEsaLists(),
 			"alicloud_cs_clusters":                                    dataSourceAliCloudAckClusters(),
 			"alicloud_threat_detection_check_item_configs":            dataSourceAliCloudThreatDetectionCheckItemConfigs(),
 			"alicloud_threat_detection_check_structures":              dataSourceAliCloudThreatDetectionCheckStructures(),

--- a/website/docs/d/esa_lists.html.markdown
+++ b/website/docs/d/esa_lists.html.markdown
@@ -1,0 +1,78 @@
+---
+subcategory: "ESA"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_esa_lists"
+description: |-
+  Provides a list of ESA Lists to the user.
+---
+
+# alicloud_esa_lists
+
+This data source provides the ESA Lists of the current Alibaba Cloud user.
+
+-> **NOTE:** Available since v1.293.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform_example"
+}
+
+resource "alicloud_esa_list" "default" {
+  kind        = "ip"
+  name        = var.name
+  description = var.name
+  items       = ["10.1.1.1", "10.1.1.2"]
+}
+
+data "alicloud_esa_lists" "ids" {
+  ids = [alicloud_esa_list.default.id]
+}
+
+output "esa_lists_id_0" {
+  value = data.alicloud_esa_lists.ids.lists.0.id
+}
+```
+
+## Argument Reference
+
+This data source automatically retrieves all pages of results; you do not need to specify `page_number` or `page_size`.
+
+The following arguments are supported:
+
+* `ids` - (Optional, List) A list of List IDs used to filter the returned results locally.
+* `name_regex` - (Optional) A regex string used to filter the returned results locally by List name.
+* `query_args` - (Optional, Set) The query parameters sent to the server. At most one block is supported. See [`query_args`](#query_args) below.
+* `output_file` - (Optional) File name where to save data source results (after running `terraform plan`).
+
+### `query_args`
+
+The query_args supports the following:
+
+* `id_like` - (Optional) The fuzzy search for list ID.
+* `name_like` - (Optional) The fuzzy search for list name.
+* `description_like` - (Optional) The fuzzy search for list description.
+* `name_item_like` - (Optional) The fuzzy search matching a list name or its items.
+* `item_like` - (Optional) The value passed to the ListLists API to filter list contents.
+* `kind` - (Optional) The type of the custom list, e.g. `ip`.
+* `order_by` - (Optional) Specify the column to sort by.
+* `desc` - (Optional, Bool) Whether to sort in descending order. Valid values: `true`, `false`.
+
+QueryArgs values are passed unchanged for server-side interpretation; filtering behavior depends on the ESA API.
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `names` - A list of List names.
+* `lists` - A list of Lists. Each element contains the following attributes:
+  * `id` - The ID of the List.
+  * `list_id` - The ID of the List.
+  * `name` - The name of the List.
+  * `kind` - The type of the List.
+  * `description` - The description of the List.
+  * `length` - The number of items contained in the List.
+  * `update_time` - The last modification time of the List.


### PR DESCRIPTION
## Summary

Add `alicloud_esa_lists` to look up existing ESA custom lists without sharing Terraform state between workspaces.

- Expose all eight `ListLists.QueryArgs` fields, including `item_like`, as API passthrough inputs.
- Support local `ids`/`name_regex` filtering, automatic pagination, and structured results.
- Cover page boundaries, matches only on later pages, empty filtered results, fuzzy searches, and exact `ItemLike` request serialization.
- Document server-side versus local filtering and provide a valid example list name.

Closes #9672

## API behavior and scope

All `query_args` values are passed to ESA without adding client-side filtering or aliasing one API field to another. Direct API checks showed that `ItemLike` could return nonmatching lists in the tested environment. The parameter remains exposed for parity with the OpenAPI contract; this change does not claim to fix the service-side behavior. `name_item_like` is a separate parameter matching names or contents, not an item-only alias.

## Validation

- `TestUnitEsaListsPagination`: 7/7 scenarios passed, including page boundaries, second-page-only matches, no matches, and exact `ItemLike` passthrough with `Desc=false`. The passthrough case also verifies that API results are not filtered again on the client.
- `TestAccAliCloudEsaListsDataSource_basic0`: PASS (40.12s), FAIL=0, SKIP=0. All 20 positive/negative configurations executed and the test list was destroyed successfully.
- `ItemLike` service-side filtering is not claimed to be fixed or validated by these passing tests; its request serialization is tested independently.

Full-package `go vet` has two unchanged baseline diagnostics in `alicloud/common.go` for unused `fmt.Sprintln` results. Focused unit execution used `-vet=off` to verify behavior separately; this is not reported as a vet pass.
