### PR TITLE
resource/alicloud_fc_service: treat empty vpc_config as unset to fix panic

### DIFF
--- a/alicloud/resource_alicloud_fc_service.go
+++ b/alicloud/resource_alicloud_fc_service.go
@@ -592,25 +592,38 @@ func parseVpcConfig(d *schema.ResourceData, meta interface{}) (config *fc.VPCCon
 		confs := v.([]interface{})
 		conf, ok := confs[0].(map[string]interface{})
 
-		if !ok {
+		if !ok || conf == nil {
 			return
+		}
+		vswitchIds := conf["vswitch_ids"].(*schema.Set).List()
+		securityGroupId := conf["security_group_id"].(string)
+		// The resource documentation (website/docs/r/fc_service.html.markdown) states that a
+		// vpc_config block whose vswitch_ids and security_group_id are both empty is considered
+		// empty/unset. Honor that contract: send no VPCConfig and skip the 'role' requirement,
+		// which only applies when vpc_config is actually set. Checking this before dereferencing
+		// vswitchIds[0] also prevents an index-out-of-range panic on an empty vswitch_ids set.
+		if len(vswitchIds) == 0 && securityGroupId == "" {
+			return nil, nil
 		}
 		if role, ok := d.GetOk("role"); !ok || role.(string) == "" {
 			err = WrapError(Error("'role' is required when 'vpc_config' is set."))
 			return
 		}
-		if conf != nil {
-			vswitchIds := conf["vswitch_ids"].(*schema.Set).List()
-			vsw, e := vpcService.DescribeVSwitch(vswitchIds[0].(string))
-			if e != nil {
-				err = WrapError(e)
-				return
-			}
-			config = &fc.VPCConfig{
-				VSwitchIDs:      expandStringList(vswitchIds),
-				SecurityGroupID: StringPointer(conf["security_group_id"].(string)),
-				VPCID:           StringPointer(vsw.VpcId),
-			}
+		if len(vswitchIds) == 0 {
+			// VPCID can only be resolved by looking up a vswitch, so a vpc_config with a
+			// security_group_id but no vswitch_ids cannot build a valid VPCConfig.
+			err = WrapError(Error("'vswitch_ids' must not be empty when 'vpc_config' is set."))
+			return
+		}
+		vsw, e := vpcService.DescribeVSwitch(vswitchIds[0].(string))
+		if e != nil {
+			err = WrapError(e)
+			return
+		}
+		config = &fc.VPCConfig{
+			VSwitchIDs:      expandStringList(vswitchIds),
+			SecurityGroupID: StringPointer(securityGroupId),
+			VPCID:           StringPointer(vsw.VpcId),
 		}
 	}
 	return

--- a/alicloud/resource_alicloud_fc_service_test.go
+++ b/alicloud/resource_alicloud_fc_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func init() {
@@ -739,3 +740,90 @@ var testFCVpcPolicyTemplate = `
   ]
 }
 `
+
+// TestUnitAliCloudFCServiceParseVpcConfig guards parseVpcConfig against a regression where a
+// vpc_config block with an empty vswitch_ids set caused an index-out-of-range panic. It also
+// pins the documented behavior that a vpc_config block whose vswitch_ids and security_group_id
+// are both empty is treated as unset (see website/docs/r/fc_service.html.markdown), including
+// the requirement that this is decided before the 'role' guard. Every case returns before
+// parseVpcConfig reaches DescribeVSwitch, so the test performs no network call and needs no
+// credentials.
+func TestUnitAliCloudFCServiceParseVpcConfig(t *testing.T) {
+	meta := &connectivity.AliyunClient{}
+	const testRole = "acs:ram::1234567890123456:role/fc-service-unit-test"
+
+	// Case 1 (regression anchor): vpc_config present but vswitch_ids and security_group_id both
+	// empty, with role set. On the unfixed code this panics at vswitchIds[0]; the fix returns
+	// (nil, nil).
+	t.Run("both empty is treated as unset", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, resourceAlicloudFCService().Schema, map[string]interface{}{
+			"role": testRole,
+			"vpc_config": []interface{}{
+				map[string]interface{}{
+					"vswitch_ids":       []interface{}{},
+					"security_group_id": "",
+				},
+			},
+		})
+		config, err := parseVpcConfig(d, meta)
+		if err != nil {
+			t.Fatalf("expected no error for an empty vpc_config block, got: %v", err)
+		}
+		if config != nil {
+			t.Fatalf("expected nil VPCConfig for an empty vpc_config block, got: %#v", config)
+		}
+	})
+
+	// Case 2: vpc_config entirely absent must also produce no VPCConfig.
+	t.Run("missing vpc_config block", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, resourceAlicloudFCService().Schema, map[string]interface{}{
+			"role": testRole,
+		})
+		config, err := parseVpcConfig(d, meta)
+		if err != nil {
+			t.Fatalf("expected no error when vpc_config is absent, got: %v", err)
+		}
+		if config != nil {
+			t.Fatalf("expected nil VPCConfig when vpc_config is absent, got: %#v", config)
+		}
+	})
+
+	// Case 3: an empty vswitch_ids with a non-empty security_group_id cannot build a valid
+	// VPCConfig, so parseVpcConfig must return a clear error instead of panicking.
+	t.Run("empty vswitch_ids with security_group_id errors", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, resourceAlicloudFCService().Schema, map[string]interface{}{
+			"role": testRole,
+			"vpc_config": []interface{}{
+				map[string]interface{}{
+					"vswitch_ids":       []interface{}{},
+					"security_group_id": "test-security-group",
+				},
+			},
+		})
+		config, err := parseVpcConfig(d, meta)
+		if err == nil {
+			t.Fatalf("expected an error when vswitch_ids is empty but security_group_id is set, got config: %#v", config)
+		}
+	})
+
+	// Case 4 (ordering anchor): an empty vpc_config block must be treated as unset before the
+	// 'role' requirement is enforced, so omitting role must not surface the "'role' is required"
+	// error.
+	t.Run("empty vpc_config does not require role", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, resourceAlicloudFCService().Schema, map[string]interface{}{
+			"vpc_config": []interface{}{
+				map[string]interface{}{
+					"vswitch_ids":       []interface{}{},
+					"security_group_id": "",
+				},
+			},
+		})
+		config, err := parseVpcConfig(d, meta)
+		if err != nil {
+			t.Fatalf("expected no error (role not required for an empty vpc_config), got: %v", err)
+		}
+		if config != nil {
+			t.Fatalf("expected nil VPCConfig for an empty vpc_config block, got: %#v", config)
+		}
+	})
+}


### PR DESCRIPTION
### Summary
`parseVpcConfig` panics with `index out of range [0] with length 0` when an
`alicloud_fc_service` is created or updated with a `vpc_config` block whose
`vswitch_ids` set is empty (for example, when the block is emitted by a
conditional expression that resolves to an empty list). The block is present,
so `d.GetOk("vpc_config")` returns true, but `vswitch_ids[0]` was dereferenced
unconditionally.

The resource documentation already states the intended contract:
> **NOTE:** If both `vswitch_ids` and `security_group_id` are empty, vpc_config
> is considered to be empty or unset.

### Changes
- When both `vswitch_ids` and `security_group_id` are empty, return no
  `VPCConfig` (treat the block as unset), matching the documented behavior.
- Perform that check before the `role` requirement, so an empty `vpc_config`
  block does not incorrectly require `role`.
- When `vswitch_ids` is empty but `security_group_id` is set, return a clear
  error instead of panicking, since a `VPCConfig` cannot be built (its
  `vpc_id` is resolved from a vswitch).
- Add `TestUnitAliCloudFCServiceParseVpcConfig` covering all four paths. The
  test drives `parseVpcConfig` via `schema.TestResourceDataRaw` and returns
  before any API call, so it needs no credentials.

### Note on behavior
A literal empty `vpc_config {}` block (both fields empty) will now show a
persistent `vpc_config.# 0 => 1` plan diff, because Read only populates
`vpc_config` in state when a VPC is actually attached. This matches the
existing behavior of the sibling optional blocks `log_config` and
`tracing_config`, and is preferable to the previous hard panic. Users who
conditionally attach a VPC can avoid the diff entirely with a `dynamic
"vpc_config"` block that emits zero blocks when not needed.

### Test
- `go test ./alicloud/ -run TestUnitAliCloudFCServiceParseVpcConfig -v` -> PASS (4/4)
- Verified the test fails with the original panic on the pre-fix code.
