### PR TITLE
resource/alicloud_config_aggregate_compliance_pack: support scope, template content and config rule fields

### DIFF
--- a/alicloud/resource_alicloud_config_aggregate_compliance_pack.go
+++ b/alicloud/resource_alicloud_config_aggregate_compliance_pack.go
@@ -72,6 +72,19 @@ func resourceAliCloudConfigAggregateCompliancePack() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"config_rule_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"risk_level": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: IntInSlice([]int{1, 2, 3}),
+						},
 						"config_rule_parameters": {
 							Type:     schema.TypeSet,
 							Optional: true,
@@ -99,6 +112,75 @@ func resourceAliCloudConfigAggregateCompliancePack() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"template_content": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"tag_key_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tag_value_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"exclude_resource_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_group_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"exclude_resource_group_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"region_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"exclude_region_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags_scope": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"tag_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"exclude_tags_scope": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"tag_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -121,6 +203,49 @@ func resourceAliCloudConfigAggregateCompliancePackCreate(d *schema.ResourceData,
 		request["CompliancePackTemplateId"] = v
 	}
 
+	if v, ok := d.GetOk("template_content"); ok {
+		request["TemplateContent"] = v
+	}
+
+	if v, ok := d.GetOk("tag_key_scope"); ok {
+		request["TagKeyScope"] = v
+	}
+	if v, ok := d.GetOk("tag_value_scope"); ok {
+		request["TagValueScope"] = v
+	}
+	if v, ok := d.GetOk("resource_ids_scope"); ok {
+		request["ResourceIdsScope"] = v
+	}
+	if v, ok := d.GetOk("exclude_resource_ids_scope"); ok {
+		request["ExcludeResourceIdsScope"] = v
+	}
+	if v, ok := d.GetOk("resource_group_ids_scope"); ok {
+		request["ResourceGroupIdsScope"] = v
+	}
+	if v, ok := d.GetOk("exclude_resource_group_ids_scope"); ok {
+		request["ExcludeResourceGroupIdsScope"] = v
+	}
+	if v, ok := d.GetOk("region_ids_scope"); ok {
+		request["RegionIdsScope"] = v
+	}
+	if v, ok := d.GetOk("exclude_region_ids_scope"); ok {
+		request["ExcludeRegionIdsScope"] = v
+	}
+	if v, ok := d.GetOk("tags_scope"); ok {
+		for i, dataLoop := range v.([]interface{}) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			request[fmt.Sprintf("TagsScope.%d.TagKey", i+1)] = dataLoopTmp["tag_key"]
+			request[fmt.Sprintf("TagsScope.%d.TagValue", i+1)] = dataLoopTmp["tag_value"]
+		}
+	}
+	if v, ok := d.GetOk("exclude_tags_scope"); ok {
+		for i, dataLoop := range v.([]interface{}) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			request[fmt.Sprintf("ExcludeTagsScope.%d.TagKey", i+1)] = dataLoopTmp["tag_key"]
+			request[fmt.Sprintf("ExcludeTagsScope.%d.TagValue", i+1)] = dataLoopTmp["tag_value"]
+		}
+	}
+
 	configRulesMaps := make([]map[string]interface{}, 0)
 	if v, ok := d.GetOk("config_rule_ids"); ok {
 		for _, configRuleIds := range v.(*schema.Set).List() {
@@ -140,6 +265,18 @@ func resourceAliCloudConfigAggregateCompliancePackCreate(d *schema.ResourceData,
 				configRulesArg := configRules.(map[string]interface{})
 
 				configRulesMap["ManagedRuleIdentifier"] = configRulesArg["managed_rule_identifier"]
+
+				if configRuleName, ok := configRulesArg["config_rule_name"]; ok {
+					configRulesMap["ConfigRuleName"] = configRuleName
+				}
+
+				if description, ok := configRulesArg["description"]; ok {
+					configRulesMap["Description"] = description
+				}
+
+				if riskLevel, ok := configRulesArg["risk_level"]; ok {
+					configRulesMap["RiskLevel"] = riskLevel
+				}
 
 				if configRuleParameters, ok := configRulesArg["config_rule_parameters"]; ok {
 					configRuleParametersMaps := make([]map[string]interface{}, 0)
@@ -225,6 +362,48 @@ func resourceAliCloudConfigAggregateCompliancePackRead(d *schema.ResourceData, m
 	d.Set("risk_level", formatInt(object["RiskLevel"]))
 	d.Set("compliance_pack_template_id", object["CompliancePackTemplateId"])
 	d.Set("status", object["Status"])
+	d.Set("template_content", object["TemplateContent"])
+
+	if scope, ok := object["Scope"].(map[string]interface{}); ok {
+		d.Set("tag_key_scope", scope["TagKeyScope"])
+		d.Set("tag_value_scope", scope["TagValueScope"])
+		d.Set("resource_ids_scope", scope["ResourceIdsScope"])
+		d.Set("exclude_resource_ids_scope", scope["ExcludeResourceIdsScope"])
+		d.Set("resource_group_ids_scope", scope["ResourceGroupIdsScope"])
+		d.Set("exclude_resource_group_ids_scope", scope["ExcludeResourceGroupIdsScope"])
+		d.Set("region_ids_scope", scope["RegionIdsScope"])
+		d.Set("exclude_region_ids_scope", scope["ExcludeRegionIdsScope"])
+
+		if tagsScopeList, ok := scope["TagsScope"].([]interface{}); ok {
+			tagsScopeMaps := make([]map[string]interface{}, 0)
+			for _, tagsScope := range tagsScopeList {
+				tagsScopeArg := tagsScope.(map[string]interface{})
+				tagsScopeMap := map[string]interface{}{
+					"tag_key":   tagsScopeArg["TagKey"],
+					"tag_value": tagsScopeArg["TagValue"],
+				}
+				tagsScopeMaps = append(tagsScopeMaps, tagsScopeMap)
+			}
+			if err := d.Set("tags_scope", tagsScopeMaps); err != nil {
+				return WrapError(err)
+			}
+		}
+
+		if excludeTagsScopeList, ok := scope["ExcludeTagsScope"].([]interface{}); ok {
+			excludeTagsScopeMaps := make([]map[string]interface{}, 0)
+			for _, excludeTagsScope := range excludeTagsScopeList {
+				excludeTagsScopeArg := excludeTagsScope.(map[string]interface{})
+				excludeTagsScopeMap := map[string]interface{}{
+					"tag_key":   excludeTagsScopeArg["TagKey"],
+					"tag_value": excludeTagsScopeArg["TagValue"],
+				}
+				excludeTagsScopeMaps = append(excludeTagsScopeMaps, excludeTagsScopeMap)
+			}
+			if err := d.Set("exclude_tags_scope", excludeTagsScopeMaps); err != nil {
+				return WrapError(err)
+			}
+		}
+	}
 
 	if _, ok := d.GetOk("config_rules"); ok {
 		if configRulesList, ok := object["ConfigRules"]; ok {
@@ -235,6 +414,18 @@ func resourceAliCloudConfigAggregateCompliancePackRead(d *schema.ResourceData, m
 
 				if managedRuleIdentifier, ok := configRulesArg["ManagedRuleIdentifier"]; ok {
 					configRulesMap["managed_rule_identifier"] = managedRuleIdentifier
+				}
+
+				if configRuleName, ok := configRulesArg["ConfigRuleName"]; ok {
+					configRulesMap["config_rule_name"] = configRuleName
+				}
+
+				if description, ok := configRulesArg["Description"]; ok {
+					configRulesMap["description"] = description
+				}
+
+				if riskLevel, ok := configRulesArg["RiskLevel"]; ok {
+					configRulesMap["risk_level"] = riskLevel
 				}
 
 				if configRuleParameters, ok := configRulesArg["ConfigRuleParameters"]; ok {
@@ -327,6 +518,18 @@ func resourceAliCloudConfigAggregateCompliancePackUpdate(d *schema.ResourceData,
 
 			configRulesMap["ManagedRuleIdentifier"] = configRulesArg["managed_rule_identifier"]
 
+			if configRuleName, ok := configRulesArg["config_rule_name"]; ok {
+				configRulesMap["ConfigRuleName"] = configRuleName
+			}
+
+			if description, ok := configRulesArg["description"]; ok {
+				configRulesMap["Description"] = description
+			}
+
+			if riskLevel, ok := configRulesArg["risk_level"]; ok {
+				configRulesMap["RiskLevel"] = riskLevel
+			}
+
 			if configRuleParameters, ok := configRulesArg["config_rule_parameters"]; ok {
 				configRuleParametersMaps := make([]map[string]interface{}, 0)
 				configRuleParametersMap := map[string]interface{}{}
@@ -359,6 +562,55 @@ func resourceAliCloudConfigAggregateCompliancePackUpdate(d *schema.ResourceData,
 		request["ConfigRules"] = configRulesJson
 	}
 
+	if d.HasChange("tag_key_scope") {
+		update = true
+		request["TagKeyScope"] = d.Get("tag_key_scope")
+	}
+	if d.HasChange("tag_value_scope") {
+		update = true
+		request["TagValueScope"] = d.Get("tag_value_scope")
+	}
+	if d.HasChange("resource_ids_scope") {
+		update = true
+		request["ResourceIdsScope"] = d.Get("resource_ids_scope")
+	}
+	if d.HasChange("exclude_resource_ids_scope") {
+		update = true
+		request["ExcludeResourceIdsScope"] = d.Get("exclude_resource_ids_scope")
+	}
+	if d.HasChange("resource_group_ids_scope") {
+		update = true
+		request["ResourceGroupIdsScope"] = d.Get("resource_group_ids_scope")
+	}
+	if d.HasChange("exclude_resource_group_ids_scope") {
+		update = true
+		request["ExcludeResourceGroupIdsScope"] = d.Get("exclude_resource_group_ids_scope")
+	}
+	if d.HasChange("region_ids_scope") {
+		update = true
+		request["RegionIdsScope"] = d.Get("region_ids_scope")
+	}
+	if d.HasChange("exclude_region_ids_scope") {
+		update = true
+		request["ExcludeRegionIdsScope"] = d.Get("exclude_region_ids_scope")
+	}
+	if d.HasChange("tags_scope") {
+		update = true
+		for i, dataLoop := range d.Get("tags_scope").([]interface{}) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			request[fmt.Sprintf("TagsScope.%d.TagKey", i+1)] = dataLoopTmp["tag_key"]
+			request[fmt.Sprintf("TagsScope.%d.TagValue", i+1)] = dataLoopTmp["tag_value"]
+		}
+	}
+	if d.HasChange("exclude_tags_scope") {
+		update = true
+		for i, dataLoop := range d.Get("exclude_tags_scope").([]interface{}) {
+			dataLoopTmp := dataLoop.(map[string]interface{})
+			request[fmt.Sprintf("ExcludeTagsScope.%d.TagKey", i+1)] = dataLoopTmp["tag_key"]
+			request[fmt.Sprintf("ExcludeTagsScope.%d.TagValue", i+1)] = dataLoopTmp["tag_value"]
+		}
+	}
+
 	if update {
 		action := "UpdateAggregateCompliancePack"
 		wait := incrementalWait(3*time.Second, 3*time.Second)
@@ -388,6 +640,16 @@ func resourceAliCloudConfigAggregateCompliancePackUpdate(d *schema.ResourceData,
 		d.SetPartial("description")
 		d.SetPartial("risk_level")
 		d.SetPartial("config_rules")
+		d.SetPartial("tag_key_scope")
+		d.SetPartial("tag_value_scope")
+		d.SetPartial("resource_ids_scope")
+		d.SetPartial("exclude_resource_ids_scope")
+		d.SetPartial("resource_group_ids_scope")
+		d.SetPartial("exclude_resource_group_ids_scope")
+		d.SetPartial("region_ids_scope")
+		d.SetPartial("exclude_region_ids_scope")
+		d.SetPartial("tags_scope")
+		d.SetPartial("exclude_tags_scope")
 	}
 
 	if d.HasChange("config_rule_ids") {

--- a/alicloud/resource_alicloud_config_aggregate_compliance_pack_test.go
+++ b/alicloud/resource_alicloud_config_aggregate_compliance_pack_test.go
@@ -198,6 +198,7 @@ func TestAccAliCloudConfigAggregateCompliancePack_basic0(t *testing.T) {
 					"aggregate_compliance_pack_name": name,
 					"description":                    name,
 					"risk_level":                     "1",
+					"template_content":               "",
 					"config_rules": []map[string]interface{}{
 						{
 							"managed_rule_identifier": "oss-bucket-public-read-prohibited",
@@ -249,6 +250,9 @@ func TestAccAliCloudConfigAggregateCompliancePack_basic0(t *testing.T) {
 					"config_rules": []map[string]interface{}{
 						{
 							"managed_rule_identifier": "ecs-snapshot-retention-days",
+							"config_rule_name":        "tf-test-snapshot-rule",
+							"description":             "test snapshot retention",
+							"risk_level":              "2",
 							"config_rule_parameters": []map[string]interface{}{
 								{
 									"parameter_name":  "days",
@@ -278,6 +282,9 @@ func TestAccAliCloudConfigAggregateCompliancePack_basic0(t *testing.T) {
 					"config_rules": []map[string]interface{}{
 						{
 							"managed_rule_identifier": "ecs-snapshot-retention-days",
+							"config_rule_name":        "tf-test-snapshot-rule-update",
+							"description":             "test snapshot retention updated",
+							"risk_level":              "3",
 							"config_rule_parameters": []map[string]interface{}{
 								{
 									"parameter_name":  "days",
@@ -292,6 +299,87 @@ func TestAccAliCloudConfigAggregateCompliancePack_basic0(t *testing.T) {
 						"config_rules.#": "1",
 					}),
 				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tag_key_scope":                    "env",
+					"tag_value_scope":                  "prod",
+					"resource_ids_scope":               "[\"i-test\"]",
+					"exclude_resource_ids_scope":       "[\"i-test2\"]",
+					"resource_group_ids_scope":         "rg-test",
+					"exclude_resource_group_ids_scope": "rg-test2",
+					"region_ids_scope":                 "cn-hangzhou",
+					"exclude_region_ids_scope":         "cn-shanghai",
+					"tags_scope": []map[string]interface{}{
+						{
+							"tag_key":   "env",
+							"tag_value": "prod",
+						},
+					},
+					"exclude_tags_scope": []map[string]interface{}{
+						{
+							"tag_key":   "team",
+							"tag_value": "dev",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tag_key_scope":                    "env",
+						"tag_value_scope":                  "prod",
+						"region_ids_scope":                 "cn-hangzhou",
+						"exclude_region_ids_scope":         "cn-shanghai",
+						"resource_group_ids_scope":         "rg-test",
+						"exclude_resource_group_ids_scope": "rg-test2",
+						"tags_scope.#":                     "1",
+						"tags_scope.0.tag_key":             "env",
+						"tags_scope.0.tag_value":           "prod",
+						"exclude_tags_scope.#":             "1",
+						"exclude_tags_scope.0.tag_key":     "team",
+						"exclude_tags_scope.0.tag_value":   "dev",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"tag_key_scope":                    "team",
+					"tag_value_scope":                  "dev",
+					"resource_ids_scope":               "[\"i-test3\"]",
+					"exclude_resource_ids_scope":       "[\"i-test4\"]",
+					"resource_group_ids_scope":         "rg-test3",
+					"exclude_resource_group_ids_scope": "rg-test4",
+					"region_ids_scope":                 "cn-shanghai",
+					"exclude_region_ids_scope":         "cn-beijing",
+					"tags_scope": []map[string]interface{}{
+						{
+							"tag_key":   "team",
+							"tag_value": "dev",
+						},
+					},
+					"exclude_tags_scope": []map[string]interface{}{
+						{
+							"tag_key":   "env",
+							"tag_value": "prod",
+						},
+					},
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"tag_key_scope":                "team",
+						"tag_value_scope":              "dev",
+						"region_ids_scope":             "cn-shanghai",
+						"exclude_region_ids_scope":     "cn-beijing",
+						"tags_scope.#":                 "1",
+						"tags_scope.0.tag_key":         "team",
+						"exclude_tags_scope.#":         "1",
+						"exclude_tags_scope.0.tag_key": "env",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceId,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/r/config_aggregate_compliance_pack.html.markdown
+++ b/website/docs/r/config_aggregate_compliance_pack.html.markdown
@@ -89,8 +89,19 @@ The following arguments are supported:
   - `2`: warning.
   - `3`: info.
 * `compliance_pack_template_id` - (Optional, ForceNew, Available since v1.141.0) The Template ID of compliance package.
+* `template_content` - (Optional, ForceNew) The template content of compliance package. It is a JSON string that defines the compliance pack rules. If not specified, the template content is derived from `compliance_pack_template_id`.
 * `config_rule_ids` - (Optional, Set, Available since v1.141.0) A list of Config Rule IDs. See [`config_rule_ids`](#config_rule_ids) below.
 * `config_rules` - (Optional, Set, Deprecated since v1.141.0) A list of Config Rules. See [`config_rules`](#config_rules) below. **NOTE:** Field `config_rules` has been deprecated from provider version 1.141.0. New field `config_rule_ids` instead.
+* `tag_key_scope` - (Optional) The tag key scope. The compliance pack only applies to resources with the specified tag key.
+* `tag_value_scope` - (Optional) The tag value scope. The compliance pack only applies to resources with the specified tag value.
+* `resource_ids_scope` - (Optional) The resource IDs scope. The compliance pack only applies to the specified resource IDs.
+* `exclude_resource_ids_scope` - (Optional) The exclude resource IDs scope. The compliance pack does not apply to the specified resource IDs.
+* `resource_group_ids_scope` - (Optional) The resource group IDs scope. The compliance pack only applies to resources in the specified resource groups.
+* `exclude_resource_group_ids_scope` - (Optional) The exclude resource group IDs scope. The compliance pack does not apply to resources in the specified resource groups.
+* `region_ids_scope` - (Optional) The region IDs scope. The compliance pack only applies to resources in the specified regions.
+* `exclude_region_ids_scope` - (Optional) The exclude region IDs scope. The compliance pack does not apply to resources in the specified regions.
+* `tags_scope` - (Optional) The tags scope. The compliance pack only applies to resources with the specified tags. See [`tags_scope`](#tags_scope) below.
+* `exclude_tags_scope` - (Optional) The exclude tags scope. The compliance pack does not apply to resources with the specified tags. See [`exclude_tags_scope`](#exclude_tags_scope) below.
 
 ### `config_rule_ids`
 
@@ -100,17 +111,34 @@ The config_rule_ids supports the following:
 
 ### `config_rules`
 
-The config_rules supports the following: 
+The config_rules supports the following:
 
 * `managed_rule_identifier` - (Required) The Managed Rule Identifier.
+* `config_rule_name` - (Optional) The name of the config rule.
+* `description` - (Optional) The description of the config rule.
+* `risk_level` - (Optional, Int) The risk level of the config rule. Valid values: `1`, `2`, `3`.
 * `config_rule_parameters` - (Optional, Set) A list of parameter rules. See [`config_rule_parameters`](#config_rules-config_rule_parameters) below.
 
 ### `config_rules-config_rule_parameters`
 
-The config_rule_parameters supports the following: 
+The config_rule_parameters supports the following:
 
 * `parameter_name` - (Optional) The Parameter Name.
 * `parameter_value` - (Optional) The Parameter Value.
+
+### `tags_scope`
+
+The tags_scope supports the following:
+
+* `tag_key` - (Optional) The tag key.
+* `tag_value` - (Optional) The tag value.
+
+### `exclude_tags_scope`
+
+The exclude_tags_scope supports the following:
+
+* `tag_key` - (Optional) The tag key.
+* `tag_value` - (Optional) The tag value.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description

Adds scope, template content, and config rule fields to the `alicloud_config_aggregate_compliance_pack` resource so the aggregate compliance pack honors the full set of attributes accepted by the Cloud Config Create/Update APIs.

## New attributes

- `template_content` (Optional, ForceNew) - inline template content (JSON string) for the compliance pack. Alternative to `compliance_pack_template_id`.
- `tag_key_scope` / `tag_value_scope` - tag key/value scope filters.
- `resource_ids_scope` / `exclude_resource_ids_scope` - resource ID scope filters.
- `resource_group_ids_scope` / `exclude_resource_group_ids_scope` - resource group scope filters.
- `region_ids_scope` / `exclude_region_ids_scope` - region scope filters.
- `tags_scope` / `exclude_tags_scope` - list of `{ tag_key, tag_value }` blocks for tag-based scope filters.

## `config_rules` block additions

- `config_rule_name` - config rule name.
- `description` - config rule description.
- `risk_level` - config rule risk level (1/2/3).

These nested fields are expanded into the `ConfigRules` JSON payload sent to Create/Update alongside the existing `managed_rule_identifier` and `config_rule_parameters`.

## Read behavior

Scope attributes are flattened from the nested `Scope` object returned by GetAggregateCompliancePack; `template_content` is read from the top-level response.

## Tests

`TestAccAliCloudConfigAggregateCompliancePack_basic0` is extended with steps that create and update scope fields, the new `config_rules` nested fields, and an import-verify step. Remote acceptance verification is pending.