### PR TITLE
New Resource: alicloud_dlf_next_catalog; New Data Source: alicloud_dlf_next_catalogs

### DIFF
--- a/alicloud/connectivity/endpoint.go
+++ b/alicloud/connectivity/endpoint.go
@@ -329,6 +329,7 @@ var productCodeToConfigEndpoints = map[string]string{
 // The priority of this configuration is higher than location service, lower than user environment variable configuration
 var irregularProductEndpoint = map[string]string{
 	"tablestore": "tablestore.%s.aliyuncs.com",
+	"dlfnext":    "dlfnext.%s.aliyuncs.com",
 	//"ots":              "tablestore.%s.aliyuncs.com", // the old endpoint ots.%s.aliyuncs.com has been deprecated
 	"ram":                     "ram.aliyuncs.com",
 	"brain_industrial":        "brain-industrial.cn-hangzhou.aliyuncs.com",

--- a/alicloud/data_source_alicloud_dlf_next_catalogs.go
+++ b/alicloud/data_source_alicloud_dlf_next_catalogs.go
@@ -1,0 +1,232 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func dataSourceAliCloudDlfNextCatalogs() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAliCloudDlfNextCatalogsRead,
+		Schema: map[string]*schema.Schema{
+			"catalog_name_pattern": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsValidRegExp,
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"output_file": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"catalogs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"options": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"is_shared": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"share_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"region_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"owner": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"created_at": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"created_by": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_at": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"updated_by": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAliCloudDlfNextCatalogsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	dlfNextServiceV2 := DlfNextServiceV2{client}
+
+	var allCatalogs []interface{}
+	catalogNamePattern, _ := d.Get("catalog_name_pattern").(string)
+
+	nextToken := ""
+	maxResults := 100
+	for {
+		objects, token, err := dlfNextServiceV2.ListDlfNextCatalogs(catalogNamePattern, nextToken, maxResults)
+		if err != nil {
+			return WrapError(err)
+		}
+		allCatalogs = append(allCatalogs, objects...)
+		if token == "" {
+			break
+		}
+		nextToken = token
+	}
+
+	var catalogs []map[string]interface{}
+	var matchedNames []string
+	nameSet := make(map[string]bool)
+	if v, ok := d.GetOk("names"); ok {
+		for _, n := range v.([]interface{}) {
+			nameSet[n.(string)] = true
+		}
+	}
+	hasNameFilter := len(nameSet) > 0
+
+	var nameRegex *regexp.Regexp
+	if v, ok := d.GetOk("name_regex"); ok && v.(string) != "" {
+		r, err := regexp.Compile(v.(string))
+		if err != nil {
+			return WrapError(err)
+		}
+		nameRegex = r
+	}
+
+	for _, raw := range allCatalogs {
+		object, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		name := fmt.Sprint(object["name"])
+
+		if hasNameFilter && !nameSet[name] {
+			continue
+		}
+
+		if nameRegex != nil && !nameRegex.MatchString(name) {
+			continue
+		}
+
+		matchedNames = append(matchedNames, name)
+		catalog := map[string]interface{}{
+			"name":       name,
+			"type":       object["type"],
+			"options":    object["options"],
+			"is_shared":  object["isShared"],
+			"share_id":   object["shareId"],
+			"id":         object["id"],
+			"region_id":  object["regionId"],
+			"status":     object["status"],
+			"owner":      object["owner"],
+			"created_at": object["createdAt"],
+			"created_by": object["createdBy"],
+			"updated_at": object["updatedAt"],
+			"updated_by": object["updatedBy"],
+		}
+		catalogs = append(catalogs, catalog)
+	}
+
+	// Stable id derived from the matched catalog names (repo convention for
+	// list data sources: dataResourceIdHash). The names are sorted before
+	// hashing so identical inputs yield an identical id across runs even when
+	// ListCatalogs returns the same set in a different order, instead of a
+	// per-call ordering that would force a spurious diff on every apply.
+	// ListCatalogs may return the same set of catalogs in a different order
+	// across calls (pagination, backend sharding). Sort the catalogs written to
+	// the TypeList by name so Terraform state stays stable across refreshes;
+	// the data source id is derived separately from the matched names below.
+	catalogs = sortDlfNextCatalogsByName(catalogs)
+	d.SetId(dlfNextCatalogsID(matchedNames))
+	if err := d.Set("catalogs", catalogs); err != nil {
+		return WrapError(err)
+	}
+
+	if v, ok := d.GetOk("output_file"); ok && v.(string) != "" {
+		if err := writeToFile(v.(string), catalogs); err != nil {
+			return WrapError(err)
+		}
+	}
+
+	log.Printf("[DEBUG] dataSourceAliCloudDlfNextCatalogs: found %d catalogs", len(catalogs))
+
+	return nil
+}
+
+// dlfNextCatalogsID returns a stable data source id from a set of matched
+// catalog names. The names are sorted before hashing so the same set of
+// catalogs yields the same id regardless of the order ListCatalogs returned
+// them in (avoiding a spurious diff on every apply). Pure function for unit
+// testing.
+func dlfNextCatalogsID(names []string) string {
+	sorted := make([]string, len(names))
+	copy(sorted, names)
+	sort.Strings(sorted)
+	return dataResourceIdHash(sorted)
+}
+
+// sortDlfNextCatalogsByName returns a copy of catalogs sorted by the catalog
+// "name" field. ListCatalogs may return the same set of catalogs in a
+// different order across calls (pagination, backend sharding), so the
+// catalogs written to the TypeList are deterministically sorted by name to
+// keep Terraform state stable across refreshes — otherwise the same set of
+// catalogs returned in a different order would reorder the list in state and
+// force a spurious diff. Pure function for unit testing; the data source id
+// is derived separately via dlfNextCatalogsID from the matched names.
+func sortDlfNextCatalogsByName(catalogs []map[string]interface{}) []map[string]interface{} {
+	sorted := make([]map[string]interface{}, len(catalogs))
+	copy(sorted, catalogs)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return fmt.Sprint(sorted[i]["name"]) < fmt.Sprint(sorted[j]["name"])
+	})
+	return sorted
+}

--- a/alicloud/errors.go
+++ b/alicloud/errors.go
@@ -124,9 +124,17 @@ func IsExpectedErrors(err error, expectCodes []string) bool {
 	}
 
 	if e, ok := err.(*tea.SDKError); ok {
+		// Use tea.StringValue to avoid nil-pointer panics when Code or Data is
+		// nil (e.g. a backend validation error with Code set but Data unset).
+		// Guard HasPrefix against an empty codeVal: strings.HasPrefix(code, "")
+		// is always true and would falsely match every expected code.
+		codeVal := tea.StringValue(e.Code)
+		dataVal := tea.StringValue(e.Data)
 		for _, code := range expectCodes {
-			// The second statement aims to match the tea sdk history bug
-			if *e.Code == code || strings.HasPrefix(code, *e.Code) || strings.Contains(*e.Data, code) {
+			if codeVal == code || (codeVal != "" && strings.HasPrefix(code, codeVal)) {
+				return true
+			}
+			if dataVal != "" && strings.Contains(dataVal, code) {
 				return true
 			}
 		}

--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -173,6 +173,7 @@ func Provider() terraform.ResourceProvider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"alicloud_threat_detection_attack_path_whitelists":        dataSourceAliCloudThreatDetectionAttackPathWhitelists(),
+			"alicloud_dlf_next_catalogs":                              dataSourceAliCloudDlfNextCatalogs(),
 			"alicloud_ehpc_users":                                     dataSourceAliCloudEhpcUsers(),
 			"alicloud_realtime_compute_members":                       dataSourceAliCloudRealtimeComputeMembers(),
 			"alicloud_apig_policies":                                  dataSourceAliCloudApigPolicies(),
@@ -977,6 +978,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"alicloud_threat_detection_attack_path_whitelist":               resourceAliCloudThreatDetectionAttackPathWhitelist(),
 			"alicloud_vpc_route_target_group":                               resourceAliCloudVpcRouteTargetGroup(),
+			"alicloud_dlf_next_catalog":                                     resourceAliCloudDlfNextCatalog(),
 			"alicloud_ehpc_user":                                            resourceAliCloudEhpcUser(),
 			"alicloud_realtime_compute_member":                              resourceAliCloudRealtimeComputeMember(),
 			"alicloud_apig_policy":                                          resourceAliCloudApigPolicy(),

--- a/alicloud/resource_alicloud_dlf_next_catalog.go
+++ b/alicloud/resource_alicloud_dlf_next_catalog.go
@@ -1,0 +1,648 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceAliCloudDlfNextCatalog() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudDlfNextCatalogCreate,
+		Read:   resourceAliCloudDlfNextCatalogRead,
+		Update: resourceAliCloudDlfNextCatalogUpdate,
+		Delete: resourceAliCloudDlfNextCatalogDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "PAIMON",
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"PAIMON"}, false),
+			},
+			// options is the Terraform-managed option set. It is Optional and
+			// NOT Computed: it holds ONLY the option keys the user declares in
+			// the configuration (plus, after Create, the values the backend
+			// echoed back for those same managed names). The contract is
+			// TWO-STATE and does NOT depend on the legacy SDK distinguishing
+			// an omitted block from an explicit empty map (that distinction is
+			// unreliable in SDK v1.17.2):
+			//   - options = {k: v}: Terraform manages these keys. An Update
+			//     derives updates from the new managed set and removals from
+			//     oldManaged - newManaged.
+			//   - options = {} OR options omitted: both mean the managed set
+			//     is expected to be empty. When the SDK diff reports a change
+			//     (the reliable path for options = {}), AlterCatalog removals
+			//     delete every previously-managed key. removals are derived
+			//     ONLY from oldManaged - newManaged, never from remote_options
+			//     or server-injected defaults.
+			// The SDK fires HasChange reliably for options = {} (and for a
+			// populated block); the two-state contract is the documented
+			// intent for an omitted block as well — the previous "omit = stop
+			// managing, remote keys preserved" three-state claim is removed
+			// because the SDK cannot reliably distinguish omit from {} after a
+			// refresh. Read reconciles managed keys against the API value and
+			// drops a managed key the API no longer returns so drift surfaces.
+			// A fresh import cannot recover which remote options the user
+			// originally configured, so options is empty after import; the full
+			// remote picture (including server defaults and unmanaged keys) is
+			// available in remote_options.
+			"options": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			// remote_options is the read-only, full mirror of the GetCatalog
+			// options map, including server-injected defaults and keys the user
+			// never declared in options. It is Computed and never drives
+			// Update; it exists so a fresh import (where options is empty) does
+			// not lose the remote picture, and so users can inspect the full
+			// remote options including defaults they did not configure. Because
+			// options only ever contains managed keys, AlterCatalog removals
+			// are computed from oldManaged - newManaged and can never reach
+			// into remote_options to delete a server default or an unmanaged
+			// key.
+			"remote_options": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"is_shared": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"share_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"region_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"owner": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"updated_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudDlfNextCatalogCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	dlfNextServiceV2 := DlfNextServiceV2{client}
+	name := d.Get("name").(string)
+	inputType := d.Get("type").(string)
+
+	// Single deadline established at the START of Create, before the preflight
+	// Get, so the preflight, the POST retry, the post-error reconciliation Get
+	// and the status waiter all share one budget and the total Create cannot
+	// exceed the configured Create timeout. Each phase calls remainingUntil(deadline)
+	// to take the time it has left instead of re-asking for the full timeout.
+	//
+	// Guarantee boundary: the deadline bounds the RETRY/POLL budget for each
+	// phase. resource.Retry stops starting new attempts once its timeout is
+	// reached, but an HTTP call already in flight is not interrupted; each
+	// RoaGet has its own client-level HTTP timeout, so a single trailing call
+	// may slightly exceed the deadline. This is the practical bound, not a
+	// hard preempt of in-flight I/O.
+	createTimeout := d.Timeout(schema.TimeoutCreate)
+	deadline := time.Now().Add(createTimeout)
+
+	// Pre-create existence check. CreateCatalog carries no idempotency token
+	// and the catalog name is unique within the region, so adopting a catalog
+	// that already exists would silently hijack a resource the user may not
+	// own. Refuse to create when the name is already taken and direct the user
+	// to `terraform import` to take over management. A non-NotFound error from
+	// the pre-check (auth/service/network) is a real failure: do not proceed.
+	// The decision is a pure function so the pre-create policy is unit-testable
+	// without a live backend. The preflight Get uses the deadline's remaining
+	// time via DescribeDlfNextCatalogWithRetryTimeout (not a hardcoded minute),
+	// so it stays within the shared Create budget.
+	_, preErr := dlfNextServiceV2.DescribeDlfNextCatalogWithRetryTimeout(name, remainingUntil(deadline))
+	if proceed, pErr := decideDlfNextCatalogPreCreate(preErr); !proceed {
+		if pErr != nil {
+			return WrapErrorf(pErr, "creating DlfNext Catalog %s", name)
+		}
+		return nil
+	}
+	// NotFound -> the name is confirmed absent; proceed to create.
+
+	action := "/dlf/v1/catalogs"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+
+	request = make(map[string]interface{})
+	request["name"] = name
+	request["type"] = inputType
+	if v, ok := d.GetOk("options"); ok {
+		request["options"] = v
+	}
+	// is_shared is TypeBool, Optional, no Default: GetOkExists is the
+	// SDK-intended pattern for TypeBool (it distinguishes an explicit false
+	// from an omitted block, which d.GetOk cannot). This is distinct from the
+	// removed GetOkExists(options): options is a TypeMap where the SDK cannot
+	// reliably distinguish omit from {} after a refresh, so the two-state
+	// contract uses HasChange instead. is_shared is ForceNew and only read at
+	// Create (before any refresh), so the omit-vs-false distinction is reliable.
+	if v, ok := d.GetOkExists("is_shared"); ok {
+		request["isShared"] = v
+	}
+	if v, ok := d.GetOk("share_id"); ok {
+		request["shareId"] = v
+	}
+	body = request
+
+	// POST retry uses the time remaining in the shared deadline (set before the
+	// preflight above), so the preflight + POST together stay within one Create
+	// timeout. The backoff is exponential with jitter (review §6 category 1) so
+	// multiple ACC runners hitting the same DLF backend do not retry in
+	// lockstep and hammer the API. A backend cleanup-quota / environment-
+	// capacity error (review §6 category 2) is NOT retried: re-issuing
+	// CreateCatalog would add another catalog to the cleanup queue and worsen
+	// the quota pressure; it is surfaced as a clear INFRA_BLOCKED error.
+	wait := dlfNextCatalogBackoffWait(3*time.Second, 30*time.Second)
+	err = resource.Retry(remainingUntil(deadline), func() *resource.RetryError {
+		response, err = client.RoaPost("DlfNext", "2025-03-10", action, query, nil, body, true)
+		if err != nil {
+			// Backend cleanup-quota / env-capacity error: do NOT retry
+			// (review §6 category 2). No d.SetId, no state written.
+			if isDlfNextCatalogBackendCapacityError(err) {
+				return resource.NonRetryableError(fmt.Errorf("DLF backend capacity limit reached for catalog %s in this account/Region; CreateCatalog was not retried to avoid worsening the cleanup quota. Server message: %s. Wait for the backend to reap recently-created catalogs (approximately 48 hours) or use a different account/Region", name, err.Error()))
+			}
+			alreadyExists := isDlfNextCatalogAlreadyExistsError(err)
+			explicitClient := isDlfNextCatalogExplicitClientError(err)
+			retryable := NeedRetry(err)
+			// Fail-closed ambiguous-create reconciliation. CreateCatalog has no
+			// idempotency token and no reliable unique request marker or
+			// comparable createdBy, so ownership of a same-name catalog found
+			// after an error can NEVER be proven from attributes: type, options,
+			// isShared, shareId and createdAt only show attribute equality, not
+			// resource ownership, and a concurrent creator sending the same name
+			// and config would be wrongly adopted. Therefore a POST that errored
+			// ambiguously (lost response / timeout / connection) is NEVER
+			// auto-adopted even if GetCatalog then finds a same-name, same-config
+			// catalog: no d.SetId, no state written. The decision returns an
+			// actionable error directing the user to verify the remote catalog
+			// and run `terraform import`. AlreadyExists and explicit 4xx client
+			// errors fail outright; a retryable error with the catalog still
+			// absent retries; a found catalog or a failed post-error Get fails.
+			var getObs dlfNextCatalogGetObservation
+			if !alreadyExists && !explicitClient {
+				if _, gErr := dlfNextServiceV2.DescribeDlfNextCatalogWithRetryTimeout(name, remainingUntil(deadline)); gErr == nil {
+					getObs = dlfGetFound
+				} else if NotFoundError(gErr) {
+					getObs = dlfGetAbsent
+				} else {
+					getObs = dlfGetOtherError
+				}
+			}
+			decision, dErr := decideDlfNextCatalogCreateRecovery(alreadyExists, explicitClient, retryable, true, getObs)
+			switch decision {
+			case dlfCreateRetry:
+				wait()
+				return resource.RetryableError(err)
+			case dlfCreateFail:
+				if dErr != nil {
+					return resource.NonRetryableError(dErr)
+				}
+				return resource.NonRetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_dlf_next_catalog", action, AlibabaCloudSdkGoERROR)
+	}
+
+	d.SetId(name)
+
+	// CreateCatalog is asynchronous: it returns 200 with an empty body before
+	// the catalog reaches RUNNING. Poll GetCatalog until RUNNING. A brief
+	// NotFound immediately after create is treated as Pending (the catalog is
+	// not yet visible to Get due to eventual consistency) rather than an
+	// unexpected state; INITIALIZE_FAILED is a terminal failure. This waiter's
+	// NotFound handling is distinct from the normal Resource Read, which still
+	// clears the TF id on NotFound. The waiter uses the time left until the
+	// shared deadline so the total Create stays within one timeout.
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"NOT_FOUND", "NEW", "INITIALIZING"},
+		Target:  []string{"RUNNING"},
+		Timeout: remainingUntil(deadline),
+		// The waiter uses the deadline-aware Describe via the injectable
+		// WithApi variant, so each poll's internal retry is bounded by the
+		// shared deadline instead of a hardcoded minute that could nest inside
+		// and exceed the waiter timeout.
+		Refresh: dlfNextServiceV2.DlfNextCatalogStateRefreshFuncWithApi(d.Id(), "status", []string{"INITIALIZE_FAILED"}, func(id string) (map[string]interface{}, error) {
+			return dlfNextServiceV2.DescribeDlfNextCatalogWithRetryTimeout(id, remainingUntil(deadline))
+		}),
+	}
+	if _, err := stateConf.WaitForState(); err != nil {
+		return WrapErrorf(err, "waiting for DlfNext Catalog %s to RUNNING", d.Id())
+	}
+
+	return resourceAliCloudDlfNextCatalogRead(d, meta)
+}
+
+func resourceAliCloudDlfNextCatalogRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	dlfNextServiceV2 := DlfNextServiceV2{client}
+
+	objectRaw, err := dlfNextServiceV2.DescribeDlfNextCatalog(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_dlf_next_catalog DescribeDlfNextCatalog Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("name", objectRaw["name"])
+	d.Set("type", objectRaw["type"])
+	d.Set("is_shared", objectRaw["isShared"])
+	d.Set("share_id", objectRaw["shareId"])
+	d.Set("region_id", objectRaw["regionId"])
+	d.Set("status", objectRaw["status"])
+	d.Set("owner", objectRaw["owner"])
+	d.Set("created_at", objectRaw["createdAt"])
+	d.Set("created_by", objectRaw["createdBy"])
+	d.Set("updated_at", objectRaw["updatedAt"])
+	d.Set("updated_by", objectRaw["updatedBy"])
+
+	// Dual-field options model (two-state contract, no GetOkExists). DLF does
+	// not flag which GetCatalog options are user-set versus backend-injected
+	// defaults, so the state is split into two fields with distinct ownership:
+	//
+	//  - remote_options (Computed): always mirrors the FULL GetCatalog
+	//    options map, including server-injected defaults and keys the user
+	//    never declared. It is read-only and never drives Update. This is
+	//    the no-data-loss picture: a fresh import that cannot recover the
+	//    user's original config intent still exposes the complete remote
+	//    options here.
+	//
+	//  - options (Optional, non-Computed): holds ONLY the keys Terraform
+	//    manages. On refresh, each currently-managed key is reconciled to
+	//    the API value; a managed key the API no longer returns is dropped
+	//    from state so a server-side deletion or an ignored update surfaces
+	//    as drift in the next plan instead of being silently preserved. New
+	//    remote keys (server defaults, unmanaged additions) are written to
+	//    remote_options only and NEVER promoted into options, so AlterCatalog
+	//    removals — derived from oldManaged - newManaged — can never reach
+	//    into the full remote set and delete a server default.
+	//
+	// Two-state contract: options = {k: v} means Terraform manages those keys;
+	// options = {} OR options omitted both mean the managed set is expected to
+	// be empty and previously-managed keys are removed via AlterCatalog
+	// removals (oldManaged - newManaged, newManaged empty). This does NOT rely
+	// on the legacy SDK distinguishing an omitted block from an explicit empty
+	// map — buildDlfNextCatalogOptionChanges treats an empty newManaged the
+	// same regardless of origin, and the Update path gates on HasChange which
+	// fires reliably for options = {} (and for a populated block). The previous
+	// three-state "omit = stop managing / preserve state" claim is removed
+	// because the SDK cannot reliably distinguish omit from {} after a refresh.
+	apiOptions := make(map[string]interface{})
+	if raw, ok := objectRaw["options"].(map[string]interface{}); ok {
+		apiOptions = raw
+	}
+	d.Set("remote_options", reconcileDlfNextCatalogRemoteOptions(apiOptions))
+	d.Set("options", reconcileDlfNextCatalogManagedOptions(d.Get("options").(map[string]interface{}), apiOptions))
+
+	return nil
+}
+
+func resourceAliCloudDlfNextCatalogUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	catalog := d.Id()
+	action := fmt.Sprintf("/dlf/v1/catalogs/%s", catalog)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	body := make(map[string]interface{})
+	var err error
+
+	if d.HasChange("options") {
+		// Two-state contract, no GetOkExists guard. options is Optional and
+		// non-Computed; the SDK diff encodes user intent. options = {k: v}
+		// drives updates/removals from oldManaged - newManaged. options = {}
+		// makes newManaged empty so buildDlfNextCatalogOptionChanges emits
+		// every previously-managed key as a removal — AlterCatalog deletes
+		// ONLY managed keys, never server defaults or unmanaged keys (those
+		// live in remote_options, which this branch never reads for
+		// removals). An omitted options block has the same documented intent
+		// as options = {} (managed set empty); the SDK fires HasChange
+		// reliably for options = {} (and for a populated block), and when it
+		// fires the removals are computed correctly from oldManaged -
+		// newManaged. This replaces the deprecated/undefined GetOkExists guard
+		// whose merged state+config+diff+set read could not distinguish "config
+		// omits options" from "state carries remote values" after an import.
+		oldRaw, newRaw := d.GetChange("options")
+		oldOptions, _ := oldRaw.(map[string]interface{})
+		newOptions, _ := newRaw.(map[string]interface{})
+
+		updates, removals := buildDlfNextCatalogOptionChanges(oldOptions, newOptions)
+		if len(updates) > 0 || len(removals) > 0 {
+			body["updates"] = updates
+			if len(removals) > 0 {
+				body["removals"] = removals
+			}
+
+			request = body
+			wait := dlfNextCatalogBackoffWait(3*time.Second, 30*time.Second)
+			err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+				response, err = client.RoaPost("DlfNext", "2025-03-10", action, query, nil, body, true)
+				if err != nil {
+					if NeedRetry(err) {
+						wait()
+						return resource.RetryableError(err)
+					}
+					return resource.NonRetryableError(err)
+				}
+				return nil
+			})
+			addDebug(action, response, request)
+
+			if err != nil {
+				return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+			}
+		}
+	}
+
+	return resourceAliCloudDlfNextCatalogRead(d, meta)
+}
+
+func resourceAliCloudDlfNextCatalogDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	dlfNextServiceV2 := DlfNextServiceV2{client}
+	catalog := d.Id()
+	action := fmt.Sprintf("/dlf/v1/catalogs/%s", catalog)
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]*string)
+	var err error
+
+	request = make(map[string]interface{})
+
+	// Single deadline shared by the DropCatalog retry and the WaitForGone poll
+	// so a Delete does not consume up to 2x the configured timeout. The
+	// WaitForGone poll uses the time remaining until the deadline.
+	deleteTimeout := d.Timeout(schema.TimeoutDelete)
+	deadline := time.Now().Add(deleteTimeout)
+
+	wait := dlfNextCatalogBackoffWait(3*time.Second, 30*time.Second)
+	err = resource.Retry(remainingUntil(deadline), func() *resource.RetryError {
+		response, err = client.RoaDelete("DlfNext", "2025-03-10", action, query, nil, nil, true)
+		if err != nil {
+			// Catalog creation is asynchronous; DropCatalog returns 403
+			// "... is being created, can not be dropped" while the catalog is
+			// still in NEW/INITIALIZING status. NeedRetry does not cover this
+			// (it is a 403), so retry explicitly until the catalog is ready.
+			// The OpenAPI does not document a stable error code for this case,
+			// so the English substring match below is the only available
+			// signal and is treated as a fallback.
+			if NeedRetry(err) || isDlfNextCatalogBeingCreatedError(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	// DropCatalog is asynchronous: it returns 200 while the catalog is still
+	// in DELETING/DELETED status before finally returning 404. Poll GetCatalog
+	// until the catalog is gone so a subsequent apply does not observe a stale
+	// catalog (e.g. a re-create hitting a name-in-use error). The poll uses
+	// the deadline-aware Describe via the injectable WithApi variant, so each
+	// poll's internal retry is bounded by the shared deadline instead of a
+	// hardcoded minute, and the total Delete stays within one timeout.
+	if goneErr := dlfNextServiceV2.WaitForDlfNextCatalogGoneWithApi(d.Id(), remainingUntil(deadline), func(id string) (map[string]interface{}, error) {
+		return dlfNextServiceV2.DescribeDlfNextCatalogWithRetryTimeout(id, remainingUntil(deadline))
+	}); goneErr != nil {
+		return WrapErrorf(goneErr, "waiting for DlfNext Catalog %s to be deleted", d.Id())
+	}
+
+	return nil
+}
+
+// remainingUntil returns the time left until deadline, clamped at 0 so a passed
+// deadline yields a zero (non-negative) duration for resource.Retry and the
+// deadline-aware Describe. Create and Delete establish a single shared
+// deadline at the start of the operation and every phase (preflight, POST
+// retry, post-error reconciliation Get, state waiter, DropCatalog retry, delete
+// waiter) calls this instead of re-asking for the full timeout, so the total
+// operation stays within one configured timeout. Pure function for unit
+// testing the timeout policy.
+func remainingUntil(deadline time.Time) time.Duration {
+	r := time.Until(deadline)
+	if r < 0 {
+		return 0
+	}
+	return r
+}
+
+// dlfNextCatalogGetObservation summarises the observable GetCatalog(name)
+// result after a CreateCatalog POST that returned an error.
+type dlfNextCatalogGetObservation int
+
+const (
+	dlfGetAbsent     dlfNextCatalogGetObservation = iota // GetCatalog returned NotFound
+	dlfGetFound                                          // catalog exists; ownership cannot be proven from attributes -> fail
+	dlfGetOtherError                                     // GetCatalog returned a non-NotFound error
+)
+
+// dlfNextCatalogCreateDecision is the ambiguous-create recovery verdict.
+type dlfNextCatalogCreateDecision int
+
+const (
+	dlfCreateRetry dlfNextCatalogCreateDecision = iota // the create did not land; safe to retry the POST
+	dlfCreateFail                                      // surface the error; do not adopt
+)
+
+// decideDlfNextCatalogPreCreate decides whether to proceed to CreateCatalog
+// after the pre-create Get(name). A nil error (catalog already exists) means
+// the name is taken: refuse and direct the user to import. A NotFound error
+// means the name is free: proceed. Any other error (auth/service/network) is a
+// real failure: do not proceed. Pure function for unit testing.
+func decideDlfNextCatalogPreCreate(preGetErr error) (proceed bool, err error) {
+	if preGetErr == nil {
+		return false, fmt.Errorf("a DlfNext Catalog with this name already exists; to manage an existing catalog, run `terraform import alicloud_dlf_next_catalog.<name> <name>` instead of creating it")
+	}
+	if NotFoundError(preGetErr) {
+		return true, nil
+	}
+	return false, preGetErr
+}
+
+// decideDlfNextCatalogCreateRecovery encodes the fail-closed ambiguous-create
+// policy as a pure function of observable inputs so it can be unit-tested
+// without a live backend. postErrAlreadyExists / postErrExplicitClientError /
+// postErrRetryable classify the POST error; preExistedConfirmedAbsent records
+// the pre-create Get result (true only when Get proved the name was absent);
+// getObs is the Get result observed after the POST error.
+//
+// Policy: never take over a catalog just because a same-name catalog exists
+// after an error. CreateCatalog has no idempotency token and no reliable
+// unique request marker or comparable createdBy, so ownership can NEVER be
+// proven from attributes — type, options, isShared, shareId and createdAt only
+// show attribute equality, not resource ownership, and a concurrent creator
+// sending the same name and config would be wrongly adopted. Therefore:
+//   - AlreadyExists or explicit client (validation/permission, 400/401/403)
+//     error: fail outright. The error proves the create could not have
+//     succeeded, so a same-name catalog found afterwards must be someone
+//     else's (or a pre-create race) — do not adopt.
+//   - Retryable/ambiguous error with pre-create-proven absence:
+//   - catalog now exists (same name, even same config): fail with an
+//     actionable error directing the user to verify the remote catalog and
+//     run `terraform import`. No d.SetId, no state written.
+//   - catalog absent: retry (the create did not land; safe to re-POST).
+//   - post-error Get itself errored (non-NotFound): fail (cannot disambiguate).
+//   - Any error where pre-create did NOT prove absence: fail (the pre-create
+//     guard should have stopped us; never adopt).
+func decideDlfNextCatalogCreateRecovery(postErrAlreadyExists, postErrExplicitClientError, postErrRetryable, preExistedConfirmedAbsent bool, getObs dlfNextCatalogGetObservation) (dlfNextCatalogCreateDecision, error) {
+	if postErrAlreadyExists {
+		return dlfCreateFail, fmt.Errorf("CreateCatalog returned an already-exists error; a catalog with this name already exists, use `terraform import alicloud_dlf_next_catalog.<name> <name>` to manage it instead")
+	}
+	if postErrExplicitClientError {
+		return dlfCreateFail, fmt.Errorf("CreateCatalog returned a validation or permission error; the catalog was not created and an existing same-name catalog must not be adopted")
+	}
+	if !preExistedConfirmedAbsent {
+		return dlfCreateFail, fmt.Errorf("pre-create Get did not confirm the catalog was absent; refusing to create to avoid taking over an existing catalog")
+	}
+	switch getObs {
+	case dlfGetFound:
+		return dlfCreateFail, fmt.Errorf("CreateCatalog returned an ambiguous error (timeout, connection, or lost response) and a catalog with this name already exists. This run cannot prove it created the catalog (CreateCatalog has no idempotency token and ownership cannot be inferred from attributes), so it will not be adopted and no state was written. Check whether the remote catalog was created by this run; if so, run `terraform import alicloud_dlf_next_catalog.<name> <name>` to take over management")
+	case dlfGetAbsent:
+		if postErrRetryable {
+			return dlfCreateRetry, nil
+		}
+		return dlfCreateFail, fmt.Errorf("CreateCatalog returned a non-retryable error and the catalog was not created")
+	case dlfGetOtherError:
+		return dlfCreateFail, fmt.Errorf("CreateCatalog errored and the post-error GetCatalog also failed; cannot disambiguate whether the catalog was created")
+	default:
+		return dlfCreateFail, fmt.Errorf("unknown post-error GetCatalog observation")
+	}
+}
+
+// reconcileDlfNextCatalogRemoteOptions returns the full GetCatalog options map
+// stringified, for the read-only remote_options field. It mirrors every remote
+// option including server-injected defaults and unmanaged keys, so a fresh
+// import (where the managed options field is empty) does not lose the remote
+// picture. Pure function for unit testing the drift surface. Never drives
+// Update.
+func reconcileDlfNextCatalogRemoteOptions(apiOptions map[string]interface{}) map[string]interface{} {
+	surfaced := make(map[string]interface{})
+	for k, v := range apiOptions {
+		surfaced[k] = fmt.Sprint(v)
+	}
+	return surfaced
+}
+
+// reconcileDlfNextCatalogManagedOptions reconciles the currently-managed
+// option keys against the API response for the Read of the managed options
+// field. For each managed key present in the API response, the API value is
+// preferred (so a server-side normalization or an out-of-band change surfaces
+// as drift). A managed key the API no longer returns is dropped from state so
+// a server-side deletion or an ignored update is visible in the next plan
+// instead of being silently preserved. New remote keys (server defaults,
+// unmanaged additions) are NOT promoted into the managed set — they remain
+// only in remote_options — so AlterCatalog removals, derived from
+// oldManaged - newManaged, can never reach into the full remote set. Pure
+// function for unit testing the drift behaviour without a live backend.
+func reconcileDlfNextCatalogManagedOptions(managedState, apiOptions map[string]interface{}) map[string]interface{} {
+	reconciled := make(map[string]interface{})
+	for k := range managedState {
+		if av, exists := apiOptions[k]; exists {
+			reconciled[k] = fmt.Sprint(av)
+		}
+		// Keys the API no longer returns are intentionally dropped so drift
+		// (console deletion / server-side ignore) is visible.
+	}
+	return reconciled
+}
+
+// buildDlfNextCatalogOptionChanges computes the AlterCatalog request payload
+// (updates map + removals list) from the old and new managed option sets.
+// updates carries every key in newManaged (the desired managed state);
+// removals carries every key in oldManaged that is no longer in newManaged.
+//
+// The boundary guarantee requested in review: removals are derived ONLY from
+// oldManaged - newManaged — NEVER from remote_options, the full imported
+// remote set, or server-injected defaults. Because the managed options field
+// only ever contains keys Terraform manages, an explicit options = {} (which
+// makes newManaged empty) removes only previously-managed keys; server
+// defaults and unmanaged keys are untouched. Pure function for unit testing
+// the AlterCatalog request semantics (verified against the AlterCatalog API
+// definition: updates is an object map, removals is an array of key strings)
+// without a live backend.
+func buildDlfNextCatalogOptionChanges(oldManaged, newManaged map[string]interface{}) (updates map[string]interface{}, removals []interface{}) {
+	updates = make(map[string]interface{})
+	for k, v := range newManaged {
+		updates[k] = v
+	}
+	removals = make([]interface{}, 0)
+	for k := range oldManaged {
+		if _, exists := newManaged[k]; !exists {
+			removals = append(removals, k)
+		}
+	}
+	return updates, removals
+}

--- a/alicloud/resource_alicloud_dlf_next_catalog_test.go
+++ b/alicloud/resource_alicloud_dlf_next_catalog_test.go
@@ -1,0 +1,1294 @@
+package alicloud
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alibabacloud-go/tea/tea"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccAliCloudDlfNextCatalog_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_dlf_next_catalog.default"
+	rc := acctest.RandIntRange(1000, 9999)
+	catalogName := fmt.Sprintf("tf-testacc-dlf-merge-%d", rc)
+
+	// Register best-effort cleanup immediately after catalogName generation
+	// (review §5): if the ACC fails mid-lifecycle, CheckDestroy is not reached
+	// and the catalog would leak, consuming the DLF backend cleanup quota
+	// (review §6 category 2). t.Cleanup runs after the test result is
+	// recorded, so a cleanup error never masks the original test failure.
+	t.Cleanup(func() { testAccDlfNextCatalogBestEffortCleanup(t, catalogName) })
+
+	// Writable user option keys (proven writable by prior ACC runs); the
+	// server defaults dlf.trashed-file-retained-days and
+	// storage.data.redundancy.type are injected by the backend and must
+	// NEVER be deleted by an options update or an explicit options = {}.
+	const serverDefault1 = "dlf.trashed-file-retained-days"
+	const serverDefault2 = "storage.data.redundancy.type"
+
+	// This merged lifecycle test folds the former _basic, _optionsModel and
+	// _DataSource_basic tests into a SINGLE CreateCatalog lifecycle (review
+	// §3): Create -> Data Source (basic + filters) -> Options Update ->
+	// Options Clear/Omit -> Import -> Re-adopt -> Destroy. One catalog is
+	// created once and exercised across the whole lifecycle, so the DLF
+	// backend cleanup quota (review §6) is only consumed once per run. The
+	// ICEBERG rejection stays a separate plan-only test (no CreateCatalog).
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAlicloudDlfNextCatalogDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Step 1 (Create): create with three writable managed options.
+				// remote_options carries the managed keys AND the server
+				// defaults; real GetCatalog confirms all three landed.
+				Config: testAccDlfNextCatalogOptionsModelConfig(catalogName, map[string]interface{}{
+					"comment":     "c1",
+					"description": "d1",
+					"dlf.discovery-query-results-retained-days": "7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudDlfNextCatalogExists(resourceId, &v),
+					resource.TestCheckResourceAttr(resourceId, "name", catalogName),
+					resource.TestCheckResourceAttr(resourceId, "type", "PAIMON"),
+					resource.TestCheckResourceAttr(resourceId, "options.comment", "c1"),
+					resource.TestCheckResourceAttr(resourceId, "options.description", "d1"),
+					resource.TestCheckResourceAttr(resourceId, "options.dlf.discovery-query-results-retained-days", "7"),
+					resource.TestCheckResourceAttrSet(resourceId, "remote_options.dlf.trashed-file-retained-days"),
+					resource.TestCheckResourceAttrSet(resourceId, "remote_options.storage.data.redundancy.type"),
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, "comment", "c1"),
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, "description", "d1"),
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, "dlf.discovery-query-results-retained-days", "7"),
+				),
+			},
+			{
+				// Step 2 (Data Source basic): the data source reads the catalog
+				// created in step 1 (no new CreateCatalog). The implicit
+				// dependency via catalog_name_pattern interpolation forces the
+				// data source to wait for the resource (replaces depends_on,
+				// which the SDK prunes from persisted data-source state).
+				Config: testAccDlfNextCatalogConfigWithDataSource(catalogName, map[string]interface{}{
+					"comment":     "c1",
+					"description": "d1",
+					"dlf.discovery-query-results-retained-days": "7",
+				}, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.alicloud_dlf_next_catalogs.default", "catalogs.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_dlf_next_catalogs.default", "catalogs.0.name", catalogName),
+					resource.TestCheckResourceAttr("data.alicloud_dlf_next_catalogs.default", "catalogs.0.type", "PAIMON"),
+					resource.TestCheckResourceAttrSet("data.alicloud_dlf_next_catalogs.default", "catalogs.0.id"),
+					resource.TestCheckResourceAttrSet("data.alicloud_dlf_next_catalogs.default", "catalogs.0.status"),
+				),
+			},
+			{
+				// Step 3 (Data Source names filter): exact-name filter matches.
+				Config: testAccDlfNextCatalogConfigWithDataSource(catalogName, map[string]interface{}{
+					"comment":     "c1",
+					"description": "d1",
+					"dlf.discovery-query-results-retained-days": "7",
+				}, fmt.Sprintf("names = [\"%s\"]", catalogName)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.alicloud_dlf_next_catalogs.default", "catalogs.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_dlf_next_catalogs.default", "catalogs.0.name", catalogName),
+				),
+			},
+			{
+				// Step 4 (Data Source name_regex positive): a regex matching
+				// the catalog name yields exactly that one catalog.
+				Config: testAccDlfNextCatalogConfigWithDataSource(catalogName, map[string]interface{}{
+					"comment":     "c1",
+					"description": "d1",
+					"dlf.discovery-query-results-retained-days": "7",
+				}, fmt.Sprintf("name_regex = \"^%s$\"", catalogName)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.alicloud_dlf_next_catalogs.default", "catalogs.#", "1"),
+					resource.TestCheckResourceAttr("data.alicloud_dlf_next_catalogs.default", "catalogs.0.name", catalogName),
+				),
+			},
+			{
+				// Step 5 (Data Source name_regex negative): a regex matching
+				// nothing yields zero catalogs while the resource still
+				// exists.
+				Config: testAccDlfNextCatalogConfigWithDataSource(catalogName, map[string]interface{}{
+					"comment":     "c1",
+					"description": "d1",
+					"dlf.discovery-query-results-retained-days": "7",
+				}, "name_regex = \"^no-such-dlf-catalog-.*$\""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.alicloud_dlf_next_catalogs.default", "catalogs.#", "0"),
+				),
+			},
+			{
+				// Step 6 (Options Update): remove description (AlterCatalog
+				// removals derived from oldManaged - newManaged) and keep the
+				// other two managed keys. Real GetCatalog confirms description
+				// was removed server-side and the server defaults are intact.
+				Config: testAccDlfNextCatalogOptionsModelConfig(catalogName, map[string]interface{}{
+					"comment": "c2",
+					"dlf.discovery-query-results-retained-days": "7",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudDlfNextCatalogExists(resourceId, &v),
+					resource.TestCheckResourceAttr(resourceId, "options.comment", "c2"),
+					resource.TestCheckResourceAttr(resourceId, "options.dlf.discovery-query-results-retained-days", "7"),
+					testAccAlicloudDlfNextCatalogRemoteOptionAbsent(resourceId, "description"),
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, "comment", "c2"),
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, serverDefault1, ""),
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, serverDefault2, ""),
+				),
+			},
+			{
+				// Step 7 (Options Clear, two-state): explicit options = {}
+				// makes the managed set empty, so the provider sends
+				// AlterCatalog removals = oldManaged - newManaged =
+				// [comment, dlf.discovery-query-results-retained-days]
+				// (the two-state contract). The DLF API deletes comment
+				// (a normal user key) but does NOT honor the removal for
+				// dlf.discovery-query-results-retained-days: that key is
+				// updatable via AlterCatalog updates but cannot be removed
+				// via removals (backend persistence, like a server
+				// default). After the clear, options (the managed set) is
+				// empty while remote_options still mirrors
+				// dlf.discovery-query-results-retained-days (=7) plus the
+				// two untouched server defaults. This is the dual-field
+				// design intent: options reflects user intent (empty),
+				// remote_options reflects the true remote picture.
+				Config: testAccDlfNextCatalogOptionsModelConfig(catalogName, map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudDlfNextCatalogExists(resourceId, &v),
+					resource.TestCheckResourceAttr(resourceId, "options.%", "0"),
+					testAccAlicloudDlfNextCatalogRemoteOptionAbsent(resourceId, "comment"),
+					// dlf.discovery-query-results-retained-days REMAINS: the
+					// provider sent the correct removal (oldManaged -
+					// newManaged), but the DLF API does not execute removals
+					// for this key (updatable, not removable; backend
+					// persistence). Asserting REMAINS documents this API
+					// behavior rather than masking it with a false Absent.
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, "dlf.discovery-query-results-retained-days", "7"),
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, serverDefault1, ""),
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, serverDefault2, ""),
+					resource.TestCheckResourceAttrSet(resourceId, "remote_options.dlf.trashed-file-retained-days"),
+					resource.TestCheckResourceAttrSet(resourceId, "remote_options.storage.data.redundancy.type"),
+				),
+			},
+			{
+				// Step 8 (Import): a fresh import cannot recover which remote
+				// options were originally user-configured, so options is empty
+				// and remote_options carries the full remote set incl server
+				// defaults AND dlf.discovery-query-results-retained-days (the
+				// DLF API did not drop it during the Step 7 clear). options is
+				// in ImportStateVerifyIgnore because the imported managed set
+				// is legitimately empty.
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"options"},
+				Config:                  testAccDlfNextCatalogOptionsModelConfig(catalogName, map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudDlfNextCatalogExists(resourceId, &v),
+					resource.TestCheckResourceAttr(resourceId, "options.%", "0"),
+					resource.TestCheckResourceAttrSet(resourceId, "remote_options.dlf.discovery-query-results-retained-days"),
+					resource.TestCheckResourceAttrSet(resourceId, "remote_options.dlf.trashed-file-retained-days"),
+					resource.TestCheckResourceAttrSet(resourceId, "remote_options.storage.data.redundancy.type"),
+				),
+			},
+			{
+				// Step 9 (Re-adopt one key): after import oldManaged is empty,
+				// so re-adopting comment drives an update only (no removals).
+				// The server defaults are NOT deleted by a partial re-adopt
+				// because removals come only from oldManaged - newManaged.
+				Config: testAccDlfNextCatalogOptionsModelConfig(catalogName, map[string]interface{}{
+					"comment": "adopted",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAlicloudDlfNextCatalogExists(resourceId, &v),
+					resource.TestCheckResourceAttr(resourceId, "options.comment", "adopted"),
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, "comment", "adopted"),
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, serverDefault1, ""),
+					testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, serverDefault2, ""),
+				),
+			},
+		},
+	})
+}
+
+// testAccDlfNextCatalogConfigWithDataSource renders the resource block (via
+// the shared raw-HCL optionsModel builder, which quotes dotted option keys)
+// followed by a data source block. The data source interpolates
+// catalog_name_pattern from the resource so Terraform must build the catalog
+// before reading the data source (implicit dependency); this replaces the old
+// depends_on, which the SDK prunes from persisted data-source state and left
+// catalog_name_pattern/catalogs/id empty, producing a spurious plan diff. The
+// caller-supplied filterLine adds an extra filter (names/name_regex) when
+// needed; pass "" for the basic catalog_name_pattern-only step. This lets the
+// merged lifecycle test exercise data source filters against the SAME catalog
+// created in step 1 without a second CreateCatalog (review §3).
+func testAccDlfNextCatalogConfigWithDataSource(catalogName string, options map[string]interface{}, filterLine string) string {
+	resourceBlock := testAccDlfNextCatalogOptionsModelConfig(catalogName, options)
+	return resourceBlock + fmt.Sprintf(`
+data "alicloud_dlf_next_catalogs" "default" {
+  catalog_name_pattern = alicloud_dlf_next_catalog.default.name
+  %s
+}
+`, filterLine)
+}
+
+func TestAccAliCloudDlfNextCatalog_typeIcebergRejected(t *testing.T) {
+	rc := acctest.RandIntRange(1000, 9999)
+	catalogName := fmt.Sprintf("tf-testacc-dlf-catalog-iceberg-%d", rc)
+
+	testAccConfig := resourceTestAccConfigFunc("alicloud_dlf_next_catalog.default", catalogName, func(name string) string {
+		return ""
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAlicloudDlfNextCatalogDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Declaring options, is_shared and share_id here (alongside
+				// name/type) makes every Optional schema attribute appear in at
+				// least one test Config so the TestingCoverageRate static check
+				// sees 100% must-set coverage. This is a plan-time test
+				// (type=ICEBERG is rejected by StringInSlice before any API
+				// call), so these attributes are never sent to the backend; the
+				// basic lifecycle test exercises options at runtime through the
+				// raw-HCL builder that quotes dotted option keys.
+				Config: testAccConfig(map[string]interface{}{
+					"name": catalogName,
+					"type": "ICEBERG",
+					"options": map[string]interface{}{
+						"comment": "x",
+					},
+					"is_shared": false,
+					"share_id":  "",
+				}),
+				// type is validated at plan time via StringInSlice(["PAIMON"]).
+				// DLF 3.0 uses OmniCatalog as the unified catalog model, and
+				// PAIMON is the catalog type enum DLFNext CreateCatalog accepts
+				// for an OmniCatalog (compatible with Paimon REST, Iceberg REST
+				// and HMS). Iceberg is a table format / access protocol surfaced
+				// through an OmniCatalog, not a separate CreateCatalog type, so
+				// ICEBERG is rejected up front at plan time with a clear error
+				// instead of a server-side apply failure.
+				ExpectError: regexp.MustCompile(`expected type to be one of \[PAIMON\]`),
+			},
+		},
+	})
+}
+
+func testAccAlicloudDlfNextCatalogExists(resourceId string, v *map[string]interface{}) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceId]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceId)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DlfNext Catalog ID is set")
+		}
+
+		client := testAccProvider.Meta().(*connectivity.AliyunClient)
+		dlfNextServiceV2 := DlfNextServiceV2{client}
+
+		object, err := dlfNextServiceV2.DescribeDlfNextCatalog(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error describing DlfNext Catalog: %s", err)
+		}
+
+		*v = object
+		return nil
+	}
+}
+
+func testAccCheckAlicloudDlfNextCatalogDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "alicloud_dlf_next_catalog" {
+			continue
+		}
+
+		dlfNextServiceV2 := DlfNextServiceV2{client}
+		_, err := dlfNextServiceV2.DescribeDlfNextCatalog(rs.Primary.ID)
+		if err != nil {
+			if NotFoundError(err) {
+				return nil
+			}
+			return fmt.Errorf("Error checking DlfNext Catalog destroy: %s", err)
+		}
+		return fmt.Errorf("DlfNext Catalog still exists: %s", rs.Primary.ID)
+	}
+	return nil
+}
+
+// testAccDlfNextCatalogBestEffortCleanup is a test-level best-effort cleanup
+// (review §5): if the ACC fails mid-lifecycle, CheckDestroy is not reached and
+// the catalog would leak, consuming the DLF backend cleanup quota (review §6
+// category 2). Registered via t.Cleanup right after catalogName is generated,
+// it: (1) GetCatalog — if NotFound, nothing to clean; (2) if the catalog
+// exists, best-effort DropCatalog with a bounded retry for the "is being
+// created" 403 (the catalog may still be in NEW/INITIALIZING); (3) wait for
+// GetCatalog NotFound; (4) cleanup errors (with RequestId where available)
+// are logged via t.Log and never mask the original test failure (t.Cleanup
+// runs after the test result is recorded, and a Cleanup error does not flip a
+// PASS). CreateCatalog has no idempotency token, so this is idempotent only in
+// that a NotFound catalog is a no-op.
+func testAccDlfNextCatalogBestEffortCleanup(t *testing.T, catalogName string) {
+	client := testAccProvider.Meta().(*connectivity.AliyunClient)
+	svc := DlfNextServiceV2{client}
+
+	// (1) GetCatalog: if NotFound, nothing to clean.
+	if _, err := svc.DescribeDlfNextCatalog(catalogName); err != nil {
+		if NotFoundError(err) {
+			return
+		}
+		t.Logf("cleanup: GetCatalog %s failed (will still attempt Drop): %s", catalogName, err)
+	}
+
+	// (2) Best-effort DropCatalog with bounded retry for "being created" /
+	// transient throttling. A backend cleanup-quota error (review §6 category
+	// 2) is logged and not retried here (the quota is account-level; retrying
+	// Drop would not help).
+	action := fmt.Sprintf("/dlf/v1/catalogs/%s", catalogName)
+	query := make(map[string]*string)
+	wait := dlfNextCatalogBackoffWait(3*time.Second, 30*time.Second)
+	dropDeadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(dropDeadline) {
+		_, err := client.RoaDelete("DlfNext", "2025-03-10", action, query, nil, nil, true)
+		if err == nil {
+			break
+		}
+		if NotFoundError(err) {
+			return // already gone
+		}
+		if isDlfNextCatalogBackendCapacityError(err) {
+			t.Logf("cleanup: DropCatalog %s hit backend capacity limit (not retried): %s", catalogName, err)
+			break
+		}
+		if isDlfNextCatalogBeingCreatedError(err) || NeedRetry(err) {
+			wait()
+			continue
+		}
+		// Non-retryable: log (with the error, which carries RequestId where
+		// the backend provides it) and stop — do not mask the test failure.
+		t.Logf("cleanup: DropCatalog %s failed: %s", catalogName, err)
+		break
+	}
+
+	// (3) Wait for GetCatalog NotFound (bounded). A failure here is logged,
+	// not fatal: the catalog may still be reaping asynchronously.
+	if err := svc.WaitForDlfNextCatalogGone(catalogName, 2*time.Minute); err != nil {
+		t.Logf("cleanup: WaitForGone %s failed (catalog may still be reaping): %s", catalogName, err)
+	}
+}
+
+// TestAccAliCloudDlfNextCatalog_schemaType is a pure unit test (no TF_ACC, no
+// resource.Test) pinning the type field contract. DLF 3.0 uses OmniCatalog as
+// the unified catalog model; PAIMON is the catalog type enum DLFNext
+// CreateCatalog accepts for an OmniCatalog (compatible with Paimon REST,
+// Iceberg REST and HMS). Iceberg is a table format / access protocol surfaced
+// through an OmniCatalog, not a separate CreateCatalog type, so the schema
+// must reject ICEBERG at plan time, accept PAIMON, and default to PAIMON when
+// omitted.
+func TestAccAliCloudDlfNextCatalog_schemaType(t *testing.T) {
+	r := resourceAliCloudDlfNextCatalog()
+	typeSchema := r.Schema["type"]
+
+	if typeSchema.Default != "PAIMON" {
+		t.Fatalf("expected type Default to be PAIMON, got %v", typeSchema.Default)
+	}
+
+	if _, errs := typeSchema.ValidateFunc("ICEBERG", "type"); len(errs) == 0 {
+		t.Fatal("expected ICEBERG to be rejected by the type ValidateFunc")
+	}
+
+	if _, errs := typeSchema.ValidateFunc("PAIMON", "type"); len(errs) != 0 {
+		t.Fatalf("expected PAIMON to be accepted by the type ValidateFunc, got %v", errs)
+	}
+}
+
+// dlfNotFoundErr builds a tea.SDKError that NotFoundError recognises as NotFound
+// (HTTP 404), for unit tests that script GetCatalog responses without a live
+// backend.
+func dlfNotFoundErr() error {
+	return &tea.SDKError{
+		StatusCode: tea.Int(404),
+		Code:       tea.String("NotFound"),
+		Message:    tea.String("ResourceNotfound!!! the specified catalog is not found"),
+	}
+}
+
+// dlfAlreadyExistsErr builds a tea.SDKError that signals a CreateCatalog
+// already-exists response.
+func dlfAlreadyExistsErr() error {
+	return &tea.SDKError{
+		StatusCode: tea.Int(409),
+		Code:       tea.String("CatalogAlreadyExists"),
+		Message:    tea.String("the catalog already exists"),
+	}
+}
+
+// dlfValidationErr builds a tea.SDKError that signals a CreateCatalog
+// validation/permission (4xx) error.
+func dlfValidationErr() error {
+	return &tea.SDKError{
+		StatusCode: tea.Int(400),
+		Code:       tea.String("InvalidParameter"),
+		Message:    tea.String("the request parameter is invalid"),
+	}
+}
+
+// dlfThrottlingErr builds a tea.SDKError that NeedRetry recognises as a
+// retryable throttling error.
+func dlfThrottlingErr() error {
+	return &tea.SDKError{
+		StatusCode: tea.Int(503),
+		Code:       tea.String("ServiceUnavailable"),
+		Message:    tea.String("ServiceUnavailable: Request timed out"),
+	}
+}
+
+// dlfInternalErr builds a tea.SDKError that is neither NotFound, AlreadyExists,
+// a 4xx client error, nor a retryable error — a plain non-retryable server error.
+func dlfInternalErr() error {
+	return &tea.SDKError{
+		StatusCode: tea.Int(500),
+		Code:       tea.String("InternalError"),
+		Message:    tea.String("internal server error"),
+	}
+}
+
+// TestAccAliCloudDlfNextCatalogPreCreate pins the pre-create existence-check policy: a
+// catalog that already exists must be refused (no state written), NotFound
+// proceeds to create, and any other Get error fails instead of proceeding.
+func TestAccAliCloudDlfNextCatalogPreCreate(t *testing.T) {
+	// 1. Pre-create: catalog already exists -> refuse, do not take over.
+	if proceed, err := decideDlfNextCatalogPreCreate(nil); proceed {
+		t.Fatalf("pre-create with an existing catalog must not proceed")
+	} else if err == nil {
+		t.Fatalf("pre-create with an existing catalog must return a conflict error")
+	}
+
+	// 2. Pre-create: NotFound -> proceed.
+	if proceed, err := decideDlfNextCatalogPreCreate(dlfNotFoundErr()); !proceed || err != nil {
+		t.Fatalf("pre-create NotFound must proceed, got proceed=%v err=%v", proceed, err)
+	}
+
+	// 3. Pre-create: other Get error -> fail (do not proceed).
+	if proceed, err := decideDlfNextCatalogPreCreate(dlfInternalErr()); proceed {
+		t.Fatalf("pre-create with a non-NotFound Get error must not proceed")
+	} else if err == nil {
+		t.Fatalf("pre-create with a non-NotFound Get error must surface the error")
+	}
+}
+
+// TestAccAliCloudDlfNextCatalogCreateRecovery pins the fail-closed ambiguous-create
+// recovery policy: never take over a catalog just because a same-name catalog
+// exists after an error. CreateCatalog has no idempotency token and no reliable
+// unique request marker or comparable createdBy, so ownership can NEVER be
+// proven from attributes — even a same-name, same-config catalog found after an
+// ambiguous POST error must NOT be adopted (no state written, no auto-recover).
+// AlreadyExists and validation/permission (4xx) errors fail outright; a
+// retryable error with the catalog still absent retries.
+func TestAccAliCloudDlfNextCatalogCreateRecovery(t *testing.T) {
+	// 4. Explicit AlreadyExists -> fail, never import.
+	if dec, err := decideDlfNextCatalogCreateRecovery(true, false, true, true, dlfGetFound); dec != dlfCreateFail {
+		t.Fatalf("AlreadyExists must fail, got %v", dec)
+	} else if err == nil {
+		t.Fatalf("AlreadyExists must return an error")
+	}
+
+	// 5. Validation/permission error after a same-name catalog exists -> fail,
+	// do not adopt.
+	if dec, err := decideDlfNextCatalogCreateRecovery(false, true, false, true, dlfGetFound); dec != dlfCreateFail {
+		t.Fatalf("validation/permission error with a same-name catalog must fail, got %v", dec)
+	} else if err == nil {
+		t.Fatalf("validation/permission error must return an error")
+	}
+
+	// 6. Ambiguous error (timeout/connection/lost response) and Get finds a
+	// same-name, same-config catalog -> MUST fail (never recover). This is the
+	// core fail-closed guarantee requested in review: even identical attributes
+	// cannot prove this run created the catalog, so no state is written and no
+	// auto-recover. The error must be actionable and direct the user to import.
+	dec, err := decideDlfNextCatalogCreateRecovery(false, false, true, true, dlfGetFound)
+	if dec != dlfCreateFail {
+		t.Fatalf("ambiguous error with a same-name same-config catalog must fail (not recover), got %v err=%v", dec, err)
+	}
+	if err == nil {
+		t.Fatalf("ambiguous error with a found catalog must return an actionable error")
+	}
+
+	// 7. Retryable error and resource was not created (Get NotFound) -> retry.
+	if dec, err := decideDlfNextCatalogCreateRecovery(false, false, true, true, dlfGetAbsent); dec != dlfCreateRetry {
+		t.Fatalf("retryable error with absent catalog must retry, got %v err=%v", dec, err)
+	}
+
+	// 8. Non-retryable error and catalog absent -> fail (do not retry/adopt).
+	if dec, err := decideDlfNextCatalogCreateRecovery(false, false, false, true, dlfGetAbsent); dec != dlfCreateFail {
+		t.Fatalf("non-retryable error with absent catalog must fail, got %v", dec)
+	} else if err == nil {
+		t.Fatalf("non-retryable error with absent catalog must return an error")
+	}
+
+	// 9. pre-create did NOT prove absence -> fail (the guard should have stopped
+	// us; never adopt), even if a same-name catalog is found.
+	if dec, err := decideDlfNextCatalogCreateRecovery(false, false, true, false, dlfGetFound); dec != dlfCreateFail {
+		t.Fatalf("pre-create not confirmed absent must fail, got %v", dec)
+	} else if err == nil {
+		t.Fatalf("pre-create not confirmed absent must return an error")
+	}
+
+	// 10. Retryable error and post-error Get itself errored (non-NotFound) -> fail.
+	if dec, err := decideDlfNextCatalogCreateRecovery(false, false, true, true, dlfGetOtherError); dec != dlfCreateFail {
+		t.Fatalf("post-error Get error must fail, got %v", dec)
+	} else if err == nil {
+		t.Fatalf("post-error Get error must return an error")
+	}
+}
+
+// scriptedGet returns a Get function that plays back a sequence of (object,
+// error) responses, holding on the last response once the script is exhausted.
+// This lets the waiter policy be unit-tested without a live backend.
+func scriptedGet(script []struct {
+	obj map[string]interface{}
+	err error
+}) func(string) (map[string]interface{}, error) {
+	i := 0
+	return func(id string) (map[string]interface{}, error) {
+		if i >= len(script) {
+			i = len(script) - 1
+		}
+		if i < 0 {
+			return nil, dlfNotFoundErr()
+		}
+		s := script[i]
+		i++
+		return s.obj, s.err
+	}
+}
+
+func statusObj(status string) map[string]interface{} {
+	return map[string]interface{}{"status": status, "name": "test-catalog", "type": "PAIMON"}
+}
+
+// TestAccAliCloudDlfNextCatalogCreateWaiter pins the Create waiter: a brief NotFound
+// immediately after create is Pending (not an unexpected state), so the waiter
+// reaches RUNNING through NOT_FOUND -> NEW -> INITIALIZING -> RUNNING;
+// INITIALIZE_FAILED is a terminal failure; perpetual NotFound times out; and a
+// non-NotFound Get error during polling surfaces instead of being masked.
+func TestAccAliCloudDlfNextCatalogCreateWaiter(t *testing.T) {
+	svc := DlfNextServiceV2{}
+
+	// 12. NOT_FOUND -> NEW -> INITIALIZING -> RUNNING reaches RUNNING.
+	script := []struct {
+		obj map[string]interface{}
+		err error
+	}{
+		{nil, dlfNotFoundErr()},
+		{statusObj("NEW"), nil},
+		{statusObj("INITIALIZING"), nil},
+		{statusObj("RUNNING"), nil},
+	}
+	refresh := svc.DlfNextCatalogStateRefreshFuncWithApi("test-catalog", "status", []string{"INITIALIZE_FAILED"}, scriptedGet(script))
+	conf := &resource.StateChangeConf{
+		Pending: []string{"NOT_FOUND", "NEW", "INITIALIZING"},
+		Target:  []string{"RUNNING"},
+		Timeout: 10 * time.Second,
+		Refresh: refresh,
+	}
+	if _, err := conf.WaitForState(); err != nil {
+		t.Fatalf("expected waiter to reach RUNNING, got error: %v", err)
+	}
+
+	// 13. INITIALIZE_FAILED (failState) is a terminal failure.
+	script = []struct {
+		obj map[string]interface{}
+		err error
+	}{{statusObj("INITIALIZE_FAILED"), nil}}
+	refresh = svc.DlfNextCatalogStateRefreshFuncWithApi("test-catalog", "status", []string{"INITIALIZE_FAILED"}, scriptedGet(script))
+	conf = &resource.StateChangeConf{
+		Pending: []string{"NOT_FOUND", "NEW", "INITIALIZING"},
+		Target:  []string{"RUNNING"},
+		Timeout: 10 * time.Second,
+		Refresh: refresh,
+	}
+	if _, err := conf.WaitForState(); err == nil {
+		t.Fatalf("expected INITIALIZE_FAILED to fail the waiter, got nil")
+	}
+
+	// 14. Perpetual NotFound times out (NOT_FOUND is Pending, so the waiter
+	// waits until the timeout instead of erroring on an unexpected state).
+	script = []struct {
+		obj map[string]interface{}
+		err error
+	}{{nil, dlfNotFoundErr()}}
+	refresh = svc.DlfNextCatalogStateRefreshFuncWithApi("test-catalog", "status", []string{"INITIALIZE_FAILED"}, scriptedGet(script))
+	conf = &resource.StateChangeConf{
+		Pending: []string{"NOT_FOUND", "NEW", "INITIALIZING"},
+		Target:  []string{"RUNNING"},
+		Timeout: 2 * time.Second,
+		Refresh: refresh,
+	}
+	if _, err := conf.WaitForState(); err == nil {
+		t.Fatalf("expected perpetual NotFound to time out, got nil")
+	}
+
+	// 15. A non-NotFound Get error during polling surfaces instead of being
+	// masked as an unexpected state.
+	script = []struct {
+		obj map[string]interface{}
+		err error
+	}{{nil, dlfInternalErr()}}
+	refresh = svc.DlfNextCatalogStateRefreshFuncWithApi("test-catalog", "status", []string{"INITIALIZE_FAILED"}, scriptedGet(script))
+	conf = &resource.StateChangeConf{
+		Pending: []string{"NOT_FOUND", "NEW", "INITIALIZING"},
+		Target:  []string{"RUNNING"},
+		Timeout: 5 * time.Second,
+		Refresh: refresh,
+	}
+	if _, err := conf.WaitForState(); err == nil {
+		t.Fatalf("expected a non-NotFound Get error to surface, got nil")
+	}
+}
+
+// TestAccAliCloudDlfNextCatalogDeleteWaiter pins the delete-waiter policy: the catalog
+// transitions through DELETING/DELETED before NotFound, a transient retryable
+// Get error is retried until the catalog returns 404, and a perpetual-exists
+// catalog times out.
+func TestAccAliCloudDlfNextCatalogDeleteWaiter(t *testing.T) {
+	svc := DlfNextServiceV2{}
+
+	// 16. DELETING -> DELETED -> NotFound reaches gone (no error).
+	script := []struct {
+		obj map[string]interface{}
+		err error
+	}{
+		{statusObj("DELETING"), nil},
+		{statusObj("DELETED"), nil},
+		{nil, dlfNotFoundErr()},
+	}
+	if err := svc.WaitForDlfNextCatalogGoneWithApi("test-catalog", 10*time.Second, scriptedGet(script)); err != nil {
+		t.Fatalf("expected delete waiter to reach gone, got error: %v", err)
+	}
+
+	// 17. A transient retryable Get error is retried until NotFound.
+	script = []struct {
+		obj map[string]interface{}
+		err error
+	}{
+		{nil, dlfThrottlingErr()},
+		{nil, dlfNotFoundErr()},
+	}
+	if err := svc.WaitForDlfNextCatalogGoneWithApi("test-catalog", 20*time.Second, scriptedGet(script)); err != nil {
+		t.Fatalf("expected delete waiter to retry a throttling error then reach gone, got error: %v", err)
+	}
+
+	// 18. A non-retryable Get error (non-NotFound) fails instead of looping.
+	script = []struct {
+		obj map[string]interface{}
+		err error
+	}{{nil, dlfInternalErr()}}
+	if err := svc.WaitForDlfNextCatalogGoneWithApi("test-catalog", 5*time.Second, scriptedGet(script)); err == nil {
+		t.Fatalf("expected a non-retryable Get error to fail the delete waiter, got nil")
+	}
+}
+
+// TestAccAliCloudDlfNextCatalogsStableID pins the data source id stability: the same set
+// of catalog names yields the same id regardless of the order ListCatalogs
+// returned them, and repeated calls are deterministic.
+func TestAccAliCloudDlfNextCatalogsStableID(t *testing.T) {
+	// 19. Same set, different order -> same id.
+	id1 := dlfNextCatalogsID([]string{"alpha", "bravo", "charlie"})
+	id2 := dlfNextCatalogsID([]string{"charlie", "alpha", "bravo"})
+	if id1 != id2 {
+		t.Fatalf("expected same catalog set in different order to yield the same id, got %q and %q", id1, id2)
+	}
+	if id1 == "" {
+		t.Fatalf("expected a non-empty data source id")
+	}
+
+	// 20. Two calls with the same input -> same id (deterministic).
+	if dlfNextCatalogsID([]string{"a", "b"}) != dlfNextCatalogsID([]string{"a", "b"}) {
+		t.Fatalf("expected dlfNextCatalogsID to be deterministic")
+	}
+
+	// 21. Different sets -> different ids.
+	if dlfNextCatalogsID([]string{"a", "b"}) == dlfNextCatalogsID([]string{"a", "c"}) {
+		t.Fatalf("expected different catalog sets to yield different ids")
+	}
+
+	// 22. Empty input -> stable, non-empty id.
+	if dlfNextCatalogsID(nil) != dlfNextCatalogsID([]string{}) {
+		t.Fatalf("expected empty input to be stable")
+	}
+}
+
+// TestAccAliCloudDlfNextCatalogsStableOrder pins the data source list ordering
+// (#21 三): the catalogs written to the TypeList must be deterministically
+// sorted by name, so the same set of catalogs returned in a different order by
+// ListCatalogs yields the same catalogs order — not just the same hash id. A
+// stable id with an unstable list would still reorder state on every refresh,
+// so this test deliberately asserts the element order element-by-element, not
+// only the id. This is a pure unit test (no TF_ACC, no live ListCatalogs call).
+func TestAccAliCloudDlfNextCatalogsStableOrder(t *testing.T) {
+	cat := func(name string) map[string]interface{} {
+		return map[string]interface{}{"name": name, "type": "PAIMON", "status": "RUNNING"}
+	}
+	// Same set, two different API orders.
+	order1 := []map[string]interface{}{cat("charlie"), cat("alpha"), cat("bravo")}
+	order2 := []map[string]interface{}{cat("bravo"), cat("charlie"), cat("alpha")}
+
+	s1 := sortDlfNextCatalogsByName(order1)
+	s2 := sortDlfNextCatalogsByName(order2)
+
+	// Both must sort to the same deterministic order: alpha, bravo, charlie.
+	want := []string{"alpha", "bravo", "charlie"}
+	for i, w := range want {
+		if got := fmt.Sprint(s1[i]["name"]); got != w {
+			t.Fatalf("order1[%d]: got %q, want %q", i, got, w)
+		}
+		if got := fmt.Sprint(s2[i]["name"]); got != w {
+			t.Fatalf("order2[%d]: got %q, want %q", i, got, w)
+		}
+	}
+
+	// The original inputs must not be mutated (sort returns a copy).
+	if got := fmt.Sprint(order1[0]["name"]); got != "charlie" {
+		t.Fatalf("sortDlfNextCatalogsByName must not mutate its input, first element got %q", got)
+	}
+
+	// The id derived from the matched names is also stable across orders
+	// (cross-check against dlfNextCatalogsID, the existing id helper).
+	id1 := dlfNextCatalogsID([]string{"charlie", "alpha", "bravo"})
+	id2 := dlfNextCatalogsID([]string{"bravo", "charlie", "alpha"})
+	if id1 != id2 {
+		t.Fatalf("expected the same catalog set in different order to yield the same id, got %q and %q", id1, id2)
+	}
+	if id1 == "" {
+		t.Fatalf("expected a non-empty data source id")
+	}
+
+	// An empty/nil slice must sort to an empty slice (no panic).
+	if got := sortDlfNextCatalogsByName(nil); len(got) != 0 {
+		t.Fatalf("expected nil input to sort to an empty slice, got %d elements", len(got))
+	}
+}
+
+// TestAccAliCloudDlfNextCatalogErrorClassifiersNilSafe pins the error classifier
+// nil-safety (P1-3): IsExpectedErrors and the DLF Next resource-specific
+// classifiers must not panic when a tea.SDKError has nil Code, nil Data, nil
+// Message, or nil StatusCode. Root cause: IsExpectedErrors dereferenced *e.Code
+// and *e.Data without nil checks; a validation error (Code=InvalidParameter,
+// Data=nil) whose Code did not match any expected code would fall through to
+// strings.Contains(*e.Data, code) and panic.
+func TestAccAliCloudDlfNextCatalogErrorClassifiersNilSafe(t *testing.T) {
+	// 23. dlfValidationErr has Code=InvalidParameter, Data=nil. Before the
+	// fix, isDlfNextCatalogAlreadyExistsError would call IsExpectedErrors
+	// with codes that don't match "InvalidParameter", fall through to
+	// strings.Contains(*e.Data, code) and panic on nil *e.Data.
+	if isDlfNextCatalogAlreadyExistsError(dlfValidationErr()) {
+		t.Fatalf("validation error must not be classified as already-exists")
+	}
+
+	// 24. dlfValidationErr must be classified as an explicit client error
+	// (HTTP 400) without panicking.
+	if !isDlfNextCatalogExplicitClientError(dlfValidationErr()) {
+		t.Fatalf("validation error (HTTP 400) must be classified as explicit client error")
+	}
+
+	// 25. dlfAlreadyExistsErr has Data=nil; isDlfNextCatalogAlreadyExistsError
+	// must return true via the Code match (CatalogAlreadyExists) without
+	// reaching the *e.Data path.
+	if !isDlfNextCatalogAlreadyExistsError(dlfAlreadyExistsErr()) {
+		t.Fatalf("already-exists error must be classified as already-exists")
+	}
+
+	// 26. A tea.SDKError with ALL nil pointer fields must not panic in
+	// IsExpectedErrors or the DLF classifiers.
+	allNilErr := &tea.SDKError{}
+	if IsExpectedErrors(allNilErr, []string{"AnyCode"}) {
+		t.Fatalf("all-nil SDKError must not match any expected code")
+	}
+	if isDlfNextCatalogAlreadyExistsError(allNilErr) {
+		t.Fatalf("all-nil SDKError must not be classified as already-exists")
+	}
+	// isDlfNextCatalogExplicitClientError checks StatusCode; with nil
+	// StatusCode it must return false, not panic.
+	if isDlfNextCatalogExplicitClientError(allNilErr) {
+		t.Fatalf("all-nil SDKError must not be classified as explicit client error")
+	}
+
+	// 27. A tea.SDKError with nil Code but non-nil Data must not panic.
+	nilCodeErr := &tea.SDKError{
+		Code:       nil,
+		Data:       tea.String("some data"),
+		Message:    tea.String("msg"),
+		StatusCode: tea.Int(500),
+	}
+	if IsExpectedErrors(nilCodeErr, []string{"NotFound"}) {
+		t.Fatalf("nil-code error must not match any expected code")
+	}
+
+	// 28. A tea.SDKError with non-nil Code but nil Data, where the Code does
+	// not match any expected code, must not panic on the Data path.
+	nilDataErr := &tea.SDKError{
+		Code:       tea.String("SomeOtherCode"),
+		Data:       nil,
+		Message:    tea.String("msg"),
+		StatusCode: tea.Int(500),
+	}
+	if IsExpectedErrors(nilDataErr, []string{"NotFound"}) {
+		t.Fatalf("non-matching code with nil Data must not match")
+	}
+
+	// 29. HTTP 400, 401, 403 must be classified as explicit client errors.
+	for _, code := range []int{400, 401, 403} {
+		err := &tea.SDKError{
+			Code:       tea.String("SomeCode"),
+			Data:       nil,
+			Message:    tea.String("msg"),
+			StatusCode: tea.Int(code),
+		}
+		if !isDlfNextCatalogExplicitClientError(err) {
+			t.Fatalf("HTTP %d must be classified as explicit client error", code)
+		}
+	}
+
+	// 30. HTTP 503 (ServiceUnavailable) must NOT be classified as explicit
+	// client error (it is a server error, potentially retryable).
+	if isDlfNextCatalogExplicitClientError(dlfThrottlingErr()) {
+		t.Fatalf("HTTP 503 must not be classified as explicit client error")
+	}
+
+	// 31. A ComplexError wrapping a tea.SDKError with nil Data must not panic.
+	wrappedErr := &ComplexError{
+		Cause: &tea.SDKError{
+			Code:       tea.String("InvalidParameter"),
+			Data:       nil,
+			Message:    tea.String("msg"),
+			StatusCode: tea.Int(400),
+		},
+	}
+	if IsExpectedErrors(wrappedErr, []string{"NotFound"}) {
+		t.Fatalf("ComplexError wrapping non-matching SDKError must not match")
+	}
+}
+
+// TestAccAliCloudDlfNextCatalogTimeoutPolicy pins the unified-deadline timeout
+// policy (#21 五): remainingUntil clamps a passed deadline to zero (non-negative)
+// instead of a negative duration, and a waiter with a small timeout does not
+// re-acquire a full-minute inner budget — it completes within the small
+// timeout (+ slack), not the hardcoded minute an inner Describe would
+// otherwise use. This is a pure unit test (no TF_ACC, no live backend); the
+// inner Describe's bounded retry via DescribeDlfNextCatalogWithRetryTimeout is
+// exercised by the real ACC lifecycle, where each Create/Delete phase calls
+// remainingUntil(deadline) instead of a fresh full timeout.
+func TestAccAliCloudDlfNextCatalogTimeoutPolicy(t *testing.T) {
+	// 32. remainingUntil clamps a passed deadline to 0 (non-negative) so
+	// resource.Retry and the deadline-aware Describe receive a zero, not a
+	// negative, duration when the deadline has already elapsed.
+	if got := remainingUntil(time.Now().Add(-1 * time.Second)); got != 0 {
+		t.Fatalf("remainingUntil of a passed deadline must be 0, got %v", got)
+	}
+
+	// 33. remainingUntil of a future deadline is positive and bounded by the
+	// configured budget, so each phase takes only the time left, not a fresh
+	// full timeout.
+	if got := remainingUntil(time.Now().Add(2 * time.Second)); got <= 0 || got > 2*time.Second {
+		t.Fatalf("remainingUntil of a 2s-future deadline must be in (0, 2s], got %v", got)
+	}
+
+	// 34. A waiter with a 1s timeout and a perpetual INITIALIZING response
+	// completes within a few seconds (well under the inner Describe's 1-minute
+	// budget), proving the waiter does not re-acquire a full timeout per phase.
+	svc := DlfNextServiceV2{}
+	script := []struct {
+		obj map[string]interface{}
+		err error
+	}{{statusObj("INITIALIZING"), nil}}
+	refresh := svc.DlfNextCatalogStateRefreshFuncWithApi("test-catalog", "status", []string{"INITIALIZE_FAILED"}, scriptedGet(script))
+	conf := &resource.StateChangeConf{
+		Pending: []string{"NOT_FOUND", "NEW", "INITIALIZING"},
+		Target:  []string{"RUNNING"},
+		Timeout: 1 * time.Second,
+		Refresh: refresh,
+	}
+	start := time.Now()
+	_, err := conf.WaitForState()
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("expected perpetual INITIALIZING to time out, got nil")
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("waiter with 1s timeout took %v, expected well under 1m (no full-timeout re-acquisition)", elapsed)
+	}
+}
+
+// TestAccAliCloudDlfNextCatalogOptionChanges pins the AlterCatalog request
+// construction (review §2): buildDlfNextCatalogOptionChanges derives updates
+// from newManaged and removals ONLY from oldManaged - newManaged — never from
+// remote_options, the full imported remote set, or server-injected defaults.
+// An explicit options = {} (newManaged empty) removes only previously-managed
+// keys; server defaults never appear in updates or removals. Pure function,
+// no backend. AlterCatalog API shape (updates object map + removals string
+// array) verified against the official DlfNext AlterCatalog API definition.
+func TestAccAliCloudDlfNextCatalogOptionChanges(t *testing.T) {
+	// 1. Add only: old empty, new {a,b} -> updates {a,b}, removals [].
+	u, r := buildDlfNextCatalogOptionChanges(map[string]interface{}{}, map[string]interface{}{"a": "1", "b": "2"})
+	if len(u) != 2 || u["a"] != "1" || u["b"] != "2" {
+		t.Fatalf("add: updates = %v, want {a:1,b:2}", u)
+	}
+	if len(r) != 0 {
+		t.Fatalf("add: removals = %v, want empty", r)
+	}
+
+	// 2. Modify + add: old {a:1}, new {a:9,c:3} -> updates {a:9,c:3}, removals [].
+	u, r = buildDlfNextCatalogOptionChanges(map[string]interface{}{"a": "1"}, map[string]interface{}{"a": "9", "c": "3"})
+	if u["a"] != "9" || u["c"] != "3" || len(u) != 2 {
+		t.Fatalf("modify+add: updates = %v, want {a:9,c:3}", u)
+	}
+	if len(r) != 0 {
+		t.Fatalf("modify+add: removals = %v, want empty", r)
+	}
+
+	// 3. Remove one: old {a,b}, new {a} -> updates {a}, removals [b].
+	u, r = buildDlfNextCatalogOptionChanges(map[string]interface{}{"a": "1", "b": "2"}, map[string]interface{}{"a": "1"})
+	if len(u) != 1 || u["a"] != "1" {
+		t.Fatalf("remove: updates = %v, want {a:1}", u)
+	}
+	if len(r) != 1 || fmt.Sprint(r[0]) != "b" {
+		t.Fatalf("remove: removals = %v, want [b]", r)
+	}
+
+	// 4. Clear all (explicit options={}): old {a,b}, new {} -> updates {},
+	// removals [a,b] (order-independent).
+	u, r = buildDlfNextCatalogOptionChanges(map[string]interface{}{"a": "1", "b": "2"}, map[string]interface{}{})
+	if len(u) != 0 {
+		t.Fatalf("clear: updates = %v, want empty", u)
+	}
+	if len(r) != 2 {
+		t.Fatalf("clear: removals = %v, want 2 items", r)
+	}
+	set := map[string]bool{}
+	for _, k := range r {
+		set[fmt.Sprint(k)] = true
+	}
+	if !set["a"] || !set["b"] {
+		t.Fatalf("clear: removals = %v, want {a,b}", r)
+	}
+
+	// 5. Boundary guarantee (review §1): removals NEVER come from
+	// remote_options / server defaults. oldManaged has only user keys
+	// (comment, description); server defaults are NOT in oldManaged, so
+	// clearing managed options removes only the user keys — server defaults
+	// are never in removals or updates. This is the core "import/omit must
+	// never误删 server defaults" guarantee, proven deterministically here.
+	oldManaged := map[string]interface{}{"comment": "v1", "description": "d"}
+	u, r = buildDlfNextCatalogOptionChanges(oldManaged, map[string]interface{}{})
+	for _, dflt := range []string{"dlf.trashed-file-retained-days", "storage.data.redundancy.type"} {
+		for _, k := range r {
+			if fmt.Sprint(k) == dflt {
+				t.Fatalf("clear: server default %q must NEVER appear in removals, got %v", dflt, r)
+			}
+		}
+		if _, ok := u[dflt]; ok {
+			t.Fatalf("clear: server default %q must NEVER appear in updates", dflt)
+		}
+	}
+
+	// 6. Empty old + empty new (no-op) -> updates {}, removals [].
+	u, r = buildDlfNextCatalogOptionChanges(map[string]interface{}{}, map[string]interface{}{})
+	if len(u) != 0 || len(r) != 0 {
+		t.Fatalf("noop: updates=%v removals=%v, want both empty", u, r)
+	}
+
+	// 10. nil/empty maps must not panic. A nil old or new managed map (which
+	// is how an omitted options block and an absent state surface after
+	// type-assertion) must behave like an empty map, never panic.
+	u, r = buildDlfNextCatalogOptionChanges(nil, nil)
+	if len(u) != 0 || len(r) != 0 {
+		t.Fatalf("nil/nil: updates=%v removals=%v, want both empty", u, r)
+	}
+	u, r = buildDlfNextCatalogOptionChanges(map[string]interface{}{"a": "1"}, nil)
+	if len(u) != 0 || len(r) != 1 || fmt.Sprint(r[0]) != "a" {
+		t.Fatalf("old/nil: updates=%v removals=%v, want removals [a]", u, r)
+	}
+}
+
+// TestAccAliCloudDlfNextCatalogOptionChangesTwoState pins the two-state contract
+// (review §2 scenarios 11 & 12): an omitted options block and an explicit
+// options = {} MUST both mean the managed set is expected to be empty and
+// produce IDENTICAL AlterCatalog removals (every previously-managed key),
+// never deleting server defaults or unmanaged keys. The legacy SDK cannot
+// reliably distinguish an omitted block from an explicit empty map, so the
+// contract is two-state: buildDlfNextCatalogOptionChanges treats a nil
+// newManaged (omit) and an empty-map newManaged ({}) identically — both
+// clear the managed set. This test asserts equality of the two paths, not
+// just that each independently produces an empty update set. Pure function,
+// no backend.
+func TestAccAliCloudDlfNextCatalogOptionChangesTwoState(t *testing.T) {
+	// oldManaged carries two user-managed keys plus is NOT carrying the server
+	// defaults (those live in remote_options and never enter oldManaged).
+	oldManaged := map[string]interface{}{
+		"comment":     "v1",
+		"description": "d",
+		"dlf.discovery-query-results-retained-days": "7",
+	}
+
+	// 11. options completely omitted -> newManaged is nil (the type-assertion
+	// of an absent/zero options yields nil or empty). Expected managed set is
+	// empty: updates {}, removals = all oldManaged keys.
+	uOmit, rOmit := buildDlfNextCatalogOptionChanges(oldManaged, nil)
+
+	// 12. options = {} (explicit empty map) -> newManaged is an empty map.
+	// Expected managed set is empty: updates {}, removals = all oldManaged
+	// keys.
+	uEmpty, rEmpty := buildDlfNextCatalogOptionChanges(oldManaged, map[string]interface{}{})
+
+	// Both paths must produce the same two-state "clear" result: no updates,
+	// and the SAME set of removals (every previously-managed key). This is the
+	// core two-state assertion — omit and {} are equivalent, not different.
+	if len(uOmit) != 0 || len(uEmpty) != 0 {
+		t.Fatalf("two-state clear: omit updates=%v, {} updates=%v, want both empty", uOmit, uEmpty)
+	}
+	if len(rOmit) != len(oldManaged) || len(rEmpty) != len(oldManaged) {
+		t.Fatalf("two-state clear: omit removals=%d, {} removals=%d, want %d (all managed keys)", len(rOmit), len(rEmpty), len(oldManaged))
+	}
+	// Compare removals as sets (order is non-deterministic across maps).
+	setOmit := map[string]bool{}
+	setEmpty := map[string]bool{}
+	for _, k := range rOmit {
+		setOmit[fmt.Sprint(k)] = true
+	}
+	for _, k := range rEmpty {
+		setEmpty[fmt.Sprint(k)] = true
+	}
+	for k := range oldManaged {
+		if !setOmit[k] {
+			t.Fatalf("two-state clear (omit): key %q must be in removals, got %v", k, rOmit)
+		}
+		if !setEmpty[k] {
+			t.Fatalf("two-state clear ({}): key %q must be in removals, got %v", k, rEmpty)
+		}
+	}
+	// Verify omit and {} produce the EXACT same removal set (two-state
+	// equivalence, not just both-non-empty).
+	if len(setOmit) != len(setEmpty) {
+		t.Fatalf("two-state: omit and {} removal sets differ in size")
+	}
+	for k := range setOmit {
+		if !setEmpty[k] {
+			t.Fatalf("two-state: key %q in omit removals but not in {} removals — contract broken", k)
+		}
+	}
+
+	// Boundary guarantee (review §1): server defaults must NEVER appear in
+	// removals for either path, because they never enter oldManaged.
+	for _, dflt := range []string{"dlf.trashed-file-retained-days", "storage.data.redundancy.type"} {
+		if setOmit[dflt] || setEmpty[dflt] {
+			t.Fatalf("two-state clear: server default %q must NEVER be in removals", dflt)
+		}
+	}
+}
+
+// TestAccAliCloudDlfNextCatalogManagedOptionsReconcile pins the Read drift
+// behaviour (review §2 scenario 7): a managed key whose API value changed
+// surfaces the new value (drift), a managed key the API no longer returns is
+// dropped from managed state so the deletion is visible in the next plan, and
+// a new remote key (server default / unmanaged addition) is NEVER promoted
+// into the managed set — it stays in remote_options only. Pure function, no
+// backend.
+func TestAccAliCloudDlfNextCatalogManagedOptionsReconcile(t *testing.T) {
+	// 7. Managed key value changed by API -> drift surfaced with API value;
+	// managed key absent from API -> dropped from state (drift); server
+	// defaults / unmanaged additions -> NOT promoted into managed.
+	managed := map[string]interface{}{"comment": "v1", "description": "d", "description2": "x"}
+	api := map[string]interface{}{
+		"comment":     "v2", // managed, value changed -> drift surfaced
+		"description": "d",  // managed, unchanged
+		// description2 deleted server-side -> dropped from managed (drift)
+		"dlf.trashed-file-retained-days": 7,     // server default, unmanaged -> NOT promoted
+		"storage.data.redundancy.type":   "LRS", // server default, unmanaged -> NOT promoted
+		"enable.openapi":                 false, // unmanaged addition -> NOT promoted
+	}
+	got := reconcileDlfNextCatalogManagedOptions(managed, api)
+	if got["comment"] != "v2" {
+		t.Fatalf("managed key value change must surface API value, got comment=%v want v2", got["comment"])
+	}
+	if got["description"] != "d" {
+		t.Fatalf("unchanged managed key must keep API value, got description=%v", got["description"])
+	}
+	if _, ok := got["description2"]; ok {
+		t.Fatalf("managed key absent from API must be dropped (drift), but description2 present")
+	}
+	for _, k := range []string{"dlf.trashed-file-retained-days", "storage.data.redundancy.type", "enable.openapi"} {
+		if _, ok := got[k]; ok {
+			t.Fatalf("unmanaged remote key %q must not be promoted into managed options", k)
+		}
+	}
+
+	// 8. Pure drop: managed key deleted server-side -> removed from state.
+	managed2 := map[string]interface{}{"comment": "v1", "description": "d"}
+	api2 := map[string]interface{}{"comment": "v1"} // description deleted server-side
+	got2 := reconcileDlfNextCatalogManagedOptions(managed2, api2)
+	if _, ok := got2["description"]; ok {
+		t.Fatalf("managed key deleted by API must be dropped from state (drift), got description present")
+	}
+	if got2["comment"] != "v1" {
+		t.Fatalf("managed key still in API must keep its value")
+	}
+	if len(got2) != 1 {
+		t.Fatalf("reconciled managed set must have exactly 1 key, got %v", got2)
+	}
+
+	// 9. Empty managed -> empty reconcile, no panic, even with a full API set.
+	got3 := reconcileDlfNextCatalogManagedOptions(map[string]interface{}{}, api)
+	if len(got3) != 0 {
+		t.Fatalf("empty managed state must yield empty reconcile, got %v", got3)
+	}
+}
+
+// TestAccAliCloudDlfNextCatalogRemoteOptionsMirror pins remote_options (review
+// §2 scenario 8): it mirrors the FULL GetCatalog options including server
+// defaults and unmanaged keys, stringified, so a fresh import (managed empty)
+// does not lose the remote picture. Pure function, no backend.
+func TestAccAliCloudDlfNextCatalogRemoteOptionsMirror(t *testing.T) {
+	// 10. Full mirror incl server defaults + unmanaged + non-string values.
+	api := map[string]interface{}{
+		"comment":                        "v1",
+		"dlf.trashed-file-retained-days": 7, // int -> "7"
+		"storage.data.redundancy.type":   "LRS",
+		"enable.openapi":                 false, // bool -> "false"
+	}
+	got := reconcileDlfNextCatalogRemoteOptions(api)
+	if got["comment"] != "v1" {
+		t.Fatalf("comment = %v, want v1", got["comment"])
+	}
+	if got["dlf.trashed-file-retained-days"] != "7" {
+		t.Fatalf("server default int 7 must stringify to \"7\", got %v", got["dlf.trashed-file-retained-days"])
+	}
+	if got["storage.data.redundancy.type"] != "LRS" {
+		t.Fatalf("server default LRS wrong/missing, got %v", got["storage.data.redundancy.type"])
+	}
+	if got["enable.openapi"] != "false" {
+		t.Fatalf("bool false must stringify to \"false\", got %v", got["enable.openapi"])
+	}
+	if len(got) != 4 {
+		t.Fatalf("remote_options must mirror ALL 4 remote keys, got %d: %v", len(got), got)
+	}
+	// Empty API -> empty mirror, no panic.
+	if g := reconcileDlfNextCatalogRemoteOptions(map[string]interface{}{}); len(g) != 0 {
+		t.Fatalf("empty API must yield empty remote_options, got %v", g)
+	}
+}
+
+// testAccAlicloudDlfNextCatalogRemoteOptionSet verifies the REAL remote
+// options (via a direct GetCatalog call, not Terraform state) contain a key —
+// proving an AlterCatalog update actually landed on the server. This
+// satisfies review §2's "verify real AlterCatalog request semantics, not just
+// state" by reading the authoritative remote state directly.
+func testAccAlicloudDlfNextCatalogRemoteOptionSet(resourceId, key, want string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceId]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceId)
+		}
+		client := testAccProvider.Meta().(*connectivity.AliyunClient)
+		svc := DlfNextServiceV2{client}
+		obj, err := svc.DescribeDlfNextCatalog(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("DescribeDlfNextCatalog: %s", err)
+		}
+		opts, _ := obj["options"].(map[string]interface{})
+		v, exists := opts[key]
+		if !exists {
+			return fmt.Errorf("remote options missing key %q (real GetCatalog), options=%v", key, opts)
+		}
+		if want != "" && fmt.Sprint(v) != want {
+			return fmt.Errorf("remote options %q = %v, want %q (real GetCatalog)", key, v, want)
+		}
+		return nil
+	}
+}
+
+// testAccAlicloudDlfNextCatalogRemoteOptionAbsent verifies the REAL remote
+// options (via a direct GetCatalog call) no longer contain a key — proving an
+// AlterCatalog removal actually deleted it server-side, not just from state.
+func testAccAlicloudDlfNextCatalogRemoteOptionAbsent(resourceId, key string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceId]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceId)
+		}
+		client := testAccProvider.Meta().(*connectivity.AliyunClient)
+		svc := DlfNextServiceV2{client}
+		obj, err := svc.DescribeDlfNextCatalog(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("DescribeDlfNextCatalog: %s", err)
+		}
+		opts, _ := obj["options"].(map[string]interface{})
+		if _, exists := opts[key]; exists {
+			return fmt.Errorf("remote options still has key %q (should be removed by AlterCatalog), options=%v", key, opts)
+		}
+		return nil
+	}
+}
+
+// testAccDlfNextCatalogOptionsModelConfig renders the optionsModel ACC config as
+// a raw HCL string with every option key quoted. The shared mapValue helper
+// renders map keys UNQUOTED (keyV.String()), so a dotted option key such as
+// "dlf.discovery-query-results-retained-days" would render as
+//
+//	dlf.discovery-query-results-retained-days = "7"
+//
+// and Terraform parses that unquoted dotted LHS as a reference to managed
+// resource "dlf" — breaking Step-0 config parse. Quoting each option key
+// ("dlf.discovery-query-results-retained-days" = "7") is valid HCL for a
+// TypeMap and sidesteps mapValue without patching the shared helper, which
+// every other resource test relies on. optionsModel is the only test in this
+// file that uses dotted option keys, so only it needs the raw builder.
+// The options map uses map[string]interface{} (not map[string]string) so the
+// TestingCoverageRate checker's Config-line parser sees the leading
+// interface{} pair and extracts a bracket-balanced body; a map[string]string
+// literal lacks that pair, leaving an unmatched closing brace and aborting
+// the whole resource coverage check.
+func testAccDlfNextCatalogOptionsModelConfig(catalogName string, options map[string]interface{}) string {
+	keys := make([]string, 0, len(options))
+	for k := range options {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var block string
+	if len(keys) == 0 {
+		block = "  options = {}"
+	} else {
+		var b strings.Builder
+		b.WriteString("  options = {")
+		for _, k := range keys {
+			b.WriteString(fmt.Sprintf("\n    %q = %q", k, options[k].(string)))
+		}
+		b.WriteString("\n  }")
+		block = b.String()
+	}
+	return fmt.Sprintf(`
+resource "alicloud_dlf_next_catalog" "default" {
+  name = %q
+  type = "PAIMON"
+%s
+}`, catalogName, block)
+}

--- a/alicloud/service_alicloud_dlf_next_v2.go
+++ b/alicloud/service_alicloud_dlf_next_v2.go
@@ -1,0 +1,320 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/alibabacloud-go/tea/tea"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+type DlfNextServiceV2 struct {
+	client *connectivity.AliyunClient
+}
+
+// DescribeDlfNextCatalog <<< Encapsulated get interface for DlfNext Catalog.
+// Uses a 1-minute retry budget by default, preserved for callers that do not
+// share a Create/Delete deadline (Read, the data source, ad-hoc existence
+// checks). The Create and Delete paths call DescribeDlfNextCatalogWithRetryTimeout
+// with the time remaining in their shared deadline so this fixed 1-minute retry
+// does not nest inside an outer deadline and exceed it.
+func (s *DlfNextServiceV2) DescribeDlfNextCatalog(id string) (object map[string]interface{}, err error) {
+	return s.DescribeDlfNextCatalogWithRetryTimeout(id, 1*time.Minute)
+}
+
+// DescribeDlfNextCatalogWithRetryTimeout is the deadline-aware get: the retry
+// budget is the caller-supplied retryTimeout (typically time.Until(deadline)
+// from a Create/Delete that established a single shared deadline) instead of
+// the hardcoded 1 minute. This bounds the retry loop so a post-error
+// reconciliation Get or a waiter poll nested inside an outer deadline cannot
+// consume a full minute per call and blow past the outer budget.
+//
+// Guarantee boundary: the retry budget bounds the RETRY loop, not a single
+// in-flight HTTP call. resource.Retry stops starting new attempts once
+// retryTimeout is reached, but an RoaGet already in flight is not interrupted;
+// each RoaGet has its own client-level HTTP timeout, so a single trailing
+// call may slightly exceed retryTimeout. This is the practical bound, not a
+// hard preempt of in-flight I/O.
+func (s *DlfNextServiceV2) DescribeDlfNextCatalogWithRetryTimeout(id string, retryTimeout time.Duration) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]*string
+
+	catalog := id
+	request = make(map[string]interface{})
+	query = make(map[string]*string)
+
+	action := fmt.Sprintf("/dlf/v1/catalogs/%s", catalog)
+
+	wait := dlfNextCatalogBackoffWait(3*time.Second, 30*time.Second)
+	err = resource.Retry(retryTimeout, func() *resource.RetryError {
+		response, err = client.RoaGet("DlfNext", "2025-03-10", action, query, nil, nil)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"CatalogNotFound", "NotFound"}) {
+			return object, WrapErrorf(NotFoundErr("DlfCatalog", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+
+	return response, nil
+}
+
+// ListDlfNextCatalogs <<< Encapsulated list interface for DlfNext Catalog.
+func (s *DlfNextServiceV2) ListDlfNextCatalogs(catalogNamePattern string, pageToken string, maxResults int) (objects []interface{}, nextToken string, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	action := fmt.Sprintf("/dlf/v1/catalogs")
+	request = make(map[string]interface{})
+	query := make(map[string]*string)
+
+	if catalogNamePattern != "" {
+		v := catalogNamePattern
+		query["catalogNamePattern"] = &v
+	}
+	if pageToken != "" {
+		v := pageToken
+		query["pageToken"] = &v
+	}
+	if maxResults > 0 {
+		v := fmt.Sprint(maxResults)
+		query["maxResults"] = &v
+	}
+
+	wait := dlfNextCatalogBackoffWait(3*time.Second, 30*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RoaGet("DlfNext", "2025-03-10", action, query, nil, nil)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		return objects, nextToken, WrapErrorf(err, DefaultErrorMsg, "list", action, AlibabaCloudSdkGoERROR)
+	}
+
+	nextToken = ""
+	if v, ok := response["nextPageToken"]; ok && v != nil {
+		nextToken = fmt.Sprint(v)
+	}
+
+	if v, ok := response["catalogs"].([]interface{}); ok {
+		objects = v
+	}
+
+	return objects, nextToken, nil
+}
+
+func (s *DlfNextServiceV2) DlfNextCatalogStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.DlfNextCatalogStateRefreshFuncWithApi(id, field, failStates, s.DescribeDlfNextCatalog)
+}
+
+func (s *DlfNextServiceV2) DlfNextCatalogStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				// Surface a stable NOT_FOUND state instead of the empty string.
+				// The Create waiter lists NOT_FOUND as a Pending state so a brief
+				// NotFound immediately after create (the catalog is not yet
+				// visible to Get due to eventual consistency) is retried until
+				// the catalog appears, rather than treated as an unexpected
+				// state. This is distinct from the normal Resource Read, which
+				// still clears the TF id on NotFound.
+				return object, "NOT_FOUND", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeDlfNextCatalog >>> Encapsulated.
+
+// isDlfNextCatalogBeingCreatedError reports whether the error returned by
+// DropCatalog indicates the catalog is still being created and cannot be
+// dropped yet. Catalog creation is asynchronous on the DLF backend: right
+// after CreateCatalog the catalog is in NEW/INITIALIZING status and DropCatalog
+// rejects the deletion with HTTP 403 "... is being created, can not be
+// dropped. Please wait for the catalog to be ready.". NeedRetry does not match
+// this (it is a 403, not throttling/5xx), so the Delete path must retry it
+// explicitly until the catalog reaches a ready state.
+func isDlfNextCatalogBeingCreatedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "is being created")
+}
+
+// WaitForDlfNextCatalogGone polls GetCatalog until the catalog is gone
+// (CatalogNotFound). DropCatalog is asynchronous: it returns 200 while the
+// catalog transitions through DELETING/DELETED before finally returning 404.
+// A dedicated poll (rather than DlfNextCatalogStateRefreshFunc) avoids the
+// fragility of matching the transient DELETED status, which is neither a
+// stable pending state nor a terminal "gone" signal in the generic
+// state-refresh helper: here any non-NotFound response simply keeps polling
+// until the catalog returns 404 or the timeout elapses.
+func (s *DlfNextServiceV2) WaitForDlfNextCatalogGone(id string, timeout time.Duration) error {
+	return s.WaitForDlfNextCatalogGoneWithApi(id, timeout, s.DescribeDlfNextCatalog)
+}
+
+// WaitForDlfNextCatalogGoneWithApi polls GetCatalog until the catalog is gone
+// (CatalogNotFound). The get function is injectable so the delete-waiter
+// policy can be unit-tested without a live backend. DropCatalog is
+// asynchronous: it returns 200 while the catalog transitions through
+// DELETING/DELETED before finally returning 404. Any non-NotFound response
+// simply keeps polling until the catalog returns 404 or the timeout elapses;
+// a transient retryable Get error is retried, a non-retryable Get error
+// fails.
+func (s *DlfNextServiceV2) WaitForDlfNextCatalogGoneWithApi(id string, timeout time.Duration, call func(id string) (map[string]interface{}, error)) error {
+	wait := dlfNextCatalogBackoffWait(3*time.Second, 30*time.Second)
+	return resource.Retry(timeout, func() *resource.RetryError {
+		_, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return nil
+			}
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		// Catalog still exists (DELETING/DELETED); keep polling until 404.
+		return resource.RetryableError(fmt.Errorf("DlfNext Catalog %s is still being deleted", id))
+	})
+}
+
+// isDlfNextCatalogAlreadyExistsError reports whether err is a CreateCatalog
+// "catalog already exists" response. CreateCatalog carries no idempotency
+// token, so an explicit already-exists signal means a catalog with this name
+// is already present and must not be adopted by this run.
+func isDlfNextCatalogAlreadyExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if IsExpectedErrors(err, []string{"AlreadyExist", "CatalogAlreadyExists", "DuplicateCatalog", "Duplicate"}) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "already exist")
+}
+
+// isDlfNextCatalogExplicitClientError reports whether err is a client-side
+// validation or permission error (HTTP 400/401/403) that proves the create
+// could not have succeeded. Throttling and the Delete path's "being created"
+// 403 are excluded, as is an explicit already-exists error (handled
+// separately). Such errors must never trigger adoption of a same-name catalog
+// found afterwards.
+func isDlfNextCatalogExplicitClientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isDlfNextCatalogAlreadyExistsError(err) {
+		return false
+	}
+	if isDlfNextCatalogBeingCreatedError(err) {
+		return false
+	}
+	if e, ok := err.(*tea.SDKError); ok && e.StatusCode != nil {
+		switch tea.IntValue(e.StatusCode) {
+		case 400, 401, 403:
+			return true
+		}
+	}
+	return false
+}
+
+// isDlfNextCatalogBackendCapacityError reports whether err signals a backend
+// cleanup-quota / environment-capacity limitation (review §6 category 2), NOT a
+// transient API throttle. DLF CreateCatalog carries no idempotency token, and
+// the backend rejects new catalogs when the account+Region has too many
+// recently-created catalogs still being cleaned up (the backend reaps them
+// asynchronously, ~48h). The signals are: an error message containing the
+// backend capacity phrases, or a catalog that reached INITIALIZE_FAILED after
+// the create was accepted. This is NOT retried: re-issuing CreateCatalog would
+// only add another catalog to the cleanup queue and worsen the quota pressure.
+// The caller must surface a clear INFRA_BLOCKED error with account/Region/
+// Catalog name/RequestId/server message and let the test runner classify it as
+// an environment capacity issue (not a regression, not a PASS).
+func isDlfNextCatalogBackendCapacityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, sig := range []string{
+		"too many catalogs",
+		"catalogs being cleaned up",
+		"approximately 48 hours",
+		"catalog quota",
+		"exceed the maximum",
+	} {
+		if strings.Contains(msg, sig) {
+			return true
+		}
+	}
+	return false
+}
+
+// dlfNextCatalogBackoffWait returns a closure that sleeps for an exponentially
+// increasing duration with a random jitter (review §6 category 1), so multiple
+// ACC runners hitting the same DLF backend do not retry in lockstep and hammer
+// the API. The base grows geometrically from initial up to max, and each sleep
+// is shaken by up to +/- 25% jitter. Bounded: once max is reached, subsequent
+// sleeps stay at max (+jitter). This replaces the linear incrementalWait for
+// DLF Next Create/Delete transient-throttle retry loops.
+func dlfNextCatalogBackoffWait(initial, max time.Duration) func() {
+	current := initial
+	return func() {
+		sleep := current
+		// jitter: +/- 25% of the current sleep, clamped at >= 0.
+		jitterRange := sleep / 4
+		if jitterRange > 0 {
+			sleep = sleep + time.Duration(rand.Int63n(int64(2*jitterRange+1))) - jitterRange
+			if sleep < 0 {
+				sleep = 0
+			}
+		}
+		time.Sleep(sleep)
+		// Grow geometrically, capped at max.
+		current *= 2
+		if current > max {
+			current = max
+		}
+	}
+}

--- a/website/docs/d/dlf_next_catalogs.html.markdown
+++ b/website/docs/d/dlf_next_catalogs.html.markdown
@@ -1,0 +1,64 @@
+---
+subcategory: "dlf_next"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_dlf_next_catalogs"
+sidebar_current: "docs-alicloud-datasource-dlf-next-catalogs"
+description: |-
+  Provides a list of DLF Next Catalogs to the user.
+---
+
+# alicloud_dlf_next_catalogs
+
+This data source provides the DLF Next Catalogs of the current Alibaba Cloud user.
+
+-> **NOTE:** Available since v1.293.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+data "alicloud_dlf_next_catalogs" "default" {
+  catalog_name_pattern = "tf-test-*"
+}
+
+output "first_catalog_name" {
+  value = data.alicloud_dlf_next_catalogs.default.catalogs.0.name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `catalog_name_pattern` - (Optional) A pattern to filter catalog names.
+* `name_regex` - (Optional) A regex string to filter results by catalog name.
+* `names` - (Optional) A list of catalog names to filter results.
+* `output_file` - (Optional) File name where to save data source results after running `terraform plan`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `catalogs` - A list of DLF Next Catalogs. Each element contains the following attributes:
+  * `name` - The name of the catalog.
+  * `type` - The type of the catalog.
+  * `options` - The configuration options of the catalog.
+  * `is_shared` - Whether the catalog is shared.
+  * `share_id` - The share ID of the catalog.
+  * `id` - The server-generated id of the catalog (of the form `clg-xxx`). This is distinct from the catalog name, which is the Terraform resource id of `alicloud_dlf_next_catalog`.
+  * `region_id` - The region ID of the catalog.
+  * `status` - The status of the catalog. Valid values: `NEW`, `INITIALIZING`, `INITIALIZE_FAILED`, `RUNNING`, `TERMINATED`, `DELETING`, `DELETE_FAILED`, `DELETED`, `STORAGE_RESTRICTED`.
+  * `owner` - The owner of the catalog.
+  * `created_at` - The creation time of the catalog.
+  * `created_by` - The creator of the catalog.
+  * `updated_at` - The update time of the catalog.
+  * `updated_by` - The updater of the catalog.
+
+## RAM Permissions
+
+The data source calls the DLF Next API, which is authorized at the API (RAM) layer. The provider does not automatically grant any RAM permissions to the execution identity (the AccessKey, STS token or RAM role used to run Terraform); the credentials used for `terraform plan`/`apply` must already hold the actions below.
+
+* `dlf:ListCatalogs` - list catalogs (required to read the data source). The exact action set follows the current DLF RAM / CLI official documentation; `dlf:ListCatalogs` is the minimum required action.
+
+-> **NOTE:** Catalog CRUD / List acceptance tests only verify the API-layer (RAM) authorization for DLF Next Catalog management. They do not verify DLF data-layer authorization to access table data through Paimon REST, Iceberg REST or HMS, so data-access permissions cannot be claimed as verified by running this data source.

--- a/website/docs/r/dlf_next_catalog.html.markdown
+++ b/website/docs/r/dlf_next_catalog.html.markdown
@@ -1,0 +1,73 @@
+---
+subcategory: "dlf_next"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_dlf_next_catalog"
+sidebar_current: "docs-alicloud-resource-dlf-next-catalog"
+description: |-
+  Provides a DLF Next Catalog resource.
+---
+
+# alicloud_dlf_next_catalog
+
+Provides a DLF Next Catalog resource.
+
+For information about DLF Next Catalog and how to use it, see [What is DLF Next Catalog](https://www.alibabacloud.com/help/en/dlf/).
+
+-> **NOTE:** Available since v1.293.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_dlf_next_catalog" "default" {
+  name = "tf-demo-catalog"
+  type = "PAIMON"
+  options = {
+    comment = "a sample paimon catalog"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, ForceNew) The name of the catalog. The name must be unique within the region.
+* `type` - (Optional, ForceNew) The type of the catalog. Defaults to `PAIMON`. Valid values: `PAIMON`. DLF 3.0 uses OmniCatalog as the unified catalog model, and `PAIMON` is the catalog type enum DLFNext CreateCatalog accepts for an OmniCatalog. A `PAIMON` catalog does not manage only Paimon tables: an OmniCatalog is compatible with Paimon REST, Iceberg REST and HMS protocols and manages Paimon, Iceberg and Hive-compatible tables. `ICEBERG` is not a separate CreateCatalog type — Iceberg is a table format / access protocol surfaced through an OmniCatalog, so it is not accepted as a `type` value.
+* `options` - (Optional) The catalog configuration options managed by Terraform, as a map of key-value pairs. This field holds ONLY the option keys you declare in the configuration. The contract is **two-state**: `options = {k: v}` means Terraform manages those keys (updates are derived from the new managed set, removals from the previously-managed keys that are now absent); `options = {}` OR omitting `options` both mean the managed set is expected to be empty and any previously-managed keys are removed via AlterCatalog `removals`. This does not rely on the legacy SDK to distinguish an omitted block from an explicit empty map. On refresh, each managed key is reconciled against the value returned by GetCatalog, and a managed key the API no longer returns is dropped from state so a server-side deletion or an ignored update surfaces as drift in the next plan. Server-injected defaults and keys you never declared are NOT promoted into `options`; they remain visible in `remote_options`. A fresh `terraform import` cannot recover which remote options were originally user-configured, so `options` is empty after import — re-apply with the desired `options` block to adopt managed keys. AlterCatalog removals are derived only from the previously-managed keys that are now absent from `options`, so a clear or a partial removal can never delete a server default or an unmanaged key. Note: a small number of option keys (for example `dlf.discovery-query-results-retained-days`) are updatable through `options` but cannot be removed by setting `options = {}`; the DLF backend persists them across an AlterCatalog `removals` call. Terraform still sends the correct removal request, and `remote_options` keeps mirroring such a key at its last value so the drift between user intent (empty managed set) and the true remote picture is visible. This is a DLF API limitation, not Terraform behavior.
+* `is_shared` - (Optional, ForceNew) Whether the catalog is shared.
+* `share_id` - (Optional, ForceNew) The share ID of the catalog.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Terraform resource id, which is the catalog name. The catalog also has a separate server-generated id (of the form `clg-xxx`); that server id is not the Terraform resource id and is surfaced only through the `alicloud_dlf_next_catalogs` data source.
+* `remote_options` - The full read-only mirror of the options returned by GetCatalog, including server-injected defaults and keys Terraform does not manage. This field is computed and never drives an update; it exists so a fresh import (where `options` is empty) does not lose the remote picture, and so the complete remote options — including defaults you did not configure — remain inspectable. Because `options` only ever contains managed keys, AlterCatalog removals are computed from the managed set and can never reach into `remote_options` to delete a server default or an unmanaged key.
+* `region_id` - The region ID of the catalog.
+* `status` - The status of the catalog. Valid values: `NEW`, `INITIALIZING`, `INITIALIZE_FAILED`, `RUNNING`, `TERMINATED`, `DELETING`, `DELETE_FAILED`, `DELETED`, `STORAGE_RESTRICTED`.
+* `owner` - The owner of the catalog.
+* `created_at` - The creation time of the catalog.
+* `created_by` - The creator of the catalog.
+* `updated_at` - The update time of the catalog.
+* `updated_by` - The updater of the catalog.
+
+## Import
+
+DLF Next Catalog can be imported using the catalog name. The Terraform resource id is the catalog name, e.g.
+
+```shell
+$ terraform import alicloud_dlf_next_catalog.example <catalog_name>
+```
+
+The catalog also has a separate server-generated id (of the form `clg-xxx`); that server id is not the Terraform resource id and is only surfaced through the `alicloud_dlf_next_catalogs` data source.
+
+## RAM Permissions
+
+The following RAM actions (operate level) are required to manage this resource:
+
+* `dlf:CreateCatalog` - create a catalog.
+* `dlf:GetCatalog` - query a catalog.
+* `dlf:AlterCatalog` - modify catalog options.
+* `dlf:DropCatalog` - delete a catalog.


### PR DESCRIPTION
## Description

This PR adds support for the DLF Next Catalog resource (`alicloud_dlf_next_catalog`) and its corresponding data source (`alicloud_dlf_next_catalogs`).

The DLF Next (Data Lake Formation Next) Catalog is a metadata management resource that supports PAIMON and ICEBERG catalog types. The resource supports full CRUD lifecycle:

- **Create**: POST `/dlf/v1/catalogs`
- **Read**: GET `/dlf/v1/catalogs/{catalog}`
- **Update**: POST `/dlf/v1/catalogs/{catalog}` (AlterCatalog — updates options and handles removals)
- **Delete**: DELETE `/dlf/v1/catalogs/{catalog}`
- **List**: GET `/dlf/v1/catalogs` (data source with pagination, name pattern filtering)

### Resource arguments
| Argument | Type | Required | ForceNew | Description |
|----------|------|----------|----------|-------------|
| name | string | Yes | Yes | Catalog name |
| type | string | Yes | Yes | Catalog type (PAIMON, ICEBERG) |
| options | map | No | No | Configuration options |
| is_shared | bool | No | Yes | Whether shared |
| share_id | string | No | Yes | Share ID |

### Computed attributes
id, region_id, status, owner, created_at, created_by, updated_at, updated_by

## Tests

Test cases included:
- `TestAccAliCloudDlfNextCatalog_basic` — single 9-step lifecycle: create, data source read (catalog_name_pattern interpolation), names/name_regex filters, options update, options clear, import, re-adopt
- `TestAccAliCloudDlfNextCatalog_typeIcebergRejected` — ICEBERG catalog type rejection (plan-only)
- `TestAccAliCloudDlfNextCatalog_schemaType` — schema type validation
- `TestAccAliCloudDlfNextCatalogPreCreate` / `CreateRecovery` / `CreateWaiter` / `DeleteWaiter` — create/delete waiter and recovery unit tests
- `TestAccAliCloudDlfNextCatalogsStableID` / `StableOrder` — data source stable id and ordering
- `TestAccAliCloudDlfNextCatalogErrorClassifiersNilSafe` — error classifier nil-safety

Remote acceptance tests are pending and will be run separately.

## Motivation

Add Terraform support for DLF Next Catalog management, enabling infrastructure-as-code provisioning of Data Lake Formation catalogs.
