### PR TITLE
New Resource: alicloud_arms_webhook_contact

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -1365,6 +1365,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_arms_addon_release":                                   resourceAliCloudArmsAddonRelease(),
 			"alicloud_arms_env_feature":                                     resourceAliCloudArmsEnvFeature(),
 			"alicloud_arms_environment":                                     resourceAliCloudArmsEnvironment(),
+			"alicloud_arms_webhook_contact":                                 resourceAliCloudArmsWebhookContact(),
 			"alicloud_hologram_instance":                                    resourceAliCloudHologramInstance(),
 			"alicloud_ack_one_cluster":                                      resourceAliCloudAckOneCluster(),
 			"alicloud_ack_one_membership_attachment":                        resourceAliCloudAckOneMembershipAttachment(),

--- a/alicloud/resource_alicloud_arms_webhook_contact.go
+++ b/alicloud/resource_alicloud_arms_webhook_contact.go
@@ -1,0 +1,269 @@
+// Package alicloud. This file is generated automatically. Please do not modify it manually, thank you!
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAliCloudArmsWebhookContact() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAliCloudArmsWebhookContactCreate,
+		Read:   resourceAliCloudArmsWebhookContactRead,
+		Delete: resourceAliCloudArmsWebhookContactDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+		Schema: map[string]*schema.Schema{
+			"webhook": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"biz_params": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"biz_headers": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							ForceNew: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"recover_body": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"method": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"body": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"webhook_contact_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAliCloudArmsWebhookContactCreate(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+
+	action := "CreateOrUpdateWebhookContact"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+
+	webhookBizHeadersJsonPath, err := jsonpath.Get("$[0].biz_headers", d.Get("webhook"))
+	if err == nil {
+		if headersJson, err := armsWebhookContactKvMapToJson(webhookBizHeadersJsonPath); err == nil {
+			request["BizHeaders"] = headersJson
+		}
+	}
+
+	webhookBizParamsJsonPath, err := jsonpath.Get("$[0].biz_params", d.Get("webhook"))
+	if err == nil {
+		if paramsJson, err := armsWebhookContactKvMapToJson(webhookBizParamsJsonPath); err == nil {
+			request["BizParams"] = paramsJson
+		}
+	}
+
+	webhookBodyJsonPath, err := jsonpath.Get("$[0].body", d.Get("webhook"))
+	if err == nil {
+		request["Body"] = webhookBodyJsonPath
+	}
+
+	webhookMethodJsonPath, err := jsonpath.Get("$[0].method", d.Get("webhook"))
+	if err == nil {
+		request["Method"] = webhookMethodJsonPath
+	}
+
+	webhookRecoverBodyJsonPath, err := jsonpath.Get("$[0].recover_body", d.Get("webhook"))
+	if err == nil {
+		request["RecoverBody"] = webhookRecoverBodyJsonPath
+	}
+
+	webhookUrlJsonPath, err := jsonpath.Get("$[0].url", d.Get("webhook"))
+	if err == nil {
+		request["Url"] = webhookUrlJsonPath
+	}
+
+	request["WebhookName"] = d.Get("webhook_contact_name")
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		response, err = client.RpcPost("ARMS", "2019-08-08", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_arms_webhook_contact", action, AlibabaCloudSdkGoERROR)
+	}
+
+	id, _ := jsonpath.Get("$.WebhookContact.WebhookId", response)
+	d.SetId(fmt.Sprint(id))
+
+	return resourceAliCloudArmsWebhookContactRead(d, meta)
+}
+
+func resourceAliCloudArmsWebhookContactRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	armsServiceV2 := ArmsServiceV2{client}
+
+	objectRaw, err := armsServiceV2.DescribeArmsWebhookContact(d.Id())
+	if err != nil {
+		if !d.IsNewResource() && NotFoundError(err) {
+			log.Printf("[DEBUG] Resource alicloud_arms_webhook_contact DescribeArmsWebhookContact Failed!!! %s", err)
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("webhook_contact_name", objectRaw["WebhookName"])
+
+	webhookMaps := make([]map[string]interface{}, 0)
+	webhookMap := make(map[string]interface{})
+	webhookRaw := make(map[string]interface{})
+	if objectRaw["Webhook"] != nil {
+		webhookRaw = objectRaw["Webhook"].(map[string]interface{})
+	}
+	if len(webhookRaw) > 0 {
+		webhookMap["biz_headers"] = armsWebhookContactKvMapFromResponse(webhookRaw["BizHeaders"])
+		webhookMap["biz_params"] = armsWebhookContactKvMapFromResponse(webhookRaw["BizParams"])
+		webhookMap["body"] = webhookRaw["Body"]
+		webhookMap["method"] = webhookRaw["Method"]
+		webhookMap["recover_body"] = webhookRaw["RecoverBody"]
+		webhookMap["url"] = webhookRaw["Url"]
+
+		webhookMaps = append(webhookMaps, webhookMap)
+	}
+	if err := d.Set("webhook", webhookMaps); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceAliCloudArmsWebhookContactDelete(d *schema.ResourceData, meta interface{}) error {
+
+	client := meta.(*connectivity.AliyunClient)
+	action := "DeleteWebhookContact"
+	var request map[string]interface{}
+	var response map[string]interface{}
+	query := make(map[string]interface{})
+	var err error
+	request = make(map[string]interface{})
+	request["WebhookId"] = d.Id()
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		response, err = client.RpcPost("ARMS", "2019-08-08", action, query, request, true)
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+
+	if err != nil {
+		if IsExpectedErrors(err, []string{"404"}) || NotFoundError(err) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
+	}
+
+	return nil
+}
+
+// The published ARMS API models BizHeaders/BizParams as string params carrying
+// a JSON array of single-entry objects (e.g. [{"Content-Type":"application/json"}]);
+// the CloudSpec model declares them as plain objects, so the generated pass-through
+// would send dotted form keys the API does not accept.
+func armsWebhookContactKvMapToJson(raw interface{}) (string, error) {
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("unexpected kv map type: %T", raw)
+	}
+	kvList := make([]map[string]interface{}, 0, len(m))
+	for k, v := range m {
+		kvList = append(kvList, map[string]interface{}{k: v})
+	}
+	b, err := json.Marshal(kvList)
+	return string(b), err
+}
+
+// DescribeWebhookContacts may return the fields as a JSON string or as an array
+// of single-entry objects; both are normalized to a flat map for TypeMap fields.
+func armsWebhookContactKvMapFromResponse(raw interface{}) map[string]interface{} {
+	switch v := raw.(type) {
+	case string:
+		var parsed interface{}
+		if err := json.Unmarshal([]byte(v), &parsed); err != nil {
+			return map[string]interface{}{}
+		}
+		return armsWebhookContactKvMapFromResponse(parsed)
+	case map[string]interface{}:
+		return v
+	case []interface{}:
+		result := make(map[string]interface{})
+		for _, item := range v {
+			if m, ok := item.(map[string]interface{}); ok {
+				for k, val := range m {
+					result[k] = val
+				}
+			}
+		}
+		return result
+	}
+	return map[string]interface{}{}
+}

--- a/alicloud/resource_alicloud_arms_webhook_contact_test.go
+++ b/alicloud/resource_alicloud_arms_webhook_contact_test.go
@@ -1,0 +1,262 @@
+package alicloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	credentials "github.com/aliyun/credentials-go/credentials"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// Test Arms WebhookContact. >>> Resource test cases, automatically generated.
+func TestAccAliCloudArmsWebhookContact_basic(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_arms_webhook_contact.default"
+	ra := resourceAttrInit(resourceId, AlicloudArmsWebhookContactMap)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ArmsServiceV2{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeArmsWebhookContact")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sarmswebhookcontact%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudArmsWebhookContactBasicDependence)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"webhook_contact_name": name,
+					"webhook": []map[string]interface{}{
+						{
+							"method":       "Post",
+							"url":          "https://example.com/webhook",
+							"body":         `{"message":"alert fired"}`,
+							"recover_body": `{"message":"alert recovered"}`,
+							"biz_headers":  map[string]interface{}{"Content-Type": "application/json"},
+							"biz_params":   map[string]interface{}{"foo": "bar"},
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"webhook_contact_name": name,
+						"webhook.#":            "1",
+						"webhook.0.method":     "Post",
+						"webhook.0.url":        "https://example.com/webhook",
+						"webhook.0.body":       `{"message":"alert fired"}`,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"webhook_contact_name": name,
+					"webhook": []map[string]interface{}{
+						{
+							"method": "Post",
+							"url":    "https://example.com/webhook",
+							"body":   `{"message":"alert fired v2"}`,
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"webhook_contact_name": name,
+						"webhook.#":            "1",
+						"webhook.0.method":     "Post",
+						"webhook.0.body":       `{"message":"alert fired v2"}`,
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+var AlicloudArmsWebhookContactMap = map[string]string{}
+
+func AlicloudArmsWebhookContactBasicDependence(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+`, name)
+}
+
+func armsWebhookContactTestClient(t *testing.T, handler http.HandlerFunc) *connectivity.AliyunClient {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Error(err)
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+	credential, err := credentials.NewCredential(new(credentials.Config).
+		SetType("access_key").SetAccessKeyId("test-key").SetAccessKeySecret("test-secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoints := new(sync.Map)
+	endpoint := strings.TrimPrefix(server.URL, "http://")
+	t.Setenv("NO_PROXY", endpoint)
+	config := &connectivity.Config{
+		AccessKey: "test-key", SecretKey: "test-secret", Credential: credential,
+		RegionId: "cn-hangzhou", AccountType: "test", Protocol: "http",
+		Endpoints: endpoints, SignVersion: new(sync.Map), SkipRegionValidation: true,
+	}
+	client, err := config.Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoints.Store("arms", endpoint)
+	return client
+}
+
+func TestUnitArmsWebhookContactCrud(t *testing.T) {
+	t.Run("create_read_delete", func(t *testing.T) {
+		var deleted string
+		client := armsWebhookContactTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			var response interface{}
+			switch r.Form.Get("Action") {
+			case "CreateOrUpdateWebhookContact":
+				if r.Form.Get("WebhookName") != "test-webhook" {
+					t.Errorf("unexpected WebhookName: %q", r.Form.Get("WebhookName"))
+				}
+				if r.Form.Get("Method") != "Post" || r.Form.Get("Url") != "https://example.com/hook" {
+					t.Errorf("unexpected webhook request params: Method=%q Url=%q", r.Form.Get("Method"), r.Form.Get("Url"))
+				}
+				if r.Form.Get("Body") != `{"message":"alert fired"}` || r.Form.Get("RecoverBody") != `{"message":"alert recovered"}` {
+					t.Errorf("unexpected template params: Body=%q RecoverBody=%q", r.Form.Get("Body"), r.Form.Get("RecoverBody"))
+				}
+				if r.Form.Get("BizHeaders") != `[{"Content-Type":"application/json"}]` {
+					t.Errorf("unexpected BizHeaders: %q", r.Form.Get("BizHeaders"))
+				}
+				if r.Form.Get("BizParams") != `[{"foo":"bar"}]` {
+					t.Errorf("unexpected BizParams: %q", r.Form.Get("BizParams"))
+				}
+				response = map[string]interface{}{
+					"WebhookContact": map[string]interface{}{"WebhookId": "wc-test-123"},
+				}
+			case "DescribeWebhookContacts":
+				if r.Form.Get("ContactIds") != "wc-test-123" {
+					t.Errorf("unexpected ContactIds: %q", r.Form.Get("ContactIds"))
+				}
+				response = map[string]interface{}{
+					"PageBean": map[string]interface{}{
+						"WebhookContacts": []interface{}{
+							map[string]interface{}{
+								"WebhookId":   "wc-test-123",
+								"WebhookName": "test-webhook",
+								"Webhook": map[string]interface{}{
+									"Method":      "Post",
+									"Url":         "https://example.com/hook",
+									"Body":        `{"message":"alert fired"}`,
+									"RecoverBody": `{"message":"alert recovered"}`,
+									"BizHeaders":  []interface{}{map[string]interface{}{"Content-Type": "application/json"}},
+									"BizParams":   `[{"foo":"bar"}]`,
+								},
+							},
+						},
+					},
+				}
+			case "DeleteWebhookContact":
+				deleted = r.Form.Get("WebhookId")
+				response = map[string]interface{}{"Code": 200}
+			default:
+				t.Errorf("unexpected action: %q", r.Form.Get("Action"))
+			}
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				t.Error(err)
+			}
+		})
+
+		d := schema.TestResourceDataRaw(t, resourceAliCloudArmsWebhookContact().Schema, map[string]interface{}{
+			"webhook_contact_name": "test-webhook",
+			"webhook": []interface{}{
+				map[string]interface{}{
+					"method":       "Post",
+					"url":          "https://example.com/hook",
+					"body":         `{"message":"alert fired"}`,
+					"recover_body": `{"message":"alert recovered"}`,
+					"biz_headers":  map[string]interface{}{"Content-Type": "application/json"},
+					"biz_params":   map[string]interface{}{"foo": "bar"},
+				},
+			},
+		})
+		if err := resourceAliCloudArmsWebhookContactCreate(d, client); err != nil {
+			t.Fatalf("create failed: %v", err)
+		}
+		if d.Id() != "wc-test-123" {
+			t.Fatalf("expected id wc-test-123, got %q", d.Id())
+		}
+		if got := d.Get("webhook_contact_name"); got != "test-webhook" {
+			t.Fatalf("read back name %q", got)
+		}
+		webhook := d.Get("webhook").([]interface{})
+		if len(webhook) != 1 {
+			t.Fatalf("expected one webhook block, got %d", len(webhook))
+		}
+		m := webhook[0].(map[string]interface{})
+		if m["method"] != "Post" || m["url"] != "https://example.com/hook" {
+			t.Fatalf("unexpected webhook read back: %v", m)
+		}
+		if m["body"] != `{"message":"alert fired"}` {
+			t.Fatalf("unexpected body read back: %v", m["body"])
+		}
+		headers, ok := m["biz_headers"].(map[string]interface{})
+		if !ok || headers["Content-Type"] != "application/json" {
+			t.Fatalf("unexpected biz_headers read back: %v", m["biz_headers"])
+		}
+		params, ok := m["biz_params"].(map[string]interface{})
+		if !ok || params["foo"] != "bar" {
+			t.Fatalf("unexpected biz_params read back: %v", m["biz_params"])
+		}
+		if err := resourceAliCloudArmsWebhookContactDelete(d, client); err != nil {
+			t.Fatalf("delete failed: %v", err)
+		}
+		if deleted != "wc-test-123" {
+			t.Fatalf("expected DeleteWebhookContact WebhookId=wc-test-123, got %q", deleted)
+		}
+	})
+
+	t.Run("read_not_found_clears_id", func(t *testing.T) {
+		client := armsWebhookContactTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			response := map[string]interface{}{
+				"PageBean": map[string]interface{}{"WebhookContacts": []interface{}{}},
+			}
+			if err := json.NewEncoder(w).Encode(response); err != nil {
+				t.Error(err)
+			}
+		})
+		d := schema.TestResourceDataRaw(t, resourceAliCloudArmsWebhookContact().Schema, map[string]interface{}{
+			"webhook_contact_name": "test-webhook",
+		})
+		d.SetId("wc-test-gone")
+		if err := resourceAliCloudArmsWebhookContactRead(d, client); err != nil {
+			t.Fatalf("read must clear the id on not found: %v", err)
+		}
+		if d.Id() != "" {
+			t.Fatalf("expected id to be cleared, got %q", d.Id())
+		}
+	})
+}

--- a/alicloud/service_alicloud_arms_v2.go
+++ b/alicloud/service_alicloud_arms_v2.go
@@ -860,3 +860,86 @@ func (s *ArmsServiceV2) ArmsGrafanaWorkspaceStateRefreshFunc(id string, field st
 }
 
 // DescribeArmsGrafanaWorkspace >>> Encapsulated.
+// DescribeArmsWebhookContact <<< Encapsulated get interface for Arms WebhookContact.
+
+func (s *ArmsServiceV2) DescribeArmsWebhookContact(id string) (object map[string]interface{}, err error) {
+	client := s.client
+	var request map[string]interface{}
+	var response map[string]interface{}
+	var query map[string]interface{}
+	request = make(map[string]interface{})
+	query = make(map[string]interface{})
+	query["ContactIds"] = id
+
+	action := "DescribeWebhookContacts"
+
+	wait := incrementalWait(3*time.Second, 5*time.Second)
+	err = resource.Retry(1*time.Minute, func() *resource.RetryError {
+		response, err = client.RpcGet("ARMS", "2019-08-08", action, query, request)
+
+		if err != nil {
+			if NeedRetry(err) {
+				wait()
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	addDebug(action, response, request)
+	if err != nil {
+		if IsExpectedErrors(err, []string{"404"}) {
+			return object, WrapErrorf(NotFoundErr("WebhookContact", id), NotFoundMsg, response)
+		}
+		return object, WrapErrorf(err, DefaultErrorMsg, id, action, AlibabaCloudSdkGoERROR)
+	}
+	code, _ := jsonpath.Get("$.Code", response)
+	if InArray(fmt.Sprint(code), []string{"404"}) {
+		return object, WrapErrorf(NotFoundErr("WebhookContact", id), NotFoundMsg, response)
+	}
+
+	v, err := jsonpath.Get("$.PageBean.WebhookContacts[*]", response)
+	if err != nil {
+		return object, WrapErrorf(err, FailedGetAttributeMsg, id, "$.PageBean.WebhookContacts[*]", response)
+	}
+
+	if len(v.([]interface{})) == 0 {
+		return object, WrapErrorf(NotFoundErr("WebhookContact", id), NotFoundMsg, response)
+	}
+
+	return v.([]interface{})[0].(map[string]interface{}), nil
+}
+
+func (s *ArmsServiceV2) ArmsWebhookContactStateRefreshFunc(id string, field string, failStates []string) resource.StateRefreshFunc {
+	return s.ArmsWebhookContactStateRefreshFuncWithApi(id, field, failStates, s.DescribeArmsWebhookContact)
+}
+
+func (s *ArmsServiceV2) ArmsWebhookContactStateRefreshFuncWithApi(id string, field string, failStates []string, call func(id string) (map[string]interface{}, error)) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		object, err := call(id)
+		if err != nil {
+			if NotFoundError(err) {
+				return object, "", nil
+			}
+			return nil, "", WrapError(err)
+		}
+		v, err := jsonpath.Get(field, object)
+		currentStatus := fmt.Sprint(v)
+
+		if strings.HasPrefix(field, "#") {
+			v, _ := jsonpath.Get(strings.TrimPrefix(field, "#"), object)
+			if v != nil {
+				currentStatus = "#CHECKSET"
+			}
+		}
+
+		for _, failState := range failStates {
+			if currentStatus == failState {
+				return object, currentStatus, WrapError(Error(FailedToReachTargetStatus, currentStatus))
+			}
+		}
+		return object, currentStatus, nil
+	}
+}
+
+// DescribeArmsWebhookContact >>> Encapsulated.

--- a/website/docs/r/arms_webhook_contact.html.markdown
+++ b/website/docs/r/arms_webhook_contact.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "Application Real-Time Monitoring Service (ARMS)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_arms_webhook_contact"
+description: |-
+  Provides a Alicloud Application Real-Time Monitoring Service (ARMS) Webhook Contact resource.
+---
+
+# alicloud_arms_webhook_contact
+
+Provides a Application Real-Time Monitoring Service (ARMS) Webhook Contact resource.
+
+
+
+For information about Application Real-Time Monitoring Service (ARMS) Webhook Contact and how to use it, see [What is Webhook Contact](https://next.api.alibabacloud.com/document/ARMS/2019-08-08/CreateOrUpdateWebhookContact).
+
+-> **NOTE:** Available since v1.294.0.
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+variable "name" {
+  default = "terraform-example"
+}
+
+resource "alicloud_arms_webhook_contact" "default" {
+  webhook_contact_name = var.name
+
+  webhook {
+    method       = "Post"
+    url          = "https://example.com/webhook"
+    body         = jsonencode({ "message" : "alert fired" })
+    recover_body = jsonencode({ "message" : "alert recovered" })
+    biz_headers = {
+      "Content-Type" = "application/json"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+* `webhook` - (Required, ForceNew, List) The webhook object that contains the request method, URL, headers, parameters, alert notification template and recover template. See [`webhook`](#webhook) below.
+* `webhook_contact_name` - (Required, ForceNew) The name of the webhook contact.
+
+### `webhook`
+
+The webhook supports the following:
+* `biz_headers` - (Optional, ForceNew, Map) The HTTP request headers.
+* `biz_params` - (Optional, ForceNew, Map) The HTTP request parameters.
+* `body` - (Optional, ForceNew) The alert notification template.
+* `method` - (Required, ForceNew) The HTTP request method.
+* `recover_body` - (Optional, ForceNew) The alert recover template.
+* `url` - (Required, ForceNew) The webhook URL.
+
+## Attributes Reference
+
+The following attributes are exported:
+* `id` - The ID of the resource supplied above.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts) for certain actions:
+* `create` - (Defaults to 5 mins) Used when create the Webhook Contact.
+* `delete` - (Defaults to 5 mins) Used when delete the Webhook Contact.
+
+## Import
+
+Application Real-Time Monitoring Service (ARMS) Webhook Contact can be imported using the id, e.g.
+
+```shell
+$ terraform import alicloud_arms_webhook_contact.example <webhook_contact_id>
+```


### PR DESCRIPTION
## Summary

Adds the `alicloud_arms_webhook_contact` resource on the ARMS 2019-08-08 API line (CreateOrUpdateWebhookContact / DescribeWebhookContacts / DeleteWebhookContact), implementing the webhook-contact part of issue #9737.

- `alicloud/resource_alicloud_arms_webhook_contact.go` — new resource (schema, create/read/delete)
- `alicloud/service_alicloud_arms_v2.go` — appended `DescribeArmsWebhookContact` + state refresh funcs (append-only, no shared semantic change)
- `alicloud/provider.go` — registration
- `website/docs/r/arms_webhook_contact.html.markdown` — docs, `Available since v1.294.0`
- `alicloud/resource_alicloud_arms_webhook_contact_test.go` — unit + acceptance tests

Wire format note: the published API models `Webhook.BizHeaders` / `Webhook.BizParams` as string params carrying a JSON array of single-entry objects (e.g. `[{"Content-Type":"application/json;charset=utf-8"}]`). The resource serializes the `TypeMap` fields to exactly that wire format on create (`armsWebhookContactKvMapToJson`) and normalizes the string / array / map response variants on read (`armsWebhookContactKvMapFromResponse`).

## Test plan

Regression tests (unit, wire-level, executed locally):

- `TestUnitArmsWebhookContactCrud/create_read_delete` — PASS — asserts the create request carries `BizHeaders` / `BizParams` as the exact JSON-string wire format, and that read normalizes both the documented array form and the schema string form of the response fields.
- `TestUnitArmsWebhookContactCrud/read_not_found_clears_id` — PASS — NotFound on read clears the ID.

Original main use cases: not applicable — brand-new resource, no pre-existing resource touched.

Formal acceptance (remote ACC) — pending QA execution via the remote ACC service; not run locally:

- `TestAccAliCloudArmsWebhookContact_basic` — create with all fields -> ForceNew recreate on body change -> ImportStateVerify.

Example (`docs` terraform snippet) init/validate: not executed locally; covered by the ACC step above.

Local verification of the delivered revision: `gofmt` clean on all changed files; `go vet -p=1 ./alicloud` reports only pre-existing findings in `alicloud/common.go` (untouched by this PR); `go run scripts/document/document_check.go website/docs/r/arms_webhook_contact.html.markdown` passes.

## Known limitations

- The upstream CloudSpec model declares `Webhook.BizHeaders` / `Webhook.BizParams` as objects while the published API expects JSON-string params; this PR carries a product-side serialization patch and the model-vs-API input conflict is reported back to the requirement owner.
- `body` / `recover_body` are documented as applicable with `method = "Post"`; no code-level guard enforces that value-conditional pairing (schema presence rules cannot express it).
