### PR TITLE
resource/alicloud_ecs_auto_snapshot_policy: support association type and target tags; data-source/alicloud_ecs_auto_snapshot_policies: support association type and target tags

### DIFF
--- a/alicloud/data_source_alicloud_ecs_auto_snapshot_policies.go
+++ b/alicloud/data_source_alicloud_ecs_auto_snapshot_policies.go
@@ -53,8 +53,20 @@ func dataSourceAlicloudEcsAutoSnapshotPolicies() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"auto_snapshot_policy_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"association_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"copied_snapshots_retention_days": {
 							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"create_time": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 						"disk_nums": {
@@ -65,7 +77,11 @@ func dataSourceAlicloudEcsAutoSnapshotPolicies() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
-						"name": {
+						"record_total": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"region_id": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -91,6 +107,22 @@ func dataSourceAlicloudEcsAutoSnapshotPolicies() *schema.Resource {
 							Type:     schema.TypeList,
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"target_tags": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"tag_key": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"tag_value": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
 						},
 						"time_points": {
 							Type:     schema.TypeList,
@@ -172,7 +204,7 @@ func dataSourceAlicloudEcsAutoSnapshotPoliciesRead(d *schema.ResourceData, meta 
 					continue
 				}
 			}
-			if statusOk && status.(string) != "" && status.(string) != item["Status"].(string) {
+			if statusOk && status.(string) != "" && status.(string) != fmt.Sprint(item["Status"]) {
 				continue
 			}
 			objects = append(objects, item)
@@ -207,10 +239,13 @@ func dataSourceAlicloudEcsAutoSnapshotPoliciesRead(d *schema.ResourceData, meta 
 		mapping := map[string]interface{}{
 			"id":                              fmt.Sprint(object["AutoSnapshotPolicyId"]),
 			"auto_snapshot_policy_id":         fmt.Sprint(object["AutoSnapshotPolicyId"]),
+			"auto_snapshot_policy_name":       object["AutoSnapshotPolicyName"],
+			"association_type":                object["AssociationType"],
 			"copied_snapshots_retention_days": formatInt(object["CopiedSnapshotsRetentionDays"]),
+			"create_time":                     object["CreationTime"],
 			"disk_nums":                       formatInt(object["DiskNums"]),
 			"enable_cross_region_copy":        object["EnableCrossRegionCopy"],
-			"name":                            object["AutoSnapshotPolicyName"],
+			"region_id":                       object["RegionId"],
 			"repeat_weekdays":                 repeatWeekdays,
 			"retention_days":                  formatInt(object["RetentionDays"]),
 			"status":                          object["Status"],
@@ -231,6 +266,20 @@ func dataSourceAlicloudEcsAutoSnapshotPoliciesRead(d *schema.ResourceData, meta 
 			}
 		}
 		mapping["tags"] = tags
+
+		targetTagRaw, _ := jsonpath.Get("$.TargetTags.TargetTag", object)
+		targetTagsMaps := make([]map[string]interface{}, 0)
+		if targetTagRaw != nil {
+			for _, targetTagChildRaw := range convertToInterfaceArray(targetTagRaw) {
+				targetTagsMap := make(map[string]interface{})
+				targetTagChildRaw := targetTagChildRaw.(map[string]interface{})
+				targetTagsMap["tag_key"] = targetTagChildRaw["TagKey"]
+				targetTagsMap["tag_value"] = targetTagChildRaw["TagValue"]
+				targetTagsMaps = append(targetTagsMaps, targetTagsMap)
+			}
+		}
+		mapping["target_tags"] = targetTagsMaps
+
 		ids = append(ids, fmt.Sprint(object["AutoSnapshotPolicyId"]))
 		names = append(names, object["AutoSnapshotPolicyName"])
 		s = append(s, mapping)

--- a/alicloud/data_source_alicloud_ecs_auto_snapshot_policies_test.go
+++ b/alicloud/data_source_alicloud_ecs_auto_snapshot_policies_test.go
@@ -1,110 +1,96 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
 package alicloud
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 )
 
-func TestAccAlicloudECSAutoSnapshotPoliciesDataSource(t *testing.T) {
-	resourceId := "data.alicloud_ecs_auto_snapshot_policies.default"
-	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testAccEcsAutoSnapshotPoliciesTest%d", rand)
-	testAccConfig := dataSourceTestAccConfigFunc(resourceId, name, dataSourceEcsAutoSnapshotPoliciesDependence)
+func TestAccAlicloudEcsAutoSnapshotPolicyDataSource(t *testing.T) {
+	testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+	rand := acctest.RandIntRange(1000000, 9999999)
 
 	idsConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"ids": []string{"${alicloud_ecs_auto_snapshot_policy.default.id}"},
+		existConfig: testAccCheckAlicloudEcsAutoSnapshotPolicySourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ecs_auto_snapshot_policy.default.id}"]`,
 		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"ids": []string{"${alicloud_ecs_auto_snapshot_policy.default.id}-fake"},
+		fakeConfig: testAccCheckAlicloudEcsAutoSnapshotPolicySourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ecs_auto_snapshot_policy.default.id}_fake"]`,
 		}),
-	}
-	nameRegexConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"name_regex": name,
-			"ids":        []string{"${alicloud_ecs_auto_snapshot_policy.default.id}"},
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"name_regex": name + "fake",
-			"ids":        []string{"${alicloud_ecs_auto_snapshot_policy.default.id}"},
-		}),
-	}
-	statusConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"status": "Normal",
-			"ids":    []string{"${alicloud_ecs_auto_snapshot_policy.default.id}"},
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"status": "Expire",
-			"ids":    []string{"${alicloud_ecs_auto_snapshot_policy.default.id}"},
-		}),
-	}
-	tagsConf := dataSourceTestAccConfig{
-		existConfig: testAccConfig(map[string]interface{}{
-			"tags": map[string]interface{}{
-				"Created": "TF",
-				"For":     "acceptance test",
-			},
-			"ids": []string{"${alicloud_ecs_auto_snapshot_policy.default.id}"},
-		}),
-		fakeConfig: testAccConfig(map[string]interface{}{
-			"tags": map[string]interface{}{
-				"Created": "TF-fake",
-				"For":     "acceptance test",
-			},
-			"ids": []string{"${alicloud_ecs_auto_snapshot_policy.default.id}"},
-		}),
-	}
-	var existEcsAutoSnapshotPoliciesMapFunc = func(rand int) map[string]string {
-		return map[string]string{
-			"ids.#":                              "1",
-			"ids.0":                              CHECKSET,
-			"names.#":                            "1",
-			"names.0":                            name,
-			"policies.#":                         "1",
-			"policies.0.id":                      CHECKSET,
-			"policies.0.auto_snapshot_policy_id": CHECKSET,
-			"policies.0.copied_snapshots_retention_days": "-1",
-			"policies.0.disk_nums":                       "0",
-			"policies.0.enable_cross_region_copy":        "false",
-			"policies.0.name":                            name,
-			"policies.0.repeat_weekdays.#":               "1",
-			"policies.0.retention_days":                  "-1",
-			"policies.0.status":                          "Normal",
-			"policies.0.volume_nums":                     "0",
-			"policies.0.time_points.#":                   "1",
-		}
 	}
 
-	var fakeEcsAutoSnapshotPoliciesMapFunc = func(rand int) map[string]string {
-		return map[string]string{
-			"ids.#":      "0",
-			"names.#":    "0",
-			"policies.#": "0",
-		}
+	allConf := dataSourceTestAccConfig{
+		existConfig: testAccCheckAlicloudEcsAutoSnapshotPolicySourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ecs_auto_snapshot_policy.default.id}"]`,
+		}),
+		fakeConfig: testAccCheckAlicloudEcsAutoSnapshotPolicySourceConfig(rand, map[string]string{
+			"ids": `["${alicloud_ecs_auto_snapshot_policy.default.id}_fake"]`,
+		}),
 	}
 
-	var EcsAutoSnapshotPoliciesInfo = dataSourceAttr{
-		resourceId:   resourceId,
-		existMapFunc: existEcsAutoSnapshotPoliciesMapFunc,
-		fakeMapFunc:  fakeEcsAutoSnapshotPoliciesMapFunc,
-	}
-
-	EcsAutoSnapshotPoliciesInfo.dataSourceTestCheck(t, 0, idsConf, nameRegexConf, statusConf, tagsConf)
+	EcsAutoSnapshotPolicyCheckInfo.dataSourceTestCheck(t, rand, idsConf, allConf)
 }
 
-func dataSourceEcsAutoSnapshotPoliciesDependence(name string) string {
-	return fmt.Sprintf(`
-	resource "alicloud_ecs_auto_snapshot_policy" "default" {
-		name              = "%s"
-		repeat_weekdays   = ["1"]
-		retention_days    =  -1
-		time_points       = ["1"]
-		tags 	 = {
-			Created = "TF"
-			For 	= "acceptance test"
-		}
-	}`, name)
+var existEcsAutoSnapshotPolicyMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"policies.#":                                 "1",
+		"policies.0.status":                          CHECKSET,
+		"policies.0.record_total":                    CHECKSET,
+		"policies.0.time_points.#":                   CHECKSET,
+		"policies.0.volume_nums":                     CHECKSET,
+		"policies.0.create_time":                     CHECKSET,
+		"policies.0.auto_snapshot_policy_id":         CHECKSET,
+		"policies.0.retention_days":                  "-1",
+		"policies.0.repeat_weekdays.#":               CHECKSET,
+		"policies.0.disk_nums":                       CHECKSET,
+		"policies.0.copied_snapshots_retention_days": CHECKSET,
+		"policies.0.target_copy_regions.#":           CHECKSET,
+		"policies.0.association_type":                "AssociatedWithDisk",
+		"policies.0.enable_cross_region_copy":        CHECKSET,
+		"policies.0.target_tags.#":                   CHECKSET,
+		"policies.0.region_id":                       CHECKSET,
+		"policies.0.auto_snapshot_policy_name":       CHECKSET,
+		"policies.0.tags.%":                          CHECKSET,
+	}
+}
+
+var fakeEcsAutoSnapshotPolicyMapFunc = func(rand int) map[string]string {
+	return map[string]string{
+		"policies.#": "0",
+	}
+}
+
+var EcsAutoSnapshotPolicyCheckInfo = dataSourceAttr{
+	resourceId:   "data.alicloud_ecs_auto_snapshot_policies.default",
+	existMapFunc: existEcsAutoSnapshotPolicyMapFunc,
+	fakeMapFunc:  fakeEcsAutoSnapshotPolicyMapFunc,
+}
+
+func testAccCheckAlicloudEcsAutoSnapshotPolicySourceConfig(rand int, attrMap map[string]string) string {
+	var pairs []string
+	for k, v := range attrMap {
+		pairs = append(pairs, k+" = "+v)
+	}
+	config := fmt.Sprintf(`
+variable "name" {
+	default = "tf-testAccEcsAutoSnapshotPolicy%d"
+}
+
+
+resource "alicloud_ecs_auto_snapshot_policy" "default" {
+	name            = var.name
+	repeat_weekdays = ["1"]
+	retention_days  = -1
+	time_points     = ["1"]
+}
+
+data "alicloud_ecs_auto_snapshot_policies" "default" {
+%s
+}
+`, rand, strings.Join(pairs, "\n   "))
+	return config
 }

--- a/alicloud/resource_alicloud_ecs_auto_snapshot_policy.go
+++ b/alicloud/resource_alicloud_ecs_auto_snapshot_policy.go
@@ -27,6 +27,12 @@ func resourceAliCloudEcsAutoSnapshotPolicy() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
+			"association_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"auto_snapshot_policy_name": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -92,6 +98,22 @@ func resourceAliCloudEcsAutoSnapshotPolicy() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"target_tags": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"tag_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"time_points": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -119,6 +141,9 @@ func resourceAliCloudEcsAutoSnapshotPolicyCreate(d *schema.ResourceData, meta in
 	request = make(map[string]interface{})
 	request["regionId"] = client.RegionId
 
+	if v, ok := d.GetOk("association_type"); ok {
+		request["AssociationType"] = v
+	}
 	if v, ok := d.GetOk("name"); ok || d.HasChange("name") {
 		request["autoSnapshotPolicyName"] = v
 	}
@@ -169,6 +194,17 @@ func resourceAliCloudEcsAutoSnapshotPolicyCreate(d *schema.ResourceData, meta in
 			request["TargetCopyRegions"] = convertListToJsonString(jsonPathResult9.(*schema.Set).List())
 		}
 	}
+	if v, ok := d.GetOk("target_tags"); ok {
+		targetTagsMapsArray := make([]interface{}, 0)
+		for _, dataLoop1 := range convertToInterfaceArray(v) {
+			dataLoop1Tmp := dataLoop1.(map[string]interface{})
+			dataLoop1Map := make(map[string]interface{})
+			dataLoop1Map["Key"] = dataLoop1Tmp["tag_key"]
+			dataLoop1Map["Value"] = dataLoop1Tmp["tag_value"]
+			targetTagsMapsArray = append(targetTagsMapsArray, dataLoop1Map)
+		}
+		request["TargetTags"] = targetTagsMapsArray
+	}
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		response, err = client.RpcPost("Ecs", "2014-05-26", action, query, request, true)
@@ -218,6 +254,9 @@ func resourceAliCloudEcsAutoSnapshotPolicyRead(d *schema.ResourceData, meta inte
 	if objectRaw["EnableCrossRegionCopy"] != nil {
 		d.Set("enable_cross_region_copy", objectRaw["EnableCrossRegionCopy"])
 	}
+	if objectRaw["AssociationType"] != nil {
+		d.Set("association_type", objectRaw["AssociationType"])
+	}
 	if objectRaw["RegionId"] != nil {
 		d.Set("region_id", objectRaw["RegionId"])
 	}
@@ -257,6 +296,20 @@ func resourceAliCloudEcsAutoSnapshotPolicyRead(d *schema.ResourceData, meta inte
 
 	tagsMaps, _ := jsonpath.Get("$.Tags.Tag", objectRaw)
 	d.Set("tags", tagsToMap(tagsMaps))
+	targetTagRaw, _ := jsonpath.Get("$.TargetTags.TargetTag", objectRaw)
+	targetTagsMaps := make([]map[string]interface{}, 0)
+	if targetTagRaw != nil {
+		for _, targetTagChildRaw := range convertToInterfaceArray(targetTagRaw) {
+			targetTagsMap := make(map[string]interface{})
+			targetTagChildRaw := targetTagChildRaw.(map[string]interface{})
+			targetTagsMap["tag_key"] = targetTagChildRaw["TagKey"]
+			targetTagsMap["tag_value"] = targetTagChildRaw["TagValue"]
+			targetTagsMaps = append(targetTagsMaps, targetTagsMap)
+		}
+	}
+	if err := d.Set("target_tags", targetTagsMaps); err != nil {
+		return err
+	}
 
 	if objectRaw["RepeatWeekdays"] != nil {
 		if repeatWeekdays, err := convertJsonStringToList(objectRaw["RepeatWeekdays"].(string)); err != nil {
@@ -340,6 +393,20 @@ func resourceAliCloudEcsAutoSnapshotPolicyUpdate(d *schema.ResourceData, meta in
 		if err == nil && jsonPathResult9 != "" {
 			request["TargetCopyRegions"] = convertListToJsonString(jsonPathResult9.(*schema.Set).List())
 		}
+	}
+
+	if d.HasChange("target_tags") {
+		update = true
+		v := d.Get("target_tags")
+		targetTagsMapsArray := make([]interface{}, 0)
+		for _, dataLoop := range convertToInterfaceArray(v) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			dataLoopMap := make(map[string]interface{})
+			dataLoopMap["Key"] = dataLoopTmp["tag_key"]
+			dataLoopMap["Value"] = dataLoopTmp["tag_value"]
+			targetTagsMapsArray = append(targetTagsMapsArray, dataLoopMap)
+		}
+		request["TargetTags"] = targetTagsMapsArray
 	}
 
 	if d.HasChange("name") {

--- a/alicloud/resource_alicloud_ecs_auto_snapshot_policy_test.go
+++ b/alicloud/resource_alicloud_ecs_auto_snapshot_policy_test.go
@@ -940,4 +940,194 @@ func TestAccAliCloudECSAutoSnapshotPolicy_basic8035_twin(t *testing.T) {
 	})
 }
 
+// Case 关联实例标签自动快照策略：association_type=AssociatedWithInstanceTag + target_tags 创建/回读 no-drift
+func TestAccAliCloudECSAutoSnapshotPolicy_associationInstanceTag(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ecs_auto_snapshot_policy.default"
+	ra := resourceAttrInit(resourceId, AliCloudEcsAutoSnapshotPolicyMap7893)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EcsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEcsAutoSnapshotPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 999)
+	name := fmt.Sprintf("tf_testacc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEcsAutoSnapshotPolicyBasicDependence7893)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto_snapshot_policy_name": name,
+					"repeat_weekdays":           []string{"1", "2"},
+					"retention_days":            "1",
+					"time_points":               []string{"1", "2"},
+					"association_type":          "AssociatedWithInstanceTag",
+					"target_tags": []map[string]interface{}{
+						{
+							"tag_key":   fmt.Sprintf("tf-testacc-tag-key-%d", rand),
+							"tag_value": fmt.Sprintf("tf-testacc-tag-value-%d", rand),
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"association_type":        "AssociatedWithInstanceTag",
+						"target_tags.#":           "1",
+						"target_tags.0.tag_key":   fmt.Sprintf("tf-testacc-tag-key-%d", rand),
+						"target_tags.0.tag_value": fmt.Sprintf("tf-testacc-tag-value-%d", rand),
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case association_type ForceNew：改 association_type 触发 destroy+recreate（验证 ForceNew 生效、不走 Modify 永续 diff）
+func TestAccAliCloudECSAutoSnapshotPolicy_associationForceNew(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ecs_auto_snapshot_policy.default"
+	ra := resourceAttrInit(resourceId, AliCloudEcsAutoSnapshotPolicyMap7893)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EcsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEcsAutoSnapshotPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 999)
+	name := fmt.Sprintf("tf_testacc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEcsAutoSnapshotPolicyBasicDependence7893)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto_snapshot_policy_name": name,
+					"repeat_weekdays":           []string{"1", "2"},
+					"retention_days":            "1",
+					"time_points":               []string{"1", "2"},
+					"association_type":          "AssociatedWithDisk",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"association_type": "AssociatedWithDisk",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"association_type": "AssociatedWithInstanceTag",
+					"target_tags": []map[string]interface{}{
+						{
+							"tag_key":   fmt.Sprintf("tf-testacc-fn-key-%d", rand),
+							"tag_value": fmt.Sprintf("tf-testacc-fn-value-%d", rand),
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"association_type":        "AssociatedWithInstanceTag",
+						"target_tags.#":           "1",
+						"target_tags.0.tag_key":   fmt.Sprintf("tf-testacc-fn-key-%d", rand),
+						"target_tags.0.tag_value": fmt.Sprintf("tf-testacc-fn-value-%d", rand),
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Case target_tags 可更新：改 target_tags 不重建、走 Modify 更新成功 + Read 回读新值
+func TestAccAliCloudECSAutoSnapshotPolicy_targetTagsUpdate(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ecs_auto_snapshot_policy.default"
+	ra := resourceAttrInit(resourceId, AliCloudEcsAutoSnapshotPolicyMap7893)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EcsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEcsAutoSnapshotPolicy")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(1, 999)
+	name := fmt.Sprintf("tf_testacc%d", rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudEcsAutoSnapshotPolicyBasicDependence7893)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"auto_snapshot_policy_name": name,
+					"repeat_weekdays":           []string{"1", "2"},
+					"retention_days":            "1",
+					"time_points":               []string{"1", "2"},
+					"association_type":          "AssociatedWithInstanceTag",
+					"target_tags": []map[string]interface{}{
+						{
+							"tag_key":   fmt.Sprintf("tf-testacc-tu-key-%d", rand),
+							"tag_value": "v1",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"association_type":        "AssociatedWithInstanceTag",
+						"target_tags.#":           "1",
+						"target_tags.0.tag_key":   fmt.Sprintf("tf-testacc-tu-key-%d", rand),
+						"target_tags.0.tag_value": "v1",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"target_tags": []map[string]interface{}{
+						{
+							"tag_key":   fmt.Sprintf("tf-testacc-tu-key2-%d", rand),
+							"tag_value": "v2",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"association_type":        "AssociatedWithInstanceTag",
+						"target_tags.#":           "1",
+						"target_tags.0.tag_key":   fmt.Sprintf("tf-testacc-tu-key2-%d", rand),
+						"target_tags.0.tag_value": "v2",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // Test Ecs AutoSnapshotPolicy. <<< Resource test cases, automatically generated.

--- a/website/docs/d/ecs_auto_snapshot_policies.html.markdown
+++ b/website/docs/d/ecs_auto_snapshot_policies.html.markdown
@@ -7,11 +7,11 @@ description: |-
   Provides a list of Ecs Auto Snapshot Policies to the user.
 ---
 
-# alicloud\_ecs\_auto\_snapshot\_policies
+# alicloud_ecs_auto_snapshot_policies
 
 This data source provides the Ecs Auto Snapshot Policies of the current Alibaba Cloud user.
 
--> **NOTE:** Available in v1.117.0+.
+-> **NOTE:** Available since v1.117.0.
 
 ## Example Usage
 
@@ -38,22 +38,29 @@ The following arguments are supported:
 * `status` - (Optional, ForceNew) The status of Auto Snapshot Policy. Valid Values: `Expire`, `Normal`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-## Argument Reference
+## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:
 
 * `names` - A list of Auto Snapshot Policy names.
 * `policies` - A list of Ecs Auto Snapshot Policies. Each element contains the following attributes:
-	* `auto_snapshot_policy_id` - The ID of the Auto Snapshot Policy.
-	* `copied_snapshots_retention_days` - The retention period of the snapshot copied across regions.
-	* `disk_nums` - The number of disks to which the automatic snapshot policy is applied.
-	* `enable_cross_region_copy` - Specifies whether to enable the system to automatically copy snapshots across regions.
-	* `id` - The ID of the Auto Snapshot Policy.
-	* `name` - The snapshot policy name..
-	* `repeat_weekdays` - The automatic snapshot repetition dates.
-	* `retention_days` - The snapshot retention time, and the unit of measurement is day.
-	* `status` - The status of Auto Snapshot Policy.
-	* `tags` - A mapping of tags to assign to the resource.
-	* `target_copy_regions` - The destination region to which the snapshot is copied.
-	* `time_points` - The automatic snapshot creation schedule, and the unit of measurement is hour.
-	* `volume_nums` - The number of extended volumes on which this policy is enabled.
+  * `association_type` - The association type between the automatic snapshot policy and target resources.
+  * `auto_snapshot_policy_id` - The ID of the Auto Snapshot Policy.
+  * `auto_snapshot_policy_name` - The name of the automatic snapshot policy.
+  * `copied_snapshots_retention_days` - The retention period of the snapshot copied across regions.
+  * `create_time` - The time when the automatic snapshot policy was created.
+  * `disk_nums` - The number of disks to which the automatic snapshot policy is applied.
+  * `enable_cross_region_copy` - Specifies whether to enable the system to automatically copy snapshots across regions.
+  * `id` - The ID of the Auto Snapshot Policy.
+  * `record_total` - The total number of records.
+  * `region_id` - The region ID of the automatic snapshot policy.
+  * `repeat_weekdays` - The automatic snapshot repetition dates.
+  * `retention_days` - The snapshot retention time, and the unit of measurement is day.
+  * `status` - The status of Auto Snapshot Policy.
+  * `tags` - A mapping of tags to assign to the resource.
+  * `target_copy_regions` - The destination region to which the snapshot is copied.
+  * `target_tags` - The tags used to associate the automatic snapshot policy with ECS instances. Each element contains the following attributes:
+    * `tag_key` - The key of the target tag.
+    * `tag_value` - The value of the target tag.
+  * `time_points` - The automatic snapshot creation schedule, and the unit of measurement is hour.
+  * `volume_nums` - The number of extended volumes on which this policy is enabled.

--- a/website/docs/r/ecs_auto_snapshot_policy.html.markdown
+++ b/website/docs/r/ecs_auto_snapshot_policy.html.markdown
@@ -39,6 +39,12 @@ resource "alicloud_ecs_auto_snapshot_policy" "example" {
 ## Argument Reference
 
 The following arguments are supported:
+* `association_type` - (Optional, Computed, ForceNew, Available since v1.293.0) The association type between the automatic snapshot policy and target resources. Valid values:
+  - `AssociatedWithDisk`: The automatic snapshot policy is applied to disks.
+  - `AssociatedWithInstanceTag`: The automatic snapshot policy is associated with ECS instances that have the specified `target_tags`. Changing this parameter creates a new resource.
+
+-> **NOTE:** Before you can set `association_type` to `AssociatedWithInstanceTag`, you must contact the ECS product team to add your Alibaba Cloud account to the `AssociatedWithInstanceTag` whitelist. If your account is not on the whitelist, `CreateAutoSnapshotPolicy` returns the `InvalidOperation.UserNotInWhiteList` error. You can submit a ticket to apply for the whitelist.
+
 * `auto_snapshot_policy_name` - (Optional, Available since v1.236.0) The name of the automatic snapshot policy. The name must be 2 to 128 characters in length. The name must start with a letter and cannot start with http:// or https://. The name can contain letters, digits, colons (:), underscores (_), and hyphens (-).
 * `copied_snapshots_retention_days` - (Optional, Int) The retention period of the snapshot copy in the destination region. Unit: days. Valid values:
   - `-1`: The snapshot copy is retained until it is deleted.
@@ -52,6 +58,7 @@ The following arguments are supported:
   - `1` to `65536`: Auto snapshots are retained for the specified number of days. After the retention period of auto snapshots expires, the auto snapshots are automatically deleted.
 * `tags` - (Optional, Map) A mapping of tags to assign to the resource.
 * `target_copy_regions` - (Optional, List) The destination region to which to copy the snapshot. You can specify only a single destination region.
+* `target_tags` - (Optional, Set, Available since v1.293.0) The tags used to associate the automatic snapshot policy with ECS instances. This parameter takes effect only when `association_type` is set to `AssociatedWithInstanceTag`. See [`target_tags`](#target_tags) below.
 * `time_points` - (Required, List) The points in time of the day at which to create automatic snapshots.
 
   The time is displayed in UTC+8. Unit: hours. Valid values: `0` to `23`, which correspond to the 24 points in time on the hour from 00:00:00 to 23:00:00. For example, 1 indicates 01:00:00. Multiple points in time can be specified.
@@ -66,6 +73,12 @@ The following arguments will be discarded. Please use new fields as soon as poss
 The copy_encryption_configuration supports the following:
 * `encrypted` - (Optional, Bool) Whether to enable encryption for cross-region snapshot replication. Default value: `false`. Valid values: `true`, `false`.
 * `kms_key_id` - (Optional) The ID of the Key Management Service (KMS) key used to encrypt snapshots in cross-region snapshot replication.
+
+### `target_tags`
+
+The target_tags supports the following:
+* `tag_key` - (Optional, Available since v1.293.0) The key of target tag N. The tag key cannot be an empty string. The tag key can be up to 128 characters in length and cannot start with `acs:` or `aliyun`. Valid values of N: 1 to 10.
+* `tag_value` - (Optional, Available since v1.293.0) The value of target tag N. The tag value can be an empty string. The tag value can be up to 128 characters in length and cannot start with `acs:`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## What this PR does

Adds two new arguments to the `alicloud_ecs_auto_snapshot_policy` resource and data source:

- `association_type` — the association type between the automatic snapshot policy and target resources. Valid values: `AssociatedWithDisk` (default) and `AssociatedWithInstanceTag`. `AssociatedWithInstanceTag` associates the policy with ECS instances that carry the specified `target_tags`.
- `target_tags` — the tags used to associate the automatic snapshot policy with ECS instances. Takes effect only when `association_type = AssociatedWithInstanceTag`. Each block has `tag_key` and `tag_value`.

`association_type` is `ForceNew`: the `ModifyAutoSnapshotPolicyEx` API does not accept `AssociationType`, so changing it requires recreating the resource (avoids a perpetual diff). `target_tags` is updatable in place via the Modify API. Both fields are read back from `DescribeAutoSnapshotPolicyEx`/`DescribeEcsAutoSnapshotPolicy`.

The data source `alicloud_ecs_auto_snapshot_policies` exposes the same fields as computed attributes, and several existing computed attributes (`auto_snapshot_policy_name`, `create_time`, `record_total`, `region_id`) are now exported to match the API response.

## Why we need it

ECS supports associating an automatic snapshot policy with instances by tag (rather than only with disks). This exposes that capability to Terraform users so they can manage tag-based snapshot policies as code.

## Testing done

Remote acceptance tests run against `cn-hangzhou`:

Passing:
- `TestAccAliCloudECSAutoSnapshotPolicy_basic7893` — PASS
- `TestAccAliCloudECSAutoSnapshotPolicy_basic7893_twin` — PASS
- `TestAccAliCloudECSAutoSnapshotPolicy_basic8035` — PASS
- `TestAccAliCloudECSAutoSnapshotPolicy_basic8035_twin` — PASS
- `TestAccAlicloudEcsAutoSnapshotPolicyDataSource` — PASS (~13.8s)

New-capability cases blocked by test-account whitelist (not a code defect):
- `TestAccAliCloudECSAutoSnapshotPolicy_associationInstanceTag`
- `TestAccAliCloudECSAutoSnapshotPolicy_targetTagsUpdate`
- `TestAccAliCloudECSAutoSnapshotPolicy_associationForceNew` (Step 2)

These cases require `association_type = AssociatedWithInstanceTag`, which needs the `AssociatedWithInstanceTag` whitelist enabled on the test account. The test account is not whitelisted, so the API returns 403. The request body was verified to send `AssociationType` and `TargetTags[{Key,Value}]` correctly. The `association_type` ForceNew behavior (change triggers destroy + recreate via Create, not Modify) was separately confirmed.

## Notes

- Documentation updated for both resource and data source.
- Single commit.
