### PR TITLE
resource/alicloud_vpc_dhcp_options_set_attachment: fix delete state refresh to terminate when the association is gone

### DIFF
--- a/alicloud/resource_alicloud_vpc_dhcp_options_set_attachment.go
+++ b/alicloud/resource_alicloud_vpc_dhcp_options_set_attachment.go
@@ -161,7 +161,7 @@ func resourceAlicloudVpcDhcpOptionsSetAttachmentDelete(d *schema.ResourceData, m
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 	}
 	vpcService := VpcService{client}
-	stateConf := BuildStateConf([]string{}, []string{}, d.Timeout(schema.TimeoutCreate), 5*time.Second, vpcService.VpcDhcpOptionsSetStateRefreshFunc(d.Id(), []string{}))
+	stateConf := BuildStateConf([]string{}, []string{}, d.Timeout(schema.TimeoutCreate), 5*time.Second, vpcService.DescribeVpcDhcpOptionsSetAttachmentDeleteStateRefreshFunc(d.Id()))
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}

--- a/alicloud/resource_alicloud_vpc_dhcp_options_set_attachment_test.go
+++ b/alicloud/resource_alicloud_vpc_dhcp_options_set_attachment_test.go
@@ -2,22 +2,29 @@ package alicloud
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/alibabacloud-go/tea-rpc/client"
 	util "github.com/alibabacloud-go/tea-utils/service"
 	"github.com/alibabacloud-go/tea/tea"
+	"github.com/aliyun/credentials-go/credentials"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAccAlicloudVPCDhcpOptionsSetAttachment_basic0(t *testing.T) {
+func TestAccAliCloudVPCDhcpOptionsSetAttachment_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_vpc_dhcp_options_set_attachment.default"
 	ra := resourceAttrInit(resourceId, AlicloudVPCDhcpOptionsSetMap0)
@@ -331,4 +338,167 @@ func TestUnitAlicloudVPCDhcpOptionsSetAttachment(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 
+}
+
+// TestUnitAlicloudVPCDhcpOptionsSetAttachmentDeleteStateRefreshId locks the
+// regression where the Delete state refresh called GetDhcpOptionsSet with the
+// composite resource ID (vpc_id:dopt_id) instead of the dopt-* ID only.
+func TestUnitAlicloudVPCDhcpOptionsSetAttachmentDeleteStateRefreshId(t *testing.T) {
+	type apiCall struct {
+		action string
+		id     string
+	}
+	var calls []apiCall
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Error(err)
+		}
+		calls = append(calls, apiCall{action: r.Form.Get("Action"), id: r.Form.Get("DhcpOptionsSetId")})
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+	credential, err := credentials.NewCredential(new(credentials.Config).
+		SetType("access_key").SetAccessKeyId("test-key").SetAccessKeySecret("test-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoints := new(sync.Map)
+	endpoint := strings.TrimPrefix(server.URL, "http://")
+	t.Setenv("NO_PROXY", endpoint)
+	config := &connectivity.Config{
+		AccessKey: "test-key", SecretKey: "test-secret", Credential: credential,
+		RegionId: "cn-hangzhou", AccountType: "test", Protocol: "http",
+		Endpoints: endpoints, SignVersion: new(sync.Map), SkipRegionValidation: true,
+	}
+	client, err := config.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoints.Store("vpc", endpoint)
+
+	d := schema.TestResourceDataRaw(t, resourceAlicloudVpcDhcpOptionsSetAttachement().Schema, map[string]interface{}{
+		"vpc_id":              "vpc_id",
+		"dhcp_options_set_id": "dhcp_options_set_id",
+		"dry_run":             false,
+	})
+	d.SetId("vpc_id:dhcp_options_set_id")
+
+	if err := resourceAlicloudVpcDhcpOptionsSetAttachmentDelete(d, client); err != nil {
+		t.Fatalf("Delete returned an error: %s", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 API calls (DetachDhcpOptionsSetFromVpc + GetDhcpOptionsSet), got %d: %+v", len(calls), calls)
+	}
+	if calls[1].action != "GetDhcpOptionsSet" {
+		t.Fatalf("expected the second call to be GetDhcpOptionsSet, got %s", calls[1].action)
+	}
+	if calls[1].id != "dhcp_options_set_id" {
+		t.Fatalf("GetDhcpOptionsSet must receive the dopt-* ID only, got %q", calls[1].id)
+	}
+}
+
+// TestUnitAlicloudVPCDhcpOptionsSetAttachmentDeleteStateRefreshGone locks the
+// wait-termination semantics of the Delete state refresh: when the DHCP
+// options set still exists but the VPC is no longer associated, Delete must
+// terminate instead of polling until the timeout.
+func TestUnitAlicloudVPCDhcpOptionsSetAttachmentDeleteStateRefreshGone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Error(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("Action") == "GetDhcpOptionsSet" {
+			_, _ = w.Write([]byte(`{"DhcpOptionsSetId":"dhcp_options_set_id","AssociateVpcs":[]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+	credential, err := credentials.NewCredential(new(credentials.Config).
+		SetType("access_key").SetAccessKeyId("test-key").SetAccessKeySecret("test-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoints := new(sync.Map)
+	endpoint := strings.TrimPrefix(server.URL, "http://")
+	t.Setenv("NO_PROXY", endpoint)
+	config := &connectivity.Config{
+		AccessKey: "test-key", SecretKey: "test-secret", Credential: credential,
+		RegionId: "cn-hangzhou", AccountType: "test", Protocol: "http",
+		Endpoints: endpoints, SignVersion: new(sync.Map), SkipRegionValidation: true,
+	}
+	client, err := config.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoints.Store("vpc", endpoint)
+
+	// ResourceData built from raw test config has no timeouts set, so
+	// d.Timeout() would fall back to the SDK's 20-minute system default and a
+	// regression would poll for minutes instead of failing fast.
+	res := resourceAlicloudVpcDhcpOptionsSetAttachement()
+	shortTimeout := 10 * time.Second
+	res.Timeouts.Create = &shortTimeout
+	res.Timeouts.Delete = &shortTimeout
+	d := res.Data(&terraform.InstanceState{
+		ID: "vpc_id:dhcp_options_set_id",
+		Attributes: map[string]string{
+			"vpc_id":              "vpc_id",
+			"dhcp_options_set_id": "dhcp_options_set_id",
+			"dry_run":             "false",
+		},
+	})
+
+	start := time.Now()
+	if err := resourceAlicloudVpcDhcpOptionsSetAttachmentDelete(d, client); err != nil {
+		t.Fatalf("Delete returned an error: %s", err)
+	}
+	if elapsed := time.Since(start); elapsed > 15*time.Second {
+		t.Fatalf("Delete state wait did not terminate after the association was gone: took %s", elapsed)
+	}
+}
+
+// TestUnitAlicloudVPCDhcpOptionsSetAttachmentDeleteStateRefreshAssociated
+// locks the other side of the wait-termination contract: while the VPC is
+// still associated, the Delete refresh keeps returning the object and its
+// status so the wait continues instead of terminating early.
+func TestUnitAlicloudVPCDhcpOptionsSetAttachmentDeleteStateRefreshAssociated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Error(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if r.Form.Get("Action") == "GetDhcpOptionsSet" {
+			_, _ = w.Write([]byte(`{"DhcpOptionsSetId":"dopt_id","AssociateVpcs":[{"VpcId":"vpc_id","AssociateStatus":"InUse"}]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+	credential, err := credentials.NewCredential(new(credentials.Config).
+		SetType("access_key").SetAccessKeyId("test-key").SetAccessKeySecret("test-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoints := new(sync.Map)
+	endpoint := strings.TrimPrefix(server.URL, "http://")
+	t.Setenv("NO_PROXY", endpoint)
+	config := &connectivity.Config{
+		AccessKey: "test-key", SecretKey: "test-secret", Credential: credential,
+		RegionId: "cn-hangzhou", AccountType: "test", Protocol: "http",
+		Endpoints: endpoints, SignVersion: new(sync.Map), SkipRegionValidation: true,
+	}
+	client, err := config.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoints.Store("vpc", endpoint)
+
+	vpcService := VpcService{client}
+	refreshFunc := vpcService.DescribeVpcDhcpOptionsSetAttachmentDeleteStateRefreshFunc("vpc_id:dopt_id")
+	object, status, err := refreshFunc()
+	assert.NoError(t, err)
+	assert.NotNil(t, object)
+	assert.Equal(t, "InUse", status)
 }

--- a/alicloud/service_alicloud_vpc.go
+++ b/alicloud/service_alicloud_vpc.go
@@ -1267,6 +1267,24 @@ func (s *VpcService) DescribeVpcDhcpOptionsSetAttachmentStateRefreshFunc(id stri
 	}
 }
 
+// DescribeVpcDhcpOptionsSetAttachmentDeleteStateRefreshFunc is the Delete
+// variant of the shared attachment refresh: when the VPC is no longer
+// associated the refresh returns a nil object, which lets WaitForState finish
+// through its resource-gone path instead of polling until the timeout.
+func (s *VpcService) DescribeVpcDhcpOptionsSetAttachmentDeleteStateRefreshFunc(id string) resource.StateRefreshFunc {
+	refreshFunc := s.DescribeVpcDhcpOptionsSetAttachmentStateRefreshFunc(id, []string{})
+	return func() (interface{}, string, error) {
+		object, status, err := refreshFunc()
+		if err != nil {
+			return object, status, err
+		}
+		if status == "" {
+			return nil, "", nil
+		}
+		return object, status, nil
+	}
+}
+
 func (s *VpcService) DescribeVpcNatIpCidr(id string) (object map[string]interface{}, err error) {
 	var response map[string]interface{}
 	client := s.client


### PR DESCRIPTION
Fixes the Delete state refresh of alicloud_vpc_dhcp_options_set_attachment:

1. Delete now queries GetDhcpOptionsSet with only the dopt-* options set id (not the composite vpc_id:dopt_id value).
2. The delete wait terminates when the association is gone, so deleting an already-disassociated attachment no longer times out.

Changes:
- resource_alicloud_vpc_dhcp_options_set_attachment.go: use the delete-specific state refresh on Delete.
- service_alicloud_vpc.go: add DescribeVpcDhcpOptionsSetAttachmentDeleteStateRefreshFunc, returning nil when the association no longer exists.
- resource_alicloud_vpc_dhcp_options_set_attachment_test.go: rename the acceptance test to the TestAccAliCloud prefix and add unit tests for refresh id handling, association-gone termination, and associated-state polling.

Testing:
- Unit: regression tests pass locally.
- ACC: remote acceptance tests passed against identical content.

Supersedes #10488.
