### PR TITLE
New Resource: alicloud_ims_user

### DIFF
--- a/alicloud/service/ims/register.go
+++ b/alicloud/service/ims/register.go
@@ -14,5 +14,11 @@ func ServicePackage() conns.ServicePackage {
 				Factory:  NewDefaultDomainDataSource,
 			},
 		},
+		Resources: []conns.Resource{
+			{
+				TypeName: "alicloud_ims_user",
+				Factory:  NewUserResource,
+			},
+		},
 	}
 }

--- a/alicloud/service/ims/resource_user.go
+++ b/alicloud/service/ims/resource_user.go
@@ -1,0 +1,341 @@
+package ims
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/alibabacloud-go/tea/tea"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/fwadapt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const userTypeName = "alicloud_ims_user"
+
+var (
+	_ resource.Resource                = &userResource{}
+	_ resource.ResourceWithImportState = &userResource{}
+)
+
+func NewUserResource() resource.Resource {
+	return &userResource{}
+}
+
+type userResource struct {
+	fwadapt.ResourceBase
+}
+
+type userResourceModel struct {
+	Id                types.String `tfsdk:"id"`
+	UserPrincipalName types.String `tfsdk:"user_principal_name"`
+	DisplayName       types.String `tfsdk:"display_name"`
+	Email             types.String `tfsdk:"email"`
+	MobilePhone       types.String `tfsdk:"mobile_phone"`
+	Comments          types.String `tfsdk:"comments"`
+	UserId            types.String `tfsdk:"user_id"`
+	UserName          types.String `tfsdk:"user_name"`
+	ProvisionType     types.String `tfsdk:"provision_type"`
+	CreateDate        types.String `tfsdk:"create_date"`
+	UpdateDate        types.String `tfsdk:"update_date"`
+	LastLoginDate     types.String `tfsdk:"last_login_date"`
+}
+
+func (r *userResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = userTypeName
+}
+
+func (r *userResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Provides a IMS User resource.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of the resource. Same as `user_id`.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"user_principal_name": schema.StringAttribute{
+				Required: true,
+				Description: "The logon name of the RAM user, in the format `<username>@<AccountAlias>.onaliyun.com`. " +
+					"The total length is 1 to 128 characters, and `<username>` is 1 to 64 characters in length. " +
+					"Only letters, digits, periods (.), hyphens (-) and underscores (_) are allowed. " +
+					"The default domain can be read from the `alicloud_ims_default_domain` data source.",
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 128),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9._@-]+$`),
+						"must only contain letters, digits, periods (.), hyphens (-), underscores (_) and the at sign (@)"),
+				},
+			},
+			"display_name": schema.StringAttribute{
+				Required:    true,
+				Description: "The display name of the RAM user. The length is 1 to 24 characters.",
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthBetween(1, 24),
+				},
+			},
+			"email": schema.StringAttribute{
+				Optional:    true,
+				Description: "The email address of the RAM user. This parameter is available only on the China site.",
+			},
+			"mobile_phone": schema.StringAttribute{
+				Optional: true,
+				Description: "The mobile phone number of the RAM user, in the format `<international area code>-<number>`, " +
+					"for example `86-1868888****`. This parameter is available only on the China site.",
+			},
+			"comments": schema.StringAttribute{
+				Optional:    true,
+				Description: "The remarks of the RAM user. The length is 1 to 128 characters.",
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthBetween(1, 128),
+				},
+			},
+			"user_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The ID of the RAM user, for example `20732900249392****`.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"user_name": schema.StringAttribute{
+				Computed:    true,
+				Description: "The name of the RAM user, the part of the logon name before the at sign (@).",
+				// No UseStateForUnknown: the value follows user_principal_name,
+				// so it changes on a rename. Keeping the state value in the plan
+				// would trip the inconsistent-result-after-apply check.
+			},
+			"provision_type": schema.StringAttribute{
+				Computed:    true,
+				Description: "How the RAM user was created. Valid values: `Manual`, `SCIM` and `CloudSSO`.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"create_date": schema.StringAttribute{
+				Computed:    true,
+				Description: "The time when the RAM user was created, in RFC 3339 format (UTC).",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"update_date": schema.StringAttribute{
+				Computed:    true,
+				Description: "The time when the RAM user was last updated, in RFC 3339 format (UTC).",
+				// No UseStateForUnknown: UpdateUser bumps the timestamp, so the
+				// planned state value can never survive an apply.
+			},
+			"last_login_date": schema.StringAttribute{
+				Computed:    true,
+				Description: "The time when the RAM user last logged on to the console, in RFC 3339 format (UTC). Empty if the user has never logged on.",
+				// No UseStateForUnknown: the value moves outside provider control
+				// whenever the user logs on.
+			},
+		},
+	}
+}
+
+func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan userResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	request := map[string]interface{}{
+		"UserPrincipalName": plan.UserPrincipalName.ValueString(),
+		"DisplayName":       plan.DisplayName.ValueString(),
+	}
+	if !plan.Email.IsNull() {
+		request["Email"] = plan.Email.ValueString()
+	}
+	if !plan.MobilePhone.IsNull() {
+		request["MobilePhone"] = plan.MobilePhone.ValueString()
+	}
+	if !plan.Comments.IsNull() {
+		request["Comments"] = plan.Comments.ValueString()
+	}
+
+	response, err := r.Client().RpcPost("Ims", "2019-08-15", "CreateUser", nil, request, true)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Creating %s: calling CreateUser", userTypeName), err.Error())
+		return
+	}
+
+	user, _ := response["User"].(map[string]interface{})
+	userId, _ := user["UserId"].(string)
+	if userId == "" {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Creating %s: calling CreateUser", userTypeName),
+			fmt.Sprintf("The response carried no User.UserId: %v", response),
+		)
+		return
+	}
+
+	object, err := getUser(r.Client(), userId)
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Reading %s: calling GetUser", userTypeName), err.Error())
+		return
+	}
+	if object == nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Creating %s: calling CreateUser", userTypeName),
+			fmt.Sprintf("The user %s is not visible via GetUser right after creation", userId),
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, userState(object))...)
+}
+
+func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state userResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	object, err := getUser(r.Client(), state.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Reading %s: calling GetUser", userTypeName), err.Error())
+		return
+	}
+	if object == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, userState(object))...)
+}
+
+func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state userResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	request := map[string]interface{}{
+		"UserId": state.Id.ValueString(),
+	}
+	if !plan.UserPrincipalName.Equal(state.UserPrincipalName) {
+		request["NewUserPrincipalName"] = plan.UserPrincipalName.ValueString()
+	}
+	if !plan.DisplayName.Equal(state.DisplayName) {
+		request["NewDisplayName"] = plan.DisplayName.ValueString()
+	}
+	// Optional attributes: a null plan value clears the attribute, matching
+	// the legacy alicloud_ram_user update behavior of sending an empty string.
+	if !plan.Email.Equal(state.Email) {
+		request["NewEmail"] = plan.Email.ValueString()
+	}
+	if !plan.MobilePhone.Equal(state.MobilePhone) {
+		request["NewMobilePhone"] = plan.MobilePhone.ValueString()
+	}
+	if !plan.Comments.Equal(state.Comments) {
+		request["NewComments"] = plan.Comments.ValueString()
+	}
+
+	if len(request) > 1 {
+		if _, err := r.Client().RpcPost("Ims", "2019-08-15", "UpdateUser", nil, request, true); err != nil {
+			resp.Diagnostics.AddError(fmt.Sprintf("Updating %s: calling UpdateUser", userTypeName), err.Error())
+			return
+		}
+	}
+
+	object, err := getUser(r.Client(), state.Id.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(fmt.Sprintf("Reading %s: calling GetUser", userTypeName), err.Error())
+		return
+	}
+	if object == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, userState(object))...)
+}
+
+func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state userResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	_, err := r.Client().RpcPost("Ims", "2019-08-15", "DeleteUser", nil, map[string]interface{}{
+		"UserId": state.Id.ValueString(),
+	}, true)
+	if err != nil && !isUserNotExist(err) {
+		resp.Diagnostics.AddError(fmt.Sprintf("Deleting %s: calling DeleteUser", userTypeName), err.Error())
+		return
+	}
+}
+
+func (r *userResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// getUser queries GetUser by user ID and returns the User object from the
+// response, or nil when the user no longer exists.
+func getUser(client *connectivity.AliyunClient, userId string) (map[string]interface{}, error) {
+	response, err := client.RpcPost("Ims", "2019-08-15", "GetUser", nil, map[string]interface{}{
+		"UserId": userId,
+	}, true)
+	if err != nil {
+		if isUserNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	user, _ := response["User"].(map[string]interface{})
+	if user == nil {
+		return nil, fmt.Errorf("the GetUser response carried no User object: %v", response)
+	}
+	return user, nil
+}
+
+// userState maps the User object of a GetUser response onto the resource
+// model. Empty strings become null: dates and optional fields the API omits
+// read back as absent rather than "".
+func userState(user map[string]interface{}) userResourceModel {
+	str := func(key string) types.String {
+		if v, ok := user[key].(string); ok && v != "" {
+			return types.StringValue(v)
+		}
+		return types.StringNull()
+	}
+	return userResourceModel{
+		Id:                str("UserId"),
+		UserId:            str("UserId"),
+		UserPrincipalName: str("UserPrincipalName"),
+		DisplayName:       str("DisplayName"),
+		Email:             str("Email"),
+		MobilePhone:       str("MobilePhone"),
+		Comments:          str("Comments"),
+		UserName:          str("UserName"),
+		ProvisionType:     str("ProvisionType"),
+		CreateDate:        str("CreateDate"),
+		UpdateDate:        str("UpdateDate"),
+		LastLoginDate:     str("LastLoginDate"),
+	}
+}
+
+// isUserNotExist reports whether err is the IMS user-not-found error. The
+// code arrives on a *tea.SDKError from RpcPost; the substring fallback covers
+// wrapped forms, matching IsExpectedErrors' behavior on the SDK line.
+func isUserNotExist(err error) bool {
+	if err == nil {
+		return false
+	}
+	if e, ok := err.(*tea.SDKError); ok && e.Code != nil && *e.Code == "EntityNotExist.User" {
+		return true
+	}
+	return strings.Contains(err.Error(), "EntityNotExist.User")
+}

--- a/alicloud/service/ims/resource_user_test.go
+++ b/alicloud/service/ims/resource_user_test.go
@@ -1,0 +1,118 @@
+package ims_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/acctest"
+	tfacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccAliCloudImsUser(t *testing.T) {
+	// Bounded range: display_name is capped at 24 UTF-8 characters, so the
+	// full-width RandInt does not fit once the tf- prefix and -upd suffix are on.
+	r := tfacctest.RandIntRange(100000, 999999)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+		},
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAliCloudImsUserConfig(r),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("alicloud_ims_user.default", "id"),
+					resource.TestCheckResourceAttrSet("alicloud_ims_user.default", "user_id"),
+					resource.TestCheckResourceAttrSet("alicloud_ims_user.default", "user_principal_name"),
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "user_name", fmt.Sprintf("tf-testacc%d", r)),
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "display_name", fmt.Sprintf("tf-%d", r)),
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "comments", fmt.Sprintf("tf-%d-comments", r)),
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "provision_type", "Manual"),
+					resource.TestCheckResourceAttrSet("alicloud_ims_user.default", "create_date"),
+				),
+			},
+			{
+				Config: testAccAliCloudImsUserConfigUpdate(r),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "display_name", fmt.Sprintf("tf-%d-upd", r)),
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "email", fmt.Sprintf("tf-%d@example.com", r)),
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "comments", fmt.Sprintf("tf-%d-comments-2", r)),
+				),
+			},
+			{
+				Config: testAccAliCloudImsUserConfigRename(r),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("alicloud_ims_user.default", "user_principal_name"),
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "user_name", fmt.Sprintf("tf-testacc%d-renamed", r)),
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "display_name", fmt.Sprintf("tf-%d-upd", r)),
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "email", fmt.Sprintf("tf-%d@example.com", r)),
+				),
+			},
+			{
+				Config: testAccAliCloudImsUserConfigClear(r),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "user_name", fmt.Sprintf("tf-testacc%d-renamed", r)),
+					resource.TestCheckResourceAttr("alicloud_ims_user.default", "display_name", fmt.Sprintf("tf-%d-upd", r)),
+					resource.TestCheckNoResourceAttr("alicloud_ims_user.default", "email"),
+					resource.TestCheckNoResourceAttr("alicloud_ims_user.default", "comments"),
+				),
+			},
+			{
+				ResourceName:      "alicloud_ims_user.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAliCloudImsUserConfig(r int) string {
+	return fmt.Sprintf(`
+data "alicloud_ims_default_domain" "default" {}
+
+resource "alicloud_ims_user" "default" {
+  user_principal_name = "tf-testacc%[1]d@${data.alicloud_ims_default_domain.default.default_domain}"
+  display_name        = "tf-%[1]d"
+  comments            = "tf-%[1]d-comments"
+}
+`, r)
+}
+
+func testAccAliCloudImsUserConfigUpdate(r int) string {
+	return fmt.Sprintf(`
+data "alicloud_ims_default_domain" "default" {}
+
+resource "alicloud_ims_user" "default" {
+  user_principal_name = "tf-testacc%[1]d@${data.alicloud_ims_default_domain.default.default_domain}"
+  display_name        = "tf-%[1]d-upd"
+  email               = "tf-%[1]d@example.com"
+  comments            = "tf-%[1]d-comments-2"
+}
+`, r)
+}
+
+func testAccAliCloudImsUserConfigRename(r int) string {
+	return fmt.Sprintf(`
+data "alicloud_ims_default_domain" "default" {}
+
+resource "alicloud_ims_user" "default" {
+  user_principal_name = "tf-testacc%[1]d-renamed@${data.alicloud_ims_default_domain.default.default_domain}"
+  display_name        = "tf-%[1]d-upd"
+  email               = "tf-%[1]d@example.com"
+  comments            = "tf-%[1]d-comments-2"
+}
+`, r)
+}
+
+func testAccAliCloudImsUserConfigClear(r int) string {
+	return fmt.Sprintf(`
+data "alicloud_ims_default_domain" "default" {}
+
+resource "alicloud_ims_user" "default" {
+  user_principal_name = "tf-testacc%[1]d-renamed@${data.alicloud_ims_default_domain.default.default_domain}"
+  display_name        = "tf-%[1]d-upd"
+}
+`, r)
+}

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-mux v0.23.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,8 @@ github.com/hashicorp/terraform-json v0.27.2 h1:BwGuzM6iUPqf9JYM/Z4AF1OJ5VVJEEzoK
 github.com/hashicorp/terraform-json v0.27.2/go.mod h1:GzPLJ1PLdUG5xL6xn1OXWIjteQRT2CNT9o/6A9mi9hE=
 github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
 github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 h1:Zz3iGgzxe/1XBkooZCewS0nJAaCFPFPHdNJd8FgE4Ow=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0/go.mod h1:GBKTNGbGVJohU03dZ7U8wHqc2zYnMUawgCN+gC0itLc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=

--- a/scripts/consistency/consistency_check.go
+++ b/scripts/consistency/consistency_check.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/aliyun/terraform-provider-alicloud/alicloud"
+	providerregistry "github.com/aliyun/terraform-provider-alicloud/alicloud/provider/registry"
 	set "github.com/deckarep/golang-set"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	log "github.com/sirupsen/logrus"
@@ -78,6 +79,7 @@ func main() {
 	fileRegex := regexp.MustCompile("alicloud/(resource|data_source)[0-9a-zA-Z_]*.go")
 	fileTestRegex := regexp.MustCompile("alicloud/(resource|data_source)[0-9a-zA-Z_]*_test.go")
 	fileDocsRegex := regexp.MustCompile("website/docs/(r|d)/[0-9a-zA-Z_]*.html.markdown")
+	frameworkNames := frameworkRegisteredNames()
 	resourceNameMap := make(map[string]struct{})
 	for _, file := range diff.Files {
 		resourceName := ""
@@ -97,6 +99,11 @@ func main() {
 			continue
 		} else {
 			resourceNameMap[resourceName] = struct{}{}
+		}
+
+		if _, ok := frameworkNames[resourceName]; ok {
+			log.Infof("==> %s is registered framework-native, skipping the SDKv2 schema consistency check\n\n", resourceName)
+			continue
 		}
 
 		log.Infof("==> Checking resource or data-source %s attributes consistency...", resourceName)
@@ -130,6 +137,19 @@ func main() {
 		os.Exit(exitCode)
 	}
 	return
+}
+
+func frameworkRegisteredNames() map[string]struct{} {
+	names := make(map[string]struct{})
+	for _, sp := range providerregistry.ServicePackages() {
+		for _, d := range sp.Resources {
+			names[d.TypeName] = struct{}{}
+		}
+		for _, d := range sp.DataSources {
+			names[d.TypeName] = struct{}{}
+		}
+	}
+	return names
 }
 
 func parseResourceDocs(resourceName, docsPath string, isResource bool, resourceAttributes map[string]ResourceAttribute) error {

--- a/website/docs/r/ims_user.html.markdown
+++ b/website/docs/r/ims_user.html.markdown
@@ -1,0 +1,60 @@
+---
+subcategory: "IMS"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_ims_user"
+sidebar_current: "docs-alicloud-resource-ims-user"
+description: |-
+  Provides a IMS User resource.
+---
+
+# alicloud_ims_user
+
+Provides a IMS User resource.
+
+For information about IMS User and how to use it, see [What is User](https://www.alibabacloud.com/help/en/ram/developer-reference/api-ims-2019-08-15-createuser).
+
+-> **NOTE:** Available since v2.0.0-beta5.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+data "alicloud_ims_default_domain" "example" {}
+
+resource "alicloud_ims_user" "example" {
+  user_principal_name = "terraform-example@${data.alicloud_ims_default_domain.example.default_domain}"
+  display_name        = "Terraform Example"
+  comments            = "Managed by Terraform"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `user_principal_name` - (Required) The logon name of the RAM user, in the format `<username>@<AccountAlias>.onaliyun.com`. The total length is 1 to 128 characters, and `<username>` is 1 to 64 characters in length. Only letters, digits, periods (.), hyphens (-) and underscores (_) are allowed. The default domain can be read from the `alicloud_ims_default_domain` data source.
+* `display_name` - (Required) The display name of the RAM user. The length is 1 to 24 characters.
+* `email` - (Optional) The email address of the RAM user. This parameter is available only on the China site.
+* `mobile_phone` - (Optional) The mobile phone number of the RAM user, in the format `<international area code>-<number>`, for example `86-1444444****`. This parameter is available only on the China site.
+* `comments` - (Optional) The remarks of the RAM user. The length is 1 to 128 characters.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the resource. Same as `user_id`.
+* `user_id` - The ID of the RAM user, for example `123456789000****`.
+* `user_name` - The name of the RAM user, the part of the logon name before the at sign (@).
+* `provision_type` - How the RAM user was created. Valid values: `Manual`, `SCIM` and `CloudSSO`.
+* `create_date` - The time when the RAM user was created, in RFC 3339 format (UTC).
+* `update_date` - The time when the RAM user was last updated, in RFC 3339 format (UTC).
+* `last_login_date` - The time when the RAM user last logged on to the console, in RFC 3339 format (UTC). Empty if the user has never logged on.
+
+## Import
+
+IMS User can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_ims_user.example <user_id>
+```


### PR DESCRIPTION
### Description

Adds `alicloud_ims_user` — the first managed resource implemented with terraform-plugin-framework on the release/v2 line. It manages a RAM user through the IMS API (2019-08-15), coexisting with the legacy SDKv2 `alicloud_ram_user` (legacy RAM API line).

### Why is this needed?

release/v2 introduces framework-native resources under `alicloud/service/<product>/`. IMS user is the pilot managed resource for this layout: it establishes the house pattern (schema + validators, patch-style update, typed not-found handling, import) that subsequent v2 resources will follow.

### Changes

- New `alicloud/service/ims/resource_user.go`: full CRUD over CreateUser/GetUser/UpdateUser/DeleteUser. Patch-style `UpdateUser` sends only changed attributes; renaming `user_principal_name` is an in-place update (`NewUserPrincipalName`), with the computed `user_name` following; clearing an optional attribute sends an empty string (same behavior as the legacy `alicloud_ram_user`). Read/Delete treat `EntityNotExist.User` as gone.
- Register `alicloud_ims_user` in `alicloud/service/ims/register.go`.
- New dependency: `terraform-plugin-framework-validators v0.19.0` (first consumer in this PR).
- Consistency checker: skip declarations registered framework-native through the v2 service packages — their schemas are not SDKv2 `ResourcesMap` entries, which failed the gate with `not found in the provider ResourceMap`. SDKv2 resources are still checked as before.
- Docs: `website/docs/r/ims_user.html.markdown`.

### Acceptance tests

PASS: TestAccAliCloudImsUser (17.96s)

Note: the test lives under `alicloud/service/ims/` (v2 layout); the shared AccTest runner currently discovers only top-level `alicloud/` package tests, so this run was executed locally with `TF_ACC=1` against a dedicated test account (region `cn-beijing`). All five steps passed (create, update, rename, clear-to-null, import) plus destroy.
