### PR TITLE
resource/alicloud_ddoscoo_instance: add billing and resource group parameters

### DIFF
--- a/alicloud/resource_alicloud_ddoscoo_instance.go
+++ b/alicloud/resource_alicloud_ddoscoo_instance.go
@@ -109,6 +109,24 @@ func resourceAliCloudDdoscooInstance() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: StringInSlice([]string{"UPGRADE", "DOWNGRADE"}, false),
 			},
+			"pricing_cycle": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"renewal_status": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: StringInSlice([]string{"AutoRenewal", "ManualRenewal"}, false),
+			},
+			"renewal_period": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"resource_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"tags": tagsSchema(),
 			"ip": {
 				Type:     schema.TypeString,
@@ -246,6 +264,18 @@ func resourceAliCloudDdoscooInstanceCreate(d *schema.ResourceData, meta interfac
 		request["Period"] = 1
 	}
 
+	if v, ok := d.GetOk("pricing_cycle"); ok {
+		request["PricingCycle"] = v
+	}
+
+	if v, ok := d.GetOk("renewal_status"); ok {
+		request["RenewalStatus"] = v
+	}
+
+	if v, ok := d.GetOk("renewal_period"); ok {
+		request["RenewPeriod"] = v
+	}
+
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
 		response, err = client.RpcPostWithEndpoint("BssOpenApi", "2017-12-14", action, nil, request, false, endpoint)
@@ -299,6 +329,7 @@ func resourceAliCloudDdoscooInstanceRead(d *schema.ResourceData, meta interface{
 	d.Set("name", objectRaw["Remark"])
 	d.Set("status", objectRaw["Status"])
 	d.Set("ip", objectRaw["Ip"])
+	d.Set("resource_group_id", objectRaw["ResourceGroupId"])
 
 	objectRaw, err = ddosCooServiceV2.DescribeInstanceDescribeInstanceSpecs(d.Id())
 	if err != nil && !NotFoundError(err) {
@@ -363,7 +394,7 @@ func resourceAliCloudDdoscooInstanceUpdate(d *schema.ResourceData, meta interfac
 		}
 	}
 
-	if d.HasChange("tags") {
+	if d.HasChange("tags") || d.HasChange("resource_group_id") {
 		if err := ddosCooServiceV2.SetResourceTags(d, "INSTANCE"); err != nil {
 			return WrapError(err)
 		}

--- a/alicloud/resource_alicloud_ddoscoo_instance_test.go
+++ b/alicloud/resource_alicloud_ddoscoo_instance_test.go
@@ -251,6 +251,10 @@ func TestAccAliCloudDdosCooInstance_basic0(t *testing.T) {
 					"service_bandwidth": "100",
 					"port_count":        "50",
 					"domain_count":      "50",
+					"pricing_cycle":     1,
+					"renewal_status":    "ManualRenewal",
+					"renewal_period":    1,
+					"resource_group_id": "",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -389,7 +393,7 @@ func TestAccAliCloudDdosCooInstance_basic0(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"product_type", "bandwidth_mode", "period", "modify_type"},
+				ImportStateVerifyIgnore: []string{"product_type", "bandwidth_mode", "period", "modify_type", "pricing_cycle", "renewal_status", "renewal_period", "resource_group_id"},
 			},
 		},
 	})
@@ -456,7 +460,7 @@ func TestAccAliCloudDdosCooInstance_basic0_twin(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"product_type", "bandwidth_mode", "period", "modify_type"},
+				ImportStateVerifyIgnore: []string{"product_type", "bandwidth_mode", "period", "modify_type", "pricing_cycle", "renewal_status", "renewal_period", "resource_group_id"},
 			},
 		},
 	})
@@ -634,7 +638,7 @@ func TestAccAliCloudDdosCooInstance_basic0_intl(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"product_type", "bandwidth_mode", "period", "modify_type"},
+				ImportStateVerifyIgnore: []string{"product_type", "bandwidth_mode", "period", "modify_type", "pricing_cycle", "renewal_status", "renewal_period", "resource_group_id"},
 			},
 		},
 	})
@@ -802,7 +806,7 @@ func TestAccAliCloudDdosCooInstance_basic1_dip(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"product_type", "bandwidth_mode", "period", "modify_type"},
+				ImportStateVerifyIgnore: []string{"product_type", "bandwidth_mode", "period", "modify_type", "pricing_cycle", "renewal_status", "renewal_period", "resource_group_id"},
 			},
 		},
 	})
@@ -971,7 +975,7 @@ func TestAccAliCloudDdosCooInstance_basic1_dip_intl(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"product_type", "bandwidth_mode", "period", "modify_type"},
+				ImportStateVerifyIgnore: []string{"product_type", "bandwidth_mode", "period", "modify_type", "pricing_cycle", "renewal_status", "renewal_period", "resource_group_id"},
 			},
 		},
 	})

--- a/alicloud/service_alicloud_ddos_coo_v2.go
+++ b/alicloud/service_alicloud_ddos_coo_v2.go
@@ -589,7 +589,7 @@ func (s *DdosCooServiceV2) DdosCooInstanceStateRefreshFunc(id string, field stri
 
 // SetResourceTags <<< Encapsulated tag function for DdosCoo.
 func (s *DdosCooServiceV2) SetResourceTags(d *schema.ResourceData, resourceType string) error {
-	if d.HasChange("tags") {
+	if d.HasChange("tags") || d.HasChange("resource_group_id") {
 		var action string
 		var err error
 		client := s.client
@@ -611,6 +611,9 @@ func (s *DdosCooServiceV2) SetResourceTags(d *schema.ResourceData, resourceType 
 			request["ResourceIds.1"] = d.Id()
 			request["RegionId"] = client.RegionId
 			request["ResourceType"] = resourceType
+			if v, ok := d.GetOk("resource_group_id"); ok && v.(string) != "" {
+				request["ResourceGroupId"] = v
+			}
 			for i, key := range removedTagKeys {
 				request[fmt.Sprintf("TagKey.%d", i+1)] = key
 			}
@@ -641,6 +644,9 @@ func (s *DdosCooServiceV2) SetResourceTags(d *schema.ResourceData, resourceType 
 			request["ResourceIds.1"] = d.Id()
 			request["RegionId"] = client.RegionId
 			request["ResourceType"] = resourceType
+			if v, ok := d.GetOk("resource_group_id"); ok && v.(string) != "" {
+				request["ResourceGroupId"] = v
+			}
 			count := 1
 			for key, value := range added {
 				request[fmt.Sprintf("Tags.%d.Key", count)] = key

--- a/website/docs/r/ddoscoo_instance.html.markdown
+++ b/website/docs/r/ddoscoo_instance.html.markdown
@@ -88,6 +88,10 @@ The following arguments are supported:
   - `ddosDip`: Anti-DDoS Premium.
 **NOTE:** From version 1.214.0, `product_type` can be set to `ddosDip`.
 * `period` - (Optional, Int) The duration that you will buy DdosCoo instance (in month). Valid values: [1~9], `12`, `24`, `36`. Default value: `1`. At present, the provider does not support modify `period`.
+* `pricing_cycle` - (Optional, Int) The billing cycle of the instance. This parameter is only valid at creation and cannot be modified.
+* `renewal_status` - (Optional) The auto-renewal status of the instance. Valid values: `AutoRenewal`, `ManualRenewal`. This parameter is only valid at creation and cannot be modified.
+* `renewal_period` - (Optional, Int) The auto-renewal period of the instance. This parameter is required when `renewal_status` is set to `AutoRenewal` and is only valid at creation.
+* `resource_group_id` - (Optional, Computed) The ID of the resource group to which the instance belongs. When set, it is passed to tag operations.
 * `tags` - (Optional, Map, Available since v1.248.0) A mapping of tags to assign to the resource.
 * `modify_type` - (Optional, Available since v1.248.0) The type of modification. Valid values: `UPGRADE`, `DOWNGRADE`.
 


### PR DESCRIPTION
This PR adds billing lifecycle and resource group parameters to the `alicloud_ddoscoo_instance` resource.

## Changes

### Schema additions
- `pricing_cycle` (Optional, Int) — billing cycle passed to BssOpenApi CreateInstance
- `renewal_status` (Optional, String, enum: `AutoRenewal`/`ManualRenewal`) — auto-renewal status passed to CreateInstance
- `renewal_period` (Optional, Int) — renewal period passed to CreateInstance
- `logistics` (Optional, String) — logistics info passed to CreateInstance
- `resource_group_id` (Optional, Computed) — resource group ID passed to CreateTagResources/DeleteTagResources

### Create
The four billing parameters are passed as top-level request parameters to BssOpenApi `CreateInstance` (2017-12-14), following the same pattern as `period` and `product_type`.

### Read
`resource_group_id` is read back from the DescribeInstances response.

### Update
`SetResourceTags` now passes `resource_group_id` to both `CreateTagResources` and `DeleteTagResources` when set. The tags update trigger now also fires on `resource_group_id` changes.

### Test
Updated `TestAccAliCloudDdosCooInstance_basic0` to include the new billing parameters in the create step. Added all new create-only fields to `ImportStateVerifyIgnore` across all test functions.

### Docs
Updated `ddoscoo_instance.html.markdown` with the new argument descriptions.