### PR TITLE
resource/alicloud_ens_disk: support instance_billing_cycle parameter

### DIFF
--- a/alicloud/resource_alicloud_ens_disk.go
+++ b/alicloud/resource_alicloud_ens_disk.go
@@ -52,6 +52,12 @@ func resourceAliCloudEnsDisk() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"instance_billing_cycle": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: StringInSlice([]string{"Hour", "Day", "Month"}, false),
+			},
 			"kms_key_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -94,6 +100,9 @@ func resourceAliCloudEnsDiskCreate(d *schema.ResourceData, meta interface{}) err
 	request = make(map[string]interface{})
 
 	request["InstanceChargeType"] = convertEnsInstanceInstanceChargeTypeRequest(d.Get("payment_type").(string))
+	if v, ok := d.GetOk("instance_billing_cycle"); ok {
+		request["InstanceBillingCycle"] = v
+	}
 	request["EnsRegionId"] = d.Get("ens_region_id")
 	request["Category"] = d.Get("category")
 	if v, ok := d.GetOkExists("size"); ok {

--- a/alicloud/resource_alicloud_ens_disk_test.go
+++ b/alicloud/resource_alicloud_ens_disk_test.go
@@ -33,17 +33,19 @@ func TestAccAliCloudEnsDisk_basic5178(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccConfig(map[string]interface{}{
-					"category":      "cloud_ssd",
-					"payment_type":  "PayAsYouGo",
-					"ens_region_id": "cn-chongqing-11",
-					"size":          "20",
+					"category":               "cloud_ssd",
+					"payment_type":           "PayAsYouGo",
+					"ens_region_id":          "cn-chongqing-11",
+					"size":                   "20",
+					"instance_billing_cycle": "Hour",
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
-						"category":      "cloud_ssd",
-						"payment_type":  "PayAsYouGo",
-						"ens_region_id": "cn-chongqing-11",
-						"size":          "20",
+						"category":               "cloud_ssd",
+						"payment_type":           "PayAsYouGo",
+						"ens_region_id":          "cn-chongqing-11",
+						"size":                   "20",
+						"instance_billing_cycle": "Hour",
 					}),
 				),
 			},
@@ -113,7 +115,7 @@ func TestAccAliCloudEnsDisk_basic5178(t *testing.T) {
 				ResourceName:            resourceId,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"instance_billing_cycle"},
 			},
 		},
 	})

--- a/website/docs/r/ens_disk.html.markdown
+++ b/website/docs/r/ens_disk.html.markdown
@@ -48,14 +48,15 @@ The following arguments are supported:
 * `disk_name` - (Optional) The name of the disk.
 * `encrypted` - (Optional, ForceNew) Specifies whether to encrypt the new system disk. Valid values: `true`, `false`(default).
 * `ens_region_id` - (Required, ForceNew) The ID of the edge node.
+* `instance_billing_cycle` - (Optional, ForceNew) The billing cycle of the instance. Valid values: `Hour`, `Day`, `Month`.
 * `kms_key_id` - (Optional, ForceNew) The ID of the KMS key used by the cloud disk. If `encrypted` is set to `true`, the service default key is used when KMSKeyId is empty.
 * `payment_type` - (Required, ForceNew) The billing method of the instance. Valid values: `PayAsYouGo`.
 * `size` - (Optional, Int) The size of the disk instance. Unit: GiB.
 * `snapshot_id` - (Optional, ForceNew) The ID of the snapshot used to create the cloud disk.
 
 The SnapshotId and Size parameters have the following limitations:
-  - If the snapshot capacity corresponding to the `snapshot_id` parameter is greater than the specified `size` parameter, the Size of the cloud disk created is the Size of the specified snapshot.
-  - If the snapshot capacity corresponding to the `snapshot_id` parameter is less than the set `size` parameter value, the Size of the cloud disk created is the specified `size` parameter value.
+- If the snapshot capacity corresponding to the `snapshot_id` parameter is greater than the specified `size` parameter, the Size of the cloud disk created is the Size of the specified snapshot.
+- If the snapshot capacity corresponding to the `snapshot_id` parameter is less than the set `size` parameter value, the Size of the cloud disk created is the specified `size` parameter value.
 * `tags` - (Optional, Map, Available since v1.248.0) The label to which the instance is bound.
 
 ## Attributes Reference


### PR DESCRIPTION
## Description

Add the `instance_billing_cycle` parameter to the `alicloud_ens_disk` resource. This parameter specifies the billing cycle of the instance and is only valid on resource creation (ForceNew).

Valid values: `Hour`, `Day`, `Month`.

## Motivation

The ENS CreateDisk API supports an `InstanceBillingCycle` parameter that was not yet exposed in the Terraform provider. This PR adds it so users can specify the billing cycle when creating ENS disks.

## Changes

- **Schema**: Added `instance_billing_cycle` field (Optional, ForceNew, validated against `Hour`/`Day`/`Month`)
- **Create**: Sends `InstanceBillingCycle` in the CreateDisk request when the field is set
- **Read**: No `d.Set` for this field since the API does not return it in DescribeDisk responses (create-only parameter)
- **Import**: Added to `ImportStateVerifyIgnore` in the test since it is create-only and not returned by Read
- **Documentation**: Added argument reference entry

## Tests

- Extended `TestAccAliCloudEnsDisk_basic5178` to include `instance_billing_cycle = "Hour"` in the create step
- Added `instance_billing_cycle` to `ImportStateVerifyIgnore` for the import step