### PR TITLE
ci: enable PR labeler for release/v2 and add IMS service label

### DIFF
--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -1,3 +1,7 @@
+IMS:
+  - changed-files:
+      - any-glob-to-any-file:
+          - alicloud/service/ims/**
 dependencies:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/pull_request_labeler.yml
+++ b/.github/workflows/pull_request_labeler.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     branches:
       - master
+      - release/v2
 
 permissions: {}
 
@@ -17,7 +18,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: terraform-ci-policy
+    runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
       - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0


### PR DESCRIPTION
## What

- Enables the PR labeler workflow for PRs targeting `release/v2`. Previously the workflow only triggered for `master`, so v2 PRs never received `size/*`, `documentation`, `dependencies`, or service labels.
- Adds a service label rule: PRs touching `alicloud/service/ims/**` get the `IMS` label (the `IMS` label has been created on the repository).
- Moves the labeler job from the internal `terraform-ci-policy` runner to `ubuntu-latest`. The job only runs the pinned `actions/labeler` action and inline `github-script` against PR metadata (no PR code checkout), so it needs no internal runner infrastructure.

## Convention

When a product migrates to the `alicloud/service/<product>/` layout, add a matching entry to `.github/labeler-pull-request-triage.yml` and create the corresponding product label.
