### PR TITLE
resource/alicloud_dts_subscription_job: support source_endpoint_ssl

### DIFF
--- a/alicloud/resource_alicloud_dts_subscription_job.go
+++ b/alicloud/resource_alicloud_dts_subscription_job.go
@@ -151,6 +151,12 @@ func resourceAliCloudDtsSubscriptionJob() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"source_endpoint_ssl": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: StringInSlice([]string{"0", "1"}, false),
+			},
 			"source_endpoint_user_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -291,6 +297,9 @@ func resourceAliCloudDtsSubscriptionJobRead(d *schema.ResourceData, meta interfa
 	d.Set("source_endpoint_port", object["SourceEndpoint"].(map[string]interface{})["Port"])
 	d.Set("source_endpoint_region", object["SourceEndpoint"].(map[string]interface{})["Region"])
 	d.Set("source_endpoint_role", object["SourceEndpoint"].(map[string]interface{})["RoleName"])
+	if ssl := convertDtsEndpointSslResponse(object["SourceEndpoint"].(map[string]interface{})["SslSolutionEnum"]); ssl != nil {
+		d.Set("source_endpoint_ssl", ssl)
+	}
 	d.Set("source_endpoint_user_name", object["SourceEndpoint"].(map[string]interface{})["UserName"])
 	d.Set("status", object["Status"])
 	d.Set("subscription_data_type_ddl", object["SubscriptionDataType"].(map[string]interface{})["Ddl"])
@@ -504,6 +513,9 @@ func resourceAliCloudDtsSubscriptionJobUpdate(d *schema.ResourceData, meta inter
 	if v, ok := d.GetOk("source_endpoint_role"); ok {
 		configureSubscriptionReq["SourceEndpointRole"] = v
 	}
+	if d.HasChange("source_endpoint_ssl") {
+		update = true
+	}
 
 	if v, ok := d.GetOk("source_endpoint_user_name"); ok {
 		configureSubscriptionReq["SourceEndpointUserName"] = v
@@ -552,6 +564,12 @@ func resourceAliCloudDtsSubscriptionJobUpdate(d *schema.ResourceData, meta inter
 		if v, ok := d.GetOk("reserve"); ok {
 			configureSubscriptionReq["Reserve"] = v
 		}
+		// Fold source_endpoint_ssl into the Reserve srcSSL key. ConfigureSubscription has no
+		// dedicated SSL parameter, so Reserve is the only place the source connection mode can be
+		// sent; a user-supplied reserve srcSSL is overwritten by the dedicated attribute.
+		if err := setDtsEndpointSSL(d, configureSubscriptionReq); err != nil {
+			return WrapError(err)
+		}
 		action := "ConfigureSubscription"
 		wait := incrementalWait(3*time.Second, 3*time.Second)
 		err = resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
@@ -584,6 +602,7 @@ func resourceAliCloudDtsSubscriptionJobUpdate(d *schema.ResourceData, meta inter
 		d.SetPartial("source_endpoint_port")
 		d.SetPartial("source_endpoint_region")
 		d.SetPartial("source_endpoint_role")
+		d.SetPartial("source_endpoint_ssl")
 		d.SetPartial("source_endpoint_user_name")
 		d.SetPartial("subscription_data_type_ddl")
 		d.SetPartial("subscription_data_type_dml")

--- a/alicloud/resource_alicloud_dts_subscription_job_test.go
+++ b/alicloud/resource_alicloud_dts_subscription_job_test.go
@@ -135,6 +135,7 @@ func TestAccAliCloudDTSSubscriptionJob_basic0(t *testing.T) {
 					"source_endpoint_database_name":      "${alicloud_rds_account.source_account.account_password}",
 					"source_endpoint_user_name":          "${alicloud_rds_account.source_account.account_name}",
 					"source_endpoint_password":           "${alicloud_rds_account.source_account.account_password}",
+					"source_endpoint_ssl":                "1",
 					"db_list":                            "{\\\"test_database\\\":{\\\"name\\\":\\\"test_database\\\",\\\"all\\\":true,\\\"state\\\":\\\"normal\\\"}}",
 					"subscription_instance_network_type": "vpc",
 					"subscription_instance_vpc_id":       "${data.alicloud_vpcs.default.ids.0}",
@@ -150,8 +151,33 @@ func TestAccAliCloudDTSSubscriptionJob_basic0(t *testing.T) {
 						"source_endpoint_database_name":      "N1cetest",
 						"source_endpoint_user_name":          "test_mysql",
 						"source_endpoint_password":           "N1cetest",
+						"source_endpoint_ssl":                "1",
 						"db_list":                            "{\"test_database\":{\"name\":\"test_database\",\"all\":true,\"state\":\"normal\"}}",
 						"subscription_instance_network_type": "vpc",
+					}),
+				),
+			},
+			// Turn SSL off on the source endpoint in place. The field is not ForceNew, so this
+			// goes through ConfigureSubscription with the srcSSL key folded into Reserve rather
+			// than recreating the job.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"source_endpoint_ssl": "0",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"source_endpoint_ssl": "0",
+					}),
+				),
+			},
+			// Turn SSL back on, covering the enable-by-update direction as well as disable.
+			{
+				Config: testAccConfig(map[string]interface{}{
+					"source_endpoint_ssl": "1",
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheck(map[string]string{
+						"source_endpoint_ssl": "1",
 					}),
 				),
 			},
@@ -522,6 +548,7 @@ var AliCloudDTSSubscriptionJobMap0 = map[string]string{
 	"auto_start":                       NOSET,
 	"database_count":                   NOSET,
 	"instance_class":                   NOSET,
+	"source_endpoint_ssl":              NOSET,
 	"subscription_data_type_ddl":       CHECKSET,
 	"destination_endpoint_engine_name": NOSET,
 	"used_time":                        NOSET,

--- a/website/docs/r/dts_subscription_job.html.markdown
+++ b/website/docs/r/dts_subscription_job.html.markdown
@@ -143,6 +143,9 @@ The following arguments were support:
 * `payment_duration_unit` - (Optional) The payment duration unit. Valid values: `Month`, `Year`. When `payment_type` is `Subscription`, this parameter is valid and must be passed in.
 * `payment_duration` - (Optional) The duration of prepaid instance purchase. When `payment_type` is `Subscription`, this parameter is valid and must be passed in.
 * `reserve` - (Optional) DTS reserves parameters, the format is a JSON string, you can pass in this parameter to complete the source and target database information (such as the data storage format of the target Kafka database, the instance ID of the cloud enterprise network CEN). For more information, please refer to the parameter description of the [Reserve parameter](https://help.aliyun.com/document_detail/176470.html).
+
+  -> **NOTE:** The `srcSSL` key is managed by the property `source_endpoint_ssl`. If the property is set, it overrides the corresponding key here.
+
 * `source_endpoint_database_name` - (Optional) To subscribe to the name of the database.
 * `source_endpoint_engine_name` - (Required) The source database type value is MySQL or Oracle. Valid values: `MySQL`, `Oracle`.
 * `source_endpoint_instance_id` - (Optional) The ID of source instance. Only when the type of source database instance was RDS MySQL, PolarDB-X 1.0, PolarDB MySQL, this parameter can be available and must be set.
@@ -155,6 +158,7 @@ The following arguments were support:
 * `source_endpoint_port` - (Optional) The port of source database.
 * `source_endpoint_region` - (Required) The region of source database.
 * `source_endpoint_role` - (Optional) Both the authorization roles. When the source instance and configure subscriptions task of the Alibaba Cloud account is not the same as the need to pass the parameter, to specify the source of the authorization roles, to allow configuration subscription task of the Alibaba Cloud account to access the source of the source instance information.
+* `source_endpoint_ssl` - (Optional, Computed) The connection method of the source instance. Valid values: `0` (an unencrypted connection), `1` (an SSL-secured connection). Only supported when the source endpoint is accessed as a cloud instance or as a self-managed database hosted on ECS.
 * `subscription_data_type_ddl` - (Optional) Whether to subscribe the DDL type of data. Valid values: `true`, `false`.
 * `subscription_data_type_dml` - (Optional) Whether to subscribe the DML type of data. Valid values: `true`, `false`.
 * `subscription_instance_network_type` - (Optional, ForceNew) Subscription task type of network value: classic: classic Network. Virtual Private Cloud (vpc): a vpc. Valid values: `classic`, `vpc`.


### PR DESCRIPTION
Add source_endpoint_ssl to alicloud_dts_subscription_job, mapping DTS SourceEndpoint.SslSolutionEnum through the existing DTS SSL helpers. Cover schema, read/import, update, documentation, and enable/disable test steps.

Validation:
- gofmt passed.
- Local go vet was interrupted by OOM in the 2 GiB sandbox; it has not passed.
- ACube task 11228 is testing this exact commit with TestAccAliCloudDTSSubscriptionJob_basic0, basic1, and basic2. Results and QA review are pending.

Tracks Aone 86422232. No merge or release is requested by this PR.