### PR TITLE
resource/alicloud_config_delivery: support delivery_snapshot_time and compliant_snapshot

### DIFF
--- a/alicloud/resource_alicloud_config_delivery.go
+++ b/alicloud/resource_alicloud_config_delivery.go
@@ -34,6 +34,14 @@ func resourceAliCloudConfigDelivery() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"compliant_snapshot": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"delivery_snapshot_time": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"delivery_channel_condition": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -97,6 +105,12 @@ func resourceAliCloudConfigDeliveryCreate(d *schema.ResourceData, meta interface
 	if v, ok := d.GetOk("configuration_snapshot"); ok {
 		request["ConfigurationSnapshot"] = v
 	}
+	if v, ok := d.GetOk("compliant_snapshot"); ok {
+		request["CompliantSnapshot"] = v
+	}
+	if v, ok := d.GetOk("delivery_snapshot_time"); ok {
+		request["DeliverySnapshotTime"] = v
+	}
 	if v, ok := d.GetOk("delivery_channel_condition"); ok {
 		request["DeliveryChannelCondition"] = v
 	}
@@ -158,6 +172,12 @@ func resourceAliCloudConfigDeliveryRead(d *schema.ResourceData, meta interface{}
 	if objectRaw["ConfigurationSnapshot"] != nil {
 		d.Set("configuration_snapshot", objectRaw["ConfigurationSnapshot"])
 	}
+	if objectRaw["CompliantSnapshot"] != nil {
+		d.Set("compliant_snapshot", objectRaw["CompliantSnapshot"])
+	}
+	if objectRaw["DeliverySnapshotTime"] != nil {
+		d.Set("delivery_snapshot_time", objectRaw["DeliverySnapshotTime"])
+	}
 	if objectRaw["DeliveryChannelCondition"] != nil {
 		d.Set("delivery_channel_condition", objectRaw["DeliveryChannelCondition"])
 	}
@@ -212,6 +232,16 @@ func resourceAliCloudConfigDeliveryUpdate(d *schema.ResourceData, meta interface
 	if !d.IsNewResource() && d.HasChange("configuration_snapshot") {
 		update = true
 		request["ConfigurationSnapshot"] = d.Get("configuration_snapshot")
+	}
+
+	if !d.IsNewResource() && d.HasChange("compliant_snapshot") {
+		update = true
+		request["CompliantSnapshot"] = d.Get("compliant_snapshot")
+	}
+
+	if !d.IsNewResource() && d.HasChange("delivery_snapshot_time") {
+		update = true
+		request["DeliverySnapshotTime"] = d.Get("delivery_snapshot_time")
 	}
 
 	if !d.IsNewResource() && d.HasChange("delivery_channel_condition") {

--- a/alicloud/resource_alicloud_config_delivery_test.go
+++ b/alicloud/resource_alicloud_config_delivery_test.go
@@ -48,6 +48,8 @@ func TestAccAliCloudConfigDelivery_OSS(t *testing.T) {
 					"description":                            "${var.name}",
 					"configuration_snapshot":                 "true",
 					"configuration_item_change_notification": "true",
+					"compliant_snapshot":                     "true",
+					"delivery_snapshot_time":                 "04:00",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
@@ -57,6 +59,8 @@ func TestAccAliCloudConfigDelivery_OSS(t *testing.T) {
 						"description":                            name,
 						"configuration_snapshot":                 "true",
 						"configuration_item_change_notification": "true",
+						"compliant_snapshot":                     "true",
+						"delivery_snapshot_time":                 "04:00",
 					}),
 				),
 			},
@@ -124,11 +128,25 @@ func TestAccAliCloudConfigDelivery_OSS(t *testing.T) {
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
+					"compliant_snapshot":     "false",
+					"delivery_snapshot_time": "16:00",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"compliant_snapshot":     "false",
+						"delivery_snapshot_time": "16:00",
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
 					"delivery_channel_name":                  "${var.name}",
 					"delivery_channel_target_arn":            "${local.bucket}",
 					"description":                            "${var.name}",
 					"configuration_snapshot":                 "true",
 					"configuration_item_change_notification": "true",
+					"compliant_snapshot":                     "true",
+					"delivery_snapshot_time":                 "04:00",
 					"status":                                 "1",
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -138,6 +156,8 @@ func TestAccAliCloudConfigDelivery_OSS(t *testing.T) {
 						"description":                            name,
 						"configuration_snapshot":                 "true",
 						"configuration_item_change_notification": "true",
+						"compliant_snapshot":                     "true",
+						"delivery_snapshot_time":                 "04:00",
 						"status":                                 "1",
 					}),
 				),

--- a/website/docs/r/config_delivery.html.markdown
+++ b/website/docs/r/config_delivery.html.markdown
@@ -64,6 +64,10 @@ The following arguments are supported:
 * `configuration_snapshot` - (Optional) Indicates whether the specified destination receives scheduled resource snapshots. Cloud Config delivers scheduled resource snapshots at 04:00Z and 16:00Z to OSS, MNS, or Log Service every day. The time is displayed in UTC. Valid values:  
   - true: The specified destination receives scheduled resource snapshots.  
   - false: The specified destination does not receive scheduled resource snapshots.  
+* `compliant_snapshot` - (Optional) Indicates whether the specified destination receives compliant snapshots. Valid values:
+  - true: The specified destination receives compliant snapshots.
+  - false: The specified destination does not receive compliant snapshots.
+* `delivery_snapshot_time` - (Optional) The time at which the scheduled resource snapshot is delivered. The time is displayed in UTC.
 * `delivery_channel_condition` - (Optional) The rule that is attached to the delivery channel.  
 
   This parameter is available when you deliver data of all types to MNS or deliver snapshots to Log Service.  


### PR DESCRIPTION
### Description

Add two new optional attributes to the `alicloud_config_delivery` resource:

- `compliant_snapshot` (bool) - maps to the `compliantSnapshot` business parameter of CreateConfigDeliveryChannel / UpdateConfigDeliveryChannel.
- `delivery_snapshot_time` (string) - maps to the `deliverySnapshotTime` business parameter of CreateConfigDeliveryChannel / UpdateConfigDeliveryChannel.

Both attributes are read back from the GetConfigDeliveryChannel response (the nested `DeliveryChannel` object) and are updatable in place (no ForceNew).

### Related tests

- `TestAccAliCloudConfigDelivery_OSS` - covers create, update (`compliant_snapshot` true -> false, `delivery_snapshot_time` change), restore, and import verification for the new attributes.

### Checklist

- [x] Local `gofmt` / `go vet` pass on the changed package
- [ ] CI green
- [ ] Remote ACC pass
