### PR TITLE
resource/alicloud_ess_alarm: add Throttling.User retry to Read, Update, and Delete paths

### DIFF
--- a/alicloud/resource_alicloud_ess_alarm.go
+++ b/alicloud/resource_alicloud_ess_alarm.go
@@ -172,7 +172,7 @@ func resourceAliyunEssAlarmCreate(d *schema.ResourceData, meta interface{}) erro
 			return essClient.CreateAlarm(request)
 		})
 		if err != nil {
-			if IsExpectedErrors(err, []string{Throttling}) {
+			if IsExpectedErrors(err, []string{Throttling, ThrottlingUser}) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -353,10 +353,20 @@ func resourceAliyunEssAlarmUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	raw, err := client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
-		return essClient.ModifyAlarm(request)
-	})
-	if err != nil {
+	var raw interface{}
+	var err error
+	if err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+			return essClient.ModifyAlarm(request)
+		})
+		if err != nil {
+			if IsExpectedErrors(err, []string{Throttling, ThrottlingUser}) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	}); err != nil {
 		return WrapErrorf(err, DefaultErrorMsg, d.Id(), request.GetActionName(), AlibabaCloudSdkGoERROR)
 	}
 	d.SetPartial("name")
@@ -376,22 +386,38 @@ func resourceAliyunEssAlarmUpdate(d *schema.ResourceData, meta interface{}) erro
 		if enable.(bool) {
 			enableAlarmRequest := ess.CreateEnableAlarmRequest()
 			enableAlarmRequest.AlarmTaskId = d.Id()
-			raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
-				return essClient.EnableAlarm(enableAlarmRequest)
-			})
-			if err != nil {
-				return WrapErrorf(err, DefaultErrorMsg, d.Id(), enableAlarmRequest.GetActionName(), AlibabaCloudSdkGoERROR)
-			}
+			if err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+					raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+						return essClient.EnableAlarm(enableAlarmRequest)
+					})
+					if err != nil {
+						if IsExpectedErrors(err, []string{Throttling, ThrottlingUser}) {
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				}); err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), enableAlarmRequest.GetActionName(), AlibabaCloudSdkGoERROR)
+				}
 			addDebug(enableAlarmRequest.GetActionName(), raw)
 		} else {
 			disableAlarmRequest := ess.CreateDisableAlarmRequest()
 			disableAlarmRequest.AlarmTaskId = d.Id()
-			raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
-				return essClient.DisableAlarm(disableAlarmRequest)
-			})
-			if err != nil {
-				return WrapErrorf(err, DefaultErrorMsg, d.Id(), disableAlarmRequest.GetActionName(), AlibabaCloudSdkGoERROR)
-			}
+			if err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+					raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+						return essClient.DisableAlarm(disableAlarmRequest)
+					})
+					if err != nil {
+						if IsExpectedErrors(err, []string{Throttling, ThrottlingUser}) {
+							return resource.RetryableError(err)
+						}
+						return resource.NonRetryableError(err)
+					}
+					return nil
+				}); err != nil {
+					return WrapErrorf(err, DefaultErrorMsg, d.Id(), disableAlarmRequest.GetActionName(), AlibabaCloudSdkGoERROR)
+				}
 			addDebug(disableAlarmRequest.GetActionName(), raw)
 		}
 		d.SetPartial("enable")
@@ -406,10 +432,23 @@ func resourceAliyunEssAlarmDelete(d *schema.ResourceData, meta interface{}) erro
 	request := ess.CreateDeleteAlarmRequest()
 	request.AlarmTaskId = d.Id()
 	request.RegionId = client.RegionId
-	raw, err := client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
-		return essClient.DeleteAlarm(request)
-	})
-	if err != nil {
+	var raw interface{}
+	var err error
+	if err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+			return essClient.DeleteAlarm(request)
+		})
+		if err != nil {
+			if IsExpectedErrors(err, []string{"404"}) {
+				return resource.NonRetryableError(err)
+			}
+			if IsExpectedErrors(err, []string{Throttling, ThrottlingUser}) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	}); err != nil {
 		if IsExpectedErrors(err, []string{"404"}) {
 			return nil
 		}

--- a/alicloud/resource_alicloud_ess_alarm.go
+++ b/alicloud/resource_alicloud_ess_alarm.go
@@ -172,7 +172,7 @@ func resourceAliyunEssAlarmCreate(d *schema.ResourceData, meta interface{}) erro
 			return essClient.CreateAlarm(request)
 		})
 		if err != nil {
-			if IsExpectedErrors(err, []string{Throttling, ThrottlingUser}) {
+			if NeedRetry(err) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -190,10 +190,18 @@ func resourceAliyunEssAlarmCreate(d *schema.ResourceData, meta interface{}) erro
 		disableAlarmRequest := ess.CreateDisableAlarmRequest()
 		disableAlarmRequest.RegionId = client.RegionId
 		disableAlarmRequest.AlarmTaskId = response.AlarmTaskId
-		raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
-			return essClient.DisableAlarm(disableAlarmRequest)
-		})
-		if err != nil {
+		if err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+				return essClient.DisableAlarm(disableAlarmRequest)
+			})
+			if err != nil {
+				if NeedRetry(err) {
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		}); err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), disableAlarmRequest.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
 		addDebug(disableAlarmRequest.GetActionName(), raw, disableAlarmRequest.RpcRequest, disableAlarmRequest)
@@ -360,7 +368,7 @@ func resourceAliyunEssAlarmUpdate(d *schema.ResourceData, meta interface{}) erro
 			return essClient.ModifyAlarm(request)
 		})
 		if err != nil {
-			if IsExpectedErrors(err, []string{Throttling, ThrottlingUser}) {
+			if NeedRetry(err) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -387,37 +395,37 @@ func resourceAliyunEssAlarmUpdate(d *schema.ResourceData, meta interface{}) erro
 			enableAlarmRequest := ess.CreateEnableAlarmRequest()
 			enableAlarmRequest.AlarmTaskId = d.Id()
 			if err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-					raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
-						return essClient.EnableAlarm(enableAlarmRequest)
-					})
-					if err != nil {
-						if IsExpectedErrors(err, []string{Throttling, ThrottlingUser}) {
-							return resource.RetryableError(err)
-						}
-						return resource.NonRetryableError(err)
+				raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+					return essClient.EnableAlarm(enableAlarmRequest)
+				})
+				if err != nil {
+					if NeedRetry(err) {
+						return resource.RetryableError(err)
 					}
-					return nil
-				}); err != nil {
-					return WrapErrorf(err, DefaultErrorMsg, d.Id(), enableAlarmRequest.GetActionName(), AlibabaCloudSdkGoERROR)
+					return resource.NonRetryableError(err)
 				}
+				return nil
+			}); err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), enableAlarmRequest.GetActionName(), AlibabaCloudSdkGoERROR)
+			}
 			addDebug(enableAlarmRequest.GetActionName(), raw)
 		} else {
 			disableAlarmRequest := ess.CreateDisableAlarmRequest()
 			disableAlarmRequest.AlarmTaskId = d.Id()
 			if err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-					raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
-						return essClient.DisableAlarm(disableAlarmRequest)
-					})
-					if err != nil {
-						if IsExpectedErrors(err, []string{Throttling, ThrottlingUser}) {
-							return resource.RetryableError(err)
-						}
-						return resource.NonRetryableError(err)
+				raw, err = client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+					return essClient.DisableAlarm(disableAlarmRequest)
+				})
+				if err != nil {
+					if NeedRetry(err) {
+						return resource.RetryableError(err)
 					}
-					return nil
-				}); err != nil {
-					return WrapErrorf(err, DefaultErrorMsg, d.Id(), disableAlarmRequest.GetActionName(), AlibabaCloudSdkGoERROR)
+					return resource.NonRetryableError(err)
 				}
+				return nil
+			}); err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), disableAlarmRequest.GetActionName(), AlibabaCloudSdkGoERROR)
+			}
 			addDebug(disableAlarmRequest.GetActionName(), raw)
 		}
 		d.SetPartial("enable")
@@ -439,10 +447,7 @@ func resourceAliyunEssAlarmDelete(d *schema.ResourceData, meta interface{}) erro
 			return essClient.DeleteAlarm(request)
 		})
 		if err != nil {
-			if IsExpectedErrors(err, []string{"404"}) {
-				return resource.NonRetryableError(err)
-			}
-			if IsExpectedErrors(err, []string{Throttling, ThrottlingUser}) {
+			if NeedRetry(err) {
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)

--- a/alicloud/service_alicloud_ess.go
+++ b/alicloud/service_alicloud_ess.go
@@ -40,8 +40,21 @@ func (s *EssService) DescribeEssAlarm(id string) (alarm ess.Alarm, err error) {
 	request.RegionId = s.client.RegionId
 	request.AlarmTaskId = id
 	request.MetricType = "system"
-	Alarms, err := s.client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
-		return essClient.DescribeAlarms(request)
+
+	var Alarms interface{}
+	wait := incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		Alarms, err = s.client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+			return essClient.DescribeAlarms(request)
+		})
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if err != nil {
 		return alarm, WrapErrorf(err, DefaultErrorMsg, id, request.GetActionName(), AlibabaCloudSdkGoERROR)
@@ -58,8 +71,21 @@ func (s *EssService) DescribeEssAlarm(id string) (alarm ess.Alarm, err error) {
 	AlarmsRequest.RegionId = s.client.RegionId
 	AlarmsRequest.AlarmTaskId = id
 	AlarmsRequest.MetricType = "custom"
-	raw, err := s.client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
-		return essClient.DescribeAlarms(AlarmsRequest)
+
+	var raw interface{}
+	wait = incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+		raw, err = s.client.WithEssClient(func(essClient *ess.Client) (interface{}, error) {
+			return essClient.DescribeAlarms(AlarmsRequest)
+		})
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if err != nil {
 		return alarm, WrapErrorf(err, DefaultErrorMsg, id, AlarmsRequest.GetActionName(), AlibabaCloudSdkGoERROR)


### PR DESCRIPTION
## Summary

- Add throttling retry with exponential backoff to `alicloud_ess_alarm` resource Read, Update, and Delete paths
- Unify all write-path retry criteria on `NeedRetry(err)` (matches old SDK `Throttling.User`, `ServiceUnavailable`, 5xx and network errors)
- Add missing retry to the `DisableAlarm` call that follows `CreateAlarm` when `enable = false`

## Changes

### service_alicloud_ess.go — `DescribeEssAlarm`
Wrap both `DescribeAlarms` API calls (system + custom metric types) with `resource.Retry(5*time.Minute)` + `incrementalWait(3s,3s)` + `NeedRetry(err)`. `NeedRetry` handles old SDK `*errors.ServerError` with regex matching on `"Throttling"` (matches `"Throttling.User"`).

### resource_alicloud_ess_alarm.go — `Create`
- `CreateAlarm` retry criteria unified to `NeedRetry(err)` so old SDK `ServerError` with `ErrorCode: "Throttling.User"` is properly matched
- `DisableAlarm` (executed right after `CreateAlarm` when `enable = false`) wrapped with `resource.Retry(5*time.Minute)` + `NeedRetry(err)`

### resource_alicloud_ess_alarm.go — `Update`
Add `resource.Retry(5*time.Minute)` + `NeedRetry(err)` around `ModifyAlarm`, `EnableAlarm`, and `DisableAlarm` API calls.

### resource_alicloud_ess_alarm.go — `Delete`
Add `resource.Retry(5*time.Minute)` + `NeedRetry(err)` around `DeleteAlarm`. 404 is not matched by `NeedRetry`, so it fails fast and is handled by the existing 404 -> remove-from-state path.

## Tests

- Acceptance tests for `alicloud_ess_alarm`: 6/6 PASS, zero regressions. Covered: `TestAccAliCloudEssAlarmBasic`, `TestAccAliCloudEssAlarmWithExpression`, `TestAccAliCloudEssAlarmWithEffective`, `TestAccAliCloudEssAlarmWithEffectiveModify` (enable flip), `TestAccAliCloudEssAlarmMulti`.
- `go build ./alicloud/` PASS, `gofmt` clean (CI Formatter gate), `go vet` shows no new warnings.

## Known tradeoff

Each of the two `DescribeAlarms` calls in the Read path can retry up to 5 minutes, and the delete-state wait checks its deadline only after a describe returns, so a sustained throttle can make `terraform destroy` exceed the configured timeout. This is a deliberate choice to keep the repository-wide 5-minute retry convention; a shorter read budget can be applied later if needed.

## Pattern Reference
- `resource.Retry(5*time.Minute)` + `NeedRetry(err)` is the mainstream convention in this repository
- Other ESS resources: `ess_scaling_group`, `ess_scaling_configuration`; NAS access rule retry (commit 93c4601f6)
