### PR TITLE
resource/alicloud_config_aggregate_remediation: send RemediationType and SourceType in Update request

### DIFF
--- a/alicloud/resource_alicloud_config_aggregate_remediation.go
+++ b/alicloud/resource_alicloud_config_aggregate_remediation.go
@@ -52,7 +52,6 @@ func resourceAliCloudConfigAggregateRemediation() *schema.Resource {
 			"remediation_source_type": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 			"remediation_template_id": {
 				Type:     schema.TypeString,
@@ -61,7 +60,6 @@ func resourceAliCloudConfigAggregateRemediation() *schema.Resource {
 			"remediation_type": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 		},
 	}
@@ -167,6 +165,14 @@ func resourceAliCloudConfigAggregateRemediationUpdate(d *schema.ResourceData, me
 		update = true
 	}
 	request["Params"] = d.Get("remediation_origin_params")
+	if d.HasChange("remediation_source_type") {
+		update = true
+	}
+	request["SourceType"] = d.Get("remediation_source_type")
+	if d.HasChange("remediation_type") {
+		update = true
+	}
+	request["RemediationType"] = d.Get("remediation_type")
 	if update {
 		wait := incrementalWait(3*time.Second, 5*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {

--- a/alicloud/resource_alicloud_config_aggregate_remediation_test.go
+++ b/alicloud/resource_alicloud_config_aggregate_remediation_test.go
@@ -59,12 +59,16 @@ func TestAccAliCloudConfigAggregateRemediation_basic11937(t *testing.T) {
 				Config: testAccConfig(map[string]interface{}{
 					"remediation_template_id":   "ACS-TAG-TagResourcesIgnoreCaseSensitive",
 					"invoke_type":               "AUTO_EXECUTION",
+					"remediation_source_type":   "CUSTOM",
+					"remediation_type":          "FC",
 					"remediation_origin_params": "{\\\"properties\\\":[{\\\"name\\\":\\\"regionId\\\",\\\"type\\\":\\\"String\\\",\\\"value\\\":\\\"{regionId}\\\",\\\"allowedValues\\\":[],\\\"description\\\":\\\"地域ID\\\"},{\\\"name\\\":\\\"tags\\\",\\\"type\\\":\\\"String\\\",\\\"value\\\":\\\"{\\\\\\\"aaa\\\\\\\":\\\\\\\"bbb\\\\\\\"}\\\",\\\"allowedValues\\\":[],\\\"description\\\":\\\"\\\\n模版tag参数占位符，不用单独设置。\\\"},{\\\"name\\\":\\\"resourceType\\\",\\\"type\\\":\\\"String\\\",\\\"value\\\":\\\"{resourceType}\\\",\\\"allowedValues\\\":[],\\\"description\\\":\\\"资源类型\\\"},{\\\"name\\\":\\\"resourceIds\\\",\\\"type\\\":\\\"ARRAY\\\",\\\"value\\\":\\\"[\\\\\\\"{resourceId}\\\\\\\"]\\\",\\\"allowedValues\\\":[],\\\"description\\\":\\\"资源ID的列表\\\"}]}",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"remediation_template_id":   "ACS-TAG-TagResourcesIgnoreCaseSensitive",
 						"invoke_type":               "AUTO_EXECUTION",
+						"remediation_source_type":   "CUSTOM",
+						"remediation_type":          "FC",
 						"remediation_origin_params": CHECKSET,
 					}),
 				),


### PR DESCRIPTION
This change makes `remediation_type` and `remediation_source_type` updatable on the `alicloud_config_aggregate_remediation` resource by removing `ForceNew` from both fields and sending the current values of `RemediationType` and `SourceType` in the UpdateAggregateRemediation request, aligning the provider Update behavior with the upstream API input contract.

The test case step now modifies both fields to cover the update path.