### PR TITLE
resource/alicloud_api_gateway_model: support tags and make model_name updatable

### DIFF
--- a/alicloud/resource_alicloud_api_gateway_model.go
+++ b/alicloud/resource_alicloud_api_gateway_model.go
@@ -32,7 +32,6 @@ func resourceAlicloudApiGatewayModel() *schema.Resource {
 			"model_name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"schema": {
 				Type:     schema.TypeString,
@@ -42,6 +41,7 @@ func resourceAlicloudApiGatewayModel() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"tags": tagsSchemaForceNew(),
 		},
 	}
 }
@@ -59,6 +59,16 @@ func resourceAlicloudApiGatewayModelCreate(d *schema.ResourceData, meta interfac
 
 	if v, ok := d.GetOk("description"); ok {
 		request["Description"] = v
+	}
+
+	if _, ok := d.GetOk("tags"); ok {
+		added, _ := parsingTags(d)
+		count := 1
+		for key, value := range added {
+			request[fmt.Sprintf("Tag.%d.Key", count)] = key
+			request[fmt.Sprintf("Tag.%d.Value", count)] = value
+			count++
+		}
 	}
 
 	wait := incrementalWait(3*time.Second, 3*time.Second)
@@ -100,6 +110,22 @@ func resourceAlicloudApiGatewayModelRead(d *schema.ResourceData, meta interface{
 	d.Set("schema", object["Schema"])
 	d.Set("description", object["Description"])
 
+	tags := make(map[string]string)
+	if v, ok := object["Tags"]; ok && v != nil {
+		if tagsMap, ok := v.(map[string]interface{}); ok {
+			if tagInfo, ok := tagsMap["TagInfo"].([]interface{}); ok {
+				for _, t := range tagInfo {
+					if tag, ok := t.(map[string]interface{}); ok {
+						if key, ok := tag["Key"]; ok {
+							tags[fmt.Sprint(key)] = fmt.Sprint(tag["Value"])
+						}
+					}
+				}
+			}
+		}
+	}
+	d.Set("tags", tags)
+
 	return nil
 }
 
@@ -131,6 +157,11 @@ func resourceAlicloudApiGatewayModelUpdate(d *schema.ResourceData, meta interfac
 		request["Description"] = v
 	}
 
+	if !d.IsNewResource() && d.HasChange("model_name") {
+		update = true
+		request["NewModelName"] = d.Get("model_name")
+	}
+
 	if update {
 		action := "ModifyModel"
 		wait := incrementalWait(3*time.Second, 3*time.Second)
@@ -148,6 +179,9 @@ func resourceAlicloudApiGatewayModelUpdate(d *schema.ResourceData, meta interfac
 		addDebug(action, response, request)
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+		}
+		if d.HasChange("model_name") {
+			d.SetId(fmt.Sprint(parts[0], ":", d.Get("model_name")))
 		}
 	}
 

--- a/alicloud/resource_alicloud_api_gateway_model_test.go
+++ b/alicloud/resource_alicloud_api_gateway_model_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAccAlicloudApiGatewayModel_basic0(t *testing.T) {
+func TestAccAliCloudApiGatewayModel_basic0(t *testing.T) {
 	var v map[string]interface{}
 	resourceId := "alicloud_api_gateway_model.default"
 	ra := resourceAttrInit(resourceId, resourceAlicloudApiGatewayModelMap)
@@ -28,7 +28,7 @@ func TestAccAlicloudApiGatewayModel_basic0(t *testing.T) {
 	rac := resourceAttrCheckInit(rc, ra)
 	testAccCheck := rac.resourceAttrMapUpdateSet()
 	rand := acctest.RandIntRange(10000, 99999)
-	name := fmt.Sprintf("tf-testacc-name%d", rand)
+	name := fmt.Sprintf("tf-m%d", rand)
 	testAccConfig := resourceTestAccConfigFunc(resourceId, name, resourceAlicloudApiGatewayModelBasicDependence)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -44,13 +44,19 @@ func TestAccAlicloudApiGatewayModel_basic0(t *testing.T) {
 					"model_name":  name,
 					"schema":      `{\"type\":\"object\",\"properties\":{\"id\":{\"format\":\"int64\",\"maximum\":100,\"exclusiveMaximum\":true,\"type\":\"integer\"},\"name\":{\"maxLength\":10,\"type\":\"string\"}}}`,
 					"description": name,
+					"tags": map[string]interface{}{
+						"Created": "tf-testacc",
+						"Env":     "test",
+					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"group_id":    CHECKSET,
-						"model_name":  name,
-						"schema":      "{\"type\":\"object\",\"properties\":{\"id\":{\"format\":\"int64\",\"maximum\":100,\"exclusiveMaximum\":true,\"type\":\"integer\"},\"name\":{\"maxLength\":10,\"type\":\"string\"}}}",
-						"description": name,
+						"group_id":     CHECKSET,
+						"model_name":   name,
+						"schema":       "{\"type\":\"object\",\"properties\":{\"id\":{\"format\":\"int64\",\"maximum\":100,\"exclusiveMaximum\":true,\"type\":\"integer\"},\"name\":{\"maxLength\":10,\"type\":\"string\"}}}",
+						"description":  name,
+						"tags.Created": "tf-testacc",
+						"tags.Env":     "test",
 					}),
 				),
 			},
@@ -71,6 +77,30 @@ func TestAccAlicloudApiGatewayModel_basic0(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"description": name + "-update",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"model_name": name + "-renamed",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"model_name": name + "-renamed",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tags": map[string]interface{}{
+						"Created": "tf-testacc",
+						"Env":     "prod",
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tags.Created": "tf-testacc",
+						"tags.Env":     "prod",
 					}),
 				),
 			},

--- a/website/docs/r/api_gateway_model.html.markdown
+++ b/website/docs/r/api_gateway_model.html.markdown
@@ -36,6 +36,10 @@ resource "alicloud_api_gateway_model" "default" {
   model_name  = "example_value"
   schema      = "{\"type\":\"object\",\"properties\":{\"id\":{\"format\":\"int64\",\"maximum\":100,\"exclusiveMaximum\":true,\"type\":\"integer\"},\"name\":{\"maxLength\":10,\"type\":\"string\"}}}"
   description = "example_value"
+  tags = {
+    Created = "example_value"
+    Env     = "example_value"
+  }
 }
 ```
 
@@ -46,9 +50,10 @@ resource "alicloud_api_gateway_model" "default" {
 The following arguments are supported:
 
 * `group_id` - (Required, ForceNew) The group of the model belongs to.
-* `model_name` - (Required, ForceNew) The name of the model.
+* `model_name` - (Required) The name of the model. It can be modified to a new name, which renames the model in place.
 * `schema` - (Required) The schema of the model.
 * `description` - (Optional) The description of the model.
+* `tags` - (Optional, ForceNew) The tags of the model. Modifying tags will trigger a rebuild of the resource.
 
 ## Attributes Reference
 


### PR DESCRIPTION
### What this PR does

Adds `tags` support to the `alicloud_api_gateway_model` resource and makes `model_name` updatable.

#### tags
- New `tags` argument (Optional, ForceNew). Tags are set at creation via the CreateModel `Tag` parameter and read back from the DescribeModels response (`Tags.TagInfo`).
- Because ModifyModel has no tag parameter, `tags` is ForceNew: changing tags triggers a rebuild of the resource.

#### model_name
- `model_name` is no longer ForceNew. When it changes, ModifyModel is called with `NewModelName` to rename the model in place, and the resource ID (`<group_id>:<model_name>`) is updated to reflect the new name.

### Tests
- `TestAccAliCloudApiGatewayModel_basic0` covers create-with-tags, schema/description update, model_name rename, tags ForceNew rebuild, and import.

### Doc
- `api_gateway_model.html.markdown` updated: `tags` argument + ForceNew note, `model_name` updatable note, example usage.
