### PR TITLE
resource/alicloud_ims_user: wrap API errors with errs.WrapErrorf

### DIFF
--- a/alicloud/service/ims/resource_user.go
+++ b/alicloud/service/ims/resource_user.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alibabacloud-go/tea/tea"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/errs"
 	"github.com/aliyun/terraform-provider-alicloud/alicloud/provider/fwadapt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -166,7 +167,10 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	response, err := r.Client().RpcPost("Ims", "2019-08-15", "CreateUser", nil, request, true)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Creating %s: calling CreateUser", userTypeName), err.Error())
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Creating %s: calling CreateUser", userTypeName),
+			errs.WrapErrorf(err, "Creating %s: calling CreateUser", userTypeName).Error(),
+		)
 		return
 	}
 
@@ -182,7 +186,10 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	object, err := getUser(r.Client(), userId)
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Reading %s: calling GetUser", userTypeName), err.Error())
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Reading %s: calling GetUser", userTypeName),
+			errs.WrapErrorf(err, "Reading %s: calling GetUser", userTypeName).Error(),
+		)
 		return
 	}
 	if object == nil {
@@ -204,7 +211,10 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	object, err := getUser(r.Client(), state.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Reading %s: calling GetUser", userTypeName), err.Error())
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Reading %s: calling GetUser", userTypeName),
+			errs.WrapErrorf(err, "Reading %s: calling GetUser", userTypeName).Error(),
+		)
 		return
 	}
 	if object == nil {
@@ -245,14 +255,20 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	if len(request) > 1 {
 		if _, err := r.Client().RpcPost("Ims", "2019-08-15", "UpdateUser", nil, request, true); err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("Updating %s: calling UpdateUser", userTypeName), err.Error())
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("Updating %s: calling UpdateUser", userTypeName),
+				errs.WrapErrorf(err, "Updating %s: calling UpdateUser", userTypeName).Error(),
+			)
 			return
 		}
 	}
 
 	object, err := getUser(r.Client(), state.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError(fmt.Sprintf("Reading %s: calling GetUser", userTypeName), err.Error())
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Reading %s: calling GetUser", userTypeName),
+			errs.WrapErrorf(err, "Reading %s: calling GetUser", userTypeName).Error(),
+		)
 		return
 	}
 	if object == nil {
@@ -273,7 +289,10 @@ func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		"UserId": state.Id.ValueString(),
 	}, true)
 	if err != nil && !isUserNotExist(err) {
-		resp.Diagnostics.AddError(fmt.Sprintf("Deleting %s: calling DeleteUser", userTypeName), err.Error())
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Deleting %s: calling DeleteUser", userTypeName),
+			errs.WrapErrorf(err, "Deleting %s: calling DeleteUser", userTypeName).Error(),
+		)
 		return
 	}
 }


### PR DESCRIPTION
### Description

`alicloud_ims_user` currently surfaces API-call errors as the raw `RpcPost` error, which renders only the SDK error block (status, code, message, data) — no indication of which provider operation failed or where. This wraps all six API-error diagnostic sites with `errs.WrapErrorf`, so the failing operation and the provider file:line travel with the error.

### Why is this needed?

Error context. A bare SDKError tells the user the API failed but not which CRUD path triggered it. The wrapped form prefixes the operation (`Creating alicloud_ims_user: calling CreateUser`) and the provider source location, matching the house error style used by the SDKv2 resources (every API-call error return goes through `WrapErrorf`).

### Changes

- `alicloud/service/ims/resource_user.go`: wrap the six API-error diag sites (CreateUser, UpdateUser, DeleteUser, and the three GetUser paths) with `errs.WrapErrorf`; import `alicloud/errs`.
- The two assertion diagnostics (missing `User.UserId` in the create response, user not visible via GetUser right after creation) already carry their own context and are unchanged.
- Not-found handling is untouched: `isUserNotExist` inspects the raw error before any wrapping, so `EntityNotExist.User` keeps triggering state removal in Read and the swallow in Delete.

### Acceptance tests

The change only executes on API-error paths, which the happy-path test does not enter; request wiring and every exercised path are unchanged from #10515. Standing evidence from the merged PR: `PASS: TestAccAliCloudImsUser (17.96s)` — local run (TF_ACC=1, cn-beijing); the remote runner does not discover `alicloud/service/*` tests.
