### PR TITLE
resource/alicloud_rocketmq_account: support remark parameter

### DIFF
--- a/alicloud/resource_alicloud_rocketmq_account.go
+++ b/alicloud/resource_alicloud_rocketmq_account.go
@@ -42,6 +42,10 @@ func resourceAliCloudRocketmqAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"remark": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"username": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -65,6 +69,9 @@ func resourceAliCloudRocketmqAccountCreate(d *schema.ResourceData, meta interfac
 	request = make(map[string]interface{})
 	request["username"] = d.Get("username")
 	request["password"] = d.Get("password")
+	if v, ok := d.GetOk("remark"); ok {
+		request["remark"] = v
+	}
 	body = request
 	wait := incrementalWait(3*time.Second, 5*time.Second)
 	err = resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
@@ -105,6 +112,7 @@ func resourceAliCloudRocketmqAccountRead(d *schema.ResourceData, meta interface{
 
 	d.Set("account_status", objectRaw["accountStatus"])
 	d.Set("password", objectRaw["password"])
+	d.Set("remark", objectRaw["remark"])
 	d.Set("username", objectRaw["username"])
 
 	parts := strings.Split(d.Id(), ":")
@@ -142,6 +150,13 @@ func resourceAliCloudRocketmqAccountUpdate(d *schema.ResourceData, meta interfac
 	}
 	if v, ok := d.GetOk("password"); ok {
 		query["password"] = StringPointer(v.(string))
+	}
+
+	if !d.IsNewResource() && d.HasChange("remark") {
+		update = true
+	}
+	if v, ok := d.GetOk("remark"); ok {
+		query["remark"] = StringPointer(v.(string))
 	}
 
 	body = request

--- a/alicloud/resource_alicloud_rocketmq_account_test.go
+++ b/alicloud/resource_alicloud_rocketmq_account_test.go
@@ -37,12 +37,14 @@ func TestAccAliCloudRocketmqAccount_basic10054(t *testing.T) {
 					"instance_id": "${alicloud_rocketmq_instance.default9hAb83.id}",
 					"username":    name,
 					"password":    "1739867871",
+					"remark":      "tfaccremark1",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"instance_id": CHECKSET,
 						"username":    name,
 						"password":    CHECKSET,
+						"remark":      "tfaccremark1",
 					}),
 				),
 			},
@@ -59,10 +61,12 @@ func TestAccAliCloudRocketmqAccount_basic10054(t *testing.T) {
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"account_status": "DISABLE",
+					"remark":         "tfaccremark2",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"account_status": "DISABLE",
+						"remark":         "tfaccremark2",
 					}),
 				),
 			},
@@ -112,9 +116,6 @@ resource "alicloud_rocketmq_instance" "default9hAb83" {
   instance_name   = var.name
   sub_series_code = "cluster_ha"
   remark          = "example"
-  software {
-    maintain_time = "02:00-06:00"
-  }
 
   tags = {
     Created = "TF"
@@ -173,6 +174,7 @@ func TestAccAliCloudRocketmqAccount_basic10054_twin(t *testing.T) {
 					"instance_id":    "${alicloud_rocketmq_instance.default9hAb83.id}",
 					"username":       name,
 					"password":       "1739867871",
+					"remark":         "tfaccremark",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -180,6 +182,7 @@ func TestAccAliCloudRocketmqAccount_basic10054_twin(t *testing.T) {
 						"instance_id":    CHECKSET,
 						"username":       name,
 						"password":       CHECKSET,
+						"remark":         "tfaccremark",
 					}),
 				),
 			},

--- a/website/docs/r/rocketmq_account.html.markdown
+++ b/website/docs/r/rocketmq_account.html.markdown
@@ -91,6 +91,7 @@ resource "alicloud_rocketmq_account" "default" {
   instance_id    = alicloud_rocketmq_instance.default9hAb83.id
   username       = "tfexample"
   password       = "1741835136"
+  remark         = "tfexample"
 }
 ```
 
@@ -102,6 +103,7 @@ The following arguments are supported:
 * `account_status` - (Optional) The status of the account. Valid values: `DISABLE`, `ENABLE`.
 * `instance_id` - (Required, ForceNew) The instance ID.
 * `password` - (Required) The password of the account.
+* `remark` - (Optional) The remark of the account.
 * `username` - (Required, ForceNew) The username of the account.
 
 ## Attributes Reference


### PR DESCRIPTION
## Description

Add `remark` parameter support to the `alicloud_rocketmq_account` resource.

The `remark` field is now configurable in the resource schema:
- **Create**: sent in the CreateInstanceAccount request body
- **Read**: populated from the GetInstanceAccount response
- **Update**: sent as a query parameter on UpdateInstanceAccount when changed

## Related Resources

Follows the same pattern as the `remark` field on `alicloud_rocketmq_topic`.

## Test cases

- `TestAccAliCloudRocketmqAccount_basic10054`: covers create with remark, update remark, and import verification
- `TestAccAliCloudRocketmqAccount_basic10054_twin`: covers create with remark and import verification

## Documentation

Updated the `rocketmq_account` resource documentation with the new `remark` argument and example.
