### PR TITLE
resource/alicloud_ecs_prefix_list: support resource_group_id

### DIFF
--- a/alicloud/resource_alicloud_ecs_prefix_list.go
+++ b/alicloud/resource_alicloud_ecs_prefix_list.go
@@ -58,6 +58,12 @@ func resourceAlicloudEcsPrefixList() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -77,6 +83,10 @@ func resourceAlicloudEcsPrefixListCreate(d *schema.ResourceData, meta interface{
 
 	if v, ok := d.GetOk("description"); ok {
 		request["Description"] = v
+	}
+
+	if v, ok := d.GetOk("resource_group_id"); ok {
+		request["ResourceGroupId"] = v
 	}
 
 	if v, ok := d.GetOk("entry"); ok {
@@ -141,6 +151,9 @@ func resourceAlicloudEcsPrefixListRead(d *schema.ResourceData, meta interface{})
 		d.Set("max_entries", formatInt(v))
 	}
 	d.Set("prefix_list_name", object["PrefixListName"])
+	if object["ResourceGroupId"] != nil {
+		d.Set("resource_group_id", object["ResourceGroupId"])
+	}
 	return nil
 }
 func resourceAlicloudEcsPrefixListUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/alicloud/resource_alicloud_ecs_prefix_list_test.go
+++ b/alicloud/resource_alicloud_ecs_prefix_list_test.go
@@ -224,9 +224,96 @@ func TestAccAliCloudECSPrefixList_basic0(t *testing.T) {
 var AlicloudECSPrefixListMap0 = map[string]string{}
 
 func AlicloudECSPrefixListBasicDependence0(name string) string {
-	return fmt.Sprintf(` 
+	return fmt.Sprintf(`
 variable "name" {
   default = "%s"
+}
+`, name)
+}
+
+func TestAccAliCloudECSPrefixList_basic1(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_ecs_prefix_list.default"
+	ra := resourceAttrInit(resourceId, AlicloudECSPrefixListMap1)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &EcsService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeEcsPrefixList")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	name := fmt.Sprintf("tf-testaccrecsprefixlistrg")
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AlicloudECSPrefixListBasicDependence1)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		IDRefreshName: resourceId,
+		Providers:     testAccProviders,
+		CheckDestroy:  rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"max_entries": "3",
+					"entry": []map[string]interface{}{
+						{
+							"description": name,
+							"cidr":        "192.168.0.0/24",
+						},
+					},
+					"address_family":    "IPv4",
+					"description":       name,
+					"prefix_list_name":  name,
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.1}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"max_entries":       "3",
+						"entry.#":           "1",
+						"address_family":    "IPv4",
+						"description":       name,
+						"prefix_list_name":  name,
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_id": "${data.alicloud_resource_manager_resource_groups.default.ids.0}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"resource_group_id": REMOVEKEY,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"resource_group_id": CHECKSET,
+					}),
+				),
+			},
+			{
+				ResourceName:            resourceId,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+var AlicloudECSPrefixListMap1 = map[string]string{}
+
+func AlicloudECSPrefixListBasicDependence1(name string) string {
+	return fmt.Sprintf(`
+variable "name" {
+  default = "%s"
+}
+
+data "alicloud_resource_manager_resource_groups" "default" {
 }
 `, name)
 }
@@ -238,10 +325,11 @@ func TestUnitAlicloudECSPrefixList(t *testing.T) {
 	dCreate, _ := schema.InternalMap(p["alicloud_ecs_prefix_list"].Schema).Data(nil, nil)
 	dCreate.MarkNewResource()
 	for key, value := range map[string]interface{}{
-		"max_entries":      3,
-		"description":      "description",
-		"prefix_list_name": "prefix_list_name",
-		"address_family":   "IPv4",
+		"max_entries":       3,
+		"description":       "description",
+		"prefix_list_name":  "prefix_list_name",
+		"address_family":    "IPv4",
+		"resource_group_id": "rg-test-id",
 		"entry": []map[string]interface{}{
 			{
 				"description": "description",
@@ -263,11 +351,12 @@ func TestUnitAlicloudECSPrefixList(t *testing.T) {
 	rawClient = rawClient.(*connectivity.AliyunClient)
 	ReadMockResponse := map[string]interface{}{
 		//DescribeEcsPrefixList
-		"MaxEntries":     3,
-		"Description":    "description",
-		"PrefixListName": "prefix_list_name",
-		"AddressFamily":  "IPv4",
-		"PrefixListId":   "PrefixListId",
+		"MaxEntries":      3,
+		"Description":     "description",
+		"PrefixListName":  "prefix_list_name",
+		"AddressFamily":   "IPv4",
+		"PrefixListId":    "PrefixListId",
+		"ResourceGroupId": "rg-test-id",
 		"Entries": []map[string]interface{}{
 			{
 				"Entry": map[string]interface{}{

--- a/website/docs/r/ecs_prefix_list.html.markdown
+++ b/website/docs/r/ecs_prefix_list.html.markdown
@@ -48,7 +48,8 @@ The following arguments are supported:
 * `max_entries` - (Required, ForceNew) The maximum number of entries that the prefix list can contain.  Valid values: 1 to 200.
 * `prefix_list_name` - (Required) The name of the prefix. The name must be 2 to 128 characters in length. It must start with a letter and cannot start with `http://`, `https://`, `com.aliyun`, or `com.alibabacloud`. It can contain letters, digits, colons (:), underscores (_), periods (.), and hyphens (-).
 * `description` - (Optional) The description of the prefix list. The description must be 2 to 256 characters in length and cannot start with `http://` or `https://`.
-* `entry` - (Required) The Entry. The details see Block `entry`. 
+* `resource_group_id` - (Optional, Computed, ForceNew) The ID of the resource group to which the prefix list belongs. If you do not specify this parameter, the prefix list is added to the default resource group.
+* `entry` - (Required) The Entry. The details see Block `entry`.
 
 
 


### PR DESCRIPTION
### What this PR does

Adds the `resource_group_id` attribute to the `alicloud_ecs_prefix_list` resource.

- **Schema**: `resource_group_id` is `Optional`, `Computed`, and `ForceNew`. The resource group is assigned at creation time and cannot be changed afterwards; changing it triggers a destroy and recreate.
- **Create**: forwards `ResourceGroupId` to the `CreatePrefixList` API when the argument is set.
- **Read**: populates `resource_group_id` from the `DescribePrefixListAttributes` response.
- **Update**: the existing `ModifyPrefixList` logic (add/remove entries, name, description) is unchanged. `resource_group_id` is `ForceNew`, so no update path is needed.
- **Docs**: document the new argument in `ecs_prefix_list.html.markdown`.
- **Tests**: add `TestAccAliCloudECSPrefixList_basic1`, which creates the prefix list in a specified resource group, changes the group (ForceNew), removes the argument, and re-imports. The existing unit test mock is updated to include `ResourceGroupId`.

### Test cases

```
=== RUN TestAccAliCloudECSPrefixList_basic0
=== RUN TestAccAliCloudECSPrefixList_basic1
=== RUN TestUnitAlicloudECSPrefixList
```

Remote acceptance tests for `alicloud_ecs_prefix_list` are pending CI / ACube verification.
