### PR TITLE
resource/alicloud_oos_execution: support executions started from trigger templates

### DIFF
--- a/alicloud/resource_alicloud_oos_execution.go
+++ b/alicloud/resource_alicloud_oos_execution.go
@@ -87,6 +87,7 @@ func resourceAlicloudOosExecution() *schema.Resource {
 			"safety_check": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"start_date": {
@@ -197,7 +198,34 @@ func resourceAlicloudOosExecutionCreate(d *schema.ResourceData, meta interface{}
 	responseExecution := response["Execution"].(map[string]interface{})
 	d.SetId(fmt.Sprint(responseExecution["ExecutionId"]))
 	oosService := OosService{client}
-	stateConf := BuildStateConf([]string{}, []string{"Success", "Failed", "Cancelled"}, d.Timeout(schema.TimeoutCreate), 3*time.Second, oosService.OosExecutionStateRefreshFunc(d.Id(), "Status", []string{}))
+
+	// StartExecution does not return Category, so it has to be read back from the execution.
+	var object map[string]interface{}
+	wait = incrementalWait(3*time.Second, 3*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		object, err = oosService.DescribeOosExecution(d.Id())
+		if err != nil {
+			if NotFoundError(err) || NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return WrapErrorf(err, IdMsg, d.Id())
+	}
+
+	// Trigger-class executions register a schedule and then settle in Waiting between triggers,
+	// so they never reach a terminal state while the schedule is active.
+	targetStatus := []string{"Success", "Failed", "Cancelled"}
+	switch fmt.Sprint(object["Category"]) {
+	case "TimerTrigger", "EventTrigger", "AlarmTrigger":
+		targetStatus = append(targetStatus, "Waiting", "Running")
+	}
+
+	stateConf := BuildStateConf([]string{}, targetStatus, d.Timeout(schema.TimeoutCreate), 3*time.Second, oosService.OosExecutionStateRefreshFunc(d.Id(), "Status", []string{}))
 	if _, err := stateConf.WaitForState(); err != nil {
 		return WrapErrorf(err, IdMsg, d.Id())
 	}
@@ -262,6 +290,13 @@ func resourceAlicloudOosExecutionDelete(d *schema.ResourceData, meta interface{}
 		response, err = client.RpcPost("oos", "2019-06-01", action, nil, request, false)
 		if err != nil {
 			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			// A trigger-class execution stays in Waiting until its trigger end date, so it can
+			// only be removed by forcing the deletion.
+			if IsExpectedErrors(err, []string{"Execution.DeleteFailed"}) && request["Force"] == nil {
+				request["Force"] = true
 				wait()
 				return resource.RetryableError(err)
 			}

--- a/alicloud/resource_alicloud_oos_execution_test.go
+++ b/alicloud/resource_alicloud_oos_execution_test.go
@@ -204,6 +204,107 @@ var OosExecutionMap = map[string]string{
 	"update_date": CHECKSET,
 }
 
+// A TimerTrigger parent execution stays in Waiting until the trigger fires, so this case only
+// passes if the create wait accepts Waiting for trigger-class executions.
+func TestAccAliCloudOOSExecution_timerTrigger(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_oos_execution.default"
+	ra := resourceAttrInit(resourceId, OosExecutionMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OosService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOosExecution")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1000000, 9999999)
+	name := fmt.Sprintf("tf-testAccOosExecutionTimer%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, OosExecutionTimerTriggerDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"template_name": "${alicloud_oos_template.default.template_name}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"template_name": CHECKSET,
+						"status":        "Waiting",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func OosExecutionTimerTriggerDependence(name string) string {
+	return fmt.Sprintf(`
+		resource "alicloud_ram_role" "default" {
+		  role_name = "%[1]s"
+		  assume_role_policy_document = <<DEFINITION
+		  {
+			"Statement": [
+			  {
+				"Action": "sts:AssumeRole",
+				"Effect": "Allow",
+				"Principal": {
+				  "Service": [
+					"oos.aliyuncs.com"
+				  ]
+				}
+			  }
+			],
+			"Version": "1"
+		  }
+		  DEFINITION
+		  force = true
+		}
+
+		resource "alicloud_oos_template" "default" {
+		  content= <<EOF
+		  {
+			"FormatVersion": "OOS-2019-06-01",
+			"Description": "Schedule to describe instances",
+			"RamRole": "${alicloud_ram_role.default.role_name}",
+			"Tasks": [
+			  {
+				"Name": "timer",
+				"Action": "ACS::TimerTrigger",
+				"Properties": {
+				  "Type": "at",
+				  "Expression": "2036-01-01T00:00:00Z",
+				  "EndDate": "2036-01-02T00:00:00Z"
+				}
+			  },
+			  {
+				"Properties" :{
+				  "Parameters":{
+					"Status": "Running"
+				  },
+				  "API": "DescribeInstances",
+				  "Service": "Ecs"
+				},
+				"Name": "describeInstances",
+				"Action": "ACS::ExecuteApi"
+			  }]
+		  }
+		  EOF
+		  template_name = "%[1]s"
+		  version_name = "test"
+		}
+	`, name)
+}
+
 func OosExecutionBasicdependence(name string) string {
 	return fmt.Sprintf(`
 		resource "alicloud_oos_template" "default" {

--- a/website/docs/r/oos_execution.html.markdown
+++ b/website/docs/r/oos_execution.html.markdown
@@ -13,6 +13,8 @@ Provides a OOS Execution resource. For information about Alicloud OOS Execution 
 
 -> **NOTE:** Available since v1.93.0.
 
+-> **NOTE:** When the execution template starts with a trigger task (`ACS::TimerTrigger`, `ACS::EventTrigger` or `ACS::AlarmTrigger`), the execution stays in the `Waiting` status between triggers and only reaches a terminal status after the trigger end date. For these templates the creation completes once the execution is registered, instead of waiting for `Success`, `Failed` or `Cancelled`.
+
 ## Example Usage
 
 <div style="display: block;margin-bottom: 40px;"><div class="oics-button" style="float: right;position: absolute;margin-bottom: 10px;">
@@ -84,7 +86,7 @@ The following arguments are supported:
 * `mode` - (Optional, ForceNew) The mode of OOS Execution. Valid: `Automatic`, `Debug`. Default to `Automatic`.
 * `parameters` - (Optional, ForceNew) The parameters required by the template. Default to `{}`.
 * `parent_execution_id` - (Optional, ForceNew) The id of parent execution.
-* `safety_check` - (Optional, ForceNew) The mode of safety check.
+* `safety_check` - (Optional, ForceNew, Computed) The mode of safety check. If not specified, the value returned by the server is used.
 * `template_name` - (Required, ForceNew) The name of execution template.
 * `template_version` - (Optional, ForceNew) The version of execution template.
 * `template_content` - (Optional, ForceNew, Available in v1.114.0+) The content of template. When the user selects an existing template to create and execute a task, it is not necessary to pass in this field.


### PR DESCRIPTION
## Summary
- An execution started from a template whose first task is a trigger action (`ACS::TimerTrigger`, `ACS::EventTrigger` or `ACS::AlarmTrigger`) registers a schedule and then stays in the `Waiting` status between triggers, reaching a terminal status only after the trigger end date. Create only accepted `Success`/`Failed`/`Cancelled`, so the apply always failed with a state timeout even though the execution had been created; raising the create timeout cannot help because a schedule may span months. The execution `Category` is now read back after `StartExecution` (which does not return it) and `Waiting`/`Running` are accepted for trigger-class executions.
- `safety_check` was `Optional` + `ForceNew` with neither a default nor `Computed`, while `Read` stores the value returned by the server, so every configuration that omitted the field produced a permanent diff that forced the execution to be replaced on every plan. The field is now `Computed`.
- `Delete` never passed `Force`, and `DeleteExecutions` refuses to remove an execution whose current status is `Waiting`, so `destroy` failed and left the execution behind. `Force` is now set when the API refuses because of the current status.

## Test plan
- [x] `TestAccAliCloudOOSExecution_timerTrigger` PASS in cn-beijing (15.96s): create an execution from a trigger template dated far in the future, assert it settles in `Waiting`, import, destroy. New case; it fails before this change with `timeout while waiting for state to become 'Success,Failed,Cancelled' (last state: 'Waiting')`.
- [x] `TestAccAliCloudOOSExecution_basic` PASS in cn-beijing (9.53s): create, import, destroy. This case fails on master with `safety_check: "Skip" => "" (forces new resource)` and is fixed by the `Computed` change.
- [x] `TestAccAliCloudOOSExecution_complete` PASS in cn-beijing (8.92s): create with the full attribute set, import, destroy.