### PR TITLE
ci: enable PR labeler for release/v2 and add service labels

### DIFF
--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -1,3 +1,7 @@
+IMS:
+  - changed-files:
+      - any-glob-to-any-file:
+          - alicloud/service/ims/**
 dependencies:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/workflows/pull_request_labeler.yml
+++ b/.github/workflows/pull_request_labeler.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     branches:
       - master
+      - release/v2
 
 permissions: {}
 
@@ -24,6 +25,88 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler-pull-request-triage.yml
+
+      - name: Apply Service Labels
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const pullNumber = context.payload.pull_request?.number;
+            if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
+              throw new Error("Invalid pull request number.");
+            }
+
+            const changedFiles = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullNumber,
+                per_page: 100,
+              }
+            );
+            const services = new Set();
+            for (const { filename } of changedFiles) {
+              const match = /^alicloud\/service\/([^/]+)\//.exec(filename);
+              if (match) {
+                services.add(match[1]);
+              }
+            }
+            if (services.size === 0) {
+              core.info("No service package files changed.");
+              return;
+            }
+
+            const repoLabels = await github.paginate(
+              github.rest.issues.listLabelsForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              }
+            );
+            const labelByName = new Map(
+              repoLabels.map(({ name }) => [name.toLowerCase(), name])
+            );
+            const serviceLabels = [];
+            for (const service of services) {
+              const label = labelByName.get(service.toLowerCase());
+              if (label) {
+                serviceLabels.push(label);
+              } else {
+                core.warning(
+                  `No repository label matches service ${service}; label skipped.`
+                );
+              }
+            }
+            if (serviceLabels.length === 0) {
+              return;
+            }
+
+            const currentLabels = await github.paginate(
+              github.rest.issues.listLabelsOnIssue,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullNumber,
+                per_page: 100,
+              }
+            );
+            const labels = new Set(
+              currentLabels.map(({ name }) => name).filter(
+                (name) => typeof name === "string"
+              )
+            );
+            for (const label of serviceLabels) {
+              labels.add(label);
+            }
+
+            await github.rest.issues.setLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullNumber,
+              labels: [...labels],
+            });
+            core.info(`Applied service labels: ${serviceLabels.join(", ")}.`);
 
       - name: Apply Pull Request Size Labels
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0


### PR DESCRIPTION
## What

- Enables the PR labeler workflow for PRs targeting `release/v2`. Previously the workflow only triggered for `master`, so v2 PRs never received `size/*`, `documentation`, `dependencies`, or service labels.
- Adds the `IMS` rule to the labeler config: PRs touching `alicloud/service/ims/**` get the `IMS` label.
- Adds an `Apply Service Labels` step to the workflow: changed paths under `alicloud/service/<product>/` are matched case-insensitively against repository labels (`ims` → `IMS`, `ecs` → `ECS`, ...) and applied, preserving existing labels; services without a matching label are skipped with a warning.

## Note

The `IMS` label has been created on the repository.
