### PR TITLE
resource/esa_custom_scene_policy: add objects attribute for Create/Update Objects parameter

### DIFF
--- a/alicloud/resource_alicloud_esa_custom_scene_policy.go
+++ b/alicloud/resource_alicloud_esa_custom_scene_policy.go
@@ -37,6 +37,11 @@ func resourceAliCloudEsaCustomScenePolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"objects": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"start_time": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -76,6 +81,9 @@ func resourceAliCloudEsaCustomScenePolicyCreate(d *schema.ResourceData, meta int
 	request["Name"] = d.Get("custom_scene_policy_name")
 	request["SiteIds"] = d.Get("site_ids")
 	request["EndTime"] = d.Get("end_time")
+	if v, ok := d.GetOk("objects"); ok {
+		request["Objects"] = v
+	}
 
 	if v, ok := d.GetOk("start_time"); ok {
 		request["StartTime"] = v
@@ -125,6 +133,7 @@ func resourceAliCloudEsaCustomScenePolicyRead(d *schema.ResourceData, meta inter
 	d.Set("custom_scene_policy_name", objectRaw["Name"])
 	d.Set("end_time", objectRaw["EndTime"])
 	d.Set("site_ids", objectRaw["SiteIds"])
+	d.Set("objects", objectRaw["Objects"])
 	d.Set("start_time", objectRaw["StartTime"])
 	d.Set("status", objectRaw["Status"])
 	d.Set("template", objectRaw["Template"])
@@ -242,6 +251,12 @@ func resourceAliCloudEsaCustomScenePolicyUpdate(d *schema.ResourceData, meta int
 		update = true
 	}
 	request["SiteIds"] = d.Get("site_ids")
+	if !d.IsNewResource() && d.HasChange("objects") {
+		update = true
+	}
+	if v, ok := d.GetOk("objects"); ok {
+		request["Objects"] = v
+	}
 	if !d.IsNewResource() && d.HasChange("end_time") {
 		update = true
 	}

--- a/alicloud/resource_alicloud_esa_custom_scene_policy_test.go
+++ b/alicloud/resource_alicloud_esa_custom_scene_policy_test.go
@@ -37,6 +37,7 @@ func TestAccAliCloudEsaCustomScenePolicy_basic0(t *testing.T) {
 					"custom_scene_policy_name": name,
 					"end_time":                 "2025-09-08T18:00:00Z",
 					"site_ids":                 "${data.alicloud_esa_sites.default.sites.0.id}",
+					"objects":                  "${data.alicloud_esa_sites.default.sites.0.id}",
 					"start_time":               "2025-08-08T18:00:00Z",
 					"template":                 "promotion",
 				}),
@@ -45,6 +46,7 @@ func TestAccAliCloudEsaCustomScenePolicy_basic0(t *testing.T) {
 						"custom_scene_policy_name": name,
 						"end_time":                 "2025-09-08T18:00:00Z",
 						"site_ids":                 CHECKSET,
+						"objects":                  CHECKSET,
 						"start_time":               "2025-08-08T18:00:00Z",
 						"template":                 "promotion",
 					}),
@@ -77,6 +79,16 @@ func TestAccAliCloudEsaCustomScenePolicy_basic0(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheck(map[string]string{
 						"site_ids": CHECKSET,
+					}),
+				),
+			},
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"objects": "${data.alicloud_esa_sites.default.sites.0.id},${data.alicloud_esa_sites.default.sites.1.id}",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"objects": CHECKSET,
 					}),
 				),
 			},

--- a/website/docs/r/esa_custom_scene_policy.html.markdown
+++ b/website/docs/r/esa_custom_scene_policy.html.markdown
@@ -64,6 +64,7 @@ The time follows the ISO 8601 standard in the yyyy-MM-ddTHH:mm:ssZ format. The t
 * `end_time` - (Required) The time when the policy expires.
 The time follows the ISO 8601 standard in the yyyy-MM-ddTHH:mm:ssZ format. The time is displayed in UTC.
 * `site_ids` - (Required) The IDs of the sites to associate with the policy. Separate multiple site IDs with commas.
+* `objects` - (Optional) The IDs of the websites that you want to associate with the policy. Separate multiple IDs with commas (,).
 * `template` - (Required) The name of the policy template. Valid value:
   - `promotion`: major events.
 * `status` - (Optional) Policy effective status. Valid values: `Disabled`, `Running`.


### PR DESCRIPTION
This PR adds the `objects` attribute to the `alicloud_esa_custom_scene_policy` resource, mapping the optional `Objects` request parameter of the Create and Update operations.

## Changes

- **Schema**: add `objects` (`Optional`, `Computed`, `TypeString`) holding the comma-separated website IDs to associate with the policy.
- **Create**: send the `Objects` parameter when the field is set.
- **Update**: send the `Objects` parameter on change, guarded by `d.HasChange("objects")`.
- **Read**: read back `Objects` from the `DescribeCustomScenePolicies` response.
- **Tests**: cover the `objects` attribute in the basic create step and add an update step changing the associated website IDs.
- **Docs**: document the `objects` argument.

## Argument

* `objects` - (Optional) The IDs of the websites that you want to associate with the policy. Separate multiple IDs with commas (,).

## Test Results

Remote acceptance tests pending.
