### PR TITLE
resource/alicloud_esa_cache_reserve_instance: support order_id attribute

### DIFF
--- a/alicloud/resource_alicloud_esa_cache_reserve_instance.go
+++ b/alicloud/resource_alicloud_esa_cache_reserve_instance.go
@@ -61,6 +61,10 @@ func resourceAliCloudEsaCacheReserveInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"order_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -111,6 +115,7 @@ func resourceAliCloudEsaCacheReserveInstanceCreate(d *schema.ResourceData, meta 
 	}
 
 	d.SetId(fmt.Sprint(response["InstanceId"]))
+	d.Set("order_id", response["OrderId"])
 
 	esaServiceV2 := EsaServiceV2{client}
 	stateConf := BuildStateConf([]string{}, []string{"online"}, d.Timeout(schema.TimeoutCreate), 10*time.Second, esaServiceV2.EsaCacheReserveInstanceStateRefreshFunc(d.Id(), "Status", []string{}))
@@ -187,6 +192,7 @@ func resourceAliCloudEsaCacheReserveInstanceUpdate(d *schema.ResourceData, meta 
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), action, AlibabaCloudSdkGoERROR)
 		}
+		d.Set("order_id", response["OrderId"])
 		esaServiceV2 := EsaServiceV2{client}
 		stateConf := BuildStateConf([]string{}, []string{"online"}, d.Timeout(schema.TimeoutUpdate), 10*time.Second, esaServiceV2.EsaCacheReserveInstanceStateRefreshFunc(d.Id(), "Status", []string{}))
 		if _, err := stateConf.WaitForState(); err != nil {

--- a/alicloud/resource_alicloud_esa_cache_reserve_instance_test.go
+++ b/alicloud/resource_alicloud_esa_cache_reserve_instance_test.go
@@ -66,7 +66,7 @@ func TestAccAliCloudEsaCacheReserveInstance_basic10493(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"auto_pay", "auto_renew"},
+				ImportStateVerifyIgnore: []string{"auto_pay", "auto_renew", "order_id"},
 			},
 		},
 	})
@@ -75,6 +75,7 @@ func TestAccAliCloudEsaCacheReserveInstance_basic10493(t *testing.T) {
 var AlicloudEsaCacheReserveInstanceMap10493 = map[string]string{
 	"status":      CHECKSET,
 	"create_time": CHECKSET,
+	"order_id":    CHECKSET,
 }
 
 func AlicloudEsaCacheReserveInstanceBasicDependence10493(name string) string {

--- a/website/docs/r/esa_cache_reserve_instance.html.markdown
+++ b/website/docs/r/esa_cache_reserve_instance.html.markdown
@@ -66,6 +66,7 @@ The following arguments are supported:
 The following attributes are exported:
 * `id` - The ID of the resource supplied above.
 * `create_time` - Instance purchase time.
+* `order_id` - The order ID of the cache reserve instance. It is generated when the instance is purchased or its spec is updated, and is not retrievable by the read API.
 * `status` - The status of the cache reserve instance. , it is unavailable.
 
 ## Timeouts


### PR DESCRIPTION
## Summary
- Expose the computed `order_id` attribute on the `alicloud_esa_cache_reserve_instance` resource, populated from the `PurchaseCacheReserve` (create) and `UpdateCacheReserveSpec` (update) responses.
- The read API `ListCacheReserveInstances` does not return the order id, so `order_id` is kept in state and ignored during import to avoid refresh plan-not-empty diffs.

## Test plan
- [ ] `TestAccAliCloudEsaCacheReserveInstance_basic10493` (remote ACC pending): create → update `quota_gb` → import (order_id ignored) → destroy, verifying `order_id` is populated after create/update and persists across refresh.
