### PR TITLE
resource/alicloud_cloud_firewall_vpc_firewall_control_policy_order: map lang and old_order to ModifyVpcFirewallControlPolicyPosition

### DIFF
--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy_order.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy_order.go
@@ -40,6 +40,11 @@ func resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrder() *schema.Resour
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"old_order": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "Use 'acl_uuid' to identify the target access control policy. 'old_order' is deprecated and only sent as the OldOrder request parameter.",
+			},
 			"vpc_firewall_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -64,6 +69,12 @@ func resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderCreate(d *schema.
 	}
 	if v, ok := d.GetOk("acl_uuid"); ok {
 		request["AclUuid"] = v
+	}
+	if v, ok := d.GetOk("lang"); ok {
+		request["Lang"] = v
+	}
+	if v, ok := d.GetOk("old_order"); ok {
+		request["OldOrder"] = v
 	}
 
 	request["NewOrder"] = d.Get("order")
@@ -127,6 +138,12 @@ func resourceAliCloudCloudFirewallVpcFirewallControlPolicyOrderUpdate(d *schema.
 	query = make(map[string]interface{})
 	request["VpcFirewallId"] = parts[0]
 	request["AclUuid"] = parts[1]
+	if v, ok := d.GetOk("lang"); ok {
+		request["Lang"] = v
+	}
+	if v, ok := d.GetOk("old_order"); ok {
+		request["OldOrder"] = v
+	}
 
 	if d.HasChange("order") {
 		update = true

--- a/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy_order_test.go
+++ b/alicloud/resource_alicloud_cloud_firewall_vpc_firewall_control_policy_order_test.go
@@ -42,6 +42,15 @@ func TestAccAliCloudCloudFirewallVpcFirewallControlPolicyOrder_basic12717(t *tes
 					}),
 				),
 			},
+			{
+				Config: alicloudCloudFirewallVpcFirewallControlPolicyOrderBasicDependenceUpdate12717(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"order": "3",
+						"lang":  "en",
+					}),
+				),
+			},
 		},
 	})
 }
@@ -87,6 +96,49 @@ resource "alicloud_cloud_firewall_vpc_firewall_control_policy_order" "test" {
   order           = "${count.index + 1}"
   vpc_firewall_id = alicloud_cen_instance.test.id
   lang            = "zh"
+  acl_uuid        = split(":", alicloud_cloud_firewall_vpc_firewall_control_policy.test[count.index].id)[1]
+}`, name)
+}
+
+func alicloudCloudFirewallVpcFirewallControlPolicyOrderBasicDependenceUpdate12717(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_account" "test" {
+}
+
+resource "alicloud_cen_instance" "test" {
+  cen_instance_name = var.name
+}
+
+resource "alicloud_cloud_firewall_vpc_firewall_control_policy" "test" {
+  count            = 3
+  order            = "-1"
+  destination      = "127.0.0.2/32"
+  application_name = "ANY"
+  description      = "example_value"
+  source_type      = "net"
+  dest_port        = "80/88"
+  acl_action       = "accept"
+  lang             = "zh"
+  destination_type = "net"
+  source           = "127.0.0.1/32"
+  dest_port_type   = "port"
+  proto            = "TCP"
+  release          = true
+  vpc_firewall_id  = alicloud_cen_instance.test.id
+  lifecycle {
+    ignore_changes = [order]
+  }
+}
+
+resource "alicloud_cloud_firewall_vpc_firewall_control_policy_order" "test" {
+  count           = 3
+  order           = "${3 - count.index}"
+  vpc_firewall_id = alicloud_cen_instance.test.id
+  lang            = "en"
   acl_uuid        = split(":", alicloud_cloud_firewall_vpc_firewall_control_policy.test[count.index].id)[1]
 }`, name)
 }

--- a/website/docs/r/cloud_firewall_vpc_firewall_control_policy_order.html.markdown
+++ b/website/docs/r/cloud_firewall_vpc_firewall_control_policy_order.html.markdown
@@ -69,6 +69,10 @@ The following arguments are supported:
 
   -> **NOTE:**  For the valid range of the new priority, see the [API for querying the effective priority range](https://help.aliyun.com/document_detail/474145.html).
 
+* `old_order` - (Optional, Deprecated) The original priority of the access control policy before modification.
+
+  -> **NOTE:** `old_order` is deprecated. Use `acl_uuid` to identify the target access control policy. This parameter is only sent as the OldOrder request parameter and is not persisted.
+
 * `vpc_firewall_id` - (Required, ForceNew) The ID of the access control policy group for the VPC border firewall. You can obtain this ID by calling the [DescribeVpcFirewallAclGroupList](https://help.aliyun.com/document_detail/159760.html) API.  
 
     Valid values:  


### PR DESCRIPTION
### What this PR does

The `alicloud_cloud_firewall_vpc_firewall_control_policy_order` resource calls `ModifyVpcFirewallControlPolicyPosition` on Create/Update. The `lang` argument was accepted in schema but never added to the request map, so the language of the request/response could not be controlled.

This PR:
- Sends `Lang` in the Create/Update request when `lang` is set (matches the sibling `alicloud_cloud_firewall_vpc_firewall_control_policy` resource convention).
- Adds a deprecated `old_order` argument mapping to the `OldOrder` request parameter, marked Deprecated in favor of `acl_uuid`. `old_order` is request-only and is not persisted by Read.

### Verification

- `gofmt` + `go vet -p=1 ./alicloud` pass locally (only pre-existing unrelated `fmt.Sprintln` notes in `common.go`).
- Existing acc test `TestAccAliCloudCloudFirewallVpcFirewallControlPolicyOrder_basic12717` already sets `lang = "zh"` in its config and asserts `lang = "zh"`; with this fix the value is now actually sent on the request.
- Remote ACC verification is pending.
