### PR TITLE
resource/alicloud_oos_parameter: support the write-only attribute value_wo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.293.0 (Unreleased)
+
+ENHANCEMENTS:
+
+- resource/alicloud_oos_parameter: support the write-only attribute `value_wo` with `value_wo_version` as its change trigger, so the parameter value can be managed without being persisted in the state or plan.
+
 ## 1.292.0 (September 8, 2026)
 
 - **New Resource:** `alicloud_threat_detection_rd_default_sync_list` ([#10207](https://github.com/aliyun/terraform-provider-alicloud/issues/10207))

--- a/alicloud/common.go
+++ b/alicloud/common.go
@@ -33,6 +33,7 @@ import (
 	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/cs"
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -727,6 +728,20 @@ func buildClientToken(action string) string {
 		token = token[0:64]
 	}
 	return token
+}
+
+func getWriteOnlyStringValue(d *schema.ResourceData, path cty.Path) (string, error) {
+	if d.GetRawConfig().IsNull() {
+		return "", nil
+	}
+	value, diags := d.GetRawConfigAt(path)
+	if diags.HasError() {
+		return "", WrapError(fmt.Errorf("error retrieving write-only argument: %s", diags[0].Summary))
+	}
+	if value.IsNull() || !value.IsKnown() || !value.Type().Equals(cty.String) {
+		return "", nil
+	}
+	return value.AsString(), nil
 }
 
 func getNextpageNumber(number requests.Integer) (requests.Integer, error) {

--- a/alicloud/resource_alicloud_oos_parameter.go
+++ b/alicloud/resource_alicloud_oos_parameter.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -38,6 +39,10 @@ func resourceAlicloudOosParameter() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(1, 200),
 			},
+			"has_value_wo": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"parameter_name": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -58,8 +63,25 @@ func resourceAlicloudOosParameter() *schema.Resource {
 			},
 			"value": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(1, 4096),
+				ExactlyOneOf: []string{"value", "value_wo"},
+			},
+			"value_wo": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				WriteOnly:    true,
+				ValidateFunc: validation.StringLenBetween(1, 4096),
+				ExactlyOneOf: []string{"value", "value_wo"},
+				RequiredWith: []string{"value_wo_version"},
+			},
+			"value_wo_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"value_wo"},
 			},
 		},
 	}
@@ -89,7 +111,13 @@ func resourceAlicloudOosParameterCreate(d *schema.ResourceData, meta interface{}
 	}
 	request["Name"] = d.Get("parameter_name")
 	request["Type"] = d.Get("type")
-	request["Value"] = d.Get("value")
+	value := d.Get("value").(string)
+	if woValue, err := getWriteOnlyStringValue(d, cty.GetAttrPath("value_wo")); err != nil {
+		return WrapError(err)
+	} else if woValue != "" {
+		value = woValue
+	}
+	request["Value"] = value
 	request["ClientToken"] = buildClientToken("CreateParameter")
 	wait := incrementalWait(3*time.Second, 3*time.Second)
 	err = retry.Retry(d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
@@ -131,7 +159,24 @@ func resourceAlicloudOosParameterRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("resource_group_id", object["ResourceGroupId"])
 	d.Set("tags", tagsToMap(object["Tags"]))
 	d.Set("type", object["Type"])
-	d.Set("value", object["Value"])
+	hasValueWo := false
+	if v, ok := d.GetOk("has_value_wo"); ok && v.(bool) {
+		hasValueWo = true
+	}
+	if rawConfig := d.GetRawConfig(); !rawConfig.IsNull() {
+		woValue, err := getWriteOnlyStringValue(d, cty.GetAttrPath("value_wo"))
+		if err != nil {
+			return WrapError(err)
+		}
+		hasValueWo = woValue != ""
+	}
+	if hasValueWo {
+		d.Set("has_value_wo", true)
+		d.Set("value", nil)
+	} else {
+		d.Set("has_value_wo", nil)
+		d.Set("value", object["Value"])
+	}
 	return nil
 }
 func resourceAlicloudOosParameterUpdate(d *schema.ResourceData, meta interface{}) error {
@@ -142,10 +187,19 @@ func resourceAlicloudOosParameterUpdate(d *schema.ResourceData, meta interface{}
 	request := map[string]interface{}{
 		"Name": d.Id(),
 	}
+	value := d.Get("value").(string)
+	if woValue, err := getWriteOnlyStringValue(d, cty.GetAttrPath("value_wo")); err != nil {
+		return WrapError(err)
+	} else if woValue != "" {
+		value = woValue
+	}
 	if d.HasChange("value") {
 		update = true
 	}
-	request["Value"] = d.Get("value")
+	if d.HasChange("value_wo_version") {
+		update = true
+	}
+	request["Value"] = value
 	if d.HasChange("description") {
 		update = true
 	}

--- a/alicloud/resource_alicloud_oos_parameter_test.go
+++ b/alicloud/resource_alicloud_oos_parameter_test.go
@@ -110,7 +110,7 @@ func testSweepOosParameter(region string) error {
 	return nil
 }
 
-func TestAccAlicloudOOSParameter_basic0(t *testing.T) {
+func TestAccAliCloudOosParameter_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_oos_parameter.default"
 	checkoutSupportedRegions(t, true, connectivity.OOSSupportRegions)
@@ -218,7 +218,7 @@ func TestAccAlicloudOOSParameter_basic0(t *testing.T) {
 	})
 }
 
-func TestAccAlicloudOOSParameter_basic1(t *testing.T) {
+func TestAccAliCloudOosParameter_basic1(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_oos_parameter.default"
 	checkoutSupportedRegions(t, true, connectivity.OOSSupportRegions)
@@ -270,6 +270,81 @@ func TestAccAlicloudOOSParameter_basic1(t *testing.T) {
 				ResourceName:      resourceId,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAliCloudOosParameter_valueWo(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_oos_parameter.default"
+	checkoutSupportedRegions(t, true, connectivity.OOSSupportRegions)
+	ra := resourceAttrInit(resourceId, map[string]string{
+		"parameter_name": CHECKSET,
+		"type":           "String",
+	})
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &OosService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeOosParameter")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%soosparameter%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudOOSParameterBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName:     resourceId,
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"parameter_name":   "${var.name}",
+					"type":             "String",
+					"value_wo":         "tf-testacc-oos_parameter_wo",
+					"value_wo_version": 1,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"parameter_name":   name,
+						"value":            "",
+						"value_wo_version": "1",
+						"has_value_wo":     "true",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"value_wo":         "tf-testacc-oos_parameter_wo_update",
+					"value_wo_version": 2,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"value_wo_version": "2",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"value":            "tf-testacc-oos_parameter",
+					"value_wo":         REMOVEKEY,
+					"value_wo_version": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"value":            "tf-testacc-oos_parameter",
+						"has_value_wo":     "false",
+						"value_wo_version": "2",
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value_wo_version"},
 			},
 		},
 	})

--- a/website/docs/r/oos_parameter.html.markdown
+++ b/website/docs/r/oos_parameter.html.markdown
@@ -7,13 +7,15 @@ description: |-
   Provides a Alicloud OOS Parameter resource.
 ---
 
-# alicloud\_oos\_parameter
+# alicloud_oos_parameter
 
 Provides a OOS Parameter resource.
 
 For information about OOS Parameter and how to use it, see [What is Parameter](https://www.alibabacloud.com/help/en/doc-detail/183408.html).
 
--> **NOTE:** Available in v1.147.0+.
+-> **NOTE:** Available since v1.147.0.
+
+-> **NOTE:** The `value_wo` and `value_wo_version` arguments require Terraform v1.11.0 or later. When `value_wo` is in use, `value` is not stored in the state or plan and reads back empty; use the `has_value_wo` attribute to check whether the value is managed by `value_wo`.
 
 ## Example Usage
 
@@ -57,7 +59,9 @@ The following arguments are supported:
 * `parameter_name` - (Required, ForceNew) The name of the common parameter. The name must be `2` to `180` characters in length, and can contain letters, digits, hyphens (-), forward slashes (/) and underscores (_). It cannot start with `ALIYUN`, `ACS`, `ALIBABA`, `ALICLOUD`, or `OOS`.
 * `resource_group_id` - (Optional, Computed) The ID of the Resource Group.
 * `type` - (Required, ForceNew) The data type of the common parameter. Valid values: `String` and `StringList`.
-* `value` - (Required) The value of the common parameter. The value must be `1` to `4096` characters in length.
+* `value` - (Optional, Computed) The value of the common parameter. The value must be `1` to `4096` characters in length. Exactly one of `value` and `value_wo` can be set.
+* `value_wo` - (Optional, Sensitive, Available since v1.293.0) The write-only value of the common parameter. It is only sent to the server when the resource is created or updated and is never stored in the state or plan. The value must be `1` to `4096` characters in length. It requires Terraform v1.11.0 or later and must be used together with `value_wo_version`. Exactly one of `value` and `value_wo` can be set.
+* `value_wo_version` - (Optional, Computed, Available since v1.293.0) The version of the write-only value. The write-only value is re-sent to the server only when this argument changes, so it must be changed whenever `value_wo` changes. Once set, the last version remains in the state after this argument is removed from the configuration together with `value_wo`.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
@@ -65,6 +69,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The resource ID in terraform of Parameter. Its value is same as `parameter_name`.
+* `has_value_wo` - Whether the value of the common parameter is currently managed by `value_wo`. When it is `true`, `value` reads back empty because the write-only value is never stored in the state.
 
 ## Import
 


### PR DESCRIPTION
### Description / Why

`alicloud_oos_parameter` persists the parameter value in the state and plan, which is undesirable when the parameter holds a secret (database password, token). This PR adds write-only support so the value can be managed without ever being stored:

- `value_wo` - (Optional, Sensitive) write-only twin of `value`: sent to the server on create and update, never stored in the state or plan. Carries the same `1` to `4096` length validation as `value`, so an invalid value fails at plan time instead of at apply. Requires Terraform >= 1.11.
- `value_wo_version` - (Optional, Computed) change trigger for the write-only value: write-only values are invisible to the diff, so the value is re-sent only when this argument changes. After both are removed from the configuration, the last version remains in the state.
- `has_value_wo` - (Computed) reports whether the value is currently managed by `value_wo`.
- `value` is relaxed from Required to Optional + Computed with `ExactlyOneOf` between `value` and `value_wo`; while `value_wo` is in use, the value read back from the API is not persisted and `value` reads empty.

### Changes

- `alicloud/resource_alicloud_oos_parameter.go`: new schema entries, write-only value resolution from the raw configuration in Create/Update, read-side mode handling for `has_value_wo` and `value`.
- `alicloud/common.go`: `getWriteOnlyStringValue` helper that reads a write-only attribute from the raw configuration (write-only values exist nowhere else).
- `alicloud/resource_alicloud_oos_parameter_test.go`: new `TestAccAliCloudOosParameter_valueWo` case; renames `TestAccAlicloudOOSParameter_basic0/basic1` to `TestAccAliCloudOosParameter_basic0/basic1` (fixture repair, see below).
- `website/docs/r/oos_parameter.html.markdown`: argument/attribute documentation plus a note on the Terraform version requirement and read-back behavior.
- `CHANGELOG.md`: entry under 1.293.0.

#### Test visibility repair

The existing cases `TestAccAlicloudOOSParameter_basic0/basic1` were invisible to the acceptance runner's case-sensitive `TestAccAliCloud{Namespace}{Resource}*` pattern (legacy `Alicloud` casing and the `OOS` abbreviation), so they never executed remotely. They are renamed to `TestAccAliCloudOosParameter_basic0/basic1` to match the convention used by the other resources. No test logic changed beyond the names.

### Acceptance tests

Pattern `TestAccAliCloudOosParameter*` — 3 pass / 0 fail / 0 skip:

```
PASS: TestAccAliCloudOosParameter_basic0 (51.28s)
PASS: TestAccAliCloudOosParameter_basic1 (10.65s)
PASS: TestAccAliCloudOosParameter_valueWo (19.65s)
```

`valueWo` covers the full lifecycle: create with `value_wo` + version 1 (state: `value` empty, `has_value_wo` true, `value_wo_version` 1), rotate the value with version 2, remove both from the configuration (asserts the last version is retained in the state and no update fires), then import with `value_wo_version` in `ImportStateVerifyIgnore`.

Coverage gap: the opposite migration direction — an existing `value` configuration switching to `value_wo` — uses the same update path (the `value_wo_version` diff triggers the update and the write-only value takes precedence in the request), but has no dedicated acceptance step; the end-to-end covered direction is write-only to legacy.

### Notes for reviewers

- `value_wo_version` is Optional + Computed rather than plain Optional: with a plain Optional `TypeInt`, the SDK zero-materializes a removed version as `0` in the state, which breaks import verification (state carries `0`, import produces absence) and produces a perpetual `0 -> null` diff that re-triggers updates on every plan. Computed semantics retain the last value with no diff, consistent with other Optional + Computed attributes in this codebase.
- The API requires `Value` on every update call, so the resolved value (from `value_wo` when set, falling back to `value`) rides the update request regardless of which argument triggered the update.
