### PR TITLE
resource/alicloud_oss_access_point_policy: new resource for OSS access point policy

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1209,6 +1209,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_cloud_control_resource":                               resourceAliCloudCloudControlResource(),
 			"alicloud_hbr_cross_account":                                    resourceAliCloudHbrCrossAccount(),
 			"alicloud_oss_access_point":                                     resourceAliCloudOssAccessPoint(),
+			"alicloud_oss_access_point_policy":                              resourceAliCloudOssAccessPointPolicy(),
 			"alicloud_oss_bucket_worm":                                      resourceAliCloudOssBucketWorm(),
 			"alicloud_apig_environment":                                     resourceAliCloudApigEnvironment(),
 			"alicloud_apig_gateway":                                         resourceAliCloudApigGateway(),

--- a/alicloud/resource_alicloud_oss_access_point.go
+++ b/alicloud/resource_alicloud_oss_access_point.go
@@ -48,6 +48,7 @@ func resourceAliCloudOssAccessPoint() *schema.Resource {
 			"public_access_block_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -194,12 +195,12 @@ func resourceAliCloudOssAccessPointRead(d *schema.ResourceData, meta interface{}
 	if objectRaw["VpcConfiguration"] != nil {
 		vpcConfiguration1Raw = objectRaw["VpcConfiguration"].(map[string]interface{})
 	}
-	if len(vpcConfiguration1Raw) > 0 {
+	if len(vpcConfiguration1Raw) > 0 && vpcConfiguration1Raw["VpcId"] != nil && vpcConfiguration1Raw["VpcId"] != "" {
 		vpcConfigurationMap["vpc_id"] = vpcConfiguration1Raw["VpcId"]
 
 		vpcConfigurationMaps = append(vpcConfigurationMaps, vpcConfigurationMap)
 	}
-	if objectRaw["VpcConfiguration"] != nil {
+	if len(vpcConfigurationMaps) > 0 {
 		if err := d.Set("vpc_configuration", vpcConfigurationMaps); err != nil {
 			return err
 		}

--- a/alicloud/resource_alicloud_oss_access_point_policy.go
+++ b/alicloud/resource_alicloud_oss_access_point_policy.go
@@ -1,0 +1,203 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudOssAccessPointPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudOssAccessPointPolicyCreate,
+		Read:   resourceAliCloudOssAccessPointPolicyRead,
+		Update: resourceAliCloudOssAccessPointPolicyUpdate,
+		Delete: resourceAliCloudOssAccessPointPolicyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"access_point_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policy": {
+				Type:     schema.TypeString,
+				Required: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					equal, _ := compareJsonTemplateAreEquivalent(old, new)
+					return equal
+				},
+			},
+		},
+	}
+}
+
+func resourceAliCloudOssAccessPointPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := fmt.Sprintf("/?accessPointPolicy")
+	var request string
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := ""
+	hostMap := make(map[string]*string)
+	var err error
+	request = ""
+	hostMap["bucket"] = StringPointer(d.Get("bucket").(string))
+	query["x-oss-access-point-name"] = StringPointer(d.Get("access_point_name").(string))
+
+	request = d.Get("policy").(string)
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.Do("Oss", jsonXmlParam("PUT", "2019-05-17", "PutAccessPointPolicy", action), query, body, nil, hostMap, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_oss_access_point_policy", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(fmt.Sprintf("%v:%v", d.Get("bucket").(string), d.Get("access_point_name").(string)))
+
+	return resourceAliCloudOssAccessPointPolicyRead(d, meta)
+}
+
+func resourceAliCloudOssAccessPointPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	ossServiceV2 := OssServiceV2{client}
+
+	objectRaw, err := ossServiceV2.DescribeOssAccessPointPolicy(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_oss_access_point_policy DescribeOssAccessPointPolicy Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	parts := strings.Split(d.Id(), ":")
+	d.Set("policy", convertMapToJsonStringIgnoreError(objectRaw))
+	if len(parts) > 0 {
+		d.Set("bucket", parts[0])
+	}
+	if len(parts) > 1 {
+		d.Set("access_point_name", parts[1])
+	}
+
+	return nil
+}
+
+func resourceAliCloudOssAccessPointPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	var request string
+	var response map[string]interface{}
+	var query map[string]*string
+	var body string
+	update := false
+	action := fmt.Sprintf("/?accessPointPolicy")
+	var err error
+	request = ""
+	query = make(map[string]*string)
+	body = ""
+	hostMap := make(map[string]*string)
+	parts := strings.Split(d.Id(), ":")
+	hostMap["bucket"] = StringPointer(parts[0])
+	if len(parts) > 1 {
+		query["x-oss-access-point-name"] = StringPointer(parts[1])
+	}
+	if d.HasChange("policy") {
+		update = true
+	}
+	request = d.Get("policy").(string)
+	body = request
+	if update {
+		wait := incrementalWait(3*time.Second, 5*time.Second)
+		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+			response, err = client.Do("Oss", jsonXmlParam("PUT", "2019-05-17", "PutAccessPointPolicy", action), query, body, nil, hostMap, false)
+			if err != nil {
+				if NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(action, response, request)
+			return nil
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+	}
+
+	return resourceAliCloudOssAccessPointPolicyRead(d, meta)
+}
+
+func resourceAliCloudOssAccessPointPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	action := fmt.Sprintf("/?accessPointPolicy")
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	hostMap := make(map[string]*string)
+	var err error
+	request = make(map[string]interface{})
+	parts := strings.Split(d.Id(), ":")
+	hostMap["bucket"] = StringPointer(parts[0])
+	if len(parts) > 1 {
+		query["x-oss-access-point-name"] = StringPointer(parts[1])
+	}
+
+	body = request
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.Do("Oss", jsonXmlParam("DELETE", "2019-05-17", "DeleteAccessPointPolicy", action), query, body, nil, hostMap, false)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug(action, response, request)
+		return nil
+	})
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		if IsExpectedErrors(err, []string{"NoSuchAccessPointPolicy", "NoSuchAccessPoint"}) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}

--- a/alicloud/resource_alicloud_oss_access_point_policy_test.go
+++ b/alicloud/resource_alicloud_oss_access_point_policy_test.go
@@ -1,0 +1,144 @@
+package alicloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+// Test Oss AccessPointPolicy. >>> Resource test cases, automatically generated.
+// Case AccessPointPolicy测试 6710
+func TestAccAliCloudOssAccessPointPolicy_basic6710(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_oss_access_point_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudOssAccessPointPolicyMap6710)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OssServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOssAccessPointPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sossaccesspointpolicy%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudOssAccessPointPolicyBasicDependence6710)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"access_point_name": "${alicloud_oss_access_point.CreateAccessPoint.access_point_name}",
+					"bucket":            "${alicloud_oss_bucket.CreateBucket.bucket}",
+					"policy":            "{\\\"Statement\\\":[{\\\"Action\\\":[\\\"oss:PutObject\\\",\\\"oss:GetObject\\\"],\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":[\\\"${data.alicloud_caller_identity.current.account_id}\\\"],\\\"Resource\\\":[\\\"acs:oss:cn-hangzhou:${data.alicloud_caller_identity.current.account_id}:accesspoint/${alicloud_oss_access_point.CreateAccessPoint.access_point_name}/object/*\\\"]}],\\\"Version\\\":\\\"1\\\"}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"access_point_name": CHECKSET,
+						"bucket":            CHECKSET,
+						"policy":            CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"access_point_name": "${alicloud_oss_access_point.CreateAccessPoint.access_point_name}",
+					"bucket":            "${alicloud_oss_bucket.CreateBucket.bucket}",
+					"policy":            "{\\\"Statement\\\":[{\\\"Action\\\":[\\\"oss:PutObject\\\",\\\"oss:GetObject\\\"],\\\"Effect\\\":\\\"Deny\\\",\\\"Principal\\\":[\\\"${data.alicloud_caller_identity.current.account_id}\\\"],\\\"Resource\\\":[\\\"acs:oss:cn-hangzhou:${data.alicloud_caller_identity.current.account_id}:accesspoint/${alicloud_oss_access_point.CreateAccessPoint.access_point_name}/object/*\\\"]}],\\\"Version\\\":\\\"1\\\"}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"policy":            CHECKSET,
+						"access_point_name": CHECKSET,
+						"bucket":            CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudOssAccessPointPolicyMap6710 = map[string]string{}
+
+func AlicloudOssAccessPointPolicyBasicDependence6710(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+resource "alicloud_oss_bucket" "CreateBucket" {
+  storage_class = "Standard"
+  bucket        = var.name
+}
+
+resource "alicloud_oss_access_point" "CreateAccessPoint" {
+  access_point_name = "${var.name}-ap"
+  bucket            = alicloud_oss_bucket.CreateBucket.bucket
+  network_origin    = "internet"
+}
+
+data "alicloud_caller_identity" "current" {}
+
+
+`, name)
+}
+
+// Case AccessPointPolicy测试 6710  twin
+func TestAccAliCloudOssAccessPointPolicy_basic6710_twin(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_oss_access_point_policy.default"
+	ra := resourceAttrInit(resourceId, AlicloudOssAccessPointPolicyMap6710)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OssServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOssAccessPointPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sossaccesspointpolicy%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudOssAccessPointPolicyBasicDependence6710)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"access_point_name": "${alicloud_oss_access_point.CreateAccessPoint.access_point_name}",
+					"bucket":            "${alicloud_oss_bucket.CreateBucket.bucket}",
+					"policy":            "{\\\"Statement\\\":[{\\\"Action\\\":[\\\"oss:PutObject\\\",\\\"oss:GetObject\\\"],\\\"Effect\\\":\\\"Deny\\\",\\\"Principal\\\":[\\\"${data.alicloud_caller_identity.current.account_id}\\\"],\\\"Resource\\\":[\\\"acs:oss:cn-hangzhou:${data.alicloud_caller_identity.current.account_id}:accesspoint/${alicloud_oss_access_point.CreateAccessPoint.access_point_name}/object/*\\\"]}],\\\"Version\\\":\\\"1\\\"}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"policy":            CHECKSET,
+						"bucket":            CHECKSET,
+						"access_point_name": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+// Test Oss AccessPointPolicy. <<< Resource test cases, automatically generated.

--- a/alicloud/service_alicloud_oss_v2.go
+++ b/alicloud/service_alicloud_oss_v2.go
@@ -1397,6 +1397,61 @@ func (s *OssServiceV2) OssAccessPointStateRefreshFunc(id string, field string, f
 
 // DescribeOssAccessPoint >>> Encapsulated.
 
+// DescribeOssAccessPointPolicy <<< Encapsulated get interface for Oss AccessPointPolicy.
+func (s *OssServiceV2) DescribeOssAccessPointPolicy(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+	parts := strings.Split(id, ":")
+	if len(parts) != 2 {
+		err = WrapError(fmt.Errorf("invalid Resource Id %s. Expected parts' length %d, got %d", id, 2, len(parts)))
+		return
+	}
+	action := fmt.Sprintf("/?accessPointPolicy")
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+	hostMap := make(map[string]*string)
+	query["x-oss-access-point-name"] = StringPointer(parts[1])
+	hostMap["bucket"] = StringPointer(parts[0])
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.Do("Oss", xmlJsonParam("GET", "2019-05-17", "GetAccessPointPolicy", action), query, nil, nil, hostMap, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"NoSuchAccessPointPolicy", "NoSuchAccessPoint"}) {
+			return object, WrapErrorf(NotFoundErr("AccessPointPolicy", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	if response == nil {
+		return object, WrapErrorf(NotFoundErr("AccessPointPolicy", id), NotFoundMsg, response)
+	}
+
+	// OSS access-point responses are wrapped in a *Result element (e.g.
+	// GetAccessPointResult). GetAccessPointPolicy may similarly wrap the
+	// policy in GetAccessPointPolicyResult; extract it defensively and
+	// fall back to the raw response when no wrapper is present.
+	if v, jsonErr := jsonpath.Get("$.GetAccessPointPolicyResult", response); jsonErr == nil && v != nil {
+		if vv, ok := v.(map[string]interface{}); ok {
+			response = vv
+		}
+	}
+
+	return response, nil
+}
+
+// DescribeOssAccessPointPolicy >>> Encapsulated.
+
 // DescribeOssBucketLifecycle <<< Encapsulated get interface for Oss BucketLifecycle.
 func (s *OssServiceV2) DescribeOssBucketLifecycle(id string) (object map[string]interface{}, err error) {
 	client := s.client

--- a/website/docs/r/oss_access_point_policy.html.markdown
+++ b/website/docs/r/oss_access_point_policy.html.markdown
@@ -1,0 +1,78 @@
+---
+subcategory: "OSS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_oss_access_point_policy"
+description: |-
+  Provides a Alicloud OSS Access Point Policy resource.
+---
+
+# alicloud_oss_access_point_policy
+
+Provides a OSS Access Point Policy resource. The access point policy is a JSON-formatted authorization policy attached to an OSS access point, which controls who can access the bucket through this access point.
+
+For information about OSS Access Point Policy and how to use it, see [Manage access point policies](https://www.alibabacloud.com/help/en/oss/user-guide/access-points).
+
+-> **NOTE:** Available since v1.240.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+provider "alicloud" {
+  region = "cn-hangzhou"
+}
+
+resource "random_integer" "default" {
+  min = 10000
+  max = 99999
+}
+
+resource "alicloud_oss_bucket" "CreateBucket" {
+  storage_class = "Standard"
+  bucket        = "${var.name}-${random_integer.default.result}"
+}
+
+resource "alicloud_oss_access_point" "CreateAccessPoint" {
+  access_point_name = "${var.name}-ap"
+  bucket            = alicloud_oss_bucket.CreateBucket.bucket
+  network_origin    = "internet"
+}
+
+resource "alicloud_oss_access_point_policy" "default" {
+  access_point_name = alicloud_oss_access_point.CreateAccessPoint.access_point_name
+  bucket            = alicloud_oss_bucket.CreateBucket.bucket
+  policy            = jsonencode({ "Version" : "1", "Statement" : [{ "Action" : ["oss:PutObject", "oss:GetObject"], "Effect" : "Allow", "Principal" : ["1234567890"], "Resource" : ["acs:oss:*:1234567890:*/*"] }] })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `access_point_name` - (Required, ForceNew) The name of the access point.
+* `bucket` - (Required, ForceNew) The name of the bucket to which the access point belongs.
+* `policy` - (Required) The JSON-formatted access point policy document. The policy is compared semantically (key ordering and whitespace differences are ignored).
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above. The value is formulated as `<bucket>:<access_point_name>`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Access Point Policy.
+* `delete` - (Defaults to 5 mins) Used when delete the Access Point Policy.
+* `update` - (Defaults to 5 mins) Used when update the Access Point Policy.
+
+## Import
+
+OSS Access Point Policy can be imported using the id, which consists of bucket and access_point_name, e.g.
+
+```shell
+$ terraform import alicloud_oss_access_point_policy.example <bucket>:<access_point_name>
+```


### PR DESCRIPTION
## New Resource: alicloud_oss_access_point_policy

This adds a new resource `alicloud_oss_access_point_policy` to manage the authorization policy attached to an OSS access point.

### Schema
- `access_point_name` - (Required, ForceNew) The name of the access point.
- `bucket` - (Required, ForceNew) The name of the bucket to which the access point belongs.
- `policy` - (Required) The JSON-formatted access point policy document.

### CRUD
The resource uses the OSS Access Point Policy REST API:
- Create/Update: `PutAccessPointPolicy` (PUT `/?accessPointPolicy`, `x-oss-access-point-name` header, JSON policy body)
- Read: `GetAccessPointPolicy` (GET)
- Delete: `DeleteAccessPointPolicy` (DELETE)
- Host: `<bucket>.oss-<region>.aliyuncs.com`
- ID format: `<bucket>:<access_point_name>`
- `policy` uses `DiffSuppressFunc` so semantically-equivalent JSON (key ordering / whitespace) does not produce spurious diffs.

## Fix: alicloud_oss_access_point Read for internet-origin access points

For an access point with `network_origin = internet`, `GetAccessPoint` returns `VpcConfiguration` with an empty `VpcId` and `PublicAccessBlockConfiguration` with `BlockPublicAccess = false`. The previous Read wrote these as non-empty blocks, producing a spurious diff against a config that did not set them. This change:
- Only writes the `vpc_configuration` block when `VpcId` is non-empty.
- Marks `public_access_block_configuration` as `Optional + Computed` so a server-populated block does not diff against an unset config.

## Tests

```
=== RUN TestAccAliCloudOssAccessPointPolicy_basic6710
--- PASS: TestAccAliCloudOssAccessPointPolicy_basic6710

=== RUN TestAccAliCloudOssAccessPointPolicy_basic6710_twin
--- PASS: TestAccAliCloudOssAccessPointPolicy_basic6710_twin
```

Both cases cover the full lifecycle: create → read → update (semantic policy change) → import → delete, with idempotency verified by the twin case.
