### PR TITLE
resource/alicloud_drds_instance: read complete instance attributes and retry transient errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 1.293.0 (Unreleased)
+
+BUG FIXES:
+
+- resource/alicloud_drds_instance: fix read not returning the required attributes vswitch_id, specification and instance_series, and add a computed status attribute. ([#10480](https://github.com/aliyun/terraform-provider-alicloud/pull/10480))
 ## 1.292.0 (September 8, 2026)
 
 - **New Resource:** `alicloud_threat_detection_rd_default_sync_list` ([#10207](https://github.com/aliyun/terraform-provider-alicloud/issues/10207))

--- a/alicloud/drds_instance_read_test.go
+++ b/alicloud/drds_instance_read_test.go
@@ -1,0 +1,169 @@
+package alicloud
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	sdkendpoints "github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints"
+	"github.com/aliyun/credentials-go/credentials"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func drdsInstanceReadTestClient(t *testing.T, handler http.HandlerFunc) *connectivity.AliyunClient {
+	t.Helper()
+	endpoint := sdkendpoints.GetEndpointFromMap("cn-hangzhou", "drds")
+	t.Cleanup(func() { sdkendpoints.AddEndpointMapping("cn-hangzhou", "drds", endpoint) })
+	for _, variable := range []string{"HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy", "ALL_PROXY", "all_proxy", "TF_ENDPOINT_PATH"} {
+		t.Setenv(variable, "")
+	}
+	t.Setenv("NO_PROXY", "*")
+	t.Setenv("no_proxy", "*")
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	credential, err := credentials.NewCredential(new(credentials.Config).
+		SetType("access_key").SetAccessKeyId("test-key").SetAccessKeySecret("test-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var endpoints, signVersion sync.Map
+	endpoints.Store("drds", strings.TrimPrefix(server.URL, "http://"))
+	config := &connectivity.Config{
+		Region: connectivity.Hangzhou, RegionId: "cn-hangzhou", Protocol: "HTTP",
+		AccessKey: "test-key", SecretKey: "test-secret", Credential: credential,
+		Endpoints: &endpoints, SignVersion: &signVersion,
+		AccountType: "test", SkipRegionValidation: true,
+		ClientReadTimeout: 1000, ClientConnectTimeout: 1000,
+	}
+	client, err := config.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestUnitDrdsInstanceReadConsistency(t *testing.T) {
+	const complete = `{"Data":{"Status":"RUN","ZoneId":"cn-hangzhou-j","Description":"test instance","InstanceSeries":"drds.sn1.4c8g","InstanceSpec":"drds.sn1.4c8g.8C16G","CommodityCode":"drdsPost","Vips":{"Vip":[{"Type":"intranet","VpcId":"vpc-test","VswitchId":"vsw-test","Dns":"db.example.com","Port":"3306"}]}}}`
+	const partialSpec = `{"Data":{"Status":"RUN","ZoneId":"cn-hangzhou-j","Description":"test instance","InstanceSpec":"8C16G","Vips":{"Vip":[{"Type":"intranet","VpcId":"vpc-test","VswitchId":"vsw-test"}]}}}`
+	const partialNetwork = `{"Data":{"Status":"RUN","ZoneId":"cn-hangzhou-j","Description":"test instance","InstanceSeries":"drds.sn1.4c8g","InstanceSpec":"drds.sn1.4c8g.8C16G"}}`
+	for _, tc := range []struct {
+		name              string
+		first             string
+		persistent        bool
+		existing          bool
+		initiallyComplete bool
+	}{
+		{name: "import waits for complete specification", first: partialSpec},
+		{name: "specification must include series", first: strings.Replace(partialSpec, `"InstanceSpec"`, `"InstanceSeries":"drds.sn1.4c8g","InstanceSpec"`, 1)},
+		{name: "import waits for network", first: partialNetwork},
+		{name: "blank description is valid", first: strings.Replace(complete, `"Description":"test instance"`, `"Description":""`, 1), initiallyComplete: true},
+		{name: "public VIP precedes network VIP", first: strings.Replace(complete, `"Vip":[`, `"Vip":[{"Type":"internet","Dns":"public.example.com","Port":"3306"},`, 1), initiallyComplete: true},
+		{name: "lowercase dns is supported", first: strings.Replace(complete, `"Dns"`, `"dns"`, 1), initiallyComplete: true},
+		{name: "numeric port is supported", first: strings.Replace(complete, `"Port":"3306"`, `"Port":3306`, 1), initiallyComplete: true},
+		{name: "incomplete import fails", first: partialSpec, persistent: true},
+		{name: "empty response preserves existing state", first: `{"Data":{"Status":"RUN"}}`, persistent: true, existing: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls int32
+			client := drdsInstanceReadTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				if err := r.ParseForm(); err != nil {
+					t.Error(err)
+				}
+				if r.Form.Get("Action") != "DescribeDrdsInstance" {
+					t.Errorf("unexpected action %q", r.Form.Get("Action"))
+				}
+				w.Header().Set("Content-Type", "application/json")
+				response := complete
+				if atomic.AddInt32(&calls, 1) == 1 || tc.persistent {
+					response = tc.first
+				}
+				fmt.Fprint(w, response)
+			})
+			attributes := map[string]string{}
+			if tc.existing {
+				attributes = map[string]string{
+					"specification": "drds.sn1.4c8g.8C16G", "instance_series": "drds.sn1.4c8g",
+					"vpc_id": "vpc-test", "vswitch_id": "vsw-test", "zone_id": "cn-hangzhou-j",
+					"description": "test instance", "connection_string": "db.example.com", "port": "3306",
+				}
+			}
+			r := resourceAlicloudDRDSInstance()
+			r.Timeouts.Read = schema.DefaultTimeout(time.Second)
+			d := r.Data(&terraform.InstanceState{ID: "drds-test", Attributes: attributes})
+			err := resourceAliCloudDRDSInstanceRead(d, client)
+			if tc.persistent {
+				if err == nil {
+					t.Error("an incomplete response must not produce a successful Read")
+				}
+				for key, want := range attributes {
+					if got := d.Get(key); got != want {
+						t.Errorf("%s changed to %q after incomplete response, want %q", key, got, want)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				for key, want := range map[string]string{
+					"specification": "drds.sn1.4c8g.8C16G", "instance_series": "drds.sn1.4c8g",
+					"vswitch_id": "vsw-test", "vpc_id": "vpc-test", "status": "RUN", "instance_charge_type": "PostPaid",
+					"connection_string": "db.example.com", "port": "3306",
+				} {
+					if got := d.Get(key); got != want {
+						t.Errorf("%s = %q, want %q", key, got, want)
+					}
+				}
+				if tc.initiallyComplete {
+					if atomic.LoadInt32(&calls) != 1 {
+						t.Error("a complete response must be read without retry")
+					}
+				} else if atomic.LoadInt32(&calls) < 2 {
+					t.Error("Read returned before the complete response")
+				}
+			}
+			if d.Id() != "drds-test" {
+				t.Error("incomplete response cleared the instance ID")
+			}
+		})
+	}
+}
+
+func TestUnitDrdsInstanceReadTransientError(t *testing.T) {
+	for _, code := range []string{"InternalError", "Throttling", "InvalidDrdsInstanceId.NotFound", "Forbidden"} {
+		t.Run(code, func(t *testing.T) {
+			var calls int32
+			client := drdsInstanceReadTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if atomic.AddInt32(&calls, 1) == 1 {
+					w.WriteHeader(http.StatusBadRequest)
+					fmt.Fprintf(w, `{"Code":%q,"Message":"test response","RequestId":"test"}`, code)
+					return
+				}
+				fmt.Fprint(w, `{"Data":{"Status":"RUN"}}`)
+			})
+			service := DrdsService{client}
+			object, state, err := service.DrdsInstanceStateRefreshFunc("drds-test", nil)()
+			switch code {
+			case "InternalError", "Throttling":
+				if err != nil || object == nil || state != "RUN" || atomic.LoadInt32(&calls) < 2 {
+					t.Errorf("transient error was treated as absence: object=%v state=%q err=%v calls=%d", object, state, err, atomic.LoadInt32(&calls))
+				}
+			case "InvalidDrdsInstanceId.NotFound":
+				if err != nil || object != nil || state != "" {
+					t.Errorf("NotFound must remain the delete target: object=%v state=%q err=%v", object, state, err)
+				}
+			case "Forbidden":
+				if err == nil {
+					t.Error("terminal error must not be treated as absence")
+				}
+			}
+		})
+	}
+}

--- a/alicloud/resource_alicloud_drds_instance.go
+++ b/alicloud/resource_alicloud_drds_instance.go
@@ -1,7 +1,9 @@
 package alicloud
 
 import (
+	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
@@ -24,6 +26,7 @@ func resourceAlicloudDRDSInstance() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
+			Read:   schema.DefaultTimeout(5 * time.Minute),
 			Update: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
@@ -81,6 +84,10 @@ func resourceAlicloudDRDSInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}
@@ -203,7 +210,24 @@ func resourceAliCloudDRDSInstanceRead(d *schema.ResourceData, meta interface{}) 
 	client := meta.(*connectivity.AliyunClient)
 	drdsService := DrdsService{client}
 
-	object, err := drdsService.DescribeDrdsInstance(d.Id())
+	var object *drds.DescribeDrdsInstanceResponse
+	var vpcId, connectionString, port, vswitchId string
+	// RUN can precede complete specification and network metadata. Use the same
+	// wait for create, import and refresh, and leave state intact on timeout.
+	err := resource.Retry(d.Timeout(schema.TimeoutRead), func() *resource.RetryError {
+		var err error
+		object, err = drdsService.DescribeDrdsInstance(d.Id())
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		data := object.Data
+		vpcId, connectionString, port, vswitchId = flattenDrdsInstanceVips(data.Vips.Vip)
+		if data.InstanceSeries == "" || !strings.HasPrefix(data.InstanceSpec, data.InstanceSeries+".") || len(data.InstanceSpec) <= len(data.InstanceSeries)+1 ||
+			data.ZoneId == "" || vpcId == "" || vswitchId == "" || data.CommodityCode == "" {
+			return resource.RetryableError(fmt.Errorf("waiting for complete DRDS instance specification and network attributes"))
+		}
+		return nil
+	})
 	if err != nil {
 		if NotFoundError(err) {
 			d.SetId("")
@@ -212,24 +236,36 @@ func resourceAliCloudDRDSInstanceRead(d *schema.ResourceData, meta interface{}) 
 		return WrapError(err)
 	}
 	data := object.Data
-	//other attribute not set,because these attribute from `data` can't  get
 	d.Set("zone_id", data.ZoneId)
 	d.Set("description", data.Description)
-	vpcId, connectionString, port := flattenDrdsInstanceVips(data.Vips.Vip)
+	d.Set("specification", data.InstanceSpec)
+	d.Set("instance_series", data.InstanceSeries)
 	d.Set("vpc_id", vpcId)
+	d.Set("vswitch_id", vswitchId)
+	// CommodityCode encodes the charge type (drdsPost/drdsPre); map it back so
+	// imported instances do not diff against the PostPaid default.
+	switch data.CommodityCode {
+	case "drdsPost":
+		d.Set("instance_charge_type", PostPaid)
+	case "drdsPre":
+		d.Set("instance_charge_type", PrePaid)
+	}
 	d.Set("connection_string", connectionString)
 	d.Set("port", port)
 	d.Set("mysql_version", data.MysqlVersion)
+	d.Set("status", data.Status)
 	return nil
 }
 
-// flattenDrdsInstanceVips extracts the vpc_id, connection_string and port from the
-// DescribeDrdsInstance VIP list. A valid instance can transiently report an empty
-// VIP list, so the first-element access is length-guarded to avoid an out-of-range
-// panic; an empty list yields zero values.
-func flattenDrdsInstanceVips(vips []drds.Vip) (vpcId, connectionString, port string) {
-	if len(vips) > 0 {
-		vpcId = vips[0].VpcId
+// Keep VPC and VSwitch IDs paired, since a public VIP can precede the network
+// VIP. An empty or incomplete VIP list yields empty network IDs.
+func flattenDrdsInstanceVips(vips []drds.Vip) (vpcId, connectionString, port, vswitchId string) {
+	for _, vip := range vips {
+		if vip.VpcId != "" && vip.VswitchId != "" {
+			vpcId = vip.VpcId
+			vswitchId = vip.VswitchId
+			break
+		}
 	}
 	for _, vip := range vips {
 		if vip.Type == "intranet" {
@@ -238,7 +274,7 @@ func flattenDrdsInstanceVips(vips []drds.Vip) (vpcId, connectionString, port str
 			break
 		}
 	}
-	return vpcId, connectionString, port
+	return vpcId, connectionString, port, vswitchId
 }
 
 func resourceAliCloudDRDSInstanceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_drds_instance_test.go
+++ b/alicloud/resource_alicloud_drds_instance_test.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"testing"
 
@@ -94,6 +95,12 @@ func testSweepDRDSInstances(region string) error {
 }
 
 func TestAccAliCloudDRDSInstance_Vpc(t *testing.T) {
+	t.Setenv("ALICLOUD_REGION", "cn-hangzhou")
+	t.Setenv("CHECKOUT_REGION", "false")
+	originalDefaultRegion := defaultRegionToTest
+	t.Cleanup(func() { defaultRegionToTest = originalDefaultRegion })
+	defaultRegionToTest = "cn-hangzhou"
+
 	var v *drds.DescribeDrdsInstanceResponse
 
 	resourceId := "alicloud_drds_instance.default"
@@ -109,12 +116,32 @@ func TestAccAliCloudDRDSInstance_Vpc(t *testing.T) {
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandInt()
 	name := fmt.Sprintf("tf-testacc%sDrdsdatabase-%d", defaultRegionToTest, rand)
-	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceDRDSInstanceConfigDependence)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, func(name string) string {
+		return resourceDRDSInstanceConfigDependence(name) + `
+	provider "alicloud" {
+	  region = "cn-hangzhou"
+	}
+	`
+	})
+	createConfig := testAccConfig(map[string]interface{}{
+		"description":          "${var.name}",
+		"zone_id":              "${data.alicloud_vswitches.default.vswitches.0.zone_id}",
+		"instance_series":      "${var.instance_series}",
+		"instance_charge_type": "PostPaid",
+		"vswitch_id":           "${data.alicloud_vswitches.default.vswitches.0.id}",
+		"specification":        "drds.sn2.4c16g.8C32G",
+	})
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckWithRegions(t, true, connectivity.DrdsSupportedRegions)
+			if region := os.Getenv("ALICLOUD_REGION"); region != "cn-hangzhou" {
+				t.Fatalf("ALICLOUD_REGION = %q, want cn-hangzhou", region)
+			}
+			if defaultRegionToTest != "cn-hangzhou" {
+				t.Fatalf("defaultRegionToTest = %q, want cn-hangzhou", defaultRegionToTest)
+			}
 		},
 		// module name
 		IDRefreshName: resourceId,
@@ -122,25 +149,26 @@ func TestAccAliCloudDRDSInstance_Vpc(t *testing.T) {
 		CheckDestroy:  rac.checkResourceDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfig(map[string]interface{}{
-					"description":          "${var.name}",
-					"zone_id":              "${data.alicloud_vswitches.default.vswitches.0.zone_id}",
-					"instance_series":      "${var.instance_series}",
-					"instance_charge_type": "PostPaid",
-					"vswitch_id":           "${data.alicloud_vswitches.default.vswitches.0.id}",
-					"specification":        "drds.sn1.4c8g.8C16G",
-				}),
+				Config: createConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"description":   name,
-						"mysql_version": "5",
+						"description":     name,
+						"mysql_version":   "5",
+						"specification":   "drds.sn2.4c16g.8C32G",
+						"instance_series": "drds.sn2.4c16g",
+						"vswitch_id":      CHECKSET,
 					}),
 				),
 			},
 			{
 				ResourceName:      resourceId,
 				ImportState:       true,
-				ImportStateVerify: false,
+				ImportStateVerify: true,
+			},
+			{
+				Config:             createConfig,
+				ExpectNonEmptyPlan: false,
+				PlanOnly:           true,
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
@@ -201,7 +229,7 @@ func TestAccAliCloudDRDSInstance_Multi(t *testing.T) {
 					"zone_id":              "${data.alicloud_vswitches.default.vswitches.0.zone_id}",
 					"instance_series":      "${var.instance_series}",
 					"instance_charge_type": "PostPaid",
-					"specification":        "drds.sn1.4c8g.8C16G",
+					"specification":        "drds.sn2.4c16g.8C32G",
 					"vswitch_id":           "${data.alicloud_vswitches.default.vswitches.0.id}",
 					"count":                "3",
 					"mysql_version":        "5",
@@ -251,7 +279,7 @@ func TestAccAliCloudDRDSInstance_VpcId(t *testing.T) {
 					"instance_series":      "${var.instance_series}",
 					"instance_charge_type": "PostPaid",
 					"vswitch_id":           "${data.alicloud_vswitches.default.vswitches.0.id}",
-					"specification":        "drds.sn1.4c8g.8C16G",
+					"specification":        "drds.sn2.4c16g.8C32G",
 					"vpc_id":               "${data.alicloud_vpcs.default.ids.0}",
 					"mysql_version":        "5",
 				}),
@@ -306,7 +334,7 @@ func TestAccAliCloudDRDSInstance_MySQLVersion(t *testing.T) {
 					"instance_series":      "${var.instance_series}",
 					"instance_charge_type": "PostPaid",
 					"vswitch_id":           "${data.alicloud_vswitches.default.vswitches.0.id}",
-					"specification":        "drds.sn1.4c8g.8C16G",
+					"specification":        "drds.sn2.4c16g.8C32G",
 					"mysql_version":        "5",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -335,7 +363,7 @@ func resourceDRDSInstanceConfigDependence(name string) string {
 	}
 	
 	variable "instance_series" {
-		default = "drds.sn1.4c8g"
+		default = "drds.sn2.4c16g"
 	}
 	
 	data "alicloud_vpcs" "default"	{
@@ -350,9 +378,9 @@ func resourceDRDSInstanceConfigDependence(name string) string {
 var drdsInstancebasicMap = map[string]string{
 	"description":          CHECKSET,
 	"zone_id":              CHECKSET,
-	"instance_series":      "drds.sn1.4c8g",
+	"instance_series":      "drds.sn2.4c16g",
 	"instance_charge_type": "PostPaid",
-	"specification":        "drds.sn1.4c8g.8C16G",
+	"specification":        "drds.sn2.4c16g.8C32G",
 	"connection_string":    CHECKSET,
 	"port":                 CHECKSET,
 }
@@ -361,33 +389,36 @@ var drdsInstancebasicMap = map[string]string{
 // panic when the DescribeDrdsInstance response returns an empty VIP list. A valid
 // instance can transiently report no VIPs, and indexing Vip[0] directly used to
 // crash the provider. The empty case must return zero values; the populated case
-// must surface the first VIP's VpcId plus the intranet connection string/port.
+// must surface paired network IDs and the intranet connection string/port.
 func TestUnitAliCloudDRDSInstanceFlattenVips(t *testing.T) {
 	// Empty VIP list: must not panic and must yield zero values.
-	vpcId, connectionString, port := flattenDrdsInstanceVips([]drds.Vip{})
-	if vpcId != "" || connectionString != "" || port != "" {
-		t.Fatalf("empty VIP list should yield zero values, got vpcId=%q connectionString=%q port=%q", vpcId, connectionString, port)
+	vpcId, connectionString, port, vswitchId := flattenDrdsInstanceVips([]drds.Vip{})
+	if vpcId != "" || connectionString != "" || port != "" || vswitchId != "" {
+		t.Fatalf("empty VIP list should yield zero values, got vpcId=%q connectionString=%q port=%q vswitchId=%q", vpcId, connectionString, port, vswitchId)
 	}
 
 	// Nil VIP list: same guarantee.
-	vpcId, connectionString, port = flattenDrdsInstanceVips(nil)
-	if vpcId != "" || connectionString != "" || port != "" {
-		t.Fatalf("nil VIP list should yield zero values, got vpcId=%q connectionString=%q port=%q", vpcId, connectionString, port)
+	vpcId, connectionString, port, vswitchId = flattenDrdsInstanceVips(nil)
+	if vpcId != "" || connectionString != "" || port != "" || vswitchId != "" {
+		t.Fatalf("nil VIP list should yield zero values, got vpcId=%q connectionString=%q port=%q vswitchId=%q", vpcId, connectionString, port, vswitchId)
 	}
 
-	// Populated VIP list: vpc_id from the first VIP, connection_string/port from the intranet VIP.
+	// The first VIP has no VSwitch. Both network IDs must come from the next VIP.
 	vips := []drds.Vip{
 		{Type: "internet", VpcId: "vpc-external", Dns: "public.example.com", Port: "3306"},
-		{Type: "intranet", VpcId: "vpc-internal", Dns: "intranet.example.com", Port: "3307"},
+		{Type: "intranet", VpcId: "vpc-internal", Dns: "intranet.example.com", Port: "3307", VswitchId: "vsw-intranet"},
 	}
-	vpcId, connectionString, port = flattenDrdsInstanceVips(vips)
-	if vpcId != "vpc-external" {
-		t.Fatalf("vpcId should come from the first VIP, got %q", vpcId)
+	vpcId, connectionString, port, vswitchId = flattenDrdsInstanceVips(vips)
+	if vpcId != "vpc-internal" {
+		t.Fatalf("vpcId should come from the VIP with the VSwitch, got %q", vpcId)
 	}
 	if connectionString != "intranet.example.com" {
 		t.Fatalf("connectionString should come from the intranet VIP, got %q", connectionString)
 	}
 	if port != "3307" {
 		t.Fatalf("port should come from the intranet VIP, got %q", port)
+	}
+	if vswitchId != "vsw-intranet" {
+		t.Fatalf("vswitchId should be the first non-empty VswitchId, got %q", vswitchId)
 	}
 }

--- a/alicloud/service_alicloud_drds.go
+++ b/alicloud/service_alicloud_drds.go
@@ -1,6 +1,7 @@
 package alicloud
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/drds"
@@ -17,8 +18,19 @@ func (s *DrdsService) DescribeDrdsInstance(id string) (*drds.DescribeDrdsInstanc
 	request := drds.CreateDescribeDrdsInstanceRequest()
 	request.RegionId = s.client.RegionId
 	request.DrdsInstanceId = id
-	raw, err := s.client.WithDrdsClient(func(drdsClient *drds.Client) (interface{}, error) {
-		return drdsClient.DescribeDrdsInstance(request)
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		raw, err := s.client.WithDrdsClient(func(drdsClient *drds.Client) (interface{}, error) {
+			return drdsClient.DescribeDrdsInstance(request)
+		})
+		if err != nil {
+			if IsExpectedErrors(err, []string{"InternalError"}) || NeedRetry(err) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(request.GetActionName(), raw, request.RpcRequest, request)
+		response, _ = raw.(*drds.DescribeDrdsInstanceResponse)
+		return nil
 	})
 
 	if err != nil {
@@ -27,10 +39,26 @@ func (s *DrdsService) DescribeDrdsInstance(id string) (*drds.DescribeDrdsInstanc
 		}
 		return response, WrapErrorf(err, DefaultErrorMsg, id, request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
-	addDebug(request.GetActionName(), raw, request.RpcRequest, request)
-	response, _ = raw.(*drds.DescribeDrdsInstanceResponse)
 	if response.Data.Status == "5" {
 		return response, WrapErrorf(err, NotFoundMsg, AlibabaCloudSdkGoERROR)
+	}
+	// The SDK's dns tag does not match the API's Dns casing.
+	var dnsResponse struct {
+		Data struct {
+			Vips struct {
+				Vip []struct {
+					Dns string
+				}
+			}
+		}
+	}
+	if err := json.Unmarshal(response.GetHttpContentBytes(), &dnsResponse); err != nil {
+		return response, WrapError(err)
+	}
+	for i, vip := range dnsResponse.Data.Vips.Vip {
+		if i < len(response.Data.Vips.Vip) {
+			response.Data.Vips.Vip[i].Dns = vip.Dns
+		}
 	}
 	return response, nil
 }

--- a/website/docs/r/drds_instance.html.markdown
+++ b/website/docs/r/drds_instance.html.markdown
@@ -69,21 +69,21 @@ The following arguments are supported:
 * `instance_charge_type` - (Optional, ForceNew) Valid values are `PrePaid`, `PostPaid`, Default to `PostPaid`.
 * `vswitch_id` - (Required from v1.91.0, ForceNew) The VSwitch ID to launch in.
 * `instance_series` - (Required, ForceNew) The parameter of the instance series. **NOTE:**  `drds.sn1.4c8g`,`drds.sn1.8c16g`,`drds.sn1.16c32g`,`drds.sn1.32c64g` are no longer supported. Valid values:
-    - `drds.sn2.4c16g` Starter Edition.
-    - `drds.sn2.8c32g` Standard Edition.
-    - `drds.sn2.16c64g` Enterprise Edition.
+  - `drds.sn2.4c16g` Starter Edition.
+  - `drds.sn2.8c32g` Standard Edition.
+  - `drds.sn2.16c64g` Enterprise Edition.
 * `specification` - (Required, ForceNew) User-defined DRDS instance specification. Value range:
-    - `drds.sn1.4c8g` for DRDS instance Starter version; 
-        - value range : `drds.sn1.4c8g.8c16g`, `drds.sn1.4c8g.16c32g`, `drds.sn1.4c8g.32c64g`, `drds.sn1.4c8g.64c128g`
-    - `drds.sn1.8c16g` for DRDS instance Standard edition;
-        - value range : `drds.sn1.8c16g.16c32g`, `drds.sn1.8c16g.32c64g`, `drds.sn1.8c16g.64c128g`
-    - `drds.sn1.16c32g` for DRDS instance Enterprise Edition;
-        - value range : `drds.sn1.16c32g.32c64g`, `drds.sn1.16c32g.64c128g`
-    - `drds.sn1.32c64g` for DRDS instance Extreme Edition;
-        - value range : `drds.sn1.32c64g.128c256g`
+  - `drds.sn1.4c8g` for DRDS instance Starter version;
+    - value range : `drds.sn1.4c8g.8c16g`, `drds.sn1.4c8g.16c32g`, `drds.sn1.4c8g.32c64g`, `drds.sn1.4c8g.64c128g`
+  - `drds.sn1.8c16g` for DRDS instance Standard edition;
+    - value range : `drds.sn1.8c16g.16c32g`, `drds.sn1.8c16g.32c64g`, `drds.sn1.8c16g.64c128g`
+  - `drds.sn1.16c32g` for DRDS instance Enterprise Edition;
+    - value range : `drds.sn1.16c32g.32c64g`, `drds.sn1.16c32g.64c128g`
+  - `drds.sn1.32c64g` for DRDS instance Extreme Edition;
+    - value range : `drds.sn1.32c64g.128c256g`
 * `vpc_id` - (Optional, ForceNew, Available since v1.185.0) The id of the VPC.
 * `mysql_version` - (Optional, ForceNew, Available since v1.201.0) The MySQL version supported by the instance, with the following range of values. `5`: Fully compatible with MySQL 5.x (default) `8`: Fully compatible with MySQL 8.0. This parameter takes effect when the primary instance is created, and the read-only instance has the same MySQL version as the primary instance by default.
-       
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -91,6 +91,7 @@ The following attributes are exported:
 * `id` - The DRDS instance ID.
 * `connection_string` - (Available since v1.196.0) The connection string of the DRDS instance.
 * `port` - (Available since v1.196.0) The connection port of the DRDS instance.
+* `status` - The status of the DRDS instance.
 
 ## Timeouts
 
@@ -99,6 +100,7 @@ The following attributes are exported:
 The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 10 mins) Used when creating the drds instance (until it reaches running status).
+* `read` - (Defaults to 5 mins) Used when waiting for complete instance specification and network attributes after creation, import, or refresh.
 * `delete` - (Defaults to 10 mins) Used when terminating the drds instance.
 
 ## Import


### PR DESCRIPTION
Importing a DRDS instance omitted required attributes and could produce a replacement plan. A newly created instance can also reach `RUN` while its specification or network fields are incomplete.

This change reads the required attributes and charge type, exposes `status`, and waits for complete metadata before updating state on create, import, and refresh. Transient Describe errors are retried without treating the instance as deleted. VPC and VSwitch IDs are read from the same VIP.

It also preserves the API's `Dns` response field despite the SDK's case-sensitive `dns` tag, while retaining the SDK's numeric port decoding. Acceptance fixtures use the supported sn2 series, and the VPC lifecycle case is pinned to Hangzhou.

Validation:

- Raw-JSON regressions reproduce empty connection strings before the DNS fix and pass afterward, including lowercase `dns`, numeric ports, and a public VIP preceding the intranet VIP.
- The VPC lifecycle and all three regression test functions pass remotely in Hangzhou: four PASS, zero FAIL/SKIP. The lifecycle covers creation, required fields and DNS readback, import-state attribute comparison, a same-configuration plan, description update/restore, and Provider destruction with the framework's destroy check.
- A separate real Terraform 1.9.7 CLI test also passes using production source at commit `85f690b6381888bb56a1180b96d1c8bdc77857ee`. An isolated directory with no state imports a new Hangzhou PostPaid/sn2 instance by ID, without copying its creation state. Both `plan -refresh=false -detailed-exitcode` and `plan -refresh=true -detailed-exitcode` return 0, and the saved plan JSON reports `["no-op"]` for the instance. The creation directory then destroys the fixture successfully and has no managed resources remaining.
- The separate CLI harness is a verification-only fixture, not part of this PR. It uses the compiled provider under test rather than a registry provider. This is distinct from the SDK import-state comparison, which does not persist the imported state for subsequent steps.
- Attribute and modification coverage both pass at 100%.
- Local package vet still reports two pre-existing unused `fmt.Sprintln` results in unchanged `common.go`.
- Earlier Beijing lifecycle failures are not the current Hangzhou result.

The final VPC test-file changes after the first remote validation only indent the embedded provider configuration and make the existing `ExpectNonEmptyPlan: false` default explicit for the repository's coverage parser; no resource behavior, test values, or assertions were relaxed. The independent empty-state CLI test validates the pushed production code.

Scope: one Hangzhou PostPaid/sn2 fixture, Terraform 1.9.7 on Linux amd64. DNS field readback is verified; DNS resolution and database connectivity are not part of this test.