### PR TITLE
resource/alicloud_vpc: fix non-idempotent handling of system_route_table_route_propagation_enable

### DIFF
--- a/alicloud/resource_alicloud_vpc.go
+++ b/alicloud/resource_alicloud_vpc.go
@@ -616,9 +616,14 @@ func resourceAliCloudVpcVpcUpdate(d *schema.ResourceData, meta interface{}) erro
 		request["RouteTableName"] = d.Get("system_route_table_name")
 	}
 
-	if v, ok := d.GetOkExists("system_route_table_route_propagation_enable"); (d.IsNewResource() && ok && !v.(bool)) || (!d.IsNewResource() && d.HasChange("system_route_table_route_propagation_enable")) {
-		update = true
-		request["RoutePropagationEnable"] = d.Get("system_route_table_route_propagation_enable")
+	if _, ok := d.GetOkExists("system_route_table_route_propagation_enable"); (d.IsNewResource() && ok) || (!d.IsNewResource() && d.HasChange("system_route_table_route_propagation_enable")) {
+		// The API rejects both enabling an already-enabled propagation and disabling an already-disabled one,
+		// so the request is driven by the live value instead of the state value.
+		target := d.Get("system_route_table_route_propagation_enable")
+		if current, exists := objectRaw["RoutePropagationEnable"]; !exists || current == nil || fmt.Sprint(current) != fmt.Sprint(target) {
+			update = true
+			request["RoutePropagationEnable"] = target
+		}
 	}
 
 	if update {

--- a/alicloud/resource_alicloud_vpc_test.go
+++ b/alicloud/resource_alicloud_vpc_test.go
@@ -1231,6 +1231,16 @@ func TestAccAliCloudVPCVPC_basic3113(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"system_route_table_route_propagation_enable": "true",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"system_route_table_route_propagation_enable": "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"vpc_name": name + "_update",
 				}),
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
### Problem

`ModifyRouteTableAttributes` is not idempotent for `RoutePropagationEnable`: it rejects
enabling route propagation that is already enabled, and equally rejects disabling it when it
is already disabled.

`resourceAliCloudVpcVpcUpdate` decided whether to send `RoutePropagationEnable` purely from
the state value — `d.HasChange` on update, plus a hardcoded assumption that the remote
default is always `true` on create (`d.IsNewResource() && ok && !v.(bool)`). Whenever the
state value and the live value disagree, the provider issues a redundant call that the API
rejects and the apply fails. This affects both directions, not just enabling.

### Fix

Keep the same user-intent gate, but decide whether to actually send the parameter by
comparing the target against the live `RoutePropagationEnable`. That value is already
fetched a few lines above from `DescribeRouteTableList` for `RouteTableId`, so no extra
API call is needed. This mirrors how `classic_link_enabled` in the same function compares
against a live describe before calling enable/disable.

Dropping the `!v.(bool)` special case also removes the assumption that propagation is
always enabled on a freshly created VPC — the live comparison covers that case correctly
either way.

### Test

`TestAccAliCloudVPCVPC_basic3113` now toggles the attribute back to `true` after disabling
it, so the re-enable direction is exercised; previously no test turned it back on.

Acceptance tests (cn-hangzhou):

```
--- PASS: TestAccAliCloudVPCVPC_basic3113 (98.61s)
--- PASS: TestAccAliCloudVPCVPC_basic3113_twin (122.52s)
--- PASS: TestAccAliCloudVPCVPC_basic9656 (40.38s)
```

Debug logs confirm `ModifyRouteTableAttributes` is now invoked exactly twice across the
suite — once for the genuine `true -> false` transition and once for `false -> true` — and
is correctly skipped on create with `system_route_table_route_propagation_enable = true`,
where the live value already matches.