### PR TITLE
resource/alicloud_ddoscoo_port: add proxy_enable, ip_mode and module attributes

### DIFF
--- a/alicloud/resource_alicloud_ddoscoo_port.go
+++ b/alicloud/resource_alicloud_ddoscoo_port.go
@@ -67,6 +67,18 @@ func resourceAliCloudDdosCooPort() *schema.Resource {
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"proxy_enable": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"ip_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"module": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -91,6 +103,9 @@ func resourceAliCloudDdosCooPortCreate(d *schema.ResourceData, meta interface{})
 	if v, ok := d.GetOk("real_servers"); ok {
 		realServersMaps := v.([]interface{})
 		request["RealServers"] = realServersMaps
+	}
+	if v, ok := d.GetOk("proxy_enable"); ok {
+		request["ProxyEnable"] = v
 	}
 
 	wait := incrementalWait(3*time.Second, 5*time.Second)
@@ -149,6 +164,10 @@ func resourceAliCloudDdosCooPortRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("real_servers", realServers1Raw)
+
+	if objectRaw["IpMode"] != nil {
+		d.Set("ip_mode", objectRaw["IpMode"])
+	}
 
 	objectRaw, err = ddosCooServiceV2.DescribeDescribeNetworkRuleAttributes(d.Id())
 	if err != nil {
@@ -218,6 +237,12 @@ func resourceAliCloudDdosCooPortUpdate(d *schema.ResourceData, meta interface{})
 		update = true
 	}
 	request["BackendPort"] = d.Get("backend_port")
+	if !d.IsNewResource() && d.HasChange("proxy_enable") {
+		update = true
+	}
+	if v, ok := d.GetOk("proxy_enable"); ok || d.HasChange("proxy_enable") {
+		request["ProxyEnable"] = v
+	}
 	if update {
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
@@ -245,7 +270,7 @@ func resourceAliCloudDdosCooPortUpdate(d *schema.ResourceData, meta interface{})
 	query["ForwardProtocol"] = parts[2]
 	query["FrontendPort"] = parts[1]
 
-	if d.HasChange("config") {
+	if d.HasChange("config") || d.HasChange("module") {
 		update = true
 	}
 	objectDataLocalMap := make(map[string]interface{})
@@ -257,6 +282,9 @@ func resourceAliCloudDdosCooPortUpdate(d *schema.ResourceData, meta interface{})
 		}
 
 		request["Config"] = convertObjectToJsonString(objectDataLocalMap)
+	}
+	if v, ok := d.GetOk("module"); ok || d.HasChange("module") {
+		request["Module"] = v
 	}
 
 	if update {

--- a/alicloud/resource_alicloud_ddoscoo_port_test.go
+++ b/alicloud/resource_alicloud_ddoscoo_port_test.go
@@ -46,7 +46,9 @@ func TestAccAliCloudDdosCooPort_basic(t *testing.T) {
 					"backend_port":      fmt.Sprint(rand + 1),
 					"instance_id":       "${data.alicloud_ddoscoo_instances.default.ids.0}",
 					"frontend_protocol": "tcp",
-					"real_servers":      []string{"192.168.0.1"},
+					"real_servers":      []string{"1.1.1.1"},
+					"proxy_enable":      1,
+					"module":            "sla",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -54,17 +56,20 @@ func TestAccAliCloudDdosCooPort_basic(t *testing.T) {
 						"backend_port":      fmt.Sprint(rand + 1),
 						"frontend_protocol": "tcp",
 						"real_servers.#":    "1",
+						"proxy_enable":      "1",
+						"module":            "sla",
 					}),
 				),
 			},
 			{
-				ResourceName:      resourceId,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"proxy_enable", "module", "ip_mode"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"real_servers": []string{"192.168.0.1", "192.168.0.2"},
+					"real_servers": []string{"1.1.1.1", "2.2.2.2"},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -74,7 +79,7 @@ func TestAccAliCloudDdosCooPort_basic(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"real_servers": []string{"192.168.0.1"},
+					"real_servers": []string{"1.1.1.1"},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -130,7 +135,7 @@ func TestAccAliCloudDdosCooPort_basic1(t *testing.T) {
 					"backend_port":      fmt.Sprint(rand + 1),
 					"instance_id":       "${data.alicloud_ddoscoo_instances.default.ids.0}",
 					"frontend_protocol": "udp",
-					"real_servers":      []string{"192.168.0.1"},
+					"real_servers":      []string{"1.1.1.1"},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -142,13 +147,14 @@ func TestAccAliCloudDdosCooPort_basic1(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceId,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ip_mode"},
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"real_servers": []string{"192.168.0.1", "192.168.0.2"},
+					"real_servers": []string{"1.1.1.1", "2.2.2.2"},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -158,7 +164,7 @@ func TestAccAliCloudDdosCooPort_basic1(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"real_servers": []string{"192.168.0.1"},
+					"real_servers": []string{"1.1.1.1"},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -225,6 +231,7 @@ func TestUnitAlicloudDdoscooPort(t *testing.T) {
 				"InstanceIds":      "CreatePortValue",
 				"BackendPort":      "443",
 				"RealServers":      "CreatePortValue",
+				"IpMode":           "ipv4",
 			},
 		},
 	}

--- a/website/docs/r/ddoscoo_port.html.markdown
+++ b/website/docs/r/ddoscoo_port.html.markdown
@@ -62,9 +62,9 @@ The following arguments are supported:
 
 * `config` - (Optional, List, Available since v1.230.0) Session persistence settings for port forwarding rules. Use a string representation in JSON format. The specific structure is described as follows.
   - `PersistenceTimeout`: is of Integer type and is required. The timeout period of the session. Value range: `30` to `3600`, in seconds. The default value is `0`, which is closed. See [`config`](#config) below.
-* `frontend_port` - (Required, ForceNew, Int) The forwarding port to query. Valid values: `0` to `65535`.
+* `frontend_port` - (Required, ForceNew, Int) The forwarding port. Valid values: `0` to `65535`.
 
-* `frontend_protocol` - (Required, ForceNew) The type of the forwarding protocol to query. Valid values:
+* `frontend_protocol` - (Required, ForceNew) The type of the forwarding protocol. Valid values:
   - `tcp`
   - `udp`
 
@@ -73,6 +73,10 @@ The following arguments are supported:
 -> **NOTE:**  You can call the [DescribeInstanceIds](https://www.alibabacloud.com/help/en/doc-detail/157459.html) operation to query the IDs of all instances.
 
 * `real_servers` - (Required, List) List of source IP addresses
+
+* `proxy_enable` - (Optional, Int) Whether to enable the Layer 4 proxy for the port forwarding rule. This is a write-only field: it can be set via CreatePort/ModifyPort but is not returned by DescribePort, so changes made outside Terraform cannot be detected.
+
+* `module` - (Optional) The module type of the network rule attribute. This is a write-only field: it can be set via ModifyNetworkRuleAttribute but is not returned by DescribeNetworkRuleAttributes, so changes made outside Terraform cannot be detected.
 
 ### `config`
 
@@ -83,6 +87,7 @@ The config supports the following:
 
 The following attributes are exported:
 * `id` - The ID of the resource supplied above.The value is formulated as `<instance_id>:<frontend_port>:<frontend_protocol>`.
+* `ip_mode` - The IP mode of the port forwarding rule.
 
 ## Timeouts
 


### PR DESCRIPTION
## Description

Add three new attributes to the `alicloud_ddoscoo_port` resource:

- `proxy_enable` (Optional, Int): Whether to enable the Layer 4 proxy for the port forwarding rule. Maps to the `ProxyEnable` parameter of CreatePort and ModifyPort.
- `ip_mode` (Computed, String): The IP mode of the port forwarding rule. Read-only, returned by DescribePort.
- `module` (Optional, String): The module type of the network rule attribute. Maps to the `Module` parameter of ModifyNetworkRuleAttribute.

Also fixed the `frontend_port` and `frontend_protocol` documentation descriptions (removed redundant "to query" wording).

## Test Plan

- [x] gofmt and go vet pass locally
- [ ] Remote ACC tests pending verification