### PR TITLE
resource/alicloud_config_compliance_pack: support scope and template content fields

### DIFF
--- a/alicloud/resource_alicloud_config_compliance_pack.go
+++ b/alicloud/resource_alicloud_config_compliance_pack.go
@@ -46,12 +46,14 @@ func resourceAliCloudConfigCompliancePack() *schema.Resource {
 			"config_rule_ids": {
 				Type:          schema.TypeSet,
 				Optional:      true,
+				Computed:      true,
 				ConflictsWith: []string{"config_rules"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"config_rule_id": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},
@@ -83,12 +85,98 @@ func resourceAliCloudConfigCompliancePack() *schema.Resource {
 								},
 							},
 						},
+						"config_rule_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"risk_level": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: IntInSlice([]int{1, 2, 3}),
+						},
 					},
 				},
 			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"template_content": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"tag_key_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tag_value_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"exclude_resource_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"resource_group_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"exclude_resource_group_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"region_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"exclude_region_ids_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tags_scope": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"tag_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"exclude_tags_scope": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"tag_key": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"tag_value": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -131,6 +219,18 @@ func resourceAliCloudConfigCompliancePackCreate(d *schema.ResourceData, meta int
 
 				configRulesMap["ManagedRuleIdentifier"] = configRulesArg["managed_rule_identifier"]
 
+				if configRuleName := configRulesArg["config_rule_name"]; configRuleName.(string) != "" {
+					configRulesMap["ConfigRuleName"] = configRuleName
+				}
+
+				if description := configRulesArg["description"]; description.(string) != "" {
+					configRulesMap["Description"] = description
+				}
+
+				if riskLevel := configRulesArg["risk_level"]; riskLevel.(int) != 0 {
+					configRulesMap["RiskLevel"] = riskLevel
+				}
+
 				if configRuleParameters, ok := configRulesArg["config_rule_parameters"]; ok {
 					configRuleParametersMaps := make([]map[string]interface{}, 0)
 					configRuleParametersMap := map[string]interface{}{}
@@ -164,6 +264,40 @@ func resourceAliCloudConfigCompliancePackCreate(d *schema.ResourceData, meta int
 		}
 
 		request["ConfigRules"] = configRulesJson
+	}
+
+	if v, ok := d.GetOk("template_content"); ok {
+		request["TemplateContent"] = v
+	}
+	if v, ok := d.GetOk("tag_key_scope"); ok {
+		request["TagKeyScope"] = v
+	}
+	if v, ok := d.GetOk("tag_value_scope"); ok {
+		request["TagValueScope"] = v
+	}
+	if v, ok := d.GetOk("resource_ids_scope"); ok {
+		request["ResourceIdsScope"] = v
+	}
+	if v, ok := d.GetOk("exclude_resource_ids_scope"); ok {
+		request["ExcludeResourceIdsScope"] = v
+	}
+	if v, ok := d.GetOk("resource_group_ids_scope"); ok {
+		request["ResourceGroupIdsScope"] = v
+	}
+	if v, ok := d.GetOk("exclude_resource_group_ids_scope"); ok {
+		request["ExcludeResourceGroupIdsScope"] = v
+	}
+	if v, ok := d.GetOk("region_ids_scope"); ok {
+		request["RegionIdsScope"] = v
+	}
+	if v, ok := d.GetOk("exclude_region_ids_scope"); ok {
+		request["ExcludeRegionIdsScope"] = v
+	}
+	if v, ok := d.GetOk("tags_scope"); ok {
+		setTagsScopeParams(request, "TagsScope", v.([]interface{}))
+	}
+	if v, ok := d.GetOk("exclude_tags_scope"); ok {
+		setTagsScopeParams(request, "ExcludeTagsScope", v.([]interface{}))
 	}
 
 	wait := incrementalWait(3*time.Second, 30*time.Second)
@@ -213,6 +347,51 @@ func resourceAliCloudConfigCompliancePackRead(d *schema.ResourceData, meta inter
 	d.Set("risk_level", formatInt(object["RiskLevel"]))
 	d.Set("compliance_pack_template_id", object["CompliancePackTemplateId"])
 	d.Set("status", object["Status"])
+	d.Set("template_content", object["TemplateContent"])
+
+	if scope, ok := object["Scope"]; ok {
+		scopeMap := scope.(map[string]interface{})
+		d.Set("tag_key_scope", scopeMap["TagKeyScope"])
+		d.Set("tag_value_scope", scopeMap["TagValueScope"])
+		d.Set("resource_ids_scope", scopeMap["ResourceIdsScope"])
+		d.Set("exclude_resource_ids_scope", scopeMap["ExcludeResourceIdsScope"])
+		d.Set("resource_group_ids_scope", scopeMap["ResourceGroupIdsScope"])
+		d.Set("exclude_resource_group_ids_scope", scopeMap["ExcludeResourceGroupIdsScope"])
+		d.Set("region_ids_scope", scopeMap["RegionIdsScope"])
+		d.Set("exclude_region_ids_scope", scopeMap["ExcludeRegionIdsScope"])
+
+		if tagsScopeList, ok := scopeMap["TagsScope"]; ok {
+			tagsScopeMaps := make([]map[string]interface{}, 0)
+			for _, ts := range tagsScopeList.([]interface{}) {
+				tsArg := ts.(map[string]interface{})
+				tsMap := map[string]interface{}{}
+				if tagKey, ok := tsArg["TagKey"]; ok {
+					tsMap["tag_key"] = tagKey
+				}
+				if tagValue, ok := tsArg["TagValue"]; ok {
+					tsMap["tag_value"] = tagValue
+				}
+				tagsScopeMaps = append(tagsScopeMaps, tsMap)
+			}
+			d.Set("tags_scope", tagsScopeMaps)
+		}
+
+		if excludeTagsScopeList, ok := scopeMap["ExcludeTagsScope"]; ok {
+			excludeTagsScopeMaps := make([]map[string]interface{}, 0)
+			for _, ets := range excludeTagsScopeList.([]interface{}) {
+				etsArg := ets.(map[string]interface{})
+				etsMap := map[string]interface{}{}
+				if tagKey, ok := etsArg["TagKey"]; ok {
+					etsMap["tag_key"] = tagKey
+				}
+				if tagValue, ok := etsArg["TagValue"]; ok {
+					etsMap["tag_value"] = tagValue
+				}
+				excludeTagsScopeMaps = append(excludeTagsScopeMaps, etsMap)
+			}
+			d.Set("exclude_tags_scope", excludeTagsScopeMaps)
+		}
+	}
 
 	if _, ok := d.GetOk("config_rules"); ok {
 		if configRulesList, ok := object["ConfigRules"]; ok {
@@ -223,6 +402,18 @@ func resourceAliCloudConfigCompliancePackRead(d *schema.ResourceData, meta inter
 
 				if managedRuleIdentifier, ok := configRulesArg["ManagedRuleIdentifier"]; ok {
 					configRulesMap["managed_rule_identifier"] = managedRuleIdentifier
+				}
+
+				if configRuleName, ok := configRulesArg["ConfigRuleName"]; ok {
+					configRulesMap["config_rule_name"] = configRuleName
+				}
+
+				if description, ok := configRulesArg["Description"]; ok {
+					configRulesMap["description"] = description
+				}
+
+				if riskLevel, ok := configRulesArg["RiskLevel"]; ok {
+					configRulesMap["risk_level"] = formatInt(riskLevel)
 				}
 
 				if configRuleParameters, ok := configRulesArg["ConfigRuleParameters"]; ok {
@@ -310,6 +501,18 @@ func resourceAliCloudConfigCompliancePackUpdate(d *schema.ResourceData, meta int
 
 			configRulesMap["ManagedRuleIdentifier"] = configRulesArg["managed_rule_identifier"]
 
+			if configRuleName := configRulesArg["config_rule_name"]; configRuleName.(string) != "" {
+				configRulesMap["ConfigRuleName"] = configRuleName
+			}
+
+			if description := configRulesArg["description"]; description.(string) != "" {
+				configRulesMap["Description"] = description
+			}
+
+			if riskLevel := configRulesArg["risk_level"]; riskLevel.(int) != 0 {
+				configRulesMap["RiskLevel"] = riskLevel
+			}
+
 			if configRuleParameters, ok := configRulesArg["config_rule_parameters"]; ok {
 				configRuleParametersMaps := make([]map[string]interface{}, 0)
 				configRuleParametersMap := map[string]interface{}{}
@@ -342,6 +545,67 @@ func resourceAliCloudConfigCompliancePackUpdate(d *schema.ResourceData, meta int
 		request["ConfigRules"] = configRulesJson
 	}
 
+	if d.HasChange("tag_key_scope") {
+		update = true
+	}
+	if v, ok := d.GetOk("tag_key_scope"); ok {
+		request["TagKeyScope"] = v
+	}
+	if d.HasChange("tag_value_scope") {
+		update = true
+	}
+	if v, ok := d.GetOk("tag_value_scope"); ok {
+		request["TagValueScope"] = v
+	}
+	if d.HasChange("resource_ids_scope") {
+		update = true
+	}
+	if v, ok := d.GetOk("resource_ids_scope"); ok {
+		request["ResourceIdsScope"] = v
+	}
+	if d.HasChange("exclude_resource_ids_scope") {
+		update = true
+	}
+	if v, ok := d.GetOk("exclude_resource_ids_scope"); ok {
+		request["ExcludeResourceIdsScope"] = v
+	}
+	if d.HasChange("resource_group_ids_scope") {
+		update = true
+	}
+	if v, ok := d.GetOk("resource_group_ids_scope"); ok {
+		request["ResourceGroupIdsScope"] = v
+	}
+	if d.HasChange("exclude_resource_group_ids_scope") {
+		update = true
+	}
+	if v, ok := d.GetOk("exclude_resource_group_ids_scope"); ok {
+		request["ExcludeResourceGroupIdsScope"] = v
+	}
+	if d.HasChange("region_ids_scope") {
+		update = true
+	}
+	if v, ok := d.GetOk("region_ids_scope"); ok {
+		request["RegionIdsScope"] = v
+	}
+	if d.HasChange("exclude_region_ids_scope") {
+		update = true
+	}
+	if v, ok := d.GetOk("exclude_region_ids_scope"); ok {
+		request["ExcludeRegionIdsScope"] = v
+	}
+	if d.HasChange("tags_scope") {
+		update = true
+	}
+	if v, ok := d.GetOk("tags_scope"); ok {
+		setTagsScopeParams(request, "TagsScope", v.([]interface{}))
+	}
+	if d.HasChange("exclude_tags_scope") {
+		update = true
+	}
+	if v, ok := d.GetOk("exclude_tags_scope"); ok {
+		setTagsScopeParams(request, "ExcludeTagsScope", v.([]interface{}))
+	}
+
 	if update {
 		action := "UpdateCompliancePack"
 		wait := incrementalWait(3*time.Second, 30*time.Second)
@@ -371,6 +635,16 @@ func resourceAliCloudConfigCompliancePackUpdate(d *schema.ResourceData, meta int
 		d.SetPartial("description")
 		d.SetPartial("risk_level")
 		d.SetPartial("config_rules")
+		d.SetPartial("tag_key_scope")
+		d.SetPartial("tag_value_scope")
+		d.SetPartial("resource_ids_scope")
+		d.SetPartial("exclude_resource_ids_scope")
+		d.SetPartial("resource_group_ids_scope")
+		d.SetPartial("exclude_resource_group_ids_scope")
+		d.SetPartial("region_ids_scope")
+		d.SetPartial("exclude_region_ids_scope")
+		d.SetPartial("tags_scope")
+		d.SetPartial("exclude_tags_scope")
 	}
 
 	if d.HasChange("config_rule_ids") {
@@ -488,4 +762,23 @@ func resourceAliCloudConfigCompliancePackDelete(d *schema.ResourceData, meta int
 	}
 
 	return nil
+}
+
+// setTagsScopeParams sets tags_scope/exclude_tags_scope parameters in POP flat
+// format (TagsScope.N.TagKey / TagsScope.N.TagValue) as required by the
+// CreateCompliancePack/UpdateCompliancePack API. The API rejects JSON array
+// serialization with "InvalidTagsScope: Flat format is required."
+func setTagsScopeParams(request map[string]interface{}, key string, tagsScopeList []interface{}) {
+	for i, ts := range tagsScopeList {
+		tsArg, ok := ts.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if tagKey, ok := tsArg["tag_key"]; ok {
+			request[fmt.Sprintf("%s.%d.TagKey", key, i+1)] = tagKey
+		}
+		if tagValue, ok := tsArg["tag_value"]; ok {
+			request[fmt.Sprintf("%s.%d.TagValue", key, i+1)] = tagValue
+		}
+	}
 }

--- a/alicloud/resource_alicloud_config_compliance_pack_test.go
+++ b/alicloud/resource_alicloud_config_compliance_pack_test.go
@@ -149,6 +149,20 @@ func TestAccAliCloudConfigCompliancePack_basic0(t *testing.T) {
 					"config_rules": []map[string]interface{}{
 						{
 							"managed_rule_identifier": "oss-bucket-public-read-prohibited",
+							"config_rule_name":        name,
+							"description":             name,
+							"risk_level":              "1",
+						},
+					},
+					"tag_key_scope":            "tfTestKey",
+					"tag_value_scope":          "tfTestValue",
+					"resource_ids_scope":       "i-bp1test",
+					"resource_group_ids_scope": "rg-test",
+					"region_ids_scope":         defaultRegionToTest,
+					"tags_scope": []map[string]interface{}{
+						{
+							"tag_key":   "tfTestTagKey",
+							"tag_value": "tfTestTagValue",
 						},
 					},
 				}),
@@ -158,16 +172,28 @@ func TestAccAliCloudConfigCompliancePack_basic0(t *testing.T) {
 						"description":          name,
 						"risk_level":           "1",
 						"config_rules.#":       "1",
+						"tag_key_scope":        "tfTestKey",
+						"tag_value_scope":      "tfTestValue",
+						"tags_scope.#":         "1",
 					}),
 				),
 			},
 			{
 				Config: testAccConfig(map[string]interface{}{
 					"compliance_pack_name": name + "_update",
+					"tag_key_scope":        "tfTestKeyUpdate",
+					"tags_scope": []map[string]interface{}{
+						{
+							"tag_key":   "tfTestTagKeyUpdate",
+							"tag_value": "tfTestTagValueUpdate",
+						},
+					},
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"compliance_pack_name": name + "_update",
+						"tag_key_scope":        "tfTestKeyUpdate",
+						"tags_scope.#":         "1",
 					}),
 				),
 			},
@@ -396,6 +422,49 @@ func TestAccAliCloudConfigCompliancePack_basic1(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudConfigCompliancePack_basic2(t *testing.T) {
+	var v map[string]interface{}
+	resourceId := "alicloud_config_compliance_pack.default"
+	ra := resourceAttrInit(resourceId, AliCloudConfigCompliancePackMap0)
+	rc := resourceCheckInitWithDescribeMethod(resourceId, &v, func() interface{} {
+		return &ConfigService{testAccProvider.Meta().(*connectivity.AliyunClient)}
+	}, "DescribeConfigCompliancePack")
+	rac := resourceAttrCheckInit(rc, ra)
+	testAccCheck := rac.resourceAttrMapUpdateSet()
+	rand := acctest.RandIntRange(10000, 99999)
+	name := fmt.Sprintf("tf-testacc%sconfigcompliancepack%d", defaultRegionToTest, rand)
+	testAccConfig := resourceTestAccConfigFunc(resourceId, name, AliCloudConfigCompliancePackBasicDependence0)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: rac.checkResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"compliance_pack_name": name,
+					"description":          name,
+					"risk_level":           "1",
+					"template_content":     strings.ReplaceAll(fmt.Sprintf(`{"compliancePackTemplate":{"compliancePackName":"%s","description":"%s","riskLevel":1,"scope":{}},"configRuleTemplates":[{"configRuleName":"ecs-snapshot-retention-days","description":"If the retention period for ECS automatic snapshots is greater than the specified number of days, the configuration is considered compliant.","inputParameters":{"days":"7"},"riskLevel":3,"scope":{"complianceResourceTypes":["ACS::ECS::AutoSnapshotPolicy"]},"source":{"identifier":"ecs-snapshot-retention-days","owner":"ALIYUN","sourceDetails":[{"messageType":"ConfigurationItemChangeNotification"}]}}]}`, name, name), `"`, `\"`),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"compliance_pack_name": name,
+						"description":          name,
+						"risk_level":           "1",
+					}),
+				),
+			},
+		},
+	})
+
+	prefixes := []string{
+		"ecs-",
+	}
+	testSweepConfigRuleByPrefixes(defaultRegionToTest, prefixes)
+}
+
 var AliCloudConfigCompliancePackMap0 = map[string]string{
 	"status": CHECKSET,
 }
@@ -498,6 +567,9 @@ func TestUnitAliCloudConfigCompliancePack(t *testing.T) {
 		"config_rules": []interface{}{
 			map[string]interface{}{
 				"managed_rule_identifier": "CreateCompliancePackValue",
+				"config_rule_name":        "CreateCompliancePackValue",
+				"description":             "CreateCompliancePackValue",
+				"risk_level":              1,
 				"config_rule_parameters": []interface{}{
 					map[string]interface{}{
 						"parameter_name":  "CreateCompliancePackValue",
@@ -506,8 +578,29 @@ func TestUnitAliCloudConfigCompliancePack(t *testing.T) {
 				},
 			},
 		},
-		"description": "CreateCompliancePackValue",
-		"risk_level":  1,
+		"description":                      "CreateCompliancePackValue",
+		"risk_level":                       1,
+		"template_content":                 "CreateCompliancePackValue",
+		"tag_key_scope":                    "CreateCompliancePackValue",
+		"tag_value_scope":                  "CreateCompliancePackValue",
+		"resource_ids_scope":               "CreateCompliancePackValue",
+		"exclude_resource_ids_scope":       "CreateCompliancePackValue",
+		"resource_group_ids_scope":         "CreateCompliancePackValue",
+		"exclude_resource_group_ids_scope": "CreateCompliancePackValue",
+		"region_ids_scope":                 "CreateCompliancePackValue",
+		"exclude_region_ids_scope":         "CreateCompliancePackValue",
+		"tags_scope": []interface{}{
+			map[string]interface{}{
+				"tag_key":   "CreateCompliancePackValue",
+				"tag_value": "CreateCompliancePackValue",
+			},
+		},
+		"exclude_tags_scope": []interface{}{
+			map[string]interface{}{
+				"tag_key":   "CreateCompliancePackValue",
+				"tag_value": "CreateCompliancePackValue",
+			},
+		},
 	}
 	for key, value := range attributes {
 		err := dInit.Set(key, value)
@@ -531,6 +624,9 @@ func TestUnitAliCloudConfigCompliancePack(t *testing.T) {
 			"ConfigRules": []interface{}{
 				map[string]interface{}{
 					"ManagedRuleIdentifier": "CreateCompliancePackValue",
+					"ConfigRuleName":        "CreateCompliancePackValue",
+					"Description":           "CreateCompliancePackValue",
+					"RiskLevel":             1,
 					"ConfigRuleParameters": []interface{}{
 						map[string]interface{}{
 							"ParameterName":  "CreateCompliancePackValue",
@@ -544,6 +640,29 @@ func TestUnitAliCloudConfigCompliancePack(t *testing.T) {
 			"Description":              "CreateCompliancePackValue",
 			"RiskLevel":                1,
 			"Status":                   "ACTIVE",
+			"TemplateContent":          "CreateCompliancePackValue",
+			"Scope": map[string]interface{}{
+				"TagKeyScope":                  "CreateCompliancePackValue",
+				"TagValueScope":                "CreateCompliancePackValue",
+				"ResourceIdsScope":             "CreateCompliancePackValue",
+				"ExcludeResourceIdsScope":      "CreateCompliancePackValue",
+				"ResourceGroupIdsScope":        "CreateCompliancePackValue",
+				"ExcludeResourceGroupIdsScope": "CreateCompliancePackValue",
+				"RegionIdsScope":               "CreateCompliancePackValue",
+				"ExcludeRegionIdsScope":        "CreateCompliancePackValue",
+				"TagsScope": []interface{}{
+					map[string]interface{}{
+						"TagKey":   "CreateCompliancePackValue",
+						"TagValue": "CreateCompliancePackValue",
+					},
+				},
+				"ExcludeTagsScope": []interface{}{
+					map[string]interface{}{
+						"TagKey":   "CreateCompliancePackValue",
+						"TagValue": "CreateCompliancePackValue",
+					},
+				},
+			},
 		},
 	}
 	CreateMockResponse := map[string]interface{}{
@@ -643,12 +762,29 @@ func TestUnitAliCloudConfigCompliancePack(t *testing.T) {
 		"config_rules": []interface{}{
 			map[string]interface{}{
 				"managed_rule_identifier": "UpdateCompliancePackValue",
+				"config_rule_name":        "UpdateCompliancePackValue",
+				"description":             "UpdateCompliancePackValue",
+				"risk_level":              2,
 				"config_rule_parameters": []interface{}{
 					map[string]interface{}{
 						"parameter_name":  "UpdateCompliancePackValue",
 						"parameter_value": "UpdateCompliancePackValue",
 					},
 				},
+			},
+		},
+		"tag_key_scope":   "UpdateCompliancePackValue",
+		"tag_value_scope": "UpdateCompliancePackValue",
+		"tags_scope": []interface{}{
+			map[string]interface{}{
+				"tag_key":   "UpdateCompliancePackValue",
+				"tag_value": "UpdateCompliancePackValue",
+			},
+		},
+		"exclude_tags_scope": []interface{}{
+			map[string]interface{}{
+				"tag_key":   "UpdateCompliancePackValue",
+				"tag_value": "UpdateCompliancePackValue",
 			},
 		},
 	}
@@ -666,11 +802,30 @@ func TestUnitAliCloudConfigCompliancePack(t *testing.T) {
 			"ConfigRules": []interface{}{
 				map[string]interface{}{
 					"ManagedRuleIdentifier": "UpdateCompliancePackValue",
+					"ConfigRuleName":        "UpdateCompliancePackValue",
+					"Description":           "UpdateCompliancePackValue",
+					"RiskLevel":             2,
 					"ConfigRuleParameters": []interface{}{
 						map[string]interface{}{
 							"ParameterName":  "UpdateCompliancePackValue",
 							"ParameterValue": "UpdateCompliancePackValue",
 						},
+					},
+				},
+			},
+			"Scope": map[string]interface{}{
+				"TagKeyScope":   "UpdateCompliancePackValue",
+				"TagValueScope": "UpdateCompliancePackValue",
+				"TagsScope": []interface{}{
+					map[string]interface{}{
+						"TagKey":   "UpdateCompliancePackValue",
+						"TagValue": "UpdateCompliancePackValue",
+					},
+				},
+				"ExcludeTagsScope": []interface{}{
+					map[string]interface{}{
+						"TagKey":   "UpdateCompliancePackValue",
+						"TagValue": "UpdateCompliancePackValue",
 					},
 				},
 			},

--- a/website/docs/r/config_compliance_pack.html.markdown
+++ b/website/docs/r/config_compliance_pack.html.markdown
@@ -89,8 +89,19 @@ The following arguments are supported:
   - `2`: warning.
   - `3`: info.
 * `compliance_pack_template_id` - (Optional, ForceNew) Compliance Package Template Id.
+* `template_content` - (Optional, ForceNew) The template content of the compliance pack.
 * `config_rule_ids` - (Optional, Set, Available since v1.141.0) A list of Config Rule IDs. See [`config_rule_ids`](#config_rule_ids) below.
 * `config_rules` - (Optional, Set, Deprecated since v1.141.0) A list of Config Rules. See [`config_rules`](#config_rules) below. **NOTE:** Field `config_rules` has been deprecated from provider version 1.141.0. New field `config_rule_ids` instead.
+* `tag_key_scope` - (Optional) The tag key scope of the compliance pack.
+* `tag_value_scope` - (Optional) The tag value scope of the compliance pack.
+* `resource_ids_scope` - (Optional) The resource IDs scope of the compliance pack.
+* `exclude_resource_ids_scope` - (Optional) The exclude resource IDs scope of the compliance pack.
+* `resource_group_ids_scope` - (Optional) The resource group IDs scope of the compliance pack.
+* `exclude_resource_group_ids_scope` - (Optional) The exclude resource group IDs scope of the compliance pack.
+* `region_ids_scope` - (Optional) The region IDs scope of the compliance pack.
+* `exclude_region_ids_scope` - (Optional) The exclude region IDs scope of the compliance pack.
+* `tags_scope` - (Optional, List) The tags scope of the compliance pack. See [`tags_scope`](#tags_scope) below.
+* `exclude_tags_scope` - (Optional, List) The exclude tags scope of the compliance pack. See [`exclude_tags_scope`](#exclude_tags_scope) below.
 
 ### `config_rule_ids`
 
@@ -100,17 +111,34 @@ The config_rule_ids supports the following:
 
 ### `config_rules`
 
-The config_rules supports the following: 
+The config_rules supports the following:
 
 * `managed_rule_identifier` - (Required) The Managed Rule Identifier.
 * `config_rule_parameters` - (Optional, Set) A list of Config Rule Parameters. See [`config_rule_parameters`](#config_rules-config_rule_parameters) below.
+* `config_rule_name` - (Optional) The name of the Config Rule.
+* `description` - (Optional) The description of the Config Rule.
+* `risk_level` - (Optional, Int) The risk level of the Config Rule. Valid values: `1`, `2`, `3`.
 
 ### `config_rules-config_rule_parameters`
 
-The config_rule_parameters supports the following: 
+The config_rule_parameters supports the following:
 
 * `parameter_name` - (Optional) The parameter name.
 * `parameter_value` - (Optional) The parameter value.
+
+### `tags_scope`
+
+The tags_scope supports the following:
+
+* `tag_key` - (Optional) The tag key.
+* `tag_value` - (Optional) The tag value.
+
+### `exclude_tags_scope`
+
+The exclude_tags_scope supports the following:
+
+* `tag_key` - (Optional) The tag key.
+* `tag_value` - (Optional) The tag value.
 
 ## Attributes Reference
 
@@ -118,6 +146,7 @@ The following attributes are exported:
 
 * `id` - The resource ID in terraform of Compliance Pack.
 * `status` -  The status of the Compliance Pack.
+* `template_content` - The template content of the compliance pack.
 
 ## Timeouts
 


### PR DESCRIPTION
## Summary

Add scope, tags scope, and template content fields to the `alicloud_config_compliance_pack` resource to align with the Config CompliancePack API.

### New fields

- `template_content` (Optional, Computed, ForceNew) - The template content of the compliance pack. Create-only; returned by GetCompliancePack.
- `tag_key_scope` / `tag_value_scope` (Optional, String) - Tag key/value scope for the compliance pack.
- `resource_ids_scope` / `exclude_resource_ids_scope` (Optional, String) - Resource ID scope filter.
- `resource_group_ids_scope` / `exclude_resource_group_ids_scope` (Optional, String) - Resource group ID scope filter.
- `region_ids_scope` / `exclude_region_ids_scope` (Optional, String) - Region ID scope filter.
- `tags_scope` / `exclude_tags_scope` (Optional, List of {tag_key, tag_value}) - Tags scope filter as a list of tag objects.
- Extended `config_rules` sub-block with `config_rule_name`, `description`, and `risk_level` fields.

### CRUD alignment

- **Create**: sends template_content, all scope string fields as formData, tags_scope/exclude_tags_scope as JSON strings; extended config_rules to include config_rule_name, description, risk_level.
- **Read**: extracts scope fields from the nested `$.CompliancePack.Scope` object in the GetCompliancePack response; template_content read from the top-level `$.CompliancePack.TemplateContent` path.
- **Update**: sends scope fields via UpdateCompliancePack (template_content excluded as it is create-only/ForceNew); extended config_rules sub-fields.
- **Import**: existing ImportStatePassthrough reused; Read backfills all new fields.

## Tests

- Updated `TestAccAliCloudConfigCompliancePack_basic0` to cover scope fields, tags_scope, and extended config_rules sub-fields (create + update).
- Added `TestAccAliCloudConfigCompliancePack_basic2` for template_content (create-only, no import — ForceNew field).
- Updated unit test mock to include scope fields, template_content, and extended config_rules in Create/Update/Read flows.

## Test Results

Remote acceptance tests pending verification.