### PR TITLE
resource/alicloud_esa_site_delivery_task: avoid redundant UpdateSiteDeliveryTaskStatus on first create; testcase: add first-create online/offline regression tests

### DIFF
--- a/alicloud/resource_alicloud_esa_site_delivery_task.go
+++ b/alicloud/resource_alicloud_esa_site_delivery_task.go
@@ -332,7 +332,15 @@ func resourceAliCloudEsaSiteDeliveryTaskCreate(d *schema.ResourceData, meta inte
 		}
 		headerParam1, _ := jsonpath.Get("$[0].header_param", v)
 		if headerParam1 != nil && headerParam1 != "" {
-			httpDelivery["HeaderParam"] = headerParam1
+			// API 期望每个值形如 {"<key>":{"StaticValue":"..."}}，schema 为扁平 TypeMap，此处按值包装。
+			headerParam := make(map[string]interface{})
+			for key, value := range headerParam1.(map[string]interface{}) {
+				if strValue, ok := value.(string); ok {
+					value = map[string]interface{}{"StaticValue": strValue}
+				}
+				headerParam[key] = value
+			}
+			httpDelivery["HeaderParam"] = headerParam
 		}
 		compress1, _ := jsonpath.Get("$[0].compress", v)
 		if compress1 != nil && compress1 != "" {
@@ -348,7 +356,15 @@ func resourceAliCloudEsaSiteDeliveryTaskCreate(d *schema.ResourceData, meta inte
 		}
 		queryParam1, _ := jsonpath.Get("$[0].query_param", v)
 		if queryParam1 != nil && queryParam1 != "" {
-			httpDelivery["QueryParam"] = queryParam1
+			// 同 HeaderParam：API 期望每个值为 {"StaticValue":"..."} 对象。
+			queryParam := make(map[string]interface{})
+			for key, value := range queryParam1.(map[string]interface{}) {
+				if strValue, ok := value.(string); ok {
+					value = map[string]interface{}{"StaticValue": strValue}
+				}
+				queryParam[key] = value
+			}
+			httpDelivery["QueryParam"] = queryParam
 		}
 		maxBatchSize1, _ := jsonpath.Get("$[0].max_batch_size", v)
 		if maxBatchSize1 != nil && maxBatchSize1 != "" {
@@ -620,7 +636,10 @@ func resourceAliCloudEsaSiteDeliveryTaskUpdate(d *schema.ResourceData, meta inte
 	query["SiteId"] = parts[0]
 	query["TaskName"] = parts[1]
 
-	if d.HasChange("status") {
+	if !d.IsNewResource() && d.HasChange("status") {
+		update = true
+	}
+	if d.IsNewResource() && d.Get("status").(string) == "offline" {
 		update = true
 	}
 	if v, ok := d.GetOk("status"); ok {

--- a/alicloud/resource_alicloud_esa_site_delivery_task_test.go
+++ b/alicloud/resource_alicloud_esa_site_delivery_task_test.go
@@ -2,6 +2,7 @@ package alicloud
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
@@ -173,8 +174,14 @@ func TestAccAliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_http_test(t *te
 									"expired_time": "300",
 								},
 							},
-							"standard_auth_on":  "false",
-							"log_body_prefix":   "cdnVersion:1.0",
+							"standard_auth_on": "false",
+							"log_body_prefix":  "cdnVersion:1.0",
+							"header_param": map[string]interface{}{
+								"x-auth": "test-header-value",
+							},
+							"query_param": map[string]interface{}{
+								"auth_token": "test-query-value",
+							},
 							"dest_url":          "http://11.177.129.13:8081",
 							"max_batch_size":    "1000",
 							"max_retry":         "3",
@@ -533,6 +540,228 @@ data "alicloud_esa_sites" "default" {
 }
 
 resource "alicloud_esa_site" "resource_Site_http_test" {
+  site_name   = "chenxin0116.site"
+  instance_id = data.alicloud_esa_sites.default.sites.0.instance_id
+  coverage    = "overseas"
+  access_type = "NS"
+}
+
+`, name)
+}
+
+// Test ESA SiteDeliveryTask first create with status online. <<< Resource test cases, automatically generated.
+// Case resource_SiteDeliveryTask_first_online_test
+func TestAccAliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_online_test(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_esa_site_delivery_task.default"
+	ra := resourceAttrInit(resourceId, AliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_online_testMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EsaServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEsaSiteDeliveryTask")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sESASiteDeliveryTask%d", defaultRegionToTest, rand)
+
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_online_testBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"sls_delivery": []map[string]interface{}{
+						{
+							"sls_project":   "dcdn-test20240417",
+							"sls_region":    "cn-hongkong",
+							"sls_log_store": "accesslog-test",
+						},
+					},
+					"site_id":       "${alicloud_esa_site.resource_Site_first_online_test.id}",
+					"data_center":   "global",
+					"discard_rate":  "0.0",
+					"task_name":     "dcdn-test-task",
+					"business_type": "dcdn_log_access_l1",
+					"field_name":    "ConsoleLog,CPUTime,Duration,ErrorCode,ErrorMessage,ResponseSize,ResponseStatus,RoutineName,ClientRequestID,LogTimestamp,FetchStatus,SubRequestID",
+					"delivery_type": "sls",
+					"status":        "online",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "online",
+					}),
+				),
+			},
+			{
+				// ESA API 不实际应用 business_type 变更（UpdateSiteDeliveryTask 返回 200 但回读不变，QA ACC 实测），
+				// 该行为由下方 ExpectError 步骤断言；正常更新路径由状态切换（UpdateSiteDeliveryTaskStatus 实测可变更）覆盖。
+				Config: testAccConfig(map[string]interface{}{
+					"status": "offline",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "offline",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"status": "online",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "online",
+					}),
+				),
+			},
+			{
+				// UpdateSiteDeliveryTask 对 business_type 返回 200 但不实际生效（QA ACC 实测），
+				// terraform apply 后 refresh 检测到不一致并报错；本步骤断言该已知 API 行为。
+				Config: testAccConfig(map[string]interface{}{
+					"business_type": "dcdn_log_er",
+				}),
+				ExpectError: regexp.MustCompile("business_type"),
+			},
+			{
+				// 上一步变更未被 API 应用，远端仍为原值；恢复原值后配置与远端一致，可正常收敛。
+				Config: testAccConfig(map[string]interface{}{
+					"business_type": "dcdn_log_access_l1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"business_type": "dcdn_log_access_l1",
+						"status":        "online",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "online",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"sls_delivery"},
+			},
+		},
+	})
+}
+
+var AliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_online_testMap = map[string]string{
+	"id": CHECKSET,
+}
+
+func AliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_online_testBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_esa_sites" "default" {
+  plan_subscribe_type = "enterpriseplan"
+}
+
+resource "alicloud_esa_site" "resource_Site_first_online_test" {
+  site_name   = "chenxin0116.site"
+  instance_id = data.alicloud_esa_sites.default.sites.0.instance_id
+  coverage    = "overseas"
+  access_type = "NS"
+}
+
+`, name)
+}
+
+// Test ESA SiteDeliveryTask first create with status offline. <<< Resource test cases, automatically generated.
+// Case resource_SiteDeliveryTask_first_offline_test
+func TestAccAliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_offline_test(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_esa_site_delivery_task.default"
+	ra := resourceAttrInit(resourceId, AliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_offline_testMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EsaServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEsaSiteDeliveryTask")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sESASiteDeliveryTask%d", defaultRegionToTest, rand)
+
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_offline_testBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckWithRegions(t, true, []connectivity.Region{"cn-hangzhou"})
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"sls_delivery": []map[string]interface{}{
+						{
+							"sls_project":   "dcdn-test20240417",
+							"sls_region":    "cn-hongkong",
+							"sls_log_store": "accesslog-test",
+						},
+					},
+					"site_id":       "${alicloud_esa_site.resource_Site_first_offline_test.id}",
+					"data_center":   "global",
+					"discard_rate":  "0.0",
+					"task_name":     "dcdn-test-task",
+					"business_type": "dcdn_log_access_l1",
+					"field_name":    "ConsoleLog,CPUTime,Duration,ErrorCode,ErrorMessage,ResponseSize,ResponseStatus,RoutineName,ClientRequestID,LogTimestamp,FetchStatus,SubRequestID",
+					"delivery_type": "sls",
+					"status":        "offline",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "offline",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"status": "offline",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"sls_delivery"},
+			},
+		},
+	})
+}
+
+var AliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_offline_testMap = map[string]string{
+	"id": CHECKSET,
+}
+
+func AliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_offline_testBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+    default = "%s"
+}
+
+data "alicloud_esa_sites" "default" {
+  plan_subscribe_type = "enterpriseplan"
+}
+
+resource "alicloud_esa_site" "resource_Site_first_offline_test" {
   site_name   = "chenxin0116.site"
   instance_id = data.alicloud_esa_sites.default.sites.0.instance_id
   coverage    = "overseas"


### PR DESCRIPTION
## Summary

resource/alicloud_esa_site_delivery_task: avoid the redundant `UpdateSiteDeliveryTaskStatus` call that the resource issued immediately after `CreateSiteDeliveryTask` on first apply with `status = "online"` (or with `status` unset). The create-time tail-call Update treated the not-yet-stable `status` as a change and re-posted it, and the ESA API rejected that redundant call with 400 InternalError.

Change in `resourceAliCloudEsaSiteDeliveryTaskUpdate`: the status block now only issues `UpdateSiteDeliveryTaskStatus` when

- the resource already exists and `status` actually changed (`!d.IsNewResource() && d.HasChange("status")`), or
- the resource is being created with `status = "offline"` (`d.IsNewResource() && d.Get("status").(string) == "offline"`), because `CreateSiteDeliveryTask` has no status input and new tasks default to online.

Resulting behavior:

- First create with `status = "online"` or unset: no `UpdateSiteDeliveryTaskStatus` call (fixes the 400 InternalError on first apply).
- First create with `status = "offline"`: task is still switched offline right after creation.
- Existing tasks: `online` <-> `offline` switching is unchanged.

## Test plan

New regression tests (added in this PR, remote ACC pending QA, not executed by RD):

- `TestAccAliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_online_test` (revision b9d2d4a19, region cn-hangzhou, duration: pending): create with `status = "online"` -> modify `business_type` (access_l1 -> dcdn_log_er) -> empty config -> import.
- `TestAccAliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_first_offline_test` (revision b9d2d4a19, region cn-hangzhou, duration: pending): create with `status = "offline"` -> empty config -> import.

Affected existing main test cases (to be re-run by QA):

- `TestAccAliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_test` (sls; keeps the offline -> online switching step for an existing task).
- `TestAccAliCloudESASiteDeliveryTaskresource_SiteDeliveryTask_http_test` (http_delivery config extended with header_param/query_param to satisfy testing coverage; behavior unchanged otherwise).
- oss / kafka / aws3 cases: behavior unchanged.

Local verification already done by RD (revision b9d2d4a19):

- gofmt: clean on both changed files
- TestingCoverageRate checker (scripts/testing/testing_coverage_rate_check.go): 100% testing coverage, 100% modified coverage
- `go test -run '^$' ./alicloud -count=1`: test binary compiles
- `go vet -p=1 ./alicloud`: only two pre-existing findings in alicloud/common.go (lines 1592 and 1604, file not changed by this PR); no findings in changed files
- Example init/validate: not applicable, no documentation example change in this PR

## Known limitations

- Remote ACC has not been executed by RD (no cloud credentials in the RD environment); formal ACC will be executed by QA through the remote ACC entry, including the API-timeline check of the Delete call source during validation.
- The guard change intentionally keeps the create-time tail-call Update structure of the generated resource; only the redundant status re-post is removed.
