### PR TITLE
resource/alicloud_nlb_listener: remove idle_timeout validation upper bound and test 3600

### DIFF
--- a/alicloud/resource_alicloud_nlb_listener.go
+++ b/alicloud/resource_alicloud_nlb_listener.go
@@ -71,10 +71,9 @@ func resourceAliCloudNlbListener() *schema.Resource {
 				ValidateFunc: IntBetween(0, 65535),
 			},
 			"idle_timeout": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: IntBetween(0, 900),
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
 			},
 			"listener_description": {
 				Type:     schema.TypeString,

--- a/alicloud/resource_alicloud_nlb_listener_test.go
+++ b/alicloud/resource_alicloud_nlb_listener_test.go
@@ -68,6 +68,36 @@ func TestAccAliCloudNlbListener_basic0(t *testing.T) {
 				),
 			},
 			{
+				Config: AlicloudNlbListenerBasicDependence0NoPreserve(name) + `
+resource "alicloud_nlb_listener" "default" {
+  listener_protocol      = "TCP"
+  listener_port          = "80"
+  listener_description   = var.name
+  load_balancer_id       = alicloud_nlb_load_balancer.default.id
+  server_group_id        = alicloud_nlb_server_group.default.id
+  idle_timeout           = "3600"
+  proxy_protocol_enabled = true
+  sec_sensor_enabled     = true
+  cps                    = "10000"
+  mss                    = "0"
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"listener_protocol":      "TCP",
+						"listener_port":          "80",
+						"listener_description":   name,
+						"load_balancer_id":       CHECKSET,
+						"server_group_id":        CHECKSET,
+						"idle_timeout":           "3600",
+						"proxy_protocol_enabled": "true",
+						"sec_sensor_enabled":     "true",
+						"cps":                    "10000",
+						"mss":                    "0",
+					}),
+				),
+			},
+			{
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -215,6 +245,83 @@ resource "alicloud_nlb_server_group" "default" {
   connection_drain           = true
   connection_drain_timeout   = 60
   preserve_client_ip_enabled = true
+  tags = {
+    Created = "TF"
+  }
+  address_ip_version = "Ipv4"
+}
+`, name)
+}
+
+func AlicloudNlbListenerBasicDependence0NoPreserve(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_nlb_zones" "default" {}
+data "alicloud_vpcs" "default" {
+    name_regex = "^default-NODELETING$"
+}
+data "alicloud_resource_manager_resource_groups" "default" {}
+data "alicloud_vswitches" "default_1" {
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+  zone_id = data.alicloud_nlb_zones.default.zones.0.id
+}
+data "alicloud_vswitches" "default_2" {
+  vpc_id  = data.alicloud_vpcs.default.ids.0
+  zone_id = data.alicloud_nlb_zones.default.zones.1.id
+}
+locals {
+  zone_id_1    = data.alicloud_nlb_zones.default.zones.0.id
+  vswitch_id_1 = data.alicloud_vswitches.default_1.ids[0]
+  zone_id_2    = data.alicloud_nlb_zones.default.zones.1.id
+  vswitch_id_2 = data.alicloud_vswitches.default_2.ids[0]
+}
+resource "alicloud_nlb_load_balancer" "default" {
+  load_balancer_name = var.name
+  resource_group_id  = data.alicloud_resource_manager_resource_groups.default.ids.0
+  load_balancer_type = "Network"
+  address_type       = "Internet"
+  address_ip_version = "Ipv4"
+  tags               = {
+    Created = "tfTestAcc0"
+    For     = "Tftestacc 0"
+  }
+  vpc_id = data.alicloud_vpcs.default.ids.0
+  zone_mappings {
+    vswitch_id = local.vswitch_id_1
+    zone_id    = local.zone_id_1
+  }
+  zone_mappings {
+    vswitch_id = local.vswitch_id_2
+    zone_id    = local.zone_id_2
+  }
+}
+
+resource "alicloud_nlb_server_group" "default" {
+  resource_group_id = data.alicloud_resource_manager_resource_groups.default.ids.0
+  server_group_name = var.name
+  server_group_type = "Instance"
+  vpc_id            = data.alicloud_vpcs.default.ids.0
+  scheduler         = "Wrr"
+  protocol          = "TCP"
+  health_check {
+	health_check_url =           "/test/index.html"
+	health_check_domain =       "tf-testAcc.com"
+    health_check_enabled         = true
+    health_check_type            = "TCP"
+    health_check_connect_port    = 0
+    healthy_threshold            = 2
+    unhealthy_threshold          = 2
+    health_check_connect_timeout = 5
+    health_check_interval        = 10
+    http_check_method            = "GET"
+    health_check_http_code       = ["http_2xx", "http_3xx", "http_4xx"]
+  }
+  connection_drain           = true
+  connection_drain_timeout   = 60
+  preserve_client_ip_enabled = false
   tags = {
     Created = "TF"
   }


### PR DESCRIPTION
## Summary

Remove the upper-bound validation of `idle_timeout` on `alicloud_nlb_listener` and cover the larger value in acceptance tests.

## Changes

- `resource_alicloud_nlb_listener.go`: drop `ValidateFunc: IntBetween(0, 900)` for `idle_timeout` so values above 900 can pass client-side validation and reach the OpenAPI (the product allows larger values on whitelisted accounts).
- `resource_alicloud_nlb_listener_test.go`:
  - `TestAccAliCloudNlbListener_basic0` gains a step that updates `idle_timeout` to `3600` and asserts the read-back value. The step uses a new dependence `AlicloudNlbListenerBasicDependence0NoPreserve` whose server group sets `preserve_client_ip_enabled = false`, because the product rejects large idle timeouts combined with client-address preservation on the server group.
  - Existing dependence with `preserve_client_ip_enabled = true` and its users (including `TestAccAliCloudNlbListener_emptyStringInList`) are untouched.
- No documentation changes.

## Verification

- `gofmt` clean on changed files.
- `go test ./alicloud -run '^$'` compiles the package and tests (exit 0).
- `go vet -p=1 ./alicloud` reports only two pre-existing findings in `alicloud/common.go` (untouched by this PR); no findings in changed files.
